### PR TITLE
fix(memory-v2): include rerank model/dtype in cache key

### DIFF
--- a/assistant/src/memory/embedding-runtime-manager.ts
+++ b/assistant/src/memory/embedding-runtime-manager.ts
@@ -44,7 +44,7 @@ const JINJA_VERSION = "0.5.5";
  * scripts when the worker IPC contract or spawn-args list changes (without
  * requiring an `@huggingface/transformers` version bump).
  */
-const RUNTIME_VERSION = `ort-${ONNXRUNTIME_NODE_VERSION}_hf-${TRANSFORMERS_VERSION}_jinja-${JINJA_VERSION}_workers-v2`;
+const RUNTIME_VERSION = `ort-${ONNXRUNTIME_NODE_VERSION}_hf-${TRANSFORMERS_VERSION}_jinja-${JINJA_VERSION}_workers-v3`;
 
 const WORKER_FILENAME = "embed-worker.mjs";
 const RERANK_WORKER_FILENAME = "rerank-worker.mjs";
@@ -252,7 +252,6 @@ async function processQueue() {
         text_pair: passages,
         padding: true,
         truncation: true,
-        return_tensors: 'pt',
       });
       const out = await session(inputs);
       const logits = out.logits.data;

--- a/assistant/src/memory/v2/reranker.ts
+++ b/assistant/src/memory/v2/reranker.ts
@@ -22,9 +22,16 @@ const CACHE_TTL_MS = 2 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 64;
 const cache = new Map<string, CacheEntry>();
 
-function cacheKey(query: string, slugs: readonly string[]): string {
+function cacheKey(
+  query: string,
+  slugs: readonly string[],
+  model: string,
+  dtype: string,
+): string {
   const sorted = [...slugs].sort().join("\0");
-  return createHash("sha256").update(`${query}\0${sorted}`).digest("hex");
+  return createHash("sha256")
+    .update(`${model}\0${dtype}\0${query}\0${sorted}`)
+    .digest("hex");
 }
 
 function evictExpired(now: number): void {
@@ -73,6 +80,7 @@ export async function rerankCandidates(
   if (queries.length === 0) return [];
   if (candidates.length === 0) return queries.map(() => new Map());
 
+  const { model, dtype } = config.memory.v2.rerank;
   const now = Date.now();
   evictExpired(now);
 
@@ -84,7 +92,7 @@ export async function rerankCandidates(
       results[i] = new Map();
       continue;
     }
-    const key = cacheKey(q, candidates);
+    const key = cacheKey(q, candidates, model, dtype);
     const cached = cache.get(key);
     if (cached) {
       // Refresh insertion order so frequently-hit entries survive eviction.
@@ -137,7 +145,6 @@ export async function rerankCandidates(
     }
   }
 
-  const { model, dtype } = config.memory.v2.rerank;
   let scores: number[];
   try {
     const backend = getOrCreateRerankBackend(model, dtype);
@@ -162,7 +169,7 @@ export async function rerankCandidates(
       result.set(slugsForPassages[i], Math.max(0, Math.min(1, s)));
     }
     results[qi] = result;
-    cache.set(cacheKey(queries[qi], candidates), {
+    cache.set(cacheKey(queries[qi], candidates, model, dtype), {
       scores: new Map(result),
       ts: now,
     });


### PR DESCRIPTION
Address review feedback on #29555.

## Summary

- Reranker cache key now includes model + dtype so switching memory.v2.rerank.model or rerank.dtype invalidates cached scores instead of serving stale results from the prior model for up to the 2m TTL window.
- Drop return_tensors: 'pt' from the generated rerank-worker.mjs tokenizer call. The JS @huggingface/transformers port returns its own Tensor type regardless; the option is silently ignored today and would only ever surface as a silent fail-open through the reranker's catch path.
- Bump RUNTIME_VERSION worker suffix v2 → v3 so existing installs regenerate the rerank worker on next daemon start.

## Test plan

- [ ] Existing reranker unit tests still pass
- [ ] Switching memory.v2.rerank.model mid-session no longer returns stale scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)