### PR TITLE
refactor(inspector): remove dead LLMContextFetchResult.empty case

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -706,13 +706,6 @@ struct MessageInspectorViewState {
                || !orderedLogs.contains(where: { $0.id == selectedLogID }) {
                 selectedLogID = orderedLogs.last?.id
             }
-        case .empty:
-            logs = []
-            memoryRecall = nil
-            memoryV2Activation = nil
-            conversationKind = nil
-            loadState = .empty
-            selectedLogID = nil
         case .failed:
             logs = []
             memoryRecall = nil

--- a/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
@@ -23,7 +23,7 @@ final class MessageInspectorViewTests: XCTestCase {
         let emptyRequestToken = state.beginLoading(resetSelection: true)
         XCTAssertEqual(state.loadState, .loading)
 
-        state.finishLoading(with: .empty, requestToken: emptyRequestToken)
+        state.finishLoading(with: .loaded(makeResponse(logs: [])), requestToken: emptyRequestToken)
         XCTAssertEqual(state.loadState, .empty)
         XCTAssertNil(state.selectedLogID)
 
@@ -113,7 +113,7 @@ final class MessageInspectorViewTests: XCTestCase {
         XCTAssertNotNil(state.memoryRecall)
 
         let emptyToken = state.beginLoading(resetSelection: true)
-        state.finishLoading(with: .empty, requestToken: emptyToken)
+        state.finishLoading(with: .loaded(makeResponse(logs: [])), requestToken: emptyToken)
         XCTAssertNil(state.memoryRecall)
     }
 

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -749,7 +749,6 @@ public struct LLMContextResponse: Codable, Sendable {
 /// Explicit outcome for an LLM context fetch.
 public enum LLMContextFetchResult: Sendable {
     case loaded(LLMContextResponse)
-    case empty
     case failed
 }
 
@@ -776,7 +775,7 @@ public struct LLMContextClient: LLMContextClientProtocol {
             switch try await fetchContextResult(messageId: messageId) {
             case .loaded(let response):
                 return response
-            case .empty, .failed:
+            case .failed:
                 return nil
             }
         } catch is CancellationError {
@@ -812,9 +811,6 @@ public struct LLMContextClient: LLMContextClientProtocol {
         do {
             let decoded = try JSONDecoder().decode(LLMContextResponse.self, from: response.data)
             try Task.checkCancellation()
-            // Always return `.loaded` so the view state receives `conversationKind`
-            // even when the log list is empty — the empty-state branch is derived
-            // from `logs.isEmpty` inside `MessageInspectorViewState.finishLoading`.
             return .loaded(decoded)
         } catch is CancellationError {
             throw CancellationError()


### PR DESCRIPTION
Addresses Devin review feedback on #29279. .empty was unreachable; removes the enum case and its handler.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->