### PR TITLE
test(daemon-skill-host): assert skillId namespacing

### DIFF
--- a/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
+++ b/assistant/src/daemon/__tests__/daemon-skill-host.test.ts
@@ -23,8 +23,9 @@ const loggerSpy = {
   warn: mock(() => {}),
   error: mock(() => {}),
 };
+const getLoggerSpy = mock((_name: string) => loggerSpy);
 mock.module("../../util/logger.js", () => ({
-  getLogger: () => loggerSpy,
+  getLogger: getLoggerSpy,
 }));
 
 mock.module("../../config/loader.js", () => ({
@@ -163,12 +164,13 @@ describe("createDaemonSkillHost", () => {
     expect(host.speakers).toBeDefined();
   });
 
-  test("logger.get returns an object with the four severity methods", () => {
+  test("logger.get prefixes the scope with the skillId", () => {
     const log = host.logger.get("test-scope");
     log.debug("d", { k: "v" });
     log.info("i");
     log.warn("w");
     log.error("e");
+    expect(getLoggerSpy).toHaveBeenCalledWith("meet-join:test-scope");
     expect(loggerSpy.debug).toHaveBeenCalled();
     expect(loggerSpy.info).toHaveBeenCalled();
     expect(loggerSpy.warn).toHaveBeenCalled();
@@ -255,8 +257,12 @@ describe("createDaemonSkillHost", () => {
     });
     expect(handle).toBeDefined();
     expect(registerSkillRouteSpy).toHaveBeenCalled();
-    host.registries.registerShutdownHook("test-hook", async () => {});
-    expect(registerShutdownHookSpy).toHaveBeenCalled();
+    const hook = async () => {};
+    host.registries.registerShutdownHook("test-hook", hook);
+    expect(registerShutdownHookSpy).toHaveBeenCalledWith(
+      "meet-join:test-hook",
+      hook,
+    );
   });
 
   test("speakers.createTracker yields a concrete tracker instance", () => {


### PR DESCRIPTION
## Summary

Addresses Devin review feedback on #28080: the test file did not assert the namespacing behavior introduced by that PR.

- Logger test now spies on `getLogger` and asserts it was called with `"meet-join:test-scope"` — verifying the skillId prefix is threaded through `buildLoggerFacet`.
- Shutdown-hook test now asserts `registerShutdownHook` was called with `"meet-join:test-hook"` — verifying namespacing in `buildRegistriesFacet`.

## Test plan
- [x] `bun test src/daemon/__tests__/daemon-skill-host.test.ts` — 14 pass