### PR TITLE
fix(db): purge orphan attachments left by prior migration 229 runs

### DIFF
--- a/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
@@ -1109,4 +1109,48 @@ describe("migrateDeletePrivateConversations", () => {
       ),
     ).toBe(1);
   });
+
+  test("removes orphan attachments left by prior runs that deleted private messages", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapTables(raw);
+    seedConversation(raw, "conv-standard", "standard");
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (
+        id,
+        original_filename,
+        mime_type,
+        size_bytes,
+        kind,
+        data_base64,
+        created_at
+      ) VALUES (
+        'orphan-private-attachment',
+        'leaked.txt',
+        'text/plain',
+        1,
+        'text',
+        'eA==',
+        ${now}
+      );
+    `);
+
+    expect(
+      countWhere(raw, "attachments", `id = 'orphan-private-attachment'`),
+    ).toBe(1);
+    expect(
+      countWhere(raw, "attachments", `id = 'conv-standard-attachment'`),
+    ).toBe(1);
+
+    migrateDeletePrivateConversations(db);
+
+    expect(
+      countWhere(raw, "attachments", `id = 'orphan-private-attachment'`),
+    ).toBe(0);
+    expect(
+      countWhere(raw, "attachments", `id = 'conv-standard-attachment'`),
+    ).toBe(1);
+  });
 });

--- a/assistant/src/memory/migrations/229-delete-private-conversations.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.ts
@@ -198,6 +198,14 @@ export function migrateDeletePrivateConversations(database: DrizzleDb): void {
     WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
   `);
   database.run(/*sql*/ `
+    DELETE FROM attachments
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM message_attachments ma
+      WHERE ma.attachment_id = attachments.id
+    )
+  `);
+  database.run(/*sql*/ `
     DELETE FROM memory_summaries
     WHERE scope_id LIKE 'private:%'
   `);


### PR DESCRIPTION
## Summary
- Earlier runs of migration 229 deleted private messages, which cascade-deleted their `message_attachments` rows and orphaned the underlying `attachments` rows. The cleanup added in #28161 only matches attachments still linked through `message_attachments`, so private blob bytes left over from those earlier runs persist indefinitely.
- Adds a final `DELETE FROM attachments WHERE NOT EXISTS message_attachments` sweep so re-running the migration on already-upgraded databases reclaims the leak.
- Adds a regression test that seeds an orphan attachment alongside an unaffected standard one and asserts only the orphan is removed.

## Test plan
- [x] `bun test src/memory/migrations/229-delete-private-conversations.test.ts`

Addresses Codex P1 review feedback on #28161.