### PR TITLE
fix(sequence): concise systemHint; skip retry on step timeout

### DIFF
--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -156,17 +156,31 @@ async function processEnrollment(
     jobName: "sequence-step",
     source: "sequence",
     prompt,
+    systemHint: `Sequence: ${sequence.name} — Step ${step.index + 1}`,
     trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
     callSite: "mainAgent",
     timeoutMs: STEP_TIMEOUT_MS,
     origin: "sequence",
   });
 
-  // Re-throw on failure so `runSequencesOnce` reschedules the enrollment
-  // for retry. The runner does not throw on failure (it returns a
-  // structured result), but the existing retry path in the outer loop
-  // expects an exception to trigger `rescheduleEnrollment`.
   if (!result.ok) {
+    // Timeouts do not cancel the in-flight `processMessage`, so retrying
+    // could double-send. Exit the enrollment instead of rescheduling.
+    if (result.errorKind === "timeout") {
+      log.error(
+        {
+          enrollmentId: enrollment.id,
+          sequenceId: sequence.id,
+          step: step.index,
+        },
+        "Sequence step timed out — exiting enrollment to prevent duplicate outreach",
+      );
+      recordEvent(sequence.id, enrollment.id, "fail", step.index, {
+        reason: "step_timeout",
+      });
+      exitEnrollment(enrollment.id, "failed");
+      return;
+    }
     throw (
       result.error ?? new Error(`Background job failed: ${result.errorKind}`)
     );


### PR DESCRIPTION
## Summary

Addresses review feedback on #28718.

- **Codex (P1)**: `runBackgroundJob` doesn't cancel in-flight `processMessage` on timeout. Throwing caused `runSequencesOnce` to reschedule the enrollment, so the original step could complete in the background (including sending email) AND the retry could fire — duplicate outreach. On timeout, exit the enrollment as `failed` with a `step_timeout` analytics event instead of throwing.
- **Devin**: `runBackgroundJob` defaults `systemHint` to `opts.prompt`, making the entire multi-paragraph step prompt the conversation systemHint. `deriveFallbackTitle` echoes that as the title when title generation fails. Pass a concise `Sequence: <name> — Step N` label.
- **Skipped**: Devin's `emitFeedEvent` re-add suggestion — removal is deliberate per the original PR description (sender-side bookkeeping; not user-relevant).

## Test plan
- [ ] Existing sequence engine tests pass
- [ ] Manual: trigger step timeout; enrollment exits as failed (no retry, no duplicate send)
- [ ] Manual: confirm conversation title for sequence steps is the short label, not the prompt