### PR TITLE
feat(memory-v2): export listSkillEntries from skill-store

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -134,8 +134,12 @@ mock.module("../../../skills/catalog-cache.js", () => ({
 }));
 
 // Imported AFTER all mocks are wired so the module under test sees the stubs.
-const { seedV2SkillEntries, getSkillCapability, _resetSkillStoreForTests } =
-  await import("../skill-store.js");
+const {
+  seedV2SkillEntries,
+  getSkillCapability,
+  listSkillEntries,
+  _resetSkillStoreForTests,
+} = await import("../skill-store.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -468,5 +472,53 @@ describe("getSkillCapability", () => {
     await seedV2SkillEntries();
 
     expect(getSkillCapability("does-not-exist")).toBeNull();
+  });
+});
+
+describe("listSkillEntries", () => {
+  test("returns [] when the cache is empty (pre-seed)", () => {
+    expect(listSkillEntries()).toEqual([]);
+  });
+
+  test("returns entries sorted by id after seeding", async () => {
+    // Insert in non-sorted order to prove the sort happens on read.
+    const skillB = makeSummary({ id: "example-skill-b" });
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillB, skillA];
+    state.resolved = [
+      { summary: skillB, state: "enabled" },
+      { summary: skillA, state: "enabled" },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2SkillEntries();
+
+    const list = listSkillEntries();
+    expect(list).toHaveLength(2);
+    expect(list.map((e) => e.id)).toEqual([
+      "example-skill-a",
+      "example-skill-b",
+    ]);
+  });
+
+  test("mutating the returned array does not affect subsequent calls", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    const first = listSkillEntries();
+    expect(first).toHaveLength(1);
+    first.length = 0;
+    first.push({ id: "injected", content: "junk" });
+
+    const second = listSkillEntries();
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe("example-skill-a");
   });
 });

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -273,6 +273,22 @@ export function isSkillSlug(slug: string): boolean {
   return slug.startsWith(SKILL_SLUG_PREFIX);
 }
 
+/**
+ * Snapshot of the in-process skill cache, sorted by skill id (ASCII order)
+ * for determinism. Returns a freshly allocated array on each call so callers
+ * cannot mutate the underlying cache.
+ *
+ * The cache is replaced atomically by `seedV2SkillEntries`, so a snapshot
+ * may be stale once a subsequent seed run completes. Callers that need
+ * up-to-the-moment state must re-call this after awaiting the seed.
+ */
+export function listSkillEntries(): SkillEntry[] {
+  if (!entries) return [];
+  return [...entries.values()].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  );
+}
+
 /** @internal Test-only: clear the module-level cache. */
 export function _resetSkillStoreForTests(): void {
   entries = null;


### PR DESCRIPTION
## Summary
- Export `listSkillEntries(): SkillEntry[]` from `skill-store.ts` returning a sorted snapshot of cached skill entries.
- Add tests covering empty, populated, and mutation-safety paths.

Part of plan: memory-v2-sonnet-router.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->