### PR TITLE
fix(filing): restore short systemHint for filing/compaction conversations

### DIFF
--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -319,6 +319,7 @@ export class FilingService {
   private executeRun(): Promise<void> {
     return this.executeBackgroundJob({
       jobName: "filing",
+      systemHint: "Knowledge base filing",
       prompt: FILING_PROMPT_TEMPLATE,
       callSite: "filingAgent",
     });
@@ -327,6 +328,7 @@ export class FilingService {
   private executeCompactionRun(): Promise<void> {
     return this.executeBackgroundJob({
       jobName: "compaction",
+      systemHint: "Knowledge base compaction",
       prompt: COMPACTION_PROMPT_TEMPLATE,
       callSite: "compactionAgent",
     });
@@ -334,6 +336,7 @@ export class FilingService {
 
   private async executeBackgroundJob(opts: {
     jobName: string;
+    systemHint: string;
     prompt: string;
     callSite: LLMCallSite;
   }): Promise<void> {
@@ -342,6 +345,7 @@ export class FilingService {
     const result = await runBackgroundJob({
       jobName: opts.jobName,
       source: "filing",
+      systemHint: opts.systemHint,
       prompt: opts.prompt,
       trustContext: {
         sourceChannel: "vellum",

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -47,8 +47,16 @@ export interface RunBackgroundJobOptions {
   jobName: string;
   /** Conversation `source` field (free-form, propagated to clients). */
   source: string;
-  /** Prompt sent both as `systemHint` to bootstrap and as the first message. */
+  /** Prompt sent as the first message of the conversation. */
   prompt: string;
+  /**
+   * Short, human-readable hint passed to `bootstrapConversation` for title
+   * generation and as the fallback title. Defaults to `prompt` when omitted,
+   * but callers with multi-paragraph prompts should supply a concise label
+   * (e.g. `"Knowledge base filing"`) — otherwise a fallback title would echo
+   * the entire prompt and title-generation requests waste tokens.
+   */
+  systemHint?: string;
   /** Trust context applied to the agent turn. */
   trustContext: TrustContext;
   /** LLM call-site identifier — drives provider/model/effort/etc. resolution. */
@@ -143,7 +151,7 @@ export async function runBackgroundJob(
     conversationType: opts.conversationType ?? "background",
     source: opts.source,
     origin: opts.origin,
-    systemHint: opts.prompt,
+    systemHint: opts.systemHint ?? opts.prompt,
     groupId: opts.groupId ?? DEFAULT_GROUP_ID,
     ...(opts.scheduleJobId ? { scheduleJobId: opts.scheduleJobId } : {}),
   });


### PR DESCRIPTION
## Summary
- Adds an optional `systemHint` field to `RunBackgroundJobOptions` so callers with multi-paragraph prompts can supply a short conversation-title hint without conflating prompt and hint.
- Filing and compaction runs now pass "Knowledge base filing" / "Knowledge base compaction" as the systemHint, restoring the pre-#28712 behavior.

## Why
Both reviewers (Codex P2, Devin yellow) flagged that #28712 began passing the full prompt template as the bootstrap systemHint, which:
1. Made `deriveFallbackTitle()` echo the entire prompt as the conversation title when LLM title generation fails or has no provider.
2. Wasted hundreds of tokens per run by injecting the prompt into the title-generation request.

Default behavior of `runBackgroundJob` is preserved (`opts.systemHint ?? opts.prompt`); follow-up callers can adopt the new field as needed.

Addresses review feedback on #28712.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->