### PR TITLE
feat(memory-v2): wire page-index invalidation hooks

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -12,6 +12,7 @@ import { isAbsolute, resolve, sep } from "node:path";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { addAppConversationId } from "../memory/app-store.js";
 import { invalidateEdgeIndex } from "../memory/v2/edge-index.js";
+import { invalidatePageIndex } from "../memory/v2/page-index.js";
 import { getConceptsDir } from "../memory/v2/page-store.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
@@ -245,10 +246,10 @@ registerHook("bash", (_name, input, result) => {
   }
 });
 
-// Invalidate the in-memory v2 edge index when the LLM writes or edits a file
-// under `memory/concepts/`. The page-store invalidates on programmatic writes;
-// this hook covers consolidation, where the LLM edits page frontmatter through
-// the file tools rather than through `writePage`.
+// Invalidate the in-memory v2 edge index and page index when the LLM writes
+// or edits a file under `memory/concepts/`. The page-store invalidates on
+// programmatic writes; this hook covers consolidation, where the LLM edits
+// page frontmatter through the file tools rather than through `writePage`.
 function invalidateEdgeIndexIfConceptPage(
   input: Record<string, unknown>,
 ): void {
@@ -264,6 +265,7 @@ function invalidateEdgeIndexIfConceptPage(
     : conceptsRoot + sep;
   if (absPath.startsWith(rootWithSep)) {
     invalidateEdgeIndex(workspaceDir);
+    invalidatePageIndex(workspaceDir);
   }
 }
 registerHook("file_write", (_name, input) =>

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -33,6 +33,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import { FRONTMATTER_REGEX } from "../../skills/frontmatter.js";
 import { invalidateEdgeIndex } from "./edge-index.js";
+import { invalidatePageIndex } from "./page-index.js";
 import { type ConceptPage, ConceptPageFrontmatterSchema } from "./types.js";
 
 /** Filename suffix for concept pages. */
@@ -287,6 +288,7 @@ export async function writePage(
     throw err;
   }
   invalidateEdgeIndex(workspaceDir);
+  invalidatePageIndex(workspaceDir);
 }
 
 /**
@@ -397,6 +399,7 @@ export async function deletePage(
     throw err;
   }
   invalidateEdgeIndex(workspaceDir);
+  invalidatePageIndex(workspaceDir);
 }
 
 /**

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -34,6 +34,7 @@ import {
   embedWithBackend,
   generateSparseEmbedding,
 } from "../embedding-backend.js";
+import { invalidatePageIndex } from "./page-index.js";
 import {
   pruneSlugsWithPrefixExcept,
   upsertConceptPageEmbedding,
@@ -245,6 +246,10 @@ async function runSeedOnce(): Promise<void> {
 
     // Atomically replace the cache only after every step above succeeds.
     entries = nextEntries;
+    // Drop the page-index cache so the next router invocation observes the
+    // freshly seeded skill set (skill entries share the unified concept-page
+    // collection and surface in the same index).
+    invalidatePageIndex();
     lastSeedError = null;
   } catch (err) {
     lastSeedError = err;


### PR DESCRIPTION
## Summary
- Call `invalidatePageIndex` alongside `invalidateEdgeIndex` in `page-store.ts` (`writePage`, `deletePage`).
- Call `invalidatePageIndex` after `seedV2SkillEntries` updates the cache in `skill-store.ts`.
- Extend the concept-page invalidation hook in `tool-side-effects.ts` to also drop the page-index cache.

Part of plan: memory-v2-sonnet-router.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->