### PR TITLE
fix(macos): reset speech accumulator on early silence in live voice auto-release

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -371,7 +371,10 @@ final class LiveVoiceChannelManager {
             return
         }
 
-        guard speechDurationInCurrentUtterance >= minimumSpeechDurationBeforeRelease else { return }
+        guard speechDurationInCurrentUtterance >= minimumSpeechDurationBeforeRelease else {
+            speechDurationInCurrentUtterance = 0
+            return
+        }
         silenceDurationAfterSpeech += chunkDuration
 
         guard silenceDurationAfterSpeech >= silenceDurationBeforeRelease else { return }


### PR DESCRIPTION
Addresses Codex review feedback on #28349.

When a chunk fell below `speechAmplitudeThreshold` before `minimumSpeechDurationBeforeRelease` was reached, the early-return branch left `speechDurationInCurrentUtterance` cumulative across disjoint bursts. A few short spikes separated by silence could eventually satisfy the 120ms gate and trigger an unwanted auto-release. Reset the accumulator on early silence so release only follows a continuous speech segment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->