### PR TITLE
fix(memory-v2): isolate per-page errors and preserve telemetry on throw

### DIFF
--- a/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
@@ -117,6 +117,7 @@ describe("memory-v2-concept-frequency", () => {
       in_context: 1,
       not_injected: 0,
       page_missing: 0,
+      corrupt: 0,
     });
     expect(bySlug.get("alice")!.totalEvaluations).toBe(3);
     expect(bySlug.get("alice")!.onDisk).toBe(true);
@@ -127,6 +128,7 @@ describe("memory-v2-concept-frequency", () => {
       in_context: 0,
       not_injected: 1,
       page_missing: 0,
+      corrupt: 0,
     });
     expect(bySlug.get("bob")!.totalEvaluations).toBe(2);
     expect(bySlug.get("bob")!.onDisk).toBe(true);
@@ -136,6 +138,7 @@ describe("memory-v2-concept-frequency", () => {
       in_context: 0,
       not_injected: 0,
       page_missing: 1,
+      corrupt: 0,
     });
     expect(bySlug.get("charlie")!.onDisk).toBe(false);
     expect(bySlug.get("charlie")!.lastInjectedAt).toBeNull();

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -7,6 +7,7 @@
 // ---------------------------------------------------------------------------
 
 import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
+import { z } from "zod";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { estimateTextTokens } from "../../context/token-estimator.js";
@@ -390,8 +391,15 @@ export class ConversationGraphMemory {
 
       return await this.runPerTurn(messages, config, abortSignal);
     } catch (err) {
+      const errCode =
+        err instanceof z.ZodError ? err.issues[0]?.code : undefined;
       log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        {
+          err: err instanceof Error ? err.message : String(err),
+          conversationId: this.conversationId,
+          turn: this.tracker.getTurn(),
+          errCode,
+        },
         "Memory retrieval failed (non-fatal)",
       );
       return noopResult;

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -40,7 +40,25 @@ export interface MemoryV2ConceptRowRecord {
   inRerankPool: boolean;
   spreadContribution: number;
   source: "prior_state" | "ann_top50" | "both";
-  status: "in_context" | "injected" | "not_injected" | "page_missing";
+  /**
+   * Per-turn outcome for this slug:
+   *   - `in_context`  — already injected on a prior turn; cached attachment
+   *     remains visible without re-rendering.
+   *   - `injected`    — freshly rendered into this turn's user message.
+   *   - `not_injected`— a candidate that didn't make `slugsToRender`.
+   *   - `page_missing`— would-have-been-injected, but `readPage` returned
+   *     null (file vanished between selection and render — stale Qdrant
+   *     or edge-index entry).
+   *   - `corrupt`     — would-have-been-injected, but `readPage` threw
+   *     (e.g. malformed frontmatter). Other slugs in the same batch
+   *     rendered normally.
+   */
+  status:
+    | "in_context"
+    | "injected"
+    | "not_injected"
+    | "page_missing"
+    | "corrupt";
 }
 
 export interface MemoryV2ConfigSnapshot {
@@ -57,7 +75,14 @@ export interface MemoryV2ConfigSnapshot {
 export interface RecordMemoryV2ActivationLogParams {
   conversationId: string;
   turn: number;
-  mode: "context-load" | "per-turn";
+  /**
+   * Call-site mode: `context-load` for fresh / post-compaction loads,
+   * `per-turn` for normal append injections, `errored` when `injectMemoryV2Block`
+   * threw before completing — telemetry is still written so silent failures
+   * are observable in the database, with whatever `concepts` rows had been
+   * built so far (possibly empty).
+   */
+  mode: "context-load" | "per-turn" | "errored";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -105,7 +130,7 @@ export function backfillMemoryV2ActivationMessageId(
 export interface MemoryV2ActivationLog {
   conversationId: string;
   turn: number;
-  mode: "context-load" | "per-turn";
+  mode: "context-load" | "per-turn" | "errored";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -126,7 +151,7 @@ export function getMemoryV2ActivationLogByMessageIds(
   return {
     conversationId: row.conversationId,
     turn: row.turn,
-    mode: row.mode as "context-load" | "per-turn",
+    mode: row.mode as "context-load" | "per-turn" | "errored",
     concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
     config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
   };

--- a/assistant/src/memory/memory-v2-concept-frequency.ts
+++ b/assistant/src/memory/memory-v2-concept-frequency.ts
@@ -52,6 +52,7 @@ const ZERO_COUNTS: ConceptFrequencyCounts = {
   in_context: 0,
   not_injected: 0,
   page_missing: 0,
+  corrupt: 0,
 };
 
 interface CountRow {
@@ -129,6 +130,9 @@ export async function getConceptFrequencySummary(
         break;
       case "page_missing":
         entry.counts.page_missing += row.count;
+        break;
+      case "corrupt":
+        entry.counts.corrupt += row.count;
         break;
       default:
         // Forward-compat: unknown status values are ignored, not summed into

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -41,6 +41,7 @@ import {
 } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { z } from "zod";
 
 import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
 import type { AssistantConfig } from "../../../config/types.js";
@@ -176,6 +177,61 @@ mock.module("../../memory-v2-activation-log-store.js", () => ({
       throw new Error("simulated telemetry write failure");
     }
     telemetryState.recordCalls.push(params);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Page-store mock — pass-through with optional per-slug failure injection
+// ---------------------------------------------------------------------------
+//
+// Most tests want the real `readPage` (it walks the temp workspace seeded in
+// `beforeAll`). The error-isolation tests stage a slug whose `readPage` call
+// must throw — typically a Zod validation error mimicking the real-world
+// "unrecognized frontmatter key" failure that motivated this work. Tests
+// stage entries via `pageStoreState.failingSlugs` and reset in `resetState`.
+//
+// Bun's `mock.module` mutates the module's exports object in place, so
+// `realPageStore.readPage` AFTER the mock applies would resolve to the mock
+// itself — calling it would recurse. We capture the original function value
+// (not a property lookup) before installing the mock so the pass-through
+// path has a real reference to the underlying implementation.
+
+const realPageStoreModule = await import("../page-store.js");
+const realReadPage = realPageStoreModule.readPage;
+const pageStoreState = {
+  failingSlugs: new Map<string, Error>(),
+};
+mock.module("../page-store.js", () => ({
+  ...realPageStoreModule,
+  readPage: async (workspaceDir: string, slug: string) => {
+    const err = pageStoreState.failingSlugs.get(slug);
+    if (err) throw err;
+    return realReadPage(workspaceDir, slug);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Activation-store mock — pass-through with optional `save` failure injection
+// ---------------------------------------------------------------------------
+//
+// One regression test forces `save` to throw to exercise the
+// `injectMemoryV2Block` outer try/finally — telemetry must still be flushed
+// (with `mode: "errored"`) and the error must propagate. Default behavior
+// delegates to the real activation-store so the rest of the suite stays
+// untouched. Same pre-mock function-capture trick as `readPage` above.
+
+const realActivationStoreModule = await import("../activation-store.js");
+const realSave = realActivationStoreModule.save;
+const activationStoreState = {
+  saveShouldThrow: false,
+};
+mock.module("../activation-store.js", () => ({
+  ...realActivationStoreModule,
+  save: async (...args: Parameters<typeof realSave>) => {
+    if (activationStoreState.saveShouldThrow) {
+      throw new Error("simulated activation-store save failure");
+    }
+    return realSave(...args);
   },
 }));
 
@@ -390,6 +446,8 @@ function resetState(): void {
   skillState.entries.clear();
   telemetryState.recordCalls.length = 0;
   telemetryState.recordShouldThrow = false;
+  pageStoreState.failingSlugs.clear();
+  activationStoreState.saveShouldThrow = false;
   // The qdrant module caches its client; the cached client may be a
   // MockQdrantClient instance from a sibling test file. Reset to force a
   // fresh `new QdrantClient()` against this file's mock.
@@ -1295,5 +1353,116 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([
       { slug: "alice-vscode", turn: 1 },
     ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-page error isolation + on-throw telemetry
+  // ---------------------------------------------------------------------------
+
+  test("one slug's page-read failing isolates the error — other slugs still render and the corrupt slug records `status: corrupt`", async () => {
+    // Two slugs rank into top-K together. Carol's page reads cleanly; alice's
+    // `readPage` throws a ZodError mimicking the real "unrecognized
+    // frontmatter key" failure that motivated this work. Before the fix, the
+    // bare `Promise.all` rejected and the entire turn lost its block AND its
+    // activation log row. With per-page isolation, carol still renders and
+    // the activation log row marks alice as `corrupt` (telemetry remains
+    // observable for triage).
+    const zodErr = z.object({ x: z.string() }).safeParse({ x: 1 }).error!;
+    pageStoreState.failingSlugs.set("alice-vscode", zodErr);
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.95 },
+      { slug: "carol-jazz", denseScore: 0.9 },
+    ]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "music and editors",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    // (a) Block is non-null and contains content from the OTHER slug; alice
+    // is dropped from the rendered block but does not poison the batch.
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("# memory/concepts/carol-jazz.md");
+    expect(result.block).not.toContain("# memory/concepts/alice-vscode.md");
+
+    // (b) Activation log row exists with carol `injected` and alice
+    // `corrupt`. Status `corrupt` is reserved for read-time throws and is
+    // distinct from `page_missing` (which is null-return / file vanished).
+    expect(telemetryState.recordCalls.length).toBe(1);
+    const row = telemetryState.recordCalls[0] as {
+      mode: string;
+      concepts: Array<{ slug: string; status: string }>;
+    };
+    expect(row.mode).toBe("per-turn");
+    const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
+    expect(byslug.get("alice-vscode")!.status).toBe("corrupt");
+    expect(byslug.get("carol-jazz")!.status).toBe("injected");
+
+    // (c) Both slugs land in `toInject` and `everInjected` — same handling
+    // as `page_missing` (see the phantom-slug test): the slug was attempted
+    // this turn, telemetry records the outcome, and we don't keep re-trying
+    // a stale Qdrant / edge-index entry on every subsequent turn.
+    expect(new Set(result.toInject)).toEqual(
+      new Set(["alice-vscode", "carol-jazz"]),
+    );
+    const persisted = await hydrate(db, "conv-1");
+    const everInjectedSlugs = persisted!.everInjected.map((e) => e.slug);
+    expect(new Set(everInjectedSlugs)).toEqual(
+      new Set(["alice-vscode", "carol-jazz"]),
+    );
+  });
+
+  test("a throw before renderInjectionBlock still flushes telemetry as `mode: errored` and re-throws", async () => {
+    // The activation-state save throws — the most realistic non-render
+    // failure mode (transient SQLite write error mid-injection). The
+    // `injectMemoryV2Block` outer try/finally must (a) flush an activation
+    // log row tagged `mode: "errored"` so silent failures stay observable
+    // in the database, and (b) re-throw so callers (e.g. `prepareMemory`'s
+    // outer catch) see the original error and can degrade gracefully.
+    activationStoreState.saveShouldThrow = true;
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    let threw: unknown = undefined;
+    try {
+      await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-1",
+        currentTurn: 1,
+        userMessage: "Alice's editor",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig(),
+      });
+    } catch (err) {
+      threw = err;
+    }
+
+    // The original error propagates to the caller.
+    expect(threw).toBeInstanceOf(Error);
+    expect((threw as Error).message).toContain(
+      "simulated activation-store save failure",
+    );
+
+    // A telemetry row was still written, tagged `errored`. `concepts` is
+    // empty because the throw fired before the row-builder ran — that's
+    // expected and documented as part of the contract.
+    expect(telemetryState.recordCalls.length).toBe(1);
+    const row = telemetryState.recordCalls[0] as {
+      mode: string;
+      conversationId: string;
+      turn: number;
+      concepts: unknown[];
+    };
+    expect(row.mode).toBe("errored");
+    expect(row.conversationId).toBe("conv-1");
+    expect(row.turn).toBe(1);
+    expect(row.concepts).toEqual([]);
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -182,7 +182,12 @@ export async function injectMemoryV2Block(
   // prior cached attachments don't exist or have been thrown away. The user
   // message gets a complete top-K dump alongside the static
   // essentials/threads/recent block, then per-turn turns just add deltas.
-  const mode = params.mode ?? "per-turn";
+  //
+  // `mode` is `let` because the trailing try/finally promotes it to "errored"
+  // when the render/telemetry path throws — we still want a log row written
+  // (with whatever conceptRows we managed to build) so silent failures are
+  // observable in the database.
+  let mode: "context-load" | "per-turn" | "errored" = params.mode ?? "per-turn";
   const priorEverInjected: readonly EverInjectedEntry[] =
     priorState?.everInjected ?? [];
   const { topNow, toInject } = selectInjections({
@@ -239,35 +244,48 @@ export async function injectMemoryV2Block(
     updatedAt: Date.now(),
   };
 
-  await save(database, conversationId, nextActivationState);
+  // `conceptRows` and `block` are declared outside the try so the finally
+  // block can flush activation telemetry even if rendering, row-building, or
+  // the activation-state save throws partway through. Without this, a Zod
+  // failure on a single concept page (e.g. unrecognized frontmatter key)
+  // silently dropped the entire turn's activation log row, masking the
+  // underlying data-corruption bug.
+  let conceptRows: MemoryV2ConceptRowRecord[] = [];
+  let block: string | null = null;
+  let caughtErr: unknown = undefined;
+  const v2Cfg = config.memory.v2;
 
-  // Render before recording telemetry so the activation log can mark slugs
-  // whose backing file is gone — those are no-op renders that would otherwise
-  // be indistinguishable from successful "injected" rows in the log.
-  // `renderInjectionBlock` itself short-circuits on empty inputs.
-  const { block, missingSlugs } = await renderInjectionBlock(
-    workspaceDir,
-    slugsToRender,
-  );
-  const missingSlugSet = new Set(missingSlugs);
-  if (missingSlugs.length > 0) {
-    log.warn(
-      {
-        conversationId,
-        turn: currentTurn,
-        missingSlugs,
-        renderedCount: slugsToRender.length - missingSlugs.length,
-      },
-      "Memory v2 injection skipped slugs whose page was missing on disk — Qdrant index may be stale; consider reembed",
-    );
-  }
+  try {
+    await save(database, conversationId, nextActivationState);
 
-  // Record per-turn activation telemetry. Failures are warn-logged and never
-  // block memory injection.
-  const toInjectSet = new Set(toInject);
-  const renderedSet = new Set(slugsToRender);
-  const conceptRows: MemoryV2ConceptRowRecord[] = [...candidates].map(
-    (slug) => {
+    // Render before recording telemetry so the activation log can mark slugs
+    // whose backing file is gone or failed to load — those are no-op renders
+    // that would otherwise be indistinguishable from successful "injected"
+    // rows in the log. `renderInjectionBlock` itself short-circuits on empty
+    // inputs and emits per-slug `log.warn` for each corrupt page.
+    const rendered = await renderInjectionBlock(workspaceDir, slugsToRender);
+    block = rendered.block;
+    const { missingSlugs, corruptSlugs } = rendered;
+    const missingSlugSet = new Set(missingSlugs);
+    const corruptSlugSet = new Set(corruptSlugs);
+    if (missingSlugs.length > 0) {
+      log.warn(
+        {
+          conversationId,
+          turn: currentTurn,
+          missingSlugs,
+          renderedCount:
+            slugsToRender.length - missingSlugs.length - corruptSlugs.length,
+        },
+        "Memory v2 injection skipped slugs whose page was missing on disk — Qdrant index may be stale; consider reembed",
+      );
+    }
+
+    // Record per-turn activation telemetry. Failures are warn-logged in the
+    // finally block and never block memory injection.
+    const toInjectSet = new Set(toInject);
+    const renderedSet = new Set(slugsToRender);
+    conceptRows = [...candidates].map((slug) => {
       const breakdown = ownBreakdown.get(slug);
       const inPrior = fromPrior.has(slug);
       const inAnn = fromAnn.has(slug);
@@ -279,10 +297,11 @@ export async function injectMemoryV2Block(
       //   - per-turn: cached attachments from prior turns are still on the
       //     user message, so prior-everInjected slugs are `in_context` and
       //     the delta (`toInject`) is `injected`.
-      // `page_missing` overrides any "would-have-been-injected" status when
-      // `readPage` returned null for the slug — telemetry surfaces stale
-      // ANN/edge entries instead of silently masquerading as a successful
-      // injection.
+      // `page_missing` and `corrupt` override any "would-have-been-injected"
+      // status when `readPage` returned null or threw — telemetry surfaces
+      // stale ANN/edge entries and malformed pages instead of silently
+      // masquerading as successful injections. `corrupt` takes priority over
+      // `page_missing` since they're mutually exclusive per slug.
       let status: MemoryV2ConceptRowRecord["status"];
       if (mode === "context-load") {
         status = renderedSet.has(slug) ? "injected" : "not_injected";
@@ -295,6 +314,9 @@ export async function injectMemoryV2Block(
       }
       if (status === "injected" && missingSlugSet.has(slug)) {
         status = "page_missing";
+      }
+      if (corruptSlugSet.has(slug)) {
+        status = "corrupt";
       }
       return {
         slug,
@@ -312,35 +334,41 @@ export async function injectMemoryV2Block(
           inPrior && inAnn ? "both" : inPrior ? "prior_state" : "ann_top50",
         status,
       };
-    },
-  );
-  conceptRows.sort((a, b) => b.finalActivation - a.finalActivation);
-
-  const v2Cfg = config.memory.v2;
-  try {
-    recordMemoryV2ActivationLog({
-      conversationId,
-      turn: currentTurn,
-      mode,
-      concepts: conceptRows,
-      config: {
-        d: v2Cfg.d,
-        c_user: v2Cfg.c_user,
-        c_assistant: v2Cfg.c_assistant,
-        c_now: v2Cfg.c_now,
-        k: v2Cfg.k,
-        hops: v2Cfg.hops,
-        top_k: v2Cfg.top_k,
-        epsilon: v2Cfg.epsilon,
-      },
     });
+    conceptRows.sort((a, b) => b.finalActivation - a.finalActivation);
   } catch (err) {
-    log.warn(
-      { err, conversationId, turn: currentTurn },
-      "Failed to record memory v2 activation telemetry — continuing",
-    );
+    // Stash the error and let `finally` flush a best-effort telemetry row
+    // before we re-throw to the caller. `mode = "errored"` flags the row
+    // for observability dashboards / inspector queries.
+    caughtErr = err;
+    mode = "errored";
+  } finally {
+    try {
+      recordMemoryV2ActivationLog({
+        conversationId,
+        turn: currentTurn,
+        mode,
+        concepts: conceptRows,
+        config: {
+          d: v2Cfg.d,
+          c_user: v2Cfg.c_user,
+          c_assistant: v2Cfg.c_assistant,
+          c_now: v2Cfg.c_now,
+          k: v2Cfg.k,
+          hops: v2Cfg.hops,
+          top_k: v2Cfg.top_k,
+          epsilon: v2Cfg.epsilon,
+        },
+      });
+    } catch (telemetryErr) {
+      log.warn(
+        { err: telemetryErr, conversationId, turn: currentTurn },
+        "Failed to record memory v2 activation telemetry — continuing",
+      );
+    }
   }
 
+  if (caughtErr !== undefined) throw caughtErr;
   return { block, toInject: newlyInjected };
 }
 
@@ -374,6 +402,15 @@ interface RenderInjectionBlockResult {
    * edge-index entries that pointed at pages no longer on disk.
    */
   missingSlugs: string[];
+  /**
+   * Slugs whose `readPage` call threw (e.g. invalid frontmatter that fails
+   * Zod validation, unreadable file). These are reported separately from
+   * `missingSlugs` because they're a different failure mode — the file
+   * exists but is malformed, not absent — and surfaced so the caller can
+   * mark them in the activation log (`status: "corrupt"`). Per-page errors
+   * are isolated: one bad page no longer rejects the whole batch.
+   */
+  corruptSlugs: string[];
 }
 
 /**
@@ -397,11 +434,15 @@ const INJECTION_HEADER =
  * trailing `### Skills You Can Use` subsection; everything else is read
  * from disk via `readPage` and rendered as a concept-page section.
  *
- * Concept pages are read in parallel via `readPage`. Pages whose file has
- * gone missing between selection and render (e.g. consolidation deleted
- * them, folder reorg renamed the slug) are dropped from the rendered
- * block but reported back via `missingSlugs` so callers can surface the
- * divergence.
+ * Concept pages are read in parallel via `Promise.allSettled`. Per-page
+ * errors are isolated: a `readPage` rejection (e.g. invalid frontmatter
+ * failing Zod validation) collects the slug into `corruptSlugs` and the
+ * remaining pages still render normally. Pages whose file has gone missing
+ * between selection and render (e.g. consolidation deleted them, folder
+ * reorg renamed the slug) are dropped from the rendered block but reported
+ * back via `missingSlugs`. The two buckets are kept separate so callers can
+ * distinguish "file vanished" (stale index) from "file is malformed"
+ * (data-corruption / programmer error).
  *
  * Skill slugs whose entry the cache no longer knows (e.g. uninstalled
  * mid-run) are silently dropped, mirroring the missing-pages behavior but
@@ -441,17 +482,26 @@ async function renderInjectionBlock(
   const conceptSlugs = slugs.filter((s) => !isSkillSlug(s));
   const skillSlugs = slugs.filter((s) => isSkillSlug(s));
 
-  const pages = await Promise.all(
-    conceptSlugs.map(async (slug) => {
-      const page = await readPage(workspaceDir, slug);
-      return { slug, page };
-    }),
+  const settled = await Promise.allSettled(
+    conceptSlugs.map((slug) => readPage(workspaceDir, slug)),
   );
 
   const sections: string[] = [];
   const missingSlugs: string[] = [];
+  const corruptSlugs: string[] = [];
   let anySummarySection = false;
-  for (const { slug, page } of pages) {
+  for (let i = 0; i < settled.length; i++) {
+    const slug = conceptSlugs[i]!;
+    const result = settled[i]!;
+    if (result.status === "rejected") {
+      corruptSlugs.push(slug);
+      log.warn(
+        { slug, err: result.reason },
+        "Memory v2 injection skipped slug whose page failed to load — frontmatter may be malformed",
+      );
+      continue;
+    }
+    const page = result.value;
     if (!page) {
       missingSlugs.push(slug);
       continue;
@@ -481,11 +531,14 @@ async function renderInjectionBlock(
     sections.push(`### Skills You Can Use\n${skillLines.join("\n")}`);
   }
 
-  if (sections.length === 0) return { block: null, missingSlugs };
+  if (sections.length === 0) {
+    return { block: null, missingSlugs, corruptSlugs };
+  }
 
   const body = sections.join("\n\n");
   return {
     block: anySummarySection ? `${INJECTION_HEADER}\n\n${body}` : body,
     missingSlugs,
+    corruptSlugs,
   };
 }


### PR DESCRIPTION
## Summary

- `renderInjectionBlock` now uses `Promise.allSettled` and surfaces corrupt pages as a `corruptSlugs` bucket parallel to `missingSlugs`. One invalid concept page no longer kills the whole batch.
- New `"corrupt"` status in `MemoryV2ConceptRowRecord` so the activation log captures which page broke and why.
- `injectMemoryV2Block` wraps its body in `try/finally` so `recordMemoryV2ActivationLog` runs even on throw, with `mode: "errored"`. Silent V2 failures are now observable in `memory_v2_activation_logs`.
- `prepareMemory`'s outer catch logs structured fields (`conversationId`, `turn`, `errCode`) instead of a bare error message.

## Original prompt

While debugging why no V2 dynamic memories appeared on a specific assistant turn in Velissa's database, root cause was traced to one concept page (`frames/procedural/wikipedia-lead-shape.md`) carrying a `ref_urls` frontmatter key that the strict `ConceptPageFrontmatterSchema` rejects. The Zod throw rejected `Promise.all` in `renderInjectionBlock`, escaped through `injectMemoryV2Block` to `prepareMemory`'s outer catch, and the activation log was never written. The user asked to fix the silent-failure mode and surface this kind of bug visibly going forward.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/memory/v2/__tests__/injection.test.ts` passes including the two new tests
- [ ] Verify in Velissa's DB that future failed turns show up as `mode: "errored"` rows in `memory_v2_activation_logs`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->