### PR TITLE
fix(memory): narrow event-date repair and gate auto triggers to future

### DIFF
--- a/assistant/src/__tests__/db-memory-graph-event-date-repair.test.ts
+++ b/assistant/src/__tests__/db-memory-graph-event-date-repair.test.ts
@@ -28,7 +28,8 @@ function bootstrapTables(raw: Database): void {
     CREATE TABLE memory_graph_nodes (
       id TEXT PRIMARY KEY,
       created INTEGER NOT NULL,
-      event_date INTEGER
+      event_date INTEGER,
+      content TEXT NOT NULL DEFAULT ''
     );
 
     CREATE TABLE memory_graph_triggers (
@@ -59,16 +60,35 @@ describe("repairMemoryGraphEventDate", () => {
     const created = Date.UTC(2026, 3, 26, 5, 23, 20);
     const wrongEventDate = Date.UTC(2025, 3, 19, 2, 32, 0);
 
-    expect(repairMemoryGraphEventDate(created, wrongEventDate)).toBe(
-      Date.UTC(2026, 3, 19, 2, 32, 0),
-    );
+    expect(
+      repairMemoryGraphEventDate(
+        created,
+        wrongEventDate,
+        "Talked about the trip on April 19",
+      ),
+    ).toBe(Date.UTC(2026, 3, 19, 2, 32, 0));
   });
 
   test("leaves distant historical dates alone", () => {
     const created = Date.UTC(2026, 3, 26, 5, 23, 20);
     const historicalEventDate = Date.UTC(2025, 10, 1, 12, 0, 0);
 
-    expect(repairMemoryGraphEventDate(created, historicalEventDate)).toBeNull();
+    expect(
+      repairMemoryGraphEventDate(created, historicalEventDate, ""),
+    ).toBeNull();
+  });
+
+  test("leaves dates alone when content explicitly mentions the prior year", () => {
+    const created = Date.UTC(2026, 3, 26, 5, 23, 20);
+    const explicitHistorical = Date.UTC(2025, 3, 19, 2, 32, 0);
+
+    expect(
+      repairMemoryGraphEventDate(
+        created,
+        explicitHistorical,
+        "User flew on April 19, 2025 to visit family",
+      ),
+    ).toBeNull();
   });
 });
 
@@ -84,21 +104,23 @@ describe("migrate231RepairMemoryGraphEventDates", () => {
     const distantHistoricalDate = Date.UTC(2025, 10, 1, 12, 0, 0);
     const futureDate = Date.UTC(2027, 0, 1, 12, 0, 0);
 
-    raw
-      .prepare(
-        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
-      )
-      .run("bad-node", created, wrongEventDate);
-    raw
-      .prepare(
-        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
-      )
-      .run("historical-node", created, distantHistoricalDate);
-    raw
-      .prepare(
-        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
-      )
-      .run("future-node", created, futureDate);
+    const insertNode = raw.prepare(
+      `INSERT INTO memory_graph_nodes (id, created, event_date, content) VALUES (?, ?, ?, ?)`,
+    );
+    insertNode.run("bad-node", created, wrongEventDate, "Trip on April 19");
+    insertNode.run(
+      "historical-node",
+      created,
+      distantHistoricalDate,
+      "Notes from last fall",
+    );
+    insertNode.run("future-node", created, futureDate, "New Year 2027 plans");
+    insertNode.run(
+      "explicit-year-node",
+      created,
+      wrongEventDate,
+      "User flew on April 19, 2025 to visit family",
+    );
     raw
       .prepare(
         `INSERT INTO memory_graph_triggers (id, node_id, type, event_date) VALUES (?, ?, ?, ?)`,
@@ -112,5 +134,6 @@ describe("migrate231RepairMemoryGraphEventDates", () => {
     expect(triggerEventDateFor(raw, "bad-trigger")).toBe(correctedEventDate);
     expect(eventDateFor(raw, "historical-node")).toBe(distantHistoricalDate);
     expect(eventDateFor(raw, "future-node")).toBe(futureDate);
+    expect(eventDateFor(raw, "explicit-year-node")).toBe(wrongEventDate);
   });
 });

--- a/assistant/src/__tests__/graph-extraction-event-date.test.ts
+++ b/assistant/src/__tests__/graph-extraction-event-date.test.ts
@@ -191,6 +191,40 @@ describe("parseExtractionResponse event_date coercion", () => {
     expect(diff.updateNodes[0].changes.eventDate).toBe(1712534400000);
   });
 
+  test("auto-creates an event trigger for future event_date", () => {
+    const conversationTs = Date.UTC(2026, 3, 26, 0, 0, 0);
+    const futureEventDate = Date.UTC(2026, 5, 1, 0, 0, 0);
+    const input = makeInput({ event_date: futureEventDate });
+    const { deferredTriggers } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      conversationTs,
+    );
+    const auto = deferredTriggers.find(
+      (t) =>
+        t.trigger.type === "event" && t.trigger.eventDate === futureEventDate,
+    );
+    expect(auto).toBeTruthy();
+  });
+
+  test("does not auto-create an event trigger for past event_date", () => {
+    const conversationTs = Date.UTC(2026, 3, 26, 0, 0, 0);
+    const pastEventDate = Date.UTC(2025, 0, 15, 0, 0, 0);
+    const input = makeInput({ event_date: pastEventDate });
+    const { deferredTriggers } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      conversationTs,
+    );
+    expect(deferredTriggers.some((t) => t.trigger.type === "event")).toBe(
+      false,
+    );
+  });
+
   test("null-clears event_date on update_nodes when explicitly null", () => {
     const existingNodeId = "existing-node-1";
     const candidates = new Set([existingNodeId]);

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -723,8 +723,12 @@ export function parseExtractionResponse(
 
     // Auto-create event trigger when event_date is set but LLM didn't include one,
     // or replace a malformed event trigger (event_date unset) with a valid one.
+    // Only auto-create for future events — past-dated memories (historical
+    // milestones, dated events that already happened) shouldn't generate
+    // ramp/follow-up reminders.
     if (
       node.eventDate != null &&
+      node.eventDate > now &&
       (!Array.isArray(raw.triggers) ||
         !raw.triggers.some((t) => t.type === "event" && t.event_date != null))
     ) {

--- a/assistant/src/memory/migrations/231-repair-memory-graph-event-dates.ts
+++ b/assistant/src/memory/migrations/231-repair-memory-graph-event-dates.ts
@@ -12,6 +12,7 @@ interface GraphNodeEventDateRow {
   id: string;
   created: number;
   event_date: number;
+  content: string;
 }
 
 interface EventDateRepair {
@@ -37,9 +38,14 @@ function replaceUtcYear(epochMs: number, year: number): number {
   );
 }
 
+function contentMentionsYear(content: string, year: number): boolean {
+  return new RegExp(`\\b${year}\\b`).test(content);
+}
+
 export function repairMemoryGraphEventDate(
   createdMs: number,
   eventDateMs: number,
+  content: string,
 ): number | null {
   if (!Number.isFinite(createdMs) || !Number.isFinite(eventDateMs)) {
     return null;
@@ -49,6 +55,10 @@ export function repairMemoryGraphEventDate(
   const eventYear = utcYear(eventDateMs);
   if (createdYear !== REPAIR_CREATED_YEAR) return null;
   if (!CORRUPT_EVENT_YEARS.includes(eventYear as 2024 | 2025)) return null;
+
+  // If the memory's prose explicitly mentions the prior year, the date is
+  // user-anchored history — not the partial-date inference bug — so leave it.
+  if (contentMentionsYear(content, eventYear)) return null;
 
   const corrected = replaceUtcYear(eventDateMs, createdYear);
   if (corrected === eventDateMs) return null;
@@ -71,7 +81,7 @@ export function migrate231RepairMemoryGraphEventDates(
     const rows = raw
       .query(
         /*sql*/ `
-          SELECT id, created, event_date
+          SELECT id, created, event_date, content
           FROM memory_graph_nodes
           WHERE event_date IS NOT NULL
             AND CAST(strftime('%Y', created / 1000, 'unixepoch') AS INTEGER) = ?
@@ -85,7 +95,11 @@ export function migrate231RepairMemoryGraphEventDates(
 
     const repairs: EventDateRepair[] = [];
     for (const row of rows) {
-      const corrected = repairMemoryGraphEventDate(row.created, row.event_date);
+      const corrected = repairMemoryGraphEventDate(
+        row.created,
+        row.event_date,
+        row.content ?? "",
+      );
       if (corrected == null) continue;
       repairs.push({
         id: row.id,


### PR DESCRIPTION
Addresses Codex review feedback on #28355.

## Summary
- `repairMemoryGraphEventDate` now also receives the node's content text and skips repair when the prose explicitly mentions the corrupt year (e.g. 'April 19, 2025'). Catches the false-positive Codex flagged where an explicitly-stated historical event would be rewritten to the creation year.
- `parseExtractionResponse` only auto-creates an event trigger when `event_date` is in the future relative to the conversation timestamp. The prompt now allows past event_dates, but past-dated memories should not produce ramp/follow-up reminders.

## Test plan
- [x] `bun test src/__tests__/db-memory-graph-event-date-repair.test.ts src/__tests__/graph-extraction-event-date.test.ts` (22 pass)
- [x] New cases: explicit-year content skips repair; future event_date triggers auto-create; past event_date does not.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->