### PR TITLE
[codex] Return JSON from cancel generation route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3511,6 +3511,22 @@ paths:
       responses:
         "202":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  cancelled:
+                    type: boolean
+                  conversationId:
+                    type: string
+                required:
+                  - ok
+                  - cancelled
+                  - conversationId
+                additionalProperties: false
       parameters:
         - name: id
           in: path

--- a/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
+++ b/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
@@ -132,4 +132,9 @@ describe("POST /v1/conversations/:id/cancel", () => {
     });
     expect(cancelledId!).toBe(directId);
   });
+
+  test("route definition advertises the cancellation response body", () => {
+    expect(cancelRoute.responseStatus).toBe("202");
+    expect(cancelRoute.responseBody).toBeDefined();
+  });
 });

--- a/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
+++ b/assistant/src/__tests__/cancel-resolves-conversation-key.test.ts
@@ -57,6 +57,7 @@ mock.module("../daemon/handlers/conversations.js", () => ({
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { initializeDb } from "../memory/db-init.js";
 import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
+import { routeDefinitionsToHTTPRoutes } from "../runtime/routes/http-adapter.js";
 
 initializeDb();
 
@@ -73,27 +74,62 @@ describe("POST /v1/conversations/:id/cancel", () => {
 
     expect(internalId).not.toBe(conversationKey);
 
-    cancelRoute.handler({
+    const result = cancelRoute.handler({
       pathParams: { id: conversationKey },
       body: {},
       headers: {},
-
     });
 
     expect(cancelledId!).toBe(internalId);
+    expect(result).toEqual({
+      ok: true,
+      cancelled: true,
+      conversationId: internalId,
+    });
   });
 
   test("falls back to raw ID when key is not in the mapping", () => {
     cancelledId = undefined;
     const directId = "direct-conversation-id";
 
-    cancelRoute.handler({
+    const result = cancelRoute.handler({
       pathParams: { id: directId },
       body: {},
       headers: {},
-
     });
 
+    expect(cancelledId!).toBe(directId);
+    expect(result).toEqual({
+      ok: true,
+      cancelled: true,
+      conversationId: directId,
+    });
+  });
+
+  test("HTTP adapter returns a serializable 202 response", async () => {
+    cancelledId = undefined;
+    const directId = "direct-http-conversation-id";
+    const [httpRoute] = routeDefinitionsToHTTPRoutes([cancelRoute]);
+    const url = new URL(`http://localhost/v1/conversations/${directId}/cancel`);
+
+    const response = await httpRoute.handler({
+      req: new Request(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      url,
+      params: { id: directId },
+      authContext: {} as never,
+      server: {} as never,
+    });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      ok: true,
+      cancelled: true,
+      conversationId: directId,
+    });
     expect(cancelledId!).toBe(directId);
   });
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -600,6 +600,11 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["conversations"],
     pathParams: [{ name: "id" }],
     responseStatus: "202",
+    responseBody: z.object({
+      ok: z.boolean(),
+      cancelled: z.boolean(),
+      conversationId: z.string(),
+    }),
     handler: handleCancelGeneration,
   },
   {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -364,8 +364,8 @@ function handleUnarchiveConversation({ pathParams = {} }: RouteHandlerArgs) {
 
 function handleCancelGeneration({ pathParams = {} }: RouteHandlerArgs) {
   const resolvedId = resolveConversationId(pathParams.id!) ?? pathParams.id!;
-  cancelGeneration(resolvedId);
-  return undefined;
+  const cancelled = cancelGeneration(resolvedId);
+  return { ok: true, cancelled, conversationId: resolvedId };
 }
 
 async function handleUndoLastMessage({ pathParams = {} }: RouteHandlerArgs) {


### PR DESCRIPTION
## Summary
- return a concrete JSON payload from `POST /v1/conversations/:id/cancel`
- extend the cancel-route regression test to cover the HTTP adapter serialization path

## Why
The cancel handler was aborting the in-flight conversation successfully, then returning `undefined`. The shared HTTP adapter passes handler results through `Response.json()`, so that produced a 500 even though cancellation had already happened. Desktop clients then saw cancel as failed while the daemon had already aborted the turn, leaving the UI waiting for a response that would never arrive.

## Validation
- `bun test src/__tests__/cancel-resolves-conversation-key.test.ts`
- `bunx tsc --noEmit`
- pre-push assistant type check and lint hooks passed