### PR TITLE
fix(macos): drop wire/persisted acpSessions slot when feature flag is off

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -41,6 +41,19 @@ extension NativePanelId: Codable {
     }
 }
 
+extension NativePanelId {
+    /// Returns false for panels whose feature flag is off in this build, so wire/persisted
+    /// layouts can't pin a slot to a panel this client cannot route or recover from.
+    static func isAvailableInThisBuild(_ panel: NativePanelId) -> Bool {
+        switch panel {
+        case .acpSessions:
+            return MacOSClientFeatureFlagManager.shared.isEnabled("coding-agents-panel")
+        default:
+            return true
+        }
+    }
+}
+
 public enum SlotContent: Equatable, Sendable {
     case native(NativePanelId)
     case surface(surfaceId: String)
@@ -76,7 +89,8 @@ extension SlotContent: Codable {
             case "debug", "usageDashboard":
                 self = .native(.logsAndUsage)
             default:
-                if let panel = NativePanelId(rawValue: rawPanel) {
+                if let panel = NativePanelId(rawValue: rawPanel),
+                   NativePanelId.isAvailableInThisBuild(panel) {
                     self = .native(panel)
                 } else {
                     self = .empty
@@ -175,7 +189,8 @@ extension SlotContent {
             case "debug", "usageDashboard":
                 id = .logsAndUsage
             default:
-                guard let parsed = NativePanelId(rawValue: panel) else { return nil }
+                guard let parsed = NativePanelId(rawValue: panel),
+                      NativePanelId.isAvailableInThisBuild(parsed) else { return nil }
                 id = parsed
             }
             return .native(id)


### PR DESCRIPTION
Addresses Codex feedback on #28262: when the coding-agents-panel feature flag is off, mixed-version daemon/client traffic could push a layout message with `.acpSessions` that decode/merge would accept and persist, leaving a hidden-but-stuck slot.

Adds `NativePanelId.isAvailableInThisBuild` (currently gates only `acpSessions` on the `coding-agents-panel` flag) and consults it in both:
- `SlotContent.init(from:)` (Decodable, on-disk config) — returns `.empty` when the panel is unavailable.
- `SlotContent.from(wire:)` (UI layout wire merge) — returns `nil` so the wire update is ignored and base state is kept.

This complements (does not replace) the existing `hideDisabledACPSessionsRightSlotIfNeeded` cleanup path, by rejecting the content at the boundary instead of letting it stick at `visible: false".