### PR TITLE
fix(macos): handle steer failures and make ACPSessionStore.steer overridable

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -624,7 +624,21 @@ struct ACPSessionDetailView: View {
         // (`acp/:id/steer`) accepts and the store keys its dictionary by.
         // `state.acpSessionId` is the protocol-level handle and would
         // miss the lookup for any session past initialization.
-        Task { await store.steer(id: session.state.id, instruction: instruction) }
+        let id = session.state.id
+        let acpSessionId = session.state.acpSessionId
+        Task { @MainActor in
+            let result = await store.steer(id: id, instruction: instruction)
+            // Surface a failure follow-up so the optimistic "→ steered: …"
+            // row above isn't misread as confirmation when the daemon
+            // rejected the instruction (transport error, session ended, etc.).
+            if case .failure = result {
+                session.appendEvent(ACPSessionUpdateMessage(
+                    acpSessionId: acpSessionId,
+                    updateType: .userMessageChunk,
+                    content: "→ steer failed — the session may have ended."
+                ))
+            }
+        }
     }
 
     // MARK: - Delete Footer

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -326,8 +326,11 @@ open class ACPSessionStore {
     /// Send a steering instruction to an active session. Does not mutate
     /// state directly — the daemon emits a regular update event the store
     /// then reflects via ``handle(_:)``.
+    ///
+    /// `open` so detail-view tests can subclass and observe invocation
+    /// without an HTTP round-trip — see ``ACPSessionStore`` doc.
     @discardableResult
-    public func steer(id: String, instruction: String) async -> Result<Bool, ACPClientError> {
+    open func steer(id: String, instruction: String) async -> Result<Bool, ACPClientError> {
         return await ACPClient.steerSession(id: id, instruction: instruction)
     }
 


### PR DESCRIPTION
Addresses review feedback on #28311.

## Summary
- `ACPSessionStore.steer` is now `open` (was `public`) so the test `SpyACPSessionStore` can override it across module boundaries — matches `cancel` and `delete` and the class doc that promises "the only public mutating entry points are explicitly `open` for that reason".
- `submitSteer` now awaits the store result and appends a brief "→ steer failed …" follow-up event when the call fails, so the optimistic timeline row is not misread as confirmation when the daemon rejected the instruction (transport error, session ended, etc.).

## Test plan
- [ ] Existing `ACPSessionDetailViewTests` still compile + pass (SpyACPSessionStore override of `steer`).
- [ ] Manual: trigger steer on a running session, verify success path unchanged; force a failure (e.g. session terminates between submit and POST) and confirm the "→ steer failed" follow-up surfaces.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->