### PR TITLE
fix(macos): show empty state when filtered ACP session list is empty

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -52,10 +52,10 @@ struct ACPSessionsPanel: View {
                 onClose: onClose,
                 pinnedContent: { headerBar }
             ) {
-                if store.sessionOrder.isEmpty {
+                if filteredSessions.isEmpty {
                     VEmptyState(
-                        title: "No coding agents yet",
-                        subtitle: "Ask the assistant to spawn Claude or Codex.",
+                        title: emptyStateTitle,
+                        subtitle: emptyStateSubtitle,
                         icon: "terminal"
                     )
                 } else {
@@ -222,6 +222,24 @@ struct ACPSessionsPanel: View {
     private var countLabel: String {
         let count = filteredSessions.count
         return count == 1 ? "1 agent" : "\(count) agents"
+    }
+
+    /// Empty-state title shown when ``filteredSessions`` is empty. When the
+    /// store has sessions in other conversations but none match the current
+    /// "This conversation" filter, the title calls that out so users
+    /// understand the list is filtered, not globally empty.
+    private var emptyStateTitle: String {
+        if !store.sessionOrder.isEmpty && activeFilter == .thisConversation {
+            return "No agents in this conversation"
+        }
+        return "No coding agents yet"
+    }
+
+    private var emptyStateSubtitle: String {
+        if !store.sessionOrder.isEmpty && activeFilter == .thisConversation {
+            return "Switch to All to see agents from other conversations."
+        }
+        return "Ask the assistant to spawn Claude or Codex."
     }
 
     /// Sessions that should appear in the list once the active filter is


### PR DESCRIPTION
## Summary
Empty-state guard checked unfiltered `store.sessionOrder` while the list iterated `filteredSessions`. With a persisted "This conversation" filter and no matching sessions but other conversations populated, users saw "0 agents" plus a blank content area. Switch the guard to `filteredSessions.isEmpty` and surface a context-aware copy that points to the All filter.

Addresses review feedback on #28307 from devin-ai-integration and chatgpt-codex-connector.

## Test plan
- [ ] Open ACPSessionsPanel with sessions in other conversations, set filter to This conversation, confirm empty-state copy points at All filter
- [ ] Confirm globally empty store still shows the original 'spawn Claude or Codex' empty state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->