### PR TITLE
fix(memory-v2): address PR 28424 review feedback

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -95,6 +95,7 @@ async function runCommand(
   args: string[],
 ): Promise<{ stdout: string; exitCode: number }> {
   const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
   const stdoutChunks: string[] = [];
 
   process.stdout.write = ((chunk: unknown) => {
@@ -113,6 +114,7 @@ async function runCommand(
     if (process.exitCode === 0) process.exitCode = 1;
   } finally {
     process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
   }
 
   const exitCode = process.exitCode ?? 0;

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -176,24 +176,10 @@ retrieval. v2 is gated behind the memory.v2.enabled config field —
 these subcommands remain useful operator tools regardless of whether
 v2 is currently active.
 
-Subcommands fall into three groups:
-
-  Mutating (return a jobId enqueued on the memory job queue):
-    migrate          One-shot v1->v2 synthesis. Refuses to overwrite an
-                     existing v2 state without --force.
-    reembed          Refresh dense + sparse vectors for every concept page.
-    activation       Refresh persisted activation state for every conversation.
-
-  Mutating (synchronous — runs inside the daemon and returns when done):
-    reembed-skills   Re-seed v2 skill entries from the current skill catalog.
-
-  Read-only:
-    validate         Print a diagnostic report of orphan outgoing-edge
-                     targets, oversized pages, and parse failures.
-
-  Calibration:
-    fit-anisotropy   Fit Mu & Viswanath's all-but-the-top correction so
-                     embedding cosines stop clustering in a narrow band.
+Subcommands split into asynchronous mutators (return a jobId enqueued
+on the memory job queue), synchronous mutators (run inside the daemon
+and return when done), read-only diagnostics, and one-shot calibration
+fits whose results persist across runs.
 
 Examples:
   $ assistant memory v2 validate

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -428,10 +428,27 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "memory rebuild-index", risk: "low" },
   { path: "memory re-extract", risk: "low" },
   { path: "memory compact", risk: "low" },
-  { path: "memory v2 migrate", risk: "low" },
-  { path: "memory v2 rebuild-edges", risk: "low" },
-  { path: "memory v2 reembed", risk: "low" },
-  { path: "memory v2 activation", risk: "low" },
+  {
+    path: "memory v2 migrate",
+    risk: "medium",
+    reason:
+      "Enqueues a v1->v2 synthesis job; --force overwrites the existing v2 state",
+  },
+  {
+    path: "memory v2 rebuild-edges",
+    risk: "medium",
+    reason: "Retired subcommand; kept for registry coverage",
+  },
+  {
+    path: "memory v2 reembed",
+    risk: "medium",
+    reason: "Enqueues bulk re-embedding of every concept page",
+  },
+  {
+    path: "memory v2 activation",
+    risk: "medium",
+    reason: "Enqueues recompute of persisted activation state",
+  },
   { path: "notifications send", risk: "low" },
   {
     path: "oauth request",


### PR DESCRIPTION
## Summary
Follow-up to merged PR #28424 addressing reviewer feedback:

- **Codex (P1)**: Reclassify the four mutating `memory v2` commands above `low` in the gateway bash risk registry. They now report `medium` with reasons; `low` is treated as auto-allow / read-only and these commands enqueue state-changing jobs (and `migrate --force` overwrites the existing v2 state).
- **Devin**: Drop the redundant subcommand list from `memory v2`'s `addHelpText` block in `memory-v2.ts` per the "No Redundant Command Lists in addHelpText" rule in `assistant/src/cli/AGENTS.md`. Commander already renders a `Commands:` section.
- **Devin**: Save and restore `process.stderr.write` in the `memory-v2.test.ts` `runCommand` helper alongside the existing `process.stdout.write` save/restore so it does not leak a no-op stderr writer into subsequent tests.

## Test plan
- [x] Risk-registry reclassification still passes the supported-paths/coverage list.
- [x] `memory v2 --help` still lists every subcommand (Commander auto-render).
- [x] `runCommand` helper restores both stdout and stderr writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)