### PR TITLE
fix(recall): tighten secret-name filter and bound traversal work

### DIFF
--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -66,6 +66,9 @@ const SECRET_SEGMENT_NAMES = new Set([
   "ces-security",
 ]);
 
+const SECRET_TOKEN_PATTERN =
+  /(?:^|[-_.])(?:keys?|secrets?|tokens?)(?:[-_.]|$)/i;
+
 const QUERY_STOP_WORDS = new Set([
   "a",
   "about",
@@ -591,8 +594,13 @@ async function maybeSearchResolvedFile(
   matches: WorkspaceMatch[],
   state: WalkState,
 ): Promise<void> {
+  if (state.scannedRelativePaths.has(relativePath)) {
+    return;
+  }
+  state.scannedRelativePaths.add(relativePath);
+  state.scannedFiles += 1;
+
   if (
-    state.scannedRelativePaths.has(relativePath) ||
     shouldSkipWorkspaceFile(relativePath) ||
     shouldSkipFilePath(relativePath) ||
     fileSizeBytes > WORKSPACE_SOURCE_MAX_FILE_SIZE_BYTES
@@ -600,8 +608,6 @@ async function maybeSearchResolvedFile(
     return;
   }
 
-  state.scannedRelativePaths.add(relativePath);
-  state.scannedFiles += 1;
   matches.push(
     ...(await searchFile(realPath, relativePath, fileSizeBytes, queryTerms)),
   );
@@ -1181,9 +1187,7 @@ function shouldSkipSegmentName(name: string): boolean {
   return (
     GENERATED_OR_DEPENDENCY_DIR_NAMES.has(lowerName) ||
     lowerName.startsWith(".env") ||
-    lowerName.includes("key") ||
-    lowerName.includes("secret") ||
-    lowerName.includes("token") ||
+    SECRET_TOKEN_PATTERN.test(lowerName) ||
     lowerName.startsWith("credentials") ||
     SECRET_SEGMENT_NAMES.has(lowerName)
   );


### PR DESCRIPTION
Follow-up to #28129 addressing review feedback.

## Summary
- Replace substring `includes("key"|"secret"|"token")` checks with a separator-bounded regex so common names like `keyboard.ts`, `tokenizer.py`, `monkey.md`, and `hotkeys.md` are no longer hidden from workspace recall. The pattern still drops genuine secret-shaped names (`api-key.md`, `secret-plan.md`, `token-cache.md`, `keys.enc`).
- Increment `state.scannedFiles` whenever a file is examined, not only when it passes extension/size filters, so the per-bucket budget bounds traversal work in dirty repos.

## Test plan
- [x] `bun test src/__tests__/context-search-workspace-source.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->