### PR TITLE
fix(bookmarks): drop unused `id` field from bookmark-deleted SSE payload

### DIFF
--- a/assistant/src/daemon/message-types/bookmarks.ts
+++ b/assistant/src/daemon/message-types/bookmarks.ts
@@ -10,10 +10,7 @@ export interface BookmarkCreated {
 
 export interface BookmarkDeleted {
   type: "bookmark.deleted";
-  /** Bookmark id when the delete happened by primary key. */
-  id?: string;
-  /** Message id when the delete happened by message id. */
-  messageId?: string;
+  messageId: string;
 }
 
 // --- Domain-level union aliases (consumed by the barrel file) ---

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -40,10 +40,7 @@ function publishBookmarkCreated(bookmark: BookmarkSummary): void {
     });
 }
 
-function publishBookmarkDeleted(payload: {
-  id?: string;
-  messageId?: string;
-}): void {
+function publishBookmarkDeleted(payload: { messageId: string }): void {
   assistantEventHub
     .publish(buildAssistantEvent({ type: "bookmark.deleted", ...payload }))
     .catch((err) => {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2280,18 +2280,15 @@ public struct BookmarkCreatedMessage: Decodable, Sendable, Equatable {
     }
 }
 
-/// An existing bookmark was deleted on the daemon. Either `id` (delete by
-/// primary key) or `messageId` (delete by message id) will be set; clients
-/// that need to react to a specific bookmark removal can prefer whichever
-/// identifier they already have indexed.
+/// An existing bookmark was deleted on the daemon, identified by the message
+/// it was attached to. Clients typically just refresh their bookmark list on
+/// receipt; the id is included for clients that index by message.
 public struct BookmarkDeletedMessage: Decodable, Sendable, Equatable {
     public let type: String
-    public let id: String?
-    public let messageId: String?
+    public let messageId: String
 
-    public init(type: String, id: String? = nil, messageId: String? = nil) {
+    public init(type: String, messageId: String) {
         self.type = type
-        self.id = id
         self.messageId = messageId
     }
 }


### PR DESCRIPTION
## Summary
- Tighten `publishBookmarkDeleted` parameter from `{ id?: string; messageId?: string }` to `{ messageId: string }` — after PR #30129 removed the `DELETE /v1/bookmarks/:id` route, the only remaining publisher passes `{ messageId }`, so the `id` half was dead.
- Mirror the slim on the wire: `BookmarkDeleted` interface (TS) and `BookmarkDeletedMessage` struct (Swift) lose the optional `id` field; `messageId` becomes non-optional. Doc comments updated.
- Considered the round-3 review's secondary suggestion to swap the em-dash in the bookmark-Open failure toast for an ASCII hyphen. **Verdict: keep the em-dash.** A grep across `clients/macos/` toast call sites shows em-dash is the dominant convention (`SeedHistorySection`, `ResetCircuitSection`, `InjectFailuresSection`, `ForceCompactSection` all use `—` as a sentence separator). The bookmark toast already matches.

## Original prompt
Two cosmetic follow-ups left over from the bookmark-messages plan: drop the now-unused `id?` field from the `bookmark.deleted` SSE payload (TS interface + TS publish-helper signature + Swift Decodable struct) since after the round-3 cleanup nothing emits it; and either confirm or normalize the em-dash in the round-3 toast copy. Bundling into one cosmetic-only PR — no observable behavior change, no test updates needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->