### PR TITLE
refactor(terminal-api): drop unused assistantId property and init param

### DIFF
--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
@@ -24,7 +24,7 @@ final class SSHTerminalWindow {
             return
         }
 
-        let apiClient = TerminalAPIClient(assistantId: assistant.assistantId)
+        let apiClient = TerminalAPIClient()
         let manager = TerminalSessionManager(apiClient: apiClient)
         self.sessionManager = manager
 

--- a/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
@@ -12,12 +12,6 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Termi
 @MainActor
 final class TerminalAPIClient {
 
-    private let assistantId: String
-
-    init(assistantId: String) {
-        self.assistantId = assistantId
-    }
-
     // MARK: - Session Lifecycle
 
     /// Creates a new terminal session and returns the session ID.


### PR DESCRIPTION
Follow-up to #29235. Devin review noted that `TerminalAPIClient` stored `assistantId` as a `private let` and accepted it via `init`, but no method ever read it after the local capture in `subscribeEvents` was removed. Drop the property, the init parameter, and update the lone call site in `SSHTerminalWindow`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->