### PR TITLE
docs(macos): rename daemon -> assistant in AppMouse client code

### DIFF
--- a/clients/macos/vellum-assistant/AppControl/AppMouse.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppMouse.swift
@@ -10,7 +10,7 @@ import VellumAssistantShared
 /// other apps unaffected.
 ///
 /// Coordinates are window-relative and translated to global at post time
-/// using the current `WindowBounds` reported by the daemon.
+/// using the current `WindowBounds` reported by the assistant.
 enum AppMouse {
 
     // MARK: - Errors

--- a/clients/macos/vellum-assistantTests/AppMouseTests.swift
+++ b/clients/macos/vellum-assistantTests/AppMouseTests.swift
@@ -69,7 +69,7 @@ final class AppMouseTests: XCTestCase {
         XCTAssertEqual(AppMouse.cgButton(for: .middle), .center)
     }
 
-    func test_mouseButton_rawValuesMatchDaemonContract() {
+    func test_mouseButton_rawValuesMatchAssistantContract() {
         XCTAssertEqual(AppMouse.MouseButton.left.rawValue, "left")
         XCTAssertEqual(AppMouse.MouseButton.right.rawValue, "right")
         XCTAssertEqual(AppMouse.MouseButton.middle.rawValue, "middle")


### PR DESCRIPTION
Addresses review feedback on #29325. Per clients/AGENTS.md terminology rule, prefer 'assistant' over 'daemon' in client-facing code (comments, identifiers).

- Update AppMouse.swift doc comment to say 'assistant' instead of 'daemon'.
- Rename test method test_mouseButton_rawValuesMatchDaemonContract -> test_mouseButton_rawValuesMatchAssistantContract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->