### PR TITLE
fix(memory-v2): persist essentials/threads/recent/buffer across daemon restart

### DIFF
--- a/assistant/src/__tests__/compaction-strip-metadata-clear.test.ts
+++ b/assistant/src/__tests__/compaction-strip-metadata-clear.test.ts
@@ -41,7 +41,7 @@ describe("clearStrippedInjectionMetadataForConversation", () => {
     resetTables();
   });
 
-  test("removes all three stripped-block fields and preserves the rest", async () => {
+  test("removes all stripped-block fields and preserves the rest", async () => {
     const conv = createConversation("Strip metadata test");
     await addMessage(
       conv.id,
@@ -56,6 +56,8 @@ describe("clearStrippedInjectionMetadataForConversation", () => {
         pkbContextBlock: "<knowledge_base>\npkb body\n</knowledge_base>",
         pkbSystemReminderBlock:
           "<system_reminder>\nreminder body\n</system_reminder>",
+        memoryV2StaticBlock:
+          "<memory>\n## Essentials\n\nstatic body\n</memory>",
       },
       { skipIndexing: true },
     );
@@ -68,12 +70,35 @@ describe("clearStrippedInjectionMetadataForConversation", () => {
     expect(meta.pkbSystemReminderBlock).toBeUndefined();
     expect(meta.nowScratchpadBlock).toBeUndefined();
     expect(meta.pkbContextBlock).toBeUndefined();
+    expect(meta.memoryV2StaticBlock).toBeUndefined();
 
     // Non-stripped fields must survive — these back blocks that
     // `stripInjectionsForCompaction` intentionally leaves in-memory.
     expect(meta.memoryInjectedBlock).toBe("mem payload");
     expect(meta.turnContextBlock).toBe("<turn_context>\nctx\n</turn_context>");
     expect(meta.workspaceBlock).toBe("<workspace>\nws\n</workspace>");
+  });
+
+  test("clears memoryV2StaticBlock alone when it is the only stripped field present", async () => {
+    const conv = createConversation("Strip v2 static only");
+    await addMessage(
+      conv.id,
+      "user",
+      "turn 1",
+      {
+        memoryInjectedBlock: "keep me",
+        memoryV2StaticBlock:
+          "<memory>\n## Essentials\n\nstatic body\n</memory>",
+      },
+      { skipIndexing: true },
+    );
+
+    clearStrippedInjectionMetadataForConversation(conv.id);
+
+    const [row] = getMessages(conv.id);
+    const meta = JSON.parse(row.metadata ?? "{}");
+    expect(meta.memoryV2StaticBlock).toBeUndefined();
+    expect(meta.memoryInjectedBlock).toBe("keep me");
   });
 
   test("is idempotent — re-running is a no-op on already-cleared rows", async () => {

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -368,4 +368,128 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(messages).toHaveLength(2);
     expect(messages[0].content).toEqual([{ type: "text", text: "First" }]);
   });
+
+  test("historical user row rehydrates memoryV2StaticBlock between memory and system_reminder", async () => {
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryInjectedBlock: "mem payload",
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+          pkbSystemReminderBlock:
+            "<system_reminder>\npkb payload\n</system_reminder>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail turn" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content).toEqual([
+      { type: "text", text: "<memory>\nmem payload\n</memory>" },
+      {
+        type: "text",
+        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+      },
+      {
+        type: "text",
+        text: "<system_reminder>\npkb payload\n</system_reminder>",
+      },
+      { type: "text", text: "First turn" },
+    ]);
+  });
+
+  test("tail user row skips memoryV2StaticBlock", async () => {
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First" }]),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({
+          memoryV2StaticBlock: "<memory>\n## Essentials\n\nleak\n</memory>",
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[2].role).toBe("user");
+    // Tail row receives fresh injection on the next turn — the persisted
+    // static block must not rehydrate here.
+    expect(messages[2].content).toEqual([{ type: "text", text: "Tail" }]);
+  });
+
+  test("untrusted-actor view does not rehydrate memoryV2StaticBlock", async () => {
+    mockConversation = defaultConv();
+    // Rows with `trusted_contact` / `unknown` provenance survive the
+    // untrusted-actor row filter, so this isolates the rehydrate gate.
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First" }]),
+        metadata: JSON.stringify({
+          provenanceTrustClass: "trusted_contact",
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "unknown" }),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "telegram",
+    });
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    // The historical row survives row-level filtering but the rehydrate gate
+    // suppresses the personal-memory block.
+    expect(messages[0].content).toEqual([{ type: "text", text: "First" }]);
+  });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1587,7 +1587,8 @@ export async function runAgentLoopImpl(
       injection.blocks.pkbSystemReminder ||
       injection.blocks.workspaceBlock ||
       injection.blocks.nowScratchpadBlock ||
-      injection.blocks.pkbContextBlock
+      injection.blocks.pkbContextBlock ||
+      injection.blocks.memoryV2StaticBlock
     ) {
       try {
         const metadataUpdates: Record<string, unknown> = {};
@@ -1608,6 +1609,10 @@ export async function runAgentLoopImpl(
         }
         if (injection.blocks.pkbContextBlock) {
           metadataUpdates.pkbContextBlock = injection.blocks.pkbContextBlock;
+        }
+        if (injection.blocks.memoryV2StaticBlock) {
+          metadataUpdates.memoryV2StaticBlock =
+            injection.blocks.memoryV2StaticBlock;
         }
         await runPipeline<PersistArgs, PersistResult>(
           "persistence",

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -183,6 +183,7 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
     ctx.contextCompactedAt = conv?.contextCompactedAt ?? null;
   }
 
+  const personalMemoryAllowed = !isUntrustedTrustClass(trustClass);
   const parsedMessages: Message[] = dbMessages
     .slice(ctx.contextCompactedMessageCount)
     .map((m, index, arr) => {
@@ -215,7 +216,8 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           // shape right-to-left, since each prepend shifts previously-
           // prepended blocks one slot right:
           //   [<workspace>, <turn_context>, <NOW.md>, <memory __injected>,
-          //    <system_reminder>, <knowledge_base>, ...original]
+          //    <memory>\n…</memory>, <system_reminder>, <knowledge_base>,
+          //    ...original]
           //
           // Persisted non-tail rows rehydrate the full set so Anthropic's
           // prefix cache keeps matching msg[0] across daemon restarts and
@@ -234,6 +236,23 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
             content = [
               { type: "text" as const, text: meta.pkbSystemReminderBlock },
+              ...content,
+            ];
+          }
+
+          // The v2 static memory block (essentials/threads/recent/buffer
+          // wrapped in `<memory>…</memory>`) carries personal user memory.
+          // Trust-gated to mirror `shouldExposePersonalMemory` at injection
+          // time — untrusted-actor views must not read persisted personal
+          // memory back through metadata. Skipped on the tail row because
+          // the next turn re-injects fresh content on full-mode turns.
+          if (
+            !isTail &&
+            personalMemoryAllowed &&
+            typeof meta.memoryV2StaticBlock === "string"
+          ) {
+            content = [
+              { type: "text" as const, text: meta.memoryV2StaticBlock },
               ...content,
             ];
           }

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1739,6 +1739,7 @@ export interface RuntimeInjectionBlocks {
   workspaceBlock?: string;
   nowScratchpadBlock?: string;
   pkbContextBlock?: string;
+  memoryV2StaticBlock?: string;
   /**
    * Composed output of every plugin-registered {@link Injector}, concatenated
    * in ascending `order`. Empty string when every injector opted out (returned
@@ -2156,6 +2157,7 @@ export async function applyRuntimeInjections(
   let nowScratchpadCaptured: string | undefined;
   let pkbContextCaptured: string | undefined;
   let pkbSystemReminderCaptured: string | undefined;
+  let memoryV2StaticCaptured: string | undefined;
   const initialTail = runMessages[runMessages.length - 1];
   const initialTailIsUser = !!initialTail && initialTail.role === "user";
   if (initialTailIsUser) {
@@ -2175,6 +2177,9 @@ export async function applyRuntimeInjections(
           break;
         case "pkb-reminder":
           pkbSystemReminderCaptured = block.text;
+          break;
+        case "memory-v2-static":
+          memoryV2StaticCaptured = block.text;
           break;
       }
     }
@@ -2357,6 +2362,7 @@ export async function applyRuntimeInjections(
       workspaceBlock: workspaceCaptured,
       nowScratchpadBlock: nowScratchpadCaptured,
       pkbContextBlock: pkbContextCaptured,
+      memoryV2StaticBlock: memoryV2StaticCaptured,
       injectorChainBlock,
     },
   };

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -115,6 +115,7 @@ export const messageMetadataSchema = z
     workspaceBlock: z.string().optional(),
     nowScratchpadBlock: z.string().optional(),
     pkbContextBlock: z.string().optional(),
+    memoryV2StaticBlock: z.string().optional(),
   })
   .passthrough();
 
@@ -1631,8 +1632,10 @@ export function updateMessageMetadata(
 /**
  * Bulk-remove the metadata fields that back the blocks stripped by
  * `stripInjectionsForCompaction` — currently `pkbSystemReminderBlock`
- * (`<system_reminder>`), `nowScratchpadBlock` (`<NOW.md …>`), and
- * `pkbContextBlock` (`<knowledge_base>`). Called from compaction-strip
+ * (`<system_reminder>`), `nowScratchpadBlock` (`<NOW.md …>`),
+ * `pkbContextBlock` (`<knowledge_base>`), and `memoryV2StaticBlock`
+ * (the static `<memory>\n…</memory>` block matched by the `<memory>\n`
+ * prefix in `RUNTIME_INJECTION_PREFIXES`). Called from compaction-strip
  * sites so post-restart rehydration stays consistent with the in-memory
  * state produced by `stripInjectionsForCompaction` (which removes those
  * tags from live messages but cannot touch the DB). Fields backing
@@ -1648,7 +1651,8 @@ export function clearStrippedInjectionMetadataForConversation(
           metadata,
           '$.pkbSystemReminderBlock',
           '$.nowScratchpadBlock',
-          '$.pkbContextBlock'
+          '$.pkbContextBlock',
+          '$.memoryV2StaticBlock'
         )
       WHERE conversation_id = ?
         AND role = 'user'
@@ -1657,6 +1661,7 @@ export function clearStrippedInjectionMetadataForConversation(
           json_extract(metadata, '$.pkbSystemReminderBlock') IS NOT NULL
           OR json_extract(metadata, '$.nowScratchpadBlock') IS NOT NULL
           OR json_extract(metadata, '$.pkbContextBlock') IS NOT NULL
+          OR json_extract(metadata, '$.memoryV2StaticBlock') IS NOT NULL
         )`,
     conversationId,
   );


### PR DESCRIPTION
## Summary
- The v2 static memory block (essentials/threads/recent/buffer wrapped in `<memory>...</memory>`) was the only injected block whose bytes were never captured for metadata persistence — it was injected onto msg[0] in-memory only and silently lost on every daemon restart, since `loadFromDb` had nothing to rehydrate and the next turn's `shouldInjectNowAndPkb` gate blocked re-injection.
- Threads `memoryV2StaticBlock` through the same lifecycle every other block already uses: capture in `applyRuntimeInjections`, persist via the existing metadata-update call in the agent loop, rehydrate in `loadFromDb` (gated `!isTail` and on personal-memory trust class so untrusted-actor views can't read it back), and clear in `clearStrippedInjectionMetadataForConversation` to match the existing `<memory>\n` prefix in `RUNTIME_INJECTION_PREFIXES`.
- Tests cover: historical-row rehydration in the documented order, tail-row skip, untrusted-actor leak guard, and metadata clear during compaction.

## Original prompt
The user reported memory v2 essentials+threads+recent+buffer injection was being stripped from older messages later in the conversation, and suspected a daemon restart was involved. Investigation traced the loss to `applyRuntimeInjections` capturing every other injected block's bytes into the metadata-persistence pipeline but missing the `memory-v2-static` injector — so the block was never written to message metadata, never rehydrated by `loadFromDb`, and the cadence gate blocked any catch-up re-injection on subsequent turns. The fix is to slot the new block into the same capture → persist → rehydrate pattern the other blocks already follow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->