### PR TITLE
fix(btw-sidechain): exclude custom system prompt prefix

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -219,6 +219,7 @@ export function ensurePromptFiles(): void {
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
   excludeBootstrap?: boolean;
+  excludeCustomPrefix?: boolean;
   userPersona?: string | null;
   channelPersona?: string | null;
   userSlug?: string | null;
@@ -242,7 +243,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // (IDENTITY.md, SOUL.md, users/<slug>.md, etc.) are edited between turns.
   const staticParts: string[] = [];
   const customPrefix = readCustomSystemPromptPrefix();
-  if (customPrefix) staticParts.push(customPrefix);
+  if (customPrefix && !options?.excludeCustomPrefix)
+    staticParts.push(customPrefix);
   staticParts.push(buildParallelToolCallsSection());
   if (getIsContainerized()) staticParts.push(buildContainerizedSection());
   staticParts.push(buildCliReferenceSection());

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -76,6 +76,7 @@ export async function runBtwSidechain(
       ? params.conversation.systemPrompt
       : buildSystemPrompt({
           excludeBootstrap: true,
+          excludeCustomPrefix: true,
           userPersona: params.userPersona,
           channelPersona: params.channelPersona,
           userSlug: params.userSlug,


### PR DESCRIPTION
## Summary
- Add `excludeCustomPrefix` option to `buildSystemPrompt` so callers can opt out of the user's custom system prompt prefix
- Set `excludeCustomPrefix: true` for the BTW sidechain so it doesn't inherit prefix instructions intended for the main agent

## Original prompt
Ship the local change that prevents the BTW sidechain from picking up the user's custom system prompt prefix. The sidechain runs as an isolated agent and shouldn't be biased by main-agent prefix instructions, so the fix threads a new option through `buildSystemPrompt` and toggles it on at the sidechain call site.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->