### PR TITLE
test(memory-v2): align injection test with skill cache-miss exclusion

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -909,9 +909,10 @@ describe("injectMemoryV2Block", () => {
 
   test("skill slugs whose entry is missing from the cache are dropped silently", async () => {
     // The skill ranks into top-K but the in-process cache no longer knows
-    // its content (skill uninstalled mid-run). The render path drops it
-    // without surfacing it as a `missingSlugs` page-missing event — that
-    // status is reserved for on-disk concept pages, not catalog-derived
+    // its content (skill uninstalled mid-run, or a startup race where the
+    // Qdrant row landed before the skill cache was seeded). The render path
+    // drops it without surfacing it as a `missingSlugs` page-missing event —
+    // that status is reserved for on-disk concept pages, not catalog-derived
     // skill entries.
     stageTurn([{ slug: "skills/missing-skill", denseScore: 0.9 }]);
     // No `stageSkills` call — cache stays empty.
@@ -927,10 +928,16 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    // `toInject` still records the slug (it ranked into top-K) but the
-    // block collapses to null because the only entry was a cache miss.
-    expect(result.toInject).toEqual(["skills/missing-skill"]);
+    // The skill is excluded from `toInject` (and `everInjected`) so future
+    // per-turn runs re-attempt the attach once the cache is populated.
+    // `block` collapses to null because the only candidate was a cache miss.
+    expect(result.toInject).toEqual([]);
     expect(result.block).toBeNull();
+
+    // Persisted `everInjected` must not record the missing skill — that
+    // would block retry on a later turn until compaction-driven eviction.
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([]);
   });
 
   test("returns null when both concept pages and skills are empty", async () => {


### PR DESCRIPTION
## Summary
- Update the \`skill slugs whose entry is missing from the cache are dropped silently\` test in \`assistant/src/memory/v2/__tests__/injection.test.ts\` to match the new contract introduced by PR #30106: missing-cache skill slugs are excluded from \`toInject\` (and \`everInjected\`) so per-turn runs can retry once the cache is populated.
- Add a \`hydrate\` assertion confirming the missing skill is not persisted to \`everInjected\`, locking in the retry-allowed state.

## Original prompt
Fix the specific CI test failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/25592474384/job/75132410180 — \`injectMemoryV2Block > skill slugs whose entry is missing from the cache are dropped silently\` was failing on main because the test was not updated alongside PR #30106, which intentionally changed \`injectMemoryV2Block\` to drop skill cache misses from both \`toInject\` and \`everInjected\` so a startup race where the Qdrant row precedes the skill seed doesn't permanently mark the slug injected. Scope: just realign the test, no production code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->