### PR TITLE
fix(providers): normalize thinking config for pass-through callers

### DIFF
--- a/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
+++ b/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
@@ -164,6 +164,21 @@ describe("retry normalization: thinking + forced tool_choice", () => {
     expect(lastConfig()?.thinking).toEqual({ type: "disabled" });
   });
 
+  test("normalizes raw { enabled: false } from pass-through callers to wire shape", async () => {
+    // Pass-through callers (e.g. host.providers.llm.complete) may forward the
+    // schema-shape `{ enabled: false }` without a callSite. The normalizer must
+    // convert it to Anthropic's wire shape `{ type: "disabled" }`, otherwise
+    // Anthropic rejects the request with a 400 on malformed `thinking`.
+    const { provider, lastConfig } = makePipeline("anthropic");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: {
+        thinking: { enabled: false },
+        tool_choice: { type: "tool", name: "select_memories" },
+      },
+    });
+    expect(lastConfig()?.thinking).toEqual({ type: "disabled" });
+  });
+
   test("preserves resolved thinking: disabled with forced tool_choice", async () => {
     setLlmConfig({
       default: {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -205,16 +205,8 @@ function normalizeSendMessageOptions(
     ) {
       nextConfig.temperature = resolved.temperature;
     }
-    if (nextConfig.thinking === undefined) {
-      // Convert the schema-shape `{ enabled, streamThinking }` into Anthropic's
-      // discriminated wire-format (`{ type: "adaptive" | "disabled" }`).
-      // Without this conversion, `thinking` arrives at `AnthropicProvider`
-      // with a shape the SDK doesn't accept (`ThinkingConfigParam` requires
-      // a `type` discriminator).
-      const thinking = normalizeThinkingConfigForWire(resolved.thinking);
-      if (thinking !== undefined) {
-        nextConfig.thinking = thinking;
-      }
+    if (nextConfig.thinking === undefined && resolved.thinking !== undefined) {
+      nextConfig.thinking = resolved.thinking;
     }
     // Forward OpenRouter-only routing preferences so `OpenRouterProvider` can
     // translate `openrouter.only` into the wire-format `provider: { only: [...] }`
@@ -234,6 +226,22 @@ function normalizeSendMessageOptions(
     // leaks unknown fields into provider request bodies — Anthropic (and other
     // strict-schema clients) reject the request with
     // "Extra inputs are not permitted".
+  }
+
+  // Convert schema-shape `{ enabled, streamThinking }` into Anthropic's
+  // discriminated wire-format (`{ type: "adaptive" | "disabled" }`).
+  // `AnthropicProvider`'s SDK requires a `type` discriminator, and downstream
+  // forced-tool/temperature conflict checks compare against the wire shape.
+  // Applies to both the resolver path above and pass-through callers (e.g.
+  // `host.providers.llm.complete`) that supply `thinking` directly without a
+  // `callSite`.
+  if (nextConfig.thinking !== undefined) {
+    const normalized = normalizeThinkingConfigForWire(nextConfig.thinking);
+    if (normalized === undefined) {
+      delete nextConfig.thinking;
+    } else {
+      nextConfig.thinking = normalized;
+    }
   }
 
   // thinking is Anthropic-specific on the wire; OpenRouter reads it as a


### PR DESCRIPTION
## Summary
- Move `normalizeThinkingConfigForWire` below the call-site block so pass-through callers (e.g. `host.providers.llm.complete`) supplying `{ enabled: false }` get converted to Anthropic's wire shape `{ type: "disabled" }`.
- Drop the now-redundant inline normalization inside the resolver path; the unified block handles it.
- Add regression test for the pass-through `{ enabled: false }` + forced `tool_choice` path.

Addresses Codex feedback on #28352.

## Test plan
- [x] `bun test src/__tests__/retry-thinking-tool-choice.test.ts src/__tests__/agent-loop-thinking.test.ts src/providers/__tests__/retry-callsite.test.ts` (37 pass)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->