### PR TITLE
feat(chat): support scrolling to a message by daemon message ID

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -6,6 +6,14 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MessageListView")
 
+/// Compound `task(id:)` key so the daemon-message-ID resolver re-fires both
+/// when the requested daemon ID changes and when the messages list grows
+/// (the matching row may not exist yet at the time the binding is set).
+struct AnchorDaemonResolveKey: Hashable {
+    let daemonId: String?
+    let messageCount: Int
+}
+
 extension MessageListView {
 
     // MARK: - onAppear
@@ -226,6 +234,18 @@ extension MessageListView {
                 scrollState.anchorTimeoutTask = nil
             }
         }
+    }
+
+    /// Resolves a daemon message ID to its client `UUID` once the messages list
+    /// contains a matching message, then assigns `anchorMessageId` to defer to
+    /// the existing UUID-based scroll-and-flash path. Cross-conversation jumps
+    /// from settings deep-links (e.g. Bookmarks) only have daemon IDs, not the
+    /// client-generated UUIDs that the scroll machinery expects.
+    func handleAnchorDaemonMessageIdTask() async {
+        guard let daemonId = anchorDaemonMessageId.wrappedValue else { return }
+        guard let match = messages.first(where: { $0.daemonMessageId == daemonId }) else { return }
+        anchorDaemonMessageId.wrappedValue = nil
+        anchorMessageId = match.id
     }
 
     // MARK: - Latest-turn pinning

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -72,6 +72,12 @@ struct MessageListView: View {
     /// When set, scroll to this message ID and clear the binding.
     /// Used by notification deep links to anchor the view to a specific message.
     @Binding var anchorMessageId: UUID?
+    /// When set, resolves a daemon message ID to its client `UUID` once the
+    /// matching message is loaded, then assigns `anchorMessageId` to trigger
+    /// the existing scroll-and-flash code path. Used by cross-conversation
+    /// deep links from settings panes (e.g. Bookmarks) that only have the
+    /// daemon (server-side) message ID, not the client-generated `UUID`.
+    var anchorDaemonMessageId: Binding<String?> = .constant(nil)
     /// Message ID to visually highlight after an anchor scroll completes.
     @Binding var highlightedMessageId: UUID?
     /// When false, disables interactive controls (buttons, actions) inside the
@@ -260,6 +266,9 @@ struct MessageListView: View {
                 #endif
             }
             .task(id: anchorMessageId) { await handleAnchorMessageTask() }
+            .task(id: AnchorDaemonResolveKey(daemonId: anchorDaemonMessageId.wrappedValue, messageCount: messages.count)) {
+                await handleAnchorDaemonMessageIdTask()
+            }
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
                 if let requestId = activePendingRequestId, scrollState.lastAutoFocusedRequestId != requestId,
                    let window = notification.object as? NSWindow,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -169,6 +169,11 @@ final class ConversationManager: ConversationRestorerDelegate {
         set { selectionStore.pendingAnchorMessageId = newValue }
     }
 
+    var pendingAnchorDaemonMessageId: String? {
+        get { selectionStore.pendingAnchorDaemonMessageId }
+        set { selectionStore.pendingAnchorDaemonMessageId = newValue }
+    }
+
     var highlightedMessageId: UUID? {
         get { selectionStore.highlightedMessageId }
         set { selectionStore.highlightedMessageId = newValue }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -42,6 +42,7 @@ final class ConversationSelectionStore {
             // on unrelated conversation switches.
             if let anchorConversation = pendingAnchorConversationId, anchorConversation != activeConversationId {
                 pendingAnchorMessageId = nil
+                pendingAnchorDaemonMessageId = nil
                 pendingAnchorConversationId = nil
             }
         }
@@ -105,6 +106,14 @@ final class ConversationSelectionStore {
 
     /// Pending anchor message ID for scroll-to behavior on notification deep links.
     var pendingAnchorMessageId: UUID?
+
+    /// Pending anchor message ID expressed as a daemon (server-side) message ID,
+    /// for callers that don't have the client-side `UUID` (e.g. cross-conversation
+    /// deep links from settings panes such as Bookmarks). The MessageListView
+    /// resolver maps this to the matching client `UUID` once the messages list
+    /// contains a message with that `daemonMessageId`, then triggers the existing
+    /// `pendingAnchorMessageId` scroll-and-flash path.
+    var pendingAnchorDaemonMessageId: String?
 
     /// Message ID to visually highlight after an anchor scroll completes.
     var highlightedMessageId: UUID?


### PR DESCRIPTION
## Summary
- Adds `anchorDaemonMessageId: String?` alongside the existing UUID-based `anchorMessageId`.
- New lifecycle hook resolves a daemon message ID to its client UUID once `messages` loads, then defers to the existing scroll-and-flash path.
- Pure plumbing — no UI changes, no callers yet. Used by the upcoming Bookmarks settings tab to jump cross-conversation from a deep-link.

Part of plan: bookmark-messages.md (PR 4 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->