### PR TITLE
fix(live-voice): exclude aux completions from assistant-message-id callback

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -293,7 +293,11 @@ export async function startVoiceTurn(
     onMessageComplete: (msg) => {
       opts.onComplete?.();
       opts.callbacks?.message_complete?.(msg);
-      if (msg.type === "message_complete" && msg.messageId) {
+      if (
+        msg.type === "message_complete" &&
+        msg.messageId &&
+        msg.source !== "aux"
+      ) {
         try {
           opts.callbacks?.persisted_assistant_message_id?.(msg.messageId);
         } catch (err) {


### PR DESCRIPTION
Codex feedback on #28300: `persisted_assistant_message_id` was invoked for any `message_complete` carrying a `messageId`, including auxiliary completions emitted by call-question notifiers (`source: "aux"`). When a session wires this callback for attachment linking, an aux completion could provide the wrong id and link audio to the notifier message instead of the assistant's main reply.

Filter to non-aux completions, matching the existing convention in `assistant/src/daemon/message-types/messages.ts` (absent source treated as main).