### PR TITLE
fix(filing): serialize filing and compaction to prevent concurrent PKB writes

### DIFF
--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -217,6 +217,13 @@ export class FilingService {
       return false;
     }
 
+    if (this.activeCompactionRun) {
+      log.debug(
+        "Compaction run in progress, skipping filing to avoid concurrent PKB writes",
+      );
+      return false;
+    }
+
     // Skip if buffer is empty — no work to do
     if (!force && !this.hasBufferContent()) {
       log.debug("Buffer is empty, skipping filing");
@@ -268,6 +275,13 @@ export class FilingService {
 
     if (this.activeCompactionRun) {
       log.debug("Previous compaction run still active, skipping");
+      return false;
+    }
+
+    if (this.activeRun) {
+      log.debug(
+        "Filing run in progress, skipping compaction to avoid concurrent PKB writes",
+      );
       return false;
     }
 


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on #28342: `runCompactionOnce()` only checked `activeCompactionRun`, so it could start while a regular filing run was still in progress. Both jobs mutate the same `pkb/*.md` files and could collide on the 24h boundary.

Adds a symmetric cross-check on both entry points so only one PKB-mutation job runs at a time.

## Test plan
- [x] Existing tests still pass (no behavior change for the single-job case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->