### PR TITLE
docs(acp): remove stale gemini reference from acp_spawn tool description

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -11,7 +11,7 @@
         "properties": {
           "agent": {
             "type": "string",
-            "description": "Which agent to spawn (e.g. 'claude', 'codex', 'gemini'). Defaults to 'claude'."
+            "description": "Which agent to spawn (e.g. 'claude', 'codex'). Defaults to 'claude'."
           },
           "task": {
             "type": "string",


### PR DESCRIPTION
Follow-up to #28114. SKILL.md states only `claude-agent-acp` and `codex-acp` are supported, but TOOLS.json still listed `'gemini'` as an example agent id. Removed the stale reference so the tool description matches the documented adapters and the configured profiles in `acp-defaults.ts`.