### PR TITLE
fix(memory-v2): dedup router slugs, distinguish carry_over telemetry

### DIFF
--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -49,8 +49,14 @@ export interface MemoryV2ConceptRowRecord {
    *     (`finalActivation`, `ownActivation`, `priorActivation`, channel
    *     similarities, rerank boosts, `spreadContribution`) because the
    *     router does not compute spreading-activation scores.
+   *   - `carry_over`  — router-mode row representing a slug carried over
+   *     from `priorEverInjected` that the router did NOT re-pick on this
+   *     turn. The cached attachment from a prior turn is still present
+   *     on a prior user message; emitting `source: "router"` for these
+   *     rows would overcount router selections in inspector queries.
+   *     Same zeroed activation values as `router`.
    */
-  source: "prior_state" | "ann_top50" | "both" | "router";
+  source: "prior_state" | "ann_top50" | "both" | "router" | "carry_over";
   /**
    * Per-turn outcome for this slug:
    *   - `in_context`  — already injected on a prior turn; cached attachment

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1772,6 +1772,116 @@ describe("injectMemoryV2Block", () => {
       expect(phantom!.source).toBe("router");
     });
 
+    test("flag-on: router re-picking a prior-everInjected slug does NOT re-render it; non-overlapping picks render and append to everInjected", async () => {
+      // Turn 1: router picks alice. Standard append.
+      routerState.nextResult = {
+        selectedSlugs: ["alice-vscode"],
+        rawIds: [1],
+        failureReason: null,
+      };
+      const turn1 = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-dedup",
+        currentTurn: 1,
+        userMessage: "Tell me about Alice",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+      expect(turn1.toInject).toEqual(["alice-vscode"]);
+
+      // Turn 2: router re-picks alice (the "re-anchor" prompt branch) AND
+      // adds bob. The block must NOT contain alice's body — her cached
+      // attachment from turn 1 is still on the prior user message — but
+      // must contain bob's.
+      telemetryState.recordCalls.length = 0;
+      routerState.nextResult = {
+        selectedSlugs: ["alice-vscode", "bob-coffee"],
+        rawIds: [1, 2],
+        failureReason: null,
+      };
+      const turn2 = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-dedup",
+        currentTurn: 2,
+        userMessage: "And Bob?",
+        assistantMessage: "Sure",
+        nowText: "Now",
+        messageId: "msg-2",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      // Re-picked alice was deduped; only bob is freshly injected.
+      expect(turn2.toInject).toEqual(["bob-coffee"]);
+      expect(turn2.block).not.toBeNull();
+      expect(turn2.block).toContain("# memory/concepts/bob-coffee.md");
+      expect(turn2.block).toContain("Bob takes his coffee");
+      expect(turn2.block).not.toContain("VS Code");
+      expect(turn2.block).not.toContain("# memory/concepts/alice-vscode.md");
+
+      // everInjected only gained bob — alice was already there.
+      const persisted = await hydrate(db, "conv-router-dedup");
+      expect(persisted!.everInjected).toEqual([
+        { slug: "alice-vscode", turn: 1 },
+        { slug: "bob-coffee", turn: 2 },
+      ]);
+    });
+
+    test("flag-on: telemetry distinguishes `source: router` (router picks) from `source: carry_over` (prior-everInjected slugs the router did not re-pick)", async () => {
+      // Turn 1: seed everInjected with alice.
+      routerState.nextResult = {
+        selectedSlugs: ["alice-vscode"],
+        rawIds: [1],
+        failureReason: null,
+      };
+      await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-source",
+        currentTurn: 1,
+        userMessage: "Alice",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+      telemetryState.recordCalls.length = 0;
+
+      // Turn 2: router picks bob only. alice is still in everInjected but
+      // not re-picked — her telemetry row must read `source: carry_over`,
+      // not `source: router`.
+      routerState.nextResult = {
+        selectedSlugs: ["bob-coffee"],
+        rawIds: [2],
+        failureReason: null,
+      };
+      await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-source",
+        currentTurn: 2,
+        userMessage: "Bob",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-2",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        concepts: Array<{ slug: string; source: string; status: string }>;
+      };
+      expect(row.mode).toBe("router");
+      const aliceRow = row.concepts.find((c) => c.slug === "alice-vscode");
+      const bobRow = row.concepts.find((c) => c.slug === "bob-coffee");
+      expect(aliceRow).toBeDefined();
+      expect(bobRow).toBeDefined();
+      expect(aliceRow!.source).toBe("carry_over");
+      expect(aliceRow!.status).toBe("in_context");
+      expect(bobRow!.source).toBe("router");
+      expect(bobRow!.status).toBe("injected");
+    });
+
     test("flag-off (default): activation pipeline still runs unchanged", async () => {
       // Regression check — with the router flag explicitly off (the
       // production default), `runRouter` must never be called and the

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -59,6 +59,16 @@ const log = getLogger("memory-v2-injection");
  */
 export type InjectMemoryV2Mode = "context-load" | "per-turn";
 
+/**
+ * Internal mode union for `finalizeInjection`. Extends the public
+ * `InjectMemoryV2Mode` with `"router"` (router-driven success path) and
+ * `"errored"` (caller-supplied failure path or the helper's own
+ * try/catch promotion). The public surface intentionally only carries
+ * the caller-facing modes — these two are persistence/telemetry concerns
+ * that don't belong on `InjectMemoryV2BlockParams`.
+ */
+type FinalizeInjectionMode = InjectMemoryV2Mode | "router" | "errored";
+
 export interface InjectMemoryV2BlockParams {
   /** SQLite database handle for activation_state hydrate/save. */
   database: DrizzleDb;
@@ -261,7 +271,6 @@ export async function injectMemoryV2Block(
     telemetryRows,
     config,
     nextStateMap,
-    candidates,
   });
 }
 
@@ -286,15 +295,14 @@ export async function injectMemoryV2Block(
  * The caller pre-builds `telemetryRows` with all per-candidate breakdown
  * fields filled in (router-mode callers can pass zeros where the
  * breakdown doesn't apply) and a placeholder `status: "not_injected"`
- * which this helper overwrites. `nextStateMap` and `candidates` are the
- * activation pipeline's sparse next-state and full candidate pool;
- * router-mode callers pass an empty map / empty set.
+ * which this helper overwrites. `nextStateMap` is the activation
+ * pipeline's sparse next-state; router-mode callers pass an empty map.
  */
 async function finalizeInjection(args: {
   workspaceDir: string;
   database: DrizzleDb;
   conversationId: string;
-  mode: InjectMemoryV2Mode | "router";
+  mode: FinalizeInjectionMode;
   currentTurn: number;
   messageId: string;
   priorEverInjected: readonly EverInjectedEntry[];
@@ -302,7 +310,6 @@ async function finalizeInjection(args: {
   telemetryRows: MemoryV2ConceptRowRecord[];
   config: AssistantConfig;
   nextStateMap: Record<string, number>;
-  candidates: ReadonlySet<string>;
 }): Promise<InjectMemoryV2BlockResult> {
   const {
     workspaceDir,
@@ -321,7 +328,7 @@ async function finalizeInjection(args: {
   // when the render/telemetry path throws — we still want a log row written
   // (with whatever rows we managed to build) so silent failures are
   // observable in the database.
-  let mode: "context-load" | "per-turn" | "router" | "errored" = args.mode;
+  let mode: FinalizeInjectionMode = args.mode;
 
   // Mark every rendered slug as ever-injected so future per-turn deltas don't
   // re-attach the same content. On context-load this is the full top-K (we
@@ -525,49 +532,51 @@ async function injectViaRouter(args: {
       { failureReason: routerResult.failureReason },
       "memory v2 router failure; skipping injection",
     );
-    // Persist a stub state so `currentTurn` and `messageId` advance even
-    // though no slugs were selected. `state: {}` matches the router's
-    // no-spreading-activation contract; `everInjected` is preserved so
-    // future turns still subtract previously-attached slugs.
-    const stubState: ActivationState = {
-      messageId,
-      state: {},
-      everInjected: [...priorEverInjected],
+    // Delegate the failure path to `finalizeInjection` with empty inputs
+    // and `mode: "errored"`. The helper persists a stub activation_state
+    // (preserving `priorEverInjected` so future turns still subtract
+    // previously-attached slugs) and writes the telemetry row through the
+    // same code path as the success branch — no inline duplication of
+    // `save` + `recordMemoryV2ActivationLog`.
+    return finalizeInjection({
+      workspaceDir,
+      database,
+      conversationId,
+      mode: "errored",
       currentTurn,
-      updatedAt: Date.now(),
-    };
-    try {
-      await save(database, conversationId, stubState);
-    } catch (err) {
-      log.warn(
-        { err, conversationId, turn: currentTurn },
-        "Failed to persist stub activation_state on router failure — continuing",
-      );
-    }
-    try {
-      recordMemoryV2ActivationLog({
-        conversationId,
-        turn: currentTurn,
-        mode: "errored",
-        concepts: [],
-        config: configSnapshot(config),
-      });
-    } catch (telemetryErr) {
-      log.warn(
-        { err: telemetryErr, conversationId, turn: currentTurn },
-        "Failed to record memory v2 router-failure telemetry — continuing",
-      );
-    }
-    return { block: null, toInject: [] };
+      messageId,
+      priorEverInjected,
+      slugsToRender: [],
+      telemetryRows: [],
+      config,
+      nextStateMap: {},
+    });
   }
 
-  const slugsToRender = routerResult.selectedSlugs;
+  // Dedupe router-picked slugs against `priorEverInjected` BEFORE rendering.
+  // The router prompt explicitly invites the model to re-pick already-injected
+  // pages "to re-anchor"; if we passed those through, `renderInjectionBlock`
+  // would re-emit the slug into a fresh `<memory>` block while the prior
+  // turn's cached attachment is still on the prior user message — duplicate
+  // content. Activation per-turn mode does not have this issue because
+  // `selectInjections()` returns `toInject = topNow - everInjected`.
+  //
+  // Telemetry rows for prior-everInjected slugs are still emitted below,
+  // but tagged `source: "carry_over"` (not `"router"`) so inspector queries
+  // can attribute selections correctly.
+  const everInjectedSet = new Set(priorEverInjected.map((e) => e.slug));
+  const slugsToRender = routerResult.selectedSlugs.filter(
+    (s) => !everInjectedSet.has(s),
+  );
 
   // Build minimal telemetry rows for the union of router-selected slugs and
   // prior `everInjected` slugs. Router-mode rows zero out every activation
-  // value (no spreading activation runs) and carry `source: "router"`. The
-  // `status` placeholder is overwritten by `finalizeInjection`.
-  const telemetrySlugs = new Set<string>(slugsToRender);
+  // value (no spreading activation runs). Slugs the router picked this turn
+  // get `source: "router"`; prior-everInjected slugs the router did NOT
+  // re-pick get `source: "carry_over"`. The `status` placeholder is
+  // overwritten by `finalizeInjection`.
+  const routerPicked = new Set(routerResult.selectedSlugs);
+  const telemetrySlugs = new Set<string>(routerPicked);
   for (const entry of priorEverInjected) telemetrySlugs.add(entry.slug);
   const telemetryRows: MemoryV2ConceptRowRecord[] = [...telemetrySlugs].map(
     (slug) => ({
@@ -582,7 +591,7 @@ async function injectViaRouter(args: {
       simAssistantRerankBoost: 0,
       inRerankPool: false,
       spreadContribution: 0,
-      source: "router",
+      source: routerPicked.has(slug) ? "router" : "carry_over",
       status: "not_injected",
     }),
   );
@@ -599,7 +608,6 @@ async function injectViaRouter(args: {
     telemetryRows,
     config,
     nextStateMap: {},
-    candidates: new Set(slugsToRender),
   });
 }
 


### PR DESCRIPTION
## Summary
Self-review fixes for the memory-v2 Sonnet router landed in earlier PRs:

- **Critical**: dedupe `slugsToRender` against `priorEverInjected` in `injectViaRouter` so re-picks of already-injected pages don't duplicate content into the new `<memory>` block.
- Add `source: 'carry_over'` to `MemoryV2ConceptRowRecord`; tag prior-everInjected slugs the router didn't re-pick with it (instead of mislabeling them as `source: 'router'`).
- Delegate the router-failure path to `finalizeInjection` with `mode: 'errored'` instead of reimplementing `save` + telemetry write inline.
- Drop the dead `candidates` parameter from `finalizeInjection`.
- Introduce `FinalizeInjectionMode` type alias to replace the longhand mode union.

Part of plan: memory-v2-sonnet-router.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->