### PR TITLE
fix(memory-v2): match consolidation cutoff to buffer-entry timestamp format

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -70,6 +70,22 @@ export function handleRemember(
 }
 
 /**
+ * Format `now` as a buffer-entry timestamp (`Mon D, h:mm AM/PM`). Exported so
+ * the memory v2 consolidation job can present its cutoff in the same shape
+ * the buffer entries use, making the agent's "timestamp ≥ cutoff" comparison
+ * unambiguous at minute precision.
+ */
+export function formatBufferTimestamp(now: Date): string {
+  const month = now.toLocaleString("en-US", { month: "short" });
+  const day = now.getDate();
+  const hours = now.getHours();
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const displayHour = hours % 12 || 12;
+  return `${month} ${day}, ${displayHour}:${minutes} ${ampm}`;
+}
+
+/**
  * Build a timestamped bullet entry for `buffer.md` / `archive/<date>.md`.
  *
  * Format mirrors the long-standing v1 PKB layout so v2 buffers stay
@@ -80,13 +96,7 @@ export function handleRemember(
  * entries identically to user-facing `remember()` calls.
  */
 export function formatRememberEntry(content: string, now: Date): string {
-  const month = now.toLocaleString("en-US", { month: "short" });
-  const day = now.getDate();
-  const hours = now.getHours();
-  const minutes = String(now.getMinutes()).padStart(2, "0");
-  const ampm = hours >= 12 ? "PM" : "AM";
-  const displayHour = hours % 12 || 12;
-  return `- [${month} ${day}, ${displayHour}:${minutes} ${ampm}] ${content}\n`;
+  return `- [${formatBufferTimestamp(now)}] ${content}\n`;
 }
 
 /**

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -265,9 +265,9 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     const hint = wakeLastArgs?.hint as string;
     expect(hint).toContain("memory consolidation");
     expect(hint).not.toContain(CUTOFF_PLACEHOLDER);
-    // Cutoff is an ISO-8601 timestamp — check the year prefix matches the
-    // current year so we know the substitution actually happened.
-    expect(hint).toContain(`${new Date().getFullYear()}`);
+    // Cutoff is a buffer-entry-format timestamp (`Mon D, h:mm AM/PM`) so it
+    // compares like-with-like against `buffer.md` lines at minute precision.
+    expect(hint).toMatch(/\b[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} (AM|PM)\b/);
   });
 
   test("honors memory.v2.consolidation_prompt_path override when set", async () => {
@@ -285,7 +285,9 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
 
     expect(result.kind).toBe("invoked");
     const hint = wakeLastArgs?.hint as string;
-    expect(hint).toMatch(/^CUSTOM CONSOLIDATION at \d{4}-/);
+    expect(hint).toMatch(
+      /^CUSTOM CONSOLIDATION at [A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} (AM|PM)$/m,
+    );
     expect(hint).not.toContain("You are running memory consolidation");
     expect(hint).not.toContain(CUTOFF_PLACEHOLDER);
   });

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -61,6 +61,7 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import { isProcessAlive } from "../../util/process-liveness.js";
 import { bootstrapConversation } from "../conversation-bootstrap.js";
 import { deleteConversation } from "../conversation-crud.js";
+import { formatBufferTimestamp } from "../graph/tool-handlers.js";
 import {
   enqueueMemoryJob,
   type MemoryJob,
@@ -121,11 +122,13 @@ export async function memoryV2ConsolidateJob(
   }
 
   try {
-    // Step 2: capture cutoff. ISO-8601 is the convention; it's a total order
-    // string that compares correctly via lexicographic <, which is all the
-    // prompt asks the agent to do. Captured here (not at enqueue time) so
-    // late-claimed rows still get a fresh cutoff.
-    const cutoff = new Date().toISOString();
+    // Step 2: capture cutoff. Formatted to match `buffer.md` entry timestamps
+    // (`Mon D, h:mm AM/PM`, see `formatBufferTimestamp`) so the agent's
+    // "timestamp ≥ cutoff" check compares like-with-like at minute precision.
+    // Same-minute entries land on the next pass — conservative but loss-free.
+    // Captured here (not at enqueue time) so late-claimed rows get a fresh
+    // cutoff.
+    const cutoff = formatBufferTimestamp(new Date());
 
     // Step 3: bail on empty buffer. Nothing for the agent to consolidate.
     // The lock is released in finally below.

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -6,9 +6,11 @@
  * runs with its full system prompt + tool surface; the text below is supplied
  * as the wake hint.
  *
- * The single placeholder `{{CUTOFF}}` is substituted at runtime with an
- * ISO-8601 timestamp captured at job dispatch. Anything appended to
- * `memory/buffer.md` after that timestamp is the next pass's problem.
+ * The single placeholder `{{CUTOFF}}` is substituted at runtime with a
+ * timestamp captured at job dispatch in the same `Mon D, h:mm AM/PM` shape
+ * that `buffer.md` entries use, so the agent's "timestamp ≥ cutoff" check
+ * compares like-with-like. Anything appended after that minute is the next
+ * pass's problem.
  *
  * Kept under `prompts/` rather than inlined in `consolidation-job.ts` so the
  * prompt body is reviewable on its own and the job module stays focused on
@@ -432,10 +434,10 @@ For each article you touched:
 This is the engine that decides who you are tomorrow. Be ORGANIZED. Care, judgment, voice. Your voice. Your wiki.`;
 
 /**
- * Resolve `CONSOLIDATION_PROMPT` with `{{CUTOFF}}` substituted. The cutoff
- * format is the caller's choice — the prompt treats it as opaque text and
- * uses string comparison, so any total-order timestamp format works (ISO-8601
- * is the convention).
+ * Resolve `CONSOLIDATION_PROMPT` with `{{CUTOFF}}` substituted. The prompt
+ * treats the cutoff as opaque text — callers pass a `Mon D, h:mm AM/PM`
+ * timestamp matching the `buffer.md` entry format so the agent compares
+ * like-with-like.
  */
 export function renderConsolidationPrompt(cutoff: string): string {
   return CONSOLIDATION_PROMPT.replaceAll(CUTOFF_PLACEHOLDER, cutoff);


### PR DESCRIPTION
## Summary

The memory v2 consolidation prompt asks the agent to retain buffer entries with `timestamp >= cutoff`, but the two timestamps were in different shapes: `buffer.md` entries use `Mon D, h:mm AM/PM` (from `formatRememberEntry`), while the cutoff was ISO-8601. Same-minute entries written just before the run started were therefore not reliably distinguishable from pre-cutoff entries and could be trimmed incorrectly.

This addresses the P2 reviewer feedback on #28420.

## Changes

- Extract `formatBufferTimestamp(now)` in `assistant/src/memory/graph/tool-handlers.ts` and reroute `formatRememberEntry` through it.
- Use the same helper in `memory_v2_consolidate` to capture the cutoff in buffer-entry shape. Same-minute entries become `>= cutoff` and land on the next pass — conservative but loss-free.
- Update the consolidation prompt docstrings and the test that asserted the old ISO year prefix.

## Test plan

- [x] `bun test src/memory/v2/__tests__/consolidation-job.test.ts src/memory/graph/__tests__/handle-remember-v2.test.ts` (23 pass)
- [x] `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->