### PR TITLE
fix(macos): gate task_complete chime to user-initiated turns

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
@@ -51,11 +51,21 @@ final class ConversationActivityStore {
     /// only fire on discrete transitions, not on every streaming delta.
     @ObservationIgnored private var previousInteractionStates: [UUID: ConversationInteractionState] = [:]
 
-    /// Last observed `turnCompletionTick` per conversation. The `task_complete`
-    /// sound fires on increments, which correspond to the daemon's
-    /// `message_complete` event — not to derived idle-state transitions that
-    /// also fire between tool calls within a single turn.
+    /// Last observed `turnCompletionTick` per conversation. Increments fire
+    /// the `onTurnComplete` callback (used for the inactive-app local
+    /// notification) and correspond to every non-aux non-cancel-ack daemon
+    /// `message_complete` — including daemon-initiated wakes. The
+    /// `task_complete` chime is gated separately on the interactive tick
+    /// below so background/scheduled turns don't trigger sound.
     @ObservationIgnored private var previousTurnCompletionTicks: [UUID: UInt64] = [:]
+
+    /// Last observed `interactiveTurnCompletionTick` per conversation. The
+    /// `task_complete` chime fires only on increments here, which match
+    /// `message_complete` events that closed a user-typed send from this
+    /// client. Daemon-initiated turns (subagents, schedulers, watchers,
+    /// opportunity wakes) bump `turnCompletionTick` but not this tick, so
+    /// they stay silent.
+    @ObservationIgnored private var previousInteractiveTurnCompletionTicks: [UUID: UInt64] = [:]
 
     /// Whether the initial interaction state has been observed for each
     /// conversation. Prevents sounds from firing on initial subscription
@@ -125,6 +135,7 @@ final class ConversationActivityStore {
         hasInitialInteractionState[conversationId] = false
         previousInteractionStates.removeValue(forKey: conversationId)
         previousTurnCompletionTicks.removeValue(forKey: conversationId)
+        previousInteractiveTurnCompletionTicks.removeValue(forKey: conversationId)
         observeInteractionStateLoop(
             conversationId: conversationId,
             messageManager: messageManager,
@@ -208,6 +219,7 @@ final class ConversationActivityStore {
         conversationInteractionStates.removeValue(forKey: conversationId)
         previousInteractionStates.removeValue(forKey: conversationId)
         previousTurnCompletionTicks.removeValue(forKey: conversationId)
+        previousInteractiveTurnCompletionTicks.removeValue(forKey: conversationId)
         hasInitialInteractionState.removeValue(forKey: conversationId)
         latestAssistantActivitySnapshots.removeValue(forKey: conversationId)
     }
@@ -258,11 +270,13 @@ final class ConversationActivityStore {
 
         var state = ConversationInteractionState.idle
         var turnCompletionTick: UInt64 = 0
+        var interactiveTurnCompletionTick: UInt64 = 0
         withObservationTracking {
             let hasError = errorManager.errorText != nil || errorManager.conversationError != nil
             let hasPendingConfirmation = messageManager.hasPendingConfirmation
             let isBusy = messageManager.isSending || messageManager.isThinking || messageManager.pendingQueuedCount > 0
             turnCompletionTick = messageManager.turnCompletionTick
+            interactiveTurnCompletionTick = messageManager.interactiveTurnCompletionTick
 
             if hasError {
                 state = .error
@@ -285,9 +299,11 @@ final class ConversationActivityStore {
 
         let previous = previousInteractionStates[conversationId]
         let previousTick = previousTurnCompletionTicks[conversationId]
+        let previousInteractiveTick = previousInteractiveTurnCompletionTicks[conversationId]
         let isInitial = hasInitialInteractionState[conversationId] != true
         hasInitialInteractionState[conversationId] = true
         previousTurnCompletionTicks[conversationId] = turnCompletionTick
+        previousInteractiveTurnCompletionTicks[conversationId] = interactiveTurnCompletionTick
 
         let stateChanged = state != previous || isInitial
         if stateChanged {
@@ -303,13 +319,21 @@ final class ConversationActivityStore {
         // conversation loads in an error state or carries a stale tick.
         guard !isInitial else { return }
 
-        // `task_complete` is driven by the daemon's `message_complete` signal
-        // (surfaced as `turnCompletionTick`) rather than by the derived
-        // processing → idle transition — that transition also fires between
-        // tool calls within a single turn, which produced duplicate sounds.
+        // `onTurnComplete` is driven by every non-aux non-cancel-ack
+        // `message_complete` (including daemon-initiated wakes) so the
+        // inactive-app local notification still posts for autonomous turns
+        // that the user might want to know about — `postTurnCompleteNotificationIfNeeded`
+        // applies its own conversationType-based suppression.
         if let previousTick, turnCompletionTick > previousTick {
-            SoundManager.shared.play(.taskComplete)
             onTurnComplete?(conversationId)
+        }
+        // The `task_complete` chime is gated to user-typed sends from this
+        // client. Daemon-initiated turns (subagents, schedulers, watchers)
+        // bump `turnCompletionTick` but not `interactiveTurnCompletionTick`,
+        // so they stay silent. A user manually sending a message inside a
+        // background or scheduled conversation still chimes here.
+        if let previousInteractiveTick, interactiveTurnCompletionTick > previousInteractiveTick {
+            SoundManager.shared.play(.taskComplete)
         }
         if stateChanged {
             switch state {

--- a/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
+++ b/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Coverage for the `task_complete` chime gate. The chime is driven by
+/// `interactiveTurnCompletionTick`, which only bumps when a user-typed send
+/// from this client is paired with a non-aux non-cancel-ack
+/// `message_complete`. Daemon-initiated turns (subagents, schedulers,
+/// watchers, opportunity wakes) bump `turnCompletionTick` but must leave
+/// the interactive tick untouched so they stay silent.
+@MainActor
+final class InteractiveTurnCompletionTickTests: XCTestCase {
+
+    private var connectionManager: GatewayConnectionManager!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: connectionManager.eventStreamClient)
+        viewModel.conversationId = "test-conversation"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Counter increments only on user-typed sends
+
+    func testUserSendIncrementsPendingUserTurnCount() {
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0)
+
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1,
+                       "User-typed send should mark a pending interactive turn")
+    }
+
+    func testHiddenSendDoesNotIncrementPendingUserTurnCount() {
+        viewModel.inputText = "Automated payload"
+        viewModel.sendMessage(hidden: true)
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0,
+                       "Automated/hidden sends are programmatic, not interactive")
+    }
+
+    func testRapidUserSendsAccumulatePendingTurns() {
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        viewModel.inputText = "Third"
+        viewModel.sendMessage()
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 3,
+                       "Each user-typed send should accumulate so each response chimes")
+    }
+
+    // MARK: - message_complete decrements counter and bumps interactive tick
+
+    func testMessageCompleteAfterUserSendBumpsInteractiveTick() {
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        let beforeTick = viewModel.messageManager.interactiveTurnCompletionTick
+        let beforeMainTick = viewModel.messageManager.turnCompletionTick
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0,
+                       "Counter should decrement on matching message_complete")
+        XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeTick &+ 1,
+                       "Interactive tick should bump for a user-initiated turn end")
+        XCTAssertEqual(viewModel.messageManager.turnCompletionTick, beforeMainTick &+ 1,
+                       "Main tick should also bump (drives notification path)")
+    }
+
+    func testMessageCompleteWithoutPendingSendDoesNotBumpInteractiveTick() {
+        // Daemon-initiated turn (e.g. subagent dispatch, scheduled job): no
+        // user message preceded it, so the chime must stay silent even
+        // though the main tick advances.
+        let beforeInteractive = viewModel.messageManager.interactiveTurnCompletionTick
+        let beforeMain = viewModel.messageManager.turnCompletionTick
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeInteractive,
+                       "Interactive tick must not bump without a pending user turn")
+        XCTAssertEqual(viewModel.messageManager.turnCompletionTick, beforeMain &+ 1,
+                       "Main tick still advances so notification-pipeline observers fire")
+    }
+
+    func testAuxMessageCompleteDoesNotDecrementCounter() {
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1)
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(source: "aux")))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1,
+                       "Auxiliary events (call summaries, watcher ticks) must not consume the pending turn")
+    }
+
+    func testTwoUserSendsTwoCompletionsBumpInteractiveTickTwice() {
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        let beforeTick = viewModel.messageManager.interactiveTurnCompletionTick
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0)
+        XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeTick &+ 2,
+                       "Each user-send/response pair should produce its own chime")
+    }
+
+    // MARK: - Cancellation clears the counter
+
+    func testUserCancelClearsPendingUserTurnCount() {
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1)
+
+        viewModel.isCancelling = true
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0,
+                       "User-initiated cancel acks should clear all pending interactive turns")
+    }
+
+    func testCancelAckDoesNotBumpInteractiveTick() {
+        viewModel.inputText = "Hello"
+        viewModel.sendMessage()
+        let beforeTick = viewModel.messageManager.interactiveTurnCompletionTick
+
+        // The daemon's `message_complete` after cancel arrives without a
+        // body and is treated as a cancel-ack inside ChatActionHandler.
+        viewModel.isCancelling = true
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+
+        XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeTick,
+                       "Cancellation must not chime")
+    }
+
+    func testPerMessageDaemonCancelDecrementsCounter() {
+        // Daemon-emitted cancel for a queued message that won't reach
+        // message_complete. The counter must shrink so the next real
+        // completion still aligns with what's actually outstanding.
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 2)
+
+        // No `isCancelling = true` — this is a daemon-initiated per-message cancel.
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1,
+                       "Per-message daemon cancel should consume one pending interactive turn")
+    }
+}

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -734,14 +734,27 @@ final class ChatActionHandler {
                 callback("Response complete")
             }
         }
-        // Signal turn completion to observers (e.g. the `task_complete` sound).
-        // Cancel-acknowledgements are user-initiated aborts, not real turn ends,
-        // so they stay silent. Auxiliary `message_complete` events (call
-        // transcript updates, summaries, watch notifiers) are tagged with
-        // `source == "aux"` and must not be counted as turn ends. Absent
-        // source is treated as main for backwards compatibility.
+        // Signal turn completion to observers. Cancel-acknowledgements are
+        // user-initiated aborts, not real turn ends, so they stay silent.
+        // Auxiliary `message_complete` events (call transcript updates,
+        // summaries, watch notifiers) are tagged with `source == "aux"` and
+        // must not be counted as turn ends. Absent source is treated as main
+        // for backwards compatibility.
+        //
+        // `turnCompletionTick` fires for every real main-turn completion —
+        // it drives type-agnostic side effects like the inactive-app local
+        // notification (which has its own conversationType-based
+        // suppression). `interactiveTurnCompletionTick` only bumps when a
+        // user-typed send from this client was awaiting completion, gating
+        // the `task_complete` chime to turns the user actually initiated
+        // here (and silencing daemon-initiated wakes, scheduled jobs,
+        // watcher ticks, and subagent dispatches).
         if !wasCancelAck && complete.source != "aux" {
             vm.messageManager.turnCompletionTick &+= 1
+            if vm.messageManager.pendingUserTurnCount > 0 {
+                vm.messageManager.pendingUserTurnCount -= 1
+                vm.messageManager.interactiveTurnCompletionTick &+= 1
+            }
         }
     }
 
@@ -786,13 +799,22 @@ final class ChatActionHandler {
             vm.requestIdToMessageId = [:]
             vm.activeRequestIdToMessageId = [:]
             vm.pendingLocalDeletions.removeAll()
+            vm.messageManager.pendingUserTurnCount = 0
             for i in vm.messages.indices {
                 if case .queued = vm.messages[i].status, vm.messages[i].role == .user {
                     vm.messages[i].status = .sent
                 }
             }
-        } else if vm.pendingQueuedCount == 0 {
-            vm.isSending = false
+        } else {
+            // Per-message cancel from the daemon (e.g. queue eviction). The
+            // matching `message_complete` will never arrive, so decrement the
+            // pending counter to keep the interactive-tick gate accurate.
+            if vm.messageManager.pendingUserTurnCount > 0 {
+                vm.messageManager.pendingUserTurnCount -= 1
+            }
+            if vm.pendingQueuedCount == 0 {
+                vm.isSending = false
+            }
         }
         vm.messageManager.batchUpdateMessages { msgs in
             if let existingId = vm.currentAssistantMessageId {

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -204,10 +204,23 @@ public final class ChatMessageManager {
     public var pendingQueuedCount: Int = 0
     /// Monotonic counter incremented once per successful main-turn completion
     /// (daemon `message_complete` event that isn't an auxiliary or cancel-ack).
-    /// Observers watch this to fire end-of-turn side effects (e.g. the
-    /// `task_complete` sound) without re-deriving state from transient flags
-    /// that also flip between tool calls.
+    /// Observers watch this for type-agnostic end-of-turn side effects (e.g.
+    /// the inactive-app local notification) without re-deriving state from
+    /// transient flags that also flip between tool calls.
     public var turnCompletionTick: UInt64 = 0
+    /// Count of user-typed sends from this client that are awaiting a matching
+    /// `message_complete`. Incremented in `MessageSendCoordinator.sendUserMessage`
+    /// when `automated == false`, decremented (paired with an
+    /// `interactiveTurnCompletionTick` bump) on each non-aux non-cancel-ack
+    /// `message_complete`, and reset to 0 by cancel paths. Daemon-initiated
+    /// turns (subagents, schedulers, watchers, opportunity wakes) never touch
+    /// this counter, so they cannot trigger the `task_complete` chime.
+    public var pendingUserTurnCount: Int = 0
+    /// Monotonic counter that bumps only when a `message_complete` matches a
+    /// pending user-typed send from this client. Observed by
+    /// `ConversationActivityStore` to gate the `task_complete` chime to
+    /// turns the user actually initiated here.
+    public var interactiveTurnCompletionTick: UInt64 = 0
     public var suggestion: String?
     public var isRecording: Bool = false
     public var recordingAmplitude: Float = 0

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -508,6 +508,13 @@ final class MessageSendCoordinator {
         if queuedMessageId == nil {
             messageManager.isThinking = true
         }
+        // Track real user-typed sends so `ConversationActivityStore` can gate
+        // the `task_complete` chime to turns the user actually initiated from
+        // this client. Automated/hidden sends (the daemon-driven `automated`
+        // flag) are excluded — they're programmatic, not interactive.
+        if !automated {
+            messageManager.pendingUserTurnCount += 1
+        }
 
         // Make sure we're listening
         if delegate.messageLoopTask == nil {
@@ -704,6 +711,7 @@ final class MessageSendCoordinator {
         delegate.requestIdToMessageId = [:]
         delegate.activeRequestIdToMessageId = [:]
         delegate.pendingLocalDeletions.removeAll()
+        messageManager.pendingUserTurnCount = 0
     }
 
     // MARK: - Offline Queue Flush


### PR DESCRIPTION
## Summary
- Track user-typed sends per `ChatViewModel` via a new `pendingUserTurnCount` counter and a paired `interactiveTurnCompletionTick` on `ChatMessageManager`; only the new tick triggers the macOS `task_complete` chime in `ConversationActivityStore`.
- Counter increments in `MessageSendCoordinator.sendUserMessage` when the send is not `automated`, decrements (with a tick bump) on each non-aux non-cancel-ack `message_complete`, and clears on cancel paths so daemon-initiated turns (subagents, schedulers, watchers, opportunity wakes) stay silent.
- A user manually sending a message inside a `background` or `scheduled` conversation still chimes — the gate is per-turn, not per-conversation-type.

## Original prompt
The user reported that the macOS desktop app's "task complete" sound played whenever any background or scheduled job finished, not just at the end of an interactive turn. They explicitly noted the chime should still fire when they navigate into a background conversation and manually send a message — so filtering on `conversationType` alone is wrong; the right semantic is "this client just initiated a turn."
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->