### PR TITLE
fix(macos): merge scheduleJobId when restoring existing conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -399,6 +399,7 @@ final class ConversationRestorer {
                 existing.conversationType = session.conversationType
                 existing.originChannel = session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
                 existing.inferenceProfile = session.inferenceProfile
+                existing.scheduleJobId = session.scheduleJobId
                 delegate.conversations[existingIdx] = existing
                 // Attention merge must go through mergeAssistantAttention so that
                 // pendingAttentionOverrides are reconciled (e.g. a notification


### PR DESCRIPTION
Addresses Devin review feedback on #28106.

The existing-conversation merge path in `ConversationRestorer.handleConversationListResponse` was missing `scheduleJobId`. The new-conversation creation path already passes it. Without this, a conversation created locally before the list arrived (e.g. via `createNotificationConversation`) whose server response includes a `scheduleJobId` would not be grouped under its schedule sub-group in the sidebar (`SidebarView.swift`, `ConversationSwitcherDrawer.swift` group by `scheduleJobId`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->