### PR TITLE
fix(memory-v2): router cache TTL, rawIds removal, resolveUserName hoist

### DIFF
--- a/assistant/src/daemon/identity-helpers.ts
+++ b/assistant/src/daemon/identity-helpers.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
 
@@ -8,6 +9,24 @@ export function getAssistantName(): string | null {
     const path = getWorkspacePromptPath("IDENTITY.md");
     if (!existsSync(path)) return null;
     const content = readFileSync(path, "utf-8");
+    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the guardian's display name from `users/default.md`. We look for the
+ * markdown-bold "Name" label (matching the IDENTITY.md convention) and fall
+ * back to `null` on any miss; callers substitute a generic label.
+ */
+export function resolveUserName(workspaceDir: string): string | null {
+  try {
+    const content = readFileSync(
+      join(workspaceDir, "users", "default.md"),
+      "utf-8",
+    );
     const match = content.match(/\*\*Name:\*\*\s*(.+)/);
     return match?.[1]?.trim() || null;
   } catch {

--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -231,7 +231,6 @@ describe("runRouter — early bails", () => {
 
     expect(result).toEqual({
       selectedSlugs: [],
-      rawIds: [],
       failureReason: "empty_index",
     });
     // Provider must NOT be invoked when there is nothing to route.
@@ -273,7 +272,6 @@ describe("runRouter — successful tool_use", () => {
     });
 
     expect(result.failureReason).toBeNull();
-    expect(result.rawIds).toEqual([3, 1]);
     expect(result.selectedSlugs).toEqual(["charlie", "alpha"]);
   });
 
@@ -288,7 +286,6 @@ describe("runRouter — successful tool_use", () => {
 
     expect(result).toEqual({
       selectedSlugs: [],
-      rawIds: [],
       failureReason: null,
     });
   });
@@ -351,15 +348,17 @@ describe("runRouter — successful tool_use", () => {
     const [blockA, blockB] = userMsg.content as Array<{
       type: string;
       text: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
 
-    // Block A — NOW with explicit ephemeral cache breakpoint.
+    // Block A — NOW with explicit ephemeral cache breakpoint at 1h TTL
+    // (matches the provider's auto-applied breakpoints; the default 5m
+    // would force re-creation across most turns since `<now>` is stable).
     expect(blockA.type).toBe("text");
     expect(blockA.text).toContain("<now>");
     expect(blockA.text).toContain("2026-05-10 14:00 PT");
     expect(blockA.text).toContain("</now>");
-    expect(blockA.cache_control).toEqual({ type: "ephemeral" });
+    expect(blockA.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     // Block B — already-injected IDs + last turn, NO cache_control.
     expect(blockB.type).toBe("text");
@@ -380,7 +379,6 @@ describe("runRouter — successful tool_use", () => {
       config: makeConfig(),
     });
 
-    expect(result.rawIds).toEqual([2, 1]);
     expect(result.selectedSlugs).toEqual(["bravo", "alpha"]);
   });
 });
@@ -438,7 +436,6 @@ describe("runRouter — failure modes", () => {
     });
 
     expect(result.failureReason).toBeNull();
-    expect(result.rawIds).toEqual([2]);
     expect(result.selectedSlugs).toEqual(["bravo"]);
     const warnSeen = warnLogs.some((l) =>
       JSON.stringify(l.args).includes("outside the valid range"),
@@ -456,7 +453,6 @@ describe("runRouter — failure modes", () => {
     });
 
     expect(result.failureReason).toBeNull();
-    expect(result.rawIds).toEqual([1, 2]);
     expect(result.selectedSlugs).toEqual(["alpha", "bravo"]);
     const warnSeen = warnLogs.some((l) =>
       JSON.stringify(l.args).includes("more page IDs than max_page_ids"),

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -12,13 +12,15 @@
  *   - validate the tool input via Zod,
  *   - map back to slugs and let the caller drive injection.
  *
- * Cache strategy. Two ephemeral breakpoints carry the bulk of the routing
- * cost across turns:
+ * Cache strategy. Two 1h ephemeral breakpoints carry the bulk of the
+ * routing cost across turns:
  *   1. The last text block of the system prompt — the page index is the
  *      single largest input and changes only when concept pages are edited.
- *   2. The first user-message block (`<now>`) — stable across consecutive
- *      router calls within the same minute even though the trailing
- *      already-injected/last-turn block changes every turn.
+ *      Auto-applied by the Anthropic provider at the configured 1h TTL.
+ *   2. The first user-message block (`<now>`) — stable across most turns
+ *      since NOW.md only changes when the model rewrites it. We set the 1h
+ *      TTL explicitly here to match the provider-side breakpoints; the
+ *      default 5m would force unnecessary cache re-creation.
  * The Anthropic provider also auto-applies a 1h breakpoint on the last text
  * block of a turn-starting user message, so the trailing uncached block does
  * not need an explicit `cache_control`.
@@ -28,13 +30,13 @@
  * `injectMemoryV2Block`; until then nothing in the daemon calls it.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../config/types.js";
-import { getAssistantName } from "../../daemon/identity-helpers.js";
+import {
+  getAssistantName,
+  resolveUserName,
+} from "../../daemon/identity-helpers.js";
 import {
   extractToolUse,
   getConfiguredProvider,
@@ -67,14 +69,11 @@ export type RouterFailureReason =
 /**
  * Result of a single router call. `selectedSlugs` preserves the order the
  * model returned and is already capped at `config.memory.v2.router.max_page_ids`
- * with out-of-range IDs dropped. `rawIds` is the model-returned ID list before
- * mapping (post-truncation, post-range-filter) for diagnostics.
+ * with out-of-range IDs dropped.
  */
 export interface RouterResult {
   /** Selected page slugs in the order the model returned them. */
   selectedSlugs: string[];
-  /** Numeric IDs the model returned (post-filter, post-truncate). */
-  rawIds: number[];
   /** `null` on success; one of the failure reasons above otherwise. */
   failureReason: RouterFailureReason | null;
 }
@@ -113,7 +112,7 @@ const RouterResultSchema = z.object({
 
 /** Empty-result helper so call sites don't reconstruct the shape inline. */
 function emptyResult(reason: RouterFailureReason | null): RouterResult {
-  return { selectedSlugs: [], rawIds: [], failureReason: reason };
+  return { selectedSlugs: [], failureReason: reason };
 }
 
 interface RunRouterParams {
@@ -193,11 +192,12 @@ export async function runRouter(
     if (idx) priorIds.push(idx.id);
   }
 
-  // Cache breakpoint 2 — `<now>` is stable for the duration of a minute, so
-  // the bulk of the user message rides the cache when the assistant chains
-  // tool calls. The trailing block has no `cache_control`; the Anthropic
-  // provider auto-applies a 1h breakpoint on the last text block of a
-  // turn-starting user message, which covers it.
+  // Cache breakpoint 2 — `<now>` is stable across most turns (NOW.md only
+  // changes when the model rewrites it), so the bulk of the user message
+  // rides the cache. We use a 1h TTL to match the system-prompt breakpoint
+  // and the provider's auto-applied breakpoints. The trailing block has no
+  // `cache_control`; the Anthropic provider auto-applies a 1h breakpoint on
+  // the last text block of a turn-starting user message, which covers it.
   const userMsg: Message = {
     role: "user",
     content: [
@@ -280,49 +280,36 @@ export async function runRouter(
   // catch repeats from the model.
   const seen = new Set<number>();
   const selectedSlugs: string[] = [];
-  const rawIds: number[] = [];
   for (const id of finalIds) {
     if (seen.has(id)) continue;
     seen.add(id);
     const entry = pageIndex.byId.get(id);
     if (!entry) continue;
-    rawIds.push(id);
     selectedSlugs.push(entry.slug);
   }
 
-  return { selectedSlugs, rawIds, failureReason: null };
+  return { selectedSlugs, failureReason: null };
 }
 
 /**
  * Build a text content block carrying an ephemeral `cache_control`
- * breakpoint. The Anthropic SDK accepts the field as an extra property on
- * text blocks, but our internal `TextContent` type intentionally omits it
- * (only the Anthropic provider transforms it onto the wire), so we reach
- * through a `Record` cast here for the same reason `client.ts` does — it
- * keeps the core types provider-agnostic.
+ * breakpoint with a 1h TTL. The Anthropic SDK accepts the field as an extra
+ * property on text blocks, but our internal `TextContent` type intentionally
+ * omits it (only the Anthropic provider transforms it onto the wire), so we
+ * reach through a `Record` cast here for the same reason `client.ts` does —
+ * it keeps the core types provider-agnostic. The 1h TTL matches the
+ * provider's auto-applied breakpoints (see `cacheTtl` in
+ * `providers/anthropic/client.ts`); the `<now>` block is stable across most
+ * turns, so default 5m would force unnecessary re-creation. The
+ * `extended-cache-ttl-2025-04-11` beta header is added unconditionally for
+ * non-Haiku models in `client.ts`, so this works without any call-site
+ * config.
  */
 function cachedTextBlock(text: string): ContentBlock {
   const block: ContentBlock = { type: "text", text };
   (block as unknown as Record<string, unknown>).cache_control = {
     type: "ephemeral",
+    ttl: "1h",
   };
   return block;
-}
-
-/**
- * Read the guardian's display name from `users/default.md`. Mirrors
- * `sweep-job.ts`'s `resolveUserName` so the two background jobs agree on
- * which file they read and what label they fall back to.
- */
-function resolveUserName(workspaceDir: string): string | null {
-  try {
-    const content = readFileSync(
-      join(workspaceDir, "users", "default.md"),
-      "utf-8",
-    );
-    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
-    return match?.[1]?.trim() || null;
-  } catch {
-    return null;
-  }
 }

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -26,7 +26,10 @@ import { and, desc, eq, gt, notInArray } from "drizzle-orm";
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../config/types.js";
-import { getAssistantName } from "../../daemon/identity-helpers.js";
+import {
+  getAssistantName,
+  resolveUserName,
+} from "../../daemon/identity-helpers.js";
 import {
   extractToolUse,
   getConfiguredProvider,
@@ -256,23 +259,4 @@ function loadRecentMessagesText(nowMs: number): string {
     joined = joined.slice(joined.length - MAX_RECENT_TEXT_CHARS);
   }
   return joined;
-}
-
-/**
- * Read the guardian's display name from `users/default.md`. We look for the
- * markdown-bold "Name" label (matching the IDENTITY.md convention) and fall
- * back to `null` on any miss; the prompt template substitutes a generic
- * label.
- */
-function resolveUserName(workspaceDir: string): string | null {
-  try {
-    const content = readFileSync(
-      join(workspaceDir, "users", "default.md"),
-      "utf-8",
-    );
-    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
-    return match?.[1]?.trim() || null;
-  } catch {
-    return null;
-  }
 }


### PR DESCRIPTION
## Summary
Self-review cleanups for the memory-v2 Sonnet router:

- Set explicit `ttl: '1h'` on both router `cache_control` blocks (system prompt + NOW.md). Default ephemeral TTL is 5 min; 1h matches the intended cross-turn cache behavior and the surrounding code style.
- Remove unused `rawIds` field from `RouterResult` (built but never consumed).
- Hoist `resolveUserName` from `sweep-job.ts` into `daemon/identity-helpers.ts`; both background jobs now import it.

Part of plan: memory-v2-sonnet-router.md (self-review cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->