### PR TITLE
fix(macos): make sanitizedFilename static to silence Swift 6 implicit self warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -156,7 +156,7 @@ final class DocumentManager {
     func exportToFile() {
         let content = currentContent ?? ""
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = sanitizedFilename(from: title) + ".md"
+        panel.nameFieldStringValue = Self.sanitizedFilename(from: title) + ".md"
         panel.canCreateDirectories = true
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
@@ -196,7 +196,7 @@ final class DocumentManager {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 let panel = NSSavePanel()
-                panel.nameFieldStringValue = sanitizedFilename(from: titleForFile) + ".pdf"
+                panel.nameFieldStringValue = Self.sanitizedFilename(from: titleForFile) + ".pdf"
                 panel.canCreateDirectories = true
                 panel.begin { response in
                     guard response == .OK, let url = panel.url else { return }
@@ -208,7 +208,7 @@ final class DocumentManager {
         }
     }
 
-    private func sanitizedFilename(from title: String) -> String {
+    private static func sanitizedFilename(from title: String) -> String {
         let replaced = title.replacingOccurrences(of: " ", with: "-")
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
         let sanitized = replaced.unicodeScalars.filter { allowed.contains($0) }


### PR DESCRIPTION
## Summary
- `DocumentManager.sanitizedFilename(from:)` is a pure function with no instance state, but was an instance method. Inside `exportToPDF`'s `Task { [weak self] in ... MainActor.run { ... } }`, the implicit `self` capture triggers a Swift 6 error-mode warning.
- Promoted the helper to `static` and updated both call sites (`exportToFile`, `exportToPDF`) to use `Self.sanitizedFilename(...)`. Avoids `self?.` optional-chaining gymnastics with the weak capture and is a cleaner expression of the function's purity.

## Original prompt
Swift 6 language mode promoted the implicit-self-in-closure warning at `clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift:199` to an error. The offending line calls `sanitizedFilename(from: titleForFile)` from inside a `MainActor.run` closure nested in a `[weak self]` Task. Fix the warning so the file compiles cleanly under the Swift 6 language mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->