### PR TITLE
feat(runtime): add /v1/bookmarks routes and SSE events

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -15,6 +15,7 @@
 // Re-export domain modules (all individual types remain importable)
 export * from "./message-types/acp.js";
 export * from "./message-types/apps.js";
+export * from "./message-types/bookmarks.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
 export * from "./message-types/contacts.js";
@@ -52,6 +53,7 @@ import type {
   _AppsClientMessages,
   _AppsServerMessages,
 } from "./message-types/apps.js";
+import type { _BookmarksServerMessages } from "./message-types/bookmarks.js";
 import type {
   _BrowserClientMessages,
   _BrowserServerMessages,
@@ -205,6 +207,7 @@ export type ServerMessage =
   | _NotificationsServerMessages
   | _UpgradesServerMessages
   | _AcpServerMessages
+  | _BookmarksServerMessages
   | _DiskPressureServerMessages
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/bookmarks.ts
+++ b/assistant/src/daemon/message-types/bookmarks.ts
@@ -1,0 +1,21 @@
+// Bookmark events. Surfaced over SSE so a `BookmarkStore` instance in any
+// connected client can stay in sync when another window mutates the list.
+
+import type { BookmarkSummary } from "../../memory/bookmark-crud.js";
+
+export interface BookmarkCreated {
+  type: "bookmark.created";
+  bookmark: BookmarkSummary;
+}
+
+export interface BookmarkDeleted {
+  type: "bookmark.deleted";
+  /** Bookmark id when the delete happened by primary key. */
+  id?: string;
+  /** Message id when the delete happened by message id. */
+  messageId?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _BookmarksServerMessages = BookmarkCreated | BookmarkDeleted;

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -79,6 +79,46 @@ export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
 }
 
 /**
+ * Fetch a single bookmark by id in the same JOIN-shaped form as
+ * {@link listBookmarks}. Returns `null` if no row matches.
+ */
+export function getBookmarkSummary(
+  db: DrizzleDb,
+  id: string,
+): BookmarkSummary | null {
+  const row = db
+    .select({
+      id: messageBookmarks.id,
+      messageId: messageBookmarks.messageId,
+      conversationId: messageBookmarks.conversationId,
+      createdAt: messageBookmarks.createdAt,
+      conversationTitle: conversations.title,
+      messageContent: messages.content,
+      messageRole: messages.role,
+      messageCreatedAt: messages.createdAt,
+    })
+    .from(messageBookmarks)
+    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
+    .innerJoin(
+      conversations,
+      eq(conversations.id, messageBookmarks.conversationId),
+    )
+    .where(eq(messageBookmarks.id, id))
+    .get();
+  if (!row) return null;
+  return {
+    id: row.id,
+    messageId: row.messageId,
+    conversationId: row.conversationId,
+    conversationTitle: row.conversationTitle,
+    messagePreview: buildPreview(row.messageContent),
+    messageRole: row.messageRole,
+    messageCreatedAt: row.messageCreatedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
  * Create a bookmark for the given message, returning the row. Idempotent
  * on the unique `message_id` index — if a bookmark already exists for
  * `messageId`, the existing row is returned and no new row is inserted.

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the bookmark route handlers in `bookmark-routes.ts`.
+ *
+ * Covers:
+ *   - POST + GET round-trip
+ *   - POST idempotency (no duplicate row, same id returned)
+ *   - POST FK validation (unknown messageId → 4xx)
+ *   - DELETE /:id
+ *   - DELETE /by-message/:messageId
+ *   - SSE event publication on create AND delete
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture publish() invocations so the tests can assert on emitted events
+// without spinning up real SSE infrastructure.
+const publishCalls: unknown[] = [];
+
+mock.module("../../assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    publish: async (event: unknown) => {
+      publishCalls.push(event);
+    },
+    subscribe: () => () => {},
+  },
+}));
+
+import { getDb } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import {
+  conversations,
+  messageBookmarks,
+  messages,
+} from "../../../memory/schema.js";
+import { ROUTES as BOOKMARK_ROUTES } from "../bookmark-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// DB bootstrap
+// ---------------------------------------------------------------------------
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = BOOKMARK_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+const listHandler = findHandler("bookmarks_list");
+const createHandler = findHandler("bookmarks_create");
+const deleteHandler = findHandler("bookmarks_delete");
+const deleteByMessageHandler = findHandler("bookmarks_delete_by_message");
+
+function clearDb(): void {
+  const db = getDb();
+  // Bookmarks first (FK), then messages, then conversations.
+  db.delete(messageBookmarks).run();
+  db.delete(messages).run();
+  db.delete(conversations).run();
+}
+
+function seedConversationAndMessage(opts: {
+  conversationId: string;
+  messageId: string;
+  conversationTitle?: string;
+  messageContent?: string;
+  messageRole?: string;
+}): void {
+  const now = Date.now();
+  const db = getDb();
+  db.insert(conversations)
+    .values({
+      id: opts.conversationId,
+      title: opts.conversationTitle ?? "Test conversation",
+      createdAt: now,
+      updatedAt: now,
+      source: "test",
+      conversationType: "standard",
+      memoryScopeId: "default",
+    })
+    .run();
+  db.insert(messages)
+    .values({
+      id: opts.messageId,
+      conversationId: opts.conversationId,
+      role: opts.messageRole ?? "user",
+      content: opts.messageContent ?? "hello world",
+      createdAt: now,
+    })
+    .run();
+}
+
+async function call(
+  handler: RouteDefinition["handler"],
+  args: RouteHandlerArgs,
+): Promise<unknown> {
+  return await handler(args);
+}
+
+interface EventEnvelope {
+  message: { type: string; [key: string]: unknown };
+}
+
+function publishedTypes(): string[] {
+  return publishCalls.map((e) => (e as EventEnvelope).message.type);
+}
+
+beforeEach(() => {
+  clearDb();
+  publishCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bookmark routes", () => {
+  test("POST then GET returns the new bookmark", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-1",
+      messageId: "msg-1",
+      messageContent: "first message body",
+      messageRole: "assistant",
+    });
+
+    const created = (await call(createHandler, {
+      body: { messageId: "msg-1", conversationId: "conv-1" },
+    })) as { id: string; messageId: string; messagePreview: string };
+
+    expect(created.messageId).toBe("msg-1");
+    expect(created.messagePreview).toBe("first message body");
+
+    const listed = (await call(listHandler, {})) as {
+      bookmarks: Array<{ id: string; messageId: string }>;
+    };
+
+    expect(listed.bookmarks).toHaveLength(1);
+    expect(listed.bookmarks[0]?.id).toBe(created.id);
+    expect(listed.bookmarks[0]?.messageId).toBe("msg-1");
+  });
+
+  test("POST is idempotent — second call returns same id, no duplicate row", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-2",
+      messageId: "msg-2",
+    });
+
+    const first = (await call(createHandler, {
+      body: { messageId: "msg-2", conversationId: "conv-2" },
+    })) as { id: string };
+    const second = (await call(createHandler, {
+      body: { messageId: "msg-2", conversationId: "conv-2" },
+    })) as { id: string };
+
+    expect(second.id).toBe(first.id);
+
+    const listed = (await call(listHandler, {})) as {
+      bookmarks: unknown[];
+    };
+    expect(listed.bookmarks).toHaveLength(1);
+  });
+
+  test("POST with non-existent messageId returns a 4xx", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-3",
+      messageId: "msg-3",
+    });
+
+    let caught: unknown = null;
+    try {
+      await call(createHandler, {
+        body: { messageId: "missing-msg", conversationId: "conv-3" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).not.toBeNull();
+    // RouteError subclasses (BadRequestError, NotFoundError, …) carry a
+    // `statusCode` field that the HTTP adapter forwards to the wire — assert
+    // that we throw something in the 4xx range without coupling to the
+    // specific subclass.
+    const statusCode = (caught as { statusCode?: number }).statusCode;
+    expect(
+      typeof statusCode === "number" && statusCode >= 400 && statusCode < 500,
+    ).toBe(true);
+  });
+
+  test("DELETE /:id removes the row", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-4",
+      messageId: "msg-4",
+    });
+    const created = (await call(createHandler, {
+      body: { messageId: "msg-4", conversationId: "conv-4" },
+    })) as { id: string };
+
+    const result = (await call(deleteHandler, {
+      pathParams: { id: created.id },
+    })) as { success: boolean };
+    expect(result.success).toBe(true);
+
+    const listed = (await call(listHandler, {})) as { bookmarks: unknown[] };
+    expect(listed.bookmarks).toHaveLength(0);
+  });
+
+  test("DELETE /by-message/:messageId removes the row", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-5",
+      messageId: "msg-5",
+    });
+    await call(createHandler, {
+      body: { messageId: "msg-5", conversationId: "conv-5" },
+    });
+
+    const result = (await call(deleteByMessageHandler, {
+      pathParams: { messageId: "msg-5" },
+    })) as { success: boolean };
+    expect(result.success).toBe(true);
+
+    const listed = (await call(listHandler, {})) as { bookmarks: unknown[] };
+    expect(listed.bookmarks).toHaveLength(0);
+  });
+
+  test("publishes SSE events on create AND delete", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-6",
+      messageId: "msg-6",
+    });
+
+    const created = (await call(createHandler, {
+      body: { messageId: "msg-6", conversationId: "conv-6" },
+    })) as { id: string };
+
+    // Publishes are fire-and-forget (`.catch(...)`), so let any pending
+    // microtasks settle before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(publishedTypes()).toEqual(["bookmark.created"]);
+    const createdEvent = publishCalls[0] as EventEnvelope;
+    expect(createdEvent.message.type).toBe("bookmark.created");
+    expect(
+      (createdEvent.message as unknown as { bookmark: { id: string } }).bookmark
+        .id,
+    ).toBe(created.id);
+
+    publishCalls.length = 0;
+
+    await call(deleteHandler, { pathParams: { id: created.id } });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(publishedTypes()).toEqual(["bookmark.deleted"]);
+    const deletedEvent = publishCalls[0] as EventEnvelope;
+    expect((deletedEvent.message as unknown as { id?: string }).id).toBe(
+      created.id,
+    );
+  });
+
+  test("DELETE on a non-existent id does not publish", async () => {
+    await call(deleteHandler, { pathParams: { id: "does-not-exist" } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(publishCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -1,0 +1,190 @@
+/**
+ * Route handlers for message bookmarks.
+ *
+ * GET    /v1/bookmarks                      — list all bookmarks (newest first)
+ * POST   /v1/bookmarks                      — bookmark a message (idempotent)
+ * DELETE /v1/bookmarks/:id                  — remove a bookmark by id
+ * DELETE /v1/bookmarks/by-message/:messageId — remove the bookmark for a given message
+ *
+ * Mutating routes publish `bookmark.created` / `bookmark.deleted` events
+ * via `assistantEventHub` so any other connected client (e.g. a second
+ * macOS window) can refresh its `BookmarkStore` in lock-step.
+ */
+
+import { z } from "zod";
+
+import {
+  type BookmarkSummary,
+  createBookmark,
+  deleteBookmark,
+  deleteBookmarkByMessageId,
+  getBookmarkSummary,
+  listBookmarks,
+} from "../../memory/bookmark-crud.js";
+import { getMessageById } from "../../memory/conversation-crud.js";
+import { getDb } from "../../memory/db-connection.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("bookmark-routes");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function publishBookmarkCreated(bookmark: BookmarkSummary): void {
+  assistantEventHub
+    .publish(buildAssistantEvent({ type: "bookmark.created", bookmark }))
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish bookmark.created");
+    });
+}
+
+function publishBookmarkDeleted(payload: {
+  id?: string;
+  messageId?: string;
+}): void {
+  assistantEventHub
+    .publish(buildAssistantEvent({ type: "bookmark.deleted", ...payload }))
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish bookmark.deleted");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleListBookmarks(): { bookmarks: BookmarkSummary[] } {
+  return { bookmarks: listBookmarks(getDb()) };
+}
+
+function handleCreateBookmark({
+  body = {},
+}: RouteHandlerArgs): BookmarkSummary {
+  const messageId = body.messageId as string | undefined;
+  const conversationId = body.conversationId as string | undefined;
+
+  if (!messageId || typeof messageId !== "string") {
+    throw new BadRequestError("messageId is required");
+  }
+  if (!conversationId || typeof conversationId !== "string") {
+    throw new BadRequestError("conversationId is required");
+  }
+
+  // Validate the message belongs to the named conversation up-front. The FK
+  // constraints would also reject a bad insert, but explicit validation
+  // keeps the idempotent path from returning a previously-bookmarked row
+  // that happens to live under a different conversation id.
+  if (!getMessageById(messageId, conversationId)) {
+    throw new NotFoundError(
+      `Message ${messageId} not found in conversation ${conversationId}`,
+    );
+  }
+
+  const db = getDb();
+  const row = createBookmark(db, { messageId, conversationId });
+  const summary = getBookmarkSummary(db, row.id);
+  if (!summary) {
+    // Unreachable: we just inserted (or fetched) this row.
+    throw new Error(`Bookmark ${row.id} disappeared between insert and read`);
+  }
+  publishBookmarkCreated(summary);
+  return summary;
+}
+
+function handleDeleteBookmark({ pathParams = {} }: RouteHandlerArgs): {
+  success: true;
+} {
+  const id = pathParams.id;
+  if (!id) {
+    throw new BadRequestError("id is required");
+  }
+  const removed = deleteBookmark(getDb(), id);
+  if (removed) {
+    publishBookmarkDeleted({ id });
+  }
+  return { success: true };
+}
+
+function handleDeleteBookmarkByMessage({ pathParams = {} }: RouteHandlerArgs): {
+  success: true;
+} {
+  const messageId = pathParams.messageId;
+  if (!messageId) {
+    throw new BadRequestError("messageId is required");
+  }
+  const removed = deleteBookmarkByMessageId(getDb(), messageId);
+  if (removed) {
+    publishBookmarkDeleted({ messageId });
+  }
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+const bookmarkSummarySchema = z.object({
+  id: z.string(),
+  messageId: z.string(),
+  conversationId: z.string(),
+  conversationTitle: z.string().nullable(),
+  messagePreview: z.string(),
+  messageRole: z.string(),
+  messageCreatedAt: z.number(),
+  createdAt: z.number(),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "bookmarks_list",
+    endpoint: "bookmarks",
+    method: "GET",
+    summary: "List bookmarks",
+    description:
+      "Return all bookmarks (newest first), joined with their parent message and conversation.",
+    tags: ["bookmarks"],
+    responseBody: z.object({ bookmarks: z.array(bookmarkSummarySchema) }),
+    handler: handleListBookmarks,
+  },
+  {
+    operationId: "bookmarks_create",
+    endpoint: "bookmarks",
+    method: "POST",
+    summary: "Create a bookmark",
+    description:
+      "Bookmark the given message. Idempotent on `messageId` — calling twice returns the same bookmark.",
+    tags: ["bookmarks"],
+    requestBody: z.object({
+      messageId: z.string(),
+      conversationId: z.string(),
+    }),
+    responseBody: bookmarkSummarySchema,
+    handler: handleCreateBookmark,
+  },
+  {
+    operationId: "bookmarks_delete",
+    endpoint: "bookmarks/:id",
+    method: "DELETE",
+    summary: "Delete a bookmark",
+    description: "Delete a bookmark by id. Succeeds even if no row matched.",
+    tags: ["bookmarks"],
+    responseBody: z.object({ success: z.literal(true) }),
+    handler: handleDeleteBookmark,
+  },
+  {
+    operationId: "bookmarks_delete_by_message",
+    endpoint: "bookmarks/by-message/:messageId",
+    method: "DELETE",
+    summary: "Delete a bookmark by message id",
+    description:
+      "Delete the bookmark (if any) attached to the given message. Succeeds even if no row matched.",
+    tags: ["bookmarks"],
+    responseBody: z.object({ success: z.literal(true) }),
+    handler: handleDeleteBookmarkByMessage,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -17,6 +17,7 @@ import { ROUTES as AUDIO_ROUTES } from "./audio-routes.js";
 import { ROUTES as AVATAR_ROUTES } from "./avatar-routes.js";
 import { ROUTES as BACKGROUND_TOOL_ROUTES } from "./background-tool-routes.js";
 import { ROUTES as BACKUP_ROUTES } from "./backup-routes.js";
+import { ROUTES as BOOKMARK_ROUTES } from "./bookmark-routes.js";
 import { ROUTES as BRAIN_GRAPH_ROUTES } from "./brain-graph-routes.js";
 import { ROUTES as BROWSER_ROUTES } from "./browser-routes.js";
 import { ROUTES as BTW_ROUTES } from "./btw-routes.js";
@@ -120,6 +121,7 @@ export const ROUTES: RouteDefinition[] = [
   ...AVATAR_ROUTES,
   ...BACKGROUND_TOOL_ROUTES,
   ...BACKUP_ROUTES,
+  ...BOOKMARK_ROUTES,
   ...CACHE_ROUTES,
   ...CALL_ROUTES,
   ...CHANNEL_ROUTES,


### PR DESCRIPTION
## Summary
- Adds the four bookmark routes (list / create / delete by id / delete by message) on top of the PR 5 CRUD helpers.
- `POST /v1/bookmarks` is idempotent and validates that the message exists in the named conversation.
- Mutating routes publish `bookmark.{created,deleted}` events via `assistantEventHub` so the upcoming `BookmarkStore` can stay in sync across windows.
- Tests cover create-then-list, idempotency, FK validation, both delete shapes, and SSE event emission.

Part of plan: bookmark-messages.md (PR 7 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->