### PR TITLE
feat(chrome-ext): implement Detail screen React component

### DIFF
--- a/clients/chrome-extension/popup/screens/DetailScreen.tsx
+++ b/clients/chrome-extension/popup/screens/DetailScreen.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import type { OperationEntry } from '../../background/event-log.js';
 
 export interface DetailScreenProps {
@@ -5,11 +7,110 @@ export interface DetailScreenProps {
   onBack: () => void;
 }
 
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatResponseContent(operation: OperationEntry): string {
+  if (operation.responseContent) {
+    try {
+      return JSON.stringify(JSON.parse(operation.responseContent), null, 2);
+    } catch {
+      return operation.responseContent;
+    }
+  }
+  if (operation.respondedAt) return 'Empty response';
+  return 'Awaiting response…';
+}
+
 export function DetailScreen({ operation, onBack }: DetailScreenProps) {
+  const [activeTab, setActiveTab] = useState<'request' | 'response'>('request');
+
+  const metaParts: string[] = [formatTime(operation.requestedAt)];
+  if (operation.durationMs != null) {
+    metaParts.push(formatDuration(operation.durationMs));
+  }
+  if (operation.isError) {
+    metaParts.push('Error');
+  }
+
+  const tabBase = 'flex-1 py-2 px-3 text-xs text-center border-b-2';
+  const tabActive = `${tabBase} text-fg border-fg font-medium`;
+  const tabInactive = `${tabBase} text-fg-muted border-transparent hover:text-fg transition-colors`;
+  const panelClass = 'bg-surface rounded-lg p-3 text-xs text-fg-muted overflow-auto max-h-64 whitespace-pre-wrap break-words font-mono';
+
   return (
     <div>
-      <p>Detail: {operation.operationName}</p>
-      <button onClick={onBack}>Back</button>
+      <header className="flex items-center gap-2 mb-3.5">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center justify-center w-7 h-7 rounded-md text-fg-muted hover:text-fg transition-colors"
+          aria-label="Back"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M9 2L4 7L9 12"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <h1 className="text-[13px] font-semibold text-fg-muted tracking-wide">
+          Operation Detail
+        </h1>
+      </header>
+
+      <div className="mb-3.5">
+        <p className="text-base font-semibold text-fg break-words">
+          {operation.operationName}
+        </p>
+        <p className="text-[11px] text-fg-subtle mt-1">
+          {metaParts.join(' · ')}
+        </p>
+      </div>
+
+      <div className="flex border-b border-edge mb-2.5">
+        <button
+          type="button"
+          onClick={() => setActiveTab('request')}
+          className={activeTab === 'request' ? tabActive : tabInactive}
+        >
+          Request
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('response')}
+          className={activeTab === 'response' ? tabActive : tabInactive}
+        >
+          Response
+        </button>
+      </div>
+
+      {activeTab === 'request' && (
+        <pre className={panelClass}>
+          {operation.request
+            ? JSON.stringify(operation.request, null, 2)
+            : 'No request data available'}
+        </pre>
+      )}
+
+      {activeTab === 'response' && (
+        <pre className={panelClass}>
+          {formatResponseContent(operation)}
+        </pre>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Implement operation detail screen with request/response tab switching
- Port JSON pretty-printing and metadata display from popup.ts

Part of plan: chrome-ext-react-tailwind.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->