### PR TITLE
fix(macos): stop live voice capture before awaiting playback drain

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -422,13 +422,16 @@ final class LiveVoiceChannelManager {
         responseAudioStarted = false
         let completedClient = client
 
+        // Stop capture before awaiting playback drain so audio captured during
+        // the post-ttsDone drain window isn't forwarded to the server.
+        stopCapture()
+
         Task { @MainActor [weak self] in
             guard let self else { return }
             await self.playback.waitUntilPlaybackFinishes()
             guard generation == self.sessionGeneration else { return }
 
             self.sessionGeneration &+= 1
-            self.stopCapture()
             self.state = .ending
             await completedClient?.close()
             self.resetIgnoredSessionState()

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -356,6 +356,28 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(client.closeCallCount, 1)
     }
 
+    func testAudioCapturedDuringPostTtsDoneDrainIsNotForwarded() async {
+        await startReadySession()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(capture.stopCallCount, 1)
+
+        capture.emitChunk(data: Data([7, 7]), amplitude: 0.5)
+        await flushAsyncTasks()
+
+        XCTAssertFalse(client.audioFrames.contains(Data([7, 7])))
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
     func testTtsDoneWithoutQueuedPlaybackClosesSessionImmediately() async {
         await startReadySession()
         await manager.stopListening()


### PR DESCRIPTION
## Summary
Follow-up to #28351. After `ttsDone`, the session-close path awaited `waitUntilPlaybackFinishes()` before calling `stopCapture()`, so capture stayed live during the drain window. `handleCapturedAudioChunk` continued forwarding frames to the server (and would still send barge-in interrupts), which could leak post-turn audio into the conversation or trigger an extra turn.

This stops capture synchronously on `ttsDone` before awaiting playback drain. Playback still drains; only audio forwarding shuts down early.

## Test plan
- [x] New unit test `testAudioCapturedDuringPostTtsDoneDrainIsNotForwarded` verifies capture is stopped before drain and chunks emitted during the drain window are not forwarded
- [x] Existing tests for deferred close, immediate close, and manual barge-in still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->