### PR TITLE
fix(acp): deep-freeze default agent profile args arrays

### DIFF
--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -29,10 +29,14 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
     });
   });
 
-  test("is frozen at runtime so mutation throws in strict mode", () => {
+  test("is deeply frozen so mutation throws in strict mode", () => {
     expect(Object.isFrozen(DEFAULT_ACP_AGENT_PROFILES)).toBe(true);
     for (const profile of Object.values(DEFAULT_ACP_AGENT_PROFILES)) {
       expect(Object.isFrozen(profile)).toBe(true);
+      // `args` arrays must also be frozen — `Object.freeze` is shallow, so
+      // an unfrozen `args` would let one caller silently corrupt every other
+      // read of the shared default via `.push(...)` / `.splice(...)`.
+      expect(Object.isFrozen(profile.args)).toBe(true);
     }
   });
 });

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -1,5 +1,11 @@
 import type { AcpAgentConfig } from "./acp-schema.js";
 
+// Shared frozen empty args array — these defaults are read by every ACP spawn,
+// so a single accidental `args.push(...)` from one caller would corrupt every
+// subsequent read. Cast through `unknown` because `AcpAgentConfig.args` is
+// `string[]` (Zod-inferred) but the value is genuinely immutable at runtime.
+const FROZEN_EMPTY_ARGS = Object.freeze([] as string[]) as unknown as string[];
+
 /**
  * Default ACP agent profiles that ship with the assistant.
  *
@@ -7,20 +13,21 @@ import type { AcpAgentConfig } from "./acp-schema.js";
  * agent id, the resolver falls back to this map so common agents like `claude`
  * and `codex` Just Work without requiring per-user config.
  *
- * Keyed by agent id. Frozen so accidental runtime mutation throws in strict
- * mode and the readonly type matches actual runtime behavior.
+ * Keyed by agent id. Deeply frozen — the outer object, each profile, and the
+ * `args` arrays — so mutation throws in strict mode rather than silently
+ * corrupting the shared defaults.
  */
 export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
   Record<string, AcpAgentConfig>
 > = Object.freeze({
   claude: Object.freeze({
     command: "claude-agent-acp",
-    args: [],
+    args: FROZEN_EMPTY_ARGS,
     description: "Claude Code (via @agentclientprotocol/claude-agent-acp)",
   }),
   codex: Object.freeze({
     command: "codex-acp",
-    args: [],
+    args: FROZEN_EMPTY_ARGS,
     description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
   }),
 });


### PR DESCRIPTION
Addresses Devin's shallow-freeze finding on #28070.

## Summary
- Replace inline empty-array literals with a shared `FROZEN_EMPTY_ARGS` constant so both default profiles share one frozen reference instead of two unfrozen ones.
- Tighten the freeze test to also assert `Object.isFrozen(profile.args)` so a future regression to a mutable array fails fast.

## Why
`Object.freeze` is shallow. The outer profile object had `args: []` — that array reference can't be reassigned after freezing the parent, but the array contents were still mutable, so `DEFAULT_ACP_AGENT_PROFILES.claude.args.push('--flag')` would silently corrupt the shared default for every subsequent read.

## Test plan
- [x] `bun test src/config/acp-defaults.test.ts` — 7/7 pass
- [x] `bunx tsc --noEmit` — no new errors in `acp-defaults.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->