### PR TITLE
fix(memory-v2): rank rerank pool by user+assistant signal only

### DIFF
--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -201,17 +201,19 @@ interface ComputeOwnActivationResult {
  *          + c_user · sim_u + c_assistant · sim_a + c_now · sim_n
  *          + c_user · α · r_norm_u + c_assistant · α · r_norm_a
  * over the candidate set, where the rerank terms only fire for slugs that
- * land in the unified top-K-by-pre-rerank-A_o window. Returns a sparse map
- * keyed by slug; slugs whose computed value rounds to 0 are still included
- * so callers can see the candidate set explicitly. Also returns a per-slug
- * breakdown of the raw inputs (decayed prior + raw sims + rerank deltas) so
- * callers can render contribution diagnostics without re-running the math.
+ * land in the unified top-K window. The pool is ranked by the rerank-eligible
+ * channels alone (`c_user · sim_u + c_assistant · sim_a`) so prior- or
+ * NOW-heavy slugs — which can't gain from rerank — don't starve out
+ * genuinely user/assistant-relevant slugs. Returns a sparse map keyed by
+ * slug; slugs whose computed value rounds to 0 are still included so callers
+ * can see the candidate set explicitly. Also returns a per-slug breakdown of
+ * the raw inputs (decayed prior + raw sims + rerank deltas) so callers can
+ * render contribution diagnostics without re-running the math.
  *
  * The three `simBatch` calls run concurrently — they hit independent named
  * vectors and embed independent query texts. Cross-encoder rerank then runs
- * once on the unified top-K (selected by pre-rerank A_o, not per-channel
- * fused sim) so an entry strong in both channels can't double-boost itself
- * past entries that only land in one channel.
+ * once on the unified top-K so an entry strong in both channels can't
+ * double-boost itself past entries that only land in one channel.
  */
 export async function computeOwnActivation(
   params: ComputeOwnActivationParams,
@@ -247,8 +249,16 @@ export async function computeOwnActivation(
     simU: number;
     simA: number;
     simN: number;
-    /** Pre-rerank A_o; ranking signal for the unified rerank pool. */
+    /** Pre-rerank A_o; full sum used for the final activation value. */
     preRerank: number;
+    /**
+     * Ranking signal for the unified rerank pool — only the channels that
+     * actually participate in rerank (user + assistant). Excluding
+     * `priorContribution` and `c_now * simN` prevents prior- or NOW-heavy
+     * slugs from consuming the rerank budget despite being ineligible for
+     * cross-encoder gains.
+     */
+    rerankPoolScore: number;
   }
   const inputs: SlugInputs[] = slugList.map((slug) => {
     const prev = priorState?.state[slug] ?? 0;
@@ -256,23 +266,24 @@ export async function computeOwnActivation(
     const simA = simAssistant.get(slug) ?? 0;
     const simN = simNow.get(slug) ?? 0;
     const priorContribution = d * prev;
+    const rerankPoolScore = c_user * simU + c_assistant * simA;
     return {
       slug,
       priorContribution,
       simU,
       simA,
       simN,
-      preRerank:
-        priorContribution + c_user * simU + c_assistant * simA + c_now * simN,
+      preRerank: priorContribution + rerankPoolScore + c_now * simN,
+      rerankPoolScore,
     };
   });
 
-  // Unified top-K by pre-rerank A_o. Both channels rerank against the **same**
-  // slug set, so a slug strong on user can't crowd out one strong on assistant
-  // by virtue of appearing in both per-channel top-Ks. Both channel queries
-  // ride in a single `rerankCandidates` call so the worker tokenizes and
-  // forward-passes them together — half the per-call overhead of two
-  // serialised round-trips.
+  // Unified top-K by rerank-eligible signal only. Both channels rerank against
+  // the **same** slug set, so a slug strong on user can't crowd out one strong
+  // on assistant by virtue of appearing in both per-channel top-Ks. Both
+  // channel queries ride in a single `rerankCandidates` call so the worker
+  // tokenizes and forward-passes them together — half the per-call overhead
+  // of two serialised round-trips.
   let userRerankBoost: ReadonlyMap<string, number> = new Map();
   let assistantRerankBoost: ReadonlyMap<string, number> = new Map();
   let inPoolSet: ReadonlySet<string> = new Set();
@@ -281,7 +292,7 @@ export async function computeOwnActivation(
     throwIfAborted(signal);
     const topSlugs = inputs
       .slice()
-      .sort((a, b) => b.preRerank - a.preRerank)
+      .sort((a, b) => b.rerankPoolScore - a.rerankPoolScore)
       .slice(0, rerankCfg.top_k)
       .map((e) => e.slug);
     if (topSlugs.length > 0) {


### PR DESCRIPTION
Addresses [Codex P1 on #29622](https://github.com/vellum-ai/vellum-assistant/pull/29622#discussion_r0).

The unified rerank pool was ranked by `preRerank` = `priorContribution + c_user*simU + c_assistant*simA + c_now*simN`, but rerank only operates on user and assistant text. Prior- and NOW-heavy slugs could therefore consume the rerank budget without benefiting from cross-encoder gains, pushing genuinely user/assistant-relevant slugs out of the pool when `top_k` is tight — a regression vs. the old per-channel selection path.

Fix: rank the pool by `c_user*simU + c_assistant*simA` alone (a new `rerankPoolScore` field). The final A_o computation is unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->