### PR TITLE
feat(macos): add observable `BookmarkStore`

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -371,6 +371,11 @@ extension AppDelegate {
                         await flagReloadTask.value
                         self?.diskPressureStatusStore.refreshForCurrentAssistant()
                     }
+                case .bookmarkCreated, .bookmarkDeleted:
+                    // Forward to BookmarkStore via NotificationCenter so any
+                    // BookmarkStore instance (in this window or another) can
+                    // refresh from the daemon's authoritative list.
+                    NotificationCenter.default.post(name: .bookmarkDidChange, object: nil)
                 // Host tool execution — run locally and post results back
                 case .hostBashRequest(let msg):
                     // Accept if the request is explicitly targeted at this client, OR if

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -6,6 +6,7 @@ import VellumAssistantShared
 public final class AppServices {
     public let connectionManager: GatewayConnectionManager
     let featureFlagStore: AssistantFeatureFlagStore
+    let bookmarkStore: BookmarkStore
     let diskPressureStatusStore: DiskPressureStatusStore
 
     public let authManager = AuthManager()
@@ -30,14 +31,23 @@ public final class AppServices {
     public init() {
         let connectionManager = GatewayConnectionManager()
         let featureFlagStore = AssistantFeatureFlagStore()
+        let bookmarkStore = BookmarkStore()
         self.connectionManager = connectionManager
         self.featureFlagStore = featureFlagStore
+        self.bookmarkStore = bookmarkStore
         diskPressureStatusStore = DiskPressureStatusStore(
             eventStreamClient: connectionManager.eventStreamClient,
             featureFlagEnabled: { key in
                 featureFlagStore.isEnabled(key)
             }
         )
+        // Hydrate bookmarks once at bootstrap so hover-time lookups via
+        // ``bookmarkedMessageIds`` are warm by the time the chat surface
+        // renders. Subsequent updates flow through the SSE-driven
+        // ``bookmarkDidChange`` notification.
+        Task { @MainActor in
+            await bookmarkStore.reload()
+        }
     }
 
     /// Reconfigure the connection for a new assistant.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -269,6 +269,11 @@ public final class MainWindow {
     public let windowState = MainWindowState()
     let documentManager = DocumentManager()
     private let assistantFeatureFlagStore: AssistantFeatureFlagStore
+    /// Long-lived store mirroring the daemon's bookmark list. Owned by
+    /// ``AppServices`` and passed through here so ``MainWindowView`` /
+    /// ``PanelCoordinator`` / ``SettingsPanel`` can observe the same
+    /// instance — UI consumers land in PRs 9-12.
+    private let bookmarkStore: BookmarkStore
     var onMicrophoneToggle: (() -> Void)?
     let liveVoiceChannelManager: LiveVoiceChannelManager
     let voiceModeManager: VoiceModeManager
@@ -327,6 +332,7 @@ public final class MainWindow {
         self.services = services
         self.updateManager = updateManager
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
+        self.bookmarkStore = services.bookmarkStore
         self.initialAssistantName = initialAssistantName
         let liveVoiceChannelManager = LiveVoiceChannelManager()
         self.liveVoiceChannelManager = liveVoiceChannelManager
@@ -472,7 +478,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, assistantFeatureFlagStore: assistantFeatureFlagStore, diskPressureStatusStore: services.diskPressureStatusStore, documentManager: documentManager, acpSessionStore: services.acpSessionStore, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback, initialAssistantName: initialAssistantName)
+        let rootView = MainWindowView(conversationManager: conversationManager, appListManager: appListManager, zoomManager: zoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, connectionManager: connectionManager, eventStreamClient: eventStreamClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, assistantFeatureFlagStore: assistantFeatureFlagStore, bookmarkStore: bookmarkStore, diskPressureStatusStore: services.diskPressureStatusStore, documentManager: documentManager, acpSessionStore: services.acpSessionStore, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, updateManager: updateManager, onSendWakeUp: wakeUpCallback, initialAssistantName: initialAssistantName)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -42,6 +42,11 @@ struct MainWindowView: View {
     /// invalidation policy — Observation still tracks property granularly.
     @Bindable var windowState: MainWindowState
     var assistantFeatureFlagStore: AssistantFeatureFlagStore
+    /// Long-lived ``BookmarkStore`` shared across panels. UI consumers
+    /// (hover star, sidebar bookmarks list, settings tab) wire up in
+    /// PRs 9-12; the dependency is threaded here ahead of time so those
+    /// PRs only have to add the read sites.
+    var bookmarkStore: BookmarkStore
     var diskPressureStatusStore: DiskPressureStatusStore
     @State var selectedConversationId: UUID?
     @State var sharing = SharingState()
@@ -122,7 +127,7 @@ struct MainWindowView: View {
     /// inside ``HomePageView``) so the selection survives any @ViewBuilder
     /// rebuild of the Home panel wrapper.
     @State var activeHomeDetailPanel: HomeDetailPanelKind? = nil
-    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, diskPressureStatusStore: DiskPressureStatusStore, documentManager: DocumentManager, acpSessionStore: ACPSessionStore, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil, initialAssistantName: String? = nil) {
+    init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, assistantFeatureFlagStore: AssistantFeatureFlagStore, bookmarkStore: BookmarkStore, diskPressureStatusStore: DiskPressureStatusStore, documentManager: DocumentManager, acpSessionStore: ACPSessionStore, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil, initialAssistantName: String? = nil) {
         self.conversationManager = conversationManager
         self.listStore = conversationManager.listStore
         self.appListManager = appListManager
@@ -137,6 +142,7 @@ struct MainWindowView: View {
         self.authManager = authManager
         self.windowState = windowState
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
+        self.bookmarkStore = bookmarkStore
         self.diskPressureStatusStore = diskPressureStatusStore
         self.documentManager = documentManager
         self.acpSessionStore = acpSessionStore

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -56,7 +56,7 @@ extension MainWindowView {
         case .chat:
             chatView
         case .settings:
-            SettingsPanel(onClose: { windowState.navigateBackOrDismiss() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
+            SettingsPanel(onClose: { windowState.navigateBackOrDismiss() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, bookmarkStore: bookmarkStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
                         message: "I'd like to enable an oauth integration. What integrations are available for me to connect to?",
                         forceNew: true
@@ -793,7 +793,7 @@ extension MainWindowView {
     func fullWindowPanel(_ panel: SidePanelType) -> some View {
         switch panel {
         case .settings:
-            SettingsPanel(onClose: { windowState.navigateBackOrDismiss() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
+            SettingsPanel(onClose: { windowState.navigateBackOrDismiss() }, store: settingsStore, connectionManager: connectionManager, conversationManager: conversationManager, authManager: authManager, assistantFeatureFlagStore: assistantFeatureFlagStore, bookmarkStore: bookmarkStore, showToast: { msg, style in windowState.showToast(message: msg, style: style) }, onEnableIntegration: {
                     conversationManager.openConversation(
                         message: "I'd like to enable an oauth integration. What integrations are available for me to connect to?",
                         forceNew: true

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -62,6 +62,10 @@ struct SettingsPanel: View {
     var conversationManager: ConversationManager
     var authManager: AuthManager
     var assistantFeatureFlagStore: AssistantFeatureFlagStore
+    /// Threaded through ahead of the dedicated bookmarks settings tab
+    /// landing in PR 12 so this PR doesn't have to revisit every call
+    /// site at the same time.
+    var bookmarkStore: BookmarkStore
     var showToast: (String, ToastInfo.Style) -> Void
     var onEnableIntegration: (() -> Void)?
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
@@ -75,6 +79,7 @@ struct SettingsPanel: View {
         conversationManager: ConversationManager,
         authManager: AuthManager,
         assistantFeatureFlagStore: AssistantFeatureFlagStore,
+        bookmarkStore: BookmarkStore,
         showToast: @escaping (String, ToastInfo.Style) -> Void,
         onEnableIntegration: (() -> Void)? = nil,
         featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
@@ -85,6 +90,7 @@ struct SettingsPanel: View {
         self.conversationManager = conversationManager
         self.authManager = authManager
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
+        self.bookmarkStore = bookmarkStore
         self.showToast = showToast
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient

--- a/clients/macos/vellum-assistant/Services/BookmarkStore.swift
+++ b/clients/macos/vellum-assistant/Services/BookmarkStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "BookmarkStore")
+
+/// Local mirror of the daemon's bookmark list. Acts as the single source of
+/// truth for hover-time "is this message bookmarked?" lookups
+/// (``bookmarkedMessageIds``) and for any UI that lists bookmarks
+/// (``bookmarks``). Mutations go through ``toggle(messageId:conversationId:)``,
+/// which optimistically updates local state and reconciles with a full
+/// ``reload()`` on error.
+///
+/// SSE events from the daemon (`bookmark.created` / `bookmark.deleted`,
+/// emitted by `bookmark-routes.ts` via `assistantEventHub`) are forwarded by
+/// the SSE router as ``Notification/Name/bookmarkDidChange`` posts so a
+/// second window mutating the list keeps every connected client in sync.
+///
+/// Mirrors the ``AssistantFeatureFlagStore`` Observable + NotificationCenter
+/// pattern so SwiftUI views are only invalidated when the specific properties
+/// they read change.
+@MainActor
+@Observable
+public final class BookmarkStore {
+    public private(set) var bookmarks: [BookmarkSummary] = []
+    public private(set) var bookmarkedMessageIds: Set<String> = []
+    public private(set) var isLoading: Bool = false
+
+    @ObservationIgnored private let client: BookmarkClientProtocol
+    @ObservationIgnored private var sseObserver: NSObjectProtocol?
+
+    public init(client: BookmarkClientProtocol = BookmarkClient()) {
+        self.client = client
+        subscribeToSSE()
+    }
+
+    deinit {
+        if let sseObserver {
+            NotificationCenter.default.removeObserver(sseObserver)
+        }
+    }
+
+    /// Fetch the authoritative bookmark list from the daemon and replace
+    /// local state. Call once at bootstrap, and whenever a `bookmark.*` SSE
+    /// event arrives from another window.
+    public func reload() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let fetched = try await client.listBookmarks()
+            bookmarks = fetched
+            bookmarkedMessageIds = Set(fetched.map(\.messageId))
+        } catch {
+            log.warning("Bookmark reload failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Toggle the bookmark for `messageId`. Optimistically mutates local
+    /// state so the UI updates instantly; on failure, recovers by issuing a
+    /// full ``reload()`` to drop back to the daemon's authoritative state.
+    public func toggle(messageId: String, conversationId: String) async {
+        if bookmarkedMessageIds.contains(messageId) {
+            bookmarkedMessageIds.remove(messageId)
+            bookmarks.removeAll { $0.messageId == messageId }
+            do {
+                _ = try await client.deleteBookmarkByMessageId(messageId)
+            } catch {
+                log.warning("Bookmark delete failed: \(error.localizedDescription, privacy: .public)")
+                await reload()
+            }
+        } else {
+            do {
+                let created = try await client.createBookmark(
+                    messageId: messageId,
+                    conversationId: conversationId
+                )
+                // Idempotent insert: an SSE-driven reload may have landed the
+                // same row first, so guard against the duplicate.
+                if !bookmarkedMessageIds.contains(created.messageId) {
+                    bookmarkedMessageIds.insert(created.messageId)
+                    bookmarks.insert(created, at: 0)
+                }
+            } catch {
+                log.warning("Bookmark create failed: \(error.localizedDescription, privacy: .public)")
+                await reload()
+            }
+        }
+    }
+
+    private func subscribeToSSE() {
+        sseObserver = NotificationCenter.default.addObserver(
+            forName: .bookmarkDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { await self?.reload() }
+        }
+    }
+}
+
+extension Notification.Name {
+    /// Posted by the SSE router when the daemon emits `bookmark.created` or
+    /// `bookmark.deleted`. ``BookmarkStore`` listens for this and triggers a
+    /// full reload so every window stays in sync with the daemon.
+    public static let bookmarkDidChange = Notification.Name("bookmarkDidChange")
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2258,6 +2258,42 @@ public struct MeetSpeakingEndedMessage: Decodable, Sendable, Equatable {
     }
 }
 
+// MARK: - Bookmark events
+//
+// Wire-compatible mirror of `assistant/src/daemon/message-types/bookmarks.ts`.
+// Emitted by `bookmark-routes.ts` after every mutation so other connected
+// clients (e.g. a second macOS window) can refresh their `BookmarkStore` in
+// lock-step. The dotted `type` strings (`bookmark.created` / `bookmark.deleted`)
+// match the daemon's serialization; the SSE router translates them into
+// `.bookmarkDidChange` notifications and `BookmarkStore` reloads on receipt.
+
+/// A new bookmark was created on the daemon.
+public struct BookmarkCreatedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let bookmark: BookmarkSummary
+
+    public init(type: String, bookmark: BookmarkSummary) {
+        self.type = type
+        self.bookmark = bookmark
+    }
+}
+
+/// An existing bookmark was deleted on the daemon. Either `id` (delete by
+/// primary key) or `messageId` (delete by message id) will be set; clients
+/// that need to react to a specific bookmark removal can prefer whichever
+/// identifier they already have indexed.
+public struct BookmarkDeletedMessage: Decodable, Sendable, Equatable {
+    public let type: String
+    public let id: String?
+    public let messageId: String?
+
+    public init(type: String, id: String? = nil, messageId: String? = nil) {
+        self.type = type
+        self.id = id
+        self.messageId = messageId
+    }
+}
+
 /// Payload posted back to the daemon with the result of a host CU action execution.
 public struct HostCuResultPayload: Codable, Sendable {
     public let requestId: String
@@ -2986,6 +3022,8 @@ public enum ServerMessage: Decodable, Sendable {
     case meetError(MeetErrorMessage)
     case meetSpeakingStarted(MeetSpeakingStartedMessage)
     case meetSpeakingEnded(MeetSpeakingEndedMessage)
+    case bookmarkCreated(BookmarkCreatedMessage)
+    case bookmarkDeleted(BookmarkDeletedMessage)
     case contextCompacted(ContextCompacted)
     case usageUpdate(UsageUpdate)
     case compactionCircuitOpen(CompactionCircuitOpen)
@@ -3542,6 +3580,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "meet.speaking_ended":
             let message = try MeetSpeakingEndedMessage(from: decoder)
             self = .meetSpeakingEnded(message)
+        case "bookmark.created":
+            let message = try BookmarkCreatedMessage(from: decoder)
+            self = .bookmarkCreated(message)
+        case "bookmark.deleted":
+            let message = try BookmarkDeletedMessage(from: decoder)
+            self = .bookmarkDeleted(message)
         case "relationship_state_updated":
             let payloadContainer = try decoder.container(keyedBy: InlinePayloadKeys.self)
             let updatedAt = try payloadContainer.decode(String.self, forKey: .updatedAt)


### PR DESCRIPTION
## Summary
- Adds the `@MainActor @Observable BookmarkStore` that owns the local mirror of bookmarks and exposes `bookmarkedMessageIds` for fast hover-time lookup.
- `toggle()` is optimistic with reload-on-error recovery.
- Subscribes to a new `.bookmarkDidChange` notification posted by the SSE event router on `bookmark.created`/`bookmark.deleted` events from the daemon.
- Constructed at bootstrap alongside `AssistantFeatureFlagStore` and threaded into `PanelCoordinator` / `SettingsPanel` for upcoming UI consumers (PRs 9-12).

Part of plan: bookmark-messages.md (PR 8 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->