### PR TITLE
fix(memory): gate embed_concept_page on Qdrant circuit breaker

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -3,7 +3,7 @@
  *
  * Before this fix, all non-embed jobs ran through a single bounded worker
  * pool, so a long-running `graph_consolidate` LLM call would pin every slot
- * and starve fast-lane jobs (e.g. `embed_concept_page` consolidation pages)
+ * and starve fast-lane jobs (e.g. `memory_v2_activation_recompute`)
  * for the duration of that call.
  *
  * The new scheduler runs slow / fast / embed lanes in parallel pools, each
@@ -87,16 +87,19 @@ mock.module("../memory/graph/consolidation.js", () => ({
 
 // Fast-lane handler: resolves on the next microtask. The test fires this
 // many times in parallel; nothing should block.
-mock.module("../memory/jobs/embed-concept-page.js", () => ({
-  embedConceptPageJob: async (job: {
-    payload: { slug?: string };
-  }): Promise<void> => {
+mock.module("../memory/v2/backfill-jobs.js", () => ({
+  memoryV2ActivationRecomputeJob: async (job: {
+    payload: { scopeId?: string };
+  }): Promise<number> => {
     completions.push({
-      type: "embed_concept_page",
-      conversationId: job.payload.slug ?? "",
+      type: "memory_v2_activation_recompute",
+      conversationId: job.payload.scopeId ?? "",
       completedAt: Date.now(),
     });
+    return 0;
   },
+  memoryV2MigrateJob: async (): Promise<void> => {},
+  memoryV2ReembedJob: async (): Promise<void> => {},
 }));
 
 // Stub remaining heavy boundaries that we never exercise but that get pulled
@@ -128,18 +131,22 @@ describe("memory jobs worker lane scheduling", () => {
 
   test("fast lane completes before slow lane releases its slot", async () => {
     // 5 slow `graph_consolidate` jobs across distinct scopes (so they would
-    // serialize behind a single shared pool) plus 5 fast `embed_concept_page`
-    // jobs across distinct slugs.
+    // serialize behind a single shared pool) plus 5 fast
+    // `memory_v2_activation_recompute` jobs across distinct scopes.
     for (let i = 0; i < 5; i++) {
       enqueueMemoryJob("graph_consolidate", { scopeId: `slow-${i}` });
     }
     for (let i = 0; i < 5; i++) {
-      enqueueMemoryJob("embed_concept_page", { slug: `fast-${i}` });
+      enqueueMemoryJob("memory_v2_activation_recompute", {
+        scopeId: `fast-${i}`,
+      });
     }
 
     await runMemoryJobsOnce();
 
-    const fastDone = completions.filter((c) => c.type === "embed_concept_page");
+    const fastDone = completions.filter(
+      (c) => c.type === "memory_v2_activation_recompute",
+    );
     const slowDone = completions.filter((c) => c.type === "graph_consolidate");
 
     // Slow lane is capped at 1 in this test, so only 1 slow job ran in this

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -52,6 +52,7 @@ export const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_graph_node",
   "embed_pkb_file",
   "graph_trigger_embed",
+  "embed_concept_page",
 ];
 
 export const SLOW_LLM_JOB_TYPES: MemoryJobType[] = [


### PR DESCRIPTION
## Summary
- Adds `embed_concept_page` to `EMBED_JOB_TYPES` so `claimMemoryJobs` gates it on the Qdrant circuit breaker (skip while open, allow one probe on cooldown) and prioritizes non-embed work over it.
- Updates the lanes scheduler test to use `memory_v2_activation_recompute` for its fast-lane fixture, since `embed_concept_page` is now embed-lane.

## Why
Addresses review feedback on #28414. The real `embed_concept_page` handler upserts to v2 Qdrant via its own `QdrantRestClient`, but both v1 and v2 clients target the same Qdrant instance — so when the v1 breaker is open, v2 calls fail too. Without this fix, embed_concept_page jobs were claimed, failed, and retried with backoff up to `RETRY_MAX_ATTEMPTS`, risking permanent failure during sustained outages.

## Test plan
- [x] `bun test src/__tests__/memory-jobs-worker-lanes.test.ts src/memory/__tests__/jobs-store-job-classes.test.ts src/memory/jobs/__tests__/embed-concept-page.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->