### PR TITLE
fix(recall): permit zero auto-injected PKB budget when cap is exhausted

### DIFF
--- a/assistant/src/memory/context-search/search.ts
+++ b/assistant/src/memory/context-search/search.ts
@@ -335,6 +335,9 @@ function getReservedAutoInjectedTextBudget(
   const sourceRemaining = autoInjectedSourceCap - sourceTextSize;
   const totalRemaining = RECALL_TOTAL_EVIDENCE_TEXT_CAP - state.totalTextSize;
   const remaining = Math.min(sourceRemaining, totalRemaining);
+  if (remaining <= 0) {
+    return 0;
+  }
   return Math.max(1, Math.floor(remaining / state.autoInjectedRemaining));
 }
 


### PR DESCRIPTION
## Summary
Addresses Codex+Devin feedback on #28225. `getReservedAutoInjectedTextBudget` clamped to `Math.max(1, ...)`, so once regular PKB evidence consumed the auto-injected cap, each auto-injected item still received a 1-char budget — producing near-useless 1-character excerpts that took up result slots. Now returns 0 when no budget remains, letting `appendCappedEvidence`'s existing `remaining <= 0` guard skip the item.

## Test plan
- [ ] Existing recall ordering tests continue to pass