### PR TITLE
fix(skill-host-contracts): preserve subscription on reopen write failure

### DIFF
--- a/packages/skill-host-contracts/src/client.ts
+++ b/packages/skill-host-contracts/src/client.ts
@@ -568,7 +568,16 @@ export class SkillHostClient implements SkillHost {
         params: { filter: fresh.filter },
       });
     } catch (err) {
-      this.cancelSubscribeAck(fresh);
+      // Drop only the pending ack and leave `fresh` registered. If the
+      // socket dropped between `doConnect()` and this write, the close
+      // handler will trigger another reconnect — and that cycle iterates
+      // `subscriptions`, so we must NOT remove or dispose `fresh` here
+      // or the stream is silently lost (autoReconnect contract).
+      const entry = this.pending.get(fresh.id);
+      if (entry) {
+        clearTimeout(entry.timer);
+        this.pending.delete(fresh.id);
+      }
       swallow(err);
     }
   }


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #28092.

In `reopenSubscription()`, when the `host.events.subscribe` write throws (typical race: socket dropped between `doConnect()` and this write), the previous catch path called `cancelSubscribeAck(fresh)`, which marks the subscription `disposed` and removes it from `this.subscriptions`. The next reconnect cycle iterates `this.subscriptions` to re-establish streams — so the subscription was silently lost, breaking the documented `autoReconnect` contract that existing subscriptions are restored after transient disconnects.

The fix drops only the pending ack entry and leaves `fresh` registered. The socket-close handler still triggers `scheduleReconnect()`, which iterates `this.subscriptions` and re-opens the entry on the next cycle.

`openSubscription()` keeps using `cancelSubscribeAck()` because that path throws to the caller, who can decide whether to retry — autoReconnect has no caller to surface to.

## Test plan
- [ ] Existing client tests still pass
