### PR TITLE
fix(macos): re-lookup profile index post-await in setProfile/replaceProfile

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3381,7 +3381,12 @@ public final class SettingsStore: ObservableObject {
             "llm": llmPatch
         ])
         if success {
-            if let index = existingIndex {
+            // Re-lookup the index after the await: a concurrent daemon
+            // config push (via `applyDaemonConfig` → `loadInferenceProfiles`)
+            // can replace `profiles` during the suspension, invalidating
+            // `existingIndex` and risking an out-of-bounds subscript or
+            // a write to the wrong row.
+            if let index = profiles.firstIndex(where: { $0.name == name }) {
                 // Daemon deep-merges the patch (toJSON omits nil fields).
                 // Mirror that locally so fields the fragment leaves nil
                 // retain whatever the daemon already had.
@@ -3440,7 +3445,10 @@ public final class SettingsStore: ObservableObject {
         if success {
             var copy = fragment
             copy.name = name
-            if let index = existingIndex {
+            // Re-lookup post-await: a concurrent `loadInferenceProfiles`
+            // can replace `profiles` during the two suspension points
+            // above, so the captured `existingIndex` may be stale.
+            if let index = profiles.firstIndex(where: { $0.name == name }) {
                 profiles[index] = copy
             } else {
                 profiles.append(copy)


### PR DESCRIPTION
## Summary
Address Devin review feedback on #28215. Capturing `existingIndex` before the `await settingsClient.patchConfig(...)` (and `replaceInferenceProfile(...)`) and reusing it afterwards is unsafe: during the suspension a daemon-pushed config update can run `loadInferenceProfiles` and replace the `profiles` array, leaving the saved index out of bounds (crash) or pointing at a different profile (silent corruption). Re-lookup the row by name post-await before subscripting.

Skipped Codex P2 ("defer order rewrite until rename transaction succeeds") — addressing it cleanly requires re-sequencing the multi-step rename in `InferenceProfilesSheet.commitEditor` against `replaceProfile`/`deleteProfile`/`moveProfile`, which carries non-trivial regression risk for a transient UI inconsistency that resolves on the next config refresh.

## Verification
- Existing `SettingsStoreInferenceProfilesTests` continue to cover the merge/append paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->