### PR TITLE
fix(memory): fork per-conversation memory state with the conversation

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -39,16 +39,23 @@ import {
 import { getConversationDirPath } from "../memory/conversation-disk-view.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import {
+  loadGraphMemoryState,
+  saveGraphMemoryState,
+} from "../memory/graph/graph-memory-state-store.js";
 import { getRequestLogsByMessageId } from "../memory/llm-request-log-store.js";
 import {
+  activationState,
   channelInboundEvents,
   conversationAssistantAttentionState,
+  conversationGraphMemoryState,
   conversations,
   externalConversationBindings,
   llmRequestLogs,
   memoryJobs,
   toolInvocations,
 } from "../memory/schema.js";
+import { hydrate as hydrateActivationState } from "../memory/v2/activation-store.js";
 
 initializeDb();
 
@@ -57,6 +64,8 @@ function resetTables(): void {
   db.delete(channelInboundEvents).run();
   db.delete(externalConversationBindings).run();
   db.delete(conversationAssistantAttentionState).run();
+  db.delete(activationState).run();
+  db.delete(conversationGraphMemoryState).run();
   db.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   db.delete(memoryJobs).run();
@@ -136,7 +145,6 @@ describe("forkConversation", () => {
       ),
     ).toBe(true);
   });
-
 
   test("preserves source order when source messages share a timestamp", () => {
     const source = createConversation("Equal timestamp thread");
@@ -499,5 +507,99 @@ describe("forkConversation", () => {
     expect(forkToolInvocationCount).toBe(0);
     expect(forkInboundEventCount).toBe(0);
     expect(forkQueuedWorkCount).toBe(0);
+  });
+
+  test("copies the parent's v2 activation state into the fork", async () => {
+    const source = createConversation("Activation thread");
+    const sourceMessage = await addMessage(
+      source.id,
+      "user",
+      "Tell me about the Q3 launch plan",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const db = getDb();
+    db.insert(activationState)
+      .values({
+        conversationId: source.id,
+        messageId: sourceMessage.id,
+        stateJson: JSON.stringify({
+          "concepts/q3-launch-plan": 0.71,
+          "concepts/marketing-ops": 0.34,
+        }),
+        everInjectedJson: JSON.stringify([
+          { slug: "concepts/q3-launch-plan", turn: 1 },
+          { slug: "concepts/marketing-ops", turn: 1 },
+        ]),
+        currentTurn: 2,
+        updatedAt: 1_700_000_000_000,
+      })
+      .run();
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    const childState = await hydrateActivationState(db, fork.id);
+    expect(childState).toEqual({
+      messageId: sourceMessage.id,
+      state: {
+        "concepts/q3-launch-plan": 0.71,
+        "concepts/marketing-ops": 0.34,
+      },
+      everInjected: [
+        { slug: "concepts/q3-launch-plan", turn: 1 },
+        { slug: "concepts/marketing-ops", turn: 1 },
+      ],
+      currentTurn: 2,
+      updatedAt: 1_700_000_000_000,
+    });
+
+    // Parent state is untouched.
+    const parentState = await hydrateActivationState(db, source.id);
+    expect(parentState?.currentTurn).toBe(2);
+  });
+
+  test("copies the parent's v1 graph memory state into the fork", async () => {
+    const source = createConversation("Graph tracker thread");
+    await addMessage(
+      source.id,
+      "user",
+      "Look up alice's preferences",
+      undefined,
+      {
+        skipIndexing: true,
+      },
+    );
+
+    const trackerSnapshot = JSON.stringify({
+      initialized: true,
+      needsReload: false,
+      inContext: ["node-alice", "node-bob"],
+      log: [
+        { nodeId: "node-alice", turn: 1 },
+        { nodeId: "node-bob", turn: 2 },
+      ],
+      currentTurn: 3,
+    });
+    saveGraphMemoryState(source.id, trackerSnapshot);
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(loadGraphMemoryState(fork.id)).toBe(trackerSnapshot);
+    // Parent row is untouched.
+    expect(loadGraphMemoryState(source.id)).toBe(trackerSnapshot);
+  });
+
+  test("leaves both memory state tables empty when the parent has none", async () => {
+    const source = createConversation("Pristine thread");
+    await addMessage(source.id, "user", "first message", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    const db = getDb();
+    expect(await hydrateActivationState(db, fork.id)).toBeNull();
+    expect(loadGraphMemoryState(fork.id)).toBeNull();
   });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -47,6 +47,7 @@ import {
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { getDb, getSqliteFrom } from "./db-connection.js";
+import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
 import { rawExec, rawGet, rawRun } from "./raw-query.js";
 import {
@@ -61,6 +62,7 @@ import {
   toolInvocations,
 } from "./schema.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
+import { forkActivationState } from "./v2/activation-store.js";
 
 const log = getLogger("conversation-store");
 
@@ -665,6 +667,12 @@ export function forkConversation(params: {
       latestAssistantMessageId: latestForkedAssistant?.messageId ?? null,
       latestAssistantMessageAt: latestForkedAssistant?.messageAt ?? null,
     });
+
+    // Carry the parent's per-conversation memory state into the child so the
+    // forked thread resumes with the same activation/injection log and
+    // in-context tracker the parent had at fork time.
+    forkActivationState(db, sourceConversation.id, fc.id);
+    forkGraphMemoryState(sourceConversation.id, fc.id);
 
     return fc;
   });

--- a/assistant/src/memory/graph/graph-memory-state-store.ts
+++ b/assistant/src/memory/graph/graph-memory-state-store.ts
@@ -24,9 +24,7 @@ export function saveGraphMemoryState(
 /**
  * Load graph memory state for a conversation, or null if none exists.
  */
-export function loadGraphMemoryState(
-  conversationId: string,
-): string | null {
+export function loadGraphMemoryState(conversationId: string): string | null {
   const db = getDb();
   const row = db
     .select({ stateJson: conversationGraphMemoryState.stateJson })
@@ -34,4 +32,19 @@ export function loadGraphMemoryState(
     .where(eq(conversationGraphMemoryState.conversationId, conversationId))
     .get();
   return row?.stateJson ?? null;
+}
+
+/**
+ * Copy the parent conversation's graph memory state row to a new conversation
+ * id so the forked conversation resumes with the parent's InContextTracker
+ * snapshot (in-context node IDs, per-node turn log, current turn). No-op if
+ * the parent has no row yet.
+ */
+export function forkGraphMemoryState(
+  parentConversationId: string,
+  newConversationId: string,
+): void {
+  const stateJson = loadGraphMemoryState(parentConversationId);
+  if (stateJson == null) return;
+  saveGraphMemoryState(newConversationId, stateJson);
 }

--- a/assistant/src/memory/v2/__tests__/activation-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation-store.test.ts
@@ -8,7 +8,7 @@ import { migrateActivationState } from "../../migrations/232-activation-state.js
 import * as schema from "../../schema.js";
 import {
   evictCompactedTurns,
-  fork,
+  forkActivationState,
   hydrate,
   save,
 } from "../activation-store.js";
@@ -113,12 +113,12 @@ describe("activation-store", () => {
     });
   });
 
-  describe("fork", () => {
+  describe("forkActivationState", () => {
     test("copies parent state to a new conversation id", async () => {
       const parentState = buildState();
       await save(db, "conv-parent", parentState);
 
-      await fork(db, "conv-parent", "conv-child");
+      forkActivationState(db, "conv-parent", "conv-child");
 
       const child = await hydrate(db, "conv-child");
       expect(child).toEqual(parentState);
@@ -129,7 +129,7 @@ describe("activation-store", () => {
     });
 
     test("is a no-op when the parent has no state", async () => {
-      await fork(db, "conv-parent-missing", "conv-child");
+      forkActivationState(db, "conv-parent-missing", "conv-child");
 
       expect(await hydrate(db, "conv-child")).toBeNull();
     });
@@ -139,7 +139,7 @@ describe("activation-store", () => {
       await save(db, "conv-parent", parentState);
       await save(db, "conv-child", buildState({ currentTurn: 99 }));
 
-      await fork(db, "conv-parent", "conv-child");
+      forkActivationState(db, "conv-parent", "conv-child");
 
       const child = await hydrate(db, "conv-child");
       expect(child?.currentTurn).toBe(7);

--- a/assistant/src/memory/v2/activation-store.ts
+++ b/assistant/src/memory/v2/activation-store.ts
@@ -82,15 +82,44 @@ export async function save(
  * The child row inherits everInjected as-is so previously-attached slugs are
  * not re-injected on the child's first turn — matching the v1 semantics where
  * a fork carries over all in-context memories.
+ *
+ * Synchronous so it can run inside the bun:sqlite transaction that wraps
+ * `forkConversation()` — keeping the state copy atomic with the message and
+ * attachment copies.
  */
-export async function fork(
+export function forkActivationState(
   database: DrizzleDb,
   parentConversationId: string,
   newConversationId: string,
-): Promise<void> {
-  const parent = await hydrate(database, parentConversationId);
-  if (!parent) return;
-  await save(database, newConversationId, parent);
+): void {
+  const row = database
+    .select()
+    .from(activationState)
+    .where(eq(activationState.conversationId, parentConversationId))
+    .get();
+  if (!row) return;
+
+  database
+    .insert(activationState)
+    .values({
+      conversationId: newConversationId,
+      messageId: row.messageId,
+      stateJson: row.stateJson,
+      everInjectedJson: row.everInjectedJson,
+      currentTurn: row.currentTurn,
+      updatedAt: row.updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: activationState.conversationId,
+      set: {
+        messageId: row.messageId,
+        stateJson: row.stateJson,
+        everInjectedJson: row.everInjectedJson,
+        currentTurn: row.currentTurn,
+        updatedAt: row.updatedAt,
+      },
+    })
+    .run();
 }
 
 /**


### PR DESCRIPTION
## Summary

- When `forkConversation()` runs, also copy the parent's v2 activation state (`activation_state`) and v1 graph memory state (`conversation_graph_memory_state`) into the new conversation so the fork resumes with the parent's activation/injection log and InContextTracker snapshot.
- Replaces the existing async `fork()` in `activation-store.ts` with a synchronous `forkActivationState()` that operates on raw rows so it can run inside the bun:sqlite transaction in `forkConversation()`. New `forkGraphMemoryState()` delegates to the existing load/save helpers.
- The state copies happen inside the existing fork transaction, so they roll back cleanly with the rest of the fork on failure.

## Original prompt

When a conversation is forked in the macOS desktop app (via `/fork` or "Fork from here"), the daemon copies messages, attachments, compaction state, and inference profile, but not the per-conversation memory state. The forked thread therefore re-injects memories from scratch and loses continuity with whatever was top-of-mind in the parent. Wire fork to also copy `activation_state` (memory v2) and `conversation_graph_memory_state` (memory v1 InContextTracker) so the child inherits the parent's activation/injection log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->