### PR TITLE
fix(live-voice): preserve transcriber handle after stop() throws

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -307,7 +307,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         )}`,
       });
       this.state = "transcriber_closed";
-      this.transcriber = null;
     }
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();


### PR DESCRIPTION
## Summary
Addresses codex P2 review feedback on #28337.

In `releaseUtterance()`, when `transcriber.stop()` throws, keep the handle around so later cleanup paths (`close()`/`interrupt()`) can still run `stopTranscriberBestEffort` on it. Previously the handle was nulled immediately in the catch block, so if `stop()` threw before the underlying stream actually shut down, the STT session could stay alive and emit late events or leak provider resources after the voice session was torn down.

## Test plan
- [ ] No behavior change on the happy path; only the failure path is affected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->