### PR TITLE
fix(macos): suppress inline task_progress when popped out, close overlay on dismiss

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
@@ -440,6 +440,13 @@ extension ChatViewModel {
     /// Handle a `ui_surface_dismiss` event: remove an inline surface widget.
     func handleSurfaceDismiss(_ msg: UiSurfaceDismissMessage) {
         guard belongsToConversation(msg.conversationId) else { return }
+        #if os(macOS)
+        // If the dismissed surface is currently popped out, close the floating
+        // overlay immediately so it doesn't orphan after the surface is gone.
+        if TaskProgressOverlayManager.shared.activeSurfaceId == msg.surfaceId {
+            TaskProgressOverlayManager.shared.close()
+        }
+        #endif
         // Find and remove the inline surface across all messages
         for msgIndex in messages.indices {
             if let surfaceIndex = messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == msg.surfaceId }) {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -76,9 +76,22 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    /// True when this surface is currently displayed in the floating task-progress overlay.
+    /// Suppress the inline rendering so the same widget doesn't show in two places.
+    private var isPoppedOut: Bool {
+        #if os(macOS)
+        if case .card(let data) = surface.data, data.template == "task_progress" {
+            return TaskProgressOverlayManager.shared.activeSurfaceId == surface.id
+        }
+        #endif
+        return false
+    }
+
     public var body: some View {
         Group {
-        if case .strippedFailed = surface.data {
+        if isPoppedOut {
+            EmptyView()
+        } else if case .strippedFailed = surface.data {
             strippedFailedPlaceholder
         } else if case .stripped = surface.data {
             strippedPlaceholder


### PR DESCRIPTION
Addresses review feedback on #29089.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->