### PR TITLE
fix(acp): apply SQL limit to acp_session_history query

### DIFF
--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -56,9 +56,7 @@ async function spawnSession({ body }: RouteHandlerArgs) {
   const cwd = (body?.cwd as string | undefined) ?? process.cwd();
 
   if (!agent || !task || !conversationId) {
-    throw new BadRequestError(
-      "agent, task, and conversationId are required",
-    );
+    throw new BadRequestError("agent, task, and conversationId are required");
   }
 
   const resolved = resolveAcpAgent(agent);
@@ -182,10 +180,7 @@ function deleteSession({ pathParams }: RouteHandlerArgs) {
     // Not in memory — fall through to the (idempotent) DB delete.
   }
 
-  getDb()
-    .delete(acpSessionHistory)
-    .where(eq(acpSessionHistory.id, id))
-    .run();
+  getDb().delete(acpSessionHistory).where(eq(acpSessionHistory.id, id)).run();
   const deleted = rawChanges() > 0;
   log.info({ acpSessionId: id, deleted }, "ACP session history delete");
   return { deleted };
@@ -376,7 +371,14 @@ function listMergedSessions(opts: {
         eq(acpSessionHistory.parentConversationId, opts.conversationId),
       )
     : baseQuery;
-  const historyRows = filtered.orderBy(desc(acpSessionHistory.startedAt)).all();
+  // Fetch only enough rows to fill the requested page after merging with
+  // in-memory sessions. In-memory entries take precedence on id collision,
+  // so we pad by inMemory.length to guarantee we still surface `limit`
+  // distinct rows even when every in-memory session shadows a DB row.
+  const historyRows = filtered
+    .orderBy(desc(acpSessionHistory.startedAt))
+    .limit(opts.limit + inMemory.length)
+    .all();
 
   for (const row of historyRows) {
     if (merged.has(row.id)) continue;


### PR DESCRIPTION
## Summary
- Pushes `?limit` into the `acp_session_history` SELECT instead of fetching every row and slicing post-merge.
- Pads the SQL limit by the in-memory session count so id collisions (in-memory takes precedence) can't drop us below `limit`.

## Why
Codex review on #28278 flagged that `.all()` over the full history table makes the endpoint scale with total history rather than the requested page — both DB scan and `event_log_json` parse cost. This change keeps cost bounded by `limit`.

Part of plan: acp-sessions-ui.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->