### PR TITLE
feat(memory-v2): add page-index module

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-index.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for `memory/v2/page-index.ts` — the router-prompt page index built
+ * from concept pages plus seeded skill entries.
+ *
+ * Tests live in temp workspaces (`mkdtemp`) and never touch `~/.vellum/`. The
+ * skill-store module is mocked so `listSkillEntries()` returns deterministic
+ * fixtures, and `page-store.js` is wrapped so we can simulate read failures
+ * without breaking writes.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+import type { ConceptPage, SkillEntry } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — programmable skill list, programmable readPage failure set,
+// recursive no-op logger. Mocks are installed BEFORE any imports of the
+// module under test so the page-index module observes them at load time.
+// ---------------------------------------------------------------------------
+
+const skillState: { entries: SkillEntry[] } = { entries: [] };
+const failingSlugs = new Set<string>();
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+mock.module("../skill-store.js", () => ({
+  SKILL_SLUG_PREFIX: "skills/",
+  listSkillEntries: () => skillState.entries,
+}));
+
+// Wrap page-store so we can simulate read failures via `failingSlugs`.
+// Re-export every other binding identity-style so writes still work.
+//
+// Capture each real export into a local const BEFORE installing the mock —
+// module namespaces hold live bindings, so a post-mock dereference of
+// `realPageStore.readPage` would resolve to the mocked function and recurse
+// infinitely.
+const realPageStore = await import("../page-store.js");
+const realReadPage = realPageStore.readPage;
+mock.module("../page-store.js", () => ({
+  ...realPageStore,
+  readPage: async (workspaceDir: string, slug: string) => {
+    if (failingSlugs.has(slug)) {
+      throw new Error(`simulated read failure for ${slug}`);
+    }
+    return realReadPage(workspaceDir, slug);
+  },
+}));
+
+const { getPageIndex, invalidatePageIndex } = await import("../page-index.js");
+const { writePage } = await import("../page-store.js");
+const { invalidateEdgeIndex } = await import("../edge-index.js");
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-memory-v2-page-index-"));
+  skillState.entries = [];
+  failingSlugs.clear();
+});
+
+afterEach(() => {
+  invalidatePageIndex();
+  invalidateEdgeIndex();
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function makePage(
+  slug: string,
+  opts: { edges?: string[]; summary?: string; body?: string } = {},
+): ConceptPage {
+  return {
+    slug,
+    frontmatter: {
+      edges: opts.edges ?? [],
+      ref_files: [],
+      ref_urls: [],
+      ...(opts.summary !== undefined ? { summary: opts.summary } : {}),
+    },
+    body: opts.body ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Build & cache
+// ---------------------------------------------------------------------------
+
+describe("getPageIndex", () => {
+  test("returns an empty index when there are no pages and no skills", async () => {
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.entries).toEqual([]);
+    expect(idx.bySlug.size).toBe(0);
+    expect(idx.byId.size).toBe(0);
+    expect(idx.rendered).toBe("");
+  });
+
+  test("caches the result so repeat calls reuse the prior build", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "First" }));
+
+    const first = await getPageIndex(workspaceDir);
+    // Mutate disk after the first read; without the cache the second call
+    // would observe the new page and return a different object.
+    await writePage(workspaceDir, makePage("bob", { summary: "Second" }));
+
+    const second = await getPageIndex(workspaceDir);
+    expect(second).toBe(first);
+    expect(second.entries.map((e) => e.slug)).toEqual(["alice"]);
+  });
+
+  test("invalidatePageIndex(workspaceDir) forces a rebuild on the next call", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "First" }));
+    const before = await getPageIndex(workspaceDir);
+
+    invalidatePageIndex(workspaceDir);
+    await writePage(workspaceDir, makePage("bob", { summary: "Second" }));
+
+    const after = await getPageIndex(workspaceDir);
+    expect(after).not.toBe(before);
+    expect(after.entries.map((e) => e.slug)).toEqual(["alice", "bob"]);
+  });
+
+  test("invalidatePageIndex() with no arg clears any cached workspace", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "First" }));
+    const before = await getPageIndex(workspaceDir);
+    invalidatePageIndex();
+    const after = await getPageIndex(workspaceDir);
+    expect(after).not.toBe(before);
+  });
+
+  test("sorts entries by slug ASCII deterministically across rebuilds", async () => {
+    await writePage(workspaceDir, makePage("zulu", { summary: "Z" }));
+    await writePage(workspaceDir, makePage("alpha", { summary: "A" }));
+    await writePage(workspaceDir, makePage("mike", { summary: "M" }));
+
+    const first = await getPageIndex(workspaceDir);
+    invalidatePageIndex();
+    const second = await getPageIndex(workspaceDir);
+
+    expect(first.entries.map((e) => e.slug)).toEqual(["alpha", "mike", "zulu"]);
+    expect(first.entries).toEqual(second.entries);
+  });
+
+  test("assigns dense 1-based IDs in slug order", async () => {
+    await writePage(workspaceDir, makePage("bravo", { summary: "B" }));
+    await writePage(workspaceDir, makePage("alpha", { summary: "A" }));
+    await writePage(workspaceDir, makePage("charlie", { summary: "C" }));
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.entries.map((e) => e.id)).toEqual([1, 2, 3]);
+    expect(idx.entries.map((e) => e.slug)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+    ]);
+    expect(idx.byId.get(1)?.slug).toBe("alpha");
+    expect(idx.bySlug.get("charlie")?.id).toBe(3);
+  });
+
+  test("drops pages whose read fails and continues the build", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "Alice" }));
+    await writePage(workspaceDir, makePage("bob", { summary: "Bob" }));
+    await writePage(workspaceDir, makePage("carol", { summary: "Carol" }));
+
+    failingSlugs.add("bob");
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.entries.map((e) => e.slug)).toEqual(["alice", "carol"]);
+    // IDs remain dense — the dropped page does not leave a hole.
+    expect(idx.entries.map((e) => e.id)).toEqual([1, 2]);
+  });
+
+  test("integrates seeded skill entries under the skills/ slug prefix", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "Alice" }));
+    skillState.entries = [
+      { id: "browser", content: "Drive a browser." },
+      { id: "calendar", content: "Schedule meetings." },
+    ];
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.entries.map((e) => e.slug)).toEqual([
+      "alice",
+      "skills/browser",
+      "skills/calendar",
+    ]);
+    expect(idx.bySlug.get("skills/browser")?.summary).toBe("Drive a browser.");
+    // Skill entries always carry an empty edge list.
+    expect(idx.bySlug.get("skills/browser")?.edges).toEqual([]);
+  });
+
+  test("resolves outgoing edges to numeric IDs and drops missing targets", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", { summary: "A", edges: ["bob", "ghost"] }),
+    );
+    await writePage(workspaceDir, makePage("bob", { summary: "B" }));
+
+    const idx = await getPageIndex(workspaceDir);
+    const alice = idx.bySlug.get("alice")!;
+    const bob = idx.bySlug.get("bob")!;
+    expect(alice.edges).toEqual([bob.id]);
+  });
+
+  test("falls back to body when frontmatter.summary is absent", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", { body: "  Body fallback content.  " }),
+    );
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.summary).toBe("Body fallback content.");
+  });
+
+  test("truncates summary to 200 characters", async () => {
+    const long = "x".repeat(500);
+    await writePage(workspaceDir, makePage("alice", { summary: long }));
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.summary.length).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+describe("rendered prompt block", () => {
+  test("renders [id] slug — summary lines with edges parenthetical when present", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", { summary: "A page", edges: ["bob"] }),
+    );
+    await writePage(workspaceDir, makePage("bob", { summary: "B page" }));
+
+    const idx = await getPageIndex(workspaceDir);
+    const alice = idx.bySlug.get("alice")!;
+    const bob = idx.bySlug.get("bob")!;
+
+    const expected =
+      `[${alice.id}] alice — A page (edges: ${bob.id})\n` +
+      `[${bob.id}] bob — B page\n`;
+    expect(idx.rendered).toBe(expected);
+  });
+
+  test("omits the parenthetical for entries with no outgoing edges", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "A page" }));
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.rendered).toBe("[1] alice — A page\n");
+  });
+});

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -1,0 +1,183 @@
+/**
+ * Memory v2 — Numbered page index for the router prompt.
+ *
+ * Renders a compact catalog of every concept page plus every seeded skill
+ * entry, sorted by slug ASCII for deterministic IDs, with each entry's
+ * outgoing edges resolved to numeric IDs. The router prompt consumes the
+ * pre-rendered block to choose which slugs to activate per turn.
+ *
+ * Skill entries (those in the `skills/<id>` namespace) participate alongside
+ * concept pages so the router can reach them through the same mechanism.
+ * Skill entries always have `edges: []` — the cross-page edge graph is a
+ * concept-page-only construct.
+ *
+ * The build is cached module-locally per `workspaceDir`, mirroring
+ * `edge-index.ts`. Callers must invalidate via `invalidatePageIndex` when
+ * concept pages or seeded skill entries change.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { listPages, readPage } from "./page-store.js";
+import { listSkillEntries, SKILL_SLUG_PREFIX } from "./skill-store.js";
+
+const log = getLogger("memory-v2-page-index");
+
+const SUMMARY_MAX_LENGTH = 200;
+
+/**
+ * One row in the rendered page index. `id` is a 1-based dense integer that is
+ * stable within a single index version (i.e. a single build). It changes when
+ * the index is rebuilt because IDs are derived from the slug-sorted position;
+ * callers must not persist them across builds.
+ */
+export interface PageIndexEntry {
+  /** 1-based dense numeric id, stable within an index version. */
+  id: number;
+  /** Concept-page slug or `skills/<id>`. */
+  slug: string;
+  /** Truncated to {@link SUMMARY_MAX_LENGTH} characters. */
+  summary: string;
+  /** Numeric IDs of outgoing edges, in sorted order. */
+  edges: number[];
+}
+
+/**
+ * Snapshot of the page index for one workspace. `entries` is sorted by slug
+ * ASCII so IDs are deterministic across rebuilds with the same input. The
+ * `bySlug` and `byId` maps are convenience lookups; `rendered` is the prompt
+ * block consumed by the router.
+ */
+export interface PageIndex {
+  entries: PageIndexEntry[];
+  bySlug: Map<string, PageIndexEntry>;
+  byId: Map<number, PageIndexEntry>;
+  rendered: string;
+}
+
+interface CachedIndex {
+  workspaceDir: string;
+  index: PageIndex;
+}
+
+let cache: CachedIndex | null = null;
+
+/**
+ * Return a `PageIndex` for `workspaceDir`. Cached module-locally; the cache
+ * is invalidated by `invalidatePageIndex` (called by daemon-side hooks when
+ * concept pages or skill entries change).
+ *
+ * Cold builds list every concept page in parallel, drop pages whose read
+ * rejects, append seeded skill entries from `listSkillEntries()`, sort by
+ * slug for deterministic IDs, then resolve outgoing edges to numeric IDs.
+ */
+export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
+  if (cache && cache.workspaceDir === workspaceDir) {
+    return cache.index;
+  }
+
+  const slugs = await listPages(workspaceDir);
+
+  // Read pages in parallel; pages whose read rejects are dropped with a warn
+  // so a single broken page never blocks the rest of the index.
+  const settled = await Promise.allSettled(
+    slugs.map((slug) => readPage(workspaceDir, slug)),
+  );
+
+  // Intermediate shape used while we still need the raw outgoing slugs to
+  // resolve into numeric IDs after sorting.
+  interface DraftEntry {
+    slug: string;
+    summary: string;
+    outgoingSlugs: string[];
+  }
+
+  const drafts: DraftEntry[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    const slug = slugs[i];
+    if (result.status === "rejected") {
+      log.warn(
+        { slug, err: result.reason },
+        "Dropping concept page from index — read failed",
+      );
+      continue;
+    }
+    const page = result.value;
+    if (!page) continue;
+    const summarySource = page.frontmatter.summary?.trim() || page.body.trim();
+    drafts.push({
+      slug,
+      summary: summarySource.slice(0, SUMMARY_MAX_LENGTH),
+      outgoingSlugs: page.frontmatter.edges,
+    });
+  }
+
+  for (const entry of listSkillEntries()) {
+    drafts.push({
+      slug: `${SKILL_SLUG_PREFIX}${entry.id}`,
+      summary: entry.content.trim().slice(0, SUMMARY_MAX_LENGTH),
+      outgoingSlugs: [],
+    });
+  }
+
+  drafts.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+
+  // Assign 1-based dense IDs in sort order so entries[i].id === i + 1.
+  const bySlug = new Map<string, PageIndexEntry>();
+  const byId = new Map<number, PageIndexEntry>();
+  const entries: PageIndexEntry[] = drafts.map((draft, i) => {
+    const entry: PageIndexEntry = {
+      id: i + 1,
+      slug: draft.slug,
+      summary: draft.summary,
+      edges: [],
+    };
+    bySlug.set(entry.slug, entry);
+    byId.set(entry.id, entry);
+    return entry;
+  });
+
+  // Edges whose target slug isn't in the index are dropped silently — the
+  // frontmatter sweep is responsible for surfacing those as warnings.
+  for (let i = 0; i < entries.length; i++) {
+    const draft = drafts[i];
+    const resolved: number[] = [];
+    for (const targetSlug of draft.outgoingSlugs) {
+      const target = bySlug.get(targetSlug);
+      if (target) resolved.push(target.id);
+    }
+    resolved.sort((a, b) => a - b);
+    entries[i].edges = resolved;
+  }
+
+  const rendered = renderIndex(entries);
+  const index: PageIndex = { entries, bySlug, byId, rendered };
+  cache = { workspaceDir, index };
+  return index;
+}
+
+/**
+ * Clear the cached index. Pass `workspaceDir` to scope invalidation to a
+ * specific cache entry; omit it to clear unconditionally.
+ */
+export function invalidatePageIndex(workspaceDir?: string): void {
+  if (!cache) return;
+  if (workspaceDir === undefined || cache.workspaceDir === workspaceDir) {
+    cache = null;
+  }
+}
+
+/**
+ * Render the prompt block: one line per entry shaped
+ * `[id] slug — summary (edges: a, b, c)`. Lines without outgoing edges drop
+ * the parenthetical entirely. Trailing newline so the block can be
+ * concatenated into a larger prompt without manual padding.
+ */
+function renderIndex(entries: readonly PageIndexEntry[]): string {
+  const lines = entries.map((entry) => {
+    const head = `[${entry.id}] ${entry.slug} — ${entry.summary}`;
+    if (entry.edges.length === 0) return head;
+    return `${head} (edges: ${entry.edges.join(", ")})`;
+  });
+  return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}


### PR DESCRIPTION
## Summary
- Add `assistant/src/memory/v2/page-index.ts` exporting `getPageIndex(workspaceDir)` and `invalidatePageIndex(workspaceDir?)`.
- Builds a numbered index of concept pages + skill entries with summaries (200 char cap) and numeric outgoing edges.
- Renders `[id] slug — summary (edges: a, b, c)` per line for prompt consumption.
- Module-local cache keyed by workspaceDir, mirroring the `edge-index.ts` pattern.
- Tests cover cache hit/invalidation, sort determinism, missing-page handling, skill integration, edge resolution, and ID density.

Part of plan: memory-v2-sonnet-router.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->