### PR TITLE
fix(memory-v2): mark memory v2 validate as low-risk command

### DIFF
--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -449,6 +449,11 @@ const riskOverrides: AssistantRiskOverride[] = [
     risk: "medium",
     reason: "Enqueues recompute of persisted activation state",
   },
+  {
+    path: "memory v2 validate",
+    risk: "low",
+    reason: "Read-only diagnostic walk over concept pages and edges",
+  },
   { path: "notifications send", risk: "low" },
   {
     path: "oauth request",


### PR DESCRIPTION
Addresses outstanding review feedback on #28426.

memory v2 validate is purely read-only (it walks concept pages and aggregates outgoing edges, never mutates) but was missing from the gateway risk-override list, while the other four v2 leaf commands (migrate, rebuild-edges, reembed, activation) all have explicit overrides. Adding an explicit `risk: low` so it doesn't inherit a higher default and trigger unneeded permission prompts.

The other PR-28426 review threads (memory-block wrapper nesting, byte-vs-char measurement, dual-gate alignment, system-prompt autoload gating) are already addressed in current main — they were either fixed in subsequent #30045–#30050 fixes or rendered moot by removal of the `memory-v2-enabled` feature flag.

## Test plan
- [ ] Manual: `assistant memory v2 validate` runs without unexpected permission prompt.