### PR TITLE
feat(inspector): capture LLM calls for background conversations

### DIFF
--- a/assistant/src/daemon/wake-target-adapter.ts
+++ b/assistant/src/daemon/wake-target-adapter.ts
@@ -14,6 +14,7 @@ import {
   provenanceFromTrustContext,
 } from "../memory/conversation-crud.js";
 import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
+import { backfillMessageIdOnLogs } from "../memory/llm-request-log-store.js";
 import type { WakeTarget } from "../runtime/agent-wake.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
@@ -197,6 +198,16 @@ export function conversationToWakeTarget(
         JSON.stringify(message.content),
         metadata,
       );
+      if (message.role === "assistant") {
+        try {
+          backfillMessageIdOnLogs(conversation.conversationId, persisted.id);
+        } catch (err) {
+          log.warn(
+            { err, conversationId: conversation.conversationId },
+            "wake adapter: backfill messageId on LLM logs failed (non-fatal)",
+          );
+        }
+      }
       try {
         const convRow = getConversation(conversation.conversationId);
         if (convRow) {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -56,6 +56,7 @@ import {
 } from "../daemon/disk-pressure-policy.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
+import { recordRequestLog } from "../memory/llm-request-log-store.js";
 import type { TurnContext } from "../plugins/types.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -539,6 +540,24 @@ export async function wakeAgentForOpportunity(
       }
     };
     const onEvent = (event: AgentEvent): void => {
+      // Replicates the recordRequestLog side-effect in `handleUsage` because
+      // wakes own their own onEvent and never reach `dispatchAgentEvent`.
+      if (event.type === "usage" && event.rawRequest && event.rawResponse) {
+        try {
+          recordRequestLog(
+            conversationId,
+            JSON.stringify(event.rawRequest),
+            JSON.stringify(event.rawResponse),
+            undefined,
+            event.actualProvider,
+          );
+        } catch (err) {
+          log.warn(
+            { err, conversationId, source },
+            "agent-wake: failed to persist LLM request log (non-fatal)",
+          );
+        }
+      }
       if (mode === "buffering") {
         buffered.push(event);
         return;

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -163,14 +163,7 @@ struct MessageInspectorView: View {
     }
 
     private var emptyStateSubtitle: String {
-        switch viewState.conversationKind {
-        case .backgroundMemoryConsolidation:
-            return "Per-call LLM context isn't currently captured for memory consolidation runs."
-        case .background, .scheduled:
-            return "Per-call LLM context isn't currently captured for this conversation type."
-        case .user, nil:
-            return "This message does not have any recorded LLM context to inspect."
-        }
+        "This message does not have any recorded LLM context to inspect."
     }
 
     private var failedState: some View {


### PR DESCRIPTION
## Summary
- Replicate `recordRequestLog` in the wake's `onEvent` and `backfillMessageIdOnLogs` in the wake adapter's `persistTailMessage`, so wake-driven (background, scheduled, memory-consolidation) turns produce inspector entries the same way user turns do.
- Drop the kind-specific "isn't currently captured" subtitle from `MessageInspectorView` now that capture works for every kind.

## Original prompt
The LLM Context Inspector was showing "Per-call LLM context isn't currently captured for this conversation type" for background conversations. The user wanted those captures wired up so background runs (memory consolidation, update bulletin, scheduled tasks) show their LLM calls in the inspector. Root cause: `wakeAgentForOpportunity` provides its own `onEvent` callback to `agentLoop.run`, which bypasses `dispatchAgentEvent` and therefore the `handleUsage`/`handleMessageComplete` side-effects that record and backfill logs for the user-turn path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->