### PR TITLE
fix(memory-jobs): re-tick immediately after processing to drain backlogs

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -124,16 +124,24 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
         enableScheduledCleanup: true,
       });
       if (processed > 0) {
-        currentIntervalMs = POLL_INTERVAL_MIN_MS;
+        // Per-tick claim budget equals the lane caps, so when a tick
+        // processed work the next tick must run immediately to drain any
+        // remaining backlog. Holding the 1.5s floor between ticks would cap
+        // sustained throughput at lane-cap jobs per 1.5s and starve large
+        // backlogs of short jobs.
+        currentIntervalMs = 0;
       } else {
         currentIntervalMs = Math.min(
-          currentIntervalMs * 2,
+          Math.max(currentIntervalMs * 2, POLL_INTERVAL_MIN_MS),
           POLL_INTERVAL_MAX_MS,
         );
       }
     } catch (err) {
       log.error({ err }, "Memory worker tick failed");
-      currentIntervalMs = Math.min(currentIntervalMs * 2, POLL_INTERVAL_MAX_MS);
+      currentIntervalMs = Math.min(
+        Math.max(currentIntervalMs * 2, POLL_INTERVAL_MIN_MS),
+        POLL_INTERVAL_MAX_MS,
+      );
     } finally {
       tickRunning = false;
     }


### PR DESCRIPTION
Address Codex P1 on #29364: with lane caps now driving the per-tick claim budget, holding the 1.5s POLL_INTERVAL_MIN_MS floor between ticks capped sustained throughput at lane-cap jobs per 1.5s — short jobs could no longer drain a backlog without long inter-tick gaps.

Schedule the next tick at 0ms when the previous tick processed any job, so the worker keeps pulling from the queue until the backlog is empty. Idle/error backoff still doubles from POLL_INTERVAL_MIN_MS up to POLL_INTERVAL_MAX_MS unchanged.