### PR TITLE
fix(acp): require settings.write for bulk-delete acp sessions

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -378,7 +378,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "acp/steer", scopes: ["chat.write"] },
   { endpoint: "acp/cancel", scopes: ["chat.write"] },
   { endpoint: "acp/close", scopes: ["chat.write"] },
-  { endpoint: "acp/sessions:DELETE", scopes: ["chat.write"] },
+  // Bulk-clear acp_session_history is a destructive global operation;
+  // require settings.write to match conversations/clear-all. The per-row
+  // delete below (acp/sessions/delete) stays at chat.write.
+  { endpoint: "acp/sessions:DELETE", scopes: ["settings.write"] },
   { endpoint: "acp/sessions/delete", scopes: ["chat.write"] },
   { endpoint: "acp", scopes: ["chat.read"] },
 


### PR DESCRIPTION
## Summary
- Elevate \`DELETE /v1/acp/sessions?status=completed\` from \`chat.write\` to \`settings.write\`.
- This bulk-clear wipes all terminal ACP history rows across the workspace and should not be reachable from lower-privilege chat tokens, mirroring \`conversations/clear-all\`.
- Per-row \`acp/sessions/delete\` keeps \`chat.write\`, matching single-conversation \`conversations:DELETE\`.

Addresses Codex P2 feedback on #28279.