### PR TITLE
fix(macos): repair ACPSessionDetail auto-scroll at event-cap and trim

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -306,7 +306,12 @@ struct ACPSessionDetailView: View {
                 .onPreferenceChange(ACPSessionDetailScrollOffsetKey.self) { contentMinY in
                     handleScrollOffsetChange(contentMinY)
                 }
-                .onChange(of: session.events.count) {
+                .onChange(of: session.events.last?.id) {
+                    // `events.count` plateaus at `ACPSessionStore.eventsCapPerSession`
+                    // (the ring buffer trims oldest entries on append), so a count-keyed
+                    // `.onChange` would silently stop firing for long sessions. Observe
+                    // the last event's id instead — each `ACPSessionUpdateMessage`
+                    // carries a unique UUID, so this fires on every append.
                     if autoScrollEnabled {
                         // .easeOut keeps the jump readable when many events
                         // arrive at once.
@@ -314,6 +319,17 @@ struct ACPSessionDetailView: View {
                             proxy.scrollTo(Self.bottomAnchorId, anchor: .bottom)
                         }
                     }
+                }
+                .onChange(of: session.events.first?.id) {
+                    // Oldest event changed — content was trimmed from the head of
+                    // the ring buffer, which shrinks total content height and shifts
+                    // the offset baseline. Without resetting the watermark here,
+                    // `returnedToBottom` would never be satisfied again (the stored
+                    // max stays beyond the new actual bottom) and auto-scroll would
+                    // permanently lock out. The next offset reading re-establishes
+                    // both values for the now-shorter content.
+                    lastMaxScrollOffset = 0
+                    lastScrollOffset = 0
                 }
                 .onAppear {
                     // First-paint: park at the bottom so the user lands on
@@ -349,12 +365,17 @@ struct ACPSessionDetailView: View {
         let currentOffset = -contentMinY
         defer { lastScrollOffset = currentOffset }
 
+        let movedUp = currentOffset < lastScrollOffset - Self.scrollAtBottomTolerance
+        // Evaluate against the *prior* high-water mark, before bumping it.
+        // If we updated the mark first, any offset that exceeds it (e.g. the
+        // user scrolling partway down into newly-arrived content) would
+        // immediately satisfy `abs(0) < tolerance` and re-engage auto-scroll
+        // — yanking the user away from where they were reading.
+        let returnedToBottom = abs(currentOffset - lastMaxScrollOffset) < Self.scrollAtBottomTolerance
+
         if currentOffset > lastMaxScrollOffset {
             lastMaxScrollOffset = currentOffset
         }
-
-        let movedUp = currentOffset < lastScrollOffset - Self.scrollAtBottomTolerance
-        let returnedToBottom = abs(currentOffset - lastMaxScrollOffset) < Self.scrollAtBottomTolerance
 
         if movedUp {
             autoScrollEnabled = false


### PR DESCRIPTION
## Summary
Follow-up to #28301 addressing reviewer feedback on `ACPSessionDetailView` auto-scroll.

- `.onChange(of: session.events.count)` silently stopped firing once the session hit `ACPSessionStore.eventsCapPerSession` (500) because the ring buffer trims on append, leaving `count` constant. Switched to `session.events.last?.id` so the trigger fires per event.
- In `handleScrollOffsetChange`, the high-water mark was bumped before evaluating `returnedToBottom`, so any offset exceeding the previous bottom immediately satisfied `abs(0) < tolerance` and re-engaged auto-scroll. Evaluate against the prior watermark first, then bump.
- After ring-buffer trim, content shrinks but `lastMaxScrollOffset` did not, leaving `returnedToBottom` permanently unreachable. Reset `lastMaxScrollOffset` + `lastScrollOffset` on `session.events.first?.id` changes (oldest event id only changes when a trim occurs); the next offset reading re-establishes both for the shorter content.

## Test plan
- [ ] Open a long ACP session that exceeds 500 events; confirm auto-scroll keeps tracking the latest event.
- [ ] Scroll up while events are arriving, then scroll down partway into freshly-arrived content; confirm auto-scroll does not flip back on prematurely.
- [ ] After 500-event cap is hit, scroll up and back down to actual bottom; confirm auto-scroll re-engages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->