### PR TITLE
fix(memory-v2): raise reranker passage cap for ModernBERT context (#29557 follow-up)

### DIFF
--- a/assistant/src/memory/v2/reranker.ts
+++ b/assistant/src/memory/v2/reranker.ts
@@ -10,8 +10,8 @@ import { readPage } from "./page-store.js";
 
 const log = getLogger("memory-v2-reranker");
 
-// ~512-token model context for bge-reranker-base; cap input to bound payload.
-const PASSAGE_CHAR_CAP = 240;
+// Cap passage input to bound batched payload size and tokenization cost.
+const PASSAGE_CHAR_CAP = 1500;
 
 interface CacheEntry {
   scores: Map<string, number>;


### PR DESCRIPTION
Devin review on #29557 flagged that PASSAGE_CHAR_CAP in assistant/src/memory/v2/reranker.ts was calibrated for the old bge-reranker-base ~512-token context. The new default model gte-reranker-modernbert-base has a ~8192-token window, so the 240-char cap was over-restrictive and the comment referenced the now-removed default by name.

- Raise PASSAGE_CHAR_CAP from 240 to 1500 to give the new ModernBERT-based reranker meaningfully more passage context while keeping batched payload bounded.
- Drop the model-specific reference in the adjacent comment.

## Test plan
- Existing reranker tests cover behavior; cap is a tuning constant with no test reference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->