### PR TITLE
feat(memory-v2): allow ref_urls in concept-page frontmatter

### DIFF
--- a/assistant/src/__tests__/context-search-memory-v2-source.test.ts
+++ b/assistant/src/__tests__/context-search-memory-v2-source.test.ts
@@ -181,7 +181,7 @@ describe("searchMemoryV2Source", () => {
     qdrantHits = [{ slug: "alice", denseScore: 0.9 }];
     pageStore.set("alice", {
       slug: "alice",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice prefers concise notes.",
     });
 
@@ -297,7 +297,7 @@ describe("searchMemoryV2Source", () => {
     const root = makeTempDir();
     pageStore.set("alice", {
       slug: "alice",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice memory body content.",
     });
     qdrantHits = [{ slug: "alice", denseScore: 0.85 }];
@@ -322,7 +322,7 @@ describe("searchMemoryV2Source", () => {
     qdrantHits = [{ slug: "people/alice", denseScore: 0.92 }];
     pageStore.set("people/alice", {
       slug: "people/alice",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice prefers concise notes.",
     });
 

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -203,7 +203,7 @@ describe("embedConceptPageJob — happy path", () => {
   test("reads the page, embeds it, and upserts to the v2 collection", async () => {
     await writePage(tmpWorkspace, {
       slug: "alice-prefers-vs-code",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice prefers VS Code over Vim.\nShe ships at end of day.\n",
     });
 
@@ -231,7 +231,7 @@ describe("embedConceptPageJob — happy path", () => {
   test("populates the SQLite embedding cache row keyed on (concept_page, slug)", async () => {
     await writePage(tmpWorkspace, {
       slug: "bob-uses-zsh",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Bob uses zsh.\n",
     });
 
@@ -257,6 +257,7 @@ describe("embedConceptPageJob — summary embedding", () => {
       frontmatter: {
         edges: [],
         ref_files: [],
+        ref_urls: [],
         summary: "A short prose summary that retrieval indexes separately.",
       },
       body: "Long-form body content.\n",
@@ -282,7 +283,7 @@ describe("embedConceptPageJob — summary embedding", () => {
   test("skips summary embedding when the page has no summary in frontmatter", async () => {
     await writePage(tmpWorkspace, {
       slug: "legacy-page",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Body only — no summary in frontmatter.\n",
     });
 
@@ -303,6 +304,7 @@ describe("embedConceptPageJob — summary embedding", () => {
       frontmatter: {
         edges: [],
         ref_files: [],
+        ref_urls: [],
         summary: "   ",
       },
       body: "Body content.\n",
@@ -324,14 +326,12 @@ describe("embedConceptPageJob — summary embedding", () => {
       frontmatter: {
         edges: [],
         ref_files: [],
+        ref_urls: [],
         summary: "First version of the summary.",
       },
       body: "Stable body that never changes.\n",
     });
-    await embedConceptPageJob(
-      makeJob({ slug: "cached-summary" }),
-      TEST_CONFIG,
-    );
+    await embedConceptPageJob(makeJob({ slug: "cached-summary" }), TEST_CONFIG);
     // Body + summary batched into a single backend call on first run.
     expect(embedWithBackendCalls).toHaveLength(1);
     expect(embedWithBackendCalls[0].inputs).toHaveLength(2);
@@ -344,14 +344,12 @@ describe("embedConceptPageJob — summary embedding", () => {
       frontmatter: {
         edges: [],
         ref_files: [],
+        ref_urls: [],
         summary: "Second version of the summary, different wording.",
       },
       body: "Stable body that never changes.\n",
     });
-    await embedConceptPageJob(
-      makeJob({ slug: "cached-summary" }),
-      TEST_CONFIG,
-    );
+    await embedConceptPageJob(makeJob({ slug: "cached-summary" }), TEST_CONFIG);
     // One additional backend call with only the summary text — body hit the cache.
     expect(embedWithBackendCalls).toHaveLength(2);
     expect(embedWithBackendCalls[1].inputs).toHaveLength(1);
@@ -362,7 +360,7 @@ describe("embedConceptPageJob — cache hit", () => {
   test("reuses the cached dense vector when content hash matches", async () => {
     await writePage(tmpWorkspace, {
       slug: "alice-prefers-vs-code",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Stable content.\n",
     });
 
@@ -387,7 +385,7 @@ describe("embedConceptPageJob — cache hit", () => {
   test("re-embeds when the body changes (content hash mismatch)", async () => {
     await writePage(tmpWorkspace, {
       slug: "alice-prefers-vs-code",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "First content.\n",
     });
     await embedConceptPageJob(
@@ -398,7 +396,7 @@ describe("embedConceptPageJob — cache hit", () => {
     // Rewrite with different body.
     await writePage(tmpWorkspace, {
       slug: "alice-prefers-vs-code",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Second content (different).\n",
     });
     await embedConceptPageJob(
@@ -453,7 +451,7 @@ describe("enqueueEmbedConceptPageJob", () => {
   test("round-trip: enqueued job dispatches through embedConceptPageJob", async () => {
     await writePage(tmpWorkspace, {
       slug: "round-trip-slug",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Round-trip body.\n",
     });
 

--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -323,12 +323,12 @@ describe("memoryV2ReembedJob", () => {
   test("returns N (one per concept page) and writes that many job rows", async () => {
     await writePage(tmpWorkspace, {
       slug: "alice",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice.\n",
     });
     await writePage(tmpWorkspace, {
       slug: "bob",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Bob.\n",
     });
 
@@ -373,7 +373,7 @@ describe("memoryV2ReembedJob", () => {
     // (`[a-z0-9][a-z0-9-]*`), so the reembed fan-out must not enqueue them.
     await writePage(tmpWorkspace, {
       slug: "alice",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Alice.\n",
     });
 

--- a/assistant/src/memory/v2/__tests__/edge-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/edge-index.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 function makePage(slug: string, edges: string[] = [], body = ""): ConceptPage {
   return {
     slug,
-    frontmatter: { edges, ref_files: [] },
+    frontmatter: { edges, ref_files: [], ref_urls: [] },
     body,
   };
 }

--- a/assistant/src/memory/v2/__tests__/migration.test.ts
+++ b/assistant/src/memory/v2/__tests__/migration.test.ts
@@ -403,7 +403,11 @@ describe("synthesizeConceptPage", () => {
     );
     const page = await synthesizeConceptPage(cluster, null, provider);
     expect(page.slug).toBe("alice-ides");
-    expect(page.frontmatter).toEqual({ edges: [], ref_files: [] });
+    expect(page.frontmatter).toEqual({
+      edges: [],
+      ref_files: [],
+      ref_urls: [],
+    });
     expect(page.body).toContain("VS Code");
     expect(page.body.endsWith("\n")).toBe(true);
   });

--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -62,7 +62,7 @@ afterEach(() => {
 function makePage(overrides: Partial<ConceptPage> = {}): ConceptPage {
   return {
     slug: "alice-preferences",
-    frontmatter: { edges: ["bob-handoff"], ref_files: [] },
+    frontmatter: { edges: ["bob-handoff"], ref_files: [], ref_urls: [] },
     body: "Alice prefers VS Code over Vim.\nShe ships at end of day.\n",
     ...overrides,
   };

--- a/assistant/src/memory/v2/migration.ts
+++ b/assistant/src/memory/v2/migration.ts
@@ -345,7 +345,7 @@ export async function synthesizeConceptPage(
 
   return {
     slug: slugify(cluster.slugHint),
-    frontmatter: { edges: [], ref_files: [] },
+    frontmatter: { edges: [], ref_files: [], ref_urls: [] },
     body: body.endsWith("\n") ? body : `${body}\n`,
   };
 }

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -25,7 +25,8 @@ import { z } from "zod";
  * `edges:` means "activating A pulls in B" — activation flows A → B but not
  * B → A. The full graph is the union of every page's `edges:` list — there
  * is no separate edges-index file. `ref_files` lists paths to attached media
- * (images, audio, etc.).
+ * (images, audio, etc.). `ref_urls` lists external URL references (e.g.
+ * citations, source links).
  *
  * `summary` is a 1-4 sentence prose description of the page. When present,
  * retrieval injects the path + summary instead of the full page so the agent
@@ -37,6 +38,7 @@ export const ConceptPageFrontmatterSchema = z
   .object({
     edges: z.array(z.string()).default([]),
     ref_files: z.array(z.string()).default([]),
+    ref_urls: z.array(z.string().url()).default([]),
     summary: z.string().optional(),
   })
   .strict();

--- a/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
@@ -67,17 +67,17 @@ describe("memory_v2_list_concept_pages handler", () => {
     const pages: ConceptPage[] = [
       {
         slug: "alice",
-        frontmatter: { edges: ["bob", "carol"], ref_files: [] },
+        frontmatter: { edges: ["bob", "carol"], ref_files: [], ref_urls: [] },
         body: "Alice prefers VS Code.\n",
       },
       {
         slug: "bob",
-        frontmatter: { edges: [], ref_files: [] },
+        frontmatter: { edges: [], ref_files: [], ref_urls: [] },
         body: "Bob ships at end of day.\nLikes async standups.\n",
       },
       {
         slug: "people/carol",
-        frontmatter: { edges: ["alice"], ref_files: [] },
+        frontmatter: { edges: ["alice"], ref_files: [], ref_urls: [] },
         body: "Carol leads the platform team.\n",
       },
     ];
@@ -122,7 +122,7 @@ describe("memory_v2_list_concept_pages handler", () => {
   test("tolerates a single corrupt page — returns valid pages and skips the broken one", async () => {
     await writePage(workspaceDir, {
       slug: "valid-page",
-      frontmatter: { edges: [], ref_files: [] },
+      frontmatter: { edges: [], ref_files: [], ref_urls: [] },
       body: "Body of the valid page.\n",
     });
 


### PR DESCRIPTION
## Summary

- Adds `ref_urls: z.array(z.string().url()).default([])` to `ConceptPageFrontmatterSchema`, parallel to `ref_files`. The schema stays `.strict()`.

## Original prompt

A concept page (`frames/procedural/wikipedia-lead-shape.md`) included a `ref_urls` frontmatter field for external URL references — a parallel convention to the existing `ref_files`. After the schema was switched to `.strict()` (PR #30029), that page started failing to parse, which silently broke V2 dynamic memory injection on any turn whose top-K included it. The user opted to ratify the field rather than rewrite the page.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/memory/v2/__tests__/page-store.test.ts` passes
- [ ] Restart daemon and confirm `wikipedia-lead-shape.md` no longer triggers schema-validation failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->