### PR TITLE
feat(memory-v2): add router prompt template

### DIFF
--- a/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
+++ b/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
@@ -1,0 +1,27 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renderRouterPrompt — determinism & snapshot stability snapshot of fixed inputs 1`] = `
+"You are a background helper for Aria. Your job is to route memory pages for the next assistant turn between Aria and Alice.
+
+You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
+
+Pick up to a handful of concept pages whose contents would meaningfully help Aria respond well on this turn. Abstain (return an empty list) when nothing in the index is clearly relevant — over-injection is worse than missing a page, because the always-on essentials/threads/recent/buffer block is already in context and you must not duplicate that material here.
+
+Index format. Each line of the index has the shape:
+
+    [id] slug — summary (edges: a, b, c)
+
+\`id\` is a small integer used to refer to this page. \`edges\` are numeric IDs into the same list, pointing at related pages; you may follow them when one page strongly implies another.
+
+Already-injected pages. Pages whose IDs appear in \`<already_injected_ids>\` were picked on the previous turn. Do not pick them again unless Aria should re-anchor on that material — e.g., the topic genuinely returns after drifting away. Routine continuity does not require re-picking; the prior turn's pages are already in the assistant's working context.
+
+Time. Bias toward pages that match the current state implied by \`<now>\` and the active conversational threads (what is happening today, what was just decided, who is being discussed). Stale pages with no bearing on the live conversation should be skipped even if their summaries look superficially relevant.
+
+Emit your selection by calling \`select_pages_to_inject\` with the chosen \`ids\`. Return an empty array to abstain.
+
+# Concept Page Index
+
+[1] morning-routine — coffee, walk, journal (edges: 2)
+[2] journal-style — terse, dated, no fluff (edges: 1)
+[3] taxes-2025 — Q1 estimate due April 15 (edges: )"
+`;

--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for `assistant/src/memory/v2/prompts/router.ts` —
+ * specifically `renderRouterPrompt`, which substitutes the assistant name,
+ * user name, and rendered page index into the bundled router prompt body.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { renderRouterPrompt } from "../prompts/router.js";
+
+const SAMPLE_INDEX = `[1] morning-routine — coffee, walk, journal (edges: 2)
+[2] journal-style — terse, dated, no fluff (edges: 1)
+[3] taxes-2025 — Q1 estimate due April 15 (edges: )`;
+
+describe("renderRouterPrompt — substitution", () => {
+  test("replaces all three placeholders with the supplied values", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).not.toContain("{{ASSISTANT_NAME}}");
+    expect(out).not.toContain("{{USER_NAME}}");
+    expect(out).not.toContain("{{PAGE_INDEX}}");
+    expect(out).toContain("Aria");
+    expect(out).toContain("Alice");
+    expect(out).toContain(SAMPLE_INDEX);
+  });
+
+  test("substitutes every occurrence of the assistant name placeholder", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    // Body references the assistant name in multiple sentences; ensure none
+    // of them leak the raw placeholder.
+    const matches = out.match(/Aria/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("renderRouterPrompt — neutral fallbacks", () => {
+  test("falls back to 'the assistant' when assistantName is null", () => {
+    const out = renderRouterPrompt({
+      assistantName: null,
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("the assistant");
+    expect(out).not.toContain("{{ASSISTANT_NAME}}");
+  });
+
+  test("falls back to 'the user' when userName is null", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: null,
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("the user");
+    expect(out).not.toContain("{{USER_NAME}}");
+  });
+
+  test("uses both fallbacks when both names are null", () => {
+    const out = renderRouterPrompt({
+      assistantName: null,
+      userName: null,
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("the assistant");
+    expect(out).toContain("the user");
+  });
+
+  test("falls back when names are whitespace-only strings", () => {
+    const out = renderRouterPrompt({
+      assistantName: "   ",
+      userName: "\t\n",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("the assistant");
+    expect(out).toContain("the user");
+  });
+});
+
+describe("renderRouterPrompt — page index handling", () => {
+  test("substitutes an empty pageIndexBlock cleanly without double-newline artifacts", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: "",
+    });
+
+    expect(out).not.toContain("{{PAGE_INDEX}}");
+    // The header should still be present and not followed by a stray
+    // triple-newline run from collapsing the empty block.
+    expect(out).toContain("# Concept Page Index");
+    expect(out).not.toMatch(/\n\n\n/);
+    // Output should end at the header section without trailing whitespace.
+    expect(out.endsWith("# Concept Page Index\n\n")).toBe(true);
+  });
+
+  test("preserves the page index body verbatim, including edges syntax", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain(
+      "[1] morning-routine — coffee, walk, journal (edges: 2)",
+    );
+    expect(out).toContain(
+      "[3] taxes-2025 — Q1 estimate due April 15 (edges: )",
+    );
+  });
+});
+
+describe("renderRouterPrompt — determinism & snapshot stability", () => {
+  test("returns the same string for the same inputs", () => {
+    const opts = {
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    };
+    expect(renderRouterPrompt(opts)).toBe(renderRouterPrompt(opts));
+  });
+
+  test("snapshot of fixed inputs", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toMatchSnapshot();
+  });
+});
+
+describe("renderRouterPrompt — content expectations", () => {
+  test("references the select_pages_to_inject tool name", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("select_pages_to_inject");
+  });
+
+  test("describes the already_injected_ids and now markers", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out).toContain("<already_injected_ids>");
+    expect(out).toContain("<now>");
+  });
+
+  test("warns against duplicating the always-on essentials block", () => {
+    const out = renderRouterPrompt({
+      assistantName: "Aria",
+      userName: "Alice",
+      pageIndexBlock: SAMPLE_INDEX,
+    });
+
+    expect(out.toLowerCase()).toContain("essentials");
+  });
+});

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -1,0 +1,81 @@
+/**
+ * Memory v2 — router prompt template.
+ *
+ * The router runs once per assistant turn and decides which concept pages (if
+ * any) should be injected on top of the always-on essentials/threads/recent
+ * block. The body lives here (under `prompts/`) so it is reviewable on its
+ * own, mirroring the convention established in `sweep.ts`.
+ *
+ * Three placeholders are substituted at runtime:
+ *
+ *   - `{{ASSISTANT_NAME}}` — assistant display name (from IDENTITY.md when
+ *     available, else the neutral fallback "the assistant").
+ *   - `{{USER_NAME}}` — guardian display name (from the guardian persona when
+ *     available, else "the user").
+ *   - `{{PAGE_INDEX}}` — pre-rendered page index. Each line has the shape
+ *     `[id] slug — summary (edges: a, b, c)` where edges are numeric IDs into
+ *     the same list. The caller renders this so the prompt module stays
+ *     stateless.
+ */
+
+/** Sentinel substituted with the assistant's display name at runtime. */
+const ASSISTANT_NAME_PLACEHOLDER = "{{ASSISTANT_NAME}}";
+
+/** Sentinel substituted with the guardian's display name at runtime. */
+const USER_NAME_PLACEHOLDER = "{{USER_NAME}}";
+
+/** Sentinel substituted with the rendered page index block at runtime. */
+const PAGE_INDEX_PLACEHOLDER = "{{PAGE_INDEX}}";
+
+/**
+ * Router prompt — picks at most a handful of concept pages to inject for the
+ * next assistant turn. The model emits a `select_pages_to_inject` tool call
+ * with an `ids` array; the runtime parses the response via the tool
+ * definition declared in the router job module.
+ *
+ * Recent message context and `<now>` / `<already_injected_ids>` blocks are
+ * appended at the call site so we don't inadvertently expand `{{` inside
+ * dynamic content.
+ */
+const ROUTER_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOLDER}. Your job is to route memory pages for the next assistant turn between ${ASSISTANT_NAME_PLACEHOLDER} and ${USER_NAME_PLACEHOLDER}.
+
+You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
+
+Pick up to a handful of concept pages whose contents would meaningfully help ${ASSISTANT_NAME_PLACEHOLDER} respond well on this turn. Abstain (return an empty list) when nothing in the index is clearly relevant — over-injection is worse than missing a page, because the always-on essentials/threads/recent/buffer block is already in context and you must not duplicate that material here.
+
+Index format. Each line of the index has the shape:
+
+    [id] slug — summary (edges: a, b, c)
+
+\`id\` is a small integer used to refer to this page. \`edges\` are numeric IDs into the same list, pointing at related pages; you may follow them when one page strongly implies another.
+
+Already-injected pages. Pages whose IDs appear in \`<already_injected_ids>\` were picked on the previous turn. Do not pick them again unless ${ASSISTANT_NAME_PLACEHOLDER} should re-anchor on that material — e.g., the topic genuinely returns after drifting away. Routine continuity does not require re-picking; the prior turn's pages are already in the assistant's working context.
+
+Time. Bias toward pages that match the current state implied by \`<now>\` and the active conversational threads (what is happening today, what was just decided, who is being discussed). Stale pages with no bearing on the live conversation should be skipped even if their summaries look superficially relevant.
+
+Emit your selection by calling \`select_pages_to_inject\` with the chosen \`ids\`. Return an empty array to abstain.
+
+# Concept Page Index
+
+${PAGE_INDEX_PLACEHOLDER}`;
+
+interface RenderRouterPromptOpts {
+  assistantName: string | null;
+  userName: string | null;
+  pageIndexBlock: string;
+}
+
+/**
+ * Resolve `ROUTER_PROMPT` with assistant name, user name, and the rendered
+ * page index substituted in. Falls back to neutral defaults so the prompt
+ * still produces well-formed English when either name is unavailable on this
+ * workspace. The page index is substituted verbatim — callers are responsible
+ * for trimming/formatting it.
+ */
+export function renderRouterPrompt(opts: RenderRouterPromptOpts): string {
+  const assistant = opts.assistantName?.trim() || "the assistant";
+  const user = opts.userName?.trim() || "the user";
+  return ROUTER_PROMPT.replaceAll(ASSISTANT_NAME_PLACEHOLDER, assistant)
+    .replaceAll(USER_NAME_PLACEHOLDER, user)
+    .replaceAll(PAGE_INDEX_PLACEHOLDER, opts.pageIndexBlock);
+}


### PR DESCRIPTION
## Summary
- Add `renderRouterPrompt` in `assistant/src/memory/v2/prompts/router.ts` following the sweep prompt pattern.
- Substitutes `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, `{{PAGE_INDEX}}`; falls back to neutral names when null.
- Add tests for substitution, null fallback, empty index, and snapshot stability.

Part of plan: memory-v2-sonnet-router.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->