### PR TITLE
fix(macos): use design tokens in thoughtRow and reset auto-scroll on toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -331,6 +331,16 @@ struct ACPSessionDetailView: View {
                     lastMaxScrollOffset = 0
                     lastScrollOffset = 0
                 }
+                .onChange(of: showThoughts) {
+                    // Toggling thought visibility shrinks/grows the timeline,
+                    // which moves the bottom offset. Reset the watermark for
+                    // the same reason as the ring-buffer trim above and
+                    // re-engage auto-scroll so users who flip the toggle while
+                    // parked at the bottom keep getting new events pinned.
+                    lastMaxScrollOffset = 0
+                    lastScrollOffset = 0
+                    autoScrollEnabled = true
+                }
                 .onAppear {
                     // First-paint: park at the bottom so the user lands on
                     // the latest activity instead of the start of the log.
@@ -531,11 +541,11 @@ struct ACPSessionDetailView: View {
         HStack(spacing: 0) {
             HStack(alignment: .top, spacing: VSpacing.xs) {
                 VIconView(.lightbulb, size: 12)
-                    .foregroundStyle(Color.secondary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .padding(.top, 2)
                 Text(content)
                     .font(VFont.bodyMediumDefault.italic())
-                    .foregroundStyle(Color.secondary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .textSelection(.enabled)
             }
             .padding(VSpacing.sm)


### PR DESCRIPTION
## Summary
Address review feedback on #28305:

- Swap `Color.secondary` for `VColor.contentTertiary` in `thoughtRow` (Devin) — design-system rule mandates tokens.
- Add `.onChange(of: showThoughts)` handler that resets the scroll watermark and re-engages auto-scroll (Codex P2). Toggling thoughts shrinks/grows timeline content height; without the reset, `returnedToBottom` evaluates against a stale max and auto-scroll would lock out.

## Test plan
- [ ] Toggle 'Show thoughts' off while parked at bottom of a running session — new events still pin to bottom.
- [ ] Verify thought bubbles render with secondary tone matching other tertiary content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->