### PR TITLE
fix(profiles): reject reserved names and mirror server state on replace

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -95,6 +95,12 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
 
 import { MANAGED_PROFILE_NAMES } from "../../config/seed-inference-profiles.js";
 
+const RESERVED_PROFILE_NAMES = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 const INFERENCE_PROFILE_UI_KEYS = new Set([
   "provider",
   "model",
@@ -449,6 +455,11 @@ function handleReplaceInferenceProfile({
   }
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BadRequestError("Body must be a JSON object");
+  }
+  if (RESERVED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(
+      `Profile name "${name}" is reserved and cannot be used.`,
+    );
   }
   if (MANAGED_PROFILE_NAMES.has(name)) {
     throw new BadRequestError(

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3433,6 +3433,23 @@ public final class SettingsStore: ObservableObject {
             name: name,
             fragment: fragment.toJSON()
         )
+        if success {
+            // Mirror the server state locally before attempting the order
+            // patch. If the order patch fails, the profile data is still
+            // saved on the server, so the local cache must reflect that to
+            // avoid a divergence where the user is told the save failed
+            // while the profile is in fact persisted.
+            var copy = fragment
+            copy.name = name
+            // Re-lookup post-await: a concurrent `loadInferenceProfiles`
+            // can replace `profiles` during the suspension above, so the
+            // captured `existingIndex` may be stale.
+            if let index = profiles.firstIndex(where: { $0.name == name }) {
+                profiles[index] = copy
+            } else {
+                profiles.append(copy)
+            }
+        }
         if success, let nextOrder {
             let orderSuccess = await settingsClient.patchConfig([
                 "llm": ["profileOrder": nextOrder]
@@ -3443,16 +3460,6 @@ public final class SettingsStore: ObservableObject {
             }
         }
         if success {
-            var copy = fragment
-            copy.name = name
-            // Re-lookup post-await: a concurrent `loadInferenceProfiles`
-            // can replace `profiles` during the two suspension points
-            // above, so the captured `existingIndex` may be stale.
-            if let index = profiles.firstIndex(where: { $0.name == name }) {
-                profiles[index] = copy
-            } else {
-                profiles.append(copy)
-            }
             if let nextOrder {
                 profileOrder = nextOrder
                 reorderPublishedProfiles(to: nextOrder)


### PR DESCRIPTION
## Summary

Addresses review feedback on #28218.

- **Daemon**: `handleReplaceInferenceProfile` now rejects `__proto__`, `constructor`, and `prototype` as profile names. Previously the route validated only that the name was non-empty, so a user-controlled name like `__proto__` would mutate the in-memory `llm.profiles` object's prototype rather than creating a normal key.
- **macOS**: `SettingsStore.replaceProfile` now updates the local profile cache immediately after the server-side replace succeeds, before issuing the follow-up `profileOrder` patch. Previously, when the replace succeeded but the order patch failed, the function returned `false` and skipped the cache update — telling the user "Couldn't save profile" while the server in fact had the new data. Order patch failure still surfaces as a failed call so the caller retries; on retry both calls are idempotent.

## Verification

- Existing replace-profile tests in `SettingsStoreInferenceProfilesTests` continue to assert the post-success cache state and still pass through this code path.
- Skipped CI per default.

## Original prompt

Address feedback on https://github.com/vellum-ai/vellum-assistant/pull/28218
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->