### PR TITLE
fix(macos): preserve foreground-only serverOffset on SSE pushes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -108,7 +108,11 @@ final class ConversationRestorer {
             for await message in self.eventStreamClient.subscribe() {
                 switch message {
                 case .conversationListResponse(let response):
-                    self.handleConversationListResponse(response)
+                    // SSE-pushed responses don't have the foreground/background
+                    // separation that fetchConversationList enforces, so they
+                    // must not touch serverOffset (which paginates the
+                    // foreground endpoint only).
+                    self.handleConversationListResponse(response, updateServerOffset: false)
                 case .historyResponse(let response):
                     self.handleHistoryResponse(response)
                 case .conversationTitleUpdated(let response):


### PR DESCRIPTION
## Summary

Address Devin review feedback on #28143: the new `updateServerOffset` parameter on `handleConversationListResponse` defaulted to `true`, so SSE-pushed conversation list responses could overwrite `serverOffset` with a count that includes background conversations — breaking foreground-only pagination semantics that `fetchConversationList` carefully maintains.

Pass `updateServerOffset: false` from the SSE event subscription so SSE responses preserve the prior behavior where only `fetchConversationList` controls `serverOffset`.

## Test plan
- [ ] Existing ConversationRestorer tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->