### PR TITLE
feat(memory-v2): add router mode to activation log enums

### DIFF
--- a/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -23,6 +23,7 @@ import { initializeDb } from "../db-init.js";
 import {
   backfillMemoryV2ActivationMessageId,
   getMemoryV2ActivationLogByMessageIds,
+  type MemoryV2ConceptRowRecord,
   recordMemoryV2ActivationLog,
 } from "../memory-v2-activation-log-store.js";
 import { memoryV2ActivationLogs } from "../schema.js";
@@ -64,6 +65,74 @@ describe("memory-v2-activation-log-store", () => {
     expect(result!.mode).toBe("per-turn");
     expect(result!.concepts).toEqual(sampleConcepts);
     expect(result!.config).toEqual(sampleConfig);
+  });
+
+  test("round-trip: router-mode log row with zeroed activations and source: 'router'", () => {
+    const conversationId = "conv-router";
+    const messageId = "msg-router";
+
+    const routerConcepts: MemoryV2ConceptRowRecord[] = [
+      {
+        slug: "concept-router-a",
+        finalActivation: 0,
+        ownActivation: 0,
+        priorActivation: 0,
+        simUser: 0,
+        simAssistant: 0,
+        simNow: 0,
+        simUserRerankBoost: 0,
+        simAssistantRerankBoost: 0,
+        inRerankPool: false,
+        spreadContribution: 0,
+        source: "router",
+        status: "injected",
+      },
+      {
+        slug: "concept-router-b",
+        finalActivation: 0,
+        ownActivation: 0,
+        priorActivation: 0,
+        simUser: 0,
+        simAssistant: 0,
+        simNow: 0,
+        simUserRerankBoost: 0,
+        simAssistantRerankBoost: 0,
+        inRerankPool: false,
+        spreadContribution: 0,
+        source: "router",
+        status: "not_injected",
+      },
+    ];
+
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 7,
+      mode: "router",
+      concepts: routerConcepts,
+      config: sampleConfig,
+    });
+
+    backfillMemoryV2ActivationMessageId(conversationId, messageId);
+
+    const result = getMemoryV2ActivationLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe(conversationId);
+    expect(result!.turn).toBe(7);
+    expect(result!.mode).toBe("router");
+    expect(result!.concepts).toEqual(routerConcepts);
+    expect(result!.config).toEqual(sampleConfig);
+    for (const concept of result!.concepts) {
+      expect(concept.source).toBe("router");
+      expect(concept.finalActivation).toBe(0);
+      expect(concept.ownActivation).toBe(0);
+      expect(concept.priorActivation).toBe(0);
+      expect(concept.simUser).toBe(0);
+      expect(concept.simAssistant).toBe(0);
+      expect(concept.simNow).toBe(0);
+      expect(concept.simUserRerankBoost).toBe(0);
+      expect(concept.simAssistantRerankBoost).toBe(0);
+      expect(concept.spreadContribution).toBe(0);
+    }
   });
 
   test("returns null for empty messageIds array", () => {

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -39,7 +39,18 @@ export interface MemoryV2ConceptRowRecord {
    */
   inRerankPool: boolean;
   spreadContribution: number;
-  source: "prior_state" | "ann_top50" | "both";
+  /**
+   * Provenance of this concept row.
+   *   - `prior_state` — carried over from prior turn's activation state.
+   *   - `ann_top50`   — entered via ANN top-K candidate pool.
+   *   - `both`        — present in both prior state and ANN pool.
+   *   - `router`      — selected by the Sonnet router (memory-v2 router
+   *     mode). Router-mode rows zero out all activation values
+   *     (`finalActivation`, `ownActivation`, `priorActivation`, channel
+   *     similarities, rerank boosts, `spreadContribution`) because the
+   *     router does not compute spreading-activation scores.
+   */
+  source: "prior_state" | "ann_top50" | "both" | "router";
   /**
    * Per-turn outcome for this slug:
    *   - `in_context`  — already injected on a prior turn; cached attachment
@@ -80,9 +91,11 @@ export interface RecordMemoryV2ActivationLogParams {
    * `per-turn` for normal append injections, `errored` when `injectMemoryV2Block`
    * threw before completing — telemetry is still written so silent failures
    * are observable in the database, with whatever `concepts` rows had been
-   * built so far (possibly empty).
+   * built so far (possibly empty). `router` indicates the Sonnet
+   * router selected the per-turn page set; router-mode rows carry zeroed
+   * activation values and `source: "router"` on every concept row.
    */
-  mode: "context-load" | "per-turn" | "errored";
+  mode: "context-load" | "per-turn" | "errored" | "router";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -130,7 +143,7 @@ export function backfillMemoryV2ActivationMessageId(
 export interface MemoryV2ActivationLog {
   conversationId: string;
   turn: number;
-  mode: "context-load" | "per-turn" | "errored";
+  mode: "context-load" | "per-turn" | "errored" | "router";
   concepts: MemoryV2ConceptRowRecord[];
   config: MemoryV2ConfigSnapshot;
 }
@@ -151,7 +164,7 @@ export function getMemoryV2ActivationLogByMessageIds(
   return {
     conversationId: row.conversationId,
     turn: row.turn,
-    mode: row.mode as "context-load" | "per-turn" | "errored",
+    mode: row.mode as "context-load" | "per-turn" | "errored" | "router",
     concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
     config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
   };


### PR DESCRIPTION
## Summary
- Append `router` to the `mode` literal union on `recordMemoryV2ActivationLog` parameters.
- Append `router` to the `source` literal union on `MemoryV2ConceptRowRecord`.
- Update JSDoc to note that router-mode rows carry zeroed activation values.
- Add a round-trip test for router-mode log rows.

Part of plan: memory-v2-sonnet-router.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->