### PR TITLE
fix(skills): regenerate catalog for memory-v2-migration

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -790,26 +790,24 @@
     {
       "id": "vellum-memory-v2-migration",
       "name": "vellum-memory-v2-migration",
-      "description": "Hand-write a memory v2 backfill from /workspace/pkb/ + memory/buffer.md and bring v2 online. Use for first-time memory v2 setup when concepts/ is empty and v2.enabled is false.",
+      "description": "Perform a one-time migration from memory v1, to memory v2, which was introduced in 0.8.0.",
       "metadata": {
         "emoji": "🧠",
         "vellum": {
           "display-name": "Memory v2 Migration",
           "user-invocable": "true",
           "activation-hints": [
-            "When the user asks to migrate to memory v2, set up the memory wiki, or do a v2 backfill",
-            "When /workspace/memory/concepts/ is empty or near-empty and memory.v2.enabled is false",
-            "When /workspace/pkb/ or /workspace/memory/buffer.md has substantive content that needs to become the wiki"
+            "When the user asks to migrate to memory v2",
+            "When /workspace/memory/concepts/ is empty or near-empty and memory.v2.enabled is false"
           ],
           "avoid-when": [
             "When concept pages are already populated and memory.v2.enabled is already true",
-            "When /workspace/pkb/ and /workspace/memory/buffer.md are both empty (nothing to migrate)",
-            "Never run `assistant memory v2 migrate` during this skill — it overwrites hand-written pages"
+            "When /workspace/pkb/ and /workspace/memory/buffer.md are both empty (nothing to migrate)"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-10T02:43:59Z"
+      "updatedAt": "2026-05-10T11:35:07-04:00"
     },
     {
       "id": "vellum-oauth-integrations",


### PR DESCRIPTION
## Summary
- Regenerate `skills/catalog.json` to reflect the updated `vellum-memory-v2-migration` SKILL.md frontmatter (description and activation hints changed after adding user confirmation step)

## Original prompt
User updated the vellum-memory-v2-migration skill to add a preflight confirmation step using `assistant ui confirm`, then asked to regenerate the skill catalog to keep it in sync with the SKILL.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->