### PR TITLE
fix(recall): address #28177 review feedback

### DIFF
--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -499,7 +499,7 @@ async function runSeedRecallSearch(
       context,
       searchOptions,
     );
-    evidence = mergeEvidence(expansionResult.evidence, evidence);
+    evidence = mergeEvidence(evidence, expansionResult.evidence);
   }
 
   return withFallbackEvidence(baseResult, evidence);

--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -124,13 +124,19 @@ export async function searchPkbSource(
   }
 
   let lexicalEvidence: RecallEvidence[] = [];
-  try {
-    lexicalEvidence = await searchPkbLexicalFallback(query, context, limit * 2);
-  } catch (err) {
-    if (isAbortError(err) || context.signal?.aborted) {
-      throw err;
+  if (semanticEvidence.length < limit) {
+    try {
+      lexicalEvidence = await searchPkbLexicalFallback(
+        query,
+        context,
+        limit * 2,
+      );
+    } catch (err) {
+      if (isAbortError(err) || context.signal?.aborted) {
+        throw err;
+      }
+      log.warn({ err }, "Lexical PKB recall fallback failed");
     }
-    log.warn({ err }, "Lexical PKB recall fallback failed");
   }
 
   return {
@@ -201,7 +207,15 @@ async function searchPkbLexicalFallback(
   }
 
   const matches: PkbLexicalMatch[] = [];
-  await walkPkbDirectory(pkbRoot, pkbRoot, queryTerms, matches, context.signal);
+  const visitedDirs = new Set<string>([pkbRoot]);
+  await walkPkbDirectory(
+    pkbRoot,
+    pkbRoot,
+    queryTerms,
+    matches,
+    visitedDirs,
+    context.signal,
+  );
 
   return matches
     .sort(comparePkbLexicalMatches)
@@ -231,6 +245,7 @@ async function walkPkbDirectory(
   pkbRoot: string,
   queryTerms: ReadonlySet<string>,
   matches: PkbLexicalMatch[],
+  visitedDirs: Set<string>,
   signal: AbortSignal | undefined,
 ): Promise<void> {
   throwIfAborted(signal);
@@ -267,11 +282,16 @@ async function walkPkbDirectory(
     }
 
     if (entryStats.isDirectory()) {
+      if (visitedDirs.has(entryRealPath)) {
+        continue;
+      }
+      visitedDirs.add(entryRealPath);
       await walkPkbDirectory(
         entryRealPath,
         pkbRoot,
         queryTerms,
         matches,
+        visitedDirs,
         signal,
       );
       continue;


### PR DESCRIPTION
## Summary

Addresses post-merge review feedback on #28177.

- **PKB lexical fallback gating** (Codex P2 / Devin): only run the filesystem walk when semantic search returns fewer than `limit` results. Avoids the per-query Qdrant + filesystem double-pass on healthy PKBs.
- **PKB walker symlink-cycle guard** (Codex P1): thread a `visitedDirs` realpath set through `walkPkbDirectory`, mirroring the workspace walker. Symlink loops inside `pkb/` no longer recurse unbounded.
- **Seed expansion merge order** (Devin): `mergeEvidence(evidence, expansionResult.evidence)` so the original/focused query keeps priority and the broader expansion fills the tail. Matches the convention used elsewhere in the agent loop.

Skipped:
- Hardcoded query-intent heuristics (Devin, agent-runner.ts:78-141): the patterns are mechanical query-expansion preprocessing for a downstream LLM agent — not a judgement call about user-facing behavior. Reverting would gut the PR's whole point and the LLM still does the actual reasoning. Keeping as-is.
- Workspace dot-file allowlist (Devin analysis): informational — the workspace is a controlled directory and the remaining filters (`.env*`, key/secret name matches, extension allowlist) cover realistic risks.

## Test plan

- [ ] Existing recall tests continue to pass