### PR TITLE
feat(macos): copy conversation ID from title dropdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -9,6 +9,7 @@ import AppKit
 struct ConversationTitleActionsControl: View {
     let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
+    let onCopyConversationId: () -> Void
     let onForkConversation: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
@@ -141,6 +142,7 @@ struct ConversationTitleActionsControl: View {
             ConversationActionsMenuContent(
                 presentation: presentation,
                 onCopy: onCopy,
+                onCopyConversationId: onCopyConversationId,
                 onForkConversation: onForkConversation,
                 onPin: onPin,
                 onUnpin: onUnpin,
@@ -162,6 +164,7 @@ struct ConversationTitleActionsControl: View {
 struct ConversationActionsMenuContent: View {
     let presentation: ConversationHeaderPresentation
     let onCopy: () -> Void
+    let onCopyConversationId: () -> Void
     let onForkConversation: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
@@ -175,6 +178,10 @@ struct ConversationActionsMenuContent: View {
         VMenu(width: ConversationTitleActionsControl.menuWidth) {
             if presentation.canCopy {
                 VMenuItem(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
+            }
+
+            if presentation.isPersisted {
+                VMenuItem(icon: VIcon.hash.rawValue, label: "Copy conversation ID", action: onCopyConversationId)
             }
 
             if presentation.showsForkConversationAction && !presentation.isChannelConversation {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -285,9 +285,14 @@ struct MainWindowView: View {
             participantNames: names
         )
         guard !markdown.isEmpty else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(markdown, forType: .string)
+        VCopyButton.copyToPasteboard(markdown)
         windowState.showToast(message: "Conversation copied to clipboard", style: .success)
+    }
+
+    func copyActiveConversationIdToClipboard() {
+        guard let conversationId = conversationManager.activeConversation?.conversationId else { return }
+        VCopyButton.copyToPasteboard(conversationId)
+        windowState.showToast(message: "Conversation ID copied to clipboard", style: .success)
     }
 
     var conversationHeaderPresentation: ConversationHeaderPresentation {
@@ -635,6 +640,7 @@ struct MainWindowView: View {
                 sidebarExpandedWidth: sidebarExpandedWidth,
                 sidebarCollapsedWidth: sidebarCollapsedWidth,
                 onCopyConversation: { copyActiveConversationToClipboard() },
+                onCopyConversationId: { copyActiveConversationIdToClipboard() },
                 onRenameConversation: { startRenameActiveConversation() },
                 onOpenForkParent: { openForkParentConversation() }
             )
@@ -821,6 +827,7 @@ struct ConversationTitleOverlay: View {
     let sidebarCollapsedWidth: CGFloat
     let isSettingsOpen: Bool
     let onCopy: () -> Void
+    let onCopyConversationId: () -> Void
     let onForkConversation: () -> Void
     let onPin: () -> Void
     let onUnpin: () -> Void
@@ -843,6 +850,7 @@ struct ConversationTitleOverlay: View {
         ConversationTitleActionsControl(
             presentation: presentation,
             onCopy: onCopy,
+            onCopyConversationId: onCopyConversationId,
             onForkConversation: onForkConversation,
             onPin: onPin,
             onUnpin: onUnpin,

--- a/clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift
@@ -23,6 +23,7 @@ struct TopBarView: View {
     let sidebarExpandedWidth: CGFloat
     let sidebarCollapsedWidth: CGFloat
     let onCopyConversation: () -> Void
+    let onCopyConversationId: () -> Void
     let onRenameConversation: () -> Void
     let onOpenForkParent: () -> Void
 
@@ -180,6 +181,7 @@ struct TopBarView: View {
                     sidebarCollapsedWidth: sidebarCollapsedWidth,
                     isSettingsOpen: isSettingsOpen,
                     onCopy: onCopyConversation,
+                    onCopyConversationId: onCopyConversationId,
                     onForkConversation: {
                         Task { await conversationManager.forkActiveConversation() }
                     },


### PR DESCRIPTION
## Summary
- Adds "Copy conversation ID" to the conversation title dropdown (below "Copy full conversation"), gated on `presentation.isPersisted` so it only appears once the conversation has a server-side ID.
- Uses `VCopyButton.copyToPasteboard` for the clipboard write — also migrates the existing `copyActiveConversationToClipboard` to the same helper to remove the inline `NSPasteboard.clearContents()` + `setString()` duplication.

## Original prompt
Sidd wanted to be able to copy the server-side conversation ID directly from the title dropdown in the macOS client — useful for cross-referencing logs, debugging, and Linear/Sentry triage. The change is macOS-only (this dropdown does not exist in the Chrome extension or other clients).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->