### PR TITLE
chore(tests): drop historical comment in memory-v2 reseed test

### DIFF
--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -245,12 +245,4 @@ describe("v2 skill re-seed gating in skill handlers", () => {
     expect(mockMaybeSeedMemoryV2Skills).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["v1"]);
   });
-
-  // Note: "seed rejection swallowed" is now an internal concern of
-  // `maybeSeedMemoryV2Skills` — it dispatches the seed call as a
-  // fire-and-forget promise with `.catch(log.warn)`. That behavior is
-  // covered by `lifecycle-memory-v2-seed.test.ts`. From the handler's
-  // perspective, we only need to verify the helper is invoked
-  // synchronously with the correct config — which the cases above already
-  // exercise.
 });


### PR DESCRIPTION
Address Devin review on #28602: removes the trailing comment block in `handlers-skills-memory-v2-reseed.test.ts` that narrated history of moved code ("is now an internal concern of..."), per `assistant/AGENTS.md`'s no-historical-comments rule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->