### PR TITLE
fix(daemon): never block startup on IPC server failures

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -260,13 +260,27 @@ export class DaemonServer {
 
     this.evictor.start();
 
-    await this.cliIpc.start();
+    try {
+      await this.cliIpc.start();
+    } catch (err) {
+      log.warn(
+        { err },
+        "CLI IPC server failed to start — continuing startup with degraded CLI connectivity",
+      );
+    }
 
     // Start the skill IPC server. First-party skill processes connect to this
     // socket to access host capabilities (host.log, host.config.*,
     // host.events.*, host.registries.*). Route registry is populated by
     // subsequent PRs in the skill-isolation plan.
-    await this.skillIpc.start();
+    try {
+      await this.skillIpc.start();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Skill IPC server failed to start — continuing startup with degraded skill host connectivity",
+      );
+    }
 
     this.configWatcher.start(
       () => this.evictConversationsForReload(),


### PR DESCRIPTION
## Summary

Follow-up to #28120 addressing Devin review feedback. The async `ensureSocketPathFree` introduced in #28120 can throw `EADDRINUSE` (live listener) or a probe-timeout error, and `server.ts` was awaiting both `cliIpc.start()` and `skillIpc.start()` without a try/catch — so a stale or occupied socket could fatally abort daemon startup.

Per the `assistant/AGENTS.md` rule:

> The daemon must **never** block startup under _any circumstance_. All possible errors should be logged so that the assistant can recover from its corrupted state after the fact.

Both calls are now wrapped in try/catch with a warning log, matching the pattern used elsewhere in the file. The daemon stays functional (HTTP routes, etc.) even if one of the IPC servers fails to bind.

## Test plan

- [x] `bunx tsc --noEmit` (assistant package)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->