### PR TITLE
fix(providers): allow text.verbosity for GPT-5 fine-tune IDs

### DIFF
--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -677,6 +677,23 @@ describe("OpenAIResponsesProvider", () => {
     expect(lastStreamParams!.text).toEqual({ verbosity: "high" });
   });
 
+  test("verbosity is forwarded for GPT-5 fine-tune IDs", async () => {
+    const ftProvider = new OpenAIResponsesProvider(
+      "sk-test",
+      "ft:gpt-5.2:acme::abc123",
+    );
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await ftProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      { config: { verbosity: "low" } },
+    );
+
+    expect(lastStreamParams!.text).toEqual({ verbosity: "low" });
+  });
+
   // -----------------------------------------------------------------------
   // Model override
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -49,9 +49,11 @@ const VALID_VERBOSITIES = new Set<string>(["low", "medium", "high"]);
  *  Responses API (o-series, etc.) reject unknown wire fields with HTTP 400, so
  *  gate forwarding by model name here. The retry layer can't make this call
  *  because verbosity defaults to "medium" in the LLM schema, so every
- *  callSite-resolved request would otherwise carry it regardless of model. */
+ *  callSite-resolved request would otherwise carry it regardless of model.
+ *  Also matches OpenAI fine-tune IDs of the form `ft:gpt-5.x:org::id` so users
+ *  on GPT-5 fine-tunes keep explicit verbosity control. */
 function modelSupportsVerbosity(model: string): boolean {
-  return /^gpt-5(\b|[-.])/i.test(model);
+  return /^(ft:)?gpt-5(\b|[-.])/i.test(model);
 }
 
 /** Loosely-typed Responses stream event to avoid `any` while the SDK types settle. */


### PR DESCRIPTION
## Summary

Codex P2 follow-up to #28082.

`modelSupportsVerbosity` only matched bare `gpt-5` IDs, so OpenAI fine-tune IDs of the form `ft:gpt-5.2:acme::abc123` were treated as unsupported and `text.verbosity` got silently dropped — even though the underlying model is still GPT-5 family. Other code in this repo already recognizes the `ft:` prefix as OpenAI (see `hasOpenAiModelPrefix`), so this was a real regression for users on GPT-5 fine-tunes.

Extends the model gate to accept the optional `ft:` prefix.

## Test plan

- [x] Added `verbosity is forwarded for GPT-5 fine-tune IDs` test (instantiates a provider with `ft:gpt-5.2:acme::abc123` and asserts `text.verbosity` is forwarded).
- [x] Existing verbosity gating tests still pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->