### PR TITLE
fix(memory-v2): guard concepts walker against symlink cycles

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -295,11 +295,13 @@ async function lexicalEvidence(
   if (!conceptsRoot) return [];
 
   const matches: MemoryV2LexicalMatch[] = [];
+  const visitedDirectories = new Set<string>([conceptsRoot]);
   await walkConceptsDirectory(
     conceptsRoot,
     conceptsRoot,
     queryTerms,
     matches,
+    visitedDirectories,
     context.signal,
   );
 
@@ -330,6 +332,7 @@ async function walkConceptsDirectory(
   conceptsRoot: string,
   queryTerms: ReadonlySet<string>,
   matches: MemoryV2LexicalMatch[],
+  visitedDirectories: Set<string>,
   signal: AbortSignal | undefined,
 ): Promise<void> {
   throwIfAborted(signal);
@@ -364,11 +367,14 @@ async function walkConceptsDirectory(
     }
 
     if (entryStats.isDirectory()) {
+      if (visitedDirectories.has(entryRealPath)) continue;
+      visitedDirectories.add(entryRealPath);
       await walkConceptsDirectory(
         entryRealPath,
         conceptsRoot,
         queryTerms,
         matches,
+        visitedDirectories,
         signal,
       );
       continue;


### PR DESCRIPTION
Follow-up to #28761 addressing P1 review feedback.

The lexical fallback in `memory-v2.ts` resolves each entry via `realpath` and was containing escapes outside `conceptsRoot`, but a symlink that resolved back *inside* the root (e.g. to an ancestor directory) would still drive `walkConceptsDirectory` into unbounded recursion and stack-overflow. Track visited real directories in a `Set` and skip any directory we have already entered.

## Test plan
- [x] `bunx tsc --noEmit` clean