### PR TITLE
fix(memory-v2): mark inRerankPool only after cross-encoder evaluates

### DIFF
--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -285,13 +285,16 @@ export async function computeOwnActivation(
       .slice(0, rerankCfg.top_k)
       .map((e) => e.slug);
     if (topSlugs.length > 0) {
-      inPoolSet = new Set(topSlugs);
       const [userScores, assistantScores] = await rerankCandidates(
         [userText, assistantText],
         topSlugs,
         config,
       );
       throwIfAborted(signal);
+      // Build the pool from slugs the cross-encoder actually scored, so a
+      // backend failure (which yields empty maps) doesn't mislabel candidates
+      // as `inRerankPool` in the inspector.
+      inPoolSet = new Set([...userScores.keys(), ...assistantScores.keys()]);
       userRerankBoost = normalizeRerankScores(userScores, rerankCfg.alpha);
       assistantRerankBoost = normalizeRerankScores(
         assistantScores,


### PR DESCRIPTION
Codex review feedback on #29634: `inPoolSet` was populated from `topSlugs` before `rerankCandidates` ran, so when the rerank backend failed (returning empty maps) candidates were still marked `inRerankPool: true` in the inspector — misrepresenting an unevaluated rerank as a deliberate +0.000 score.

Build the pool set from the slugs the cross-encoder actually returned scores for, so `inRerankPool` means "evaluated" rather than "selected for attempt."
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->