### PR TITLE
fix(macos/chat): hide profile picker during draft-promotion window

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -516,19 +516,22 @@ struct ChatView: View {
 
     /// Bundles the inference-profile pill state for ``ComposerView``. Returns
     /// `nil` when no manager is wired (preview/testing) so the pill stays
-    /// hidden until a real persistence path exists.
+    /// hidden until a real persistence path exists, and also when the
+    /// conversation has been promoted out of draft state but the daemon-side
+    /// conversation ID has not yet been backfilled — in that window
+    /// ``ConversationManager.setConversationInferenceProfile`` would silently
+    /// no-op. Drafts remain enabled because the manager routes draft
+    /// selections through ``ChatViewModel.pendingInferenceProfile``.
     private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
-        guard let conversationManager else { return nil }
+        guard let conversationManager, let conversationId else { return nil }
+        let isDraft = conversationManager.draftLocalId == conversationId
+        let isPersisted = currentConversation?.conversationId != nil
+        guard isDraft || isPersisted else { return nil }
         return ChatProfilePickerConfiguration(
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,
             profiles: inferenceProfiles,
             activeProfile: activeInferenceProfile,
             onSelect: { profile in
-                if conversationId == nil {
-                    viewModel.pendingInferenceProfile = profile
-                    return
-                }
-                guard let conversationId else { return }
                 Task { @MainActor in
                     await conversationManager.setConversationInferenceProfile(
                         id: conversationId,


### PR DESCRIPTION
## Summary
Addresses review feedback on #28062 from chatgpt-codex-connector and devin-ai-integration.

Both reviewers flagged the same gap: the inference-profile picker was enabled based on the local UUID, but `ConversationManager.setConversationInferenceProfile` checks the daemon-side `conversationId` and silently returns false when it is still nil — i.e. between the moment a draft is promoted and the moment the daemon backfills the conversation ID. Selecting a profile in that window did nothing.

The fix gates `inferenceProfilePicker` on either:
- `isDraft` — the manager routes the selection through `pendingInferenceProfile`, or
- `isPersisted` — the manager has a daemon ID to send to.

Also drops the dead `if conversationId == nil` branch in `onSelect` (drafts always have a non-nil local UUID; that branch never fired).

## Test plan
- [ ] Open a fresh chat → picker visible (draft path).
- [ ] Send first message → picker stays interactive after the daemon backfills the ID.
- [ ] Open an existing conversation → picker visible and selecting a profile persists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->