### PR TITLE
fix(memory-v2): strip static <memory> block on compaction; decouple trust from cadence

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1425,20 +1425,21 @@ export async function runAgentLoopImpl(
     const pkbContext = shouldInjectNowAndPkb ? currentPkbContent : null;
     const pkbActive = currentPkbContent !== null;
 
-    // V2 static memory block (essentials/threads/recent/buffer). Same
-    // first-turn / post-compaction cadence as PKB. `shouldLoadMemoryV2Static`
-    // also blocks remote-channel non-guardian actors from inducing the
-    // model to recite private memory; `readMemoryV2StaticContent` self-gates
-    // on the v2 flag + config and returns null when v2 is off, so the file
-    // reads are skipped on non-injection turns.
+    // V2 static memory block (essentials/threads/recent/buffer).
+    // `currentMemoryV2Static` is the trust-gated content reused by every
+    // re-injection path — it stays non-null on non-full-mode turns so
+    // that mid-turn reducer compaction (which strips the prior `<memory>`
+    // block) can restore the freshest content. `memoryV2Static` is the
+    // first-turn / post-compaction cadence-gated value for initial
+    // injection only. `readMemoryV2StaticContent` self-gates on the v2
+    // flag + config and returns null when v2 is off.
     const currentMemoryV2Static = shouldLoadMemoryV2Static({
-      shouldInjectNowAndPkb,
       sourceChannel: ctx.trustContext?.sourceChannel,
       isTrustedActor,
     })
       ? readMemoryV2StaticContent()
       : null;
-    const memoryV2Static = currentMemoryV2Static;
+    const memoryV2Static = shouldInjectNowAndPkb ? currentMemoryV2Static : null;
 
     // PKB relevance-hint inputs. Resolved once per turn and reused across
     // re-injections so post-compaction rebuilds pick up fresh hints against

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1641,12 +1641,15 @@ const RUNTIME_INJECTION_PREFIXES = [
   // blocks persist in history so the assistant retains temporal/actor grounding.
   "<memory_context __injected>",
   "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
-  // NOTE: `<memory>` blocks (both the dynamic activation block from
-  // `injectTextBlock` and the static `memory-v2-static` injector) are
-  // intentionally NOT stripped — memory injections persist in history so
-  // the assistant retains intra-turn memory state. The activation pipeline
-  // dedupes via `everInjected`, and compaction handles aggregate growth, so
+  // The static `memory-v2-static` block (opens `<memory>\n…`) IS stripped
+  // so each compaction re-injects the freshest essentials/threads/recent/
+  // buffer view, matching the `<knowledge_base>` cadence. The dynamic
+  // activation block (opens `<memory __injected>…`) is intentionally NOT
+  // stripped — `startsWith("<memory>\n")` does not match it — so per-turn
+  // memory activations persist in history. The activation pipeline dedupes
+  // via `everInjected`, and compaction handles aggregate growth, so
   // accumulation does not cause unbounded context growth.
+  "<memory>\n",
   "<voice_call_control>",
   "<workspace_top_level>", // backward-compat: strip legacy workspace blocks
   // NOTE: <workspace> is intentionally NOT stripped — workspace context

--- a/assistant/src/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/memory/v2/__tests__/static-context.test.ts
@@ -141,20 +141,9 @@ describe("readMemoryV2StaticContent", () => {
 });
 
 describe("shouldLoadMemoryV2Static", () => {
-  test("blocks all turns until the cadence gate fires", () => {
-    expect(
-      shouldLoadMemoryV2Static({
-        shouldInjectNowAndPkb: false,
-        sourceChannel: "vellum",
-        isTrustedActor: true,
-      }),
-    ).toBe(false);
-  });
-
   test("allows guardian-trusted local conversations", () => {
     expect(
       shouldLoadMemoryV2Static({
-        shouldInjectNowAndPkb: true,
         sourceChannel: "vellum",
         isTrustedActor: true,
       }),
@@ -164,7 +153,6 @@ describe("shouldLoadMemoryV2Static", () => {
   test("allows local-channel conversations even when trust class is unknown (analyze runs, dev)", () => {
     expect(
       shouldLoadMemoryV2Static({
-        shouldInjectNowAndPkb: true,
         sourceChannel: "vellum",
         isTrustedActor: false,
       }),
@@ -174,7 +162,6 @@ describe("shouldLoadMemoryV2Static", () => {
   test("allows turns with no trust context (work-item task runs, internal background)", () => {
     expect(
       shouldLoadMemoryV2Static({
-        shouldInjectNowAndPkb: true,
         sourceChannel: undefined,
         isTrustedActor: false,
       }),
@@ -193,7 +180,6 @@ describe("shouldLoadMemoryV2Static", () => {
     for (const channel of REMOTE_CHANNELS) {
       expect(
         shouldLoadMemoryV2Static({
-          shouldInjectNowAndPkb: true,
           sourceChannel: channel,
           isTrustedActor: true,
         }),
@@ -205,7 +191,6 @@ describe("shouldLoadMemoryV2Static", () => {
     for (const channel of REMOTE_CHANNELS) {
       expect(
         shouldLoadMemoryV2Static({
-          shouldInjectNowAndPkb: true,
           sourceChannel: channel,
           isTrustedActor: false,
         }),

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -66,13 +66,18 @@ export function readMemoryV2StaticContent(): string | null {
  * can be prompt-injected into reciting private memory. Internal flows
  * (`sourceChannel: "vellum"`) and turns with no trust context pass through
  * unchanged; this gate exists only to keep remote untrusted actors out.
+ *
+ * This is the trust-only gate. Cadence (first-turn / post-compaction) is
+ * applied separately by the caller so that `currentMemoryV2Static` remains
+ * available for re-injection after a mid-turn reducer-triggered compaction
+ * — the initial-injection turn may not have been a `shouldInjectNowAndPkb`
+ * turn, but compaction strips the existing `<memory>` block and we still
+ * need the freshest content to re-inject.
  */
 export function shouldLoadMemoryV2Static(args: {
-  shouldInjectNowAndPkb: boolean;
   sourceChannel: ChannelId | undefined;
   isTrustedActor: boolean;
 }): boolean {
-  if (!args.shouldInjectNowAndPkb) return false;
   const isRemoteUntrustedActor =
     args.sourceChannel !== undefined &&
     args.sourceChannel !== "vellum" &&


### PR DESCRIPTION
## Summary

Follow-up to #28767 addressing review feedback.

The original PR's description stated two things that did not actually land on the merged commit:

1. **`<memory>\n` was supposedly added to `RUNTIME_INJECTION_PREFIXES`** — it wasn't. The static `memory-v2-static` block was never stripped on compaction, so re-injection duplicated it: the prior block remained on a previous user message while a new block was spliced onto the tail. Caught by Devin Review.
2. **`currentMemoryV2Static` was supposedly the ungated source for re-injection paths** — it was actually gated by `shouldInjectNowAndPkb`. On non-first turns before any compaction, it was null; if reducer-triggered compaction happened mid-turn and stripped the existing block, re-injection passed null and the static memory disappeared. Caught by Codex Review (P1).

This PR realigns the implementation with the documented intent:

- Add `<memory>\n` to `RUNTIME_INJECTION_PREFIXES`. `startsWith` matching only fires on the static block (which opens `<memory>\n…`); the dynamic activation block (`<memory __injected>…`) is unaffected.
- Split the cadence gate out of `shouldLoadMemoryV2Static` so the trust gate stands alone. `currentMemoryV2Static` is loaded once per turn whenever the trust gate permits; `memoryV2Static` (used only for initial injection) keeps the first-turn / post-compaction cadence.

Net effect: on each compaction the static block is stripped and re-injected with the freshest essentials/threads/recent/buffer view, matching the `<knowledge_base>` cadence as the original PR description stated.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/memory/v2/__tests__/static-context.test.ts` — 10 pass
- [x] `bun test src/__tests__/memory-v2-static-injector.test.ts src/__tests__/injector-chain.test.ts` — 20 pass
- [x] `bun test src/__tests__/strip-memory-injections.test.ts src/__tests__/compaction-strip-metadata-clear.test.ts src/__tests__/conversation-runtime-assembly.test.ts` — 189 pass