### PR TITLE
fix(recall): preserve abort errors in deterministic recall fanout

### DIFF
--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -1,3 +1,4 @@
+import { isAbortReason } from "../../util/abort-reasons.js";
 import {
   ALL_RECALL_SOURCES,
   type NormalizedRecallInput,
@@ -72,6 +73,7 @@ export async function runDeterministicRecallSearch(
       );
       appendEvidence(evidenceBySource, "pkb", contextEvidence);
     } catch (err) {
+      if (isAbortLikeError(err)) throw err;
       errorsBySource.set("pkb", errorToMessage(err));
     }
   }
@@ -88,17 +90,20 @@ export async function runDeterministicRecallSearch(
     ),
   );
 
-  adapterResults.forEach((settledResult, index) => {
+  for (const [index, settledResult] of adapterResults.entries()) {
     const source = selectedAdapters[index]?.source;
-    if (!source) return;
+    if (!source) continue;
 
     if (settledResult.status === "fulfilled") {
       appendEvidence(evidenceBySource, source, settledResult.value.evidence);
-      return;
+      continue;
     }
 
+    if (isAbortLikeError(settledResult.reason)) {
+      throw settledResult.reason;
+    }
     errorsBySource.set(source, errorToMessage(settledResult.reason));
-  });
+  }
 
   const evidence = capEvidence(
     dedupeEvidence(sortEvidence([...evidenceBySource.values()].flat())),
@@ -384,4 +389,16 @@ function errorToMessage(err: unknown): string {
     return err.message;
   }
   return String(err);
+}
+
+function isAbortLikeError(err: unknown): boolean {
+  if (err instanceof Error && err.name === "AbortError") return true;
+  if (
+    typeof DOMException !== "undefined" &&
+    err instanceof DOMException &&
+    err.name === "AbortError"
+  ) {
+    return true;
+  }
+  return isAbortReason(err);
 }


### PR DESCRIPTION
Addresses Codex P1 feedback on #28134.

`runDeterministicRecallSearch` was folding every adapter rejection (including `AbortError` from cancelled `context.signal`) into a degraded-source note, breaking cancellation propagation. Now re-throws abort-class errors (DOMException AbortError, Error.name === 'AbortError', tagged `AbortReason`) from both the pkb context fetch and the `Promise.allSettled` fanout.