### PR TITLE
fix(memory-v2): clamp negative cosines instead of affine-rescaling them in hybrid fusion

### DIFF
--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -470,10 +470,10 @@ describe("computeOwnActivation", () => {
         c_now: 0.2,
       }),
     });
-    // cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6.
-    // Expected: 0.3*0.6 + 0.3*0.75 + 0.2*0.7 + 0.2*0.6
-    //         = 0.18+0.225+0.14+0.12 = 0.665
-    expect(out.activation.get("alice")).toBeCloseTo(0.665, 6);
+    // Positive cosines pass through unchanged (negatives clamp to 0).
+    // Expected: 0.3*0.6 + 0.3*0.5 + 0.2*0.4 + 0.2*0.2
+    //         = 0.18 + 0.15 + 0.08 + 0.04 = 0.45
+    expect(out.activation.get("alice")).toBeCloseTo(0.45, 6);
   });
 
   test("clamps over-1.0 results down to [0, 1]", async () => {
@@ -525,9 +525,9 @@ describe("computeOwnActivation", () => {
         c_now: 0.2,
       }),
     });
-    // cosine→unit mapping: 1.0→1.0, 0→0.5.
-    // 0.3*0 + 0.3*1 + 0.2*0.5 + 0.2*0.5 = 0.5
-    expect(out.activation.get("fresh")).toBeCloseTo(0.5, 6);
+    // Positive cosines pass through unchanged: 1.0 stays 1.0; 0 stays 0.
+    // 0.3*0 + 0.3*1 + 0.2*0 + 0.2*0 = 0.3
+    expect(out.activation.get("fresh")).toBeCloseTo(0.3, 6);
   });
 
   test("candidate with no sim hits resolves to 0", async () => {
@@ -576,11 +576,11 @@ describe("computeOwnActivation", () => {
     expect(breakdown).toBeDefined();
     // priorContribution is `d * prev`, not the weighted sim term.
     expect(breakdown?.priorContribution).toBeCloseTo(d * 0.6, 6);
-    // Fused sims (post cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6),
-    // captured before c_user / c_assistant / c_now weighting.
-    expect(breakdown?.simUser).toBeCloseTo(0.75, 6);
-    expect(breakdown?.simAssistant).toBeCloseTo(0.7, 6);
-    expect(breakdown?.simNow).toBeCloseTo(0.6, 6);
+    // Fused sims (positive cosines pass through unchanged), captured before
+    // c_user / c_assistant / c_now weighting.
+    expect(breakdown?.simUser).toBeCloseTo(0.5, 6);
+    expect(breakdown?.simAssistant).toBeCloseTo(0.4, 6);
+    expect(breakdown?.simNow).toBeCloseTo(0.2, 6);
   });
 
   test("breakdown defaults priorContribution to 0 when priorState is null", async () => {
@@ -805,10 +805,10 @@ describe("computeOwnActivation", () => {
   });
 
   test("rerank boost is additive on A_o and leaves raw simUser / simAssistant untouched", async () => {
-    // Input cosines chosen so post `(x+1)/2` mapping yields the round
-    // fused values used in the formula assertion below.
-    stageHybridResponse([{ slug: "a", denseScore: 0 }]); // user — cosine 0 → 0.5
-    stageHybridResponse([{ slug: "a", denseScore: -0.2 }]); // assistant — cosine -0.2 → 0.4
+    // Positive cosines pass through unchanged; pick 0.5 / 0.4 directly so
+    // the round fused values used in the formula assertion below hold.
+    stageHybridResponse([{ slug: "a", denseScore: 0.5 }]); // user — fused 0.5
+    stageHybridResponse([{ slug: "a", denseScore: 0.4 }]); // assistant — fused 0.4
     stageHybridResponse([]); // now
     rerankState.scores = new Map([["a", 0.8]]);
 
@@ -1225,9 +1225,9 @@ describe("skills participate in the unified pipeline", () => {
     });
 
     // No prior state → priorContribution = 0.
-    // cosine→unit mapping: 0.5→0.75, 0.4→0.7, 0.2→0.6.
-    // 0.3*0.75 + 0.2*0.7 + 0.2*0.6 = 0.225 + 0.14 + 0.12 = 0.485
-    expect(out.activation.get("skills/example-skill-a")).toBeCloseTo(0.485, 6);
+    // Positive cosines pass through unchanged.
+    // 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.15 + 0.08 + 0.04 = 0.27
+    expect(out.activation.get("skills/example-skill-a")).toBeCloseTo(0.27, 6);
     expect(out.breakdown.get("skills/example-skill-a")?.priorContribution).toBe(
       0,
     );

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -433,8 +433,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["dense-only-page"], config);
 
-    // cosine 0.5 → unit 0.75; 0.7 * 0.75 + 0.3 * 0 = 0.525
-    expect(out.get("dense-only-page")).toBeCloseTo(0.525, 6);
+    // cosine 0.5 (positive, passes through); 0.7 * 0.5 + 0.3 * 0 = 0.35
+    expect(out.get("dense-only-page")).toBeCloseTo(0.35, 6);
   });
 
   test("sparse-only hit gets dense contribution of 0; sparse normalized to 1.0", async () => {
@@ -475,11 +475,11 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice", "bob"], config);
 
-    // cosine→unit: alice 0.5 → 0.75, bob 0.25 → 0.625.
-    // alice: 0.4 * 0.75 + 0.6 * 1.0 = 0.9
-    // bob:   0.4 * 0.625 + 0.6 * 0.5 = 0.55
-    expect(out.get("alice")).toBeCloseTo(0.9, 6);
-    expect(out.get("bob")).toBeCloseTo(0.55, 6);
+    // Positive cosines pass through unchanged.
+    // alice: 0.4 * 0.5 + 0.6 * 1.0 = 0.8
+    // bob:   0.4 * 0.25 + 0.6 * 0.5 = 0.4
+    expect(out.get("alice")).toBeCloseTo(0.8, 6);
+    expect(out.get("bob")).toBeCloseTo(0.4, 6);
   });
 
   test("scores are clamped into [0, 1] even when fused values overshoot", async () => {
@@ -538,8 +538,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice"], config);
 
-    // cosine 0.7 → unit 0.85; cosine 0.3 → unit 0.65; max = 0.85.
-    expect(out.get("alice")).toBeCloseTo(0.85, 6);
+    // Positive cosines pass through unchanged: max(0.3, 0.7) = 0.7.
+    expect(out.get("alice")).toBeCloseTo(0.7, 6);
   });
 
   test("takes max(body, summary) per slug — body higher than summary wins", async () => {
@@ -555,8 +555,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["alice"], config);
 
-    // cosine 0.9 → unit 0.95; cosine 0.4 → unit 0.7; max = 0.95.
-    expect(out.get("alice")).toBeCloseTo(0.95, 6);
+    // Positive cosines pass through unchanged: max(0.9, 0.4) = 0.9.
+    expect(out.get("alice")).toBeCloseTo(0.9, 6);
   });
 
   test("falls back to body-only when the page has no summary embedding", async () => {
@@ -573,8 +573,8 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["legacy-page"], config);
 
-    // cosine 0.6 → unit 0.8.
-    expect(out.get("legacy-page")).toBeCloseTo(0.8, 6);
+    // Positive cosine 0.6 passes through unchanged.
+    expect(out.get("legacy-page")).toBeCloseTo(0.6, 6);
   });
 
   test("normalizes body and summary sparse channels independently", async () => {
@@ -611,6 +611,31 @@ describe("simBatch", () => {
     expect(out.get("bob")).toBeCloseTo(1.0, 6);
   });
 
+  test("dense-favored config keeps the dense-strong candidate above the sparse-strong one", async () => {
+    // Regression guard: an earlier fix mapped cosines into [0, 1] via
+    // `(cos + 1) / 2` before fusion, which halved every pairwise dense
+    // difference and silently shifted ranking toward sparse. With dense
+    // weighted higher than sparse, the dense-only hit must outrank the
+    // sparse-only hit even though sparse normalizes to 1.0.
+    const config = configWithWeights(0.7, 0.3);
+    stageHybridResponse([
+      { slug: "dense-strong", denseScore: 0.5 /* sparseScore omitted */ },
+      { slug: "sparse-strong", denseScore: 0.0, sparseScore: 1 },
+    ]);
+
+    const out = await simBatch(
+      "query",
+      ["dense-strong", "sparse-strong"],
+      config,
+    );
+
+    // dense-strong: 0.7 * max(0, 0.5) + 0.3 * 0 = 0.35
+    // sparse-strong: 0.7 * max(0, 0.0) + 0.3 * 1.0 = 0.30
+    expect(out.get("dense-strong")).toBeCloseTo(0.35, 6);
+    expect(out.get("sparse-strong")).toBeCloseTo(0.3, 6);
+    expect(out.get("dense-strong")!).toBeGreaterThan(out.get("sparse-strong")!);
+  });
+
   test("negative cosine maps to a non-negative dense contribution", async () => {
     // Qdrant cosine search returns scores in [-1, 1]. A near-zero or
     // negative cosine must not yield a negative dense contribution that
@@ -622,7 +647,7 @@ describe("simBatch", () => {
 
     const out = await simBatch("query", ["anti-match"], config);
 
-    // cosine -1 → unit 0; sparse-norm = 1.0; fused = 0.7*0 + 0.3*1 = 0.3.
+    // cosine -1 → clamped to 0; sparse-norm = 1.0; fused = 0.7*0 + 0.3*1 = 0.3.
     expect(out.get("anti-match")).toBeCloseTo(0.3, 6);
   });
 

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -18,21 +18,24 @@
 //   `sparse_weight` (which the schema validates sum to 1.0).
 //
 // Score normalization:
-//   Qdrant returns cosine similarity in [-1, 1]; we map it to [0, 1] via
-//   `mapCosineToUnit` before fusing. Skipping this step systematically
-//   depresses dense contributions for near-zero or negative cosines and
-//   skews ordering toward sparse-only matches. Qdrant's sparse score is on
-//   a different, unbounded scale (it depends on query and document term
-//   weights), so we divide by the per-batch maximum sparse score to bring
-//   it into [0, 1] before fusing. This is the design doc's choice (§4) —
-//   batch-relative normalization is sufficient because the score is
-//   consumed only as a per-turn ordering signal, not compared across
-//   turns.
+//   Qdrant returns cosine similarity in [-1, 1]. We clamp negative cosines
+//   to 0 before fusion so anti-correlated documents contribute zero, rather
+//   than a negative term that subtracts from the sparse channel and can
+//   depress the fused score below the sparse-only floor. Positive cosines
+//   pass through unchanged — affine-rescaling them into [0, 1] via
+//   `(cos + 1) / 2` would halve every pairwise dense difference and shift
+//   ranking toward the sparse channel, the opposite of intent. Qdrant's
+//   sparse score is on a different, unbounded scale (it depends on query
+//   and document term weights), so we divide by the per-batch maximum
+//   sparse score to bring it into [0, 1] before fusing. This is the design
+//   doc's choice (§4) — batch-relative normalization is sufficient because
+//   the score is consumed only as a per-turn ordering signal, not compared
+//   across turns.
 
 import type { AssistantConfig } from "../../config/types.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embedding-backend.js";
-import { clampUnitInterval, mapCosineToUnit } from "../validation.js";
+import { clampUnitInterval } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
 import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
 
@@ -268,10 +271,12 @@ function computeMaxSparse<T>(
 
 /**
  * Fuse one half of a hit (body or summary) into a normalized [0, 1] score
- * via `clamp01(dense_weight · denseUnit + sparse_weight · sparse/maxSparse)`,
- * where `denseUnit = (cosine + 1) / 2`. Returns `undefined` when neither
- * channel hit — a signal the half had no match at all, so the caller can
- * fall back to the other half cleanly.
+ * via `clamp01(dense_weight · max(0, cosine) + sparse_weight ·
+ * sparse/maxSparse)`. Negative cosines clamp to 0 so they don't subtract
+ * from sparse; positive cosines pass through unchanged so the
+ * operator-configured dense/sparse balance is preserved. Returns
+ * `undefined` when neither channel hit — a signal the half had no match
+ * at all, so the caller can fall back to the other half cleanly.
  */
 function fuseHalf(
   denseScore: number | undefined,
@@ -281,7 +286,7 @@ function fuseHalf(
   sparseWeight: number,
 ): number | undefined {
   if (denseScore === undefined && sparseScore === undefined) return undefined;
-  const dense = denseScore !== undefined ? mapCosineToUnit(denseScore) : 0;
+  const dense = denseScore !== undefined ? Math.max(0, denseScore) : 0;
   const sparseNormalized =
     sparseScore !== undefined && maxSparse > 0 ? sparseScore / maxSparse : 0;
   return clamp01(denseWeight * dense + sparseWeight * sparseNormalized);

--- a/assistant/src/memory/validation.ts
+++ b/assistant/src/memory/validation.ts
@@ -11,9 +11,12 @@ export function clampUnitInterval(value: number): number {
 
 /**
  * Map cosine similarity [-1, 1] into the unit interval [0, 1] via
- * `(x + 1) / 2`, then clamp. Used by hybrid retrieval (v2) and legacy
- * semantic search to put dense and sparse channels on the same scale
- * before fusion.
+ * `(x + 1) / 2`, then clamp. Single-channel display normalization for the
+ * legacy v1 semantic-search path; do **not** use before hybrid fusion —
+ * the affine rescale halves pairwise dense differences and shifts ranking
+ * toward sparse. Hybrid fusion (`v2/sim.ts`) instead clamps negative
+ * cosines to 0 with `Math.max(0, x)` and lets positive cosines pass
+ * through unchanged.
  */
 export function mapCosineToUnit(value: number): number {
   return clampUnitInterval((value + 1) / 2);

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -50,7 +50,6 @@ import {
   getConceptPageCorpusStats,
   rebuildConceptPageCorpusStats,
 } from "../../memory/v2/sparse-bm25.js";
-import { mapCosineToUnit } from "../../memory/validation.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
@@ -344,7 +343,7 @@ export interface MemoryV2ExplainSimilarityRow {
   sparseRaw: number | null;
   /** Sparse score divided by the per-batch max, in [0, 1]. */
   sparseNorm: number | null;
-  /** `clamp01(dense_weight·denseUnit + sparse_weight·sparseNorm)` where `denseUnit = (cosine + 1) / 2` — the simBatch fused value. */
+  /** `clamp01(dense_weight · max(0, cosine) + sparse_weight · sparseNorm)` — the simBatch fused value. */
   fused: number;
 }
 
@@ -442,14 +441,15 @@ async function scoreChannel(
   } = effectiveWeights(hits, maxSparse, denseWeight, sparseWeight, config);
 
   const rows: MemoryV2ExplainSimilarityRow[] = hits.map((hit) => {
-    // Map cosine [-1, 1] → unit [0, 1] before fusion to mirror simBatch.
-    const denseUnit =
-      hit.denseScore !== undefined ? mapCosineToUnit(hit.denseScore) : 0;
+    // Clamp negative cosines to 0 before fusion to mirror simBatch — keeps
+    // anti-correlated documents from subtracting against the sparse channel.
+    const denseClamped =
+      hit.denseScore !== undefined ? Math.max(0, hit.denseScore) : 0;
     const sparseNorm =
       hit.sparseScore !== undefined && maxSparse > 0
         ? hit.sparseScore / maxSparse
         : 0;
-    const fusedRaw = effDense * denseUnit + effSparse * sparseNorm;
+    const fusedRaw = effDense * denseClamped + effSparse * sparseNorm;
     const fused = Math.max(0, Math.min(1, fusedRaw));
     return {
       slug: hit.slug,


### PR DESCRIPTION
## Summary
- **Bug**: PR #30033 added `mapCosineToUnit(x) = (x+1)/2` before hybrid fusion in `sim.ts:fuseHalf`. As an affine transform it halves every pairwise dense difference, so the dense channel's effective ranking power dropped 2x while sparse stayed the same. The fix it claimed to make (reduce sparse bias) actually pushed ordering further toward sparse.
- **Fix**: Replace the affine rescale with `Math.max(0, denseScore)` in `sim.ts:fuseHalf` and the matching `memory-v2-routes.ts:scoreChannel` diagnostic. This still clamps negative cosines to 0 (the original Codex concern - anti-correlated documents no longer subtract from sparse-strong items below the `clamp01` floor) but preserves positive-cosine variance so the operator-configured `dense_weight` / `sparse_weight` balance stays meaningful.
- **Regression guard**: New `sim.test.ts` ranking-stability test asserts the dense-strong candidate beats the sparse-strong one under `dense_weight=0.7`. The previous tests only checked absolute fused values, which is why the variance compression slipped through; this one checks the actual ordering invariant.

### Counterexample (`dense_weight=0.7, sparse_weight=0.3`)

| Candidate | cosine | sparseNorm | Pre-#30033 | Post-#30033 (`(x+1)/2`) | This PR (`max(0, x)`) |
|---|---:|---:|---:|---:|---:|
| A (dense-strong) | 0.5 | 0.0 | **0.35** | 0.525 | **0.35** |
| B (sparse-strong) | 0.0 | 1.0 | 0.30 | **0.65** | 0.30 |

Bold = winner. Pre-#30033 dense correctly outranks sparse; #30033 silently flipped the order despite dense being the heavier-weighted channel; this PR restores the intended ordering while still solving the negative-cosine concern.

`mapCosineToUnit` is kept for `assistant/src/memory/search/semantic.ts:134`, where it normalizes the dense-only path's single-channel score for display - that's a legitimate single-channel use that doesn't depend on cross-channel variance equality. The jsdoc now warns against using it pre-fusion.

## Original prompt
The user noticed that PR #30033's `(cos + 1) / 2` mapping is mathematically equivalent to halving the dense channel's contribution to ranking variance, which would shift ordering toward sparse - the opposite of what the commit claimed to fix. They asked whether the commit does the opposite of its intent. The analysis confirmed it: the affine rescale halves every pairwise dense difference while sparse is unchanged, and the existing tests didn't catch it because they only assert absolute fused values, not relative orderings. This PR ships the corrected fix (`Math.max(0, x)`) with a ranking-stability regression test.

Generated with Claude Code