### PR TITLE
feat(memory-v2): add router config block

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -32,6 +32,10 @@ describe("MemoryV2ConfigSchema", () => {
         model: "Alibaba-NLP/gte-reranker-modernbert-base",
         dtype: "q8",
       },
+      router: {
+        enabled: false,
+        max_page_ids: 25,
+      },
     });
   });
 
@@ -154,6 +158,32 @@ describe("MemoryV2ConfigSchema", () => {
   test("rejects epsilon outside [0, 1]", () => {
     expect(() => MemoryV2ConfigSchema.parse({ epsilon: -0.01 })).toThrow();
     expect(() => MemoryV2ConfigSchema.parse({ epsilon: 1.5 })).toThrow();
+  });
+
+  test("router defaults to disabled with max_page_ids=25", () => {
+    const parsed = MemoryV2ConfigSchema.parse({});
+    expect(parsed.router.enabled).toBe(false);
+    expect(parsed.router.max_page_ids).toBe(25);
+  });
+
+  test("accepts explicit router overrides", () => {
+    const parsed = MemoryV2ConfigSchema.parse({
+      router: { enabled: true, max_page_ids: 50 },
+    });
+    expect(parsed.router.enabled).toBe(true);
+    expect(parsed.router.max_page_ids).toBe(50);
+  });
+
+  test("rejects router.max_page_ids below 1", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({ router: { max_page_ids: 0 } }),
+    ).toThrow();
+  });
+
+  test("rejects router.max_page_ids above 100", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({ router: { max_page_ids: 101 } }),
+    ).toThrow();
   });
 });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -256,6 +256,28 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Cross-encoder rerank configuration. When enabled, picks the top-K candidates by pre-rerank A_o, runs the cross-encoder once per channel (user, assistant) on that unified set, and adds an alpha-weighted normalized boost to A_o for each scored slug.",
       ),
+    router: z
+      .object({
+        enabled: z
+          .boolean()
+          .default(false)
+          .describe(
+            "Whether to use the LLM router as the per-turn page-selection mechanism in place of spreading activation. Disabled by default — opt in once the router orchestration and dispatcher land.",
+          ),
+        max_page_ids: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .default(25)
+          .describe(
+            "Upper bound on the number of concept-page ids the router may return per turn. Caps both prompt size and downstream injection budget.",
+          ),
+      })
+      .default({ enabled: false, max_page_ids: 25 })
+      .describe(
+        "LLM router configuration. When enabled, a single Sonnet router call replaces spreading activation for per-turn page selection.",
+      ),
   })
   .describe(
     "Memory v2 — concept-page activation model with periodic LLM-driven consolidation",


### PR DESCRIPTION
## Summary
- Add `router` block to `MemoryV2ConfigSchema` with `enabled` (default false) and `max_page_ids` (default 25, range 1-100).
- Add tests covering default, override, and validation paths.

Part of plan: memory-v2-sonnet-router.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->