### PR TITLE
fix(memory-v2): trim whitespace-only ANN candidate text before embedding

### DIFF
--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -125,12 +125,13 @@ export async function selectCandidates(
 
   // (2) ANN top-50 against the concatenated turn text. Pure whitespace joins
   // (no separators) keep the embedding behavior aligned with how callers
-  // would naturally read the three texts together.
+  // would naturally read the three texts together. Whitespace-only channels
+  // contribute no semantic content, so trim before deciding whether to embed.
   const annQueryText = [userText, assistantText, nowText]
-    .filter((s) => s.length > 0)
+    .filter((s) => s.trim().length > 0)
     .join("\n");
 
-  if (annQueryText.length > 0) {
+  if (annQueryText.trim().length > 0) {
     throwIfAborted(signal);
     const denseResult = await embedWithBackend(config, [annQueryText], {
       signal,


### PR DESCRIPTION
## Summary
- In `selectCandidates`, swap `s.length > 0` → `s.trim().length > 0` when filtering channel texts and re-check the joined query the same way before embedding.
- Whitespace-only inputs no longer trigger `embedWithBackend` + a Qdrant top-K hybrid query that adds noise (and load) to the candidate set.

Aligns with `simBatch`'s existing `text.trim().length === 0` short-circuit (added in #29237).

Follow-up to review feedback on #28417 (codex P2). Codex P1 / Devin findings about `computeOwnActivation` calling `simBatch` on empty channel text are already addressed by that same simBatch short-circuit — no Qdrant round-trip and no non-zero contribution is possible there.