### PR TITLE
fix(memory-v2): handle page_missing status and cancelled page fetches in inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ConceptPageContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ConceptPageContentView.swift
@@ -53,7 +53,16 @@ struct ConceptPageContentView: View {
             guard state == .idle else { return }
             state = .loading
             let client = LLMContextClient()
-            if let rendered = await client.fetchConceptPage(slug: slug) {
+            let rendered = await client.fetchConceptPage(slug: slug)
+            // If the task was cancelled (e.g. user collapsed the row before
+            // the fetch returned), `fetchConceptPage` swallows the
+            // CancellationError and returns nil. Reset to `.idle` instead of
+            // `.missing` so a subsequent re-expand retries the load.
+            if Task.isCancelled {
+                state = .idle
+                return
+            }
+            if let rendered {
                 state = .loaded(rendered)
             } else {
                 state = .missing

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -337,6 +337,8 @@ private func statusColor(_ status: String) -> Color {
         return VColor.systemPositiveStrong
     case "not_injected":
         return VColor.contentDisabled
+    case "page_missing":
+        return VColor.systemMidStrong
     default:
         return VColor.contentTertiary
     }
@@ -350,6 +352,8 @@ private func statusLabel(_ status: String) -> String {
         return "Injected"
     case "not_injected":
         return "Not injected"
+    case "page_missing":
+        return "Page missing"
     default:
         return status
     }


### PR DESCRIPTION
Addresses review feedback on #29237. Adds page_missing status handling in inspector status helpers, and resets state to .idle on cancelled fetches so re-expanding retries instead of showing a stuck Page missing. The other two review threads (FlexFrame, Qdrant MAX_SAFE_INTEGER OOM) were already addressed in main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->