### PR TITLE
fix(live-voice): stop live channel session when pausing for permission

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -538,6 +538,12 @@ final class VoiceModeManager {
         liveVoiceStartTask = nil
         activeVoicePath = .turnBased
         liveVoicePausedForPermission = true
+
+        if let liveVoiceChannelManager {
+            Task { @MainActor [weak liveVoiceChannelManager] in
+                await liveVoiceChannelManager?.end()
+            }
+        }
     }
 
     private func resumeLiveVoiceAfterPermissionIfNeeded() {


### PR DESCRIPTION
## Summary
Addresses Codex P1 feedback on #28335: `pauseLiveVoiceForTurnBasedPermission()` only updated local state and left `LiveVoiceChannelManager` capturing/sending mic audio while the turn-based permission prompt ran, racing the user's response across two pipelines.

End the live session on pause (matching the deactivate-flow pattern already used at VoiceModeManager.swift:259-263). Resume re-enters `syncLiveVoiceState`, which auto-starts a new live session from the `.idle` branch.

## Test plan
- [ ] Trigger a permission prompt while in live voice mode and confirm only one capture pipeline is active during the prompt
- [ ] Approve and deny via voice; verify live voice resumes cleanly afterward
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->