### PR TITLE
fix(live-voice): close client before transitioning to idle after ttsDone

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -429,10 +429,11 @@ final class LiveVoiceChannelManager {
 
             self.sessionGeneration &+= 1
             self.stopCapture()
+            self.state = .ending
+            await completedClient?.close()
             self.resetIgnoredSessionState()
             self.sessionId = nil
             self.state = .idle
-            await completedClient?.close()
         }
     }
 


### PR DESCRIPTION
## Summary

Address Codex P1 review on #28302.

After a normal push-to-talk turn, `closeCompletedUtteranceSessionAfterPlayback` was setting `state = .idle` before awaiting `completedClient?.close()`. In that window:
- `end()` short-circuited as a no-op (state == .idle, client == nil)
- `start()` could create a second client while the first close was still in flight

Fix: set state to `.ending` while the close runs, transition to `.idle` only after the client is fully torn down. This guarantees that whenever state is `.idle`, no client is in flight.

## Test plan

- [ ] `swift test --filter LiveVoiceChannelManagerTests`
- [ ] `swift test --filter VoiceModeManagerTests`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->