### PR TITLE
fix(app-control): validate app field type before case-fold

### DIFF
--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -146,12 +146,12 @@ function checkNonStartAuthorization(
   // except `stop`, and `stop` short-circuits in conversation-surfaces and
   // does not reach this method in production. A stop reaching here would
   // be a defensive bug — surface it explicitly rather than dispatch.
-  const requestedApp = (input as { app?: string }).app;
-  if (requestedApp == null) {
+  const requestedApp = (input as { app?: unknown }).app;
+  if (typeof requestedApp !== "string") {
     return {
       content:
-        "Tool input missing required 'app' field; cannot validate against " +
-        "the active app-control session.",
+        "Tool input missing required string 'app' field; cannot validate " +
+        "against the active app-control session.",
       isError: true,
     };
   }


### PR DESCRIPTION
Address Codex P1 from #29592: non-start app-control tool input reaches `checkNonStartAuthorization` via an unchecked `as unknown as HostAppControlInput` cast (conversation-surfaces.ts:2067), so a non-string `app` payload would throw `TypeError` at `.toLowerCase()`. Replace the null-check with a `typeof requestedApp !== 'string'` guard so malformed input produces a controlled `isError` response.

Devin's stop-ownership note is intentional/no-op (idempotent stop confirmed in #30086).