### PR TITLE
feat(macos): show loading spinner during PDF export

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -35,6 +35,9 @@ final class DocumentManager {
     /// Debounced auto-save task cancelled and rescheduled on every content update
     @ObservationIgnored private var autoSaveTask: Task<Void, Never>?
 
+    /// In-flight PDF export task, cancelled on document close
+    @ObservationIgnored private var pdfExportTask: Task<Void, Never>?
+
     /// Reference to daemon client for saving documents
     @ObservationIgnored weak var connectionManager: GatewayConnectionManager?
     @ObservationIgnored private let documentClient: DocumentClientProtocol = DocumentClient()
@@ -134,6 +137,8 @@ final class DocumentManager {
         save()
         autoSaveTask?.cancel()
         autoSaveTask = nil
+        pdfExportTask?.cancel()
+        pdfExportTask = nil
         hasActiveDocument = false
         surfaceId = nil
         conversationId = nil
@@ -169,9 +174,12 @@ final class DocumentManager {
         let wordCountToSave = wordCount
         let client = documentClient
         isExportingPDF = true
-        Task {
-            defer { isExportingPDF = false }
-            // Await the save so the server has the latest content before rendering
+        pdfExportTask?.cancel()
+        pdfExportTask = Task { [weak self] in
+            defer {
+                guard let self, self.surfaceId == surfaceId else { return }
+                self.isExportingPDF = false
+            }
             _ = await client.saveDocument(
                 surfaceId: surfaceId,
                 conversationId: conversationId,
@@ -179,10 +187,12 @@ final class DocumentManager {
                 content: contentToSave,
                 wordCount: wordCountToSave
             )
+            guard !Task.isCancelled else { return }
             guard let pdfData = await client.exportDocumentPDF(surfaceId: surfaceId) else {
                 log.error("PDF export failed: no data returned")
                 return
             }
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 let panel = NSSavePanel()
                 panel.nameFieldStringValue = sanitizedFilename(from: titleForFile) + ".pdf"

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -17,6 +17,7 @@ final class DocumentManager {
     var surfaceId: String?
     var conversationId: String?
     var isSaving: Bool = false
+    var isExportingPDF: Bool = false
     var lastSaveError: String?
 
     /// Current document content and metadata.
@@ -142,6 +143,7 @@ final class DocumentManager {
         initialContent = ""
         pendingInitialContent = nil
         isSaving = false
+        isExportingPDF = false
         lastSaveError = nil
         log.info("Document closed")
     }
@@ -166,7 +168,9 @@ final class DocumentManager {
         let contentToSave = currentContent ?? ""
         let wordCountToSave = wordCount
         let client = documentClient
+        isExportingPDF = true
         Task {
+            defer { isExportingPDF = false }
             // Await the save so the server has the latest content before rendering
             _ = await client.saveDocument(
                 surfaceId: surfaceId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -177,8 +177,9 @@ final class DocumentManager {
         pdfExportTask?.cancel()
         pdfExportTask = Task { [weak self] in
             defer {
-                guard let self, self.surfaceId == surfaceId else { return }
-                self.isExportingPDF = false
+                if let self, self.surfaceId == surfaceId {
+                    self.isExportingPDF = false
+                }
             }
             _ = await client.saveDocument(
                 surfaceId: surfaceId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -27,8 +27,15 @@ struct DocumentEditorPanelView: View {
                         .background(VColor.surfaceLift)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.chip))
                 }
-                if documentManager.isSaving {
-                    ProgressView().controlSize(.small).scaleEffect(0.7)
+                if documentManager.isSaving || documentManager.isExportingPDF {
+                    HStack(spacing: VSpacing.sm) {
+                        ProgressView().controlSize(.small).scaleEffect(0.7)
+                        if documentManager.isExportingPDF {
+                            Text("Exporting PDF…")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    }
                 } else {
                     VSplitButton(
                         label: "Export",


### PR DESCRIPTION
Adds a visual loading indicator when the user exports a document as PDF, so they know the export is in progress rather than seeing no feedback while the server renders the PDF (which can take several seconds, especially on first use when the Chromium binary is being downloaded).

The export button is replaced with a spinner and "Exporting PDF…" label during the async operation. The button reappears once the export completes or the document is closed.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/b045587642024a6782279fb6a59eaac5

## Human review checklist
- [ ] Verify this compiles in Xcode (CI skips macOS builds)
- [ ] Confirm the `defer { isExportingPDF = false }` inside the `@MainActor`-isolated Task correctly resets state on all exit paths (success, failure, early return from nil pdfData)
- [ ] Verify the "Exporting PDF…" label fits the toolbar without layout overflow on narrow windows
- [ ] Note: if PDF export fails, the spinner disappears but there is no user-facing error feedback (pre-existing — `exportToPDF` only calls `log.error`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->