### PR TITLE
fix(bookmarks): decode message content for preview + drop dead code

### DIFF
--- a/assistant/src/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-crud.test.ts
@@ -7,7 +7,6 @@ import {
   createBookmark,
   deleteBookmark,
   deleteBookmarkByMessageId,
-  isMessageBookmarked,
   listBookmarks,
 } from "../bookmark-crud.js";
 import type { DrizzleDb } from "../db-connection.js";
@@ -111,6 +110,27 @@ describe("bookmark-crud", () => {
     expect(all.length).toBe(1);
   });
 
+  test("createBookmark returns the JOIN-shaped summary directly", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-summary",
+      messageId: "msg-summary",
+      conversationTitle: "Title goes here",
+      messageContent: "summary body",
+      messageRole: "assistant",
+    });
+
+    const summary = createBookmark(db, {
+      messageId: "msg-summary",
+      conversationId: "conv-summary",
+    });
+
+    expect(summary.conversationTitle).toBe("Title goes here");
+    expect(summary.messagePreview).toBe("summary body");
+    expect(summary.messageRole).toBe("assistant");
+    expect(typeof summary.messageCreatedAt).toBe("number");
+  });
+
   test("listBookmarks returns rows newest-first and includes joined fields", () => {
     const { db, raw } = setupDb();
     seedConversationAndMessage(raw, {
@@ -198,17 +218,47 @@ describe("bookmark-crud", () => {
     expect(deleteBookmarkByMessageId(db, "msg-d")).toBe(false);
   });
 
-  test("isMessageBookmarked is true after create, false after delete", () => {
+  test("messagePreview decodes JSON-serialized ContentBlock[] rows", () => {
     const { db, raw } = setupDb();
     seedConversationAndMessage(raw, {
-      conversationId: "conv-x",
-      messageId: "msg-x",
+      conversationId: "conv-blocks",
+      messageId: "msg-blocks",
+      messageContent: JSON.stringify([
+        { type: "text", text: "Hello, can you help with…" },
+      ]),
+      messageRole: "user",
     });
 
-    expect(isMessageBookmarked(db, "msg-x")).toBe(false);
-    createBookmark(db, { messageId: "msg-x", conversationId: "conv-x" });
-    expect(isMessageBookmarked(db, "msg-x")).toBe(true);
-    expect(deleteBookmarkByMessageId(db, "msg-x")).toBe(true);
-    expect(isMessageBookmarked(db, "msg-x")).toBe(false);
+    const summary = createBookmark(db, {
+      messageId: "msg-blocks",
+      conversationId: "conv-blocks",
+    });
+
+    // Without the decode step, this would render as the raw JSON literal
+    // (`[{"type":"text","text":"…"}]`) rather than the spoken text.
+    expect(summary.messagePreview).toBe("Hello, can you help with…");
+    const listed = listBookmarks(db);
+    expect(listed[0]?.messagePreview).toBe("Hello, can you help with…");
+  });
+
+  test("messagePreview concatenates multi-text blocks and drops non-text blocks", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-multi",
+      messageId: "msg-multi",
+      messageContent: JSON.stringify([
+        { type: "text", text: "first paragraph" },
+        { type: "tool_use", id: "x", name: "noop", input: {} },
+        { type: "text", text: "second paragraph" },
+      ]),
+      messageRole: "assistant",
+    });
+
+    const summary = createBookmark(db, {
+      messageId: "msg-multi",
+      conversationId: "conv-multi",
+    });
+
+    expect(summary.messagePreview).toBe("first paragraph\nsecond paragraph");
   });
 });

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -2,12 +2,8 @@ import { desc, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { DrizzleDb } from "./db-connection.js";
-import {
-  conversations,
-  type MessageBookmarkRow,
-  messageBookmarks,
-  messages,
-} from "./schema.js";
+import { stringifyMessageContent } from "./message-content.js";
+import { conversations, messageBookmarks, messages } from "./schema.js";
 
 /**
  * Wire-shape representation of a bookmark, joined with the bookmarked
@@ -32,80 +28,46 @@ export interface BookmarkSummary {
 
 const PREVIEW_MAX_CHARS = 240;
 
+/**
+ * Decode the on-disk message content (legacy plain string OR JSON-serialized
+ * `ContentBlock[]`) into a single text string and cap it at
+ * `PREVIEW_MAX_CHARS`. Without the decode step, modern rows would render as
+ * raw JSON in the bookmark list.
+ */
 function buildPreview(content: string): string {
-  return content.length > PREVIEW_MAX_CHARS
-    ? content.slice(0, PREVIEW_MAX_CHARS)
-    : content;
+  const text = stringifyMessageContent(content);
+  return text.length > PREVIEW_MAX_CHARS
+    ? text.slice(0, PREVIEW_MAX_CHARS)
+    : text;
 }
 
 /**
- * List all bookmarks newest-first, joined against `messages` and
- * `conversations`. Bookmarks whose parent message or conversation has
- * been deleted are naturally excluded by the inner-join semantics; the
- * `ON DELETE CASCADE` on the FKs means rows should never end up in this
- * orphan state, but the join provides a defense-in-depth guarantee.
+ * Shared SELECT shape used by the JOIN-based readers. Pulling this out
+ * avoids duplicating the column list and the row-mapping below.
  */
-export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
-  const rows = db
-    .select({
-      id: messageBookmarks.id,
-      messageId: messageBookmarks.messageId,
-      conversationId: messageBookmarks.conversationId,
-      createdAt: messageBookmarks.createdAt,
-      conversationTitle: conversations.title,
-      messageContent: messages.content,
-      messageRole: messages.role,
-      messageCreatedAt: messages.createdAt,
-    })
-    .from(messageBookmarks)
-    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
-    .innerJoin(
-      conversations,
-      eq(conversations.id, messageBookmarks.conversationId),
-    )
-    .orderBy(desc(messageBookmarks.createdAt))
-    .all();
+const BOOKMARK_JOIN_COLUMNS = {
+  id: messageBookmarks.id,
+  messageId: messageBookmarks.messageId,
+  conversationId: messageBookmarks.conversationId,
+  createdAt: messageBookmarks.createdAt,
+  conversationTitle: conversations.title,
+  messageContent: messages.content,
+  messageRole: messages.role,
+  messageCreatedAt: messages.createdAt,
+} as const;
 
-  return rows.map((row) => ({
-    id: row.id,
-    messageId: row.messageId,
-    conversationId: row.conversationId,
-    conversationTitle: row.conversationTitle,
-    messagePreview: buildPreview(row.messageContent),
-    messageRole: row.messageRole,
-    messageCreatedAt: row.messageCreatedAt,
-    createdAt: row.createdAt,
-  }));
-}
+type BookmarkJoinRow = {
+  id: string;
+  messageId: string;
+  conversationId: string;
+  createdAt: number;
+  conversationTitle: string | null;
+  messageContent: string;
+  messageRole: string;
+  messageCreatedAt: number;
+};
 
-/**
- * Fetch a single bookmark by id in the same JOIN-shaped form as
- * {@link listBookmarks}. Returns `null` if no row matches.
- */
-export function getBookmarkSummary(
-  db: DrizzleDb,
-  id: string,
-): BookmarkSummary | null {
-  const row = db
-    .select({
-      id: messageBookmarks.id,
-      messageId: messageBookmarks.messageId,
-      conversationId: messageBookmarks.conversationId,
-      createdAt: messageBookmarks.createdAt,
-      conversationTitle: conversations.title,
-      messageContent: messages.content,
-      messageRole: messages.role,
-      messageCreatedAt: messages.createdAt,
-    })
-    .from(messageBookmarks)
-    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
-    .innerJoin(
-      conversations,
-      eq(conversations.id, messageBookmarks.conversationId),
-    )
-    .where(eq(messageBookmarks.id, id))
-    .get();
-  if (!row) return null;
+function rowToSummary(row: BookmarkJoinRow): BookmarkSummary {
   return {
     id: row.id,
     messageId: row.messageId,
@@ -118,43 +80,78 @@ export function getBookmarkSummary(
   };
 }
 
+function selectBookmarkJoin(db: DrizzleDb) {
+  return db
+    .select(BOOKMARK_JOIN_COLUMNS)
+    .from(messageBookmarks)
+    .innerJoin(messages, eq(messages.id, messageBookmarks.messageId))
+    .innerJoin(
+      conversations,
+      eq(conversations.id, messageBookmarks.conversationId),
+    );
+}
+
 /**
- * Create a bookmark for the given message, returning the row. Idempotent
- * on the unique `message_id` index — if a bookmark already exists for
- * `messageId`, the existing row is returned and no new row is inserted.
+ * List all bookmarks newest-first, joined against `messages` and
+ * `conversations`. Bookmarks whose parent message or conversation has
+ * been deleted are naturally excluded by the inner-join semantics; the
+ * `ON DELETE CASCADE` on the FKs means rows should never end up in this
+ * orphan state, but the join provides a defense-in-depth guarantee.
+ */
+export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
+  const rows = selectBookmarkJoin(db)
+    .orderBy(desc(messageBookmarks.createdAt))
+    .all();
+  return rows.map(rowToSummary);
+}
+
+/**
+ * Create a bookmark for the given message and return its JOIN-shaped
+ * {@link BookmarkSummary}. Idempotent on the unique `message_id` index —
+ * if a bookmark already exists for `messageId`, the existing summary is
+ * returned and no new row is inserted.
  */
 export function createBookmark(
   db: DrizzleDb,
   params: { messageId: string; conversationId: string },
-): MessageBookmarkRow {
+): BookmarkSummary {
   const { messageId, conversationId } = params;
   const existing = db
-    .select()
+    .select({ id: messageBookmarks.id })
     .from(messageBookmarks)
     .where(eq(messageBookmarks.messageId, messageId))
     .get();
-  if (existing) return existing;
+  if (existing) return readBookmarkSummaryOrThrow(db, existing.id);
 
-  const row: MessageBookmarkRow = {
-    id: uuid(),
-    messageId,
-    conversationId,
-    createdAt: Date.now(),
-  };
-
+  const id = uuid();
   try {
-    db.insert(messageBookmarks).values(row).run();
-    return row;
+    db.insert(messageBookmarks)
+      .values({ id, messageId, conversationId, createdAt: Date.now() })
+      .run();
   } catch (err) {
-    // Lost a race against a concurrent create — fall back to fetch.
+    // Lost a race against a concurrent create — fall back to fetch by
+    // messageId so we still return the winning row.
     const winner = db
-      .select()
+      .select({ id: messageBookmarks.id })
       .from(messageBookmarks)
       .where(eq(messageBookmarks.messageId, messageId))
       .get();
-    if (winner) return winner;
-    throw err;
+    if (!winner) throw err;
+    return readBookmarkSummaryOrThrow(db, winner.id);
   }
+  return readBookmarkSummaryOrThrow(db, id);
+}
+
+function readBookmarkSummaryOrThrow(
+  db: DrizzleDb,
+  id: string,
+): BookmarkSummary {
+  const row = selectBookmarkJoin(db).where(eq(messageBookmarks.id, id)).get();
+  if (!row) {
+    // Unreachable: caller just observed (or inserted) this id.
+    throw new Error(`Bookmark ${id} disappeared between insert and read`);
+  }
+  return rowToSummary(row);
 }
 
 /**
@@ -193,16 +190,4 @@ export function deleteBookmarkByMessageId(
     .where(eq(messageBookmarks.messageId, messageId))
     .run();
   return true;
-}
-
-/**
- * True iff a bookmark exists for the given `messageId`.
- */
-export function isMessageBookmarked(db: DrizzleDb, messageId: string): boolean {
-  const row = db
-    .select({ id: messageBookmarks.id })
-    .from(messageBookmarks)
-    .where(eq(messageBookmarks.messageId, messageId))
-    .get();
-  return row != null;
 }

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -121,11 +121,48 @@ export function extractMediaBlockMeta(
   }
 }
 
-
 function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
     return "<unserializable />";
   }
+}
+
+/**
+ * Coerce stored message content into a single human-readable text string,
+ * dropping non-text blocks (images, tool calls, tool results, thinking,
+ * …). Used by call sites that want only the spoken text — sweep-model
+ * context, RAG backfill, bookmark previews. For richer renderings that
+ * include tool metadata, use {@link extractTextFromStoredMessageContent}
+ * instead.
+ *
+ * Handles the two on-disk shapes:
+ *   - Modern rows: JSON-serialized `ContentBlock[]`
+ *   - Legacy rows: plain string
+ *
+ * Parse failures fall back to returning the raw input trimmed (the
+ * legacy-string path).
+ */
+export function stringifyMessageContent(stored: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return stored.trim();
+  }
+  if (typeof parsed === "string") return parsed.trim();
+  if (!Array.isArray(parsed)) return "";
+  const parts: string[] = [];
+  for (const block of parsed) {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: string }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      parts.push((block as { text: string }).text);
+    }
+  }
+  return parts.join("\n").trim();
 }

--- a/assistant/src/memory/v2/backfill-jobs.ts
+++ b/assistant/src/memory/v2/backfill-jobs.ts
@@ -26,6 +26,7 @@ import { listConversations } from "../conversation-queries.js";
 import { getDb } from "../db-connection.js";
 import { enqueueEmbedConceptPageJob } from "../jobs/embed-concept-page.js";
 import type { MemoryJob } from "../jobs-store.js";
+import { stringifyMessageContent } from "../message-content.js";
 import {
   computeOwnActivation,
   selectCandidates,
@@ -286,32 +287,4 @@ function lastExchangeTexts(conversationId: string): {
     if (userText && assistantText) break;
   }
   return { userText, assistantText };
-}
-
-/**
- * Coerce stored message content (JSON-serialized `ContentBlock[]` *or* plain
- * string in legacy rows) into a single text string. Image / tool blocks are
- * dropped — recompute only needs the spoken text.
- */
-function stringifyMessageContent(stored: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stored);
-  } catch {
-    return stored.trim();
-  }
-  if (typeof parsed === "string") return parsed.trim();
-  if (!Array.isArray(parsed)) return "";
-  const parts: string[] = [];
-  for (const block of parsed) {
-    if (
-      block &&
-      typeof block === "object" &&
-      (block as { type?: string }).type === "text" &&
-      typeof (block as { text?: unknown }).text === "string"
-    ) {
-      parts.push((block as { text: string }).text);
-    }
-  }
-  return parts.join("\n").trim();
 }

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -41,6 +41,7 @@ import {
   formatRememberEntry,
 } from "../graph/tool-handlers.js";
 import type { MemoryJob } from "../jobs-store.js";
+import { stringifyMessageContent } from "../message-content.js";
 import { conversations, messages } from "../schema.js";
 import { renderSweepPrompt } from "./prompts/sweep.js";
 
@@ -255,34 +256,6 @@ function loadRecentMessagesText(nowMs: number): string {
     joined = joined.slice(joined.length - MAX_RECENT_TEXT_CHARS);
   }
   return joined;
-}
-
-/**
- * Coerce stored message content (JSON-serialized `ContentBlock[]` *or* plain
- * string in legacy rows) into a single text string. Image / tool blocks are
- * dropped — the sweep model only needs the spoken context.
- */
-function stringifyMessageContent(stored: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stored);
-  } catch {
-    return stored.trim();
-  }
-  if (typeof parsed === "string") return parsed.trim();
-  if (!Array.isArray(parsed)) return "";
-  const parts: string[] = [];
-  for (const block of parsed) {
-    if (
-      block &&
-      typeof block === "object" &&
-      (block as { type?: string }).type === "text" &&
-      typeof (block as { text?: unknown }).text === "string"
-    ) {
-      parts.push((block as { text: string }).text);
-    }
-  }
-  return parts.join("\n").trim();
 }
 
 /**

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -18,7 +18,6 @@ import {
   createBookmark,
   deleteBookmark,
   deleteBookmarkByMessageId,
-  getBookmarkSummary,
   listBookmarks,
 } from "../../memory/bookmark-crud.js";
 import { getMessageById } from "../../memory/conversation-crud.js";
@@ -85,13 +84,7 @@ function handleCreateBookmark({
     );
   }
 
-  const db = getDb();
-  const row = createBookmark(db, { messageId, conversationId });
-  const summary = getBookmarkSummary(db, row.id);
-  if (!summary) {
-    // Unreachable: we just inserted (or fetched) this row.
-    throw new Error(`Bookmark ${row.id} disappeared between insert and read`);
-  }
+  const summary = createBookmark(getDb(), { messageId, conversationId });
   publishBookmarkCreated(summary);
   return summary;
 }


### PR DESCRIPTION
## Summary
Addresses 3 gaps surfaced by the post-execution review of the bookmark-messages plan.

- **Critical**: `messagePreview` was emitting raw JSON for messages stored as serialized `ContentBlock[]`. Now decoded via the canonical content-stringifier before truncation. Regression test added.
- **Slop**: drop unused `isMessageBookmarked` (the client-side `BookmarkStore.bookmarkedMessageIds` Set is the only consumer of "is this message bookmarked" semantics).
- **Slop**: collapse `getBookmarkSummary` and `listBookmarks` to share their JOIN+row-mapping helper (in fact, eliminate `getBookmarkSummary` entirely by having `createBookmark` return the JOIN-shaped `BookmarkSummary` directly).

Part of plan: bookmark-messages.md (post-execution remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->