### PR TITLE
fix(githooks): respect commit.cleanup in commit-msg generic-examples scan

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -61,11 +61,11 @@ Runs the same generic-examples patterns as `pre-commit`, but against the commit 
 
 **Behavior:**
 
-- Comment lines (lines starting with `#`) are stripped before scanning, since git removes them from the recorded commit anyway.
+- Comment lines (lines starting with `#`) are stripped before scanning when `commit.cleanup` is `default`, `strip`, or `scissors` (the modes that drop them from the recorded commit). Under `verbatim` or `whitespace`, comment lines are scanned because git keeps them.
 - Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is ignored, since git also drops it.
 <!-- generic-examples:ignore-next-line — illustrative example of what the rule flags -->
 - Patterns are quote-anchored — they catch quoted/back-ticked emails and phone numbers (e.g., `Updated "alice@gmail.com" to be hashed`), not bare prose. Angle-bracketed trailers like `Co-Authored-By: Claude <noreply@anthropic.com>` are not flagged.
-- Same suppression syntax as `pre-commit`: `generic-examples:ignore-line` / `generic-examples:ignore-next-line` (note that the marker survives into the recorded message).
+- Suppression: `generic-examples:ignore-line` on the flagged line itself works (note that the marker survives into the recorded message). `generic-examples:ignore-next-line` is intentionally not supported here, since the marker line would also survive into the recorded message — use the same-line form instead.
 
 **Bypass (not recommended):**
 ```bash

--- a/scripts/check-generic-examples.ts
+++ b/scripts/check-generic-examples.ts
@@ -200,15 +200,45 @@ function parseUnifiedDiff(diff: string): AddedLine[] {
 // everything below it is dropped before the commit is recorded.
 const COMMIT_MSG_SCISSORS = "# ------------------------ >8 ------------------------";
 
-function parseCommitMessage(text: string): AddedLine[] {
+// `verbatim` and `whitespace` cleanup modes keep `#` lines in the recorded
+// commit message, so we cannot blindly skip them — quoted real data on a
+// `#` line would slip through the scan. `default`/`strip`/`scissors` strip
+// `#` lines, so skipping them avoids false positives on git editor template
+// text (`# Please enter the commit message...`).
+const STRIPS_HASH_LINES: ReadonlySet<string> = new Set([
+  "default",
+  "strip",
+  "scissors",
+]);
+
+function getCommitCleanupMode(): string {
+  try {
+    const value = execSync("git config --get commit.cleanup", {
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    return value || "default";
+  } catch {
+    return "default";
+  }
+}
+
+function parseCommitMessage(
+  text: string,
+  cleanupMode: string = getCommitCleanupMode(),
+): AddedLine[] {
   const result: AddedLine[] = [];
   const lines = text.split("\n");
+  const stripsHashLines = STRIPS_HASH_LINES.has(cleanupMode);
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
+    // Always honor the scissors marker: under `scissors` cleanup (and the
+    // implicit mode used by `git commit -v`) everything below it is dropped
+    // before the commit is recorded, and that region typically contains the
+    // diff which can include quoted strings unrelated to the message.
     if (raw === COMMIT_MSG_SCISSORS) break;
-    // Lines starting with `#` are stripped before the commit is recorded;
-    // skip them so we don't false-positive on guidance text.
-    if (raw.startsWith("#")) continue;
+    if (stripsHashLines && raw.startsWith("#")) continue;
     // No previousContent tracking: prior-line suppression markers in commit
     // messages would survive into the recorded message (odd UX). Same-line
     // `generic-examples:ignore-line` still works via isSuppressed().
@@ -390,6 +420,7 @@ const TEST_CASES: TestCase[] = [
 interface CommitMsgTestCase {
   name: string;
   text: string;
+  cleanupMode?: string;
   expectPatterns: string[];
 }
 
@@ -410,9 +441,21 @@ const COMMIT_MSG_TEST_CASES: CommitMsgTestCase[] = [
     expectPatterns: [],
   },
   {
-    name: "comment line containing real email is skipped",
-    text: 'fix: bug\n\n# Please enter the commit message. Lines starting with\n# "#" will be ignored. Example: alice@gmail.com\n',
+    name: "comment line containing quoted real email is skipped under default cleanup",
+    text: 'fix: bug\n\n# note: was "alice@gmail.com"\n',
     expectPatterns: [],
+  },
+  {
+    name: "comment line containing quoted real email is flagged under verbatim cleanup",
+    text: 'fix: bug\n\n# note: was "alice@gmail.com"\n',
+    cleanupMode: "verbatim",
+    expectPatterns: ["non-example-email"],
+  },
+  {
+    name: "comment line containing quoted real email is flagged under whitespace cleanup",
+    text: 'fix: bug\n\n# note: was "alice@gmail.com"\n',
+    cleanupMode: "whitespace",
+    expectPatterns: ["non-example-email"],
   },
   {
     name: "scissors line truncates scan",
@@ -453,7 +496,7 @@ function runSelfTest(): number {
     }
   }
   for (const tc of COMMIT_MSG_TEST_CASES) {
-    const lines = parseCommitMessage(tc.text);
+    const lines = parseCommitMessage(tc.text, tc.cleanupMode ?? "default");
     const findings = scan(lines, SHAPE_PATTERNS);
     const got = findings.map((f) => f.pattern).sort();
     const want = [...tc.expectPatterns].sort();


### PR DESCRIPTION
## Summary

Addresses review feedback on #29523:

- **Codex (P2)**: `parseCommitMessage()` always stripped `#` lines and truncated at the scissors marker, but `git`'s `commit.cleanup` modes `verbatim` and `whitespace` keep comment lines in the recorded commit. Quoted real data on those lines bypassed the scan. Now we read `git config commit.cleanup` and only skip `#` lines under `default`/`strip`/`scissors`. Scissors-marker truncation is preserved unconditionally — the diff region below is unrelated to the message under any realistic cleanup mode.
- **Devin**: `.githooks/README.md` documented `generic-examples:ignore-next-line` as supported in commit messages, but the implementation intentionally drops `previousContent` tracking for the commit-msg path (the marker line would survive into the recorded commit, which is bad UX). Updated the README to document only the same-line `generic-examples:ignore-line` form and explain why.

## Test plan

- [x] Added self-test cases covering `verbatim` and `whitespace` cleanup modes (comment-line content gets flagged) plus the existing default-mode case (comment-line content is skipped). `bun scripts/check-generic-examples.ts --self-test` → 16/16 pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->