### PR TITLE
fix(bookmarks): drop orphan delete-by-id route + handle archived conv on Open

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1738,33 +1738,6 @@ paths:
                 - messageId
                 - conversationId
               additionalProperties: false
-  /v1/bookmarks/{id}:
-    delete:
-      operationId: bookmarks_by_id_delete
-      summary: Delete a bookmark
-      description: Delete a bookmark by id. Succeeds even if no row matched.
-      tags:
-        - bookmarks
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    const: true
-                required:
-                  - success
-                additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
   /v1/bookmarks/by-message/{messageId}:
     delete:
       operationId: bookmarks_bymessage_by_messageId_delete

--- a/assistant/src/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-crud.test.ts
@@ -5,7 +5,6 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import {
   createBookmark,
-  deleteBookmark,
   deleteBookmarkByMessageId,
   listBookmarks,
 } from "../bookmark-crud.js";
@@ -196,11 +195,6 @@ describe("bookmark-crud", () => {
     const remaining = listBookmarks(db);
     expect(remaining.length).toBe(1);
     expect(remaining[0]?.conversationId).toBe("conv-keep");
-  });
-
-  test("deleteBookmark returns false when the id does not exist", () => {
-    const { db } = setupDb();
-    expect(deleteBookmark(db, "does-not-exist")).toBe(false);
   });
 
   test("deleteBookmarkByMessageId removes the matching row", () => {

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -155,26 +155,12 @@ function readBookmarkSummaryOrThrow(
 }
 
 /**
- * Delete a bookmark by id. Returns true iff a row was removed.
+ * Delete the bookmark (if any) attached to the given `messageId`.
+ * Returns true iff a row was removed.
  *
  * Drizzle's high-level `.run()` is typed as `void` for the sync sqlite
  * driver, so we check existence with a follow-up SELECT instead of
  * relying on a row-count from the delete statement.
- */
-export function deleteBookmark(db: DrizzleDb, id: string): boolean {
-  const existed = db
-    .select({ id: messageBookmarks.id })
-    .from(messageBookmarks)
-    .where(eq(messageBookmarks.id, id))
-    .get();
-  if (!existed) return false;
-  db.delete(messageBookmarks).where(eq(messageBookmarks.id, id)).run();
-  return true;
-}
-
-/**
- * Delete the bookmark (if any) attached to the given `messageId`.
- * Returns true iff a row was removed.
  */
 export function deleteBookmarkByMessageId(
   db: DrizzleDb,

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -430,10 +430,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Queued message deletion
   { endpoint: "messages/queued", scopes: ["chat.write"] },
 
-  // Bookmarks (DELETE /bookmarks/:id strips the :id segment to "bookmarks")
+  // Bookmarks
   { endpoint: "bookmarks:GET", scopes: ["chat.read"] },
   { endpoint: "bookmarks:POST", scopes: ["chat.write"] },
-  { endpoint: "bookmarks:DELETE", scopes: ["chat.write"] },
   { endpoint: "bookmarks/by-message:DELETE", scopes: ["chat.write"] },
 
   // Interfaces

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -5,7 +5,6 @@
  *   - POST + GET round-trip
  *   - POST idempotency (no duplicate row, same id returned)
  *   - POST FK validation (unknown messageId → 4xx)
- *   - DELETE /:id
  *   - DELETE /by-message/:messageId
  *   - SSE event publication on create AND delete
  */
@@ -53,7 +52,6 @@ function findHandler(operationId: string): RouteDefinition["handler"] {
 
 const listHandler = findHandler("bookmarks_list");
 const createHandler = findHandler("bookmarks_create");
-const deleteHandler = findHandler("bookmarks_delete");
 const deleteByMessageHandler = findHandler("bookmarks_delete_by_message");
 
 function clearDb(): void {
@@ -191,24 +189,6 @@ describe("bookmark routes", () => {
     ).toBe(true);
   });
 
-  test("DELETE /:id removes the row", async () => {
-    seedConversationAndMessage({
-      conversationId: "conv-4",
-      messageId: "msg-4",
-    });
-    const created = (await call(createHandler, {
-      body: { messageId: "msg-4", conversationId: "conv-4" },
-    })) as { id: string };
-
-    const result = (await call(deleteHandler, {
-      pathParams: { id: created.id },
-    })) as { success: boolean };
-    expect(result.success).toBe(true);
-
-    const listed = (await call(listHandler, {})) as { bookmarks: unknown[] };
-    expect(listed.bookmarks).toHaveLength(0);
-  });
-
   test("DELETE /by-message/:messageId removes the row", async () => {
     seedConversationAndMessage({
       conversationId: "conv-5",
@@ -251,18 +231,20 @@ describe("bookmark routes", () => {
 
     publishCalls.length = 0;
 
-    await call(deleteHandler, { pathParams: { id: created.id } });
+    await call(deleteByMessageHandler, { pathParams: { messageId: "msg-6" } });
     await new Promise((r) => setTimeout(r, 0));
 
     expect(publishedTypes()).toEqual(["bookmark.deleted"]);
     const deletedEvent = publishCalls[0] as EventEnvelope;
-    expect((deletedEvent.message as unknown as { id?: string }).id).toBe(
-      created.id,
-    );
+    expect(
+      (deletedEvent.message as unknown as { messageId?: string }).messageId,
+    ).toBe("msg-6");
   });
 
-  test("DELETE on a non-existent id does not publish", async () => {
-    await call(deleteHandler, { pathParams: { id: "does-not-exist" } });
+  test("DELETE on a non-existent messageId does not publish", async () => {
+    await call(deleteByMessageHandler, {
+      pathParams: { messageId: "does-not-exist" },
+    });
     await new Promise((r) => setTimeout(r, 0));
     expect(publishCalls).toHaveLength(0);
   });

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -3,7 +3,6 @@
  *
  * GET    /v1/bookmarks                      — list all bookmarks (newest first)
  * POST   /v1/bookmarks                      — bookmark a message (idempotent)
- * DELETE /v1/bookmarks/:id                  — remove a bookmark by id
  * DELETE /v1/bookmarks/by-message/:messageId — remove the bookmark for a given message
  *
  * Mutating routes publish `bookmark.created` / `bookmark.deleted` events
@@ -16,7 +15,6 @@ import { z } from "zod";
 import {
   type BookmarkSummary,
   createBookmark,
-  deleteBookmark,
   deleteBookmarkByMessageId,
   listBookmarks,
 } from "../../memory/bookmark-crud.js";
@@ -89,20 +87,6 @@ function handleCreateBookmark({
   return summary;
 }
 
-function handleDeleteBookmark({ pathParams = {} }: RouteHandlerArgs): {
-  success: true;
-} {
-  const id = pathParams.id;
-  if (!id) {
-    throw new BadRequestError("id is required");
-  }
-  const removed = deleteBookmark(getDb(), id);
-  if (removed) {
-    publishBookmarkDeleted({ id });
-  }
-  return { success: true };
-}
-
 function handleDeleteBookmarkByMessage({ pathParams = {} }: RouteHandlerArgs): {
   success: true;
 } {
@@ -158,16 +142,6 @@ export const ROUTES: RouteDefinition[] = [
     }),
     responseBody: bookmarkSummarySchema,
     handler: handleCreateBookmark,
-  },
-  {
-    operationId: "bookmarks_delete",
-    endpoint: "bookmarks/:id",
-    method: "DELETE",
-    summary: "Delete a bookmark",
-    description: "Delete a bookmark by id. Succeeds even if no row matched.",
-    tags: ["bookmarks"],
-    responseBody: z.object({ success: z.literal(true) }),
-    handler: handleDeleteBookmark,
   },
   {
     operationId: "bookmarks_delete_by_message",

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -474,8 +474,15 @@ struct SettingsPanel: View {
                 bookmarkStore: bookmarkStore,
                 conversationManager: conversationManager,
                 openMessage: { conversationId, daemonMessageId in
-                    guard conversationManager.selectConversationByConversationId(conversationId),
-                          let activeLocalId = conversationManager.activeConversationId else { return }
+                    // Async path so archived / paginated-out conversations
+                    // are fetched (and unarchived) instead of silently
+                    // no-oping when the conversation is not in the current
+                    // sidebar slice.
+                    let opened = await conversationManager.selectConversationByConversationIdAsync(conversationId)
+                    guard opened, let activeLocalId = conversationManager.activeConversationId else {
+                        showToast("Couldn't open bookmark — conversation is no longer available.", .error)
+                        return
+                    }
                     // Recording the conversation alongside the daemon ID lets
                     // ConversationSelectionStore's stale-anchor cleanup fire
                     // if the user switches away before the resolver runs.
@@ -483,6 +490,7 @@ struct SettingsPanel: View {
                         conversationId: activeLocalId,
                         daemonMessageId: daemonMessageId
                     )
+                    onClose()
                 },
                 onClose: onClose
             )

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBookmarksTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBookmarksTab.swift
@@ -14,7 +14,10 @@ import VellumAssistantShared
 struct SettingsBookmarksTab: View {
     @Bindable var bookmarkStore: BookmarkStore
     var conversationManager: ConversationManager
-    var openMessage: (_ conversationId: String, _ daemonMessageId: String) -> Void
+    /// Async so the caller can fetch (and unarchive) conversations that are
+    /// not in the current sidebar slice. The closure owns dismissal on
+    /// success and toast surfacing on failure.
+    var openMessage: (_ conversationId: String, _ daemonMessageId: String) async -> Void
     var onClose: () -> Void
 
     @State private var hoveredBookmarkId: String? = nil
@@ -48,8 +51,9 @@ struct SettingsBookmarksTab: View {
                                 }
                             },
                             onOpen: {
-                                openMessage(bookmark.conversationId, bookmark.messageId)
-                                onClose()
+                                Task {
+                                    await openMessage(bookmark.conversationId, bookmark.messageId)
+                                }
                             },
                             onRemove: {
                                 Task {


### PR DESCRIPTION
## Summary
Addresses 2 residual gaps from round-2 review of the bookmark-messages plan.

- **Dead code**: drop the daemon `DELETE /v1/bookmarks/:id` route (`bookmarks_delete`), `handleDeleteBookmark`, the `deleteBookmark(db, id)` CRUD helper, their tests, the route-policy entry, and the OpenAPI path. The Swift client only uses `DELETE /v1/bookmarks/by-message/:messageId` after the round-1 simplification, so the by-id endpoint had no caller.
- **UX edge case**: `SettingsBookmarksTab` Open now uses the async conversation-selection path so archived / unloaded conversations are fetched (and unarchived if needed). On failure a toast surfaces instead of silently dismissing the settings panel.

Part of plan: bookmark-messages.md (post-execution remediation, round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->