### PR TITLE
fix(auth): register route policies for /v1/bookmarks endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -430,6 +430,12 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Queued message deletion
   { endpoint: "messages/queued", scopes: ["chat.write"] },
 
+  // Bookmarks (DELETE /bookmarks/:id strips the :id segment to "bookmarks")
+  { endpoint: "bookmarks:GET", scopes: ["chat.read"] },
+  { endpoint: "bookmarks:POST", scopes: ["chat.write"] },
+  { endpoint: "bookmarks:DELETE", scopes: ["chat.write"] },
+  { endpoint: "bookmarks/by-message:DELETE", scopes: ["chat.write"] },
+
   // Interfaces
   { endpoint: "interfaces", scopes: ["settings.read"] },
 


### PR DESCRIPTION
## Summary
- Register `bookmarks:GET`, `bookmarks:POST`, `bookmarks:DELETE`, and `bookmarks/by-message:DELETE` in `route-policy.ts` so the new bookmark routes added in #30118 satisfy `guard-tests.test.ts`'s route-policy-coverage check.
- Use `chat.read` for the list endpoint and `chat.write` for the mutating endpoints, matching how `messages:GET`/`messages:POST` and similar chat-scoped resources are gated today.

## Original prompt
Fix the specific CI failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/25594599225/job/75138242565 (the "Test" job on main). `guard-tests.test.ts` flagged `bookmarks` and `bookmarks/by-message` as endpoints dispatched in the route table without a corresponding entry in `route-policy.ts`, after PR #30118 added the new `/v1/bookmarks` routes. Address only that failure — leave the separate OpenAPI-spec staleness job alone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->