### PR TITLE
fix(macos): clearer error when live voice fallback is blocked by speech auth

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -515,9 +515,18 @@ final class VoiceModeManager {
 
         liveFallbackAttemptedForSession = true
         activeVoicePath = .turnBased
-        errorMessage = "Live voice is unavailable. Using standard voice mode."
         state = .idle
         log.warning("Voice mode: live channel failed, falling back to standard voice mode — \(fallbackMessage, privacy: .public)")
+
+        if !STTProviderRegistry.isServiceConfigured {
+            let speechStatus = speechRecognizerAdapter.authorizationStatus()
+            if speechStatus != .authorized && speechStatus != .notDetermined {
+                errorMessage = "Live voice is unavailable, and speech recognition permission is required for standard voice mode."
+                return
+            }
+        }
+
+        errorMessage = "Live voice is unavailable. Using standard voice mode."
         startTurnBasedListeningWithAuthorization()
     }
 


### PR DESCRIPTION
## Summary

Address Devin review feedback on #28313: when live voice fails and the turn-based fallback is blocked by denied/restricted speech recognition permission, the original `Live voice is unavailable. Using standard voice mode.` message was getting overwritten by `Speech recognition permission is required for standard voice mode.`, losing the live-voice context.

This adds a pre-check in `handleLiveVoiceFailure` mirroring the gate already used in `startTurnBasedListeningWithAuthorization` (STT configured OR speech authorized OR not-determined). When neither path can proceed, surface a single combined message and skip the no-op fallback call.

The P1 barge-in concern raised in the same review was already addressed in #28335 via `interruptLiveVoiceAndStartListening`.

## Test plan

- [ ] Manually verify on macOS that denying speech recognition and triggering a live voice failure shows the combined message