### PR TITLE
feat(memory-v2): add memoryRouter LLM call site

### DIFF
--- a/assistant/src/__tests__/llm-callsite-catalog.test.ts
+++ b/assistant/src/__tests__/llm-callsite-catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { getLLMCallSiteLabel } from "../config/llm-callsite-catalog.js";
 import { CALL_SITE_CATALOG } from "../config/schemas/call-site-catalog.js";
-import { LLMCallSiteEnum } from "../config/schemas/llm.js";
+import { LLMCallSiteEnum, LLMSchema } from "../config/schemas/llm.js";
 
 describe("LLM call-site catalog", () => {
   test("resolves every backend call-site enum value from the catalog", () => {
@@ -30,5 +30,24 @@ describe("LLM call-site catalog", () => {
 
   test("returns the raw ID for unknown call sites", () => {
     expect(getLLMCallSiteLabel("unknownCallSite")).toBe("unknownCallSite");
+  });
+
+  test("registers the memoryRouter call site under the memory domain", () => {
+    expect(LLMCallSiteEnum.options).toContain("memoryRouter");
+
+    const entry = CALL_SITE_CATALOG.find(({ id }) => id === "memoryRouter");
+    expect(entry).toBeDefined();
+    expect(entry?.domain).toBe("memory");
+    expect(entry?.displayName).toBe("Memory Router");
+    expect(entry?.description).toBe(
+      "Selects which concept pages to inject for the next agent turn by routing over a cached page index.",
+    );
+  });
+
+  test("memoryRouter is addressable as a call-site override key in LLMSchema", () => {
+    const parsed = LLMSchema.parse({
+      callSites: { memoryRouter: { model: "claude-sonnet-4-6" } },
+    });
+    expect(parsed.callSites.memoryRouter?.model).toBe("claude-sonnet-4-6");
   });
 });

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -114,6 +114,13 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "Background sweep pass for V2 memory maintenance.",
     domain: "memory",
   },
+  memoryRouter: {
+    id: "memoryRouter",
+    displayName: "Memory Router",
+    description:
+      "Selects which concept pages to inject for the next agent turn by routing over a cached page index.",
+    domain: "memory",
+  },
   recall: {
     id: "recall",
     displayName: "Recall",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -47,6 +47,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryRetrieval",
   "memoryV2Migration",
   "memoryV2Sweep",
+  "memoryRouter",
   "recall",
   "narrativeRefinement",
   "patternScan",


### PR DESCRIPTION
## Summary
- Append `memoryRouter` to `LLMCallSiteEnum`.
- Register `memoryRouter` entry in call-site catalog under the `memory` domain.
- Extend catalog test to cover the new entry.

Part of plan: memory-v2-sonnet-router.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->