### PR TITLE
fix(memory-v2): keep explain-similarity diagnostic read-only

### DIFF
--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -188,7 +188,8 @@ Examples:
   $ assistant memory v2 reembed
   $ assistant memory v2 reembed-skills
   $ assistant memory v2 activation
-  $ assistant memory v2 fit-anisotropy`,
+  $ assistant memory v2 fit-anisotropy
+  $ assistant memory v2 explain --text "..."`,
   );
 
   // ── migrate ───────────────────────────────────────────────────────────

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -436,6 +436,22 @@ export async function countConceptPagePoints(): Promise<number> {
 }
 
 /**
+ * Probe whether the v2 concept-page collection currently exists in Qdrant
+ * **without** triggering creation. Read-only diagnostics use this to avoid
+ * the side effect of bootstrapping storage just by inspecting it.
+ */
+export async function conceptPageCollectionExists(): Promise<boolean> {
+  const client = getClient();
+  try {
+    const result = await client.collectionExists(MEMORY_V2_COLLECTION);
+    return result.exists;
+  } catch (err) {
+    if (isCollectionMissing(err)) return false;
+    throw err;
+  }
+}
+
+/**
  * Best-effort delete of the legacy `memory_v2_skills` Qdrant collection. Skill
  * embeddings now live alongside concept pages in `memory_v2_concept_pages`
  * under the `skills/<id>` slug prefix, so the dedicated collection is dead

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -40,6 +40,7 @@ import {
   renderPageContent,
 } from "../../memory/v2/page-store.js";
 import {
+  conceptPageCollectionExists,
   hybridQueryConceptPages,
   sampleConceptPageDenseVectors,
 } from "../../memory/v2/qdrant.js";
@@ -498,6 +499,18 @@ async function handleExplainSimilarity({
   const config = loadConfig();
   const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
     config.memory.v2;
+
+  // Read-only diagnostic: refuse to bootstrap the v2 collection just by
+  // inspecting it. `hybridQueryConceptPages` would otherwise call
+  // `ensureConceptPageCollection()` and silently create state on a fresh
+  // workspace.
+  if (!(await conceptPageCollectionExists())) {
+    throw new RouteError(
+      "Memory v2 concept-page collection does not exist. Run 'assistant memory v2 migrate' (or 'reembed' on an existing workspace) to populate it before running explain.",
+      "MEMORY_V2_COLLECTION_MISSING",
+      409,
+    );
+  }
 
   const channels: MemoryV2ExplainSimilarityChannel[] = [];
   channels.push(


### PR DESCRIPTION
Address review feedback on #29334:

- **Codex (P2)**: `hybridQueryConceptPages` calls `ensureConceptPageCollection()`, which silently creates the v2 Qdrant collection on a fresh workspace. The `explain` command is documented as read-only, so we now probe collection existence first via a new `conceptPageCollectionExists()` helper and throw `MEMORY_V2_COLLECTION_MISSING` (409) when the collection does not exist. Operators get a clear pointer to `migrate` / `reembed` instead of accidentally bootstrapping state.
- **Devin (P2)**: add the new `explain` subcommand to the v2 namespace's `addHelpText` Examples block so `assistant memory v2 --help` lists every read-only diagnostic.