### PR TITLE
test(app-control): update stop test for idempotent no-proxy behavior

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -130,15 +130,18 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
       proxy.dispose();
     });
 
-    test("returns isError for app_control_stop when no proxy is attached", async () => {
+    test("app_control_stop succeeds idempotently when no proxy is attached", async () => {
+      // Stop is local-only and runs BEFORE the isAvailable() gate so a
+      // disconnected client cannot strand the singleton lock. With no proxy
+      // attached at all, it must still succeed as a no-op without dispatching.
       const ctx = buildMockContext();
 
       const result = await surfaceProxyResolver(ctx, "app_control_stop", {
         tool: "stop",
       });
 
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain("not available");
+      expect(result.isError).toBe(false);
+      expect(result.content.toLowerCase()).toContain("stopped");
       expect(sentMessages).toHaveLength(0);
     });
   });


### PR DESCRIPTION
## Summary
- Updates \`conversation-surfaces-app-control.test.ts\` so the \`app_control_stop\` no-proxy case asserts the post-#30079 behavior: stop succeeds idempotently as a no-op rather than returning an \`isError\` result.
- Fixes the \`Test\` job failure on origin/main (1 fail / 7 pass on this file).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25591538830/job/75129999980

The failing job's only red signal was \`conversation-surfaces-app-control.test.ts:140\` — a stale assertion left behind when #30079 moved the \`app_control_stop\` short-circuit ahead of the \`isAvailable()\` gate to keep a disconnected client from stranding the singleton lock. Scope is intentionally limited to that one test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->