### PR TITLE
fix(acp): persist buffered event log on close() abort paths

### DIFF
--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -278,12 +278,26 @@ export class AcpSessionManager {
 
   /**
    * Kills the agent process and removes the session from tracking.
+   *
+   * Persists the buffered event log first so abort paths
+   * (`executeAcpAbort`, daemon shutdown) don't drop history. If the
+   * session is still in a non-terminal state, mark it cancelled so the
+   * persisted row reflects reality. The in-flight prompt's then/catch
+   * handler will short-circuit after teardown removes the entry.
    */
   close(acpSessionId: string): void {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
+    if (
+      entry.state.status === "running" ||
+      entry.state.status === "initializing"
+    ) {
+      entry.state.status = "cancelled";
+      entry.state.completedAt = Date.now();
+    }
+    this.persistTerminal(acpSessionId, entry);
     this.teardownSession(acpSessionId, entry);
   }
 


### PR DESCRIPTION
## Summary
- close()/closeAll() previously bypassed persistTerminal, dropping the buffered event log on abort paths (executeAcpAbort, daemon shutdown).
- Now marks non-terminal sessions cancelled, persists the row, then tears down.
- onConflictDoNothing protects the rare race where the prompt's terminal handler ran first.

Addresses Codex feedback on #28272.