### PR TITLE
feat(chat): add bookmark icon to message hover overflow menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -26,6 +26,9 @@ struct ChatBubbleOverflowMenu: View {
     let showInspectButton: Bool
     var onForkFromMessage: ((String) -> Void)?
     var onInspectMessage: ((String?) -> Void)?
+    var bookmarkStore: BookmarkStore?
+    var onToggleBookmark: ((String, String) -> Void)?
+    var conversationId: String?
 
     @State private var audioPlayer = MessageAudioPlayer()
     @State private var showCopyConfirmation = false
@@ -46,8 +49,12 @@ struct ChatBubbleOverflowMenu: View {
         onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("fork-from-message")
     }
 
+    private var canBookmarkMessage: Bool {
+        onToggleBookmark != nil && bookmarkStore != nil && message.daemonMessageId != nil && conversationId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("bookmarks")
+    }
+
     private var hasOverflowActions: Bool {
-        hasCopyableText || canInspectMessage || canForkFromMessage
+        hasCopyableText || canInspectMessage || canForkFromMessage || canBookmarkMessage
     }
 
     private var showOverflowMenu: Bool {
@@ -155,6 +162,22 @@ struct ChatBubbleOverflowMenu: View {
                 }
                 .equatable()
                 .vTooltip("Inspect", edge: .bottom)
+            }
+            if let onToggleBookmark, let store = bookmarkStore,
+               let daemonMessageId = message.daemonMessageId,
+               let conversationId,
+               !message.isStreaming,
+               MacOSClientFeatureFlagManager.shared.isEnabled("bookmarks") {
+                let isBookmarked = store.bookmarkedMessageIds.contains(daemonMessageId)
+                ChatEquatableButton(
+                    label: isBookmarked ? "Remove bookmark" : "Bookmark message",
+                    iconOnly: VIcon.bookmark.rawValue,
+                    iconColorRole: isBookmarked ? .primaryBase : .contentTertiary
+                ) {
+                    onToggleBookmark(daemonMessageId, conversationId)
+                }
+                .equatable()
+                .vTooltip(isBookmarked ? "Bookmarked" : "Bookmark", edge: .bottom)
             }
         }
         .textSelection(.disabled)


### PR DESCRIPTION
## Summary
- Adds the fourth (bookmark) icon to `ChatBubbleOverflowMenu` alongside Copy / Fork / Inspect, gated on the `bookmarks` client flag.
- Renders filled (primary color) when the message is already bookmarked, outlined (tertiary) otherwise.
- New `bookmarkStore`, `onToggleBookmark`, `conversationId` props are optional and default to nil, so this PR is a safe no-op until PR 10 wires the parents.

Part of plan: bookmark-messages.md (PR 9 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->