### PR TITLE
fix(memory-v2): only unwrap rehydrated memory block when full pair is present

### DIFF
--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -242,11 +242,16 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           // Strip any pre-existing wrapper before re-wrapping so historical
           // rows persisted with the wrapper (v2 path before the
           // injectedBlockText contract was unified with v1's unwrapped form)
-          // don't render double-wrapped after rehydrate.
+          // don't render double-wrapped after rehydrate. Only unwrap when
+          // the full <memory>...</memory> pair is present so we don't mutate
+          // legitimate unwrapped payloads that happen to start with
+          // "<memory>\n" or end with "\n</memory>".
           if (typeof meta.memoryInjectedBlock === "string") {
-            const inner = meta.memoryInjectedBlock
-              .replace(/^<memory>\n/, "")
-              .replace(/\n<\/memory>$/, "");
+            const block = meta.memoryInjectedBlock;
+            const inner =
+              block.startsWith("<memory>\n") && block.endsWith("\n</memory>")
+                ? block.slice("<memory>\n".length, -"\n</memory>".length)
+                : block;
             content = [
               {
                 type: "text" as const,


### PR DESCRIPTION
## Summary

Addresses Codex P2 feedback on #29358: the rehydrate path stripped the leading `<memory>\n` and trailing `\n</memory>` independently, which could mutate legitimate unwrapped payloads whose content naturally starts with `<memory>\n` or ends with `\n</memory>`, or produce malformed output when only one side matched.

Now we only unwrap when both halves are present together, leaving any other shape untouched before re-wrapping.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->