### PR TITLE
fix(live-voice): hold session lock until close completes

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -328,6 +328,52 @@ describe("LiveVoiceSessionManager", () => {
     expect(manager.activeSessionId).toBe("session-1");
   });
 
+  test("holds the session lock until close completes", async () => {
+    const sessions: TestSession[] = [];
+    let resolveClose: (() => void) | undefined;
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: () => {
+        const session = createTestSession({
+          close: mock(
+            (reason: LiveVoiceSessionCloseReason) =>
+              new Promise<void>((resolve) => {
+                sessions[sessions.length - 1]?.closeReasons.push(reason);
+                resolveClose = resolve;
+              }),
+          ),
+        });
+        sessions.push(session);
+        return session;
+      },
+    });
+    const first = createSink();
+    const second = createSink();
+    const third = createSink();
+
+    await manager.startSession(START_FRAME, first.sink);
+    const releasePromise = manager.releaseSession("session-1", "client_end");
+    const concurrent = await manager.startSession(START_FRAME, second.sink);
+    const concurrentDispatch = await manager.handleClientFrame("session-1", {
+      type: "interrupt",
+    });
+
+    expect(concurrent).toEqual({
+      status: "busy",
+      activeSessionId: "session-1",
+      frame: { type: "busy", seq: 1, activeSessionId: "session-1" },
+    });
+    expect(concurrentDispatch).toEqual({ status: "not_found" });
+    expect(sessions).toHaveLength(1);
+
+    resolveClose?.();
+    await releasePromise;
+
+    const next = await manager.startSession(START_FRAME, third.sink);
+    expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
+    expect(manager.activeSessionId).toBe("session-2");
+  });
+
   test("does not import runtime, gateway, provider, or conversation modules", async () => {
     const source = await Bun.file(
       new URL("../live-voice-session-manager.ts", import.meta.url),

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -85,6 +85,7 @@ export type LiveVoiceSessionReleaseResult =
 interface ActiveLiveVoiceSession {
   sessionId: string;
   session: LiveVoiceSession;
+  closing: boolean;
 }
 
 export class LiveVoiceSessionManager {
@@ -132,7 +133,7 @@ export class LiveVoiceSessionManager {
       },
     };
     const session = this.createSession(context);
-    this.activeSession = { sessionId, session };
+    this.activeSession = { sessionId, session, closing: false };
 
     try {
       await session.start();
@@ -198,14 +199,20 @@ export class LiveVoiceSessionManager {
       return { released: false };
     }
 
-    this.activeSession = null;
-    await active.session.close(reason);
+    active.closing = true;
+    try {
+      await active.session.close(reason);
+    } finally {
+      if (this.activeSession === active) {
+        this.activeSession = null;
+      }
+    }
     return { released: true, sessionId };
   }
 
   private findActiveSession(sessionId: string): ActiveLiveVoiceSession | null {
     const active = this.activeSession;
-    if (active === null || active.sessionId !== sessionId) {
+    if (active === null || active.sessionId !== sessionId || active.closing) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Codex flagged a race in `LiveVoiceSessionManager.releaseSession`: `activeSession` was cleared before awaiting `session.close()`, so a concurrent `startSession` could be accepted while the previous session was still asynchronously tearing down shared STT/TTS/network resources — breaking the single-active-session invariant.

This change marks the active session as `closing` before awaiting close, and only clears the slot in a `finally` block. `findActiveSession` treats closing sessions as not-found (so dispatches return `not_found` and idempotent re-release calls return `released: false`), while `activeSessionId` still reports the closing session id (so concurrent starts get a `busy` frame).

Adds a regression test that pauses `close()` mid-flight and verifies the manager rejects concurrent `startSession` and `handleClientFrame` calls until close resolves.

Addresses review feedback on #28299.

## Test plan
- [x] `bun test src/live-voice/__tests__/live-voice-session-manager.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)