### PR TITLE
fix(macos): reserve __custom__ as a reserved profile name

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -471,6 +471,15 @@ struct InferenceProfilesSheet: View {
         // would accept them but the row would render unusably.
         guard !name.isEmpty else { return }
 
+        // Reserve the call-site picker's Custom sentinel: a profile with
+        // this name would collide with the synthetic option in
+        // `CallSiteOverrideRow`'s VDropdown (same value identity), making
+        // the profile unselectable as itself.
+        if name == CallSiteOverrideRow.customSentinel {
+            actionError = "\"\(name)\" is reserved. Pick a different name."
+            return
+        }
+
         // Defense-in-depth: the UI disables Edit for managed profiles, but
         // guard here in case the method is reached through an unexpected
         // path. The daemon also rejects writes to managed profiles.


### PR DESCRIPTION
Addresses Codex review feedback on #28095.

The call-site override picker uses `__custom__` as a sentinel value for the synthetic "Custom" option. Profile names were only validated as non-empty, so a user could create a real profile named `__custom__` — VDropdown would then have two options sharing the same value identity, and the synthetic-mode path would intercept the real profile.

Reject the sentinel at `commitEditor` time so the value is reserved.

## Test plan
- [ ] Manual: try to create a profile named `__custom__` — should be rejected with an error message