### PR TITLE
fix(memory-v2): strict frontmatter parse rejects unknown keys

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -238,6 +238,19 @@ describe("writePage + readPage round-trip", () => {
     expect(read!.body).toBe(body);
   });
 
+  test("readPage throws on unknown frontmatter keys instead of silently dropping them", async () => {
+    const slug = "extra-keys";
+    const raw =
+      "---\nedges: []\nref_files: []\nunknown_field: oops\n---\nbody\n";
+    writeFileSync(
+      join(workspaceDir, "memory", "concepts", `${slug}.md`),
+      raw,
+      "utf-8",
+    );
+
+    await expect(readPage(workspaceDir, slug)).rejects.toThrow();
+  });
+
   test("writePage overwrites an existing page", async () => {
     const page1 = makePage({ body: "first version\n" });
     await writePage(workspaceDir, page1);

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -33,11 +33,13 @@ import { z } from "zod";
  * the summary field still parse — those fall back to full-page injection and
  * full-page-only similarity.
  */
-export const ConceptPageFrontmatterSchema = z.object({
-  edges: z.array(z.string()).default([]),
-  ref_files: z.array(z.string()).default([]),
-  summary: z.string().optional(),
-});
+export const ConceptPageFrontmatterSchema = z
+  .object({
+    edges: z.array(z.string()).default([]),
+    ref_files: z.array(z.string()).default([]),
+    summary: z.string().optional(),
+  })
+  .strict();
 
 export type ConceptPageFrontmatter = z.infer<
   typeof ConceptPageFrontmatterSchema


### PR DESCRIPTION
## Summary
Switches `ConceptPageFrontmatterSchema` to `.strict()` so a concept page with unknown frontmatter keys throws a parse error rather than silently dropping the data on read/write round-trip.

## Context
Follow-up to review feedback on #28410 (P2 from Codex). The other path-traversal concern flagged in that review is already addressed in current code via `validateSlug()` at every public entry point of `page-store.ts`.

## Test plan
- [x] `bun test src/memory/v2/__tests__/page-store.test.ts` — 58 pass (new regression test included)