### PR TITLE
fix(macos): cancel in-flight history reconstruction tasks in ConversationRestorer deinit

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -94,6 +94,9 @@ final class ConversationRestorer {
         fetchConversationListTask?.cancel()
         invalidationRefetchTask?.cancel()
         reconnectHistoryDrainTask?.cancel()
+        for entry in inFlightHistoryReconstructionTasks {
+            entry.task.cancel()
+        }
         if let daemonReconnectObserver {
             NotificationCenter.default.removeObserver(daemonReconnectObserver)
         }


### PR DESCRIPTION
Follow-up to #29380. The new `inFlightHistoryReconstructionTasks` list was added to track spawned reconstruction tasks but was not cancelled in `deinit`, unlike every other stored `Task` property on the restorer. Without cancellation, a deallocated restorer leaves its inner detached reconstruction work running on the cooperative thread pool with a result that nothing consumes (`viewModel` and `self` are both weak-nil). Per `clients/AGENTS.md`: 'Always cancel subscriptions and tasks. Store AnyCancellable tokens and cancel them in deinit or onDisappear.'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->