### PR TITLE
fix(macos-ci): match SPM stale artifact paths containing spaces

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -140,7 +140,7 @@ swift_with_retry() {
         # Common on hosted CI runners with rotated/partial caches.
         if [ "$_artifact_cleaned" -eq 0 ] && grep -q "already exists in file system" "$_stderr_log" 2>/dev/null; then
             echo "warning: stale SPM binary artifact detected, cleaning and retrying..."
-            sed -nE 's/.*: (\/[^[:space:]]+) already exists in file system.*/\1/p' "$_stderr_log" 2>/dev/null \
+            sed -nE 's/.*: (\/.+) already exists in file system.*/\1/p' "$_stderr_log" 2>/dev/null \
                 | sort -u \
                 | while IFS= read -r _stale_path; do
                     [ -n "$_stale_path" ] && rm -rf "$_stale_path"


### PR DESCRIPTION
Addresses Codex feedback on #28233.

The previous regex `\/[^[:space:]]+` could not capture artifact paths when the checkout directory contained spaces (common on macOS). When that happened, no stale path was removed but `_artifact_cleaned` was still set, so the same `already exists in file system` failure repeated on retry.

Capture everything up to the fixed ` already exists in file system` suffix instead of rejecting whitespace in the path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->