### PR TITLE
fix(bookmarks): wire anchor binding + clean up macOS bookmark surface

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -199,6 +199,13 @@ extension AppDelegate {
                     await flagReloadTask.value
                     self?.diskPressureStatusStore.refreshForCurrentAssistant()
                 }
+                // Hydrate the bookmark mirror so hover-time
+                // `bookmarkedMessageIds` lookups are warm by the time the
+                // chat surface renders. Deferred to here (instead of
+                // `AppServices.init`) to avoid racing auth bootstrap.
+                Task { @MainActor [weak self] in
+                    await self?.bookmarkStore.reload()
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -101,6 +101,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var contactPromptManager: ContactPromptManager { services.contactPromptManager }
     var zoomManager: ZoomManager { services.zoomManager }
     var featureFlagStore: AssistantFeatureFlagStore { services.featureFlagStore }
+    var bookmarkStore: BookmarkStore { services.bookmarkStore }
     var diskPressureStatusStore: DiskPressureStatusStore { services.diskPressureStatusStore }
 
     let conversationListClient: any ConversationListClientProtocol = ConversationListClient()

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -41,13 +41,9 @@ public final class AppServices {
                 featureFlagStore.isEnabled(key)
             }
         )
-        // Hydrate bookmarks once at bootstrap so hover-time lookups via
-        // ``bookmarkedMessageIds`` are warm by the time the chat surface
-        // renders. Subsequent updates flow through the SSE-driven
-        // ``bookmarkDidChange`` notification.
-        Task { @MainActor in
-            await bookmarkStore.reload()
-        }
+        // Bookmark hydration is deferred until the gateway is connected
+        // (see ``AppDelegate+ConnectionSetup``) so it doesn't race auth
+        // bootstrap and 401.
     }
 
     /// Reconfigure the connection for a new assistant.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -73,6 +73,14 @@ struct ChatView: View {
 
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
+    /// When set, MessageListView resolves the daemon (server-side) message
+    /// ID to its client `UUID` once the matching message is loaded, then
+    /// triggers the existing UUID-based scroll-and-flash. Used by deep
+    /// links from settings panes (e.g. Bookmarks) that only have the
+    /// daemon ID, not the client-generated `UUID`. Defaults to a constant
+    /// nil binding so non-bookmark hosts (e.g. `ThreadWindow`) don't need
+    /// to allocate a `@State` they never write to.
+    var anchorDaemonMessageId: Binding<String?> = .constant(nil)
     /// Message ID to visually highlight after an anchor scroll completes.
     @Binding var highlightedMessageId: UUID?
 
@@ -352,6 +360,7 @@ struct ChatView: View {
                 // -- Scroll state inputs --
                 conversationId: conversationId,
                 anchorMessageId: $anchorMessageId,
+                anchorDaemonMessageId: anchorDaemonMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 isInteractionEnabled: isInteractionEnabled,
                 containerWidth: containerWidth,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1329,6 +1329,19 @@ final class ConversationManager: ConversationRestorerDelegate {
         selectionStore.pendingAnchorConversationId = conversationId
     }
 
+    /// Set the pending anchor by daemon (server-side) message ID. Used by
+    /// callers that only know the daemon ID — the MessageListView resolver
+    /// maps it to the client `UUID` once the message has loaded. Recording
+    /// `pendingAnchorConversationId` here is essential: without it, the
+    /// `ConversationSelectionStore.activeConversationId` didSet won't clear
+    /// a stale daemon-id when the user switches conversations before the
+    /// resolver fires.
+    func setPendingAnchorDaemonMessage(conversationId: UUID, daemonMessageId: String) {
+        guard selectionStore.activeConversationId == conversationId else { return }
+        selectionStore.pendingAnchorDaemonMessageId = daemonMessageId
+        selectionStore.pendingAnchorConversationId = conversationId
+    }
+
     // MARK: - Delegated Activity Operations
 
     func isConversationBusy(_ conversationId: UUID) -> Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -784,6 +784,7 @@ extension MainWindowView {
                 },
                 conversationId: conversationManager.activeConversationId ?? conversationManager.draftLocalId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
+                anchorDaemonMessageId: $conversationManager.pendingAnchorDaemonMessageId,
                 highlightedMessageId: $conversationManager.highlightedMessageId,
                 isInteractionEnabled: viewModel.isHistoryLoaded
             )
@@ -995,6 +996,11 @@ struct ActiveChatViewWrapper: View {
     var onOpenConversationDocument: ((ConversationArtifact) -> Void)? = nil
     var conversationId: UUID?
     @Binding var anchorMessageId: UUID?
+    /// Daemon (server-side) message ID to anchor on. Forwarded from
+    /// `ConversationSelectionStore.pendingAnchorDaemonMessageId` so deep
+    /// links from settings panes (e.g. Bookmarks) can scroll to a message
+    /// without first knowing its client-generated `UUID`.
+    @Binding var anchorDaemonMessageId: String?
     @Binding var highlightedMessageId: UUID?
     var isInteractionEnabled: Bool = true
 
@@ -1064,6 +1070,7 @@ struct ActiveChatViewWrapper: View {
                     windowState.selection = .panel(.settings)
                 },
                 anchorMessageId: $anchorMessageId,
+                anchorDaemonMessageId: $anchorDaemonMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 conversationId: conversationId,
                 isInteractionEnabled: isInteractionEnabled && windowState.inspectorMessageId == nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -474,8 +474,15 @@ struct SettingsPanel: View {
                 bookmarkStore: bookmarkStore,
                 conversationManager: conversationManager,
                 openMessage: { conversationId, daemonMessageId in
-                    _ = conversationManager.selectConversationByConversationId(conversationId)
-                    conversationManager.pendingAnchorDaemonMessageId = daemonMessageId
+                    guard conversationManager.selectConversationByConversationId(conversationId),
+                          let activeLocalId = conversationManager.activeConversationId else { return }
+                    // Recording the conversation alongside the daemon ID lets
+                    // ConversationSelectionStore's stale-anchor cleanup fire
+                    // if the user switches away before the resolver runs.
+                    conversationManager.setPendingAnchorDaemonMessage(
+                        conversationId: activeLocalId,
+                        daemonMessageId: daemonMessageId
+                    )
                 },
                 onClose: onClose
             )

--- a/clients/macos/vellum-assistant/Services/BookmarkStore.swift
+++ b/clients/macos/vellum-assistant/Services/BookmarkStore.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Observation
 import VellumAssistantShared
@@ -14,39 +15,41 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Bookm
 ///
 /// SSE events from the daemon (`bookmark.created` / `bookmark.deleted`,
 /// emitted by `bookmark-routes.ts` via `assistantEventHub`) are forwarded by
-/// the SSE router as ``Notification/Name/bookmarkDidChange`` posts so a
-/// second window mutating the list keeps every connected client in sync.
+/// the app-layer SSE subscriber as ``Notification/Name/bookmarkDidChange``
+/// posts so a second window mutating the list keeps every connected client
+/// in sync.
 ///
-/// Mirrors the ``AssistantFeatureFlagStore`` Observable + NotificationCenter
-/// pattern so SwiftUI views are only invalidated when the specific properties
-/// they read change.
+/// Mirrors the ``AssistantFeatureFlagStore`` Observable + Combine
+/// `AnyCancellable` pattern. Holding the NotificationCenter subscription in
+/// an `@ObservationIgnored` cancellable lets it tear down automatically and
+/// avoids a manual `removeObserver` call from the `nonisolated` deinit
+/// (which can't read the actor-isolated stored property under Swift 6
+/// strict concurrency).
 @MainActor
 @Observable
 public final class BookmarkStore {
     public private(set) var bookmarks: [BookmarkSummary] = []
     public private(set) var bookmarkedMessageIds: Set<String> = []
-    public private(set) var isLoading: Bool = false
 
-    @ObservationIgnored private let client: BookmarkClientProtocol
-    @ObservationIgnored private var sseObserver: NSObjectProtocol?
+    @ObservationIgnored private let client: BookmarkClient
+    @ObservationIgnored private var sseChangeCancellable: AnyCancellable?
 
-    public init(client: BookmarkClientProtocol = BookmarkClient()) {
+    public init(
+        client: BookmarkClient = BookmarkClient(),
+        notificationCenter: NotificationCenter = .default
+    ) {
         self.client = client
-        subscribeToSSE()
-    }
-
-    deinit {
-        if let sseObserver {
-            NotificationCenter.default.removeObserver(sseObserver)
-        }
+        sseChangeCancellable = notificationCenter.publisher(for: .bookmarkDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { await self?.reload() }
+            }
     }
 
     /// Fetch the authoritative bookmark list from the daemon and replace
-    /// local state. Call once at bootstrap, and whenever a `bookmark.*` SSE
-    /// event arrives from another window.
+    /// local state. Call once the gateway connection is established, and
+    /// whenever a `bookmark.*` SSE event arrives from another window.
     public func reload() async {
-        isLoading = true
-        defer { isLoading = false }
         do {
             let fetched = try await client.listBookmarks()
             bookmarks = fetched
@@ -64,44 +67,40 @@ public final class BookmarkStore {
             bookmarkedMessageIds.remove(messageId)
             bookmarks.removeAll { $0.messageId == messageId }
             do {
-                _ = try await client.deleteBookmarkByMessageId(messageId)
+                try await client.deleteBookmarkByMessageId(messageId)
             } catch {
                 log.warning("Bookmark delete failed: \(error.localizedDescription, privacy: .public)")
                 await reload()
             }
         } else {
+            // Optimistic flip so the icon updates in the same frame as the
+            // click — symmetric with the delete branch above. The full row
+            // (with daemon-assigned summary fields) is appended once
+            // `createBookmark` returns.
+            bookmarkedMessageIds.insert(messageId)
             do {
                 let created = try await client.createBookmark(
                     messageId: messageId,
                     conversationId: conversationId
                 )
-                // Idempotent insert: an SSE-driven reload may have landed the
-                // same row first, so guard against the duplicate.
-                if !bookmarkedMessageIds.contains(created.messageId) {
-                    bookmarkedMessageIds.insert(created.messageId)
+                // Guard against a duplicate row if an SSE-driven reload
+                // landed the same record first.
+                if !bookmarks.contains(where: { $0.messageId == created.messageId }) {
                     bookmarks.insert(created, at: 0)
                 }
             } catch {
                 log.warning("Bookmark create failed: \(error.localizedDescription, privacy: .public)")
+                bookmarkedMessageIds.remove(messageId)
                 await reload()
             }
-        }
-    }
-
-    private func subscribeToSSE() {
-        sseObserver = NotificationCenter.default.addObserver(
-            forName: .bookmarkDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { await self?.reload() }
         }
     }
 }
 
 extension Notification.Name {
-    /// Posted by the SSE router when the daemon emits `bookmark.created` or
-    /// `bookmark.deleted`. ``BookmarkStore`` listens for this and triggers a
-    /// full reload so every window stays in sync with the daemon.
+    /// Posted by the app-layer SSE subscriber when the daemon emits
+    /// `bookmark.created` or `bookmark.deleted`. ``BookmarkStore`` listens for
+    /// this and triggers a full reload so every window stays in sync with the
+    /// daemon.
     public static let bookmarkDidChange = Notification.Name("bookmarkDidChange")
 }

--- a/clients/shared/Network/BookmarkClient.swift
+++ b/clients/shared/Network/BookmarkClient.swift
@@ -3,19 +3,6 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "BookmarkClient")
 
-/// Focused client for message-bookmark operations routed through the gateway.
-///
-/// Wraps `GET/POST/DELETE /v1/bookmarks` plus the
-/// `DELETE /v1/bookmarks/by-message/{messageId}` convenience route exposed by
-/// the daemon. Mirrors the structure of ``FeatureFlagClient`` so neighboring
-/// stores can adopt either client interchangeably.
-public protocol BookmarkClientProtocol {
-    func listBookmarks() async throws -> [BookmarkSummary]
-    func createBookmark(messageId: String, conversationId: String) async throws -> BookmarkSummary
-    func deleteBookmark(id: String) async throws -> Bool
-    func deleteBookmarkByMessageId(_ messageId: String) async throws -> Bool
-}
-
 public enum BookmarkClientError: Error, LocalizedError {
     case requestFailed(Int)
 
@@ -27,10 +14,12 @@ public enum BookmarkClientError: Error, LocalizedError {
     }
 }
 
-// MARK: - Gateway-Backed Implementation
-
-/// Gateway-backed implementation of ``BookmarkClientProtocol``.
-public struct BookmarkClient: BookmarkClientProtocol {
+/// Focused client for message-bookmark operations routed through the gateway.
+///
+/// Wraps `GET/POST /v1/bookmarks` plus the
+/// `DELETE /v1/bookmarks/by-message/{messageId}` convenience route exposed by
+/// the daemon.
+public struct BookmarkClient {
     nonisolated public init() {}
 
     public func listBookmarks() async throws -> [BookmarkSummary] {
@@ -58,18 +47,7 @@ public struct BookmarkClient: BookmarkClientProtocol {
         return try JSONDecoder().decode(BookmarkSummary.self, from: response.data)
     }
 
-    public func deleteBookmark(id: String) async throws -> Bool {
-        let response = try await GatewayHTTPClient.delete(
-            path: "bookmarks/\(id)", timeout: 10
-        )
-        guard response.isSuccess else {
-            log.error("deleteBookmark failed (HTTP \(response.statusCode))")
-            throw BookmarkClientError.requestFailed(response.statusCode)
-        }
-        return true
-    }
-
-    public func deleteBookmarkByMessageId(_ messageId: String) async throws -> Bool {
+    public func deleteBookmarkByMessageId(_ messageId: String) async throws {
         let response = try await GatewayHTTPClient.delete(
             path: "bookmarks/by-message/\(messageId)", timeout: 10
         )
@@ -77,6 +55,5 @@ public struct BookmarkClient: BookmarkClientProtocol {
             log.error("deleteBookmarkByMessageId failed (HTTP \(response.statusCode))")
             throw BookmarkClientError.requestFailed(response.statusCode)
         }
-        return true
     }
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2262,10 +2262,12 @@ public struct MeetSpeakingEndedMessage: Decodable, Sendable, Equatable {
 //
 // Wire-compatible mirror of `assistant/src/daemon/message-types/bookmarks.ts`.
 // Emitted by `bookmark-routes.ts` after every mutation so other connected
-// clients (e.g. a second macOS window) can refresh their `BookmarkStore` in
+// clients (e.g. a second macOS window) can refresh their bookmark cache in
 // lock-step. The dotted `type` strings (`bookmark.created` / `bookmark.deleted`)
-// match the daemon's serialization; the SSE router translates them into
-// `.bookmarkDidChange` notifications and `BookmarkStore` reloads on receipt.
+// match the daemon's serialization. Each platform client decides how to react
+// — see the platform-specific event subscriber for the translation
+// (e.g. `AppDelegate+ConnectionSetup.swift` on macOS posts a
+// `.bookmarkDidChange` NotificationCenter event).
 
 /// A new bookmark was created on the daemon.
 public struct BookmarkCreatedMessage: Decodable, Sendable, Equatable {


### PR DESCRIPTION
## Summary
Addresses 10 gaps surfaced by the post-execution review of the bookmark-messages plan.

**Critical**
- Wire `anchorDaemonMessageId` binding from `ConversationManager.pendingAnchorDaemonMessageId` through `PanelCoordinator` -> `ChatView` -> `MessageListView` so the Bookmarks-tab Open action actually scrolls the bookmarked message into view.
- Clear `pendingAnchorDaemonMessageId` correctly on conversation switches via a new `setPendingAnchorDaemonMessage` helper that records `pendingAnchorConversationId` so the existing didSet cleanup fires.

**Concurrency / lifecycle**
- Fix `BookmarkStore.deinit` actor-isolation issue (match `AssistantFeatureFlagStore` Combine `AnyCancellable` pattern; no manual removeObserver).
- Defer the initial `BookmarkStore.reload()` until the gateway connection is established so cold-start hover state isn't 401-shaped.

**UX**
- Make `BookmarkStore.toggle()` symmetric: optimistic membership update on both create and delete branches.

**Slop cleanup**
- Drop unused `BookmarkClientProtocol` (single consumer, no mock).
- Drop unused `BookmarkClient.deleteBookmark(id:)`.
- Change `deleteBookmarkByMessageId` to `async throws -> Void` (the `Bool` return was always `true`).
- Drop unread `BookmarkStore.isLoading`.

**Doc**
- Correct the misleading SSE-router attribution in `MessageTypes.swift`.

Part of plan: bookmark-messages.md (post-execution remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->