### PR TITLE
test(macos): assert clear-PATCH precedes SET-PATCH in CallSiteOverridesSheetTests

### DIFF
--- a/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/CallSiteOverridesSheetTests.swift
@@ -41,29 +41,31 @@ final class CallSiteOverridesSheetTests: XCTestCase {
     }
 
     /// Returns the most recent `llm.callSites.<id>` SET payload (a
-    /// dictionary entry) written to the mock client. Walks the patch
-    /// history newest-first and skips clear-PATCHes (which encode the
-    /// entry as `NSNull`).
-    private func lastEntryPatch(for id: String) -> [String: Any]? {
-        for payload in mockSettingsClient.patchConfigCalls.reversed() {
+    /// dictionary entry) written to the mock client, paired with its
+    /// index in the patch history. Walks the patch history newest-first
+    /// and skips clear-PATCHes (which encode the entry as `NSNull`).
+    private func lastEntryPatch(for id: String) -> (index: Int, entry: [String: Any])? {
+        for (index, payload) in mockSettingsClient.patchConfigCalls.enumerated().reversed() {
             guard let llm = payload["llm"] as? [String: Any],
                   let sites = llm["callSites"] as? [String: Any],
                   let entry = sites[id] as? [String: Any] else { continue }
-            return entry
+            return (index, entry)
         }
         return nil
     }
 
-    /// Returns true if any patch in history nulled `llm.callSites.<id>`
-    /// at the entry level. `replaceCallSiteOverride` emits a clear-PATCH
-    /// (`[id: NSNull()]`) first, then a set-PATCH with the new fields.
-    private func didClearEntry(for id: String) -> Bool {
-        for payload in mockSettingsClient.patchConfigCalls {
+    /// Returns the index of the first patch that nulled
+    /// `llm.callSites.<id>` at the entry level, or nil if no such patch
+    /// exists. `replaceCallSiteOverride` must emit this clear-PATCH
+    /// (`[id: NSNull()]`) before the set-PATCH; callers assert the
+    /// returned index precedes the set-PATCH index.
+    private func entryClearIndex(for id: String) -> Int? {
+        for (index, payload) in mockSettingsClient.patchConfigCalls.enumerated() {
             guard let llm = payload["llm"] as? [String: Any],
                   let sites = llm["callSites"] as? [String: Any] else { continue }
-            if sites[id] is NSNull { return true }
+            if sites[id] is NSNull { return index }
         }
-        return false
+        return nil
     }
 
     // MARK: - Profile picker value derivation
@@ -199,20 +201,30 @@ final class CallSiteOverridesSheetTests: XCTestCase {
         // Assert: an entry-level clear-PATCH preceded the SET-PATCH, so any
         // stale fragment leaves on the daemon are deleted. The SET-PATCH
         // then contains only `{ profile }` — no NSNull leaves are needed
-        // because the entry was already wiped.
-        XCTAssertTrue(
-            didClearEntry(for: "memoryRetrieval"),
-            "replaceCallSiteOverride must first NSNull-clear the entry"
+        // because the entry was already wiped. Order matters: a regression
+        // that emits SET before CLEAR would leave the daemon in a cleared
+        // state, so we assert the relative indices, not just presence.
+        guard let clearIndex = entryClearIndex(for: "memoryRetrieval") else {
+            XCTFail("replaceCallSiteOverride must first NSNull-clear the entry")
+            return
+        }
+        guard let setPatch = lastEntryPatch(for: "memoryRetrieval") else {
+            XCTFail("replaceCallSiteOverride must emit a SET-PATCH after the clear")
+            return
+        }
+        XCTAssertLessThan(
+            clearIndex, setPatch.index,
+            "Entry-level clear-PATCH must precede the SET-PATCH"
         )
-        let entry = lastEntryPatch(for: "memoryRetrieval")
-        XCTAssertEqual(entry?["profile"] as? String, "balanced")
+        let entry = setPatch.entry
+        XCTAssertEqual(entry["profile"] as? String, "balanced")
         // SET-PATCH carries only `profile`; the entry-level clear deletes
         // all legacy fragment fields, so no NSNull leaves are needed here.
-        XCTAssertNil(entry?["provider"])
-        XCTAssertNil(entry?["model"])
-        XCTAssertNil(entry?["maxTokens"])
-        XCTAssertNil(entry?["effort"])
-        XCTAssertNil(entry?["thinking"])
+        XCTAssertNil(entry["provider"])
+        XCTAssertNil(entry["model"])
+        XCTAssertNil(entry["maxTokens"])
+        XCTAssertNil(entry["effort"])
+        XCTAssertNil(entry["thinking"])
 
         // Local cache reflects the new profile-only override.
         let cached = store.callSiteOverrides.first(where: { $0.id == "memoryRetrieval" })
@@ -242,10 +254,20 @@ final class CallSiteOverridesSheetTests: XCTestCase {
         )
         waitForPatchCount(2)
 
-        XCTAssertTrue(didClearEntry(for: "mainAgent"))
-        let entry = lastEntryPatch(for: "mainAgent")
-        XCTAssertEqual(entry?["profile"] as? String, "balanced")
-        XCTAssertNil(entry?["provider"])
-        XCTAssertNil(entry?["model"])
+        guard let clearIndex = entryClearIndex(for: "mainAgent") else {
+            XCTFail("replaceCallSiteOverride must first NSNull-clear the entry")
+            return
+        }
+        guard let setPatch = lastEntryPatch(for: "mainAgent") else {
+            XCTFail("replaceCallSiteOverride must emit a SET-PATCH after the clear")
+            return
+        }
+        XCTAssertLessThan(
+            clearIndex, setPatch.index,
+            "Entry-level clear-PATCH must precede the SET-PATCH"
+        )
+        XCTAssertEqual(setPatch.entry["profile"] as? String, "balanced")
+        XCTAssertNil(setPatch.entry["provider"])
+        XCTAssertNil(setPatch.entry["model"])
     }
 }


### PR DESCRIPTION
## Summary
Address codex P2 feedback on #28146: the prior assertions checked that an entry-level NSNull clear-PATCH appeared *somewhere* in history and that the latest dictionary patch carried only `{ profile }`, but did not enforce the relative order. A regression in `replaceCallSiteOverride` that emitted SET before CLEAR would still pass both assertions even though the daemon's final state would be cleared.

- `lastEntryPatch(for:)` now returns `(index, entry)` instead of just the entry.
- `didClearEntry(for:)` is now `entryClearIndex(for:)` and returns the index (or nil).
- Both `testSelectingProfileClearsLegacyFragmentFieldsInPatch` and `testSelectingProfileFromAnotherProfileEmitsCleanEntry` now assert `clearIndex < setIndex`.

## Test plan
- [x] `cd clients && swift test --filter CallSiteOverridesSheetTests` — all 8 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->