### PR TITLE
fix(recall): guard against empty cited evidence after finish_recall

### DIFF
--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -694,6 +694,13 @@ function finishRecallFromToolUse(
   }
 
   const citedEvidence = selectCitedEvidence(promptEvidence, finish.citationIds);
+  if (citedEvidence.length === 0) {
+    return {
+      ok: false,
+      reason: "citation_validation_failed",
+      detail: "finish_recall returned no resolvable citations",
+    };
+  }
   debug.finish = {
     confidence: finish.confidence,
     citationIds: finish.citationIds,


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #28138.

`validateFinishRecallPayload` already rejects empty \`citation_ids\` at the protocol layer, but Codex flagged a defense-in-depth concern at the call site: if \`selectCitedEvidence\` ever returns an empty array (e.g., a future protocol change relaxing the empty-citations check), the agent would emit an uncited final answer that bypasses deterministic fallback.

Adds an explicit guard in \`finishRecallFromToolUse\` that triggers \`citation_validation_failed\` fallback when \`citedEvidence\` is empty.

## Test plan
- [x] Type-check
- [ ] No behavior change for the validated path (citation_ids non-empty + all valid → guard never trips)

Addresses feedback on #28138.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->