### PR TITLE
fix(daemon): tag guardian-router delta with conversationId

### DIFF
--- a/assistant/src/__tests__/compact-event-conversation-id-guard.test.ts
+++ b/assistant/src/__tests__/compact-event-conversation-id-guard.test.ts
@@ -25,9 +25,10 @@ describe("compact slash-command emits conversationId on assistant_text_delta", (
       const source = readFileSync(fullPath, "utf-8");
 
       // Find every `type: "assistant_text_delta"` literal and inspect the
-      // surrounding object literal for a `conversationId` key. Looking at a
-      // ~200-char window forward covers multi-line object literals while
-      // staying tight enough to avoid matching unrelated nearby code.
+      // enclosing object literal for a `conversationId` key. Scope the scan to
+      // the matched `{ ... }` that contains `type:` so an adjacent event (e.g.
+      // a following `message_complete` that happens to carry `conversationId`)
+      // cannot mask a missing field on the delta itself.
       const TYPE_LITERAL = /type:\s*"assistant_text_delta"/g;
       const offsets: number[] = [];
       let match: RegExpExecArray | null;
@@ -38,8 +39,35 @@ describe("compact slash-command emits conversationId on assistant_text_delta", (
 
       const violations: string[] = [];
       for (const offset of offsets) {
-        const window = source.slice(offset, offset + 200);
-        if (!/conversationId/.test(window)) {
+        let openIdx = -1;
+        for (let i = offset; i >= 0; i--) {
+          if (source[i] === "{") {
+            openIdx = i;
+            break;
+          }
+        }
+        let body = "";
+        if (openIdx === -1) {
+          body = source.slice(offset, offset + 200);
+        } else {
+          let depth = 0;
+          let closeIdx = -1;
+          for (let i = openIdx; i < source.length; i++) {
+            if (source[i] === "{") depth++;
+            else if (source[i] === "}") {
+              depth--;
+              if (depth === 0) {
+                closeIdx = i;
+                break;
+              }
+            }
+          }
+          body = source.slice(
+            openIdx,
+            closeIdx === -1 ? undefined : closeIdx + 1,
+          );
+        }
+        if (!/conversationId/.test(body)) {
           const lineNumber = source.slice(0, offset).split("\n").length;
           violations.push(`${relativePath}:${lineNumber}`);
         }

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1318,7 +1318,11 @@ export async function processMessage(
       );
       conversation.messages.push(assistantMsg);
 
-      onEvent({ type: "assistant_text_delta", text: replyText });
+      onEvent({
+        type: "assistant_text_delta",
+        text: replyText,
+        conversationId: conversation.conversationId,
+      });
       onEvent({
         type: "message_complete",
         conversationId: conversation.conversationId,


### PR DESCRIPTION
## Summary

Follow-up to #28729 addressing Codex/Devin review feedback.

- Adds `conversationId` to the `assistant_text_delta` emission in the guardian reply router path of `processMessage()` (`conversation-process.ts`) — the only remaining unfixed instance from the original PR. Same cross-conversation leak risk: a guardian reply completing after the user switches conversations would render into the wrong VM via macOS `belongsToConversation(nil) → true`.
- Tightens `compact-event-conversation-id-guard.test.ts` to scope its scan to the enclosing `{ ... }` object literal that contains `type: "assistant_text_delta"` (using brace-balanced matching) instead of a fixed 200-char window. The wider window produced a false negative because an adjacent `message_complete` event carrying `conversationId` fell within range.

## Test plan
- [x] `bun test src/__tests__/compact-event-conversation-id-guard.test.ts` passes (and would now fail without the source fix)