### PR TITLE
fix(memory-v2): address review feedback on reembed-skills

### DIFF
--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -177,7 +177,7 @@ these subcommands remain useful operator tools regardless of whether
 v2 is currently active.
 
 Subcommands split into asynchronous mutators (return a jobId enqueued
-on the memory job queue), synchronous mutators (run inside the daemon
+on the memory job queue), synchronous mutators (run inside the assistant
 and return when done), read-only diagnostics, and one-shot calibration
 fits whose results persist across runs.
 
@@ -259,7 +259,7 @@ prefix). Useful after editing a skill's SKILL.md, after a feature-flag flip
 changes the enabled-skill set, or to recover corrupted skill embeddings.
 
 Unlike 'reembed' (concept pages), this runs synchronously inside the
-daemon — the command returns only once the seed completes. Requires
+assistant — the command returns only once the seed completes. Requires
 memory.v2.enabled to be true.
 
 Examples:

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -68,25 +68,35 @@ let entries: Map<string, SkillEntry> | null = null;
 
 /**
  * Seed (or re-seed) skill embeddings into the unified concept-page collection.
- * Idempotent and best-effort — never throws.
+ * Idempotent. Defaults to best-effort (errors are logged but swallowed) for
+ * background callers like daemon startup; pass `{ throwOnError: true }` from
+ * synchronous CLI-driven paths that need to surface failures to the operator.
  *
  * Single-flight + coalesced: at most one seed runs at a time, and concurrent
  * callers are coalesced into one follow-up re-snapshot that runs after the
  * in-flight seed completes. Without this, an older snapshot can finish after
- * a newer one and overwrite the newer skill state.
+ * a newer one and overwrite the newer skill state. Strict callers observe
+ * the most recent run's outcome via `lastSeedError`.
  */
 let seedTail: Promise<void> = Promise.resolve();
 let seedPending: Promise<void> | null = null;
+let lastSeedError: unknown = null;
 
-export function seedV2SkillEntries(): Promise<void> {
-  if (seedPending) return seedPending;
-  const next = seedTail.then(async () => {
-    seedPending = null;
-    await runSeedOnce();
-  });
-  seedTail = next.catch(() => {});
-  seedPending = next;
-  return next;
+export async function seedV2SkillEntries(
+  opts: { throwOnError?: boolean } = {},
+): Promise<void> {
+  if (!seedPending) {
+    const next = seedTail.then(async () => {
+      seedPending = null;
+      await runSeedOnce();
+    });
+    seedTail = next.catch(() => {});
+    seedPending = next;
+  }
+  await seedPending;
+  if (opts.throwOnError && lastSeedError) {
+    throw lastSeedError;
+  }
 }
 
 /**
@@ -205,7 +215,9 @@ async function runSeedOnce(): Promise<void> {
 
     // Atomically replace the cache only after every step above succeeds.
     entries = nextEntries;
+    lastSeedError = null;
   } catch (err) {
+    lastSeedError = err;
     log.warn({ err }, "Failed to seed v2 skill entries");
   }
 }
@@ -236,4 +248,5 @@ export function _resetSkillStoreForTests(): void {
   entries = null;
   seedTail = Promise.resolve();
   seedPending = null;
+  lastSeedError = null;
 }

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -317,8 +317,10 @@ async function handleReembedSkills({
 
   // Unlike the queued backfill jobs above, this is a CLI-driven sync
   // request: the operator wants the cache replaced before the next prompt
-  // assembly, so we await the seed inline rather than enqueueing it.
-  await seedV2SkillEntries();
+  // assembly, so we await the seed inline rather than enqueueing it. Pass
+  // `throwOnError` so embedding/Qdrant failures surface to the CLI instead
+  // of being swallowed by the default best-effort behavior.
+  await seedV2SkillEntries({ throwOnError: true });
 
   return { success: true };
 }

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -157,6 +157,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v2 migrate",
   "memory v2 rebuild-edges",
   "memory v2 reembed",
+  "memory v2 reembed-skills",
   "memory v2 activation",
   "memory v2 validate",
   "notifications",
@@ -443,6 +444,12 @@ const riskOverrides: AssistantRiskOverride[] = [
     path: "memory v2 reembed",
     risk: "medium",
     reason: "Enqueues bulk re-embedding of every concept page",
+  },
+  {
+    path: "memory v2 reembed-skills",
+    risk: "medium",
+    reason:
+      "Synchronously re-seeds the v2 skill catalog into the concept-page collection",
   },
   {
     path: "memory v2 activation",


### PR DESCRIPTION
## Summary

Addresses outstanding review feedback on #28598 (already merged):

- **Help text**: Replace user-facing 'daemon' with 'assistant' in two \`addHelpText\` blocks under \`memory v2\` (AGENTS.md user-facing terminology rule).
- **Gateway risk registry**: Register \`memory v2 reembed-skills\` in \`ASSISTANT_SUPPORTED_COMMAND_PATHS\` and add a \`medium\` risk override so the new subcommand resolves to its own action node instead of falling back to the parent path.
- **Surface re-seed failures**: \`seedV2SkillEntries\` now accepts \`{ throwOnError }\`. The CLI-driven \`memory_v2_reembed_skills\` IPC route passes \`throwOnError: true\` so embedding/Qdrant failures propagate to the operator instead of being silently logged. Background callers (daemon startup) keep the existing best-effort default.

Addresses Devin and Codex review threads on #28598.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->