### PR TITLE
test(btw-routes): expect excludeCustomPrefix in buildSystemPrompt args

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -320,6 +320,7 @@ describe("POST /v1/btw", () => {
     expect(mockBuildSystemPrompt).toHaveBeenCalledWith({
       channelPersona: null,
       excludeBootstrap: true,
+      excludeCustomPrefix: true,
       userPersona: null,
       userSlug: null,
     });


### PR DESCRIPTION
## Summary
- Update `btw-routes.test.ts` to expect `excludeCustomPrefix: true` in the `buildSystemPrompt` call args, matching the production code change in #30048.

## Original prompt
Fix the specific CI issue in this failing job: https://github.com/vellum-ai/vellum-assistant/actions/runs/25590148708/job/75126205047 — the `test:stable` job was failing because `btw-routes.test.ts` expected `mockBuildSystemPrompt` to be called without `excludeCustomPrefix`, but commit ec17513058 added that argument to the production call without updating the test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->