### PR TITLE
fix(acp): raise acp_steer risk to high to match acp_spawn

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -67,7 +67,7 @@
       "name": "acp_steer",
       "description": "**Interrupts** the in-flight prompt of a running ACP session and replaces it with `instruction`. Use to redirect the agent (e.g., 'stop, do X instead'). For follow-up work that should happen *after* the current task, do NOT use this — wait for `acp_session_completed` and `acp_spawn` again.",
       "category": "orchestration",
-      "risk": "medium",
+      "risk": "high",
       "input_schema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Addresses Codex review feedback on #28075.

`acp_steer` can replace a live ACP agent's task with arbitrary new instructions — equivalent execution authority to `acp_spawn` (high risk). Registering it as medium risk allowed it to be auto-approved in some contexts (e.g., the default background threshold), so a session approved for one task could be silently redirected to unrelated high-impact work without another high-risk approval. Raising to high closes that permission-boundary gap.