### PR TITLE
feat(memory-v2): startup sweep for invalid concept-page frontmatter

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -836,6 +836,26 @@ export async function runDaemon(): Promise<void> {
             );
           }
         })();
+
+        // Validate every concept page's frontmatter against the strict
+        // schema and emit a `warn` per offender. Surfaces schema drift
+        // (unknown keys, type mismatches) at boot time instead of waiting
+        // for the failure to manifest as a silent V2 retrieval no-op when
+        // a bad page first lands in a conversation's top-K. Fire-and-forget
+        // and the sweep itself never throws — defense in depth via the
+        // outer try/catch.
+        void (async () => {
+          try {
+            const { sweepConceptPageFrontmatter } =
+              await import("../memory/v2/frontmatter-sweep.js");
+            await sweepConceptPageFrontmatter(getWorkspaceDir());
+          } catch (err) {
+            log.warn(
+              { err },
+              "Concept page frontmatter sweep threw — continuing startup",
+            );
+          }
+        })();
       }
 
       log.info("Daemon startup: starting memory worker");

--- a/assistant/src/memory/v2/__tests__/frontmatter-sweep.test.ts
+++ b/assistant/src/memory/v2/__tests__/frontmatter-sweep.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `assistant/src/memory/v2/frontmatter-sweep.ts`.
+ *
+ * Coverage:
+ *   - Empty workspace → no warns, no throw.
+ *   - One bad page (unknown frontmatter key) → exactly one warn carrying
+ *     `errCode: "unrecognized_keys"` and the offending slug.
+ *   - Two bad + one good page → two warns; good page produces nothing.
+ *   - Malformed YAML → a warn surfaces; the sweep does not crash.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const warnCalls: Array<{ data: Record<string, unknown>; msg: string }> = [];
+const recordingLogger = {
+  warn: (data: Record<string, unknown>, msg: string) => {
+    warnCalls.push({ data, msg });
+  },
+  info: () => {},
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => recordingLogger,
+};
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => recordingLogger,
+}));
+
+const { sweepConceptPageFrontmatter } = await import("../frontmatter-sweep.js");
+
+function makeWorkspace(pages: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "frontmatter-sweep-"));
+  const conceptsDir = join(dir, "memory", "concepts");
+  if (Object.keys(pages).length > 0) {
+    mkdirSync(conceptsDir, { recursive: true });
+    for (const [slug, content] of Object.entries(pages)) {
+      writeFileSync(join(conceptsDir, `${slug}.md`), content, "utf-8");
+    }
+  }
+  return dir;
+}
+
+const goodPage = `---\nedges: []\nref_files: []\n---\nbody\n`;
+const badPage = `---\nedges: []\nref_files: []\nbogus_field: 1\n---\nbody\n`;
+
+describe("sweepConceptPageFrontmatter", () => {
+  beforeEach(() => {
+    warnCalls.length = 0;
+  });
+  afterEach(() => {
+    warnCalls.length = 0;
+  });
+
+  test("empty workspace: no warns, no throw", async () => {
+    const dir = makeWorkspace({});
+    try {
+      await sweepConceptPageFrontmatter(dir);
+      expect(warnCalls).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("one bad page emits exactly one unrecognized_keys warn", async () => {
+    const dir = makeWorkspace({ "bad-one": badPage });
+    try {
+      await sweepConceptPageFrontmatter(dir);
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0].data.slug).toBe("bad-one");
+      expect(warnCalls[0].data.errCode).toBe("unrecognized_keys");
+      expect(warnCalls[0].data.errKeys).toEqual(["bogus_field"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("two bad and one good page: one warn per bad slug, none for the good", async () => {
+    const dir = makeWorkspace({
+      good: goodPage,
+      "bad-a": badPage,
+      "bad-b": badPage,
+    });
+    try {
+      await sweepConceptPageFrontmatter(dir);
+      const slugs = warnCalls.map((c) => c.data.slug).sort();
+      expect(slugs).toEqual(["bad-a", "bad-b"]);
+      for (const call of warnCalls) {
+        expect(call.data.errCode).toBe("unrecognized_keys");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("malformed YAML: warn surfaces, sweep does not throw", async () => {
+    const dir = makeWorkspace({
+      mangled: `---\nedges: [unterminated\n---\nbody\n`,
+    });
+    try {
+      await sweepConceptPageFrontmatter(dir);
+      expect(warnCalls.length).toBeGreaterThanOrEqual(1);
+      expect(warnCalls.some((c) => c.data.slug === "mangled")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/assistant/src/memory/v2/frontmatter-sweep.ts
+++ b/assistant/src/memory/v2/frontmatter-sweep.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — Concept page frontmatter sweep
+// ---------------------------------------------------------------------------
+//
+// At daemon startup, walk every concept page on disk and validate its
+// frontmatter against `ConceptPageFrontmatterSchema` (which is `.strict()`).
+// Schema-drifted pages — e.g. a user-authored file that adds a frontmatter
+// key the schema doesn't allow — would otherwise stay invisible until the
+// page lands in a conversation's top-K and `renderInjectionBlock`'s
+// `Promise.all` rejects, silently no-op'ing V2 dynamic injection for the
+// whole turn. Surfacing them as `warn` log lines at boot turns that into a
+// debuggable signal.
+//
+// This sweep is intentionally separate from `rebuildConceptPageCorpusStats`:
+// the BM25 walker reads only page bodies (skipping frontmatter parsing for
+// speed) and integrating the schema check there would mean reshaping its
+// hot loop. A second, simple walker is cheaper to read and trivial to
+// delete once schema drift has stopped happening in practice.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse as parseYaml } from "yaml";
+
+import { FRONTMATTER_REGEX } from "../../skills/frontmatter.js";
+import { getLogger } from "../../util/logger.js";
+import { listPages } from "./page-store.js";
+import { ConceptPageFrontmatterSchema } from "./types.js";
+
+const log = getLogger("memory-v2-frontmatter-sweep");
+
+/**
+ * Validate every concept page's frontmatter against the strict schema and
+ * emit a `warn` per offender. Never throws — daemon startup must not block
+ * on this safety net.
+ */
+export async function sweepConceptPageFrontmatter(
+  workspaceDir: string,
+): Promise<void> {
+  let slugs: string[];
+  try {
+    slugs = await listPages(workspaceDir);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Concept page frontmatter sweep failed to enumerate pages — skipping",
+    );
+    return;
+  }
+
+  for (const slug of slugs) {
+    const path = join(workspaceDir, "memory", "concepts", `${slug}.md`);
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf-8");
+    } catch (err) {
+      log.warn({ slug, err }, "Concept page frontmatter sweep: read failed");
+      continue;
+    }
+
+    const match = raw.match(FRONTMATTER_REGEX);
+    const yamlBlock = match ? match[1] : "";
+
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(yamlBlock) ?? {};
+    } catch (err) {
+      log.warn(
+        { slug, err },
+        "Concept page has malformed YAML frontmatter — V2 injection will throw if this slug enters top-K",
+      );
+      continue;
+    }
+
+    const result = ConceptPageFrontmatterSchema.safeParse(parsed);
+    if (result.success) continue;
+
+    for (const issue of result.error.issues) {
+      log.warn(
+        {
+          slug,
+          errCode: issue.code,
+          errKeys: "keys" in issue ? issue.keys : [],
+          errPath: issue.path,
+          errMessage: issue.message,
+        },
+        "Concept page has invalid frontmatter — V2 injection will throw if this slug enters top-K",
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `sweepConceptPageFrontmatter()` walks every concept page on disk at daemon startup, runs `safeParse` against `ConceptPageFrontmatterSchema`, and emits a `warn` per offender.
- Sweep is non-blocking and never throws; daemon startup is unaffected when the workspace is missing or pages are malformed.
- Wired in next to `rebuildConceptPageCorpusStats` so the cost is amortized into the existing startup pass.

## Original prompt

A concept page (`wikipedia-lead-shape.md`) had a `ref_urls` key that the now-`.strict()` `ConceptPageFrontmatterSchema` rejects. When that page entered a conversation's top-K, `renderInjectionBlock`'s `Promise.all` rejected and V2 dynamic injection silently no-op'd the entire turn. This sweep surfaces such drift at boot time, before any user-facing turn hits it.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/memory/v2/__tests__/frontmatter-sweep.test.ts` passes
- [ ] Confirm at next daemon restart that any pre-existing bad pages produce warn lines in the daemon log
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->