### PR TITLE
fix(recall): dedupe agentic fallback evidence by content signature

### DIFF
--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -1291,7 +1291,9 @@ function withFallbackEvidence(
   result: DeterministicRecallSearchResult,
   evidence: readonly RecallEvidence[],
 ): DeterministicRecallSearchResult {
-  const orderedEvidence = demoteAutoInjectedContextEvidence(evidence);
+  const orderedEvidence = demoteAutoInjectedContextEvidence(
+    dedupeEvidenceByContent(evidence),
+  );
   const evidenceCountBySource = new Map<RecallSource, number>();
   for (const item of orderedEvidence) {
     evidenceCountBySource.set(
@@ -1308,6 +1310,29 @@ function withFallbackEvidence(
       evidenceCount: evidenceCountBySource.get(note.source) ?? 0,
     })),
   };
+}
+
+function dedupeEvidenceByContent(
+  evidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  const seenIds = new Set<string>();
+  const seenContent = new Set<string>();
+  const deduped: RecallEvidence[] = [];
+
+  for (const item of evidence) {
+    if (seenIds.has(item.id)) {
+      continue;
+    }
+    const contentKey = `${item.source}\0${item.locator}\0${item.excerpt}`;
+    if (seenContent.has(contentKey)) {
+      continue;
+    }
+    seenIds.add(item.id);
+    seenContent.add(contentKey);
+    deduped.push(item);
+  }
+
+  return deduped;
 }
 
 function deterministicFallback(


### PR DESCRIPTION
Addresses Codex feedback on #28160.

`withFallbackEvidence` now returns the accumulated evidence after a content-based dedupe (`source + locator + excerpt`), in addition to the existing id dedupe in `mergeEvidence`. PKB semantic IDs include a rank index (`pkb:<path>:<index>`), so the same underlying hit returned with different ranks across rounds previously surfaced as duplicate citations and inflated source counts in round-limit/citation-validation fallback paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->