### PR TITLE
fix(macos): voice-mode bootstrap uses observation stream instead of polling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,6 +6,15 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ConversationManager")
 
+/// Paired snapshot of the `ChatViewModel` signals that
+/// `prepareActiveConversationForVoiceMode` waits on. Wrapping them in a single
+/// `Equatable & Sendable` value lets one `observationStream` yield on either
+/// transition without spinning up a second observation task.
+private struct VoiceBootstrapSnapshot: Equatable, Sendable {
+    let hasConversationId: Bool
+    let isBootstrapping: Bool
+}
+
 // MARK: - Conversation Client Protocol
 
 /// Abstraction for direct conversation mutations, decoupled from GatewayConnectionManager.
@@ -574,7 +583,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     }
 
     @discardableResult
-    func prepareActiveConversationForVoiceMode(timeoutSeconds: TimeInterval = 3.0) async -> ChatViewModel? {
+    func prepareActiveConversationForVoiceMode(timeoutSeconds: TimeInterval = 10.0) async -> ChatViewModel? {
         if activeViewModel == nil {
             enterDraftMode()
         }
@@ -591,15 +600,30 @@ final class ConversationManager: ConversationRestorerDelegate {
 
         viewModel.createConversationIfNeeded()
 
-        let deadline = Date().addingTimeInterval(timeoutSeconds)
-        while Date() < deadline {
-            if viewModel.conversationId != nil {
-                return viewModel
+        // Wait for bootstrap to settle: either `conversationId` becomes
+        // non-nil (success) or `isBootstrapping` flips to false (failure).
+        // The timeout is a safety net for a stuck state machine; it must
+        // exceed the gateway health-check window so cold-start bootstraps
+        // are not falsely reported as failed.
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor [weak viewModel] in
+                guard let viewModel else { return }
+                for await snapshot in observationStream({
+                    VoiceBootstrapSnapshot(
+                        hasConversationId: viewModel.conversationId != nil,
+                        isBootstrapping: viewModel.isBootstrapping
+                    )
+                }) {
+                    if snapshot.hasConversationId || !snapshot.isBootstrapping {
+                        return
+                    }
+                }
             }
-            if !viewModel.isBootstrapping {
-                break
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
             }
-            try? await Task.sleep(nanoseconds: 50_000_000)
+            await group.next()
+            group.cancelAll()
         }
 
         return viewModel.conversationId == nil ? nil : viewModel


### PR DESCRIPTION
## Summary
- Replace the 50ms polling loop in `prepareActiveConversationForVoiceMode` with an `observationStream` that yields on `conversationId` / `isBootstrapping` transitions, raced against a timeout via `withTaskGroup`. Matches the pattern already in `UpdateManager.checkForUpdatesAsync` and `AppDelegate+MenuBar`.
- Bump the safety timeout from 3s → 10s so cold-start bootstraps (which can wait on the gateway health check, itself up to 10s) are not falsely reported as failed.

Addresses review feedback on #28350:
- Devin: busy-wait loop violates the `clients/AGENTS.md` rule on `AsyncStream` for state transitions.
- Codex: 3s timeout converts legitimate slow bootstraps into voice-mode failures, defeating the empty-chat startup path the original PR fixed.

## Test plan
- [ ] Trigger voice mode from the empty chat screen on a cold start; voice UI activates without a 'failed' toast.
- [ ] Trigger voice mode on an existing conversation; behavior unchanged.
- [ ] Force a bootstrap failure (offline gateway); voice mode reports failure as before, within ~10s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->