### PR TITLE
fix(macos): refetch concept page on slug change

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ConceptPageContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ConceptPageContentView.swift
@@ -46,11 +46,9 @@ struct ConceptPageContentView: View {
         .padding(isDetailPane ? VSpacing.lg : 0)
         .background(isDetailPane ? VColor.surfaceBase : Color.clear)
         .task(id: slug) {
-            // SwiftUI fires `.task` when this view first renders inside the
-            // disclosed body (inspector) or when the panel selection changes.
-            // The load runs once per slug; cached `state` is reused across
-            // re-renders of the same slug.
-            guard state == .idle else { return }
+            // `.task(id: slug)` handles deduplication: the closure only re-fires
+            // when slug changes, so always reset to loading at the start to
+            // refetch when the slug changes.
             state = .loading
             let client = LLMContextClient()
             let rendered = await client.fetchConceptPage(slug: slug)


### PR DESCRIPTION
Addresses Devin review feedback on #29802.

`.task(id: slug)` was guarded by `state == .idle`, which prevented the refetch when the slug changed because `@State` retained the previous `.loaded(...)` value. Removed the guard — `.task(id:)` already handles deduplication by only re-firing on id change.

The other two Devin findings (Divider accessibility, #Preview cleanup) are moot: `MemoriesV2Panel` was removed in #29894 and the inspector file no longer has #Preview blocks.