### PR TITLE
fix(recall): gate inspect_workspace_paths on sources and normalize paths

### DIFF
--- a/assistant/src/memory/context-search/agent-runner.ts
+++ b/assistant/src/memory/context-search/agent-runner.ts
@@ -34,6 +34,7 @@ import {
   extractWorkspacePathLiterals,
   inspectWorkspacePaths,
   isSafeWorkspaceRelativePath,
+  normalizeWorkspacePathLiteral,
 } from "./sources/workspace.js";
 import type {
   RecallAnswer,
@@ -967,14 +968,17 @@ async function executeInspectWorkspacePaths(
 }> {
   const reason = readSearchReason(payload.reason);
   const requestedPaths = readInspectPaths(payload.paths);
-  const allowedPaths = collectInspectableWorkspacePaths(input.query, evidence);
+  const workspaceSourcesEnabled =
+    input.sources.includes("workspace") || input.sources.includes("pkb");
+  const allowedPaths = workspaceSourcesEnabled
+    ? collectInspectableWorkspacePaths(input.query, evidence)
+    : new Set<string>();
   const acceptedPaths: string[] = [];
   const rejectedPaths: string[] = [];
   for (const requestedPath of requestedPaths) {
-    const acceptedPath = normalizeRequestedWorkspaceInspectionPath(
-      requestedPath,
-      allowedPaths,
-    );
+    const acceptedPath = workspaceSourcesEnabled
+      ? normalizeRequestedWorkspaceInspectionPath(requestedPath, allowedPaths)
+      : null;
     if (acceptedPath) {
       acceptedPaths.push(acceptedPath);
     } else {
@@ -1001,6 +1005,7 @@ async function executeInspectWorkspacePaths(
       ],
       debug: {
         ...debug,
+        evidenceCount: 1,
         errors: [
           {
             path: "inspect_workspace_paths",
@@ -1013,8 +1018,9 @@ async function executeInspectWorkspacePaths(
 
   const errors = rejectedPaths.map((path) => ({
     path,
-    reason:
-      "path was not a safe relative workspace file surfaced by the query or prior evidence",
+    reason: workspaceSourcesEnabled
+      ? "path was not a safe relative workspace file surfaced by the query or prior evidence"
+      : "workspace and pkb sources are disabled for this recall request",
   }));
 
   let inspectionEvidence: RecallEvidence[] = [];
@@ -1165,13 +1171,18 @@ function normalizeRequestedWorkspaceInspectionPath(
   requestedPath: string,
   allowedPaths: ReadonlySet<string>,
 ): string | null {
-  const pkbPrefixedPath = `pkb/${requestedPath}`;
-  if (!requestedPath.startsWith("pkb/") && allowedPaths.has(pkbPrefixedPath)) {
+  const normalized = normalizeWorkspacePathLiteral(requestedPath);
+  if (!normalized) {
+    return null;
+  }
+
+  const pkbPrefixedPath = `pkb/${normalized}`;
+  if (!normalized.startsWith("pkb/") && allowedPaths.has(pkbPrefixedPath)) {
     return pkbPrefixedPath;
   }
 
-  if (allowedPaths.has(requestedPath)) {
-    return requestedPath;
+  if (allowedPaths.has(normalized)) {
+    return normalized;
   }
 
   return null;

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -1193,7 +1193,9 @@ function shouldSkipSegmentName(name: string): boolean {
   );
 }
 
-function normalizeWorkspacePathLiteral(pathLiteral: string): string | null {
+export function normalizeWorkspacePathLiteral(
+  pathLiteral: string,
+): string | null {
   const trimmed = pathLiteral
     .trim()
     .replace(/^["'`]+|["'`.,;:)>\]}]+$/g, "")


### PR DESCRIPTION
## Summary
Addresses review feedback on #28183.

- **Codex P1 — Source gating**: \`executeInspectWorkspacePaths\` now rejects every requested path when the recall request did not include \`workspace\` or \`pkb\` in \`input.sources\`. Previously a memory-only recall could still surface workspace file contents through inspection of paths the model had seen in prior evidence.
- **Codex P2 — Path normalization**: \`normalizeRequestedWorkspaceInspectionPath\` now normalizes the requested string via the existing \`normalizeWorkspacePathLiteral\` (now exported) before checking it against the normalized allowlist, so locators like \`scratch/handoff.md:4\` reused from evidence are accepted instead of being silently rejected as unsafe.
- **Devin BUG — debug.evidenceCount**: The empty-paths early return in \`executeInspectWorkspacePaths\` now sets \`evidenceCount: 1\`, matching the single error-evidence item it actually returns.

## Skipped
- Devin's bucket-budget analysis is intentional behavior, not a regression.
- Devin's per-round inspect-budget suggestion is bounded by per-call (5) + evidence-allowlist limits; adding a hard \`roundLimit\` cap risks regressing legitimate inspect workflows.

## Test plan
- [x] \`bunx tsc --noEmit\` passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->