### PR TITLE
fix(recall): reject finish_recall payloads without supporting citations

### DIFF
--- a/assistant/src/__tests__/context-search-agent-protocol.test.ts
+++ b/assistant/src/__tests__/context-search-agent-protocol.test.ts
@@ -214,6 +214,25 @@ describe("recall agent validation helpers", () => {
         citationIds: [],
       },
     });
+
+    expect(
+      validateFinishRecallPayload(
+        {
+          answer: "Confident answer with no supporting evidence.",
+          confidence: "high",
+          citation_ids: [],
+        },
+        [makeEvidence("ev-1")],
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_citations",
+      finish: {
+        answer: "No reliable answer could be produced by the recall agent.",
+        confidence: "low",
+        citationIds: [],
+      },
+    });
   });
 
   test("defaults to all source descriptions when available sources are omitted", () => {

--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -263,8 +263,8 @@ describe("runAgenticRecall", () => {
     ]);
     expect(result.debug).toMatchObject({
       mode: "deterministic_fallback",
-      fallbackReason: "finish_answer_validation_failed",
-      fallbackDetail: "negative_or_incomplete_finish_with_relevant_evidence",
+      fallbackReason: "citation_validation_failed",
+      fallbackDetail: "missing_citations",
     });
     expect(result.content).toContain("Found evidence:");
     expect(result.content).toContain("Lives at Bob's parents' house in Katy");

--- a/assistant/src/memory/context-search/agent-protocol.ts
+++ b/assistant/src/memory/context-search/agent-protocol.ts
@@ -34,6 +34,7 @@ type RecallFinishFallbackReason =
   | "malformed_finish_payload"
   | "invalid_confidence"
   | "invalid_citation_ids"
+  | "missing_citations"
   | "unknown_citation_ids"
   | "empty_answer";
 
@@ -291,6 +292,10 @@ export function validateFinishRecallPayload(
 
   if (!isStringArray(payload.citation_ids)) {
     return fallbackFinish("invalid_citation_ids");
+  }
+
+  if (payload.citation_ids.length === 0) {
+    return fallbackFinish("missing_citations");
   }
 
   const citationValidation = validateRecallCitationIds(


### PR DESCRIPTION
## Summary
- Reject finish_recall payloads with empty `citation_ids` so confident answers without supporting evidence trigger the deterministic fallback instead of propagating.
- Adds `missing_citations` fallback reason and a focused test for the confident-empty-citations case.

Addresses Codex feedback on #28136.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->