### PR TITLE
fix(migrations): gate 057 stale Gemini repair on Gemini provider context

### DIFF
--- a/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
+++ b/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
@@ -217,6 +217,64 @@ describe("057-repair-stale-gemini-model-ids migration", () => {
     expect(config.llm.profiles.balanced.model).toBe("gemini-3-flash-preview");
   });
 
+  test("does not rewrite blocks whose effective provider is not Gemini", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "ollama",
+          model: "gemini-3-flash",
+        },
+        callSites: {
+          analyzeConversation: {
+            provider: "openrouter",
+            model: "gemini-3-flash",
+          },
+          recall: {
+            model: "gemini-3-flash",
+          },
+        },
+        profiles: {
+          custom: {
+            provider: "ollama",
+            model: "gemini-3-flash",
+          },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("rewrites call-site/profile blocks without local provider when default is Gemini", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-3-flash-preview" },
+        callSites: {
+          memoryRetrieval: { model: "gemini-3-flash" },
+        },
+        profiles: {
+          balanced: { model: "gemini-3-flash" },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        callSites: Record<string, { model: string }>;
+        profiles: Record<string, { model: string }>;
+      };
+    };
+    expect(config.llm.callSites.memoryRetrieval.model).toBe(
+      "gemini-3.1-flash-lite-preview",
+    );
+    expect(config.llm.profiles.balanced.model).toBe("gemini-3-flash-preview");
+  });
+
   test("no-ops when config.json is missing or invalid", () => {
     repairStaleGeminiModelIdsMigration.run(workspaceDir);
     expect(existsSync(configPath())).toBe(false);

--- a/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
+++ b/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
@@ -7,9 +7,10 @@ import type { WorkspaceMigration } from "./types.js";
  * Repair stale Gemini model IDs that earlier workspace migrations could seed.
  *
  * `gemini-3-flash` is no longer a catalog model ID. Repair only known LLM
- * config leaves where migrations write model IDs, and only when the value is
- * an exact stale match so unrelated user config and substring values are left
- * untouched.
+ * config leaves where migrations write model IDs, only when the value is an
+ * exact stale match, and only when the effective provider context is Gemini —
+ * a custom Ollama/OpenRouter config that happens to use the literal
+ * `"gemini-3-flash"` string must be left untouched.
  */
 export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
   id: "057-repair-stale-gemini-model-ids",
@@ -33,7 +34,9 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
     let changed = false;
 
     const defaultBlock = readObject(llm.default);
-    if (defaultBlock !== null) {
+    const defaultProvider = readProvider(defaultBlock);
+
+    if (defaultBlock !== null && isGeminiBlock(defaultBlock, defaultProvider)) {
       changed = repairModel(defaultBlock, DEFAULT_REPLACEMENT_MODEL) || changed;
     }
 
@@ -42,6 +45,7 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       for (const [site, rawConfig] of Object.entries(callSites)) {
         const callSiteConfig = readObject(rawConfig);
         if (callSiteConfig === null) continue;
+        if (!isGeminiBlock(callSiteConfig, defaultProvider)) continue;
         const replacement = LATENCY_CALL_SITES.has(site)
           ? LATENCY_REPLACEMENT_MODEL
           : DEFAULT_REPLACEMENT_MODEL;
@@ -54,6 +58,7 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       for (const rawProfile of Object.values(profiles)) {
         const profile = readObject(rawProfile);
         if (profile === null) continue;
+        if (!isGeminiBlock(profile, defaultProvider)) continue;
         changed = repairModel(profile, DEFAULT_REPLACEMENT_MODEL) || changed;
       }
     }
@@ -95,4 +100,23 @@ function readObject(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function readProvider(
+  block: Record<string, unknown> | null,
+): string | undefined {
+  if (block === null) return undefined;
+  return typeof block.provider === "string" ? block.provider : undefined;
+}
+
+// A block targets Gemini if it explicitly sets provider="gemini", or if it has
+// no provider field and the default block resolves to Gemini. An explicit
+// non-Gemini provider blocks the rewrite.
+function isGeminiBlock(
+  block: Record<string, unknown>,
+  defaultProvider: string | undefined,
+): boolean {
+  const local = readProvider(block);
+  const effective = local ?? defaultProvider;
+  return effective === undefined || effective === "gemini";
 }


### PR DESCRIPTION
## Summary
- Workspace migration 057 (\`repair-stale-gemini-model-ids\`) previously rewrote any LLM config block whose \`model === \"gemini-3-flash\"\` regardless of the effective provider. A user with a custom Ollama/OpenRouter config that happened to use the literal string \`gemini-3-flash\` as a model ID would have it silently mutated.
- Now gated on the effective provider: rewrite only when the block (or its inherited default) targets Gemini. An explicit non-Gemini provider blocks the rewrite. No-provider-anywhere preserves the original behavior so existing tests and the historical seeding path remain covered.

Addresses Codex P2 feedback on #28256.

## Test plan
- [x] \`bun test src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts\` — 8 pass (added 2 cases: explicit non-Gemini provider blocks rewrite; default-only Gemini propagates to providerless call-sites/profiles)
- [x] \`bunx tsc --noEmit\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->