### PR TITLE
fix(memory-v2): single-flight seed + prune on uninstall

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1209,6 +1209,10 @@ export async function uninstallSkill(
       state: "uninstalled",
     });
 
+    // Without this, an uninstalled skill remains queryable in v2 until the
+    // next incidental seed event (enable/disable/install).
+    maybeSeedMemoryV2Skills(getConfig());
+
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -68,10 +68,29 @@ let entries: Map<string, SkillEntry> | null = null;
 
 /**
  * Seed (or re-seed) skill embeddings into the unified concept-page collection.
- * Idempotent: safe to call repeatedly. Best-effort: never throws — any
- * failure leaves the prior `entries` cache in place and logs a warning.
+ * Idempotent and best-effort — never throws.
  *
- * Steps:
+ * Single-flight + coalesced: at most one seed runs at a time, and concurrent
+ * callers are coalesced into one follow-up re-snapshot that runs after the
+ * in-flight seed completes. Without this, an older snapshot can finish after
+ * a newer one and overwrite the newer skill state.
+ */
+let seedTail: Promise<void> = Promise.resolve();
+let seedPending: Promise<void> | null = null;
+
+export function seedV2SkillEntries(): Promise<void> {
+  if (seedPending) return seedPending;
+  const next = seedTail.then(async () => {
+    seedPending = null;
+    await runSeedOnce();
+  });
+  seedTail = next.catch(() => {});
+  seedPending = next;
+  return next;
+}
+
+/**
+ * Steps (per run):
  *   1. Enumerate the local skill catalog and resolve each skill's enabled
  *      state (`resolveSkillStates`).
  *   2. Build a `SkillEntry` per enabled skill, applying the mcp-setup
@@ -90,7 +109,7 @@ let entries: Map<string, SkillEntry> | null = null;
  *      stale points from prior catalog state (e.g. uninstalled skills).
  *   7. Replace the module-level `entries` cache with the freshly built map.
  */
-export async function seedV2SkillEntries(): Promise<void> {
+async function runSeedOnce(): Promise<void> {
   try {
     const config = getConfig();
     const catalog = loadSkillCatalog();
@@ -211,4 +230,6 @@ export function isSkillSlug(slug: string): boolean {
 /** @internal Test-only: clear the module-level cache. */
 export function _resetSkillStoreForTests(): void {
   entries = null;
+  seedTail = Promise.resolve();
+  seedPending = null;
 }


### PR DESCRIPTION
## Summary
Addresses codex/devin review feedback on #28597.

- **P1 (codex+devin) — uninstall left v2 entries stale.** `uninstallSkill` cleaned up the v1 capability node but didn't trigger any v2 reseed, so an uninstalled skill remained queryable in `memory_v2_concept_pages` until the next incidental seed event (enable/disable/install). Added `maybeSeedMemoryV2Skills(getConfig())` after the existing v1 cleanup; `seedV2SkillEntries`'s built-in `pruneSlugsWithPrefixExcept` removes the stale slug.
- **P2 (codex) — concurrent reseeds could overwrite newer state.** Each handler launches `seedV2SkillEntries()` as an untracked background task, so rapid state changes could run multiple reseeds concurrently and let an older snapshot finish last. Wrapped the seed body in a single-flight + coalesced queue: at most one run at a time, and concurrent callers are folded into exactly one queued follow-up that re-snapshots after the in-flight run.

## Test plan
- [x] `bunx tsc --noEmit` passes (only unrelated sibling-worktree error).
- [ ] Existing `skill-store.test.ts` and `handlers-skills-memory-v2-reseed.test.ts` still pass against the wrapped function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->