### PR TITLE
test(inline-skill-load-permissions): reset feature flag overrides between tests

### DIFF
--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -14,7 +14,7 @@
 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Mock setup (must be before any imports from the project) ──────────────
 
@@ -115,6 +115,7 @@ describe("inline-command skill_load permissions", () => {
   beforeEach(() => {
     clearRiskCache();
     _clearGlobalCacheForTesting();
+    _setOverridesForTesting({});
     mockIpcResponse("get_global_thresholds", {
       interactive: "low",
       autonomous: "medium",
@@ -131,6 +132,10 @@ describe("inline-command skill_load permissions", () => {
     } catch {
       /* may not exist */
     }
+  });
+
+  afterEach(() => {
+    _setOverridesForTesting({});
   });
 
   // ── Default behavior ─────────────────────────────────────────────────


### PR DESCRIPTION
Addresses review feedback on #29263 — resets feature flag overrides between tests for hermeticity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->