### PR TITLE
refactor(llm): decouple reply suggestion from conversationStarters call site

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -532,7 +532,7 @@ describe("GET /v1/suggestion", () => {
     );
   });
 
-  test("uses conversationStarters call site", async () => {
+  test("uses replySuggestion call site", async () => {
     const provider = makeMockProvider("Quick reply");
     mockGetConfiguredProvider.mockImplementation(async () => provider);
     mockGetConversationByKey.mockImplementation(() => ({
@@ -558,7 +558,7 @@ describe("GET /v1/suggestion", () => {
     const options = callArgs[3] as
       | { config?: { callSite?: string } }
       | undefined;
-    expect(options?.config?.callSite).toBe("conversationStarters");
+    expect(options?.config?.callSite).toBe("replySuggestion");
   });
 
   test("disables thinking and zeros effort to avoid Anthropic temp/thinking 400", async () => {
@@ -612,7 +612,7 @@ describe("GET /v1/suggestion", () => {
     // whenever the request triggers extended thinking (e.g. Opus 4.x at
     // `effort: "xhigh"`). The suggestion generator must only send a
     // single user-role message so it stays compatible with every
-    // possible `conversationStarters` call-site config.
+    // possible `replySuggestion` call-site config.
     const provider = makeMockProvider("<reply>Sure, works for me</reply>");
     mockGetConfiguredProvider.mockImplementation(async () => provider);
     mockGetConversationByKey.mockImplementation(() => ({

--- a/assistant/src/__tests__/workspace-migration-072-seed-reply-suggestion-callsite.test.ts
+++ b/assistant/src/__tests__/workspace-migration-072-seed-reply-suggestion-callsite.test.ts
@@ -1,0 +1,191 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedReplySuggestionCallsiteMigration } from "../workspace/migrations/072-seed-reply-suggestion-callsite.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-072-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("072-seed-reply-suggestion-callsite migration", () => {
+  test("has correct migration id", () => {
+    expect(seedReplySuggestionCallsiteMigration.id).toBe(
+      "072-seed-reply-suggestion-callsite",
+    );
+  });
+
+  test("seeds haiku callsite entry on Anthropic workspace without override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        callSites: {
+          conversationStarters: {
+            model: "claude-haiku-4-5-20251001",
+            effort: "low",
+            thinking: { enabled: false },
+          },
+        },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+    // Does not clobber unrelated entries.
+    expect(config.llm.callSites.conversationStarters).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("seeds openrouter-shaped model ID on openrouter workspace", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openrouter", model: "anthropic/claude-opus-4.7" },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "anthropic/claude-haiku-4.5",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("skips when replySuggestion already has an explicit override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          replySuggestion: {
+            model: "claude-opus-4-7",
+            effort: "high",
+          },
+        },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "claude-opus-4-7",
+      effort: "high",
+    });
+  });
+
+  test("skips entirely when non-Anthropic, non-OpenRouter provider is configured", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    // No callSites object created at all.
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("skips when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("runs on fresh install (no config.json) and writes seed config", () => {
+    expect(existsSync(configPath())).toBe(false);
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("is idempotent — a second run is a no-op", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+    const afterSecond = readFileSync(configPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+});

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -152,7 +152,14 @@ const CATALOG_RECORD: CatalogRecord = {
     id: "conversationStarters",
     displayName: "Conversation Starters",
     description:
-      "Generates suggested conversation openers for the home screen.",
+      "Generates the personalized starter chips on the empty conversation page.",
+    domain: "ui",
+  },
+  replySuggestion: {
+    id: "replySuggestion",
+    displayName: "Reply Suggestion",
+    description:
+      "Generates the tab-to-accept reply hint shown in the chat composer after each assistant turn.",
     domain: "ui",
   },
   conversationTitle: {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -52,6 +52,7 @@ export const LLMCallSiteEnum = z.enum([
   "patternScan",
   "conversationSummarization",
   "conversationStarters",
+  "replySuggestion",
   "conversationTitle",
   "commitMessage",
   "identityIntro",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2011,7 +2011,7 @@ async function generateLlmSuggestion(
     systemPrompt,
     {
       config: {
-        callSite: "conversationStarters",
+        callSite: "replySuggestion",
         max_tokens: 60,
         stop_sequences: ["</reply>"],
         temperature: 0.7,
@@ -2140,7 +2140,7 @@ export async function handleGetSuggestion(
     }
 
     // Try LLM suggestion using the configured provider
-    const provider = await getConfiguredProvider("conversationStarters");
+    const provider = await getConfiguredProvider("replySuggestion");
     if (provider) {
       try {
         // Deduplicate concurrent requests

--- a/assistant/src/workspace/migrations/072-seed-reply-suggestion-callsite.ts
+++ b/assistant/src/workspace/migrations/072-seed-reply-suggestion-callsite.ts
@@ -4,30 +4,30 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
- * Seed a latency-optimized default for the `conversationStarters` LLM
- * call site.
+ * Seed a latency-optimized default for the `replySuggestion` LLM call site.
  *
- * `conversationStarters` drives the personalized starter chips rendered
- * on the empty conversation page in the macOS client. Without this seed
- * the call site falls through to `llm.default` — on workspaces where the
- * default is a high-effort / extended-thinking configured model
- * (e.g. Opus 4.x at `effort: "xhigh"`), chip generation kicks off an
- * expensive reasoning call that adds noticeable cost and latency.
+ * `replySuggestion` drives the tab-to-accept ghost-text reply hint rendered in
+ * the chat composer after every assistant turn (`GET /v1/suggestion`). It was
+ * split out of `conversationStarters` so the empty-state chip generator and
+ * the inline reply hint can be tuned independently. Without this seed the
+ * call site falls through to `llm.default` — on workspaces with a
+ * high-effort / extended-thinking default, every turn would kick off an
+ * expensive reasoning call and reject the assistant prefill.
  *
- * Follows the same contract as `040-seed-latency-callsite-defaults`:
+ * Mirrors `046-seed-conversation-starters-callsite`:
  *   - Skip entirely when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set
  *     (platform overlay owns call-site seeds).
- *   - Skip when the resolved provider is not Anthropic (the seeded
- *     model IDs are Anthropic-shaped, so mixing with another provider
- *     would guarantee invalid-model errors).
- *   - No-op when `llm.callSites.conversationStarters` is already set.
+ *   - Skip when the resolved provider is not Anthropic or OpenRouter (the
+ *     seeded model IDs are Anthropic-shaped, so mixing with another
+ *     provider would guarantee invalid-model errors).
+ *   - No-op when `llm.callSites.replySuggestion` is already set.
  *
- * Idempotent, append-only — existing 040 entries are untouched.
+ * Idempotent, append-only — existing entries are untouched.
  */
-export const seedConversationStartersCallsiteMigration: WorkspaceMigration = {
-  id: "046-seed-conversation-starters-callsite",
+export const seedReplySuggestionCallsiteMigration: WorkspaceMigration = {
+  id: "072-seed-reply-suggestion-callsite",
   description:
-    "Seed latency-optimized default for conversationStarters LLM call site",
+    "Seed latency-optimized default for replySuggestion LLM call site",
   run(workspaceDir: string): void {
     if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
 
@@ -61,9 +61,9 @@ export const seedConversationStartersCallsiteMigration: WorkspaceMigration = {
     if (fastModel === undefined) return;
 
     const callSites = readObject(llm.callSites) ?? {};
-    if (readObject(callSites.conversationStarters) !== null) return;
+    if (readObject(callSites.replySuggestion) !== null) return;
 
-    callSites.conversationStarters = {
+    callSites.replySuggestion = {
       model: fastModel,
       effort: "low",
       thinking: { enabled: false },
@@ -75,8 +75,7 @@ export const seedConversationStartersCallsiteMigration: WorkspaceMigration = {
   },
   down(_workspaceDir: string): void {
     // Forward-only: removing the seeded default would reintroduce the
-    // cost/latency regression and the assistant-prefill 400 that this
-    // migration fixes.
+    // cost/latency regression that this migration fixes.
   },
 };
 

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -69,6 +69,7 @@ import { releaseNotesLocalTimezoneMigration } from "./068-release-notes-local-ti
 import { seedOnboardingThreadsMigration } from "./069-seed-onboarding-threads.js";
 import { memoryV2SummarySchemaRebuildMigration } from "./070-memory-v2-summary-schema-rebuild.js";
 import { removeSafeStorageReleaseNoteMigration } from "./071-remove-safe-storage-release-note.js";
+import { seedReplySuggestionCallsiteMigration } from "./072-seed-reply-suggestion-callsite.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -149,4 +150,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedOnboardingThreadsMigration,
   memoryV2SummarySchemaRebuildMigration,
   removeSafeStorageReleaseNoteMigration,
+  seedReplySuggestionCallsiteMigration,
 ];


### PR DESCRIPTION
## Summary
- Split the overloaded `conversationStarters` LLM call site into `conversationStarters` (empty-state chips) and a new `replySuggestion` (tab-to-accept reply hint after each assistant turn) so they can be configured independently.
- Add workspace migration `072-seed-reply-suggestion-callsite.ts`, mirroring `046`, to seed `replySuggestion` with Haiku-4.5 / low-effort / no-thinking on Anthropic and OpenRouter workspaces — current behavior is preserved on existing installs and fresh installs alike.
- Update the call-site catalog (new `replySuggestion` entry, tighten `conversationStarters` description), the reply-suggestion consumer in `conversation-routes.ts`, the suggestion-routes test, and add a migration test mirroring 046's. Tighten 046's docstring to reflect that it now seeds only the chip generator.

## Original prompt
The user asked which inference profile drives the chat-composer's tab-to-accept ghost-text suggestion. Tracing the path showed both the empty-state starter chips and the inline reply hint were routing through the single `conversationStarters` call site, with migration 046 pinning both to Haiku for latency. The user asked to decouple them so each feature can be tuned independently — the chip generator remains heavy and personalized while the inline reply stays lightweight.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->