### PR TITLE
fix(macos): muted fallback for ACP spawn dot when store entry missing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1088,9 +1088,10 @@ struct ToolCallStepDetailRow: View {
     /// ``ACPSessionStore`` and re-renders as the daemon streams status
     /// updates for this session, so an inline block transitions
     /// running → completed/failed without the user expanding it. When the
-    /// store has no entry for the session id (history cleared, daemon
-    /// restarted) the dot falls back to the static tool-call result so a
-    /// successful spawn still reads as "completed".
+    /// store has no entry for the session id (spawn-event race window or
+    /// history-cleared) the dot falls back to a muted indeterminate glyph
+    /// rather than a positive check, so the resolver never claims a
+    /// terminal state we can't prove.
     @ViewBuilder
     private func acpSpawnDeepLinkRow(acpSessionId: String) -> some View {
         Button {

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -457,14 +457,18 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         )
     }
 
-    /// Nil (no entry in the store — history was cleared, daemon
-    /// restarted) falls back to the static "completed" indicator. Same
-    /// reasoning as `.unknown`: the row only renders when the tool call
-    /// itself succeeded.
-    func test_acpSpawnStatusIndicator_missingStoreEntryFallsBackToCompleted() {
+    /// Nil (no entry in the store) falls back to a muted dashed glyph.
+    /// Two cases land here — the spawn-event race window before the store
+    /// observes `acp_session_spawned`, and history-cleared-after-success.
+    /// Neither justifies a positive terminal check: the race case would
+    /// flip backward to pulsing once the entry arrives, and the cleared
+    /// case can no longer prove the session's terminal disposition. A
+    /// muted indeterminate glyph honestly conveys "we don't know" without
+    /// pulsing indefinitely.
+    func test_acpSpawnStatusIndicator_missingStoreEntryFallsBackToMuted() {
         XCTAssertEqual(
             ACPSpawnStatusIndicator.resolve(forStatus: nil),
-            .icon(glyph: .check, role: .positive)
+            .icon(glyph: .dash, role: .muted)
         )
     }
 

--- a/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
+++ b/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
@@ -63,16 +63,19 @@ public enum ACPSpawnStatusIndicator: Equatable {
     }
 
     /// Map a live ``ACPSessionState/Status`` into a render decision.
-    /// Falls back to a static "completed" check when the store has no
-    /// entry for the session id (`status` is nil) — for an `acp_spawn`
-    /// row to render at all the tool call already succeeded, so a
-    /// missing-from-store entry is almost always "history was cleared
-    /// after a successful run" rather than "something unobservable went
-    /// wrong". Treating it as completed keeps the inline block honest
-    /// instead of perpetually pulsing on a stale id.
+    /// Falls back to a muted dashed glyph when the store has no entry for
+    /// the session id (`status` is nil). Two distinct cases land here and
+    /// neither warrants a positive terminal check: (1) the store hasn't
+    /// yet observed the `acp_session_spawned` event for a freshly spawned
+    /// session — claiming "completed" in that race window would be wrong
+    /// and would visibly flip backward to pulsing once the entry arrives;
+    /// (2) history was cleared after a successful run — the spawn tool
+    /// itself did succeed, but we can no longer prove the session's
+    /// terminal disposition. A muted indeterminate glyph honestly conveys
+    /// "we don't know" without pulsing indefinitely on a stale id.
     public static func resolve(forStatus status: ACPSessionState.Status?) -> ACPSpawnStatusIndicator {
         guard let status else {
-            return .icon(glyph: .check, role: .positive)
+            return .icon(glyph: .dash, role: .muted)
         }
         switch status {
         case .running, .initializing:


### PR DESCRIPTION
Addresses Codex P2 feedback on #28321.

The shared `ACPSpawnStatusIndicator.resolve(forStatus:)` previously fell back to a positive completed check when the store had no entry for the session id. Codex pointed out that nil also occurs in the spawn-event race window before `acp_session_spawned` is observed — in that window a still-running session was rendered as completed and would later flip backward to pulsing once the store entry arrived.

Switch the nil fallback to a muted dashed glyph (`.icon(glyph: .dash, role: .muted)`) so the indicator honestly conveys "we don't know" without pulsing indefinitely on a stale id. Both the spawn-race window and the history-cleared-after-success case now render the same neutral indeterminate dot.

Updated the matching test and the doc comments on the resolver and the macOS `acpSpawnDeepLinkRow` to reflect the new behavior.

## Test plan
- [ ] `ChatBubbleACPSpawnTests.test_acpSpawnStatusIndicator_missingStoreEntryFallsBackToMuted`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->