### PR TITLE
refactor(chrome-ext): deduplicate format helpers and remove dead code

### DIFF
--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { CloudAssistant } from '../background/cloud-api.js';
 import type { OperationEntry } from '../background/event-log.js';
 import { AppContext, type Screen } from './AppContext.js';
-import { useBranding } from './hooks/use-branding.js';
 import { useSession } from './hooks/use-session.js';
 import { useStatusPoll } from './hooks/use-status-poll.js';
 import { sendMessage } from './lib/chrome-message.js';
@@ -19,8 +18,6 @@ export function App() {
   const [mode, setMode] = useState<'self-hosted' | 'cloud' | null>(null);
   const [operationCount, setOperationCount] = useState(0);
   const [selfHostedPaired, setSelfHostedPaired] = useState(false);
-
-  const _branding = useBranding();
 
   // Determine initial screen from session state once loading completes
   useEffect(() => {
@@ -182,7 +179,6 @@ export function App() {
       operationCount,
       selfHostedPaired,
       setScreen,
-      sendMessage,
       onSignOut: handleSignOut,
     }),
     [mode, health, healthDetail, authProfile, operationCount, selfHostedPaired, handleSignOut],

--- a/clients/chrome-extension/popup/AppContext.tsx
+++ b/clients/chrome-extension/popup/AppContext.tsx
@@ -20,7 +20,6 @@ export interface AppContextValue {
   operationCount: number;
   selfHostedPaired: boolean;
   setScreen: (screen: Screen) => void;
-  sendMessage: <T>(message: Record<string, unknown>) => Promise<T>;
   onSignOut: () => void;
 }
 

--- a/clients/chrome-extension/popup/lib/format.ts
+++ b/clients/chrome-extension/popup/lib/format.ts
@@ -1,0 +1,12 @@
+export function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/clients/chrome-extension/popup/screens/ActivityScreen.tsx
+++ b/clients/chrome-extension/popup/screens/ActivityScreen.tsx
@@ -2,20 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { OperationEntry } from '../../background/event-log.js';
 import { sendMessage } from '../lib/chrome-message.js';
+import { formatDuration, formatTime } from '../lib/format.js';
 
 export interface ActivityScreenProps {
   onBack: () => void;
   onSelectOperation: (op: OperationEntry) => void;
-}
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 export function ActivityScreen({

--- a/clients/chrome-extension/popup/screens/DetailScreen.tsx
+++ b/clients/chrome-extension/popup/screens/DetailScreen.tsx
@@ -1,23 +1,11 @@
 import { useState } from 'react';
 
 import type { OperationEntry } from '../../background/event-log.js';
+import { formatDuration, formatTime } from '../lib/format.js';
 
 export interface DetailScreenProps {
   operation: OperationEntry;
   onBack: () => void;
-}
-
-function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 function formatResponseContent(operation: OperationEntry): string {


### PR DESCRIPTION
## Summary
- Extract shared formatTime/formatDuration into popup/lib/format.ts
- Remove unused useBranding call from App.tsx
- Remove unused sendMessage from AppContext interface and provider

Fixes gaps from plan review for chrome-ext-react-tailwind.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->