### PR TITLE
fix: remove deleted popup.ts from gateway-only-guard allowlist

### DIFF
--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -34,7 +34,6 @@ const ALLOWLIST = new Set([
 
   // --- Chrome extension (local relay communication, not gateway API consumption) ---
   "clients/chrome-extension/background/worker.ts",
-  "clients/chrome-extension/popup/popup.ts",
   // --- Documentation and comments that mention the port for explanatory purposes ---
   "AGENTS.md", // documents the gateway-only rule itself
   "ARCHITECTURE.md", // architecture overview with port references


### PR DESCRIPTION
## Summary
- Remove stale reference to deleted popup.ts from gateway-only-guard test allowlist

Fixes gap from plan review for chrome-ext-react-tailwind.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->