### PR TITLE
fix(memory-v2): count page chars not utf-8 bytes in validator

### DIFF
--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -148,7 +148,7 @@ async function handleValidate({
       const page = await readPage(workspaceDir, slug);
       if (!page) continue;
       knownSlugs.add(slug);
-      const chars = Buffer.byteLength(page.body, "utf8");
+      const chars = page.body.length;
       if (chars > maxPageChars) {
         oversizedPages.push({ slug, chars });
       }


### PR DESCRIPTION
Follow-up to #28413.

Both Devin and Codex flagged that `handleValidate` measured page size with `Buffer.byteLength(page.body, "utf8")` while the config knob is `memory.v2.max_page_chars` and the result field is `chars`. For multibyte content that overcounts by 2-4x and reports pages as oversized when their character count is within the configured cap.

Switched to `page.body.length`.

## Test plan
- [ ] Existing memory-v2 validator tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->