### PR TITLE
fix(memory-v2): drop premature loadConfig in startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -327,8 +327,6 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Background feature flag init failed"),
     );
 
-    maybeSeedMemoryV2Skills(loadConfig());
-
     seedInterfaceFiles();
 
     log.info("Daemon startup: initializing DB");


### PR DESCRIPTION
Addresses review feedback on #29276. The early maybeSeedMemoryV2Skills(loadConfig()) in runDaemon ran before mergeDefaultWorkspaceConfig(), violating the documented invariant that the merge must run before the first loadConfig(). The early seed was added in #29276 to dodge a memory-v2-enabled flag race; that flag was removed in #29860, so initializeQdrantAndMemory already seeds with the post-merge config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->