### PR TITLE
[LUM-1299] Remove dead onboarding-pre-chat feature flag property

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -27,10 +27,6 @@ struct OnboardingFlowView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
 
-    private var preChatOnboardingEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
-    }
-
     private var maxOnboardingStep: Int {
         return 3
     }


### PR DESCRIPTION
Removes the unused `preChatOnboardingEnabled` computed property from `OnboardingFlowView.swift`. This property was left behind as dead code when PR #29161 GA'd the `onboarding-pre-chat` flag — all call sites were removed but the property itself was not.

Companion PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/6279

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/7aac2b34a5d54b9c8b39d6671bc04d1e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
