### PR TITLE
docs(memory-v2): clarify toInject contract for phantom slugs

### DIFF
--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -94,8 +94,12 @@ export interface InjectMemoryV2BlockResult {
    */
   block: string | null;
   /**
-   * Slugs that were freshly attached on this turn. Empty when `block` is
-   * null. Returned for telemetry / debug logging by the call site.
+   * Slugs we attempted to attach this turn (top-K minus everInjected).
+   * Always populated even when `block` is `null` — phantom slugs whose
+   * backing page is missing on disk land here and are recorded in
+   * `everInjected` so we don't infinite-retry next turn. Callers using
+   * this for "we injected N slugs" telemetry should cross-reference
+   * `block !== null` (or the activation log's `page_missing` status).
    */
   toInject: string[];
 }


### PR DESCRIPTION
Address review feedback on #28419.

The JSDoc on `InjectMemoryV2BlockResult.toInject` claimed it would be empty when `block` is null, but the implementation deliberately returns the attempted slugs so they get recorded in `everInjected` and we don't infinite-retry phantom (missing-page) slugs next turn — see the regression test at `injection.test.ts:737`. Update the JSDoc to match actual contract; telemetry callers should gate on `block !== null` (or the activation log's `page_missing` status).

Codex's adjacent suggestion (don't persist phantom slugs in `everInjected`) was deliberately rejected by the original design to prevent infinite-retry loops; the test at line 758 asserts that behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->