### PR TITLE
feat(chrome-ext): add Chrome hooks, app context, and screen routing shell

### DIFF
--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -1,3 +1,232 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { CloudAssistant } from '../background/cloud-api.js';
+import type { OperationEntry } from '../background/event-log.js';
+import { AppContext, type Screen } from './AppContext.js';
+import { useBranding } from './hooks/use-branding.js';
+import { useSession } from './hooks/use-session.js';
+import { useStatusPoll } from './hooks/use-status-poll.js';
+import { sendMessage } from './lib/chrome-message.js';
+import { ActivityScreen } from './screens/ActivityScreen.js';
+import { DetailScreen } from './screens/DetailScreen.js';
+import { MainScreen } from './screens/MainScreen.js';
+import { PickerScreen } from './screens/PickerScreen.js';
+import { WelcomeScreen } from './screens/WelcomeScreen.js';
+
 export function App() {
-  return <div className="text-fg">Vellum Assistant</div>
+  const session = useSession();
+  const [screen, setScreen] = useState<Screen>({ name: 'welcome' });
+  const [mode, setMode] = useState<'self-hosted' | 'cloud' | null>(null);
+  const [operationCount, setOperationCount] = useState(0);
+
+  const _branding = useBranding();
+
+  // Determine initial screen from session state once loading completes
+  useEffect(() => {
+    if (session.loading) return;
+
+    if (session.mode === 'self-hosted') {
+      setMode('self-hosted');
+      setScreen({ name: 'main' });
+      if (session.selfHostedPaired) {
+        sendMessage({ type: 'connect' });
+      }
+    } else if (session.mode === 'cloud') {
+      setMode('cloud');
+      if (session.session && !session.selectedAssistant) {
+        // Signed in but no assistant chosen — go to picker
+        sendMessage<{
+          ok: boolean;
+          assistants?: CloudAssistant[];
+          error?: string;
+        }>({ type: 'list-assistants' }).then((response) => {
+          if (response?.ok && response.assistants) {
+            setScreen({
+              name: 'picker',
+              assistants: response.assistants,
+              email: session.session?.email,
+            });
+          } else {
+            setScreen({ name: 'welcome' });
+          }
+        });
+      } else {
+        setScreen({ name: 'main' });
+        sendMessage({ type: 'connect' });
+      }
+    } else {
+      setScreen({ name: 'welcome' });
+    }
+  }, [session.loading, session.mode, session.session, session.selectedAssistant, session.selfHostedPaired]);
+
+  // Poll status when on the main screen
+  const { health, healthDetail, authProfile } = useStatusPoll(screen.name === 'main');
+
+  // Refresh activity count when on the main screen
+  useEffect(() => {
+    if (screen.name !== 'main') return;
+
+    function refreshCount() {
+      sendMessage<{ ok: boolean; operations: OperationEntry[] }>({
+        type: 'get-operations',
+      }).then((response) => {
+        if (response?.ok) {
+          setOperationCount(response.operations.length);
+        }
+      });
+    }
+
+    refreshCount();
+  }, [screen.name]);
+
+  // Navigate to picker when assistant is removed
+  useEffect(() => {
+    if (health !== 'assistant_gone') return;
+
+    sendMessage<{
+      ok: boolean;
+      assistants?: CloudAssistant[];
+      error?: string;
+    }>({ type: 'list-assistants' }).then((response) => {
+      if (response?.ok && response.assistants) {
+        setScreen({ name: 'picker', assistants: response.assistants });
+      }
+    });
+  }, [health]);
+
+  // Navigation callbacks
+
+  const handleSignIn = useCallback(() => {
+    sendMessage<{
+      ok: boolean;
+      session?: { email: string };
+      assistants?: CloudAssistant[];
+      assistantsError?: string;
+      error?: string;
+    }>({ type: 'cloud-login' }).then((response) => {
+      if (!response?.ok) return;
+
+      setMode('cloud');
+      const assistants = response.assistants ?? [];
+
+      if (response.assistantsError || assistants.length === 0) {
+        setScreen({ name: 'main' });
+        sendMessage({ type: 'connect' });
+      } else if (assistants.length === 1) {
+        const a = assistants[0]!;
+        sendMessage({
+          type: 'select-assistant',
+          assistantId: a.id,
+          assistantName: a.name,
+        });
+        setScreen({ name: 'main' });
+        sendMessage({ type: 'connect' });
+      } else {
+        setScreen({
+          name: 'picker',
+          assistants,
+          email: response.session?.email,
+        });
+      }
+    });
+  }, []);
+
+  const handleSelfHosted = useCallback(() => {
+    setMode('self-hosted');
+    sendMessage({ type: 'set-mode', mode: 'self-hosted' });
+    setScreen({ name: 'main' });
+  }, []);
+
+  const handleSelectAssistant = useCallback(
+    (id: string, name: string) => {
+      setMode('cloud');
+      sendMessage({ type: 'select-assistant', assistantId: id, assistantName: name });
+      setScreen({ name: 'main' });
+      sendMessage({ type: 'connect' });
+    },
+    [],
+  );
+
+  const handleSignOut = useCallback(() => {
+    const msgType = mode === 'self-hosted' ? 'self-hosted-disconnect' : 'cloud-logout';
+    sendMessage({ type: msgType }).then(() => {
+      setMode(null);
+      setScreen({ name: 'welcome' });
+    });
+  }, [mode]);
+
+  const handleSelectOperation = useCallback((op: OperationEntry) => {
+    setScreen({ name: 'detail', operation: op });
+  }, []);
+
+  const handleBackToMain = useCallback(() => {
+    setScreen({ name: 'main' });
+  }, []);
+
+  const handleBackToActivity = useCallback(() => {
+    setScreen({ name: 'activity' });
+  }, []);
+
+  const handleBackToWelcome = useCallback(() => {
+    setScreen({ name: 'welcome' });
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      mode,
+      health,
+      healthDetail,
+      authProfile,
+      operationCount,
+      setScreen,
+      sendMessage,
+      onSignOut: handleSignOut,
+    }),
+    [mode, health, healthDetail, authProfile, operationCount, handleSignOut],
+  );
+
+  if (session.loading) {
+    return null;
+  }
+
+  return (
+    <AppContext.Provider value={contextValue}>
+      {(() => {
+        switch (screen.name) {
+          case 'welcome':
+            return (
+              <WelcomeScreen
+                onSignIn={handleSignIn}
+                onSelfHosted={handleSelfHosted}
+              />
+            );
+          case 'picker':
+            return (
+              <PickerScreen
+                assistants={screen.assistants}
+                email={screen.email}
+                onSelect={handleSelectAssistant}
+                onBack={handleBackToWelcome}
+              />
+            );
+          case 'main':
+            return <MainScreen />;
+          case 'activity':
+            return (
+              <ActivityScreen
+                onBack={handleBackToMain}
+                onSelectOperation={handleSelectOperation}
+              />
+            );
+          case 'detail':
+            return (
+              <DetailScreen
+                operation={screen.operation}
+                onBack={handleBackToActivity}
+              />
+            );
+        }
+      })()}
+    </AppContext.Provider>
+  );
 }

--- a/clients/chrome-extension/popup/AppContext.tsx
+++ b/clients/chrome-extension/popup/AppContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react';
+
+import type { AssistantAuthProfile } from '../background/assistant-auth-profile.js';
+import type { CloudAssistant } from '../background/cloud-api.js';
+import type { OperationEntry } from '../background/event-log.js';
+import type { ConnectionHealthDetail, ConnectionHealthState } from './popup-state.js';
+
+export type Screen =
+  | { name: 'welcome' }
+  | { name: 'picker'; assistants: CloudAssistant[]; email?: string }
+  | { name: 'main' }
+  | { name: 'activity' }
+  | { name: 'detail'; operation: OperationEntry };
+
+export interface AppContextValue {
+  mode: 'self-hosted' | 'cloud' | null;
+  health: ConnectionHealthState;
+  healthDetail: ConnectionHealthDetail;
+  authProfile: AssistantAuthProfile | null;
+  operationCount: number;
+  setScreen: (screen: Screen) => void;
+  sendMessage: <T>(message: Record<string, unknown>) => Promise<T>;
+  onSignOut: () => void;
+}
+
+export const AppContext = createContext<AppContextValue | null>(null);
+
+export function useAppContext(): AppContextValue {
+  const ctx = useContext(AppContext);
+  if (!ctx) {
+    throw new Error('useAppContext must be used within an AppContext.Provider');
+  }
+  return ctx;
+}

--- a/clients/chrome-extension/popup/hooks/use-branding.ts
+++ b/clients/chrome-extension/popup/hooks/use-branding.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+interface Branding {
+  name: string;
+  icons: {
+    icon48: string;
+    icon128: string;
+  };
+}
+
+export function useBranding(): Branding {
+  return useMemo(() => {
+    const manifest = chrome.runtime.getManifest();
+    const manifestIcons = manifest.icons as Record<string, string> | undefined;
+    const icon48 = manifestIcons?.['48']
+      ? chrome.runtime.getURL(manifestIcons['48'])
+      : '';
+    const icon128 = manifestIcons?.['128']
+      ? chrome.runtime.getURL(manifestIcons['128'])
+      : '';
+    const name =
+      typeof manifest.name === 'string' ? manifest.name : 'Vellum Assistant';
+    return { name, icons: { icon48, icon128 } };
+  }, []);
+}

--- a/clients/chrome-extension/popup/hooks/use-session.ts
+++ b/clients/chrome-extension/popup/hooks/use-session.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+import { sendMessage } from '../lib/chrome-message.js';
+
+interface SessionState {
+  loading: boolean;
+  mode: 'self-hosted' | 'cloud' | null;
+  session: { email: string } | null;
+  selectedAssistant: { id: string; name: string } | null;
+  selfHostedPaired: boolean;
+}
+
+interface GetSessionResponse {
+  ok: boolean;
+  mode: 'self-hosted' | 'cloud' | null;
+  session?: { email: string } | null;
+  selectedAssistant?: { id: string; name: string } | null;
+  selfHostedPaired?: boolean;
+}
+
+export function useSession(): SessionState {
+  const [state, setState] = useState<SessionState>({
+    loading: true,
+    mode: null,
+    session: null,
+    selectedAssistant: null,
+    selfHostedPaired: false,
+  });
+
+  useEffect(() => {
+    sendMessage<GetSessionResponse>({ type: 'get-session' }).then((response) => {
+      if (!response?.ok) {
+        setState({
+          loading: false,
+          mode: null,
+          session: null,
+          selectedAssistant: null,
+          selfHostedPaired: false,
+        });
+        return;
+      }
+      setState({
+        loading: false,
+        mode: response.mode,
+        session: response.session ?? null,
+        selectedAssistant: response.selectedAssistant ?? null,
+        selfHostedPaired: response.selfHostedPaired === true,
+      });
+    });
+  }, []);
+
+  return state;
+}

--- a/clients/chrome-extension/popup/hooks/use-status-poll.ts
+++ b/clients/chrome-extension/popup/hooks/use-status-poll.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+import type { AssistantAuthProfile } from '../../background/assistant-auth-profile.js';
+import type {
+  ConnectionHealthDetail,
+  ConnectionHealthState,
+  GetStatusResponse,
+} from '../popup-state.js';
+import { sendMessage } from '../lib/chrome-message.js';
+
+const STATUS_POLL_INTERVAL_MS = 2_000;
+
+interface StatusPollState {
+  health: ConnectionHealthState;
+  healthDetail: ConnectionHealthDetail;
+  authProfile: AssistantAuthProfile | null;
+}
+
+export function useStatusPoll(enabled: boolean): StatusPollState {
+  const [state, setState] = useState<StatusPollState>({
+    health: 'paused',
+    healthDetail: { lastChangeAt: 0 },
+    authProfile: null,
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function poll() {
+      sendMessage<GetStatusResponse>({ type: 'get_status' }).then((response) => {
+        if (!response) return;
+        setState((prev) => {
+          if (
+            prev.health === response.health &&
+            prev.authProfile === response.authProfile &&
+            prev.healthDetail.lastChangeAt === response.healthDetail.lastChangeAt
+          ) {
+            return prev;
+          }
+          return {
+            health: response.health,
+            healthDetail: response.healthDetail,
+            authProfile: response.authProfile,
+          };
+        });
+      });
+    }
+
+    poll();
+    const timer = setInterval(poll, STATUS_POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [enabled]);
+
+  return state;
+}

--- a/clients/chrome-extension/popup/lib/chrome-message.ts
+++ b/clients/chrome-extension/popup/lib/chrome-message.ts
@@ -1,0 +1,26 @@
+/**
+ * Promise-based wrapper around chrome.runtime.sendMessage with retry
+ * logic for MV3 service worker wake-up.
+ *
+ * Chrome MV3 service workers may not be awake when the popup first
+ * opens. If the message port closes before a response is received
+ * (chrome.runtime.lastError set, response undefined), we retry once
+ * after a short delay to give the worker time to wake.
+ */
+
+export function sendMessage<T>(
+  message: Record<string, unknown>,
+  retries = 1,
+): Promise<T> {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(message, (response: T) => {
+      if (chrome.runtime.lastError && response === undefined && retries > 0) {
+        setTimeout(() => {
+          sendMessage<T>(message, retries - 1).then(resolve);
+        }, 200);
+        return;
+      }
+      resolve(response);
+    });
+  });
+}

--- a/clients/chrome-extension/popup/screens/ActivityScreen.tsx
+++ b/clients/chrome-extension/popup/screens/ActivityScreen.tsx
@@ -1,0 +1,18 @@
+import type { OperationEntry } from '../../background/event-log.js';
+
+export interface ActivityScreenProps {
+  onBack: () => void;
+  onSelectOperation: (op: OperationEntry) => void;
+}
+
+export function ActivityScreen({
+  onBack,
+  onSelectOperation: _onSelectOperation,
+}: ActivityScreenProps) {
+  return (
+    <div>
+      <p>Activity</p>
+      <button onClick={onBack}>Back</button>
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/DetailScreen.tsx
+++ b/clients/chrome-extension/popup/screens/DetailScreen.tsx
@@ -1,0 +1,15 @@
+import type { OperationEntry } from '../../background/event-log.js';
+
+export interface DetailScreenProps {
+  operation: OperationEntry;
+  onBack: () => void;
+}
+
+export function DetailScreen({ operation, onBack }: DetailScreenProps) {
+  return (
+    <div>
+      <p>Detail: {operation.operationName}</p>
+      <button onClick={onBack}>Back</button>
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/MainScreen.tsx
+++ b/clients/chrome-extension/popup/screens/MainScreen.tsx
@@ -1,0 +1,3 @@
+export function MainScreen() {
+  return <div>Main</div>;
+}

--- a/clients/chrome-extension/popup/screens/PickerScreen.tsx
+++ b/clients/chrome-extension/popup/screens/PickerScreen.tsx
@@ -1,0 +1,27 @@
+import type { CloudAssistant } from '../../background/cloud-api.js';
+
+export interface PickerScreenProps {
+  assistants: CloudAssistant[];
+  email?: string;
+  onSelect: (id: string, name: string) => void;
+  onBack: () => void;
+}
+
+export function PickerScreen({
+  assistants,
+  email: _email,
+  onSelect,
+  onBack,
+}: PickerScreenProps) {
+  return (
+    <div>
+      <p>Picker</p>
+      <button onClick={onBack}>Back</button>
+      {assistants.map((a) => (
+        <button key={a.id} onClick={() => onSelect(a.id, a.name)}>
+          {a.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/WelcomeScreen.tsx
+++ b/clients/chrome-extension/popup/screens/WelcomeScreen.tsx
@@ -1,0 +1,14 @@
+export interface WelcomeScreenProps {
+  onSignIn: () => void;
+  onSelfHosted: () => void;
+}
+
+export function WelcomeScreen({ onSignIn, onSelfHosted }: WelcomeScreenProps) {
+  return (
+    <div>
+      <p>Welcome</p>
+      <button onClick={onSignIn}>Sign in</button>
+      <button onClick={onSelfHosted}>Self-hosted</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create Promise-based Chrome message bridge with MV3 service worker retry logic
- Add React hooks for status polling, session initialization, and extension branding
- Build App shell with screen routing state machine and navigation callbacks
- Create stub screen components with correct prop interfaces for parallel implementation

Part of plan: chrome-ext-react-tailwind.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->