### PR TITLE
feat(chrome-ext): implement Main screen React component

### DIFF
--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -18,6 +18,7 @@ export function App() {
   const [screen, setScreen] = useState<Screen>({ name: 'welcome' });
   const [mode, setMode] = useState<'self-hosted' | 'cloud' | null>(null);
   const [operationCount, setOperationCount] = useState(0);
+  const [selfHostedPaired, setSelfHostedPaired] = useState(false);
 
   const _branding = useBranding();
 
@@ -27,6 +28,7 @@ export function App() {
 
     if (session.mode === 'self-hosted') {
       setMode('self-hosted');
+      setSelfHostedPaired(!!session.selfHostedPaired);
       setScreen({ name: 'main' });
       if (session.selfHostedPaired) {
         sendMessage({ type: 'connect' });
@@ -178,11 +180,12 @@ export function App() {
       healthDetail,
       authProfile,
       operationCount,
+      selfHostedPaired,
       setScreen,
       sendMessage,
       onSignOut: handleSignOut,
     }),
-    [mode, health, healthDetail, authProfile, operationCount, handleSignOut],
+    [mode, health, healthDetail, authProfile, operationCount, selfHostedPaired, handleSignOut],
   );
 
   if (session.loading) {

--- a/clients/chrome-extension/popup/AppContext.tsx
+++ b/clients/chrome-extension/popup/AppContext.tsx
@@ -18,6 +18,7 @@ export interface AppContextValue {
   healthDetail: ConnectionHealthDetail;
   authProfile: AssistantAuthProfile | null;
   operationCount: number;
+  selfHostedPaired: boolean;
   setScreen: (screen: Screen) => void;
   sendMessage: <T>(message: Record<string, unknown>) => Promise<T>;
   onSignOut: () => void;

--- a/clients/chrome-extension/popup/screens/MainScreen.tsx
+++ b/clients/chrome-extension/popup/screens/MainScreen.tsx
@@ -12,9 +12,9 @@ import { StatusCard } from './main/StatusCard.js';
  * controls for cloud or self-hosted operation.
  */
 export function MainScreen() {
-  const { mode, operationCount, setScreen } = useAppContext();
+  const { mode, operationCount, selfHostedPaired, setScreen, onSignOut } = useAppContext();
 
-  const [paired, setPaired] = useState(false);
+  const [paired, setPaired] = useState(selfHostedPaired);
   const [assistantName, setAssistantName] = useState('');
   const [accountEmail, setAccountEmail] = useState('');
 
@@ -42,10 +42,6 @@ export function MainScreen() {
   const handlePaired = useCallback(() => {
     setPaired(true);
   }, []);
-
-  const handleBackToWelcome = useCallback(() => {
-    setScreen({ name: 'welcome' });
-  }, [setScreen]);
 
   const handleActivityClick = useCallback(() => {
     setScreen({ name: 'activity' });
@@ -100,7 +96,7 @@ export function MainScreen() {
 
       {showSelfHostedSettings && <SelfHostedSettings onPaired={handlePaired} />}
 
-      <SessionActions paired={paired} onBack={handleBackToWelcome} />
+      <SessionActions paired={paired} onBack={onSignOut} />
     </div>
   );
 }

--- a/clients/chrome-extension/popup/screens/MainScreen.tsx
+++ b/clients/chrome-extension/popup/screens/MainScreen.tsx
@@ -1,3 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAppContext } from '../AppContext.js';
+import { sendMessage } from '../lib/chrome-message.js';
+import { AssistantInfoBar } from './main/AssistantInfoBar.js';
+import { SelfHostedSettings } from './main/SelfHostedSettings.js';
+import { SessionActions } from './main/SessionActions.js';
+import { StatusCard } from './main/StatusCard.js';
+
+/**
+ * Main screen showing connection status, activity, and mode-specific
+ * controls for cloud or self-hosted operation.
+ */
 export function MainScreen() {
-  return <div>Main</div>;
+  const { mode, operationCount, setScreen } = useAppContext();
+
+  const [paired, setPaired] = useState(false);
+  const [assistantName, setAssistantName] = useState('');
+  const [accountEmail, setAccountEmail] = useState('');
+
+  useEffect(() => {
+    sendMessage<{
+      ok: boolean;
+      mode: 'self-hosted' | 'cloud' | null;
+      session?: { email: string } | null;
+      selectedAssistant?: { id: string; name: string } | null;
+      selfHostedPaired?: boolean;
+    }>({ type: 'get-session' }).then((response) => {
+      if (!response?.ok) return;
+      if (response.selectedAssistant?.name) {
+        setAssistantName(response.selectedAssistant.name);
+      }
+      if (response.session?.email) {
+        setAccountEmail(response.session.email);
+      }
+      if (response.selfHostedPaired) {
+        setPaired(true);
+      }
+    });
+  }, []);
+
+  const handlePaired = useCallback(() => {
+    setPaired(true);
+  }, []);
+
+  const handleBackToWelcome = useCallback(() => {
+    setScreen({ name: 'welcome' });
+  }, [setScreen]);
+
+  const handleActivityClick = useCallback(() => {
+    setScreen({ name: 'activity' });
+  }, [setScreen]);
+
+  const isCloud = mode === 'cloud';
+  const isSelfHosted = mode === 'self-hosted';
+
+  const showConnectedState = isCloud || (isSelfHosted && paired);
+  const showSelfHostedSettings = isSelfHosted && !paired;
+
+  return (
+    <div className="flex min-h-[calc(300px-32px)] flex-col">
+      {isCloud && (
+        <AssistantInfoBar
+          assistantName={assistantName || 'Assistant'}
+          accountEmail={accountEmail}
+        />
+      )}
+
+      {showConnectedState && <StatusCard />}
+
+      {showConnectedState && (
+        <button
+          type="button"
+          onClick={handleActivityClick}
+          className="mb-2.5 flex w-full cursor-pointer items-center justify-between rounded-xl border border-edge bg-surface px-4 py-3.5 transition-colors hover:border-edge-hover hover:bg-surface-alt"
+        >
+          <div className="flex items-center gap-2.5">
+            <span className="text-[13px] font-medium text-fg">Activity</span>
+            <span className="rounded-[10px] bg-surface-alt px-2 py-0.5 text-[11px] font-medium text-fg-muted">
+              {operationCount}
+            </span>
+          </div>
+          <svg
+            className="shrink-0 text-fg-subtle"
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+          >
+            <path
+              d="M5 2L10 7L5 12"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
+
+      {showSelfHostedSettings && <SelfHostedSettings onPaired={handlePaired} />}
+
+      <SessionActions paired={paired} onBack={handleBackToWelcome} />
+    </div>
+  );
 }

--- a/clients/chrome-extension/popup/screens/main/AssistantInfoBar.tsx
+++ b/clients/chrome-extension/popup/screens/main/AssistantInfoBar.tsx
@@ -1,0 +1,26 @@
+/**
+ * Cloud-mode assistant identity bar showing avatar initial, name, and
+ * account email. Only rendered when mode is 'cloud'.
+ */
+export interface AssistantInfoBarProps {
+  assistantName: string;
+  accountEmail: string;
+}
+
+export function AssistantInfoBar({ assistantName, accountEmail }: AssistantInfoBarProps) {
+  const initial = assistantName.charAt(0).toUpperCase();
+
+  return (
+    <div className="flex items-center gap-2.5 rounded-xl border border-edge bg-surface px-3.5 py-2.5 mb-2.5">
+      <div className="flex size-[34px] shrink-0 items-center justify-center rounded-full bg-surface-alt text-sm font-medium text-fg-muted">
+        {initial}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-fg">{assistantName}</p>
+        {accountEmail && (
+          <p className="truncate text-xs text-fg-muted">{accountEmail}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/main/SelfHostedSettings.tsx
+++ b/clients/chrome-extension/popup/screens/main/SelfHostedSettings.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { sendMessage } from '../../lib/chrome-message.js';
+import type { GatewayUrlGetResponse } from '../../popup-state.js';
+
+export interface SelfHostedSettingsProps {
+  onPaired: () => void;
+}
+
+/**
+ * Gateway URL input and pairing flow for self-hosted mode.
+ * Only rendered when mode is 'self-hosted' and not yet paired.
+ */
+export function SelfHostedSettings({ onPaired }: SelfHostedSettingsProps) {
+  const [gatewayUrl, setGatewayUrl] = useState('http://127.0.0.1:7830');
+  const [pairing, setPairing] = useState(false);
+  const [localStatus, setLocalStatus] = useState<string | null>(null);
+
+  // Load saved gateway URL on mount
+  useEffect(() => {
+    sendMessage<GatewayUrlGetResponse>({ type: 'gateway-url-get' }).then(
+      (response) => {
+        if (response?.ok && response.gatewayUrl) {
+          setGatewayUrl(response.gatewayUrl);
+        }
+      },
+    );
+  }, []);
+
+  const pairAndConnect = useCallback(async () => {
+    const url = gatewayUrl.trim();
+    if (!url) return;
+
+    setPairing(true);
+    setLocalStatus(null);
+
+    // Step 1: save the URL
+    await sendMessage({ type: 'gateway-url-set', gatewayUrl: url });
+
+    // Step 2: pair with the gateway
+    const response = await sendMessage<{ ok: boolean; error?: string }>({
+      type: 'self-hosted-pair',
+    });
+
+    if (response?.ok) {
+      // Step 3: connect
+      await sendMessage({ type: 'connect' });
+      setPairing(false);
+      onPaired();
+    } else {
+      setPairing(false);
+      setLocalStatus(response?.error ?? 'Pairing failed');
+    }
+  }, [gatewayUrl, onPaired]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        pairAndConnect();
+      }
+    },
+    [pairAndConnect],
+  );
+
+  return (
+    <div className="mt-1.5 mb-3.5">
+      <label className="mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        Gateway URL
+      </label>
+      <div className="flex items-stretch gap-1.5">
+        <input
+          type="text"
+          value={gatewayUrl}
+          onChange={(e) => setGatewayUrl(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="http://127.0.0.1:7830"
+          className="flex-1 rounded-lg border border-edge bg-bg px-2.5 py-2 font-mono text-[13px] text-fg outline-none transition-colors focus:border-fg-muted"
+        />
+        <button
+          type="button"
+          onClick={pairAndConnect}
+          disabled={pairing}
+          className="shrink-0 rounded-lg border border-edge bg-surface-alt px-3.5 py-2 text-xs font-medium text-fg transition-colors hover:border-edge-hover hover:bg-surface disabled:opacity-35 disabled:cursor-default"
+        >
+          {pairing ? 'Pairing…' : 'Pair'}
+        </button>
+      </div>
+      <p className="mt-1.5 text-[10px] leading-snug text-fg-subtle">
+        The HTTP address of your self-hosted assistant gateway.
+      </p>
+      {localStatus && (
+        <p className="mt-1.5 break-all font-mono text-[11px] leading-relaxed text-fg-subtle">
+          {localStatus}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/main/SelfHostedSettings.tsx
+++ b/clients/chrome-extension/popup/screens/main/SelfHostedSettings.tsx
@@ -55,11 +55,11 @@ export function SelfHostedSettings({ onPaired }: SelfHostedSettingsProps) {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && !pairing) {
         pairAndConnect();
       }
     },
-    [pairAndConnect],
+    [pairAndConnect, pairing],
   );
 
   return (

--- a/clients/chrome-extension/popup/screens/main/SessionActions.tsx
+++ b/clients/chrome-extension/popup/screens/main/SessionActions.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+
+import { useAppContext } from '../../AppContext.js';
+import { sendMessage } from '../../lib/chrome-message.js';
+
+export interface SessionActionsProps {
+  paired: boolean;
+  onBack: () => void;
+}
+
+/**
+ * Bottom action buttons: optional reconnect, divider, and sign-out /
+ * disconnect / back button depending on mode and paired state.
+ */
+export function SessionActions({ paired, onBack }: SessionActionsProps) {
+  const { mode, health, onSignOut } = useAppContext();
+
+  const isFailure =
+    health === 'error' || health === 'auth_required' || health === 'reconnecting';
+
+  const handleReconnect = useCallback(() => {
+    sendMessage({ type: 'connect' });
+  }, []);
+
+  // Determine the label and action for the bottom button
+  let actionLabel: string;
+  let actionHandler: () => void;
+
+  if (mode === 'cloud') {
+    actionLabel = 'Sign out';
+    actionHandler = onSignOut;
+  } else if (paired) {
+    actionLabel = 'Disconnect';
+    actionHandler = onSignOut;
+  } else {
+    actionLabel = 'Back';
+    actionHandler = onBack;
+  }
+
+  return (
+    <div className="mt-auto flex flex-col items-center pt-1">
+      {/* Reconnect button: only in self-hosted + failure state */}
+      {mode === 'self-hosted' && isFailure && (
+        <button
+          type="button"
+          onClick={handleReconnect}
+          className="mb-2.5 w-full rounded-lg border border-edge bg-surface-alt px-3 py-2.5 text-xs font-medium text-fg transition-colors hover:border-edge-hover hover:bg-surface"
+        >
+          Reconnect with assistant
+        </button>
+      )}
+
+      <div className="w-full border-t border-edge" />
+
+      <button
+        type="button"
+        onClick={actionHandler}
+        className="border-none bg-transparent px-0 py-2 text-[11px] text-fg-subtle transition-colors hover:text-fg-muted"
+      >
+        {actionLabel}
+      </button>
+    </div>
+  );
+}

--- a/clients/chrome-extension/popup/screens/main/StatusCard.tsx
+++ b/clients/chrome-extension/popup/screens/main/StatusCard.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useState } from 'react';
+
+import { useAppContext } from '../../AppContext.js';
+import {
+  type ConnectionHealthState,
+  deriveHealthStatusDisplay,
+  deriveSetupMessage,
+  healthToPhase,
+} from '../../popup-state.js';
+
+function statusBadgeDisplay(health: ConnectionHealthState): { text: string; bgClass: string; textClass: string } {
+  switch (health) {
+    case 'connected':
+      return { text: 'Online', bgClass: 'bg-success-soft', textClass: 'text-success' };
+    case 'connecting':
+      return { text: 'Starting', bgClass: 'bg-warning-soft', textClass: 'text-warning' };
+    case 'reconnecting':
+      return { text: 'Recovering', bgClass: 'bg-warning-soft', textClass: 'text-warning' };
+    case 'paused':
+      return { text: 'Paused', bgClass: 'bg-warning-soft', textClass: 'text-warning' };
+    case 'auth_required':
+      return { text: 'Needs action', bgClass: 'bg-danger-soft', textClass: 'text-danger' };
+    case 'assistant_gone':
+      return { text: 'Assistant removed', bgClass: 'bg-danger-soft', textClass: 'text-danger' };
+    case 'error':
+      return { text: 'Issue detected', bgClass: 'bg-danger-soft', textClass: 'text-danger' };
+    default:
+      return { text: 'Unknown', bgClass: 'bg-surface-alt', textClass: 'text-fg-subtle' };
+  }
+}
+
+function dotClasses(dotClass: string): string {
+  switch (dotClass) {
+    case 'connected':
+      return 'bg-success shadow-[0_0_8px_rgba(74,222,128,0.5)] animate-pulse-ring';
+    case 'paused':
+      return 'bg-warning shadow-[0_0_6px_rgba(251,191,36,0.3)]';
+    case 'disconnected':
+      return 'bg-danger shadow-[0_0_6px_rgba(251,113,133,0.35)]';
+    default:
+      return 'bg-fg-subtle';
+  }
+}
+
+/**
+ * Connection health display card with status dot, text, badge,
+ * error/debug details, and setup message.
+ */
+export function StatusCard() {
+  const { health, healthDetail } = useAppContext();
+  const [copyLabel, setCopyLabel] = useState('Copy');
+
+  const display = deriveHealthStatusDisplay(health, healthDetail);
+  const badge = statusBadgeDisplay(health);
+  const phase = healthToPhase(health);
+  const setupMsg = deriveSetupMessage(phase);
+
+  const showError =
+    healthDetail?.lastErrorMessage &&
+    (health === 'auth_required' || health === 'error');
+
+  const handleCopy = useCallback(async () => {
+    if (!healthDetail?.lastErrorMessage) return;
+    try {
+      await navigator.clipboard.writeText(healthDetail.lastErrorMessage);
+      setCopyLabel('Copied!');
+      setTimeout(() => setCopyLabel('Copy'), 1500);
+    } catch {
+      // Clipboard API may fail in some contexts; ignore.
+    }
+  }, [healthDetail?.lastErrorMessage]);
+
+  return (
+    <>
+      <div className="rounded-xl border border-edge bg-surface px-4 py-3.5 mb-2.5 transition-[border-color,box-shadow] duration-[400ms]">
+        <div className="flex items-center justify-between gap-2.5">
+          <div className="flex items-center gap-2.5 min-w-0">
+            <div
+              className={`size-2.5 shrink-0 rounded-full transition-[background,box-shadow] duration-300 ${dotClasses(display.dotClass)}`}
+            />
+            <p className="text-[13px] font-medium leading-snug text-fg">
+              {display.text}
+            </p>
+          </div>
+          <span
+            className={`shrink-0 rounded-[5px] px-[7px] py-[3px] text-[10px] font-semibold uppercase tracking-wide ${badge.bgClass} ${badge.textClass}`}
+          >
+            {badge.text}
+          </span>
+        </div>
+      </div>
+
+      {/* Error alert */}
+      {showError && (
+        <p className="mb-2.5 rounded-lg border border-danger-soft bg-danger-soft px-3 py-2.5 text-xs leading-relaxed text-danger">
+          {healthDetail.lastErrorMessage}
+        </p>
+      )}
+
+      {/* Debug details */}
+      {showError && (
+        <div className="mb-2.5 rounded-lg border border-edge bg-white/[0.03] px-2.5 py-2">
+          <div className="flex items-center justify-between gap-2.5 mb-1.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+              Debug details
+            </span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="rounded-md border border-edge bg-surface-alt px-2 py-1 text-[10px] font-medium text-fg transition-colors hover:border-edge-hover hover:bg-surface"
+            >
+              {copyLabel}
+            </button>
+          </div>
+          <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-snug text-fg-muted">
+            {healthDetail.lastErrorMessage}
+          </pre>
+        </div>
+      )}
+
+      {/* Setup message */}
+      {setupMsg && (
+        <p className="mb-2.5 rounded-lg border border-warning-soft bg-warning-soft px-3 py-2.5 text-xs leading-relaxed text-warning">
+          {setupMsg}
+        </p>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Implement Main screen with StatusCard, AssistantInfoBar, SelfHostedSettings, and SessionActions sub-components
- Port connection health display, self-hosted pairing flow, and session management from popup.ts
- Wire mode-based conditional rendering for cloud vs self-hosted views

Part of plan: chrome-ext-react-tailwind.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->