### PR TITLE
fix(memory-v2): align sparse query/doc encoding for ANN candidates and skills

### DIFF
--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -36,15 +36,13 @@
 
 import type { AssistantConfig } from "../../config/types.js";
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
-import {
-  embedWithBackend,
-  generateSparseEmbedding,
-} from "../embedding-backend.js";
+import { embedWithBackend } from "../embedding-backend.js";
 import { clampUnitInterval } from "../validation.js";
 import type { EdgeIndex } from "./edge-index.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
 import { rerankCandidates } from "./reranker.js";
 import { simBatch } from "./sim.js";
+import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 /**
@@ -142,7 +140,9 @@ export async function selectCandidates(
       denseResult.model,
     );
     throwIfAborted(signal);
-    const sparse = generateSparseEmbedding(annQueryText);
+    // BM25 query encoder: matches the doc-side encoding written by
+    // `embed-concept-page.ts`. Stateless — no corpus-stats coordination needed.
+    const sparse = generateBm25QueryEmbedding(annQueryText);
     const limit =
       config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;
     const hits = await hybridQueryConceptPages(dense, sparse, limit);

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -42,6 +42,10 @@ import {
   augmentMcpSetupDescription,
   buildSkillContent,
 } from "./skill-content.js";
+import {
+  generateBm25DocEmbedding,
+  getConceptPageCorpusStats,
+} from "./sparse-bm25.js";
 import type { SkillEntry } from "./types.js";
 
 const log = getLogger("memory-v2-skill-store");
@@ -182,13 +186,26 @@ async function runSeedOnce(): Promise<void> {
         ),
       );
 
+      // Match the doc-side encoding written by `embed-concept-page.ts` so
+      // skill points score consistently with concept pages under the unified
+      // sparse query path. Falls back to legacy TF-only when corpus stats
+      // aren't built yet (cold daemon); the next reembed pass overwrites.
+      const corpusStats = getConceptPageCorpusStats();
+      const encodeSparse = (input: string) =>
+        corpusStats
+          ? generateBm25DocEmbedding(input, corpusStats, {
+              k1: config.memory.v2.bm25_k1,
+              b: config.memory.v2.bm25_b,
+            })
+          : generateSparseEmbedding(input);
+
       const now = Date.now();
       await Promise.all(
         seeds.map((seed, i) =>
           upsertConceptPageEmbedding({
             slug: skillSlugFor(seed.id),
             dense: denseVectors[i],
-            sparse: generateSparseEmbedding(seed.content),
+            sparse: encodeSparse(seed.content),
             updatedAt: now,
           }),
         ),


### PR DESCRIPTION
## Summary

Follow-up to #29344 addressing two unresolved review threads where the BM25 migration was incomplete:

1. **`activation.ts` ANN candidate selection** — `selectCandidates` was still encoding the ANN query with the legacy TF-only `generateSparseEmbedding`, while concept-page docs are now stored with BM25 weights. The dot product of legacy query × BM25 doc produces incorrect candidate ranking, so common-word-poisoned pages could be filtered out at the candidate gate before BM25 scoring ever runs. Switched to `generateBm25QueryEmbedding` (stateless, no corpus-stats coordination).

2. **`skill-store.ts` skill doc encoding** — Skills were embedded with `generateSparseEmbedding` (legacy TF-IDF) but the unified concept-page query path uses BM25 binary vectors. Now skill docs use `generateBm25DocEmbedding` when corpus stats are available, falling back to legacy TF-only when stats aren't built yet (cold daemon) — same pattern as `embed-concept-page.ts`. The next reembed pass overwrites.

No behavior change to BM25 parameters or fusion math.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->