### PR TITLE
fix(live-voice): defer secret_request to desktop UI in local-live-voice mode

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -539,7 +539,14 @@ export async function startVoiceTurn(
         return;
       }
     } else if (msg.type === "secret_request") {
-      // Voice has no secret-entry UI, so resolve immediately
+      if (usesLocalInteractiveApprovals) {
+        // Local live voice runs alongside the desktop client, which has a
+        // secret-entry UI (SecretPromptManager). Forward the broadcast and
+        // let the prompter's existing registration handle the response.
+        broadcastMessage(msg);
+        return;
+      }
+      // Phone voice has no secret-entry UI, so resolve immediately.
       log.info(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",


### PR DESCRIPTION
## Summary
Addresses Devin review on #28332 — `secret_request` was auto-resolved with `undefined` for all voice turns including `local-live-voice`, which has a desktop-client secret-entry UI (`SecretPromptManager`). Mirrors the `confirmation_request` branch by broadcasting and letting the prompter's existing pendingInteractions registration handle the response. Phone voice retains the existing auto-resolve.

## Test plan
- [ ] Trigger a secret request during a local-live-voice turn; confirm desktop secret prompt appears and resolves the tool with the entered value
- [ ] Phone voice secret request still auto-resolves to `undefined`/`store`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->