### PR TITLE
fix(voice): restore side-effect double-defense for non-guardian phone voice

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -314,7 +314,8 @@ export async function startVoiceTurn(
 
   // Phone voice has no interactive permission/secret UI, so apply explicit
   // per-role policies by default. Local live voice opts into the normal
-  // client approval path instead.
+  // client approval path instead. Side-effect double-defense is wired
+  // below at the conversation-configure point.
   const trustClass = opts.trustContext?.trustClass;
   const isGuardian = trustClass === "guardian";
   const approvalMode = opts.approvalMode ?? "phone-call";
@@ -386,7 +387,13 @@ export async function startVoiceTurn(
     }
   }
 
-  // Configure conversation for this voice turn
+  // Non-guardian phone voice forces side-effect tools to prompt so the
+  // auto-deny handler below reliably sees a confirmation_request. Without
+  // this, a broad allow trust rule (e.g. wildcard bash) would let
+  // side-effect tools execute without ever emitting an event for the
+  // auto-deny / scoped-grant handler to intercept.
+  conversation.forcePromptSideEffects =
+    !isGuardian && !usesLocalInteractiveApprovals;
   conversation.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
   conversation.callSessionId = voiceSessionId;
   conversation.setTrustContext(opts.trustContext ?? null);
@@ -549,6 +556,7 @@ export async function startVoiceTurn(
     conversation.setAssistantId("self");
     conversation.setVoiceCallControlPrompt(null);
     conversation.callSessionId = undefined;
+    conversation.forcePromptSideEffects = false;
     // Reset the conversation's client callback to a no-op so the stale
     // closure doesn't intercept events from future turns on the same conversation.
     conversation.updateClient(() => {}, true);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -156,6 +156,7 @@ export function createToolExecutor(
       onOutput,
       signal: ctx.abortController?.signal,
       allowedToolNames: ctx.allowedToolNames,
+      forcePromptSideEffects: ctx.forcePromptSideEffects,
       diskPressureCleanupModeActive: ctx.diskPressureCleanupModeActive,
       toolUseId,
       isPlatformHosted: getIsPlatform(),

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -233,6 +233,14 @@ export class Conversation {
   };
   /** @internal */ surfaceActionRequestIds = new Set<string>();
   /** @internal */ approvedViaPromptThisTurn = false;
+  /**
+   * When true, side-effect tools must prompt even if a trust/allow rule
+   * would auto-allow. Set by non-interactive callers (e.g. non-guardian
+   * phone voice) so their auto-deny handler reliably sees a
+   * `confirmation_request` event. See ToolSetupContext.forcePromptSideEffects.
+   * @internal
+   */
+  forcePromptSideEffects = false;
   /** @internal */ pendingSurfaceActions = new Map<
     string,
     { surfaceType: SurfaceType }

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -41,6 +41,15 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   /** Turn-scoped flag: true when any tool call in the current turn received explicit user approval via interactive prompt. Cleared at turn end. */
   approvedViaPromptThisTurn?: boolean;
   /**
+   * When true, side-effect tools must prompt for confirmation even if a
+   * trust/allow rule would auto-allow them. Set by callers without an
+   * interactive approval UI (e.g. non-guardian phone voice turns) to force
+   * a `confirmation_request` event that the caller's auto-deny / scoped-grant
+   * handler can intercept. Provides a second layer of defense against broad
+   * trust rules auto-executing side-effect tools in non-interactive contexts.
+   */
+  forcePromptSideEffects?: boolean;
+  /**
    * Per-turn snapshot of the resolved inference-profile override, set by
    * `runAgentLoopImpl`. Propagated into `ToolContext.overrideProfile` so
    * tools that spawn nested invocations (e.g. `subagent_spawn`) can forward

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -9,7 +9,11 @@ import {
 } from "../permissions/checker.js";
 import { getAutoApproveThreshold } from "../permissions/gateway-threshold-reader.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
-import type { ApprovalMode, ApprovalReason, RiskThreshold } from "../permissions/types.js";
+import type {
+  ApprovalMode,
+  ApprovalReason,
+  RiskThreshold,
+} from "../permissions/types.js";
 import { RiskLevel } from "../permissions/types.js";
 import { getLogger } from "../util/logger.js";
 import { buildPolicyContext } from "./policy-context.js";
@@ -160,9 +164,11 @@ export class PermissionChecker {
       );
       const riskThreshold = conversationThreshold as RiskThreshold;
 
-      // Some callers force prompting for side-effect tools even when a
-      // trust/allow rule would auto-allow. Deny decisions are preserved -
-      // only allow → prompt promotion happens here.
+      // Non-interactive callers (e.g. non-guardian phone voice) force
+      // prompting for side-effect tools even when a trust/allow rule would
+      // auto-allow, so their auto-deny handler always sees a
+      // confirmation_request. Deny decisions are preserved — only
+      // allow → prompt promotion happens here.
       if (
         context.forcePromptSideEffects &&
         result.decision === "allow" &&
@@ -200,7 +206,9 @@ export class PermissionChecker {
           reason: result.reason,
           durationMs,
         });
-        const provenance = mapApprovalProvenance("denied", { matchedTrustRuleId });
+        const provenance = mapApprovalProvenance("denied", {
+          matchedTrustRuleId,
+        });
         return {
           allowed: false,
           decision: "denied",


### PR DESCRIPTION
## Summary

Addresses Codex P1 and Devin review feedback on #28139.

PR #28139 removed `strictSideEffects` from `ConversationMemoryPolicy`. As a side effect, it dropped the only caller setting `forcePromptSideEffects` on tool execution — the voice bridge had relied on that wiring to promote trust-rule `allow` → `prompt` for non-guardian voice callers, with the auto-deny confirmation handler as the second layer of defense.

With only the auto-deny layer left, broad allow trust rules (e.g. a wildcard `bash` allow) let side-effect tools auto-execute without ever firing a `confirmation_request` event. The auto-deny / scoped-grant handler in `updateClient` never fires, and a non-guardian phone caller could trigger arbitrary side-effect tools.

This PR restores the double-defense by adding a `forcePromptSideEffects` flag directly on `Conversation` (independent of the now-removed memory-policy wiring), threaded into `ToolContext.forcePromptSideEffects`. The voice bridge sets it for non-guardian phone turns and clears it on cleanup.

## Why not restore via ConversationMemoryPolicy

The `strictSideEffects` removal is the deliberate intent of the `remove-private-conversations` plan. Re-adding it to `ConversationMemoryPolicy` would undo that work. The new flag is a per-conversation runtime concern (non-interactive caller posture), not a memory-isolation concern, so it lives directly on `Conversation` and is plumbed through `ToolSetupContext`.

## Skipped: Codex's suggestion to restore private memory policy derivation

Codex's other P1 (`assistant/src/daemon/server.ts:410`, \"restore private memory policy derivation for private threads\") was deliberately skipped — that suggestion would undo the explicit removal of private conversations in the parent plan. After migration 229 (`delete-private-conversations`), no private-conversation rows remain; `normalizeConversationType` collapses \"private\" → \"standard\" for any callers still passing the legacy value; and the runtime indexing/summarization paths all write `scopeId: \"default\"`. The split Devin's analysis warned about doesn't materialize at runtime.

## Files changed

- `assistant/src/daemon/conversation.ts` — new `forcePromptSideEffects` field
- `assistant/src/daemon/tool-setup-types.ts` — add field to `ToolSetupContext`
- `assistant/src/daemon/conversation-tool-setup.ts` — propagate to `ToolContext`
- `assistant/src/calls/voice-session-bridge.ts` — set for non-guardian phone voice; clear on cleanup
- `assistant/src/tools/permission-checker.ts` — comment refresh

## Test plan

- [ ] Existing `voice-session-bridge.test.ts` and `tool-executor.test.ts` cover the auto-deny path
- [ ] Manual: non-guardian phone call attempting a side-effect tool with a broad allow trust rule should now hit the auto-deny path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->