### PR TITLE
fix(macos): hide decorative ACPSessionsPanel dividers from VoiceOver

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -153,7 +153,7 @@ struct ACPSessionsPanel: View {
             filterPicker
         }
 
-        Divider().background(VColor.borderBase)
+        Divider().background(VColor.borderBase).accessibilityHidden(true)
     }
 
     /// Header overflow ("…") menu. Currently only houses the destructive
@@ -257,7 +257,7 @@ struct ACPSessionsPanel: View {
                 }
                 .buttonStyle(.plain)
                 if viewModel.id != visible.last?.id {
-                    Divider().background(VColor.borderBase)
+                    Divider().background(VColor.borderBase).accessibilityHidden(true)
                 }
             }
         }


### PR DESCRIPTION
Addresses Devin review feedback on #28298: the header and inter-row `Divider()`s in `ACPSessionsPanel` are visual-only and per `clients/AGENTS.md` must be hidden from VoiceOver via `.accessibilityHidden(true)`.

The third Codex/Devin finding (`.frame(maxWidth: .infinity)` FlexFrame violation) is already resolved on main.