### PR TITLE
fix(chat): add primaryBase case to ChatButtonColorRole

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
@@ -10,12 +10,14 @@ enum ChatButtonColorRole: Equatable, Hashable {
     case contentTertiary
     case systemPositiveStrong
     case systemNegativeStrong
+    case primaryBase
 
     var resolved: Color {
         switch self {
         case .contentTertiary: VColor.contentTertiary
         case .systemPositiveStrong: VColor.systemPositiveStrong
         case .systemNegativeStrong: VColor.systemNegativeStrong
+        case .primaryBase: VColor.primaryBase
         }
     }
 }

--- a/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
@@ -177,6 +177,10 @@ struct ChatButtonColorRoleTests {
     @Test func systemNegativeStrongResolvesCorrectly() {
         #expect(ChatButtonColorRole.systemNegativeStrong.resolved == VColor.systemNegativeStrong)
     }
+
+    @Test func primaryBaseResolvesCorrectly() {
+        #expect(ChatButtonColorRole.primaryBase.resolved == VColor.primaryBase)
+    }
 }
 
 // MARK: - ChatEquatableButton Equality


### PR DESCRIPTION
## Summary
- Adds the missing \`primaryBase\` case to \`ChatButtonColorRole\` (mapping to \`VColor.primaryBase\`), restoring the macOS build broken by #30120.
- The bookmark overflow-menu button in \`ChatBubbleOverflowMenu.swift\` already references \`.primaryBase\`; this fix wires up the enum so the reference compiles.
- Adds a parity unit test alongside the existing role-resolution tests.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25595486730/job/75140593020

The \`macOS Tests / Run tests\` job on \`main\` was failing with \`type 'ChatButtonColorRole' has no member 'primaryBase'\` at \`ChatBubbleOverflowMenu.swift:175\`. The fix is scoped to the enum definition and a single test addition.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->