### PR TITLE
fix(recall): extend private filter to sidebar search + add LIKE-path test

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -146,6 +146,27 @@ describe("searchConversationSource", () => {
     ]);
   });
 
+  test("excludes legacy private conversations through the LIKE fallback", async () => {
+    const visible = await seedConversation({
+      title: "Visible non-ASCII conversation",
+      content: "東京 appears in a normal conversation.",
+    });
+    const legacyPrivate = await seedConversation({
+      title: "Legacy private non-ASCII conversation",
+      content: "東京 appears in a private conversation.",
+    });
+    rawRun(
+      "UPDATE conversations SET conversation_type = 'private' WHERE id = ?",
+      legacyPrivate.conversation.id,
+    );
+
+    const result = await searchConversationSource("東京", makeContext(), 10);
+
+    expect(result.evidence.map((item) => item.locator)).toEqual([
+      `${visible.conversation.id}#${visible.message.id}`,
+    ]);
+  });
+
   test("includes archived, scheduled, and background conversations", async () => {
     const archived = await seedConversation({
       title: "Archived conversation",

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -262,7 +262,7 @@ export function searchConversations(
         FROM messages_fts f
         JOIN messages m ON m.id = f.message_id
         JOIN conversations c ON c.id = m.conversation_id
-        WHERE messages_fts MATCH ? AND c.conversation_type NOT IN ('background', 'scheduled') AND c.archived_at IS NULL
+        WHERE messages_fts MATCH ? AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND c.archived_at IS NULL
         LIMIT 1000
       `,
         ftsMatch,
@@ -287,7 +287,7 @@ export function searchConversations(
       SELECT DISTINCT m.conversation_id
       FROM messages m
       JOIN conversations c ON c.id = m.conversation_id
-      WHERE m.content LIKE ? ESCAPE '\\' AND c.conversation_type NOT IN ('background', 'scheduled') AND c.archived_at IS NULL
+      WHERE m.content LIKE ? ESCAPE '\\' AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND c.archived_at IS NULL
       LIMIT 1000
     `,
       likePattern,
@@ -301,7 +301,7 @@ export function searchConversations(
     .from(conversations)
     .where(
       and(
-        sql`${conversations.conversationType} NOT IN ('background', 'scheduled')`,
+        sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`,
         sql`${conversations.title} LIKE ${titlePattern} ESCAPE '\\'`,
         sql`${conversations.archivedAt} IS NULL`,
       ),


### PR DESCRIPTION
## Summary

Addresses Devin review feedback on #28169 (already merged; #29996 restored the filter).

- Adds the missing LIKE-path test for the private-conversation filter in \`searchConversationSource\`. The existing \`privatetoken\` test only exercised the FTS path; \`東京\` forces the LIKE fallback because \`buildFtsMatchQuery\` drops non-ASCII tokens.
- Extends \`searchConversations\` (sidebar/global search in \`conversation-queries.ts\`) to also exclude \`conversation_type = 'private'\`, matching the defense-in-depth pattern already used by \`listConversations\`. The same import-flow window that motivated the recall filter applies here.