### PR TITLE
feat(flags): add `bookmarks` client feature flag (default off)

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -194,6 +194,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "bookmarks",
+      "scope": "client",
+      "key": "bookmarks",
+      "label": "Message Bookmarks",
+      "description": "Show the bookmark icon on messages and enable the Bookmarks tab in Settings",
+      "defaultEnabled": false
+    },
+    {
       "id": "fork-from-message",
       "scope": "client",
       "key": "fork-from-message",


### PR DESCRIPTION
## Summary
- Adds the `bookmarks` client-scope flag (default off) so the upcoming Bookmark-message UI can be soft-launched.
- Modeled after the existing `fork-from-message` entry.

**Cross-repo follow-up required:** companion `vellum-assistant-platform` Terraform PR to register `bookmarks` in LaunchDarkly so the flag is flippable remotely. Local override via `~/.vellum/protected/feature-flags.json` works for development meanwhile.

Part of plan: bookmark-messages.md (PR 1 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->