### PR TITLE
fix(live-voice): treat STT error events as non-terminal

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -340,12 +340,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       case "error":
+        // Non-terminal: providers like OpenAI Whisper emit `error` for
+        // transient poll failures and continue streaming. Let `closed` /
+        // `final` drive turn lifecycle so we don't drain audio buffers or
+        // mark the turn cancelled prematurely.
         await this.sendFrame({
           type: "error",
           code: LiveVoiceProtocolErrorCode.InvalidField,
           message: event.message,
         });
-        await this.finalizePendingTurn("stt_error");
         return;
       case "closed":
         if (!this.isClosed) {


### PR DESCRIPTION
## Summary
- Stop finalizing the pending turn on every transcriber `error` event in `LiveVoiceSession.handleTranscriberEvent`. Providers like `OpenAIWhisperStreamingTranscriber` emit `type: "error"` for transient poll failures and keep streaming, so finalizing prematurely drained user audio buffers and marked the turn cancelled before the eventual `final`/`closed` events arrived.
- Lifecycle is now driven by `closed` (and the `final` → empty-transcript path), matching how `stt-stream-session.ts` already treats errors. The `error` frame is still forwarded to the client.

Addresses Codex P1 feedback on #28322.

## Test plan
- [x] `bun test src/live-voice/__tests__/live-voice-events.test.ts src/live-voice/__tests__/live-voice-stt.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->