### PR TITLE
fix(memory-v2): align activation/injection tests with cosine→unit mapping

### DIFF
--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -470,8 +470,10 @@ describe("computeOwnActivation", () => {
         c_now: 0.2,
       }),
     });
-    // Expected: 0.3*0.6 + 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.18+0.15+0.08+0.04 = 0.45
-    expect(out.activation.get("alice")).toBeCloseTo(0.45, 6);
+    // cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6.
+    // Expected: 0.3*0.6 + 0.3*0.75 + 0.2*0.7 + 0.2*0.6
+    //         = 0.18+0.225+0.14+0.12 = 0.665
+    expect(out.activation.get("alice")).toBeCloseTo(0.665, 6);
   });
 
   test("clamps over-1.0 results down to [0, 1]", async () => {
@@ -523,8 +525,9 @@ describe("computeOwnActivation", () => {
         c_now: 0.2,
       }),
     });
-    // 0.3*0 + 0.3*1 + 0.2*0 + 0.2*0 = 0.3
-    expect(out.activation.get("fresh")).toBeCloseTo(0.3, 6);
+    // cosine→unit mapping: 1.0→1.0, 0→0.5.
+    // 0.3*0 + 0.3*1 + 0.2*0.5 + 0.2*0.5 = 0.5
+    expect(out.activation.get("fresh")).toBeCloseTo(0.5, 6);
   });
 
   test("candidate with no sim hits resolves to 0", async () => {
@@ -573,10 +576,11 @@ describe("computeOwnActivation", () => {
     expect(breakdown).toBeDefined();
     // priorContribution is `d * prev`, not the weighted sim term.
     expect(breakdown?.priorContribution).toBeCloseTo(d * 0.6, 6);
-    // Raw sims, captured before c_user / c_assistant / c_now weighting.
-    expect(breakdown?.simUser).toBeCloseTo(0.5, 6);
-    expect(breakdown?.simAssistant).toBeCloseTo(0.4, 6);
-    expect(breakdown?.simNow).toBeCloseTo(0.2, 6);
+    // Fused sims (post cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6),
+    // captured before c_user / c_assistant / c_now weighting.
+    expect(breakdown?.simUser).toBeCloseTo(0.75, 6);
+    expect(breakdown?.simAssistant).toBeCloseTo(0.7, 6);
+    expect(breakdown?.simNow).toBeCloseTo(0.6, 6);
   });
 
   test("breakdown defaults priorContribution to 0 when priorState is null", async () => {
@@ -801,8 +805,10 @@ describe("computeOwnActivation", () => {
   });
 
   test("rerank boost is additive on A_o and leaves raw simUser / simAssistant untouched", async () => {
-    stageHybridResponse([{ slug: "a", denseScore: 0.5 }]); // user
-    stageHybridResponse([{ slug: "a", denseScore: 0.4 }]); // assistant
+    // Input cosines chosen so post `(x+1)/2` mapping yields the round
+    // fused values used in the formula assertion below.
+    stageHybridResponse([{ slug: "a", denseScore: 0 }]); // user — cosine 0 → 0.5
+    stageHybridResponse([{ slug: "a", denseScore: -0.2 }]); // assistant — cosine -0.2 → 0.4
     stageHybridResponse([]); // now
     rerankState.scores = new Map([["a", 0.8]]);
 
@@ -1219,8 +1225,9 @@ describe("skills participate in the unified pipeline", () => {
     });
 
     // No prior state → priorContribution = 0.
-    // 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.15 + 0.08 + 0.04 = 0.27
-    expect(out.activation.get("skills/example-skill-a")).toBeCloseTo(0.27, 6);
+    // cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6.
+    // 0.3*0.75 + 0.2*0.7 + 0.2*0.6 = 0.225 + 0.14 + 0.12 = 0.485
+    expect(out.activation.get("skills/example-skill-a")).toBeCloseTo(0.485, 6);
     expect(out.breakdown.get("skills/example-skill-a")?.priorContribution).toBe(
       0,
     );

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -712,11 +712,13 @@ describe("injectMemoryV2Block", () => {
   });
 
   test("persists sparse state — only slugs above epsilon survive", async () => {
-    // Carol scores high; alice/bob essentially zero. After saving, only
-    // carol should appear in the persisted state map.
+    // Carol scores high; alice essentially zero. After saving, only carol
+    // should appear in the persisted state map. denseScore is the raw
+    // Qdrant cosine in [-1, 1]; alice uses -1 so the post `(x+1)/2`
+    // unit-mapping pins her fused score to 0 — below epsilon.
     stageTurn([
       { slug: "carol-jazz", denseScore: 1.0 },
-      { slug: "alice-vscode", denseScore: 0.0 },
+      { slug: "alice-vscode", denseScore: -1.0 },
     ]);
     await injectMemoryV2Block({
       database: db,


### PR DESCRIPTION
## Summary
- Update memory v2 activation and injection tests so their fused-sim assertions match the cosine→unit mapping introduced in #30033 (commit 4c7eb28760), which silently broke 6 tests on main.
- Where post-mapping values would clamp to 1.0 and obscure the formula being tested, switch input cosines (e.g. `0`, `-0.2`) so the post-mapping values match the original round numbers; everywhere else, update only the expected fused values and comments.
- For the injection-pruning test, swap alice's `denseScore: 0.0` for `-1.0` so her post-mapping fused score is 0 again (below epsilon), restoring the test's intent.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25589886856/job/75125455152 — `assistant/src/memory/v2/__tests__/injection.test.ts` (`persists sparse state — only slugs above epsilon survive`) and `assistant/src/memory/v2/__tests__/activation.test.ts` (5 `computeOwnActivation` cases) were failing because their staged dense scores were treated as fused sims, but #30033 now correctly maps Qdrant cosine to `[0, 1]` via `(x + 1) / 2` before fusion. Scope is limited to making these tests pass without changing production behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->