### PR TITLE
fix(macos): block PCM during non-PCM playback and preserve failed state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
@@ -90,6 +90,7 @@ final class LiveVoiceAudioPlayer {
     @ObservationIgnored private let output: any LiveVoiceAudioOutput
     @ObservationIgnored private var queuedChunks: [LiveVoiceAudioChunk] = []
     @ObservationIgnored private var scheduledPlaybackCount = 0
+    @ObservationIgnored private var hasNonPCMInFlight = false
     @ObservationIgnored private var playbackGeneration: UInt64 = 0
     @ObservationIgnored private var acceptsAudio = true
     @ObservationIgnored private var playbackWaiters: [CheckedContinuation<Void, Never>] = []
@@ -139,6 +140,7 @@ final class LiveVoiceAudioPlayer {
         acceptsAudio = false
         queuedChunks.removeAll()
         scheduledPlaybackCount = 0
+        hasNonPCMInFlight = false
         output.stop()
         state = .stopped(reason)
         notifyPlaybackWaiters()
@@ -149,6 +151,7 @@ final class LiveVoiceAudioPlayer {
         output.stop()
         queuedChunks.removeAll()
         scheduledPlaybackCount = 0
+        hasNonPCMInFlight = false
         acceptsAudio = true
         state = .idle
         notifyPlaybackWaiters()
@@ -164,6 +167,9 @@ final class LiveVoiceAudioPlayer {
 
     private func playNextChunkIfNeeded() {
         while acceptsAudio, !queuedChunks.isEmpty {
+            if hasNonPCMInFlight {
+                return
+            }
             let chunk = queuedChunks[0]
             if scheduledPlaybackCount > 0, !chunk.isPCM {
                 return
@@ -172,6 +178,9 @@ final class LiveVoiceAudioPlayer {
             queuedChunks.removeFirst()
             let generation = playbackGeneration
             scheduledPlaybackCount += 1
+            if !chunk.isPCM {
+                hasNonPCMInFlight = true
+            }
             state = .playing
 
             output.play(chunk) { [weak self] result in
@@ -187,11 +196,14 @@ final class LiveVoiceAudioPlayer {
     private func handlePlaybackCompletion(_ result: Result<Void, Error>, generation: UInt64) {
         guard generation == playbackGeneration, scheduledPlaybackCount > 0 else { return }
         scheduledPlaybackCount -= 1
+        if scheduledPlaybackCount == 0 {
+            hasNonPCMInFlight = false
+        }
 
         switch result {
         case .success:
             playNextChunkIfNeeded()
-            if queuedChunks.isEmpty, scheduledPlaybackCount == 0 {
+            if generation == playbackGeneration, queuedChunks.isEmpty, scheduledPlaybackCount == 0 {
                 state = .idle
                 notifyPlaybackWaiters()
             }
@@ -201,6 +213,7 @@ final class LiveVoiceAudioPlayer {
             acceptsAudio = false
             queuedChunks.removeAll()
             scheduledPlaybackCount = 0
+            hasNonPCMInFlight = false
             output.stop()
             state = .failed(error.localizedDescription)
             notifyPlaybackWaiters()


### PR DESCRIPTION
## Summary
Follow-up to #28362 addressing post-merge review feedback.

- **PCM/non-PCM concurrency**: The previous guard only blocked non-PCM from being scheduled while something was in-flight, but allowed PCM to schedule alongside an active buffered (non-PCM) player. Because the PCM path skips `stop()`, both players ran simultaneously, producing overlapping audio. Track non-PCM in-flight separately and block all new scheduling while it is set.
- **Failed→idle race**: In the success branch of `handlePlaybackCompletion`, `playNextChunkIfNeeded()` can synchronously re-enter the failure path (e.g. `AVAudioEngine.start` throwing), which sets `state = .failed` and bumps the generation. The outer success then saw an empty queue and zero count and overwrote `.failed` with `.idle`, swallowing the error. Gate the idle transition on the generation still matching.

## Test plan
- [ ] Stream mixed-MIME TTS (audio/mpeg + audio/pcm) and confirm no overlap
- [ ] Force a PCM engine-start failure and confirm `state` stays `.failed`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->