### PR TITLE
fix(memory-v2): auto-enqueue reembed after lowering bm25_b default

### DIFF
--- a/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
+++ b/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Enqueue a one-shot `memory_v2_reembed` job so existing concept pages pick
+ * up the new `memory.v2.bm25_b` default (0.4, lowered from 0.75 in PR
+ * #29345). `embed_concept_page` bakes `bm25_b` into the stored sparse
+ * vectors at write time, so without this nudge workspaces that never pinned
+ * the field would silently mix old and new length normalization until a
+ * manual reembed.
+ */
+export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
+  id: "075-memory-v2-bm25-b-default-reembed",
+  description:
+    "Enqueue memory_v2_reembed so existing concept pages pick up the new bm25_b=0.4 default",
+
+  run(workspaceDir: string): void {
+    const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+    if (!existsSync(dbPath)) return; // Fresh install — pages will embed at the new default.
+
+    let db: Database;
+    try {
+      db = new Database(dbPath);
+    } catch {
+      return;
+    }
+
+    try {
+      const tableRow = db
+        .query(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_jobs'`,
+        )
+        .get();
+      if (!tableRow) return;
+
+      const existing = db
+        .query(
+          `SELECT id FROM memory_jobs WHERE type='memory_v2_reembed' AND status IN ('pending','running') LIMIT 1`,
+        )
+        .get();
+      if (existing) return;
+
+      const now = Date.now();
+      db.query(
+        `INSERT INTO memory_jobs
+           (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+         VALUES (?, 'memory_v2_reembed', '{}', 'pending', 0, 0, ?, NULL, ?, ?)`,
+      ).run(randomUUID(), now, now, now);
+    } finally {
+      db.close();
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: the reembed is a one-shot data refresh.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -72,6 +72,7 @@ import { removeSafeStorageReleaseNoteMigration } from "./071-remove-safe-storage
 import { seedReplySuggestionCallsiteMigration } from "./072-seed-reply-suggestion-callsite.js";
 import { repairRecallCallsiteEmptyProfileMigration } from "./073-repair-recall-callsite-empty-profile.js";
 import { dropDeprecatedSecretDetectionKeysMigration } from "./074-drop-deprecated-secret-detection-keys.js";
+import { memoryV2Bm25BDefaultReembedMigration } from "./075-memory-v2-bm25-b-default-reembed.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -155,4 +156,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedReplySuggestionCallsiteMigration,
   repairRecallCallsiteEmptyProfileMigration,
   dropDeprecatedSecretDetectionKeysMigration,
+  memoryV2Bm25BDefaultReembedMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration 075 that enqueues `memory_v2_reembed` once on first daemon startup so existing concept-page sparse vectors get re-encoded with the new `bm25_b=0.4` default from #29345.
- `embed_concept_page` bakes `bm25_b` into stored sparse vectors at write time, so before this migration workspaces that never pinned the field would silently mix old (0.75) and new (0.4) length normalization across the corpus until a manual reembed.
- Migration is idempotent and self-contained per `assistant/src/workspace/migrations/AGENTS.md`: skips when the workspace DB does not yet exist (fresh installs embed at the new default from the start) and when a `memory_v2_reembed` job is already pending or running (avoid duplicates).

Addresses Codex P1 and Devin review feedback on #29345.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->