### PR TITLE
fix(macos): re-trigger ACP deep-link consume on session arrival

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -83,6 +83,9 @@ struct ACPSessionsPanel: View {
         .onChange(of: store.selectedSessionId) {
             consumeSelectedSessionIdIfPresent()
         }
+        .onChange(of: store.sessionOrder.count) {
+            consumeSelectedSessionIdIfPresent()
+        }
         .alert("Clear completed history?", isPresented: $showClearCompletedConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
@@ -104,8 +107,9 @@ struct ACPSessionsPanel: View {
     /// top of the stack, we still clear the store field but skip the push
     /// to avoid stacking duplicate detail views. Resilient to a deep-link
     /// arriving before its matching SSE `acp_session_spawned` event — the
-    /// field stays set so a subsequent consume (driven by the next
-    /// `onChange` tick or panel mount) can flush once the row appears.
+    /// field stays set, and a separate `onChange(of: store.sessionOrder.count)`
+    /// observer re-runs this helper when the store's session set mutates so
+    /// the pending id is flushed once the row appears.
     func consumeSelectedSessionIdIfPresent() {
         Self.consumeSelectedSessionIdIfPresent(store: store, path: &navigationPath)
     }


### PR DESCRIPTION
## Summary
Follow-up to #28320. Bot reviewers flagged a race where a deep-link landing before its matching SSE `acp_session_spawned` event would be silently lost: `consumeSelectedSessionIdIfPresent` early-returns when the session isn't in the store yet, leaving `store.selectedSessionId` set, but `.onChange(of: store.selectedSessionId)` never re-fires (value didn't change) and `.onAppear` only runs on initial mount.

## Fix
Add a second observer `.onChange(of: store.sessionOrder.count)` that re-runs the consume helper. When the deferred session arrives via `handleSpawned` and is appended to `sessionOrder`, the consume runs again, finds the matching view model, clears `selectedSessionId`, and pushes the detail view.

Docstring on `consumeSelectedSessionIdIfPresent` updated to reflect the actual re-trigger mechanism.