### PR TITLE
fix(tests): pass nil bookmarkStore/conversationId in MessageListTypographyRefreshTests

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -50,7 +50,9 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
             pinnedLatestTurnAnchorMessageId: nil,
-            searchQuery: ""
+            searchQuery: "",
+            bookmarkStore: nil,
+            bookmarkConversationId: nil
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds `bookmarkStore: nil` and `bookmarkConversationId: nil` to the `MessageListContentView` call in `MessageListTypographyRefreshTests.makeMessageListContentView`.
- Restores the macOS Tests CI job, which had been failing on every PR with `error: missing arguments for parameters 'bookmarkStore', 'bookmarkConversationId' in call`.

## Original prompt
Fix the specific CI issue in https://github.com/vellum-ai/vellum-assistant/actions/runs/25596901861/job/75144297595 only — no broader cleanup. The macOS Tests job was red because a recent PR added required `bookmarkStore`/`bookmarkConversationId` params to `MessageListContentView` but didn't update this test helper.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->