### PR TITLE
fix(live-voice): suppress onError after assistant turn completion

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -470,16 +470,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           },
         },
         onError: (message) => {
-          if (!this.isActiveAssistantTurn(token)) return;
+          const activeTurn = this.activeAssistantTurn;
+          if (
+            !this.isActiveAssistantTurn(token) ||
+            activeTurn?.assistantCompleted
+          ) {
+            return;
+          }
           void (async () => {
             await this.sendFrame({
               type: "error",
               code: LiveVoiceProtocolErrorCode.InvalidField,
               message,
             });
-            const activeTurn = this.activeAssistantTurn;
-            if (activeTurn?.token !== token) return;
-            await this.finalizeAssistantTurn(activeTurn, "cancelled", "error");
+            const currentTurn = this.activeAssistantTurn;
+            if (currentTurn?.token !== token) return;
+            await this.finalizeAssistantTurn(currentTurn, "cancelled", "error");
           })();
         },
       });


### PR DESCRIPTION
Addresses Codex P2 feedback on #28319.

The `onError` handler relied on `isActiveAssistantTurn(token)` which does
not check `assistantCompleted`. Late bridge errors emitted after
`message_complete` (e.g. during cleanup) were being forwarded as
live-voice `error` frames, so a successfully completed turn could be
reported as failed in UI/telemetry.

Now also gates on `!activeTurn.assistantCompleted` so completion
state suppresses these late errors as it did before #28319.