### PR TITLE
fix(chat): restore starter chip on delete failure

### DIFF
--- a/clients/shared/Features/Chat/ChatGreetingState.swift
+++ b/clients/shared/Features/Chat/ChatGreetingState.swift
@@ -140,8 +140,12 @@ public final class ChatGreetingState {
     }
 
     public func removeConversationStarter(_ starter: ConversationStarter) {
+        guard let removedIndex = conversationStarters.firstIndex(where: { $0.id == starter.id }) else {
+            return
+        }
+        let removedStarter = conversationStarters[removedIndex]
         removedConversationStarterIds.insert(starter.id)
-        conversationStarters.removeAll { $0.id == starter.id }
+        conversationStarters.remove(at: removedIndex)
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -149,6 +153,10 @@ public final class ChatGreetingState {
             guard !Task.isCancelled else { return }
             if !deleted {
                 self.removedConversationStarterIds.remove(starter.id)
+                if !self.conversationStarters.contains(where: { $0.id == removedStarter.id }) {
+                    let insertAt = min(removedIndex, self.conversationStarters.count)
+                    self.conversationStarters.insert(removedStarter, at: insertAt)
+                }
                 self.fetchConversationStarters()
             }
         }


### PR DESCRIPTION
Addresses Codex P2 feedback on #28208: when the DELETE round-trip fails, optimistically restore the chip locally so a failed reconciliation fetch can't silently swallow the starter for the rest of the session.