### PR TITLE
fix(memory-v2): map dense cosine to unit before hybrid fusion

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -9,6 +9,7 @@ import type {
 } from "../qdrant-client.js";
 import { getQdrantClient } from "../qdrant-client.js";
 import { memorySegments, memorySummaries } from "../schema.js";
+import { mapCosineToUnit } from "../validation.js";
 // ── Types (inlined from deleted types.ts) ──────────────────────────
 
 type CandidateType = "segment" | "item" | "summary" | "media";
@@ -234,8 +235,4 @@ function buildHybridFilter(
     must: mustConditions,
     must_not: mustNotConditions,
   };
-}
-
-function mapCosineToUnit(value: number): number {
-  return Math.max(0, Math.min(1, (value + 1) / 2));
 }

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -433,8 +433,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["dense-only-page"], config);
 
-    // 0.7 * 0.5 + 0.3 * 0 = 0.35
-    expect(out.get("dense-only-page")).toBeCloseTo(0.35, 6);
+    // cosine 0.5 → unit 0.75; 0.7 * 0.75 + 0.3 * 0 = 0.525
+    expect(out.get("dense-only-page")).toBeCloseTo(0.525, 6);
   });
 
   test("sparse-only hit gets dense contribution of 0; sparse normalized to 1.0", async () => {
@@ -475,10 +475,11 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice", "bob"], config);
 
-    // alice: 0.4 * 0.5 + 0.6 * 1.0 = 0.8
-    // bob:   0.4 * 0.25 + 0.6 * 0.5 = 0.4
-    expect(out.get("alice")).toBeCloseTo(0.8, 6);
-    expect(out.get("bob")).toBeCloseTo(0.4, 6);
+    // cosine→unit: alice 0.5 → 0.75, bob 0.25 → 0.625.
+    // alice: 0.4 * 0.75 + 0.6 * 1.0 = 0.9
+    // bob:   0.4 * 0.625 + 0.6 * 0.5 = 0.55
+    expect(out.get("alice")).toBeCloseTo(0.9, 6);
+    expect(out.get("bob")).toBeCloseTo(0.55, 6);
   });
 
   test("scores are clamped into [0, 1] even when fused values overshoot", async () => {
@@ -537,7 +538,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice"], config);
 
-    expect(out.get("alice")).toBeCloseTo(0.7, 6);
+    // cosine 0.7 → unit 0.85; cosine 0.3 → unit 0.65; max = 0.85.
+    expect(out.get("alice")).toBeCloseTo(0.85, 6);
   });
 
   test("takes max(body, summary) per slug — body higher than summary wins", async () => {
@@ -553,7 +555,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice"], config);
 
-    expect(out.get("alice")).toBeCloseTo(0.9, 6);
+    // cosine 0.9 → unit 0.95; cosine 0.4 → unit 0.7; max = 0.95.
+    expect(out.get("alice")).toBeCloseTo(0.95, 6);
   });
 
   test("falls back to body-only when the page has no summary embedding", async () => {
@@ -570,7 +573,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["legacy-page"], config);
 
-    expect(out.get("legacy-page")).toBeCloseTo(0.6, 6);
+    // cosine 0.6 → unit 0.8.
+    expect(out.get("legacy-page")).toBeCloseTo(0.8, 6);
   });
 
   test("normalizes body and summary sparse channels independently", async () => {
@@ -605,6 +609,21 @@ describe("simBatch", () => {
     // Body side has only bob's tiny sparse=0.5 against the body batch max
     // of 100 → ~0.005. The max picks the summary side.
     expect(out.get("bob")).toBeCloseTo(1.0, 6);
+  });
+
+  test("negative cosine maps to a non-negative dense contribution", async () => {
+    // Qdrant cosine search returns scores in [-1, 1]. A near-zero or
+    // negative cosine must not yield a negative dense contribution that
+    // depresses the fused score below the sparse-only floor.
+    const config = configWithWeights(0.7, 0.3);
+    stageHybridResponse([
+      { slug: "anti-match", denseScore: -1.0, sparseScore: 1 },
+    ]);
+
+    const out = await simBatch("query", ["anti-match"], config);
+
+    // cosine -1 → unit 0; sparse-norm = 1.0; fused = 0.7*0 + 0.3*1 = 0.3.
+    expect(out.get("anti-match")).toBeCloseTo(0.3, 6);
   });
 
   test("returned scores are always in [0, 1] for arbitrary inputs", async () => {

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -17,18 +17,22 @@
 //   channel separately and fuses with the configured `dense_weight` /
 //   `sparse_weight` (which the schema validates sum to 1.0).
 //
-// Sparse normalization:
-//   Dense cosine similarity is already in [0, 1]. Qdrant's sparse score is
-//   on a different, unbounded scale (it depends on query and document term
+// Score normalization:
+//   Qdrant returns cosine similarity in [-1, 1]; we map it to [0, 1] via
+//   `mapCosineToUnit` before fusing. Skipping this step systematically
+//   depresses dense contributions for near-zero or negative cosines and
+//   skews ordering toward sparse-only matches. Qdrant's sparse score is on
+//   a different, unbounded scale (it depends on query and document term
 //   weights), so we divide by the per-batch maximum sparse score to bring
 //   it into [0, 1] before fusing. This is the design doc's choice (§4) —
-//   batch-relative normalization is sufficient because the score is consumed
-//   only as a per-turn ordering signal, not compared across turns.
+//   batch-relative normalization is sufficient because the score is
+//   consumed only as a per-turn ordering signal, not compared across
+//   turns.
 
 import type { AssistantConfig } from "../../config/types.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embedding-backend.js";
-import { clampUnitInterval } from "../validation.js";
+import { clampUnitInterval, mapCosineToUnit } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
 import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
 
@@ -264,9 +268,10 @@ function computeMaxSparse<T>(
 
 /**
  * Fuse one half of a hit (body or summary) into a normalized [0, 1] score
- * via `clamp01(dense_weight · dense + sparse_weight · sparse/maxSparse)`.
- * Returns `undefined` when neither channel hit — a signal the half had no
- * match at all, so the caller can fall back to the other half cleanly.
+ * via `clamp01(dense_weight · denseUnit + sparse_weight · sparse/maxSparse)`,
+ * where `denseUnit = (cosine + 1) / 2`. Returns `undefined` when neither
+ * channel hit — a signal the half had no match at all, so the caller can
+ * fall back to the other half cleanly.
  */
 function fuseHalf(
   denseScore: number | undefined,
@@ -276,7 +281,7 @@ function fuseHalf(
   sparseWeight: number,
 ): number | undefined {
   if (denseScore === undefined && sparseScore === undefined) return undefined;
-  const dense = denseScore ?? 0;
+  const dense = denseScore !== undefined ? mapCosineToUnit(denseScore) : 0;
   const sparseNormalized =
     sparseScore !== undefined && maxSparse > 0 ? sparseScore / maxSparse : 0;
   return clamp01(denseWeight * dense + sparseWeight * sparseNormalized);

--- a/assistant/src/memory/validation.ts
+++ b/assistant/src/memory/validation.ts
@@ -8,3 +8,13 @@
 export function clampUnitInterval(value: number): number {
   return Math.min(1, Math.max(0, value));
 }
+
+/**
+ * Map cosine similarity [-1, 1] into the unit interval [0, 1] via
+ * `(x + 1) / 2`, then clamp. Used by hybrid retrieval (v2) and legacy
+ * semantic search to put dense and sparse channels on the same scale
+ * before fusion.
+ */
+export function mapCosineToUnit(value: number): number {
+  return clampUnitInterval((value + 1) / 2);
+}

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -50,6 +50,7 @@ import {
   getConceptPageCorpusStats,
   rebuildConceptPageCorpusStats,
 } from "../../memory/v2/sparse-bm25.js";
+import { mapCosineToUnit } from "../../memory/validation.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
@@ -341,7 +342,7 @@ export interface MemoryV2ExplainSimilarityRow {
   sparseRaw: number | null;
   /** Sparse score divided by the per-batch max, in [0, 1]. */
   sparseNorm: number | null;
-  /** `clamp01(dense_weight·dense + sparse_weight·sparseNorm)` — the simBatch fused value. */
+  /** `clamp01(dense_weight·denseUnit + sparse_weight·sparseNorm)` where `denseUnit = (cosine + 1) / 2` — the simBatch fused value. */
   fused: number;
 }
 
@@ -439,12 +440,14 @@ async function scoreChannel(
   } = effectiveWeights(hits, maxSparse, denseWeight, sparseWeight, config);
 
   const rows: MemoryV2ExplainSimilarityRow[] = hits.map((hit) => {
-    const dense = hit.denseScore ?? 0;
+    // Map cosine [-1, 1] → unit [0, 1] before fusion to mirror simBatch.
+    const denseUnit =
+      hit.denseScore !== undefined ? mapCosineToUnit(hit.denseScore) : 0;
     const sparseNorm =
       hit.sparseScore !== undefined && maxSparse > 0
         ? hit.sparseScore / maxSparse
         : 0;
-    const fusedRaw = effDense * dense + effSparse * sparseNorm;
+    const fusedRaw = effDense * denseUnit + effSparse * sparseNorm;
     const fused = Math.max(0, Math.min(1, fusedRaw));
     return {
       slug: hit.slug,


### PR DESCRIPTION
## Summary
- Map Qdrant cosine [-1, 1] to [0, 1] in `fuseHalf` before weighted fusion with the [0, 1]-normalized sparse channel. Previously the raw cosine was multiplied by `dense_weight` directly, which systematically depressed dense contributions for near-zero or negative cosines and skewed ordering toward sparse-only matches.
- Extract shared `mapCosineToUnit` into `assistant/src/memory/validation.ts` (next to `clampUnitInterval`) and use it from `memory/search/semantic.ts`, `memory/v2/sim.ts`, and the `explain-similarity` diagnostic route in `memory-v2-routes.ts`.
- Update fusion-math tests to reflect the new mapping; add a regression test that a strongly negative cosine (-1.0) yields a non-negative dense contribution.

Addresses [Codex P2 feedback](https://github.com/vellum-ai/vellum-assistant/pull/28415#discussion_r2421110698) on the merged PR #28415.

## Test plan
- [x] `bun test src/memory/v2/__tests__/sim.test.ts` (27 pass)
- [x] `bunx tsc --noEmit`