### PR TITLE
fix(auth): remove duplicate fit-anisotropy route policy registration

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -456,7 +456,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     scopes: ["settings.write"],
   },
   { endpoint: "memory/v2/concept-frequency:POST", scopes: ["settings.read"] },
-  { endpoint: "memory/v2/fit-anisotropy:POST", scopes: ["settings.write"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
Follow-up to review feedback on #29626.

Devin flagged that `memory/v2/fit-anisotropy:POST` was registered twice in `ACTOR_ENDPOINTS` — once before and once after the new `concept-frequency` entry. Since `registerPolicy` uses `policyRegistry.set()`, the duplicate silently overwrote the first registration. Removed the duplicate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->