### PR TITLE
fix(memory): short-circuit v1 Qdrant jobs when memory v2 is enabled

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -79,6 +79,26 @@ import { memoryV2SweepJob } from "./v2/sweep-job.js";
 const log = getLogger("memory-jobs-worker");
 
 /**
+ * V1 job types that read or write the v1 Qdrant collection via
+ * `getQdrantClient()`. When `memory.v2.enabled` is true, the v1 client is
+ * intentionally left uninitialized in `lifecycle.ts`, so these handlers would
+ * throw `BackendUnavailableError` and accumulate as a deferred backlog. Stale
+ * rows from indexer.ts and other unguarded enqueue sites must short-circuit
+ * here for the same reason `graph_extract` does below.
+ */
+const V1_QDRANT_JOB_TYPES = new Set<MemoryJobType>([
+  "embed_segment",
+  "embed_summary",
+  "embed_media",
+  "embed_attachment",
+  "embed_graph_node",
+  "embed_pkb_file",
+  "graph_trigger_embed",
+  "rebuild_index",
+  "delete_qdrant_vectors",
+]);
+
+/**
  * Job types whose handlers have been removed. Existing rows may still sit in
  * the database — the worker completes them silently instead of throwing.
  */
@@ -470,6 +490,9 @@ async function processJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): Promise<void> {
+  if (config.memory.v2.enabled && V1_QDRANT_JOB_TYPES.has(job.type)) {
+    return;
+  }
   switch (job.type) {
     case "embed_segment":
       await embedSegmentJob(job, config);


### PR DESCRIPTION
## Summary
- PR #29878 gated v1 \`initQdrantClient(...)\` behind \`!memory.v2.enabled\`, but \`indexer.ts\` and other unguarded sites still enqueue v1 embed jobs (e.g. \`embed_segment\`) on every persisted message. Their handlers call \`getQdrantClient()\` via \`embedAndUpsert\`, which now throws \`BackendUnavailableError\` under v2 and accumulates as a persistent deferred backlog (Codex P1 finding).
- Mirror the existing \`graph_extract\` short-circuit by adding a \`V1_QDRANT_JOB_TYPES\` set checked at the top of the worker dispatch — stale enqueues become silent no-ops with no Qdrant calls.

## Test plan
- [ ] Manual: enable memory v2, persist messages, confirm worker logs no \`BackendUnavailableError\` deferrals for \`embed_segment\` / \`embed_summary\` / \`embed_attachment\` / \`embed_media\` / \`embed_graph_node\` / \`embed_pkb_file\` / \`graph_trigger_embed\` / \`rebuild_index\` / \`delete_qdrant_vectors\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->