### PR TITLE
feat(memory): add `message_bookmarks` table

### DIFF
--- a/assistant/src/memory/__tests__/bookmark-schema.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-schema.test.ts
@@ -1,0 +1,181 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../db-connection.js";
+import { migrateMessageBookmarks } from "../migrations/242-message-bookmarks.js";
+import * as schema from "../schema.js";
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+  pk: number;
+}
+
+interface IndexInfoRow {
+  name: string;
+  unique: number;
+}
+
+interface CountRow {
+  n: number;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/**
+ * Recreate just enough of the conversations + messages tables to exercise
+ * CASCADE behavior. We only need the columns the FKs reference (id) plus
+ * NOT NULL columns required to insert a row.
+ */
+function bootstrapMessageTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function seedConversationAndMessage(
+  raw: Database,
+  conversationId: string,
+  messageId: string,
+): void {
+  const now = Date.now();
+  raw
+    .query(
+      `INSERT INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+    )
+    .run(conversationId, "Example", now, now);
+  raw
+    .query(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(messageId, conversationId, "user", "hello", now);
+}
+
+function insertBookmark(
+  raw: Database,
+  id: string,
+  messageId: string,
+  conversationId: string,
+): void {
+  raw
+    .query(
+      `INSERT INTO message_bookmarks (id, message_id, conversation_id, created_at) VALUES (?, ?, ?, ?)`,
+    )
+    .run(id, messageId, conversationId, Date.now());
+}
+
+function countBookmarks(raw: Database): number {
+  const row = raw
+    .query(`SELECT COUNT(*) AS n FROM message_bookmarks`)
+    .get() as CountRow | null;
+  return row?.n ?? 0;
+}
+
+describe("message_bookmarks schema migration", () => {
+  test("creates table with expected columns and indexes", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapMessageTables(raw);
+
+    migrateMessageBookmarks(db);
+
+    const columns = raw
+      .query(`PRAGMA table_info(message_bookmarks)`)
+      .all() as ColumnRow[];
+    const byName = new Map(columns.map((c) => [c.name, c]));
+    expect(byName.get("id")?.pk).toBe(1);
+    expect(byName.get("id")?.type).toBe("TEXT");
+    expect(byName.get("message_id")?.notnull).toBe(1);
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("created_at")?.notnull).toBe(1);
+    expect(byName.get("created_at")?.type).toBe("INTEGER");
+
+    const indexes = raw
+      .query(`PRAGMA index_list(message_bookmarks)`)
+      .all() as IndexInfoRow[];
+    const indexByName = new Map(indexes.map((i) => [i.name, i]));
+    const uniqIndex = indexByName.get("message_bookmarks_message_id_uniq");
+    expect(uniqIndex).toBeDefined();
+    expect(uniqIndex?.unique).toBe(1);
+    expect(indexByName.get("message_bookmarks_created_at_idx")).toBeDefined();
+  });
+
+  test("CASCADE removes bookmark when parent message is deleted", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapMessageTables(raw);
+    migrateMessageBookmarks(db);
+
+    seedConversationAndMessage(raw, "conv-1", "msg-1");
+    insertBookmark(raw, "bm-1", "msg-1", "conv-1");
+    expect(countBookmarks(raw)).toBe(1);
+
+    raw.query(`DELETE FROM messages WHERE id = ?`).run("msg-1");
+    expect(countBookmarks(raw)).toBe(0);
+  });
+
+  test("CASCADE removes bookmark when parent conversation is deleted", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapMessageTables(raw);
+    migrateMessageBookmarks(db);
+
+    seedConversationAndMessage(raw, "conv-2", "msg-2");
+    insertBookmark(raw, "bm-2", "msg-2", "conv-2");
+    expect(countBookmarks(raw)).toBe(1);
+
+    raw.query(`DELETE FROM conversations WHERE id = ?`).run("conv-2");
+    // Deleting the conversation cascades to messages, which cascades to
+    // bookmarks. Either FK alone would suffice; both fire here.
+    expect(countBookmarks(raw)).toBe(0);
+  });
+
+  test("unique constraint on message_id rejects a second bookmark", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapMessageTables(raw);
+    migrateMessageBookmarks(db);
+
+    seedConversationAndMessage(raw, "conv-3", "msg-3");
+    insertBookmark(raw, "bm-3a", "msg-3", "conv-3");
+
+    expect(() => insertBookmark(raw, "bm-3b", "msg-3", "conv-3")).toThrow();
+    expect(countBookmarks(raw)).toBe(1);
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -115,6 +115,7 @@ import {
   migrateMemoryItemSupersession,
   migrateMemoryRecallLogsQueryContext,
   migrateMemoryV2ActivationLogs,
+  migrateMessageBookmarks,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -414,6 +415,7 @@ export function initializeDb(): void {
     migrateScheduleRetryPolicy,
     migrateTraceEventsCreatedAtIndex,
     migrateConversationInferenceProfileSession,
+    migrateMessageBookmarks,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/242-message-bookmarks.ts
+++ b/assistant/src/memory/migrations/242-message-bookmarks.ts
@@ -1,0 +1,38 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_message_bookmarks_v1";
+
+/**
+ * Create the message_bookmarks table for user-saved message bookmarks.
+ *
+ * Both foreign keys cascade so bookmarks are cleaned up automatically when
+ * their parent message or conversation is deleted. A unique index on
+ * message_id keeps the create-bookmark code path idempotent (a message can
+ * be bookmarked at most once at a time).
+ */
+export function migrateMessageBookmarks(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS message_bookmarks (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+        conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS message_bookmarks_message_id_uniq
+      ON message_bookmarks (message_id)
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS message_bookmarks_created_at_idx
+      ON message_bookmarks (created_at)
+    `);
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -203,6 +203,7 @@ export { migrateScheduleRetryPolicy } from "./238-schedule-retry-policy.js";
 export { migrateTraceEventsCreatedAtIndex } from "./239-trace-events-created-at-index.js";
 export { migrateConversationInferenceProfileSession } from "./240-conversation-inference-profile-session.js";
 export { migrateActivationStateFkCascade } from "./241-activation-state-fk-cascade.js";
+export { migrateMessageBookmarks } from "./242-message-bookmarks.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/bookmarks.ts
+++ b/assistant/src/memory/schema/bookmarks.ts
@@ -1,0 +1,38 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+import { conversations, messages } from "./conversations.js";
+
+/**
+ * User-saved bookmarks for individual messages. Surfaced in the macOS app
+ * Settings → Bookmarks tab and on the message hover overflow menu, behind the
+ * `bookmarks` client feature flag.
+ *
+ * Both foreign keys CASCADE so bookmarks disappear automatically when their
+ * parent message or conversation is deleted. A unique index on `message_id`
+ * keeps the create-bookmark path idempotent.
+ */
+export const messageBookmarks = sqliteTable(
+  "message_bookmarks",
+  {
+    id: text("id").primaryKey(),
+    messageId: text("message_id")
+      .notNull()
+      .references(() => messages.id, { onDelete: "cascade" }),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("message_bookmarks_message_id_uniq").on(table.messageId),
+    index("message_bookmarks_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export type MessageBookmarkRow = typeof messageBookmarks.$inferSelect;

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -1,4 +1,5 @@
 export * from "./acp.js";
+export * from "./bookmarks.js";
 export * from "./calls.js";
 export * from "./contacts.js";
 export * from "./conversations.js";


### PR DESCRIPTION
## Summary
- Adds drizzle schema and migration for the new `message_bookmarks` table (FK CASCADE on conversation/message deletion, unique on message_id).
- Schema-only PR — no CRUD helpers, routes, or UI yet (those land in subsequent PRs).
- Includes migration tests (table shape, CASCADE behavior, uniqueness).

Part of plan: bookmark-messages.md (PR 2 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->