### PR TITLE
feat(memory): add bookmark CRUD helpers

### DIFF
--- a/assistant/src/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-crud.test.ts
@@ -1,0 +1,214 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import {
+  createBookmark,
+  deleteBookmark,
+  deleteBookmarkByMessageId,
+  isMessageBookmarked,
+  listBookmarks,
+} from "../bookmark-crud.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { migrateMessageBookmarks } from "../migrations/242-message-bookmarks.js";
+import * as schema from "../schema.js";
+
+/**
+ * Recreate just enough of the conversations + messages tables to satisfy
+ * the bookmark JOIN and FK CASCADE behavior. The PR-2 schema test uses
+ * the same lightweight bootstrap.
+ */
+function bootstrapMessageTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+interface SeedOptions {
+  conversationId: string;
+  messageId: string;
+  conversationTitle?: string | null;
+  messageContent?: string;
+  messageRole?: string;
+  messageCreatedAt?: number;
+}
+
+function seedConversationAndMessage(raw: Database, opts: SeedOptions): void {
+  const now = Date.now();
+  raw
+    .query(
+      `INSERT INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+    )
+    .run(opts.conversationId, opts.conversationTitle ?? "Example", now, now);
+  raw
+    .query(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      opts.messageId,
+      opts.conversationId,
+      opts.messageRole ?? "user",
+      opts.messageContent ?? "hello",
+      opts.messageCreatedAt ?? now,
+    );
+}
+
+function setupDb(): { db: DrizzleDb; raw: Database } {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  const db = drizzle(sqlite, { schema });
+  const raw = getSqliteFrom(db);
+  bootstrapMessageTables(raw);
+  migrateMessageBookmarks(db);
+  return { db, raw };
+}
+
+describe("bookmark-crud", () => {
+  test("createBookmark is idempotent — second call returns the existing row", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-1",
+      messageId: "msg-1",
+    });
+
+    const first = createBookmark(db, {
+      messageId: "msg-1",
+      conversationId: "conv-1",
+    });
+    const second = createBookmark(db, {
+      messageId: "msg-1",
+      conversationId: "conv-1",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.createdAt).toBe(first.createdAt);
+
+    const all = listBookmarks(db);
+    expect(all.length).toBe(1);
+  });
+
+  test("listBookmarks returns rows newest-first and includes joined fields", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-A",
+      messageId: "msg-A",
+      conversationTitle: "Older",
+      messageContent: "first message",
+      messageRole: "user",
+    });
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-B",
+      messageId: "msg-B",
+      conversationTitle: "Newer",
+      messageContent: "second message",
+      messageRole: "assistant",
+    });
+
+    // Force deterministic ordering by inserting bookmarks with explicit
+    // created_at values 1 ms apart.
+    raw
+      .query(
+        `INSERT INTO message_bookmarks (id, message_id, conversation_id, created_at) VALUES (?, ?, ?, ?)`,
+      )
+      .run("bm-A", "msg-A", "conv-A", 1000);
+    raw
+      .query(
+        `INSERT INTO message_bookmarks (id, message_id, conversation_id, created_at) VALUES (?, ?, ?, ?)`,
+      )
+      .run("bm-B", "msg-B", "conv-B", 2000);
+
+    const result = listBookmarks(db);
+    expect(result.map((r) => r.id)).toEqual(["bm-B", "bm-A"]);
+    expect(result[0]?.conversationTitle).toBe("Newer");
+    expect(result[0]?.messagePreview).toBe("second message");
+    expect(result[0]?.messageRole).toBe("assistant");
+    expect(result[1]?.conversationTitle).toBe("Older");
+    expect(result[1]?.messageRole).toBe("user");
+  });
+
+  test("listBookmarks excludes bookmarks whose conversation no longer exists (CASCADE)", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-keep",
+      messageId: "msg-keep",
+    });
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-drop",
+      messageId: "msg-drop",
+    });
+    createBookmark(db, {
+      messageId: "msg-keep",
+      conversationId: "conv-keep",
+    });
+    createBookmark(db, {
+      messageId: "msg-drop",
+      conversationId: "conv-drop",
+    });
+    expect(listBookmarks(db).length).toBe(2);
+
+    // Deleting the parent conversation cascades through messages → bookmarks.
+    raw.query(`DELETE FROM conversations WHERE id = ?`).run("conv-drop");
+
+    const remaining = listBookmarks(db);
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.conversationId).toBe("conv-keep");
+  });
+
+  test("deleteBookmark returns false when the id does not exist", () => {
+    const { db } = setupDb();
+    expect(deleteBookmark(db, "does-not-exist")).toBe(false);
+  });
+
+  test("deleteBookmarkByMessageId removes the matching row", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-d",
+      messageId: "msg-d",
+    });
+    createBookmark(db, { messageId: "msg-d", conversationId: "conv-d" });
+    expect(listBookmarks(db).length).toBe(1);
+
+    expect(deleteBookmarkByMessageId(db, "msg-d")).toBe(true);
+    expect(listBookmarks(db).length).toBe(0);
+    // Calling again with no row present returns false.
+    expect(deleteBookmarkByMessageId(db, "msg-d")).toBe(false);
+  });
+
+  test("isMessageBookmarked is true after create, false after delete", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-x",
+      messageId: "msg-x",
+    });
+
+    expect(isMessageBookmarked(db, "msg-x")).toBe(false);
+    createBookmark(db, { messageId: "msg-x", conversationId: "conv-x" });
+    expect(isMessageBookmarked(db, "msg-x")).toBe(true);
+    expect(deleteBookmarkByMessageId(db, "msg-x")).toBe(true);
+    expect(isMessageBookmarked(db, "msg-x")).toBe(false);
+  });
+});

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -1,0 +1,168 @@
+import { desc, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import type { DrizzleDb } from "./db-connection.js";
+import {
+  conversations,
+  type MessageBookmarkRow,
+  messageBookmarks,
+  messages,
+} from "./schema.js";
+
+/**
+ * Wire-shape representation of a bookmark, joined with the bookmarked
+ * message and its parent conversation. Mirrors
+ * `clients/shared/Network/BookmarkSummary.swift` — dates are emitted as
+ * unix-millisecond integers, and the message preview is capped to keep
+ * the list payload bounded.
+ */
+export interface BookmarkSummary {
+  id: string;
+  messageId: string;
+  conversationId: string;
+  conversationTitle: string | null;
+  messagePreview: string;
+  /** "user" | "assistant" — kept as a free-form string so it round-trips raw. */
+  messageRole: string;
+  /** Unix milliseconds. */
+  messageCreatedAt: number;
+  /** Unix milliseconds. */
+  createdAt: number;
+}
+
+const PREVIEW_MAX_CHARS = 240;
+
+function buildPreview(content: string): string {
+  return content.length > PREVIEW_MAX_CHARS
+    ? content.slice(0, PREVIEW_MAX_CHARS)
+    : content;
+}
+
+/**
+ * List all bookmarks newest-first, joined against `messages` and
+ * `conversations`. Bookmarks whose parent message or conversation has
+ * been deleted are naturally excluded by the inner-join semantics; the
+ * `ON DELETE CASCADE` on the FKs means rows should never end up in this
+ * orphan state, but the join provides a defense-in-depth guarantee.
+ */
+export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
+  const rows = db
+    .select({
+      id: messageBookmarks.id,
+      messageId: messageBookmarks.messageId,
+      conversationId: messageBookmarks.conversationId,
+      createdAt: messageBookmarks.createdAt,
+      conversationTitle: conversations.title,
+      messageContent: messages.content,
+      messageRole: messages.role,
+      messageCreatedAt: messages.createdAt,
+    })
+    .from(messageBookmarks)
+    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
+    .innerJoin(
+      conversations,
+      eq(conversations.id, messageBookmarks.conversationId),
+    )
+    .orderBy(desc(messageBookmarks.createdAt))
+    .all();
+
+  return rows.map((row) => ({
+    id: row.id,
+    messageId: row.messageId,
+    conversationId: row.conversationId,
+    conversationTitle: row.conversationTitle,
+    messagePreview: buildPreview(row.messageContent),
+    messageRole: row.messageRole,
+    messageCreatedAt: row.messageCreatedAt,
+    createdAt: row.createdAt,
+  }));
+}
+
+/**
+ * Create a bookmark for the given message, returning the row. Idempotent
+ * on the unique `message_id` index — if a bookmark already exists for
+ * `messageId`, the existing row is returned and no new row is inserted.
+ */
+export function createBookmark(
+  db: DrizzleDb,
+  params: { messageId: string; conversationId: string },
+): MessageBookmarkRow {
+  const { messageId, conversationId } = params;
+  const existing = db
+    .select()
+    .from(messageBookmarks)
+    .where(eq(messageBookmarks.messageId, messageId))
+    .get();
+  if (existing) return existing;
+
+  const row: MessageBookmarkRow = {
+    id: uuid(),
+    messageId,
+    conversationId,
+    createdAt: Date.now(),
+  };
+
+  try {
+    db.insert(messageBookmarks).values(row).run();
+    return row;
+  } catch (err) {
+    // Lost a race against a concurrent create — fall back to fetch.
+    const winner = db
+      .select()
+      .from(messageBookmarks)
+      .where(eq(messageBookmarks.messageId, messageId))
+      .get();
+    if (winner) return winner;
+    throw err;
+  }
+}
+
+/**
+ * Delete a bookmark by id. Returns true iff a row was removed.
+ *
+ * Drizzle's high-level `.run()` is typed as `void` for the sync sqlite
+ * driver, so we check existence with a follow-up SELECT instead of
+ * relying on a row-count from the delete statement.
+ */
+export function deleteBookmark(db: DrizzleDb, id: string): boolean {
+  const existed = db
+    .select({ id: messageBookmarks.id })
+    .from(messageBookmarks)
+    .where(eq(messageBookmarks.id, id))
+    .get();
+  if (!existed) return false;
+  db.delete(messageBookmarks).where(eq(messageBookmarks.id, id)).run();
+  return true;
+}
+
+/**
+ * Delete the bookmark (if any) attached to the given `messageId`.
+ * Returns true iff a row was removed.
+ */
+export function deleteBookmarkByMessageId(
+  db: DrizzleDb,
+  messageId: string,
+): boolean {
+  const existed = db
+    .select({ id: messageBookmarks.id })
+    .from(messageBookmarks)
+    .where(eq(messageBookmarks.messageId, messageId))
+    .get();
+  if (!existed) return false;
+  db.delete(messageBookmarks)
+    .where(eq(messageBookmarks.messageId, messageId))
+    .run();
+  return true;
+}
+
+/**
+ * True iff a bookmark exists for the given `messageId`.
+ */
+export function isMessageBookmarked(db: DrizzleDb, messageId: string): boolean {
+  const row = db
+    .select({ id: messageBookmarks.id })
+    .from(messageBookmarks)
+    .where(eq(messageBookmarks.messageId, messageId))
+    .get();
+  return row != null;
+}


### PR DESCRIPTION
## Summary
- Adds typed CRUD helpers (`listBookmarks`, `createBookmark`, `deleteBookmark`, `deleteBookmarkByMessageId`, `isMessageBookmarked`) on top of the new `message_bookmarks` table.
- `createBookmark` is idempotent (returns the existing row on unique-constraint conflict).
- Exports a wire-shape `BookmarkSummary` TS type that mirrors `clients/shared/Network/BookmarkSummary.swift` (dates as unix-ms integers).
- 6 unit tests cover idempotency, ordering, CASCADE, deletion semantics, and existence check.

Part of plan: bookmark-messages.md (PR 5 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->