### PR TITLE
fix(macos): load bundle icon from .icns to avoid stale Finder cache

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -560,19 +560,24 @@ final class AvatarAppearanceManager {
     /// `applicationIconImage` is set at runtime and already includes all
     /// system-resolved representations.
     ///
-    /// Marked `nonisolated` to opt this static out of the enclosing
-    /// `@MainActor` isolation so the background prefetch in `start()` can
-    /// trigger the lazy initializer off the main thread without crossing
-    /// an actor boundary. The initializer is safe to run on any thread:
-    /// `NSWorkspace.icon(forFile:)` is documented thread-safe, and the
-    /// resulting `NSImage` is treated as a single immutable value for the
-    /// life of the process.
+    /// Loaded directly from `AppIcon.icns` rather than via
+    /// `NSWorkspace.icon(forFile: bundlePath)` because `updateDockIcon()`
+    /// writes a custom Finder icon (`Icon\r`) onto the `.app` bundle to
+    /// override the notification daemon's icon. That custom file persists
+    /// across launches, so reading the bundle's Finder icon would capture
+    /// the stale avatar from a previous session and cause `restoreBundleIcon()`
+    /// to "restore" it instead of the real Vellum logo. Reading the `.icns`
+    /// resource bypasses Finder metadata entirely.
     ///
-    /// References:
-    /// - https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
-    /// - https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md
+    /// Marked `nonisolated` so the background prefetch in `start()` can
+    /// trigger the lazy initializer off the main thread without crossing
+    /// the enclosing `@MainActor` boundary.
     private nonisolated static let bundledAppIcon: NSImage = {
-        NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
+        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+           let image = NSImage(contentsOf: url) {
+            return image
+        }
+        return NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 
     /// Restores the dock icon to the default Vellum logo.


### PR DESCRIPTION
## Summary

Addresses review feedback on #29813 (Codex P1, Devin) about `bundledAppIcon` capturing a stale custom Finder icon across app restarts.

`updateDockIcon()` calls `NSWorkspace.setIcon(icon, forFile: bundlePath)` to override the notification daemon's icon. That writes an `Icon\r` file into the `.app` bundle which persists across launches. `bundledAppIcon` was lazily initialized via `NSWorkspace.icon(forFile: bundlePath)`, which reads that custom Finder icon — so a restart while an avatar was active captured the avatar as the cached 'bundled' icon, and subsequent `restoreBundleIcon()` calls would 'restore' the stale avatar.

Fix: load the icon directly from the `AppIcon.icns` resource URL, which bypasses Finder custom-icon metadata.

## Test plan
- [ ] Set custom avatar, quit app, relaunch, disconnect → Dock shows real Vellum logo (not stale avatar)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->