### PR TITLE
fix(acp): honor agent env.PATH in resolver binary preflight

### DIFF
--- a/assistant/src/acp/__tests__/helpers/which-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/which-stub.ts
@@ -11,7 +11,8 @@
  * in `afterAll` so the swap doesn't leak into other files.
  */
 
-type WhichStub = (command: string) => string | null;
+type WhichOptions = { PATH?: string; cwd?: string };
+type WhichStub = (command: string, options?: WhichOptions) => string | null;
 
 /**
  * Installs a process-global stub for Bun.which. Returns helpers to drive and
@@ -30,7 +31,8 @@ export function installWhichStub(): {
   const originalWhich = Bun.which;
   let whichStub: WhichStub = () => null;
 
-  (Bun as unknown as { which: WhichStub }).which = (cmd) => whichStub(cmd);
+  (Bun as unknown as { which: WhichStub }).which = (cmd, options) =>
+    whichStub(cmd, options);
 
   function setWhich(arg: Record<string, string | null> | WhichStub): void {
     whichStub = typeof arg === "function" ? arg : (cmd) => arg[cmd] ?? null;

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -161,6 +161,31 @@ describe("resolveAcpAgent", () => {
     expect(result.hint).toBe("npm i -g @zed-industries/codex-acp");
   });
 
+  test("binary preflight honors agent.env.PATH override (matches spawn env)", () => {
+    // The actual spawn merges `agentConfig.env` into the child env, so a
+    // per-agent PATH override wins over the daemon's PATH. The preflight
+    // must use the same PATH or it will reject configs that would have
+    // spawned successfully.
+    config.setConfig({
+      agents: {
+        custom: {
+          command: "my-binary",
+          args: [],
+          env: { PATH: "/opt/custom/bin" },
+        },
+      },
+    });
+    which.setWhich((cmd, options) =>
+      cmd === "my-binary" && options?.PATH === "/opt/custom/bin"
+        ? "/opt/custom/bin/my-binary"
+        : null,
+    );
+
+    const result = resolveAcpAgent("custom");
+
+    expect(result.ok).toBe(true);
+  });
+
   test("ok result when user config provides agent and binary is on PATH", () => {
     config.setConfig({
       agents: {

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -66,6 +66,17 @@ function installHintFor(command: string): string {
 }
 
 /**
+ * Resolve the binary using the same PATH the spawn will see. `AcpAgentProcess`
+ * spawns with `{ ...process.env, ...config.env }`, so a per-agent `env.PATH`
+ * override wins over the daemon's PATH. Mirror that here so a config that
+ * relies on a custom PATH to locate the binary doesn't fail preflight.
+ */
+function findAgentBinary(agent: AcpAgentConfig): string | null {
+  const PATH = agent.env?.PATH ?? process.env.PATH;
+  return Bun.which(agent.command, PATH ? { PATH } : undefined);
+}
+
+/**
  * Resolve an id against user config first, then bundled defaults. Returns the
  * resolved entry plus a `source` label so callers can surface "user override
  * vs bundled default" without re-deriving it.
@@ -122,7 +133,7 @@ export function resolveAcpAgent(id: string): ResolveAcpAgentResult {
   }
 
   const { agent } = found;
-  if (!Bun.which(agent.command)) {
+  if (!findAgentBinary(agent)) {
     return {
       ok: false,
       reason: "binary_not_found",
@@ -157,7 +168,7 @@ export function listAcpAgents(): {
   const agents: AcpAgentEntry[] = mergedAgentIds(userAgents).map((id) => {
     // Non-null: ids come from `mergedAgentIds` so the lookup always resolves.
     const { agent, source } = lookupAgent(userAgents, id)!;
-    const available = Bun.which(agent.command) !== null;
+    const available = findAgentBinary(agent) !== null;
     const entry: AcpAgentEntry = {
       id,
       command: agent.command,


### PR DESCRIPTION
## Summary
- The resolver's `Bun.which(agent.command)` preflight only checked the daemon's PATH, but `AcpAgentProcess.spawn` merges `agentConfig.env` into the child env — so a config that relies on a per-agent `env.PATH` override to locate its binary used to spawn fine, but after PR #28110 hits a hard `binary_not_found` before spawn.
- Resolve via the same PATH the spawn will use (`agent.env?.PATH ?? process.env.PATH`) in both `resolveAcpAgent` and `listAcpAgents`.
- Adds a regression test; extends the test which-stub to forward the `options` arg.

Addresses Codex P2 feedback on #28110.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->