### PR TITLE
fix(macos): kill running siblings before deleting stale bundles

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -958,6 +958,24 @@ for stale in "$SCRIPT_DIR/dist"/*.app; do
     [ "$stale" = "$APP_DIR" ] && continue
     stale_id=$(plutil -extract CFBundleIdentifier raw "$stale/Contents/Info.plist" 2>/dev/null || true)
     if [ "$stale_id" = "$BUNDLE_ID" ]; then
+        # Kill processes from this bundle before removing it — the `run`
+        # kill pass below matches by reading each PID's Info.plist, so
+        # deleting first would orphan a running sibling and leave a
+        # duplicate Dock entry.
+        stale_pids=""
+        while IFS= read -r line; do
+            read -r pid exe_path <<< "$line"
+            [ -n "$pid" ] || continue
+            case "$exe_path" in
+                "$stale"/Contents/MacOS/*) stale_pids+="$pid " ;;
+            esac
+        done < <(ps -ax -o pid=,comm=)
+        if [ -n "$stale_pids" ]; then
+            echo "Stopping process(es) inside stale bundle $stale: $stale_pids"
+            echo "$stale_pids" | xargs kill 2>/dev/null || true
+            sleep 0.3
+            echo "$stale_pids" | xargs kill -9 2>/dev/null || true
+        fi
         echo "Removing stale bundle with matching ID: $stale"
         rm -rf "$stale"
     fi


### PR DESCRIPTION
Codex P1 follow-up on https://github.com/vellum-ai/vellum-assistant/pull/29861.

## Summary
- The stale-bundle cleanup in `clients/macos/build.sh` removed sibling `.app` directories sharing our `CFBundleIdentifier` before the run-command kill pass could match them.
- That pass identifies targets by reading each running PID's `Info.plist`, so once the bundle was deleted the process was no longer matched and the old persona-named app survived, producing duplicate Dock entries.
- Now we snapshot any process whose executable path lives inside the stale bundle, SIGTERM, briefly wait, then SIGKILL stragglers before `rm -rf`. Pattern mirrors the existing run-mode kill pass.

## Test plan
- [ ] Launch persona-named bundle, run `build.sh run` under a different display name, confirm only the new app remains in the Dock.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->