### PR TITLE
fix(workspace-migrations): gate onboarding-threads seeding to new workspaces

### DIFF
--- a/assistant/src/__tests__/workspace-migration-069-seed-onboarding-threads.test.ts
+++ b/assistant/src/__tests__/workspace-migration-069-seed-onboarding-threads.test.ts
@@ -2,8 +2,11 @@
  * Tests for workspace migration `069-seed-onboarding-threads`.
  *
  * The migration writes onboarding bullet content to `memory/threads.md` only
- * when the file exists and is empty (or whitespace-only). It must preserve
- * any existing content and must be idempotent.
+ * for newly-created workspaces (`ctx.isNewWorkspace === true`) when the file
+ * exists and is empty (or whitespace-only). For upgrading workspaces it must
+ * be a no-op even if `threads.md` is currently empty (the user may have
+ * cleaned it up themselves). It must preserve any existing content and be
+ * idempotent.
  */
 
 import {
@@ -20,6 +23,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { memoryV2InitMigration } from "../workspace/migrations/060-memory-v2-init.js";
 import { seedOnboardingThreadsMigration } from "../workspace/migrations/069-seed-onboarding-threads.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
 
 let workspaceDir: string;
 
@@ -48,18 +55,44 @@ describe("069-seed-onboarding-threads migration", () => {
   test.each([
     ["empty file", ""],
     ["whitespace-only file", "   \n\n"],
-  ])("seeds onboarding bullets when memory/threads.md is %s", (_, initial) => {
-    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
-    writeFileSync(join(workspaceDir, "memory", "threads.md"), initial, "utf-8");
+  ])(
+    "seeds onboarding bullets when new workspace and memory/threads.md is %s",
+    (_, initial) => {
+      mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "memory", "threads.md"),
+        initial,
+        "utf-8",
+      );
 
-    seedOnboardingThreadsMigration.run(workspaceDir);
+      seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
 
-    const content = readThreads();
-    expect(content).toContain("Figure out what kind of personality");
-    expect(content).toContain("data/avatar/avatar-image.png");
-    expect(content).toContain("ChatGPT, Claude");
-    expect(content).toContain("Slack or Telegram");
-  });
+      const content = readThreads();
+      expect(content).toContain("Figure out what kind of personality");
+      expect(content).toContain("data/avatar/avatar-image.png");
+      expect(content).toContain("ChatGPT, Claude");
+      expect(content).toContain("Slack or Telegram");
+    },
+  );
+
+  test.each([
+    ["empty file", ""],
+    ["whitespace-only file", "   \n\n"],
+  ])(
+    "no-op on upgrade when memory/threads.md is %s (user may have cleared it)",
+    (_, initial) => {
+      mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+      writeFileSync(
+        join(workspaceDir, "memory", "threads.md"),
+        initial,
+        "utf-8",
+      );
+
+      seedOnboardingThreadsMigration.run(workspaceDir, UPGRADE_CTX);
+
+      expect(readThreads()).toBe(initial);
+    },
+  );
 
   test("preserves existing content when memory/threads.md is non-empty", () => {
     mkdirSync(join(workspaceDir, "memory"), { recursive: true });
@@ -70,13 +103,13 @@ describe("069-seed-onboarding-threads migration", () => {
       "utf-8",
     );
 
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
 
     expect(readThreads()).toBe(existing);
   });
 
   test("no-op when memory/threads.md does not exist", () => {
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
     expect(existsSync(join(workspaceDir, "memory", "threads.md"))).toBe(false);
   });
 
@@ -84,18 +117,18 @@ describe("069-seed-onboarding-threads migration", () => {
     mkdirSync(join(workspaceDir, "memory"), { recursive: true });
     writeFileSync(join(workspaceDir, "memory", "threads.md"), "", "utf-8");
 
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
     const afterFirst = readThreads();
 
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
     const afterSecond = readThreads();
 
     expect(afterSecond).toBe(afterFirst);
   });
 
   test("composes with 060: fresh workspace -> 060 -> 069 produces seeded threads.md", () => {
-    memoryV2InitMigration.run(workspaceDir);
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    memoryV2InitMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
 
     expect(readThreads()).toContain("Figure out what kind of personality");
     // The other v2 prose files are untouched (still empty).
@@ -110,7 +143,7 @@ describe("069-seed-onboarding-threads migration", () => {
     mkdirSync(join(workspaceDir, "memory"), { recursive: true });
     writeFileSync(join(workspaceDir, "memory", "threads.md"), "", "utf-8");
 
-    seedOnboardingThreadsMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir, NEW_WORKSPACE_CTX);
     const seeded = readThreads();
 
     seedOnboardingThreadsMigration.down(workspaceDir);

--- a/assistant/src/workspace/migrations/069-seed-onboarding-threads.ts
+++ b/assistant/src/workspace/migrations/069-seed-onboarding-threads.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import type { WorkspaceMigration } from "./types.js";
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
 
 const ONBOARDING_THREADS = `- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.
 - Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.
@@ -14,7 +14,13 @@ export const seedOnboardingThreadsMigration: WorkspaceMigration = {
   description:
     "Seed memory/threads.md with onboarding tasks for brand new assistants",
 
-  run(workspaceDir: string): void {
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // Only seed onboarding tasks for newly-created workspaces. An existing
+    // assistant whose user has cleaned up threads.md must not have onboarding
+    // bullets injected into static memory context on upgrade. When invoked
+    // without a context (e.g. from older callers), default to the safe path
+    // and skip — the runner always supplies one in production.
+    if (!ctx?.isNewWorkspace) return;
     const filePath = join(workspaceDir, "memory", "threads.md");
     if (!existsSync(filePath)) return;
     const current = readFileSync(filePath, "utf-8");

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -3,7 +3,11 @@ import { dirname, join } from "node:path";
 
 import { ensureDir, readTextFileSync } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
-import type { WorkspaceMigration, WorkspaceMigrationStatus } from "./types.js";
+import type {
+  MigrationRunContext,
+  WorkspaceMigration,
+  WorkspaceMigrationStatus,
+} from "./types.js";
 
 const log = getLogger("workspace-migrations");
 
@@ -76,6 +80,13 @@ export async function runWorkspaceMigrations(
     seen.add(m.id);
   }
 
+  // Detect a brand-new workspace: no checkpoint file existed before this run.
+  // Captured before loadCheckpoints so seeding migrations can distinguish a
+  // first-ever boot from an upgrade where the user may have cleared seeded files.
+  const ctx: MigrationRunContext = {
+    isNewWorkspace: readTextFileSync(getCheckpointPath(workspaceDir)) == null,
+  };
+
   const checkpoints = loadCheckpoints(workspaceDir);
 
   for (const [id, entry] of Object.entries(checkpoints.applied)) {
@@ -104,7 +115,7 @@ export async function runWorkspaceMigrations(
     saveCheckpoints(workspaceDir, checkpoints);
 
     try {
-      await migration.run(workspaceDir);
+      await migration.run(workspaceDir, ctx);
     } catch (error) {
       log.error(
         { migrationId: migration.id, error },

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -1,13 +1,23 @@
+/** Runtime context passed to each migration's `run()`.
+ *  Lets seeding migrations distinguish a brand-new workspace from a workspace
+ *  upgrading through this migration for the first time. */
+export interface MigrationRunContext {
+  /** True when no workspace-migration checkpoint file existed at the start of
+   *  this run — i.e., this is a freshly-created workspace, not an upgrade. */
+  isNewWorkspace: boolean;
+}
+
 export interface WorkspaceMigration {
   /** Unique identifier, e.g. "001-avatar-rename". Used as the checkpoint key.
    *  Must be unique across all registered migrations — the runner validates this at startup. */
   id: string;
   /** Human-readable description for logging. */
   description: string;
-  /** The migration function. Receives the workspace directory path.
-   *  Must be idempotent — safe to re-run if it was interrupted.
+  /** The migration function. Receives the workspace directory path and an
+   *  optional context object (always supplied by the runner; tests may omit
+   *  it). Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous migrations are supported. */
-  run(workspaceDir: string): void | Promise<void>;
+  run(workspaceDir: string, ctx?: MigrationRunContext): void | Promise<void>;
   /** Reverse the migration. Receives the workspace directory path.
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous rollbacks are supported. */


### PR DESCRIPTION
## Summary

Codex P1 follow-up to #29821: workspace migration `069-seed-onboarding-threads` was seeding onboarding bullets on every workspace whose `memory/threads.md` was whitespace-only at upgrade time, not just on freshly-created workspaces. Existing assistants whose users had cleaned up `threads.md` would have onboarding tasks re-injected into static memory context.

- Add `MigrationRunContext` to the workspace-migration interface and have the runner synthesise it once per boot. `isNewWorkspace` is `true` iff the checkpoint file (`data/.workspace-migrations.json`) did not exist when the runner started.
- Gate `069-seed-onboarding-threads` on `ctx.isNewWorkspace`. The migration is now a no-op for upgrades regardless of `threads.md` state. When invoked without a context (e.g. older test callers), default to the safe path and skip.
- Update the 069 test to cover both new-workspace and upgrade contexts.

## Test plan
- [ ] `bun test src/__tests__/workspace-migration-069-seed-onboarding-threads.test.ts`
- [ ] `bun test src/__tests__/workspace-migrations-runner.test.ts`
- [ ] `bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->