### PR TITLE
fix(memory-v2): scope skill prune by payload kind and skip everInjected on cache miss

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -39,11 +39,13 @@ interface UpsertCall {
   dense: number[];
   sparse: { indices: number[]; values: number[] };
   updatedAt: number;
+  kind?: string;
 }
 
 interface PruneCall {
   prefix: string;
   activeSuffixes: readonly string[];
+  options?: { kind?: string };
 }
 
 interface TestState {
@@ -118,8 +120,9 @@ mock.module("../qdrant.js", () => ({
   pruneSlugsWithPrefixExcept: async (
     prefix: string,
     activeSuffixes: readonly string[],
+    options?: { kind?: string },
   ) => {
-    state.pruneCalls.push({ prefix, activeSuffixes });
+    state.pruneCalls.push({ prefix, activeSuffixes, options });
   },
 }));
 

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -210,9 +210,21 @@ export async function injectMemoryV2Block(
   // like concept slugs — once attached on a turn, the cached attachment lives
   // on that user message and the agent keeps seeing it across subsequent turns
   // until compaction evicts the turn.
+  //
+  // Skill slugs whose in-process cache entry is missing (e.g. startup race
+  // between the skill seed and the first turn, or stale Qdrant index pointing
+  // at an uninstalled skill) are excluded from `everInjected` so future
+  // per-turn runs re-attempt attachment once the cache is populated. Without
+  // this, the slug would be marked injected even though `renderInjectionBlock`
+  // silently dropped it.
+  const missingSkillSlugs = new Set(
+    slugsToRender.filter(
+      (slug) => isSkillSlug(slug) && !getSkillCapability(slug),
+    ),
+  );
   const everInjectedSet = new Set(priorEverInjected.map((entry) => entry.slug));
   const newlyInjected = slugsToRender.filter(
-    (slug) => !everInjectedSet.has(slug),
+    (slug) => !everInjectedSet.has(slug) && !missingSkillSlugs.has(slug),
   );
   const nextEverInjected: EverInjectedEntry[] = [
     ...priorEverInjected,

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -279,10 +279,17 @@ export async function upsertConceptPageEmbedding(params: {
   sparse: SparseEmbedding;
   summary?: { dense: number[]; sparse: SparseEmbedding };
   updatedAt: number;
+  /**
+   * Optional payload discriminator. Used to distinguish skill-seeded points
+   * (`kind: "skill"`) from user-authored concept pages so namespace pruning
+   * via {@link pruneSlugsWithPrefixExcept} can scope deletes to a single kind.
+   * Omitted for plain concept pages.
+   */
+  kind?: string;
 }): Promise<void> {
   await ensureConceptPageCollection();
 
-  const { slug, dense, sparse, summary, updatedAt } = params;
+  const { slug, dense, sparse, summary, updatedAt, kind } = params;
   const client = getClient();
   const pointId = pointIdForSlug(slug);
 
@@ -296,6 +303,9 @@ export async function upsertConceptPageEmbedding(params: {
     vector.summary_sparse = summary.sparse;
   }
 
+  const payload: Record<string, unknown> = { slug, updated_at: updatedAt };
+  if (kind !== undefined) payload.kind = kind;
+
   const upsertOnce = () =>
     client.upsert(MEMORY_V2_COLLECTION, {
       wait: true,
@@ -303,7 +313,7 @@ export async function upsertConceptPageEmbedding(params: {
         {
           id: pointId,
           vector,
-          payload: { slug, updated_at: updatedAt },
+          payload,
         },
       ],
     });
@@ -352,17 +362,25 @@ export async function deleteConceptPageEmbedding(slug: string): Promise<void> {
  * since skills now share the concept-page collection rather than living in a
  * dedicated one.
  *
+ * `kind` scopes pruning to a payload discriminator: only points whose
+ * `payload.kind` matches are eligible for deletion. This is critical because
+ * `validateSlug` permits user-authored concept pages slugged like
+ * `skills/foo`; without a kind filter they would collide with the skill
+ * namespace and be repeatedly pruned every seed run.
+ *
  * Idempotent: when the live `<prefix>*` slugs already match `activeSuffixes`,
  * the function performs a single scroll and no deletes.
  */
 export async function pruneSlugsWithPrefixExcept(
   prefix: string,
   activeSuffixes: readonly string[],
+  options: { kind?: string } = {},
 ): Promise<void> {
   await ensureConceptPageCollection();
 
   const client = getClient();
   const activeSet = new Set(activeSuffixes);
+  const requiredKind = options.kind;
 
   const doPrune = async (): Promise<void> => {
     const stalePointIds: Array<string | number> = [];
@@ -377,9 +395,15 @@ export async function pruneSlugsWithPrefixExcept(
         ...(offset !== undefined ? { offset } : {}),
       });
       for (const point of result.points) {
-        const slug = (point.payload as { slug?: unknown } | null)?.slug;
+        const payload = point.payload as {
+          slug?: unknown;
+          kind?: unknown;
+        } | null;
+        const slug = payload?.slug;
         if (typeof slug !== "string") continue;
         if (!slug.startsWith(prefix)) continue;
+        if (requiredKind !== undefined && payload?.kind !== requiredKind)
+          continue;
         const suffix = slug.slice(prefix.length);
         if (!activeSet.has(suffix)) {
           stalePointIds.push(point.id);

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -58,6 +58,14 @@ const log = getLogger("memory-v2-skill-store");
  */
 export const SKILL_SLUG_PREFIX = "skills/";
 
+/**
+ * Payload discriminator written on every skill-seeded Qdrant point. Keeps
+ * skill rows distinguishable from user-authored concept pages that happen to
+ * be slugged under `skills/...`, so prefix pruning never deletes a hand-
+ * authored page sitting in the same namespace.
+ */
+const SKILL_PAYLOAD_KIND = "skill";
+
 /** Compose the unified-collection slug for a skill id. */
 export function skillSlugFor(id: string): string {
   return `${SKILL_SLUG_PREFIX}${id}`;
@@ -210,6 +218,7 @@ async function runSeedOnce(): Promise<void> {
             dense: denseVectors[i],
             sparse: encodeSparse(seed.content),
             updatedAt: now,
+            kind: SKILL_PAYLOAD_KIND,
           }),
         ),
       );
@@ -226,6 +235,7 @@ async function runSeedOnce(): Promise<void> {
       await pruneSlugsWithPrefixExcept(
         SKILL_SLUG_PREFIX,
         seeds.map((s) => s.id),
+        { kind: SKILL_PAYLOAD_KIND },
       );
     } else {
       log.info(


### PR DESCRIPTION
Addresses codex P1 review feedback on #29619.

## Summary
- **Skill namespace pruning**: skill-seeded points now carry `payload.kind="skill"` and `pruneSlugsWithPrefixExcept` accepts a `kind` filter, so user-authored concept pages slugged under `skills/...` are no longer eligible for deletion on every seed run.
- **everInjected bookkeeping**: skill slugs whose in-process cache entry is missing at injection time are excluded from `everInjected`. Without this, a startup race between the skill seed and the first turn marks the slug injected even though `renderInjectionBlock` silently dropped it, blocking re-attempts until compaction.

## Test plan
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->