### PR TITLE
fix(runtime): wrap bootstrapConversation in runBackgroundJob's try block

### DIFF
--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -139,36 +139,41 @@ function classifyError(err: unknown): BackgroundJobErrorKind {
 export async function runBackgroundJob(
   opts: RunBackgroundJobOptions,
 ): Promise<RunBackgroundJobResult> {
-  const conversation = bootstrapConversation({
-    conversationType: opts.conversationType ?? "background",
-    source: opts.source,
-    origin: opts.origin,
-    systemHint: opts.prompt,
-    groupId: opts.groupId ?? DEFAULT_GROUP_ID,
-    ...(opts.scheduleJobId ? { scheduleJobId: opts.scheduleJobId } : {}),
-  });
-
-  // Fire the sidebar-creation callback synchronously after bootstrap so
-  // connected clients (macOS sidebar, etc.) see the conversation appear
-  // immediately rather than after `processMessage` returns. Wrapped so a
-  // callback throw cannot abort the job.
-  if (opts.onConversationCreated) {
-    try {
-      opts.onConversationCreated(conversation.id);
-    } catch (cbErr) {
-      log.warn(
-        {
-          err: cbErr instanceof Error ? cbErr.message : String(cbErr),
-          jobName: opts.jobName,
-          conversationId: conversation.id,
-        },
-        "onConversationCreated callback threw; continuing job",
-      );
-    }
-  }
-
+  let conversation: ReturnType<typeof bootstrapConversation> | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
+    // Bootstrap inside the try so that a `createConversation` /
+    // `queueGenerateConversationTitle` failure is caught and surfaced as a
+    // structured `{ ok: false }` result rather than re-thrown to the caller —
+    // the documented contract of this runner.
+    conversation = bootstrapConversation({
+      conversationType: opts.conversationType ?? "background",
+      source: opts.source,
+      origin: opts.origin,
+      systemHint: opts.prompt,
+      groupId: opts.groupId ?? DEFAULT_GROUP_ID,
+      ...(opts.scheduleJobId ? { scheduleJobId: opts.scheduleJobId } : {}),
+    });
+
+    // Fire the sidebar-creation callback synchronously after bootstrap so
+    // connected clients (macOS sidebar, etc.) see the conversation appear
+    // immediately rather than after `processMessage` returns. Wrapped so a
+    // callback throw cannot abort the job.
+    if (opts.onConversationCreated) {
+      try {
+        opts.onConversationCreated(conversation.id);
+      } catch (cbErr) {
+        log.warn(
+          {
+            err: cbErr instanceof Error ? cbErr.message : String(cbErr),
+            jobName: opts.jobName,
+            conversationId: conversation.id,
+          },
+          "onConversationCreated callback threw; continuing job",
+        );
+      }
+    }
+
     // SECURITY: Optional anti-injection sandwich. Attacker-controllable data
     // is wrapped in an assistant-role message between two static user-role
     // messages. The LLM treats assistant-role content as its own prior
@@ -222,13 +227,16 @@ export async function runBackgroundJob(
   } catch (err) {
     const errorKind = classifyError(err);
     const error = err instanceof Error ? err : new Error(String(err));
+    // Bootstrap can fail before `conversation` is assigned; fall back to ""
+    // so the structured failure result still flows to the caller.
+    const conversationId = conversation?.id ?? "";
 
     log.error(
       {
         err: error.message,
         errorKind,
         jobName: opts.jobName,
-        conversationId: conversation.id,
+        conversationId,
       },
       "Background job failed",
     );
@@ -248,7 +256,7 @@ export async function runBackgroundJob(
       const dedupeKey = `activity-failed:${opts.jobName}:${day}`;
       emitNotificationSignal({
         sourceChannel: "assistant_tool",
-        sourceContextId: conversation.id,
+        sourceContextId: conversationId,
         sourceEventName: "activity.failed",
         dedupeKey,
         contextPayload: {
@@ -262,7 +270,7 @@ export async function runBackgroundJob(
           {
             err: emitErr instanceof Error ? emitErr.message : String(emitErr),
             jobName: opts.jobName,
-            conversationId: conversation.id,
+            conversationId,
           },
           "Failed to emit activity.failed notification for background job",
         );
@@ -270,7 +278,7 @@ export async function runBackgroundJob(
     }
 
     return {
-      conversationId: conversation.id,
+      conversationId,
       ok: false,
       error,
       errorKind,


### PR DESCRIPTION
## Summary

Addresses review feedback on #28709 (Devin P1 + Codex P1).

`runBackgroundJob` documents that it never re-throws — callers always get a structured `{ ok: false, errorKind, … }` result. But `bootstrapConversation()` was called *before* the `try` block, so a failure in `createConversation` (e.g., persistent SQLITE_BUSY) or `queueGenerateConversationTitle` propagated out of the wrapper, defeating the contract and skipping the `activity.failed` notification.

This PR moves the bootstrap call inside the `try` block, declares `conversation` as `let … | undefined`, and falls back to `conversationId: ''` in the failure path when bootstrap itself was the failure.

The `onConversationCreated` callback was previously also outside `try`; it's now inside too (safe — it has its own inner try/catch).

The Devin "timeout race leaves processMessage running" note is documented behavior and not actionable.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/runtime/__tests__/background-job-runner.test.ts` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->