### PR TITLE
fix(recall): propagate aborts from memory source embedding

### DIFF
--- a/assistant/src/memory/context-search/sources/memory.ts
+++ b/assistant/src/memory/context-search/sources/memory.ts
@@ -34,6 +34,7 @@ export async function searchMemorySource(
     });
     queryVector = result.vectors[0] ?? null;
   } catch (err) {
+    if (context.signal?.aborted || isAbortError(err)) throw err;
     log.warn({ err }, "Failed to embed memory recall query");
     return { evidence: [] };
   }
@@ -67,9 +68,15 @@ export async function searchMemorySource(
 
     return { evidence };
   } catch (err) {
+    if (context.signal?.aborted || isAbortError(err)) throw err;
     log.warn({ err }, "Failed to search memory graph for recall");
     return { evidence: [] };
   }
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === "AbortError" || err.name === "APIUserAbortError";
 }
 
 function memoryNodeToEvidence(node: MemoryNode, score: number): RecallEvidence {


### PR DESCRIPTION
Addresses Codex review feedback on #28131.

The catch block around `embedWithRetry` was converting abort-shaped errors into `{ evidence: [] }`, masking cancellation as a successful empty search. The graph-search catch had the same problem. Both now re-throw on abort so recall orchestration can terminate promptly.

Mirrors the pattern already used in `embed.ts` and `agent-runner.ts`.