### PR TITLE
fix(macos): post turn-complete notification in voice mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -501,8 +501,6 @@ final class ConversationManager: ConversationRestorerDelegate {
         if conversation.shouldSuppressUnreadIndicator { return }
         guard let daemonConversationId = conversation.conversationId else { return }
         guard let vm = selectionStore.chatViewModels[conversationId] else { return }
-        // Voice path posts its own VOICE_RESPONSE_COMPLETE notification; skip to avoid duplicates.
-        if vm.isVoiceModeActive { return }
 
         let lastAssistantText = vm.messages.last(where: { $0.role == .assistant })?.text ?? ""
         let bodyText = lastAssistantText.isEmpty ? "Response complete" : String(lastAssistantText.prefix(200))


### PR DESCRIPTION
Address Codex review feedback on #29093. VoiceModeManager swaps in its own onVoiceResponseComplete handler when voice mode is active, so VOICE_RESPONSE_COMPLETE is never posted. The new isVoiceModeActive guard in postTurnCompleteNotificationIfNeeded then suppressed ACTIVITY_COMPLETE as well, leaving voice-mode turn completions with no notification when the app was unfocused. Removing the guard lets ACTIVITY_COMPLETE fire for voice-mode turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->