### PR TITLE
fix(recall): drop dead conversation_type='private' filter

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -121,52 +121,6 @@ describe("searchConversationSource", () => {
     ]);
   });
 
-  test("does not return legacy private conversations through the FTS path", async () => {
-    const visible = await seedConversation({
-      title: "Visible conversation",
-      content: "privatesecret belongs to a normal conversation.",
-    });
-    const hidden = await seedConversation({
-      title: "Private conversation",
-      content: "privatesecret belongs to a private conversation.",
-    });
-    rawRun(
-      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
-      hidden.conversation.id,
-    );
-
-    const result = await searchConversationSource(
-      "privatesecret",
-      makeContext(),
-      10,
-    );
-
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${visible.conversation.id}#${visible.message.id}`,
-    ]);
-  });
-
-  test("does not return legacy private conversations through the LIKE path", async () => {
-    const visible = await seedConversation({
-      title: "Visible short query conversation",
-      content: "zz appears in a normal conversation.",
-    });
-    const hidden = await seedConversation({
-      title: "Private short query conversation",
-      content: "zz appears in a private conversation.",
-    });
-    rawRun(
-      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
-      hidden.conversation.id,
-    );
-
-    const result = await searchConversationSource("zz", makeContext(), 10);
-
-    expect(result.evidence.map((item) => item.locator)).toEqual([
-      `${visible.conversation.id}#${visible.message.id}`,
-    ]);
-  });
-
   test("includes archived, scheduled, and background conversations", async () => {
     const archived = await seedConversation({
       title: "Archived conversation",

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -147,7 +147,6 @@ function searchWithFts(
     JOIN messages m ON m.id = messages_fts.message_id
     JOIN conversations c ON c.id = m.conversation_id
     WHERE messages_fts MATCH ?
-      AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
       AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
       AND c.id != ?
     ORDER BY bm25(messages_fts), m.created_at DESC
@@ -179,7 +178,6 @@ function searchWithLike(
     FROM messages m
     JOIN conversations c ON c.id = m.conversation_id
     WHERE m.content LIKE ? ESCAPE '\\'
-      AND (c.conversation_type IS NULL OR c.conversation_type != 'private')
       AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
       AND c.id != ?
     ORDER BY m.created_at DESC


### PR DESCRIPTION
## Summary
- Remove the `conversation_type != 'private'` clause from both FTS and LIKE recall queries in `assistant/src/memory/context-search/sources/conversations.ts`. Migration 229 already deletes every `private` row and no code path can insert one, so the filter is dead.
- Drop the two `legacy private conversations` tests that hand-set `conversation_type='private'` to exercise the filter. They no longer test a reachable behavior.

Addresses [Devin's review feedback](https://github.com/vellum-ai/vellum-assistant/pull/28150#discussion_r3141811339) on #28150.

## Test plan
- [x] `bun test src/__tests__/context-search-conversations-source.test.ts` (7 pass)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->