### PR TITLE
feat(memory): give v2 consolidation its own LLM call site

### DIFF
--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -114,6 +114,13 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "Background sweep pass for V2 memory maintenance.",
     domain: "memory",
   },
+  memoryV2Consolidation: {
+    id: "memoryV2Consolidation",
+    displayName: "Memory V2 Consolidation",
+    description:
+      "Routes accumulated buffer entries into concept pages and rewrites the recent summary during V2 memory maintenance.",
+    domain: "memory",
+  },
   recall: {
     id: "recall",
     displayName: "Recall",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -47,6 +47,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryRetrieval",
   "memoryV2Migration",
   "memoryV2Sweep",
+  "memoryV2Consolidation",
   "recall",
   "narrativeRefinement",
   "patternScan",

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -258,6 +258,7 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     expect(wakeCalls).toBe(1);
     expect(wakeLastArgs?.conversationId).toBe("conv-1");
     expect(wakeLastArgs?.source).toBe("memory_v2_consolidation");
+    expect(wakeLastArgs?.callSite).toBe("memoryV2Consolidation");
 
     // The hint must contain the prompt body with the cutoff timestamp
     // substituted in. Asserting the placeholder is GONE catches a regression

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -140,9 +140,11 @@ export async function memoryV2ConsolidateJob(
 
     // Step 4: bootstrap a background conversation and wake the assistant
     // with the cutoff-templated prompt. Mirrors the UPDATES.md pattern in
-    // `runUpdateBulletinJobIfNeeded` — the wake runs `mainAgent` against
-    // the assistant's full system prompt, so consolidation thinks and
-    // writes in the assistant's voice.
+    // `runUpdateBulletinJobIfNeeded`, but routes through its own
+    // `memoryV2Consolidation` call site so operators can tune the
+    // model/profile and observability bucket independently of the user's
+    // chat selection. The wake still loads the assistant's full system
+    // prompt, so consolidation thinks and writes in the assistant's voice.
     const conversation = bootstrapConversation({
       conversationType: "background",
       source: MEMORY_V2_CONSOLIDATION_SOURCE,
@@ -162,6 +164,7 @@ export async function memoryV2ConsolidateJob(
         ),
         source: MEMORY_V2_CONSOLIDATION_SOURCE,
         trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+        callSite: "memoryV2Consolidation",
       });
       wakeInvoked = result.invoked;
       failureReason = result.reason;

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -49,6 +49,7 @@ import type {
 import type { InterfaceId } from "../channels/types.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import {
   classifyDiskPressureTurnPolicy,
@@ -184,6 +185,13 @@ export interface WakeOptions {
    */
   sourceChannel?: TrustContext["sourceChannel"];
   sourceInterface?: InterfaceId | "vellum";
+  /**
+   * LLM call site to route this wake through. Defaults to `"mainAgent"` so
+   * conversation wakes share the user's chat-model selection. Background jobs
+   * (e.g. memory consolidation) pass their own call site so operators can
+   * tune the model/profile and observability bucket independently.
+   */
+  callSite?: LLMCallSite;
 }
 
 /**
@@ -654,10 +662,11 @@ export async function wakeAgentForOpportunity(
     // `markProcessing(true)` so a thrown DB/config read can't strand the
     // processing flag.
     const overrideProfile = getConversationOverrideProfile(conversationId);
+    const callSite = opts.callSite ?? "mainAgent";
     const config = getConfig();
     const effectiveContextWindow = resolveEffectiveContextWindow({
       llm: config.llm,
-      callSite: "mainAgent",
+      callSite,
       overrideProfile,
     });
 
@@ -695,12 +704,13 @@ export async function wakeAgentForOpportunity(
           undefined, // no external abort signal
           `wake:${source}`,
           onCheckpoint,
-          // Route through `mainAgent` — same as a normal user turn on this
-          // conversation. Without an explicit callSite, the resolver in
+          // Route through the caller-supplied call site (defaults to
+          // `mainAgent` so a normal user-turn wake shares the user's chat
+          // selection). Without an explicit callSite, the resolver in
           // `RetryProvider` and the routing in `CallSiteRoutingProvider`
-          // short-circuit and silently drop both `llm.callSites.mainAgent`
-          // config and the pinned `overrideProfile` below.
-          "mainAgent",
+          // short-circuit and silently drop both per-callsite config and the
+          // pinned `overrideProfile` below.
+          callSite,
           wakeTurnContext,
           overrideProfile,
           effectiveContextWindow.maxInputTokens,


### PR DESCRIPTION
## Summary
- Add `memoryV2Consolidation` to `LLMCallSiteEnum` and the call-site catalog so it joins `memoryV2Sweep` / `memoryV2Migration` as a first-class background-memory call site.
- Plumb an optional `callSite` through `WakeOptions` (defaults to `mainAgent`) and have `wakeAgentForOpportunity()` route both the `resolveEffectiveContextWindow()` lookup and `agentLoop.run()` through it.
- Have `memoryV2ConsolidateJob` pass `callSite: "memoryV2Consolidation"` so consolidation no longer inherits the user's chat-model selection or pollutes mainAgent token-spend telemetry. Default behavior for every other wake caller is unchanged.

## Original prompt
Memory v2 consolidation routes through `wakeAgentForOpportunity()` and the wake helper hardcoded the LLM call site to `mainAgent`. The user wanted consolidation to have its own call site so operators can configure a different model/profile for the hourly background pass and so its token spend can be bucketed separately from foreground chat. The change had to keep the wake helper backwards-compatible — every other caller continues to fall through to `mainAgent`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->