### PR TITLE
fix(live-voice): preserve monotonic frame seq

### DIFF
--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -348,6 +348,7 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
       conversationId: "conversation-after-error",
     });
     expect(typeof ready.sessionId).toBe("string");
+    expect(ready.seq as number).toBeGreaterThan(error.seq as number);
   });
 
   test("releases the session lock when the WebSocket closes", async () => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -565,7 +565,6 @@ export class RuntimeHttpServer {
       return handleReadyz();
     }
 
-
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.
     if (
@@ -1021,8 +1020,9 @@ export class RuntimeHttpServer {
     ws: ServerWebSocket<LiveVoiceWebSocketData>,
     frame: LiveVoiceServerFrame,
   ): void {
-    ws.data.lastSeq = Math.max(ws.data.lastSeq, frame.seq);
-    ws.send(JSON.stringify(frame));
+    const seq = Math.max(ws.data.lastSeq + 1, frame.seq);
+    ws.data.lastSeq = seq;
+    ws.send(JSON.stringify({ ...frame, seq }));
   }
 
   private releaseLiveVoiceSession(


### PR DESCRIPTION
## Summary

Codex flagged that `sendLiveVoiceFrame` could emit duplicate or
out-of-order `seq` values on a single socket — e.g. a malformed
pre-`start` message produces an `error` with `seq=1`, and the
subsequent `ready` from the stub session reuses `seq=1`.

Normalize outbound `seq` to `max(lastSeq + 1, frame.seq)` before
sending so per-socket sequence numbers are always strictly increasing.
Extend the existing malformed-frame test to assert ready.seq > error.seq.

Addresses review feedback on #28312.

## Test plan
- [x] `bun test src/live-voice/__tests__/runtime-websocket-shell.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->