### PR TITLE
fix(memory-v2): align sparse query/doc encoders with stemmed BM25 across all v2 callers

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -28,7 +28,6 @@ import { extname, isAbsolute, join, relative } from "node:path";
 
 import { getLogger } from "../../../util/logger.js";
 import { embedWithRetry } from "../../embed.js";
-import { generateSparseEmbedding } from "../../embedding-backend.js";
 import { spreadActivation } from "../../v2/activation.js";
 import { getEdgeIndex } from "../../v2/edge-index.js";
 import {
@@ -37,6 +36,7 @@ import {
   slugFromConceptPath,
 } from "../../v2/page-store.js";
 import { hybridQueryConceptPages } from "../../v2/qdrant.js";
+import { generateBm25QueryEmbedding } from "../../v2/sparse-bm25.js";
 import { clampUnitInterval } from "../../validation.js";
 import type {
   RecallEvidence,
@@ -173,7 +173,7 @@ async function activationEvidence(
   });
   const denseVector = denseResult.vectors[0];
   if (!denseVector || denseVector.length === 0) return [];
-  const sparseVector = generateSparseEmbedding(trimmedQuery);
+  const sparseVector = generateBm25QueryEmbedding(trimmedQuery);
 
   const annLimit =
     context.config.memory.v2.ann_candidate_limit ??

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -36,15 +36,13 @@
 
 import type { AssistantConfig } from "../../config/types.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
-import {
-  embedWithBackend,
-  generateSparseEmbedding,
-} from "../embedding-backend.js";
+import { embedWithBackend } from "../embedding-backend.js";
 import { clampUnitInterval } from "../validation.js";
 import type { EdgeIndex } from "./edge-index.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
 import { rerankCandidates } from "./reranker.js";
 import { simBatch } from "./sim.js";
+import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 /**
@@ -142,7 +140,7 @@ export async function selectCandidates(
       denseResult.model,
     );
     throwIfAborted(signal);
-    const sparse = generateSparseEmbedding(annQueryText);
+    const sparse = generateBm25QueryEmbedding(annQueryText);
     const limit =
       config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;
     const hits = await hybridQueryConceptPages(dense, sparse, limit);

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -42,6 +42,10 @@ import {
   augmentMcpSetupDescription,
   buildSkillContent,
 } from "./skill-content.js";
+import {
+  generateBm25DocEmbedding,
+  getConceptPageCorpusStats,
+} from "./sparse-bm25.js";
 import type { SkillEntry } from "./types.js";
 
 const log = getLogger("memory-v2-skill-store");
@@ -182,13 +186,29 @@ async function runSeedOnce(): Promise<void> {
         ),
       );
 
+      // Skills share the concept-page Qdrant collection, so the sparse vector
+      // must use the same stemmed BM25 encoding the concept-page documents
+      // carry — otherwise the stemmed BM25 query vectors used by callers (see
+      // `simBatch`, `activation.selectCandidates`, recall) hash to different
+      // buckets than the stored skill vectors and skip the sparse channel
+      // entirely. Fall back to the legacy TF encoder only during the cold-start
+      // window before corpus stats finish building.
+      const corpusStats = getConceptPageCorpusStats();
+      const encodeSparse = (input: string) =>
+        corpusStats
+          ? generateBm25DocEmbedding(input, corpusStats, {
+              k1: config.memory.v2.bm25_k1,
+              b: config.memory.v2.bm25_b,
+            })
+          : generateSparseEmbedding(input);
+
       const now = Date.now();
       await Promise.all(
         seeds.map((seed, i) =>
           upsertConceptPageEmbedding({
             slug: skillSlugFor(seed.id),
             dense: denseVectors[i],
-            sparse: generateSparseEmbedding(seed.content),
+            sparse: encodeSparse(seed.content),
             updatedAt: now,
           }),
         ),


### PR DESCRIPTION
## Summary

Follow-up to #29354. Three v2 sparse-channel callers were left on the unstemmed legacy encoder while the BM25 doc/query path moved to Porter stemming, causing token-bucket mismatches that silently zeroed the sparse channel.

- \`activation.ts:selectCandidates\` (per-turn ANN candidate selection) — query side now uses \`generateBm25QueryEmbedding\` instead of \`generateSparseEmbedding\`. Hits the v2 concept-page collection, whose docs are stemmed.
- \`context-search/sources/memory-v2.ts:activationEvidence\` (recall activation path) — same query-side fix.
- \`v2/skill-store.ts:runSeedOnce\` (skill embedding indexer) — skills share the concept-page Qdrant collection, so the doc-side encoder now uses \`generateBm25DocEmbedding\` (with the existing concept-page corpus stats) when stats are available, falling back to the legacy TF encoder only during cold start. Mirrors the pattern in \`embed-concept-page.ts\`.

After this, every doc/query encoder hitting the v2 concept-page collection — concept pages, skills, ANN candidate selection, recall, and \`simBatch\` — agrees on stemmed tokens, so morphological variants share hash buckets end-to-end.

Operators should re-run \`assistant memory v2 reembed\` after deploy to rematerialize skill sparse vectors against stemmed buckets (concept pages were already covered by the prior PR's reembed instruction).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->