### PR TITLE
fix(memory-v2): exclude background/scheduled conversations from sweep input

### DIFF
--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -166,6 +166,7 @@ function extractFirstUserText(msgs: { content: unknown }[]): string {
 function seedMessages(
   conversationId: string,
   rows: Array<{ role: string; content: string; offsetMs: number }>,
+  conversationType: "standard" | "background" | "scheduled" = "standard",
 ): void {
   const db = getDb();
   const now = Date.now();
@@ -175,6 +176,7 @@ function seedMessages(
       title: null,
       createdAt: now - 60_000,
       updatedAt: now,
+      conversationType,
     })
     .run();
   for (let i = 0; i < rows.length; i++) {
@@ -416,6 +418,53 @@ describe("memoryV2SweepJob — recent messages", () => {
     const written = await memoryV2SweepJob(makeJob(), CONFIG);
 
     expect(written).toBe(0);
+  });
+});
+
+describe("memoryV2SweepJob — background/scheduled conversation filter", () => {
+  test("excludes background/scheduled conversation content from sweep input", async () => {
+    seedMessages(
+      `conv-bg-${++convCounter}`,
+      [
+        {
+          role: "assistant",
+          content:
+            "[heartbeat] internal automation chatter that should not leak",
+          offsetMs: -60_000,
+        },
+      ],
+      "background",
+    );
+    seedMessages(
+      `conv-sched-${++convCounter}`,
+      [
+        {
+          role: "assistant",
+          content:
+            "[scheduled] scheduled-job chatter that should not leak either",
+          offsetMs: -45_000,
+        },
+      ],
+      "scheduled",
+    );
+    seedMessages(`conv-user-${++convCounter}`, [
+      {
+        role: "user",
+        content: "Bob mentioned he prefers dark mode.",
+        offsetMs: -30_000,
+      },
+    ]);
+
+    providerStub = makeEntriesProvider(["Bob prefers dark mode."]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(1);
+    expect(providerCalls).toHaveLength(1);
+    const [{ userText }] = providerCalls;
+    expect(userText).toContain("Bob mentioned he prefers dark mode.");
+    expect(userText).not.toContain("internal automation chatter");
+    expect(userText).not.toContain("scheduled-job chatter");
   });
 });
 

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -22,7 +22,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { desc, gt } from "drizzle-orm";
+import { and, desc, eq, gt, notInArray } from "drizzle-orm";
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../config/types.js";
@@ -41,7 +41,7 @@ import {
   formatRememberEntry,
 } from "../graph/tool-handlers.js";
 import type { MemoryJob } from "../jobs-store.js";
-import { messages } from "../schema.js";
+import { conversations, messages } from "../schema.js";
 import { renderSweepPrompt } from "./prompts/sweep.js";
 
 const log = getLogger("memory-v2-sweep");
@@ -219,14 +219,22 @@ function loadRecentMessagesText(nowMs: number): string {
   const db = getDb();
   // Pull newest-first then reverse for chronological output. Bounding the
   // initial limit (1000) defends against pathological busy windows where a
-  // naive scan would touch every recent message.
+  // naive scan would touch every recent message. Joining conversations and
+  // excluding background/scheduled types keeps automation chatter
+  // (heartbeats, filing, update bulletins, scheduled jobs) out of buffer.md.
   const rows = db
     .select({
       role: messages.role,
       content: messages.content,
     })
     .from(messages)
-    .where(gt(messages.createdAt, cutoff))
+    .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+    .where(
+      and(
+        gt(messages.createdAt, cutoff),
+        notInArray(conversations.conversationType, ["background", "scheduled"]),
+      ),
+    )
     .orderBy(desc(messages.createdAt))
     .limit(1000)
     .all();


### PR DESCRIPTION
## Summary
Addresses review feedback on #28418 (Codex P1, Devin P3).

The sweep job's `loadRecentMessagesText` queried the `messages` table
without joining `conversations`, so background/scheduled assistant
chatter (heartbeats, filing, update-bulletin, scheduled jobs) running in
the same 30-minute window could be fed into the sweep prompt and end up
in long-term memory.

Inner-join `conversations` and exclude `background`/`scheduled` types
using the same pattern `conversation-graph-memory.ts` already uses for
its own user-facing summary list.

## Test plan
- [x] `bun test src/memory/v2/__tests__/sweep-job.test.ts` — 12 pass
- [x] Added regression test verifying background/scheduled content is
  excluded from the sweep model's user message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->