### PR TITLE
fix(macos): pass paths argument in importIfAvailable call site

### DIFF
--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -95,7 +95,7 @@ public enum GuardianTokenFileReader {
     /// file does not exist, is unreadable, or the refresh token is already
     /// expired.
     public static func importIfAvailable(assistantId: String) -> Bool {
-        let path = guardianTokenPath(for: assistantId)
+        let path = guardianTokenPath(for: assistantId, paths: VellumPaths.current)
         let nowMs = Int(Date().timeIntervalSince1970 * 1000)
 
         let decision = decideImport(fromPath: path, nowMs: nowMs)


### PR DESCRIPTION
## Summary
- Update the one remaining call site in `GuardianTokenFileReader.importIfAvailable` to pass `paths: VellumPaths.current`, matching the post-#30182 `guardianTokenPath(for:paths:)` signature already used by `deleteTokenFile` (line 197) and `deleteTokenFileAcrossAllEnvs` (line 227).
- Unbreaks the macOS Build CI job that started failing on `main` after #30182 with `error: missing argument for parameter 'paths' in call`.

## Original prompt
Fix the specific CI issue in the failing macOS Build job at https://github.com/vellum-ai/vellum-assistant/actions/runs/25620554767/job/75206195154 — a one-line compile error introduced when #30182 widened `guardianTokenPath`'s signature but missed the `importIfAvailable` call site.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->