### PR TITLE
fix(recall): exclude current conversation and notification seeds from conversation source

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -68,7 +68,7 @@ describe("searchConversationSource", () => {
     ]);
   });
 
-  test("does not return derived subagent or auto-analysis conversations", async () => {
+  test("does not return derived subagent, auto-analysis, or notification conversations", async () => {
     const visible = await seedConversation({
       title: "User conversation",
       content: "derivedtoken belongs to a user-authored conversation.",
@@ -83,6 +83,11 @@ describe("searchConversationSource", () => {
       source: "auto-analysis",
       content: "derivedtoken should not include auto-analysis output.",
     });
+    await seedConversation({
+      title: "Notification conversation",
+      source: "notification",
+      content: "derivedtoken should not include notification seed output.",
+    });
 
     const result = await searchConversationSource(
       "derivedtoken",
@@ -92,6 +97,27 @@ describe("searchConversationSource", () => {
 
     expect(result.evidence.map((item) => item.locator)).toEqual([
       `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
+  test("excludes the current conversation from recall results", async () => {
+    const other = await seedConversation({
+      title: "Other conversation",
+      content: "currenttoken appears in another conversation.",
+    });
+    const current = await seedConversation({
+      title: "Current conversation",
+      content: "currenttoken appears in the active conversation.",
+    });
+
+    const result = await searchConversationSource(
+      "currenttoken",
+      makeContext({ conversationId: current.conversation.id }),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${other.conversation.id}#${other.message.id}`,
     ]);
   });
 

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -7,6 +7,7 @@ import { rawAll } from "../../raw-query.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
 const SUBAGENT_SOURCE = "subagent";
+const NOTIFICATION_SOURCE = "notification";
 
 interface ConversationEvidenceRow {
   message_id: string;
@@ -88,7 +89,10 @@ export async function searchConversationSource(
 
   for (const ftsMatch of ftsMatches) {
     try {
-      rows = mergeConversationRows(rows, searchWithFts(ftsMatch, queryLimit));
+      rows = mergeConversationRows(
+        rows,
+        searchWithFts(ftsMatch, queryLimit, context.conversationId),
+      );
     } catch {
       // Try the next, broader query shape.
     }
@@ -97,7 +101,7 @@ export async function searchConversationSource(
   }
 
   if (rows.length === 0) {
-    rows = searchWithLike(trimmedQuery, queryLimit);
+    rows = searchWithLike(trimmedQuery, queryLimit, context.conversationId);
   }
 
   const sortedRows = rows
@@ -128,6 +132,7 @@ export async function searchConversationSource(
 function searchWithFts(
   ftsMatch: string,
   limit: number,
+  excludedConversationId: string,
 ): ConversationEvidenceRow[] {
   return rawAll<ConversationEvidenceRow>(
     `
@@ -143,13 +148,16 @@ function searchWithFts(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
       AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
-      AND (c.source IS NULL OR c.source NOT IN (?, ?))
+      AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
+      AND c.id != ?
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
     `,
     ftsMatch,
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
+    NOTIFICATION_SOURCE,
+    excludedConversationId,
     limit,
   );
 }
@@ -157,6 +165,7 @@ function searchWithFts(
 function searchWithLike(
   query: string,
   limit: number,
+  excludedConversationId: string,
 ): ConversationEvidenceRow[] {
   return rawAll<ConversationEvidenceRow>(
     `
@@ -171,13 +180,16 @@ function searchWithLike(
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
       AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
-      AND (c.source IS NULL OR c.source NOT IN (?, ?))
+      AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
+      AND c.id != ?
     ORDER BY m.created_at DESC
     LIMIT ?
     `,
     buildLikePattern(query),
     SUBAGENT_SOURCE,
     AUTO_ANALYSIS_SOURCE,
+    NOTIFICATION_SOURCE,
+    excludedConversationId,
     limit,
   );
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from devin and codex on #28132.

- Filter out the current conversation (`context.conversationId`) from `searchConversationSource` results in both the FTS and LIKE paths.
- Exclude conversations with `source = 'notification'` from recall results, alongside the existing `subagent` and `auto-analysis` exclusions. Notification seeds are deliberately not memory-indexed; they should not be returned as conversational evidence either.

## Test plan
- [x] `bun test src/__tests__/context-search-conversations-source.test.ts`