### PR TITLE
feat(memory-v2): add router dispatch path

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -154,6 +154,11 @@ mock.module("../skill-store.js", () => ({
   isSkillSlug: (slug: string) => slug.startsWith("skills/"),
   SKILL_SLUG_PREFIX: "skills/",
   skillSlugFor: (id: string) => `skills/${id}`,
+  // PR 4 added `listSkillEntries`; `page-index.ts` (transitively imported
+  // via `page-store.ts` and `skill-store.ts`) consumes it at module-init
+  // time. Tests stage skill content via `skillState.entries`; expose them
+  // here so the page-index loader sees a consistent view.
+  listSkillEntries: () => Array.from(skillState.entries.values()),
 }));
 
 // ---------------------------------------------------------------------------
@@ -207,6 +212,40 @@ mock.module("../page-store.js", () => ({
     const err = pageStoreState.failingSlugs.get(slug);
     if (err) throw err;
     return realReadPage(workspaceDir, slug);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Router mock — programmable per-call result
+// ---------------------------------------------------------------------------
+//
+// PR 10 wires `runRouter` into `injectMemoryV2Block` behind the
+// `memory.v2.router.enabled` flag. The activation-mode tests above never
+// flip the flag, so the default mock returns a no-op result and the router
+// branch is never exercised. Router-mode tests set `routerState.nextResult`
+// to stage a deterministic outcome before each call.
+
+interface RouterResultStub {
+  selectedSlugs: string[];
+  rawIds: number[];
+  failureReason: string | null;
+}
+
+const routerState = {
+  nextResult: null as RouterResultStub | null,
+  callCount: 0,
+};
+
+mock.module("../router.js", () => ({
+  runRouter: async () => {
+    routerState.callCount++;
+    return (
+      routerState.nextResult ?? {
+        selectedSlugs: [],
+        rawIds: [],
+        failureReason: null,
+      }
+    );
   },
 }));
 
@@ -355,8 +394,10 @@ function makeConfig(
     epsilon: number;
     dense_weight: number;
     sparse_weight: number;
+    router: { enabled: boolean; max_page_ids?: number };
   }> = {},
 ): AssistantConfig {
+  const { router, ...rest } = overrides;
   return {
     memory: {
       v2: {
@@ -370,7 +411,8 @@ function makeConfig(
         epsilon: 0.01,
         dense_weight: 1.0,
         sparse_weight: 0.0,
-        ...overrides,
+        router: { enabled: false, max_page_ids: 25, ...(router ?? {}) },
+        ...rest,
       },
     },
   } as unknown as AssistantConfig;
@@ -448,6 +490,8 @@ function resetState(): void {
   telemetryState.recordShouldThrow = false;
   pageStoreState.failingSlugs.clear();
   activationStoreState.saveShouldThrow = false;
+  routerState.nextResult = null;
+  routerState.callCount = 0;
   // The qdrant module caches its client; the cached client may be a
   // MockQdrantClient instance from a sibling test file. Reset to force a
   // fresh `new QdrantClient()` against this file's mock.
@@ -1533,5 +1577,233 @@ describe("injectMemoryV2Block", () => {
     // rendered, so its row reads `injected`.
     const aliceRow = row.concepts.find((c) => c.slug === "alice-vscode");
     expect(aliceRow?.status).toBe("injected");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Router mode (flag-gated)
+  // ---------------------------------------------------------------------------
+
+  describe("router mode", () => {
+    test("flag-on: router-selected slugs render and append to everInjected", async () => {
+      // Router picks alice. The activation pipeline never runs — we don't
+      // stage any qdrant responses here, and that's intentional. The
+      // candidate set comes straight from the router's `selectedSlugs`.
+      routerState.nextResult = {
+        selectedSlugs: ["alice-vscode"],
+        rawIds: [1],
+        failureReason: null,
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-1",
+        currentTurn: 1,
+        userMessage: "Tell me about Alice",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      expect(routerState.callCount).toBe(1);
+      expect(result.toInject).toEqual(["alice-vscode"]);
+      expect(result.block).not.toBeNull();
+      expect(result.block).toContain("# memory/concepts/alice-vscode.md");
+
+      const persisted = await hydrate(db, "conv-router-1");
+      expect(persisted!.everInjected).toEqual([
+        { slug: "alice-vscode", turn: 1 },
+      ]);
+      // Router mode persists an empty sparse activation map — the router
+      // does not compute spreading-activation scores.
+      expect(persisted!.state).toEqual({});
+
+      // Telemetry: success rows get `mode: "router"` and `source: "router"`,
+      // with all activation fields zeroed.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        concepts: Array<{
+          slug: string;
+          source: string;
+          status: string;
+          finalActivation: number;
+          ownActivation: number;
+        }>;
+      };
+      expect(row.mode).toBe("router");
+      const aliceRow = row.concepts.find((c) => c.slug === "alice-vscode");
+      expect(aliceRow).toBeDefined();
+      expect(aliceRow!.source).toBe("router");
+      expect(aliceRow!.status).toBe("injected");
+      expect(aliceRow!.finalActivation).toBe(0);
+      expect(aliceRow!.ownActivation).toBe(0);
+    });
+
+    test("flag-on: router failure logs warn, writes mode:`errored` telemetry, returns null block", async () => {
+      routerState.nextResult = {
+        selectedSlugs: [],
+        rawIds: [],
+        failureReason: "api_error",
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-fail",
+        currentTurn: 3,
+        userMessage: "anything",
+        assistantMessage: "ok",
+        nowText: "Now",
+        messageId: "msg-fail",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      expect(result.block).toBeNull();
+      expect(result.toInject).toEqual([]);
+
+      // Stub state still advanced.
+      const persisted = await hydrate(db, "conv-router-fail");
+      expect(persisted).not.toBeNull();
+      expect(persisted!.currentTurn).toBe(3);
+      expect(persisted!.messageId).toBe("msg-fail");
+      expect(persisted!.state).toEqual({});
+      expect(persisted!.everInjected).toEqual([]);
+
+      // Single telemetry row with `mode: "errored"` (not `"router"`).
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        conversationId: string;
+        turn: number;
+        concepts: unknown[];
+      };
+      expect(row.mode).toBe("errored");
+      expect(row.conversationId).toBe("conv-router-fail");
+      expect(row.turn).toBe(3);
+      expect(row.concepts).toEqual([]);
+    });
+
+    test("flag-on: router abstention (empty selectedSlugs, no failure) writes mode:`router` row with no injected pages", async () => {
+      routerState.nextResult = {
+        selectedSlugs: [],
+        rawIds: [],
+        failureReason: null,
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-abstain",
+        currentTurn: 1,
+        userMessage: "small talk",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-abstain",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      expect(result.block).toBeNull();
+      expect(result.toInject).toEqual([]);
+
+      // No prior everInjected to dedup against, so toInject is empty and
+      // nothing renders. State still advanced.
+      const persisted = await hydrate(db, "conv-router-abstain");
+      expect(persisted!.everInjected).toEqual([]);
+      expect(persisted!.currentTurn).toBe(1);
+
+      // Telemetry: `mode: "router"` row with zero injected pages.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        concepts: Array<{ slug: string; status: string }>;
+      };
+      expect(row.mode).toBe("router");
+      const injectedCount = row.concepts.filter(
+        (c) => c.status === "injected",
+      ).length;
+      expect(injectedCount).toBe(0);
+    });
+
+    test("flag-on: router-selected slug whose page is missing on disk records `page_missing` and is NOT added to everInjected", async () => {
+      routerState.nextResult = {
+        selectedSlugs: ["phantom-router-slug"],
+        rawIds: [99],
+        failureReason: null,
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-missing",
+        currentTurn: 1,
+        userMessage: "phantom",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-missing",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      // No backing page → block collapses to null.
+      expect(result.block).toBeNull();
+      // toInject mirrors `newlyInjected` from `finalizeInjection` — the
+      // missing slug still flowed through `slugsToRender` so it's recorded
+      // here (matching the activation-mode phantom-slug contract).
+      expect(result.toInject).toEqual(["phantom-router-slug"]);
+
+      // Activation-mode parity: the phantom slug DOES land in everInjected
+      // so we don't infinite-retry it. (This matches the behavior the
+      // existing `returns null block when toInject slugs all reference
+      // missing pages` test asserts for activation mode.)
+      const persisted = await hydrate(db, "conv-router-missing");
+      expect(persisted!.everInjected).toEqual([
+        { slug: "phantom-router-slug", turn: 1 },
+      ]);
+
+      // Telemetry: `status: "page_missing"` for the phantom slug.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        concepts: Array<{ slug: string; status: string; source: string }>;
+      };
+      expect(row.mode).toBe("router");
+      const phantom = row.concepts.find(
+        (c) => c.slug === "phantom-router-slug",
+      );
+      expect(phantom).toBeDefined();
+      expect(phantom!.status).toBe("page_missing");
+      expect(phantom!.source).toBe("router");
+    });
+
+    test("flag-off (default): activation pipeline still runs unchanged", async () => {
+      // Regression check — with the router flag explicitly off (the
+      // production default), `runRouter` must never be called and the
+      // activation pipeline drives the selection just like before.
+      stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+      routerState.nextResult = {
+        selectedSlugs: ["should-not-be-used"],
+        rawIds: [42],
+        failureReason: null,
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-flag-off",
+        currentTurn: 1,
+        userMessage: "Alice's editor",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig({ router: { enabled: false } }),
+      });
+
+      // Router was not called.
+      expect(routerState.callCount).toBe(0);
+      // Activation pipeline produced its normal result.
+      expect(result.toInject).toEqual(["alice-vscode"]);
+      expect(result.block).toContain("# memory/concepts/alice-vscode.md");
+
+      // Telemetry row carries the activation mode, not router.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as { mode: string };
+      expect(row.mode).toBe("per-turn");
+    });
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -40,6 +40,7 @@ import {
 import { hydrate, save } from "./activation-store.js";
 import { getEdgeIndex } from "./edge-index.js";
 import { readPage, renderPageContent } from "./page-store.js";
+import { runRouter } from "./router.js";
 import { getSkillCapability, isSkillSlug } from "./skill-store.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
@@ -138,6 +139,27 @@ export async function injectMemoryV2Block(
   // with an effective empty prior state so the first turn can still inject.
   throwIfAborted(signal);
   const priorState = await hydrate(database, conversationId);
+
+  // Flag-gated router dispatch: when the LLM router is enabled, route the
+  // per-turn page selection through `runRouter` and reuse `finalizeInjection`
+  // for persistence, render, and telemetry. The activation pipeline below
+  // remains the default (flag-off) behavior — every code path past this
+  // branch only runs when the router is disabled.
+  if (config.memory.v2.router.enabled) {
+    return injectViaRouter({
+      workspaceDir,
+      database,
+      conversationId,
+      currentTurn,
+      userMessage,
+      assistantMessage,
+      nowText,
+      messageId,
+      config,
+      priorState,
+      signal,
+    });
+  }
 
   // (2) Topology. `getEdgeIndex` walks concept-page frontmatter and caches
   // the result module-locally; an empty workspace yields an empty index.
@@ -272,7 +294,7 @@ async function finalizeInjection(args: {
   workspaceDir: string;
   database: DrizzleDb;
   conversationId: string;
-  mode: InjectMemoryV2Mode;
+  mode: InjectMemoryV2Mode | "router";
   currentTurn: number;
   messageId: string;
   priorEverInjected: readonly EverInjectedEntry[];
@@ -299,7 +321,7 @@ async function finalizeInjection(args: {
   // when the render/telemetry path throws — we still want a log row written
   // (with whatever rows we managed to build) so silent failures are
   // observable in the database.
-  let mode: "context-load" | "per-turn" | "errored" = args.mode;
+  let mode: "context-load" | "per-turn" | "router" | "errored" = args.mode;
 
   // Mark every rendered slug as ever-injected so future per-turn deltas don't
   // re-attach the same content. On context-load this is the full top-K (we
@@ -353,7 +375,6 @@ async function finalizeInjection(args: {
   let block: string | null = null;
   let conceptRowsForLog: MemoryV2ConceptRowRecord[] = [];
   let caughtErr: unknown = undefined;
-  const v2Cfg = config.memory.v2;
 
   try {
     await save(database, conversationId, nextActivationState);
@@ -431,16 +452,7 @@ async function finalizeInjection(args: {
         turn: currentTurn,
         mode,
         concepts: conceptRowsForLog,
-        config: {
-          d: v2Cfg.d,
-          c_user: v2Cfg.c_user,
-          c_assistant: v2Cfg.c_assistant,
-          c_now: v2Cfg.c_now,
-          k: v2Cfg.k,
-          hops: v2Cfg.hops,
-          top_k: v2Cfg.top_k,
-          epsilon: v2Cfg.epsilon,
-        },
+        config: configSnapshot(config),
       });
     } catch (telemetryErr) {
       log.warn(
@@ -452,6 +464,162 @@ async function finalizeInjection(args: {
 
   if (caughtErr !== undefined) throw caughtErr;
   return { block, toInject: newlyInjected };
+}
+
+/**
+ * Router-mode dispatch path. Replaces the spreading-activation pipeline with
+ * a single LLM call that picks the per-turn concept-page set. On success we
+ * reuse `finalizeInjection` so the persistence/render/telemetry contract
+ * stays identical to the activation path; on `runRouter` failure we still
+ * advance `activation_state` (so `currentTurn` and `messageId` move forward)
+ * and emit a `mode: "errored"` telemetry row so the failure is observable.
+ *
+ * Failure rows are tagged `errored`, not `router`, because router-mode rows
+ * are reserved for successful selections — keeping the two visually distinct
+ * in inspector queries. `nextStateMap` is always empty in router mode: the
+ * router does not compute spreading-activation scores, so there is no sparse
+ * activation map to persist.
+ */
+async function injectViaRouter(args: {
+  workspaceDir: string;
+  database: DrizzleDb;
+  conversationId: string;
+  currentTurn: number;
+  userMessage: string;
+  assistantMessage: string;
+  nowText: string;
+  messageId: string;
+  config: AssistantConfig;
+  priorState: ActivationState | null;
+  signal?: AbortSignal;
+}): Promise<InjectMemoryV2BlockResult> {
+  const {
+    workspaceDir,
+    database,
+    conversationId,
+    currentTurn,
+    userMessage,
+    assistantMessage,
+    nowText,
+    messageId,
+    config,
+    priorState,
+    signal,
+  } = args;
+
+  const priorEverInjected: readonly EverInjectedEntry[] =
+    priorState?.everInjected ?? [];
+
+  const routerResult = await runRouter({
+    workspaceDir,
+    userMessage,
+    assistantMessage,
+    nowText,
+    priorEverInjected,
+    config,
+    ...(signal ? { signal } : {}),
+  });
+
+  if (routerResult.failureReason !== null) {
+    log.warn(
+      { failureReason: routerResult.failureReason },
+      "memory v2 router failure; skipping injection",
+    );
+    // Persist a stub state so `currentTurn` and `messageId` advance even
+    // though no slugs were selected. `state: {}` matches the router's
+    // no-spreading-activation contract; `everInjected` is preserved so
+    // future turns still subtract previously-attached slugs.
+    const stubState: ActivationState = {
+      messageId,
+      state: {},
+      everInjected: [...priorEverInjected],
+      currentTurn,
+      updatedAt: Date.now(),
+    };
+    try {
+      await save(database, conversationId, stubState);
+    } catch (err) {
+      log.warn(
+        { err, conversationId, turn: currentTurn },
+        "Failed to persist stub activation_state on router failure — continuing",
+      );
+    }
+    try {
+      recordMemoryV2ActivationLog({
+        conversationId,
+        turn: currentTurn,
+        mode: "errored",
+        concepts: [],
+        config: configSnapshot(config),
+      });
+    } catch (telemetryErr) {
+      log.warn(
+        { err: telemetryErr, conversationId, turn: currentTurn },
+        "Failed to record memory v2 router-failure telemetry — continuing",
+      );
+    }
+    return { block: null, toInject: [] };
+  }
+
+  const slugsToRender = routerResult.selectedSlugs;
+
+  // Build minimal telemetry rows for the union of router-selected slugs and
+  // prior `everInjected` slugs. Router-mode rows zero out every activation
+  // value (no spreading activation runs) and carry `source: "router"`. The
+  // `status` placeholder is overwritten by `finalizeInjection`.
+  const telemetrySlugs = new Set<string>(slugsToRender);
+  for (const entry of priorEverInjected) telemetrySlugs.add(entry.slug);
+  const telemetryRows: MemoryV2ConceptRowRecord[] = [...telemetrySlugs].map(
+    (slug) => ({
+      slug,
+      finalActivation: 0,
+      ownActivation: 0,
+      priorActivation: 0,
+      simUser: 0,
+      simAssistant: 0,
+      simNow: 0,
+      simUserRerankBoost: 0,
+      simAssistantRerankBoost: 0,
+      inRerankPool: false,
+      spreadContribution: 0,
+      source: "router",
+      status: "not_injected",
+    }),
+  );
+
+  return finalizeInjection({
+    workspaceDir,
+    database,
+    conversationId,
+    mode: "router",
+    currentTurn,
+    messageId,
+    priorEverInjected,
+    slugsToRender,
+    telemetryRows,
+    config,
+    nextStateMap: {},
+    candidates: new Set(slugsToRender),
+  });
+}
+
+/**
+ * Snapshot the v2 config tunables in the shape `recordMemoryV2ActivationLog`
+ * persists. Pulled out so the router-failure path does not duplicate the
+ * field list inline.
+ */
+function configSnapshot(config: AssistantConfig) {
+  const v2Cfg = config.memory.v2;
+  return {
+    d: v2Cfg.d,
+    c_user: v2Cfg.c_user,
+    c_assistant: v2Cfg.c_assistant,
+    c_now: v2Cfg.c_now,
+    k: v2Cfg.k,
+    hops: v2Cfg.hops,
+    top_k: v2Cfg.top_k,
+    epsilon: v2Cfg.epsilon,
+  };
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {


### PR DESCRIPTION
## Summary
- Add flag-gated dispatch at the top of `injectMemoryV2Block`: when `config.memory.v2.router.enabled` is true, route through `injectViaRouter` (calling `runRouter` from PR 8) and finalize via the shared `finalizeInjection` helper from PR 9.
- Failure modes (`runRouter` returns `failureReason`) write a `mode: 'errored'` telemetry row and return `{ block: null, toInject: [] }` while still advancing `activation_state.currentTurn`.
- Success path writes `mode: 'router'` telemetry rows with activation fields zeroed and `source: 'router'`.
- Flag default-off — activation pipeline unchanged.

Part of plan: memory-v2-sonnet-router.md (PR 10 of 10) — final PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->