### PR TITLE
feat(shared): add `BookmarkSummary` model

### DIFF
--- a/clients/shared/Network/BookmarkSummary.swift
+++ b/clients/shared/Network/BookmarkSummary.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// A bookmarked message, joined against its conversation for display.
+///
+/// Wire-compatible Swift mirror of the TypeScript `BookmarkSummary` type
+/// emitted by `assistant/src/memory/bookmark-crud.ts`. The daemon emits
+/// timestamps as unix-millisecond integers (matching the convention used
+/// across the rest of `clients/shared/Network/` for daemon-sourced
+/// types), so the wire fields are stored as `Int64` and exposed as
+/// `Date` via computed accessors.
+public struct BookmarkSummary: Codable, Identifiable, Equatable, Sendable, Hashable {
+    public let id: String
+    public let messageId: String
+    public let conversationId: String
+    public let conversationTitle: String?
+    public let messagePreview: String
+    /// "user" or "assistant".
+    public let messageRole: String
+    /// Unix-millisecond timestamp the underlying message was created.
+    public let messageCreatedAt: Int64
+    /// Unix-millisecond timestamp the bookmark itself was created.
+    public let createdAt: Int64
+
+    public var messageCreatedAtDate: Date {
+        Date(timeIntervalSince1970: TimeInterval(messageCreatedAt) / 1000)
+    }
+
+    public var createdAtDate: Date {
+        Date(timeIntervalSince1970: TimeInterval(createdAt) / 1000)
+    }
+
+    public init(
+        id: String,
+        messageId: String,
+        conversationId: String,
+        conversationTitle: String?,
+        messagePreview: String,
+        messageRole: String,
+        messageCreatedAt: Int64,
+        createdAt: Int64
+    ) {
+        self.id = id
+        self.messageId = messageId
+        self.conversationId = conversationId
+        self.conversationTitle = conversationTitle
+        self.messagePreview = messagePreview
+        self.messageRole = messageRole
+        self.messageCreatedAt = messageCreatedAt
+        self.createdAt = createdAt
+    }
+}
+
+/// Response shape for `GET /v1/bookmarks`.
+public struct BookmarksListResponse: Codable, Sendable {
+    public let bookmarks: [BookmarkSummary]
+
+    public init(bookmarks: [BookmarkSummary]) {
+        self.bookmarks = bookmarks
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the shared Codable `BookmarkSummary` and `BookmarksListResponse` types.
- Date decoding matches the existing convention in clients/shared/Network/.
- Intentionally unused at this point — PR 6 (BookmarkClient) is the first consumer.

Part of plan: bookmark-messages.md (PR 3 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->