### PR TITLE
fix(memory-v2): address PR #29823 review feedback

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -36,8 +36,8 @@ import {
   slugFromConceptPath,
 } from "../../v2/page-store.js";
 import { hybridQueryConceptPages } from "../../v2/qdrant.js";
+import { fuseHalf } from "../../v2/sim.js";
 import { generateBm25QueryEmbedding } from "../../v2/sparse-bm25.js";
-import { clampUnitInterval } from "../../validation.js";
 import type {
   RecallEvidence,
   RecallSearchContext,
@@ -188,24 +188,43 @@ async function activationEvidence(
   const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
     context.config.memory.v2;
 
-  let maxSparse = 0;
+  // Mirror sim.ts: normalize body and summary sparse channels against their
+  // own per-batch maxima, fuse each half via clamp01(dense·w_d + sparse·w_s),
+  // then take max(body, summary) per slug. Pages without a summary embedding
+  // return undefined for both summary scores; the max collapses cleanly to
+  // the body score so legacy pages keep their pre-summary ranking.
+  let maxBodySparse = 0;
+  let maxSummarySparse = 0;
   for (const hit of hits) {
-    if (hit.sparseScore !== undefined && hit.sparseScore > maxSparse) {
-      maxSparse = hit.sparseScore;
+    if (hit.sparseScore !== undefined && hit.sparseScore > maxBodySparse) {
+      maxBodySparse = hit.sparseScore;
+    }
+    if (
+      hit.summarySparseScore !== undefined &&
+      hit.summarySparseScore > maxSummarySparse
+    ) {
+      maxSummarySparse = hit.summarySparseScore;
     }
   }
 
   const ownActivation = new Map<string, number>();
   for (const hit of hits) {
-    const dense = hit.denseScore ?? 0;
-    const sparseNormalized =
-      hit.sparseScore !== undefined && maxSparse > 0
-        ? hit.sparseScore / maxSparse
-        : 0;
-    ownActivation.set(
-      hit.slug,
-      clampUnitInterval(denseWeight * dense + sparseWeight * sparseNormalized),
+    const bodyScore = fuseHalf(
+      hit.denseScore,
+      hit.sparseScore,
+      maxBodySparse,
+      denseWeight,
+      sparseWeight,
     );
+    const summaryScore = fuseHalf(
+      hit.summaryDenseScore,
+      hit.summarySparseScore,
+      maxSummarySparse,
+      denseWeight,
+      sparseWeight,
+    );
+    const score = Math.max(bodyScore ?? 0, summaryScore ?? bodyScore ?? 0);
+    ownActivation.set(hit.slug, score);
   }
 
   const edgeIndex = await getEdgeIndex(context.workingDir);

--- a/assistant/src/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/memory/jobs/embed-concept-page.ts
@@ -163,21 +163,54 @@ export async function embedConceptPageJob(
     slots.push("summary");
   }
 
-  let bodyDense: number[] | undefined = bodyCacheHit ? bodyCache!.dense : undefined;
+  let bodyDense: number[] | undefined = bodyCacheHit
+    ? bodyCache!.dense
+    : undefined;
   let summaryDense: number[] | undefined = summaryCacheHit
     ? summaryCache!.dense
     : undefined;
   let writeProvider = cacheProvider;
   let writeModel = cacheModel;
+  let bodyFresh = false;
+  let summaryFresh = false;
   if (toEmbed.length > 0) {
-    const embedded = await embedWithBackend(config, toEmbed);
+    let embedded = await embedWithBackend(config, toEmbed);
+    let appliedSlots = slots;
+    // Backend rotation between `getMemoryBackendStatus()` and
+    // `embedWithBackend()` would tag the cached half with the old
+    // provider/model and the fresh half with the new — writing both into
+    // one Qdrant point mixes embedding spaces. Re-embed every slot fresh
+    // when we detect the rotation so the point's named vectors share one
+    // identity.
+    const rotated =
+      (bodyCacheHit || summaryCacheHit) &&
+      (embedded.provider !== cacheProvider || embedded.model !== cacheModel);
+    if (rotated) {
+      const allTexts: Array<{ type: "text"; text: string }> = [
+        { type: "text", text },
+      ];
+      const allSlots: Slot[] = ["body"];
+      if (hasSummary) {
+        allTexts.push({ type: "text", text: summaryText });
+        allSlots.push("summary");
+      }
+      embedded = await embedWithBackend(config, allTexts);
+      appliedSlots = allSlots;
+      bodyDense = undefined;
+      summaryDense = undefined;
+    }
     writeProvider = embedded.provider;
     writeModel = embedded.model;
-    for (let i = 0; i < slots.length; i++) {
+    for (let i = 0; i < appliedSlots.length; i++) {
       const vector = embedded.vectors[i];
       if (!vector) continue;
-      if (slots[i] === "body") bodyDense = vector;
-      else summaryDense = vector;
+      if (appliedSlots[i] === "body") {
+        bodyDense = vector;
+        bodyFresh = true;
+      } else {
+        summaryDense = vector;
+        summaryFresh = true;
+      }
     }
   }
   // Body embedding is the ground truth — without it the page can't surface.
@@ -205,9 +238,12 @@ export async function embedConceptPageJob(
   const now = Date.now();
   // Persist freshly embedded vectors for cross-restart reuse. On cache hit
   // the existing row already has identical content + hash, so the write
-  // would be a no-op — skip it. Best-effort: write failure is not fatal,
-  // we still want the Qdrant upsert below to fire.
-  if (!bodyCacheHit) {
+  // would be a no-op — skip it. Backend rotation flips a cache hit into a
+  // fresh embed (see `rotated` above); the `*Fresh` flags capture that so
+  // the new vector overwrites the now-stale cache row under the new
+  // provider/model identity. Best-effort: write failure is not fatal, we
+  // still want the Qdrant upsert below to fire.
+  if (bodyFresh) {
     writeEmbeddingCache(db, {
       slug,
       cacheId: slug,
@@ -218,7 +254,7 @@ export async function embedConceptPageJob(
       now,
     });
   }
-  if (hasSummary && !summaryCacheHit && summaryDense && summaryContentHash) {
+  if (hasSummary && summaryFresh && summaryDense && summaryContentHash) {
     writeEmbeddingCache(db, {
       slug,
       cacheId: summaryCacheId,

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -365,11 +365,12 @@ interface RenderInjectionBlockResult {
 }
 
 /**
- * Leading instruction line emitted at the top of every non-empty injection
- * block. Tells the agent that what follows are page summaries and that it
- * should read the underlying file when a summary looks relevant. Pages
- * without a `summary` field render in full instead — the agent treats
- * those as inline content and doesn't need to follow up.
+ * Leading instruction line emitted at the top of an injection block when at
+ * least one section was rendered from a page's `summary` field. Tells the
+ * agent the truncated entries are summaries and to read the underlying file
+ * if relevant. Suppressed when every section is a full-page fallback —
+ * claiming "these are summaries" over already-complete content would mislead
+ * the agent into wasted reads.
  */
 const INJECTION_HEADER =
   "**CRITICAL:** These are page summaries. Read the page file if it looks relevant.";
@@ -437,6 +438,7 @@ async function renderInjectionBlock(
 
   const sections: string[] = [];
   const missingSlugs: string[] = [];
+  let anySummarySection = false;
   for (const { slug, page } of pages) {
     if (!page) {
       missingSlugs.push(slug);
@@ -446,6 +448,7 @@ async function renderInjectionBlock(
     const path = `memory/concepts/${slug}.md`;
     if (summary && summary.length > 0) {
       sections.push(`# ${path}\n${summary}`);
+      anySummarySection = true;
       continue;
     }
     // Fallback: page predates the `summary` field (or the field was set to
@@ -468,8 +471,9 @@ async function renderInjectionBlock(
 
   if (sections.length === 0) return { block: null, missingSlugs };
 
+  const body = sections.join("\n\n");
   return {
-    block: `${INJECTION_HEADER}\n\n${sections.join("\n\n")}`,
+    block: anySummarySection ? `${INJECTION_HEADER}\n\n${body}` : body,
     missingSlugs,
   };
 }

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -277,8 +277,11 @@ function computeMaxSparse<T>(
  * operator-configured dense/sparse balance is preserved. Returns
  * `undefined` when neither channel hit — a signal the half had no match
  * at all, so the caller can fall back to the other half cleanly.
+ *
+ * Exported so the context-search adapter can reuse the same fusion math
+ * for its own activation pipeline.
  */
-function fuseHalf(
+export function fuseHalf(
   denseScore: number | undefined,
   sparseScore: number | undefined,
   maxSparse: number,


### PR DESCRIPTION
## Summary

Follow-ups to PR #29823 (memory-v2 concept summaries) addressing reviewer feedback.

- **`injection.ts`** — Only emit the `**CRITICAL:** These are page summaries...` header when at least one section is actually a summary. During rollout many pages still lack a `summary` field and render in full; the unconditional header was misleading the agent into reading files whose content is already inline.
- **`context-search/sources/memory-v2.ts`** — Fuse summary dense+sparse alongside body channels via `max(body, summary)`, mirroring `sim.ts`. Recall previously read only body scores, leaving the new summary embeddings unused.
- **`embed-concept-page.ts`** — When the backend rotates between `getMemoryBackendStatus()` and `embedWithBackend()`, re-embed cache-hit slots so all of the point's named vectors share one provider/model identity. The prior path could write a stale cached vector under the rotated provider tag, mixing embedding spaces.
- Exports `fuseHalf` from `sim.ts` so the recall adapter reuses the same fusion math.

## Test plan

- [ ] Existing `injection.test.ts` cases pass (header still present in summary and mixed-batch paths).
- [ ] Existing `embed-concept-page` tests pass (rotation path is best-effort and only fires under cross-call backend swap).
- [ ] Manual: verify recall ranks summary-matching pages higher when only the summary contains the query terms.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->