### PR TITLE
fix(recall): defense-in-depth private filter for recall conversation source

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -121,6 +121,31 @@ describe("searchConversationSource", () => {
     ]);
   });
 
+  test("excludes legacy private conversations as defense-in-depth", async () => {
+    const visible = await seedConversation({
+      title: "Visible conversation",
+      content: "privatetoken belongs to a normal conversation.",
+    });
+    const legacyPrivate = await seedConversation({
+      title: "Legacy private conversation",
+      content: "privatetoken belongs to legacy private history.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
+      legacyPrivate.conversation.id,
+    );
+
+    const result = await searchConversationSource(
+      "privatetoken",
+      makeContext(),
+      10,
+    );
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
   test("includes archived, scheduled, and background conversations", async () => {
     const archived = await seedConversation({
       title: "Archived conversation",

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -149,6 +149,7 @@ function searchWithFts(
     WHERE messages_fts MATCH ?
       AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
       AND c.id != ?
+      AND c.conversation_type != 'private'
     ORDER BY bm25(messages_fts), m.created_at DESC
     LIMIT ?
     `,
@@ -180,6 +181,7 @@ function searchWithLike(
     WHERE m.content LIKE ? ESCAPE '\\'
       AND (c.source IS NULL OR c.source NOT IN (?, ?, ?))
       AND c.id != ?
+      AND c.conversation_type != 'private'
     ORDER BY m.created_at DESC
     LIMIT ?
     `,


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on #28168. PR #28168 removed the `conversation_type != 'private'` predicate from the recall conversation source on the assumption migration 229 had already deleted legacy private rows. However, the import flow (`vbundle-streaming-importer` / `migration-routes`) calls `resetDb()` and swaps `assistant.db` without invoking `initializeDb()` afterwards, so an imported older backup containing legacy private rows is queryable via recall until the daemon restarts.

- Restore the `conversation_type != 'private'` predicate in both FTS and LIKE recall queries as defense-in-depth.
- Add a regression test asserting recall does not surface rows with `conversation_type = 'private'`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->