### PR TITLE
fix(recall): rethrow aborts from PKB recall source

### DIFF
--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -114,6 +114,9 @@ export async function searchPkbSource(
       );
     }
   } catch (err) {
+    if (isAbortError(err) || context.signal?.aborted) {
+      throw err;
+    }
     log.warn(
       { err },
       "Semantic PKB recall source failed; using lexical fallback",
@@ -124,6 +127,9 @@ export async function searchPkbSource(
   try {
     lexicalEvidence = await searchPkbLexicalFallback(query, context, limit * 2);
   } catch (err) {
+    if (isAbortError(err) || context.signal?.aborted) {
+      throw err;
+    }
     log.warn({ err }, "Lexical PKB recall fallback failed");
   }
 
@@ -473,4 +479,8 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) {
     throw signal.reason ?? new Error("PKB recall search aborted");
   }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
 }


### PR DESCRIPTION
## Summary
Address Codex feedback on #28128: the semantic and lexical catch blocks in `searchPkbSource` converted every failure into `{ evidence: [] }`, including `AbortError` from a cancelled `context.signal`. Upstream couldn't detect cancellation and would assemble a partial response instead of stopping.

Now both catch blocks rethrow when the error is an `AbortError` or when the signal is already aborted, and only swallow non-abort failures.

## Test plan
- [x] Type-check unchanged callers via existing build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->