### PR TITLE
fix(db): make 227/228 inference_profile migrations replay-safe

### DIFF
--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -18,6 +18,7 @@ import { resetDb } from "../memory/db-connection.js";
 import { getSqliteFrom } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { migrateAddConversationInferenceProfile } from "../memory/migrations/227-add-conversation-inference-profile.js";
+import { migrateRenameInferenceProfileSnakeCase } from "../memory/migrations/228-rename-inference-profile-snake-case.js";
 import * as schema from "../memory/schema.js";
 import { getDbPath } from "../util/platform.js";
 
@@ -206,6 +207,42 @@ describe("conversation inference profile migration", () => {
     } | null;
 
     expect(row).toEqual({ inferenceProfile: "quality-optimized" });
+  });
+
+  test("replaying 227 + 228 across multiple boots does not re-add the camelCase column", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPreInferenceProfileConversations(raw);
+
+    // First boot: 227 adds camelCase, 228 renames to snake_case.
+    migrateAddConversationInferenceProfile(db);
+    migrateRenameInferenceProfileSnakeCase(db);
+    expect(getColumnNames(raw)).toContain("inference_profile");
+    expect(getColumnNames(raw)).not.toContain("inferenceProfile");
+
+    // Second boot: replays must not re-add the camelCase column.
+    migrateAddConversationInferenceProfile(db);
+    migrateRenameInferenceProfileSnakeCase(db);
+    expect(getColumnNames(raw)).toContain("inference_profile");
+    expect(getColumnNames(raw)).not.toContain("inferenceProfile");
+  });
+
+  test("228 self-heals when both columns are present from the legacy bug", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPreInferenceProfileConversations(raw);
+    // Simulate the legacy state: both columns exist because 227 re-added the
+    // camelCase column on a boot after 228 had already renamed it.
+    raw.exec(`ALTER TABLE conversations ADD COLUMN inference_profile TEXT`);
+    raw.exec(`ALTER TABLE conversations ADD COLUMN inferenceProfile TEXT`);
+    expect(getColumnNames(raw)).toContain("inferenceProfile");
+
+    migrateRenameInferenceProfileSnakeCase(db);
+
+    expect(getColumnNames(raw)).toContain("inference_profile");
+    expect(getColumnNames(raw)).not.toContain("inferenceProfile");
   });
 
   test("new rows default to NULL inferenceProfile after migration", () => {

--- a/assistant/src/memory/migrations/227-add-conversation-inference-profile.ts
+++ b/assistant/src/memory/migrations/227-add-conversation-inference-profile.ts
@@ -8,8 +8,13 @@ export function migrateAddConversationInferenceProfile(
   const columns = raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
     name: string;
   }>;
+  // Skip if either the original camelCase column or the renamed snake_case
+  // column from migration 228 is already present. Without the snake_case
+  // check, this migration would re-add the camelCase column on every boot
+  // after 228 runs, leaving both columns permanently.
   const hasColumn = columns.some(
-    (column) => column.name === "inferenceProfile",
+    (column) =>
+      column.name === "inferenceProfile" || column.name === "inference_profile",
   );
   if (hasColumn) {
     return;

--- a/assistant/src/memory/migrations/228-rename-inference-profile-snake-case.ts
+++ b/assistant/src/memory/migrations/228-rename-inference-profile-snake-case.ts
@@ -6,19 +6,32 @@ import { tableHasColumn } from "./schema-introspection.js";
  * by migration 227) to `inference_profile` so it matches the snake_case
  * convention used by every other column on the table.
  *
- * Idempotent:
- * - camelCase column present, snake_case absent → renames it.
- * - snake_case column already present → no-op.
- * - neither column present → no-op (shouldn't happen since 227 ran first,
- *   but we guard for completeness).
+ * Idempotent and self-healing:
+ * - both columns present → drop the camelCase one (heals instances that
+ *   already booted twice with the original buggy migration 227, where 227
+ *   re-added the camelCase column after this migration renamed it).
+ * - camelCase column present, snake_case absent → rename it.
+ * - snake_case column present, camelCase absent → no-op.
+ * - neither column present → no-op.
  */
 export function migrateRenameInferenceProfileSnakeCase(
   database: DrizzleDb,
 ): void {
-  if (tableHasColumn(database, "conversations", "inference_profile")) {
+  const hasSnake = tableHasColumn(
+    database,
+    "conversations",
+    "inference_profile",
+  );
+  const hasCamel = tableHasColumn(
+    database,
+    "conversations",
+    "inferenceProfile",
+  );
+  if (hasSnake && hasCamel) {
+    database.run(`ALTER TABLE conversations DROP COLUMN inferenceProfile`);
     return;
   }
-  if (!tableHasColumn(database, "conversations", "inferenceProfile")) {
+  if (!hasCamel) {
     return;
   }
   database.run(


### PR DESCRIPTION
## Summary
Addresses Devin/Codex feedback on #28068: migrations 227 + 228 produce
schema drift on the second boot after upgrade.

**Bug:** Migration 227 only checks for the camelCase `inferenceProfile`
column. After 228 renames it to `inference_profile`, 227 doesn't see the
camelCase column on the next boot and re-adds it. 228 then no-ops because
`inference_profile` already exists, leaving both columns permanently.

**Fix:**
- 227 now skips the add when either column name is present.
- 228 self-heals: if both columns exist (legacy state from already-buggy
  boots), drop the camelCase column.

## Test plan
- [x] Added regression test that replays 227 + 228 across multiple boots
- [x] Added regression test that 228 drops the camelCase column when both
      are present (heals existing buggy DBs)

Addressed in this PR for #28068.