### PR TITLE
[LUM-1408] Use determinate progress bar for assistant upgrade

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -371,15 +371,13 @@ describe("skill_load tool", () => {
     expect(result.content).toContain("Skill: No Includes");
   });
 
-  test("bundled app-builder loads when frontend-design is unavailable", async () => {
+  test("bundled app-builder loads without includes", async () => {
     const result = await executeSkillLoad({ skill: "app-builder" });
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Skill: App Builder");
-    expect(result.content).toContain("Suggested Included Skills (not loaded):");
-    expect(result.content).toContain("frontend-design");
+    expect(result.content).toContain("Included Skills (immediate): none");
     expect(result.content).toContain('<loaded_skill id="app-builder"');
-    expect(result.content).not.toContain('<loaded_skill id="frontend-design"');
   });
 
   test("bundled phone-calls loads when setup includes are unavailable", async () => {

--- a/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
@@ -130,7 +130,7 @@ struct UpgradeProgressOverlay: View {
                 }
             }
             .frame(height: 6)
-            .frame(maxWidth: 200)
+            .widthCap(200)
             .accessibilityElement()
             .accessibilityValue("\(Int(progress * 100)) percent")
             .accessibilityLabel("Upgrade progress")

--- a/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
@@ -19,6 +19,9 @@ struct UpgradeProgressOverlay: View {
     @State private var progressAtCompletion: Double?
     /// Timestamp when the upgrade completed (success or failure via SSE).
     @State private var completionTime: Date?
+    /// Captured estimated duration at progress start, so it survives the
+    /// observable being cleared when the upgrade completes.
+    @State private var capturedEstimatedDuration: TimeInterval = 60
 
     /// Whether to show the outcome card (success/failure) before auto-dismissing.
     @State private var showOutcome: Bool = false
@@ -51,7 +54,7 @@ struct UpgradeProgressOverlay: View {
                     // ease-out ramp to 100% from the current position.
                     if let start = progressStartDate {
                         let elapsed = max(0, Date().timeIntervalSince(start))
-                        progressAtCompletion = 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
+                        progressAtCompletion = 0.95 * (1.0 - exp(-elapsed / capturedEstimatedDuration))
                         completionTime = Date()
                     }
 
@@ -139,10 +142,6 @@ struct UpgradeProgressOverlay: View {
 
     // MARK: - Progress Computation
 
-    private var estimatedDuration: TimeInterval {
-        connectionManager.updateExpectedDowntimeSeconds ?? defaultEstimatedDuration
-    }
-
     /// Computes progress using an asymptotic curve based on elapsed time and
     /// estimated duration. Called at display refresh rate via `TimelineView`.
     ///
@@ -162,10 +161,11 @@ struct UpgradeProgressOverlay: View {
         // Asymptotic time-based progress: never reaches 95% no matter how long,
         // so the bar always appears to be moving.
         let elapsed = max(0, date.timeIntervalSince(startDate))
-        return 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
+        return 0.95 * (1.0 - exp(-elapsed / capturedEstimatedDuration))
     }
 
     private func startProgress() {
+        capturedEstimatedDuration = connectionManager.updateExpectedDowntimeSeconds ?? defaultEstimatedDuration
         progressStartDate = Date()
         progressAtCompletion = nil
         completionTime = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift
@@ -2,23 +2,31 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Full-window blocking overlay shown while a service group upgrade is in
-/// progress. Grays out the UI and displays a modal card with live status
-/// updates streamed from the daemon via SSE.
+/// progress. Grays out the UI and displays a modal card with a determinate
+/// progress bar and live status updates streamed from the daemon via SSE.
 ///
 /// The overlay is driven entirely by `GatewayConnectionManager`'s observable
-/// properties (`isUpdateInProgress`, `updateStatusMessage`, `lastUpdateOutcome`)
-/// which are set from SSE events in `handleServerMessage`.
+/// properties (`isUpdateInProgress`, `updateStatusMessage`, `lastUpdateOutcome`,
+/// `updateExpectedDowntimeSeconds`) which are set from SSE events in
+/// `handleServerMessage`.
 struct UpgradeProgressOverlay: View {
     var connectionManager: GatewayConnectionManager
 
-    /// Tracks elapsed seconds since the overlay appeared.
-    @State private var elapsedSeconds: Int = 0
-    @State private var timerTask: Task<Void, Never>?
+    /// Timestamp when the progress animation started.
+    @State private var progressStartDate: Date?
+    /// Snapshot of progress at the moment the upgrade completed, used to
+    /// animate the final ramp to 100%.
+    @State private var progressAtCompletion: Double?
+    /// Timestamp when the upgrade completed (success or failure via SSE).
+    @State private var completionTime: Date?
 
     /// Whether to show the outcome card (success/failure) before auto-dismissing.
     @State private var showOutcome: Bool = false
     /// Auto-dismiss task for the success outcome.
     @State private var dismissTask: Task<Void, Never>?
+
+    /// Fallback estimated duration when the daemon does not provide one.
+    private let defaultEstimatedDuration: TimeInterval = 60
 
     var body: some View {
         if connectionManager.isUpdateInProgress || showOutcome {
@@ -36,15 +44,20 @@ struct UpgradeProgressOverlay: View {
             }
             .animation(VAnimation.standard, value: connectionManager.isUpdateInProgress)
             .animation(VAnimation.standard, value: showOutcome)
-            .onAppear { startTimer() }
-            .onDisappear { stopTimer() }
+            .onAppear { startProgress() }
             .onChange(of: connectionManager.isUpdateInProgress) { _, inProgress in
                 if !inProgress {
-                    // Upgrade finished — show outcome briefly
+                    // Snapshot the current progress value so the bar can
+                    // ease-out ramp to 100% from the current position.
+                    if let start = progressStartDate {
+                        let elapsed = max(0, Date().timeIntervalSince(start))
+                        progressAtCompletion = 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
+                        completionTime = Date()
+                    }
+
                     withAnimation(VAnimation.standard) {
                         showOutcome = true
                     }
-                    stopTimer()
 
                     // Auto-dismiss success after 3 seconds
                     if case .succeeded = connectionManager.lastUpdateOutcome?.result {
@@ -61,8 +74,7 @@ struct UpgradeProgressOverlay: View {
                     // New upgrade starting
                     showOutcome = false
                     dismissTask?.cancel()
-                    elapsedSeconds = 0
-                    startTimer()
+                    startProgress()
                 }
             }
         }
@@ -72,10 +84,6 @@ struct UpgradeProgressOverlay: View {
 
     private var progressCard: some View {
         VStack(spacing: VSpacing.lg) {
-            ProgressView()
-                .controlSize(.large)
-                .tint(VColor.primaryBase)
-
             VStack(spacing: VSpacing.sm) {
                 Text("Upgrading Assistant")
                     .font(VFont.titleSmall)
@@ -88,6 +96,8 @@ struct UpgradeProgressOverlay: View {
                 }
             }
 
+            progressBar
+
             if let status = connectionManager.updateStatusMessage {
                 Text(status)
                     .font(VFont.labelDefault)
@@ -95,10 +105,6 @@ struct UpgradeProgressOverlay: View {
                     .multilineTextAlignment(.center)
                     .animation(VAnimation.fast, value: connectionManager.updateStatusMessage)
             }
-
-            Text(formattedElapsed)
-                .font(VFont.numericMono)
-                .foregroundStyle(VColor.contentTertiary)
         }
         .padding(VSpacing.xxl)
         .frame(minWidth: 320)
@@ -106,6 +112,63 @@ struct UpgradeProgressOverlay: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .vShadow(VShadow.modalNear)
         .vShadow(VShadow.modalFar)
+    }
+
+    // MARK: - Determinate Progress Bar
+
+    private var progressBar: some View {
+        TimelineView(.animation) { context in
+            let progress = progressValue(at: context.date)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(VColor.surfaceBase)
+                        .frame(height: 6)
+                    Capsule()
+                        .fill(VColor.primaryBase)
+                        .frame(width: geo.size.width * progress, height: 6)
+                }
+            }
+            .frame(height: 6)
+            .frame(maxWidth: 200)
+            .accessibilityElement()
+            .accessibilityValue("\(Int(progress * 100)) percent")
+            .accessibilityLabel("Upgrade progress")
+        }
+    }
+
+    // MARK: - Progress Computation
+
+    private var estimatedDuration: TimeInterval {
+        connectionManager.updateExpectedDowntimeSeconds ?? defaultEstimatedDuration
+    }
+
+    /// Computes progress using an asymptotic curve based on elapsed time and
+    /// estimated duration. Called at display refresh rate via `TimelineView`.
+    ///
+    /// The formula `0.95 * (1 - e^(-t / estimate))` ensures the bar always
+    /// appears to move but never reaches 100% until the upgrade actually
+    /// completes. On completion, an ease-out ramp fills to 100%.
+    private func progressValue(at date: Date) -> Double {
+        guard let startDate = progressStartDate else { return 0 }
+
+        // Upgrade completed — ease-out ramp from snapshot to 100%
+        if let compTime = completionTime, let baseProgress = progressAtCompletion {
+            let timeSinceCompletion = date.timeIntervalSince(compTime)
+            let rampProgress = min(1.0, 1.0 - exp(-timeSinceCompletion * 3.0))
+            return baseProgress + (1.0 - baseProgress) * rampProgress
+        }
+
+        // Asymptotic time-based progress: never reaches 95% no matter how long,
+        // so the bar always appears to be moving.
+        let elapsed = max(0, date.timeIntervalSince(startDate))
+        return 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
+    }
+
+    private func startProgress() {
+        progressStartDate = Date()
+        progressAtCompletion = nil
+        completionTime = nil
     }
 
     // MARK: - Outcome Card
@@ -195,30 +258,5 @@ struct UpgradeProgressOverlay: View {
     private func isSuccessOutcome(_ result: UpdateOutcome.Result) -> Bool {
         if case .succeeded = result { return true }
         return false
-    }
-
-    // MARK: - Timer
-
-    private var formattedElapsed: String {
-        let minutes = elapsedSeconds / 60
-        let seconds = elapsedSeconds % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
-
-    private func startTimer() {
-        timerTask?.cancel()
-        elapsedSeconds = 0
-        timerTask = Task {
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                guard !Task.isCancelled else { break }
-                elapsedSeconds += 1
-            }
-        }
-    }
-
-    private func stopTimer() {
-        timerTask?.cancel()
-        timerTask = nil
     }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -52,6 +52,7 @@ public final class GatewayConnectionManager {
     public internal(set) var isUpdateInProgress: Bool = false
     public internal(set) var updateTargetVersion: String?
     public internal(set) var updateStatusMessage: String?
+    public internal(set) var updateExpectedDowntimeSeconds: Double?
     @ObservationIgnored var updateExpiresAt: Date?
     @ObservationIgnored private var outcomeEmittedForCurrentCycle = false
     public internal(set) var lastUpdateOutcome: UpdateOutcome?
@@ -298,6 +299,7 @@ public final class GatewayConnectionManager {
         isUpdateInProgress = false
         updateTargetVersion = nil
         updateStatusMessage = nil
+        updateExpectedDowntimeSeconds = nil
         updateExpiresAt = nil
         lastUpdateOutcome = nil
         keyFingerprint = nil
@@ -504,6 +506,7 @@ public final class GatewayConnectionManager {
         lastUpdateOutcome = UpdateOutcome(result: .timedOut, timestamp: Date())
         isUpdateInProgress = false
         updateTargetVersion = nil
+        updateExpectedDowntimeSeconds = nil
         updateExpiresAt = nil
         updateStatusMessage = nil
         eventStreamClient.resetSSEReconnectDelay()
@@ -592,6 +595,7 @@ public final class GatewayConnectionManager {
                     self.isUpdateInProgress = false
                     // Preserve updateTargetVersion — only the authoritative
                     // .serviceGroupUpdateComplete SSE event or timeout clears it.
+                    self.updateExpectedDowntimeSeconds = nil
                     self.updateExpiresAt = nil
                     self.updateStatusMessage = nil
                     self.eventStreamClient.resetSSEReconnectDelay()
@@ -612,6 +616,7 @@ public final class GatewayConnectionManager {
         switch message {
         case .serviceGroupUpdateStarting(let msg):
             self.updateTargetVersion = msg.targetVersion
+            self.updateExpectedDowntimeSeconds = msg.expectedDowntimeSeconds
             self.updateExpiresAt = Date().addingTimeInterval(msg.expectedDowntimeSeconds * 2)
             self.updateStatusMessage = "Preparing to update…"
             setUpdateInProgress(true)
@@ -629,6 +634,7 @@ public final class GatewayConnectionManager {
             }
             self.isUpdateInProgress = false
             self.updateTargetVersion = nil
+            self.updateExpectedDowntimeSeconds = nil
             self.updateExpiresAt = nil
             self.updateStatusMessage = nil
             self.eventStreamClient.resetSSEReconnectDelay()

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -540,6 +540,7 @@ public final class GatewayConnectionManager {
             isUpdateInProgress = false
             // Preserve updateTargetVersion — only the authoritative
             // .serviceGroupUpdateComplete SSE event or timeout clears it.
+            updateExpectedDowntimeSeconds = nil
             updateExpiresAt = nil
             updateStatusMessage = nil
             eventStreamClient.resetSSEReconnectDelay()


### PR DESCRIPTION
Replaces the indeterminate spinner and elapsed-time counter in the upgrade overlay with a determinate capsule progress bar driven by `expectedDowntimeSeconds` from the SSE starting event. Uses the same asymptotic curve pattern as `HatchingStepView` (`0.95 * (1 - e^(-t/estimate))`) with an ease-out ramp to 100% on completion. Pure client-side UI change — no protocol or daemon modifications needed.

Also fixes a stale test for `app-builder` skill loading: commit `1deb872` removed `frontend-design` from app-builder's `includes` but didn't update the test expectations.

## Human review checklist

- [ ] **Verify Xcode build** — CI skips macOS checks; confirm the SwiftUI changes compile locally
- [ ] **Verify `capturedEstimatedDuration` @State pattern** — `updateExpectedDowntimeSeconds` is cleared when the upgrade completes (same synchronous batch as `isUpdateInProgress = false` due to `@Observable` coalescing), so the duration is captured into `@State` at progress start. Confirm this prevents the progress bar from jumping to the 60s fallback curve on completion.
- [ ] **Verify `updateExpectedDowntimeSeconds = nil` cleanup** — added to `handleDaemonVersionChanged`, `expireUpdate`, `reconnect`, and `serviceGroupUpdateComplete` paths to match other update-state cleanup
- [ ] **Visual check** — progress bar animates smoothly during upgrade and ramps to 100% on completion without jumping backward

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/a0366c6c028f489cb8836384f4ec09eb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
