### PR TITLE
docs: clarify fake AWS keys in secret-allowlist tests

### DIFF
--- a/assistant/src/__tests__/secret-allowlist.test.ts
+++ b/assistant/src/__tests__/secret-allowlist.test.ts
@@ -135,6 +135,7 @@ describe("secret-allowlist", () => {
 
   // -----------------------------------------------------------------------
   // Integration with scanText
+  // AKIAIOSFODNN7* keys below are fake — based on the AWS docs example prefix, not real credentials.
   // -----------------------------------------------------------------------
   test("[experimental] allowlisted values are suppressed by scanText", () => {
     const awsKey = "AKIAIOSFODNN7REALKEY";


### PR DESCRIPTION
## Summary
- Added a comment in `secret-allowlist.test.ts` clarifying that `AKIAIOSFODNN7*` keys are deliberately fake (based on the AWS documentation example prefix), not real credentials
- Prevents future false-positive security reports from GitHub secret scanning or manual review

## Original prompt
A security email flagged the fake AWS key `AKIAIOSFODNN7OTHERKE` in the secret-allowlist test file as a leaked credential. After confirming it's a false positive (synthetic key based on the AWS docs example prefix, used only in test assertions), the user asked for a code comment to prevent repeat reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->