### PR TITLE
fix(macos/markdown): keep emoji visible inside inline-code spans

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -571,7 +571,7 @@ struct MarkdownSegmentView: View, Equatable {
     #endif
 
     /// Pure builder with no side effects — separated for caching.
-    private static func buildAttributedStringUncached(
+    static func buildAttributedStringUncached(
         from segments: [MarkdownSegment],
         secondaryTextColor: Color,
         codeTextColor: Color = VColor.systemNegativeStrong,
@@ -681,6 +681,18 @@ struct MarkdownSegmentView: View, Equatable {
         for range in codeRanges.reversed() {
             result[range].foregroundColor = codeTextColor
             result[range].backgroundColor = codeBackgroundColor
+            // Apple Color Emoji glyphs inside an inline-code run must not carry
+            // the code foreground color, or Core Text drops the color-glyph
+            // fallback and the emoji renders as blank space. Mirrors the
+            // obliqueness strip for emoji inside italic runs.
+            var charIdx = range.lowerBound
+            while charIdx < range.upperBound {
+                let nextIdx = result.characters.index(after: charIdx)
+                if result.characters[charIdx].rendersAsEmoji {
+                    result[charIdx..<nextIdx].foregroundColor = nil
+                }
+                charIdx = nextIdx
+            }
             var trailing = AttributedString("\u{2009}")
             trailing.backgroundColor = codeBackgroundColor
             result.insert(trailing, at: range.upperBound)
@@ -1279,7 +1291,7 @@ private extension View {
     }
 }
 
-fileprivate extension Character {
+extension Character {
     /// True iff this grapheme cluster renders as emoji — either default emoji
     /// presentation, or text-default codepoints forced into emoji presentation
     /// via U+FE0F (VS16). Excludes text-presentation characters like digits

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -235,6 +235,65 @@ final class MarkdownSegmentViewTests: XCTestCase {
         XCTAssertNil(emojiObliqueness)
     }
 
+    /// Emoji wrapped in inline code (`` `🥺` ``) used to render as blank space:
+    /// the inline-code styling pass tinted every character in the span with
+    /// `.foregroundColor`, which on emoji grapheme clusters suppresses Core
+    /// Text's color-glyph fallback. The fix clears `.foregroundColor` on
+    /// emoji clusters so Apple Color Emoji renders.
+    func testEmojiInsideInlineCodeHasNoForegroundColorOverride() {
+        let segments = parseMarkdownSegments("oof `🥺` lol")
+        let source = MarkdownSegmentView.buildAttributedStringUncached(
+            from: segments,
+            secondaryTextColor: VColor.contentSecondary
+        )
+
+        let chars = source.characters
+        var idx = chars.startIndex
+        var foundEmoji = false
+        while idx < chars.endIndex {
+            let nextIdx = chars.index(after: idx)
+            if chars[idx].rendersAsEmoji {
+                foundEmoji = true
+                XCTAssertNil(
+                    source[idx..<nextIdx].foregroundColor,
+                    "Emoji inside inline-code must not carry the code foreground tint"
+                )
+            }
+            idx = nextIdx
+        }
+        XCTAssertTrue(foundEmoji, "Emoji must survive markdown parsing of an inline-code span")
+    }
+
+    /// Regression check: non-emoji characters in the same inline-code span keep
+    /// the code foreground tint — the emoji-strip is targeted, not global.
+    func testNonEmojiInsideInlineCodeKeepsCodeForegroundColor() {
+        let segments = parseMarkdownSegments("look at `flag 🥺 thing` ok")
+        let source = MarkdownSegmentView.buildAttributedStringUncached(
+            from: segments,
+            secondaryTextColor: VColor.contentSecondary
+        )
+
+        let chars = source.characters
+        var idx = chars.startIndex
+        var sawTintedAlpha = false
+        while idx < chars.endIndex {
+            let nextIdx = chars.index(after: idx)
+            let char = chars[idx]
+            let foreground = source[idx..<nextIdx].foregroundColor
+            if char.isLetter, foreground == VColor.systemNegativeStrong {
+                sawTintedAlpha = true
+            }
+            if char.rendersAsEmoji {
+                XCTAssertNil(foreground, "Emoji inside inline-code must not carry the code foreground tint")
+            }
+            idx = nextIdx
+        }
+        XCTAssertTrue(
+            sawTintedAlpha,
+            "At least one non-emoji letter inside the inline-code span must keep the code foreground tint"
+        )
+    }
+
     func testInvalidEmphasisFontsSkipMeasurementCaching() throws {
         #if DEBUG
         VFont._chatMarkdownFontSetOverride = { size in


### PR DESCRIPTION
## Summary

- Inline-code spans in chat bubbles applied the code foreground tint to every grapheme cluster, including emoji. Tinting Apple Color Emoji suppresses Core Text's color-glyph fallback, so `` `🥺` `` rendered as blank space.
- Walk each inline-code range in `buildAttributedStringUncached` and clear `.foregroundColor` on emoji grapheme clusters so the surrounding default text color takes over and Apple Color Emoji renders. Non-emoji characters keep the code tint.
- Mirrors the existing emoji-aware obliqueness strip in `convertToNSAttributedString` (lines 884–894).

## Original prompt

User flagged a chat-rendering bug: an emoji wrapped in markdown inline code was missing in the rendered chat bubble while plainly visible in the LLM Context Inspector raw text. Investigated the macOS chat markdown pipeline (`MarkdownSegmentView`), traced the regression to the inline-code styling pass tinting emoji glyphs, and shipped a targeted fix with a regression test that mirrors the existing emoji-aware obliqueness handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->