### PR TITLE
fix(memory/security): extend personal-memory trust gate to PKB and NOW.md

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -75,7 +75,7 @@ import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import {
   readMemoryV2StaticContent,
-  shouldLoadMemoryV2Static,
+  shouldExposePersonalMemory,
 } from "../memory/v2/static-context.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { defaultCompactionTerminal } from "../plugins/defaults/compaction.js";
@@ -1412,16 +1412,29 @@ export async function runAgentLoopImpl(
 
     // The `remember` tool handles scratchpad-style memory writes directly to the graph.
 
+    // Personal-memory trust gate: PKB, NOW.md, and v2 static blocks all
+    // hold private user content. Block exposure to non-guardian actors
+    // arriving over a remote channel; internal/local flows pass through.
+    // See `shouldExposePersonalMemory` for the threat model.
+    const personalMemoryAllowed = shouldExposePersonalMemory({
+      sourceChannel: ctx.trustContext?.sourceChannel,
+      isTrustedActor,
+    });
+
     // Inject NOW.md and PKB content only on the first turn (or after
     // compaction re-strips them).  Old injections persist in history and
     // are never stripped on normal turns — this preserves the cached prefix.
     // PKB/NOW content is sourced from the `memoryRetrieval` pipeline above
     // so plugins can override either source without touching the agent loop.
-    const currentNowContent = memoryResult.nowContent;
+    const currentNowContent = personalMemoryAllowed
+      ? memoryResult.nowContent
+      : null;
     const shouldInjectNowAndPkb = isFirstMessage || compactedThisTurn;
     const nowScratchpad = shouldInjectNowAndPkb ? currentNowContent : null;
 
-    const currentPkbContent = memoryResult.pkbContent;
+    const currentPkbContent = personalMemoryAllowed
+      ? memoryResult.pkbContent
+      : null;
     const pkbContext = shouldInjectNowAndPkb ? currentPkbContent : null;
     const pkbActive = currentPkbContent !== null;
 
@@ -1433,10 +1446,7 @@ export async function runAgentLoopImpl(
     // first-turn / post-compaction cadence-gated value for initial
     // injection only. `readMemoryV2StaticContent` self-gates on the v2
     // flag + config and returns null when v2 is off.
-    const currentMemoryV2Static = shouldLoadMemoryV2Static({
-      sourceChannel: ctx.trustContext?.sourceChannel,
-      isTrustedActor,
-    })
+    const currentMemoryV2Static = personalMemoryAllowed
       ? readMemoryV2StaticContent()
       : null;
     const memoryV2Static = shouldInjectNowAndPkb ? currentMemoryV2Static : null;

--- a/assistant/src/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/memory/v2/__tests__/static-context.test.ts
@@ -45,7 +45,7 @@ mock.module("../../../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
-const { readMemoryV2StaticContent, shouldLoadMemoryV2Static } =
+const { readMemoryV2StaticContent, shouldExposePersonalMemory } =
   await import("../static-context.js");
 
 const MEMORY_FILES = [
@@ -140,10 +140,10 @@ describe("readMemoryV2StaticContent", () => {
   });
 });
 
-describe("shouldLoadMemoryV2Static", () => {
+describe("shouldExposePersonalMemory", () => {
   test("allows guardian-trusted local conversations", () => {
     expect(
-      shouldLoadMemoryV2Static({
+      shouldExposePersonalMemory({
         sourceChannel: "vellum",
         isTrustedActor: true,
       }),
@@ -152,7 +152,7 @@ describe("shouldLoadMemoryV2Static", () => {
 
   test("allows local-channel conversations even when trust class is unknown (analyze runs, dev)", () => {
     expect(
-      shouldLoadMemoryV2Static({
+      shouldExposePersonalMemory({
         sourceChannel: "vellum",
         isTrustedActor: false,
       }),
@@ -161,7 +161,7 @@ describe("shouldLoadMemoryV2Static", () => {
 
   test("allows turns with no trust context (work-item task runs, internal background)", () => {
     expect(
-      shouldLoadMemoryV2Static({
+      shouldExposePersonalMemory({
         sourceChannel: undefined,
         isTrustedActor: false,
       }),
@@ -179,7 +179,7 @@ describe("shouldLoadMemoryV2Static", () => {
   test("allows guardian-trusted remote channels (user's own phone/Slack)", () => {
     for (const channel of REMOTE_CHANNELS) {
       expect(
-        shouldLoadMemoryV2Static({
+        shouldExposePersonalMemory({
           sourceChannel: channel,
           isTrustedActor: true,
         }),
@@ -190,7 +190,7 @@ describe("shouldLoadMemoryV2Static", () => {
   test("blocks non-guardian remote-channel actors (the leak this gate exists to prevent)", () => {
     for (const channel of REMOTE_CHANNELS) {
       expect(
-        shouldLoadMemoryV2Static({
+        shouldExposePersonalMemory({
           sourceChannel: channel,
           isTrustedActor: false,
         }),

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -60,21 +60,23 @@ export function readMemoryV2StaticContent(): string | null {
 }
 
 /**
- * Static memory holds the user's aggregate personal pages
- * (essentials/threads/recent/buffer). Block injection when a non-guardian
- * actor reaches the assistant over a remote channel — otherwise the model
- * can be prompt-injected into reciting private memory. Internal flows
- * (`sourceChannel: "vellum"`) and turns with no trust context pass through
- * unchanged; this gate exists only to keep remote untrusted actors out.
+ * Trust-class predicate for personal-memory injection. Personal memory
+ * spans v2 static blocks (essentials/threads/recent/buffer), the PKB
+ * context, and NOW.md — all of which can hold private user content. Block
+ * injection when a non-guardian actor reaches the assistant over a remote
+ * channel — otherwise the model can be prompt-injected into reciting
+ * private memory. Internal flows (`sourceChannel: "vellum"`) and turns
+ * with no trust context pass through unchanged; this gate exists only to
+ * keep remote untrusted actors out.
  *
  * This is the trust-only gate. Cadence (first-turn / post-compaction) is
- * applied separately by the caller so that `currentMemoryV2Static` remains
+ * applied separately by the caller so that the freshest content remains
  * available for re-injection after a mid-turn reducer-triggered compaction
  * — the initial-injection turn may not have been a `shouldInjectNowAndPkb`
- * turn, but compaction strips the existing `<memory>` block and we still
- * need the freshest content to re-inject.
+ * turn, but compaction strips the existing personal-memory blocks and we
+ * still need the freshest content to re-inject.
  */
-export function shouldLoadMemoryV2Static(args: {
+export function shouldExposePersonalMemory(args: {
   sourceChannel: ChannelId | undefined;
   isTrustedActor: boolean;
 }): boolean {


### PR DESCRIPTION
## Summary

- Addresses Devin review feedback on #29601: PKB and NOW.md were still injected via the unguarded `shouldInjectNowAndPkb` cadence gate, leaving the same remote-untrusted-actor leak vector that motivated the v2 static gate.
- Renames `shouldLoadMemoryV2Static` -> `shouldExposePersonalMemory` and applies the predicate to all three personal-memory injection paths (v2 static, PKB, NOW.md).
- Predicate semantics unchanged: blocks only when `sourceChannel` is a real remote channel AND the actor is not the guardian. Internal flows and turns without a trust context still pass through.

## Test plan

- [x] Type-check (rename propagated to test file)
- [ ] Existing `shouldExposePersonalMemory` tests cover the gate semantics
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->