### PR TITLE
fix(daemon): reject legacy private conversationType and hide private rows from foreground lists

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -51,9 +51,13 @@ export function listConversations(
   ensureDisplayOrderMigration();
   ensureGroupMigration();
   const db = getDb();
+  // 'private' is excluded defensively: in-place snapshot restore swaps the
+  // SQLite file without running migrations in-process, so legacy private rows
+  // can briefly exist before migration cleanup. Hide them from foreground
+  // lists until the next migration pass deletes them.
   const typeCond = backgroundOnly
     ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
-    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled')`;
+    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`;
   const where = includeArchived
     ? typeCond
     : sql`${typeCond} AND ${conversations.archivedAt} IS NULL`;
@@ -80,7 +84,7 @@ export function listPinnedConversations(): ConversationRow[] {
     .from(conversations)
     .where(
       and(
-        sql`${conversations.conversationType} NOT IN ('background', 'scheduled')`,
+        sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`,
         sql`is_pinned = 1`,
       ),
     )

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1243,6 +1243,15 @@ export async function handleSendMessage(
     );
   }
 
+  // Reject the legacy "private" mode explicitly rather than silently coercing
+  // it to "standard" — clients that still populate this field expect privacy
+  // semantics that no longer exist.
+  if (body.conversationType === "private") {
+    throw new BadRequestError(
+      "Private conversations are no longer supported. Update your client to omit conversationType or send 'standard'.",
+    );
+  }
+
   // Desktop messages are always from the guardian — reset the heartbeat
   // timer so the next heartbeat is a full interval after this interaction.
   HeartbeatService.getInstance()?.resetTimer();


### PR DESCRIPTION
## Summary

Addresses post-merge feedback on #28141.

- **Reject explicit \`private\` mode in send route** (Codex P1). The send route was hardcoding \`conversationType: \"standard\"\` and silently downgrading any client that still posted \`\"private\"\`. Returns a \`400\` instead so legacy clients fail loudly rather than getting persistent standard threads with privacy semantics they did not ask for.
- **Defensively exclude \`private\` from foreground conversation lists** (Codex P2). In-place snapshot restore swaps the SQLite file without running migrations in-process, so legacy private rows can transiently exist after restore. Keep them hidden from list/pinned views until migration 229 cleans them up.

Devin's flagged finding was already resolved in the merged migration (lines 152-156 / 170-173 of \`229-delete-private-conversations.ts\` already delete \`memory_graph_nodes\` and their embeddings) — no change needed.

## Test plan

- [ ] Posting \`{ conversationType: \"private\" }\` to the send route returns 400.
- [ ] Foreground conversation list does not include legacy \`private\`-typed rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->