### PR TITLE
fix(chrome-ext): restore behavioral parity with vanilla popup

### DIFF
--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -19,6 +19,10 @@ export function App() {
   const [mode, setMode] = useState<'self-hosted' | 'cloud' | null>(null);
   const [operationCount, setOperationCount] = useState(0);
   const [selfHostedPaired, setSelfHostedPaired] = useState(false);
+  const [signingIn, setSigningIn] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
+  const [assistantsError, setAssistantsError] = useState<string | null>(null);
+  const [cloudEmail, setCloudEmail] = useState<string | undefined>(undefined);
 
   const _branding = useBranding();
 
@@ -35,6 +39,9 @@ export function App() {
       }
     } else if (session.mode === 'cloud') {
       setMode('cloud');
+      if (session.session?.email) {
+        setCloudEmail(session.session.email);
+      }
       if (session.session && !session.selectedAssistant) {
         // Signed in but no assistant chosen — go to picker
         sendMessage<{
@@ -64,7 +71,7 @@ export function App() {
   // Poll status when on the main screen
   const { health, healthDetail, authProfile } = useStatusPoll(screen.name === 'main');
 
-  // Refresh activity count when on the main screen
+  // Refresh activity count when on the main screen (poll every 2s)
   useEffect(() => {
     if (screen.name !== 'main') return;
 
@@ -79,6 +86,8 @@ export function App() {
     }
 
     refreshCount();
+    const interval = setInterval(refreshCount, 2000);
+    return () => clearInterval(interval);
   }, [screen.name]);
 
   // Navigate to picker when assistant is removed
@@ -91,14 +100,17 @@ export function App() {
       error?: string;
     }>({ type: 'list-assistants' }).then((response) => {
       if (response?.ok && response.assistants) {
-        setScreen({ name: 'picker', assistants: response.assistants });
+        setScreen({ name: 'picker', assistants: response.assistants, email: cloudEmail });
       }
     });
-  }, [health]);
+  }, [health, cloudEmail]);
 
   // Navigation callbacks
 
   const handleSignIn = useCallback(() => {
+    setSigningIn(true);
+    setSignInError(null);
+
     sendMessage<{
       ok: boolean;
       session?: { email: string };
@@ -106,12 +118,24 @@ export function App() {
       assistantsError?: string;
       error?: string;
     }>({ type: 'cloud-login' }).then((response) => {
-      if (!response?.ok) return;
+      setSigningIn(false);
+
+      if (!response?.ok) {
+        setSignInError(response?.error ?? 'Sign-in failed. Please try again.');
+        return;
+      }
 
       setMode('cloud');
+      if (response.session?.email) {
+        setCloudEmail(response.session.email);
+      }
       const assistants = response.assistants ?? [];
 
-      if (response.assistantsError || assistants.length === 0) {
+      if (response.assistantsError) {
+        setAssistantsError(response.assistantsError);
+        setScreen({ name: 'main' });
+        sendMessage({ type: 'connect' });
+      } else if (assistants.length === 0) {
         setScreen({ name: 'main' });
         sendMessage({ type: 'connect' });
       } else if (assistants.length === 1) {
@@ -132,6 +156,11 @@ export function App() {
       }
     });
   }, []);
+
+  const handleRetryAssistants = useCallback(() => {
+    setAssistantsError(null);
+    handleSignIn();
+  }, [handleSignIn]);
 
   const handleSelfHosted = useCallback(() => {
     setMode('self-hosted');
@@ -181,11 +210,13 @@ export function App() {
       authProfile,
       operationCount,
       selfHostedPaired,
+      assistantsError,
       setScreen,
       sendMessage,
       onSignOut: handleSignOut,
+      onRetryAssistants: handleRetryAssistants,
     }),
-    [mode, health, healthDetail, authProfile, operationCount, selfHostedPaired, handleSignOut],
+    [mode, health, healthDetail, authProfile, operationCount, selfHostedPaired, assistantsError, handleSignOut, handleRetryAssistants],
   );
 
   if (session.loading) {
@@ -201,6 +232,8 @@ export function App() {
               <WelcomeScreen
                 onSignIn={handleSignIn}
                 onSelfHosted={handleSelfHosted}
+                signingIn={signingIn}
+                signInError={signInError}
               />
             );
           case 'picker':

--- a/clients/chrome-extension/popup/AppContext.tsx
+++ b/clients/chrome-extension/popup/AppContext.tsx
@@ -19,9 +19,11 @@ export interface AppContextValue {
   authProfile: AssistantAuthProfile | null;
   operationCount: number;
   selfHostedPaired: boolean;
+  assistantsError: string | null;
   setScreen: (screen: Screen) => void;
   sendMessage: <T>(message: Record<string, unknown>) => Promise<T>;
   onSignOut: () => void;
+  onRetryAssistants: () => void;
 }
 
 export const AppContext = createContext<AppContextValue | null>(null);

--- a/clients/chrome-extension/popup/screens/MainScreen.tsx
+++ b/clients/chrome-extension/popup/screens/MainScreen.tsx
@@ -12,7 +12,7 @@ import { StatusCard } from './main/StatusCard.js';
  * controls for cloud or self-hosted operation.
  */
 export function MainScreen() {
-  const { mode, operationCount, selfHostedPaired, setScreen, onSignOut } = useAppContext();
+  const { mode, operationCount, selfHostedPaired, assistantsError, setScreen, onSignOut, onRetryAssistants } = useAppContext();
 
   const [paired, setPaired] = useState(selfHostedPaired);
   const [assistantName, setAssistantName] = useState('');
@@ -60,6 +60,21 @@ export function MainScreen() {
           assistantName={assistantName || 'Assistant'}
           accountEmail={accountEmail}
         />
+      )}
+
+      {assistantsError && (
+        <div className="mx-0 mb-2.5 rounded-xl border border-red-300 bg-red-50 px-4 py-3 dark:border-red-700 dark:bg-red-950">
+          <p className="text-[13px] text-red-700 dark:text-red-300">
+            {assistantsError}
+          </p>
+          <button
+            type="button"
+            onClick={onRetryAssistants}
+            className="mt-2 cursor-pointer rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+          >
+            Retry
+          </button>
+        </div>
       )}
 
       {showConnectedState && <StatusCard />}

--- a/clients/chrome-extension/popup/screens/WelcomeScreen.tsx
+++ b/clients/chrome-extension/popup/screens/WelcomeScreen.tsx
@@ -1,12 +1,28 @@
+import { useEffect, useState } from 'react';
+
 import { useBranding } from '../hooks/use-branding.js';
 
 export interface WelcomeScreenProps {
   onSignIn: () => void;
   onSelfHosted: () => void;
+  signingIn?: boolean;
+  signInError?: string | null;
 }
 
-export function WelcomeScreen({ onSignIn, onSelfHosted }: WelcomeScreenProps) {
+export function WelcomeScreen({ onSignIn, onSelfHosted, signingIn, signInError }: WelcomeScreenProps) {
   const branding = useBranding();
+  const [visibleError, setVisibleError] = useState<string | null>(null);
+
+  // Show error for 4 seconds then clear
+  useEffect(() => {
+    if (!signInError) {
+      setVisibleError(null);
+      return;
+    }
+    setVisibleError(signInError);
+    const timer = setTimeout(() => setVisibleError(null), 4000);
+    return () => clearTimeout(timer);
+  }, [signInError]);
 
   return (
     <div className="flex flex-col items-center justify-center min-h-[320px] px-4 pt-8 pb-4 text-center">
@@ -35,18 +51,26 @@ export function WelcomeScreen({ onSignIn, onSelfHosted }: WelcomeScreenProps) {
         <button
           type="button"
           onClick={onSignIn}
-          className="bg-fg text-bg rounded-lg px-4 py-2.5 text-sm font-medium w-full hover:opacity-90 transition-opacity cursor-pointer"
+          disabled={signingIn}
+          className="bg-fg text-bg rounded-lg px-4 py-2.5 text-sm font-medium w-full hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          Sign in with Vellum
+          {signingIn ? 'Signing in...' : 'Sign in with Vellum'}
         </button>
         <button
           type="button"
           onClick={onSelfHosted}
-          className="bg-transparent text-fg-muted border border-edge rounded-lg px-4 py-2.5 text-sm w-full hover:border-edge-hover hover:text-fg transition-colors cursor-pointer"
+          disabled={signingIn}
+          className="bg-transparent text-fg-muted border border-edge rounded-lg px-4 py-2.5 text-sm w-full hover:border-edge-hover hover:text-fg transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
         >
           Connect to self-hosted
         </button>
       </div>
+
+      {visibleError && (
+        <p className="text-xs text-red-500 mt-3 max-w-[240px]">
+          {visibleError}
+        </p>
+      )}
 
       <p className="text-xs text-fg-subtle mt-auto pt-4">
         &copy; 2026 Vellum Inc.


### PR DESCRIPTION
## Summary
- Add activity count polling every 2s to match old behavior
- Add sign-in loading state and error feedback on WelcomeScreen
- Add assistantsError display with retry button on MainScreen
- Pass email when navigating to picker on assistant_gone

Fixes gaps from plan review for chrome-ext-react-tailwind.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->