### PR TITLE
fix(macos): guarantee detail-view dismiss after ACP session delete

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -35,7 +35,14 @@ struct ACPSessionDetailView: View {
     /// Pop-to-list callback fired after a successful "Delete from history".
     /// Hosting view (the panel's `NavigationStack`) is responsible for the
     /// actual back-pop; we just signal that the underlying row is gone.
+    /// When unset, we fall back to the environment's `dismiss` action so a
+    /// successful delete always returns the user to the list.
     var onDismiss: (() -> Void)? = nil
+
+    /// Fallback dismiss action used when no explicit `onDismiss` callback is
+    /// wired by the host. Resolves to the enclosing `NavigationStack`'s
+    /// pop action when this view is pushed via `navigationDestination`.
+    @Environment(\.dismiss) private var dismissEnvironment
 
     /// True while a cancel HTTP request is in flight. Disables the button and
     /// shows an inline spinner so the user can't double-tap.
@@ -688,7 +695,11 @@ struct ACPSessionDetailView: View {
             // to react if the daemon reports a 409 (still active) or other
             // failure — the row stays put and the button re-enables.
             if case .success = result {
-                onDismiss?()
+                if let onDismiss {
+                    onDismiss()
+                } else {
+                    dismissEnvironment()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `ACPSessionDetailView` now falls back to `@Environment(\.dismiss)` when no `onDismiss` callback is wired, so a successful delete always pops back to the list.

## Why
Addresses Codex (P2) and Devin feedback on #28314: the production caller `ACPSessionsPanel.navigationDestination` constructs the detail view without an `onDismiss`, so a successful delete left the user on a stale detail screen for a row that had already been removed from the store.

## Test plan
- [ ] Delete a terminal ACP session from the detail view; verify the view pops back to the panel list.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->