### PR TITLE
fix(db): clean scoped_approval_grants by private call_session_id

### DIFF
--- a/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
@@ -615,7 +615,8 @@ function seedGuardianAndApprovalRows(raw: Database, now: number): void {
       created_at,
       updated_at
     ) VALUES
-      ('call-standard-guardian', 'conv-standard', 'test-provider', '+15550100', '+15550101', 'initiated', ${now}, ${now});
+      ('call-standard-guardian', 'conv-standard', 'test-provider', '+15550100', '+15550101', 'initiated', ${now}, ${now}),
+      ('call-private-guardian', 'conv-private', 'test-provider', '+15550102', '+15550103', 'initiated', ${now}, ${now});
 
     INSERT INTO call_pending_questions (
       id,
@@ -707,6 +708,23 @@ function seedGuardianAndApprovalRows(raw: Database, now: number): void {
       ('scoped-grant-private', 'request_id', 'canonical-request-private-source', NULL, NULL, 'vellum', 'vellum', 'conv-private', 'active', ${now + 60000}, ${now}, ${now}),
       ('scoped-grant-standard', 'request_id', 'canonical-request-standard', NULL, NULL, 'vellum', 'vellum', 'conv-standard', 'active', ${now + 60000}, ${now}, ${now}),
       ('scoped-grant-unscoped', 'tool_signature', NULL, 'test_tool', 'digest-123', 'vellum', 'vellum', NULL, 'active', ${now + 60000}, ${now}, ${now});
+
+    INSERT INTO scoped_approval_grants (
+      id,
+      scope_mode,
+      request_id,
+      tool_name,
+      input_digest,
+      request_channel,
+      decision_channel,
+      conversation_id,
+      call_session_id,
+      status,
+      expires_at,
+      created_at,
+      updated_at
+    ) VALUES
+      ('scoped-grant-private-call-only', 'tool_signature', NULL, 'test_tool', 'digest-456', 'vellum', 'vellum', NULL, 'call-private-guardian', 'active', ${now + 60000}, ${now}, ${now});
 
     INSERT INTO channel_guardian_approval_requests (
       id,
@@ -1034,6 +1052,13 @@ describe("migrateDeletePrivateConversations", () => {
     expect(
       countWhere(raw, "scoped_approval_grants", `id = 'scoped-grant-unscoped'`),
     ).toBe(1);
+    expect(
+      countWhere(
+        raw,
+        "scoped_approval_grants",
+        `id = 'scoped-grant-private-call-only'`,
+      ),
+    ).toBe(0);
     expect(
       countWhere(
         raw,

--- a/assistant/src/memory/migrations/229-delete-private-conversations.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.ts
@@ -47,6 +47,10 @@ export function migrateDeletePrivateConversations(database: DrizzleDb): void {
   database.run(/*sql*/ `
     DELETE FROM scoped_approval_grants
     WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+       OR call_session_id IN (
+        SELECT id FROM call_sessions
+        WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
+      )
   `);
   database.run(/*sql*/ `
     DELETE FROM guardian_action_deliveries


### PR DESCRIPTION
## Summary
Round-3 self-review fix on top of #28155.

**Gap:** `scoped_approval_grants.call_session_id` has no FK, so a grant with `conversation_id = NULL` but `call_session_id` referencing a private conversation's call_session would survive migration 229 — the call_session itself cascade-deletes (FK on `call_sessions.conversation_id`), leaving the grant as a dangling reference.

**Fix:** extend the `DELETE FROM scoped_approval_grants` clause to also match `call_session_id IN (call_sessions for private conversations)`. Added test coverage that seeds a private call_session and a call-only-scoped grant, and asserts deletion.

Addresses [Devin review thread](https://github.com/vellum-ai/vellum-assistant/pull/28155#discussion_r3141825608).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->