### PR TITLE
fix(memory-v2): correct schema description for 4h consolidation

### DIFF
--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -258,7 +258,7 @@ export const MemoryV2ConfigSchema = z
       ),
   })
   .describe(
-    "Memory v2 — concept-page activation model with hourly LLM-driven consolidation",
+    "Memory v2 — concept-page activation model with periodic LLM-driven consolidation",
   )
   .superRefine((config, ctx) => {
     const activationSum =


### PR DESCRIPTION
Followup to #28566 — Devin flagged that the top-level `MemoryV2ConfigSchema.describe()` still said 'hourly LLM-driven consolidation' after the default cadence changed to 4h. Replaced with 'periodic' so the description stays accurate regardless of the configured interval.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->