### PR TITLE
test(memory-v2): align reranker passage cap test with raised 1500-char limit

### DIFF
--- a/assistant/src/memory/v2/__tests__/reranker.test.ts
+++ b/assistant/src/memory/v2/__tests__/reranker.test.ts
@@ -215,8 +215,8 @@ describe("rerankCandidates", () => {
     expect(backendState.calls).toHaveLength(1);
   });
 
-  test("passage construction caps at 240 chars after slug newline", async () => {
-    const longBody = "a".repeat(500);
+  test("passage construction caps at 1500 chars after slug newline", async () => {
+    const longBody = "a".repeat(2000);
     pageState.pages.set("slug", { body: longBody });
     backendState.scores = [0.5];
 
@@ -224,9 +224,9 @@ describe("rerankCandidates", () => {
 
     expect(backendState.calls).toHaveLength(1);
     const passage = backendState.calls[0].passages[0];
-    // "slug\n" prefix + 240 chars of body
+    // "slug\n" prefix + 1500 chars of body
     expect(passage.startsWith("slug\n")).toBe(true);
-    expect(passage.length).toBeLessThanOrEqual(5 + 240);
+    expect(passage.length).toBeLessThanOrEqual(5 + 1500);
   });
 
   test("first paragraph is taken (body truncated at blank line)", async () => {


### PR DESCRIPTION
## Summary
- PR #30090 raised \`PASSAGE_CHAR_CAP\` from 240 to 1500 in \`reranker.ts\` but the corresponding assertion in \`reranker.test.ts\` still expected the old cap, so the \`passage construction caps at 240 chars\` test failed in CI (received 505 chars, expected ≤ 245).
- Update the test to use a 2000-char body (so the cap actually engages) and assert \`length <= 5 + 1500\`. Rename the test description and update the comment.

## Original prompt
Fix the specific CI failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/25591748010/job/75130525532. The Test job's \`reranker.test.ts > passage construction caps at 240 chars after slug newline\` was failing because the production cap was raised to 1500 in #30090 but the test wasn't updated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->