### PR TITLE
feat(memory-v2): make router prompt configurable via file path

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -35,6 +35,7 @@ describe("MemoryV2ConfigSchema", () => {
       router: {
         enabled: false,
         max_page_ids: 25,
+        router_prompt_path: null,
       },
     });
   });
@@ -183,6 +184,24 @@ describe("MemoryV2ConfigSchema", () => {
   test("rejects router.max_page_ids above 100", () => {
     expect(() =>
       MemoryV2ConfigSchema.parse({ router: { max_page_ids: 101 } }),
+    ).toThrow();
+  });
+
+  test("router_prompt_path defaults to null", () => {
+    const parsed = MemoryV2ConfigSchema.parse({});
+    expect(parsed.router.router_prompt_path).toBeNull();
+  });
+
+  test("accepts an explicit router_prompt_path override", () => {
+    const parsed = MemoryV2ConfigSchema.parse({
+      router: { router_prompt_path: "~/prompts/router.md" },
+    });
+    expect(parsed.router.router_prompt_path).toBe("~/prompts/router.md");
+  });
+
+  test("rejects non-string router_prompt_path", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({ router: { router_prompt_path: 42 } }),
     ).toThrow();
   });
 });

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -273,8 +273,17 @@ export const MemoryV2ConfigSchema = z
           .describe(
             "Upper bound on the number of concept-page ids the router may return per turn. Caps both prompt size and downstream injection budget.",
           ),
+        router_prompt_path: z
+          .string({
+            error: "memory.v2.router.router_prompt_path must be a string",
+          })
+          .nullable()
+          .default(null)
+          .describe(
+            "Optional path to a file whose contents replace the bundled router prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, and `{{PAGE_INDEX}}`, which are substituted at runtime. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+          ),
       })
-      .default({ enabled: false, max_page_ids: 25 })
+      .default({ enabled: false, max_page_ids: 25, router_prompt_path: null })
       .describe(
         "LLM router configuration. When enabled, a single Sonnet router call replaces spreading activation for per-turn page selection.",
       ),

--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -1,11 +1,14 @@
 /**
  * Tests for `assistant/src/memory/v2/prompts/router.ts` —
- * specifically `renderRouterPrompt`, which substitutes the assistant name,
- * user name, and rendered page index into the bundled router prompt body.
+ * `renderRouterPrompt` (placeholder substitution in the bundled body) and
+ * `resolveRouterPrompt` (file-override path with fallback).
  */
-import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { renderRouterPrompt } from "../prompts/router.js";
+import { renderRouterPrompt, resolveRouterPrompt } from "../prompts/router.js";
 
 const SAMPLE_INDEX = `[1] morning-routine — coffee, walk, journal (edges: 2)
 [2] journal-style — terse, dated, no fluff (edges: 1)
@@ -171,5 +174,83 @@ describe("renderRouterPrompt — content expectations", () => {
     });
 
     expect(out.toLowerCase()).toContain("essentials");
+  });
+});
+
+describe("resolveRouterPrompt — override path", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "vellum-router-prompt-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const STD_OPTS = {
+    assistantName: "Aria",
+    userName: "Alice",
+    pageIndexBlock: SAMPLE_INDEX,
+  };
+
+  test("null overridePath returns the bundled prompt verbatim", () => {
+    expect(resolveRouterPrompt(null, STD_OPTS)).toEqual(
+      renderRouterPrompt(STD_OPTS),
+    );
+  });
+
+  test("loads override and substitutes placeholders", () => {
+    const overridePath = join(tmpDir, "router.md");
+    writeFileSync(
+      overridePath,
+      "Hi {{ASSISTANT_NAME}}, you are routing for {{USER_NAME}}.\n\n{{PAGE_INDEX}}",
+      "utf-8",
+    );
+
+    const out = resolveRouterPrompt(overridePath, STD_OPTS);
+    expect(out).toContain("Hi Aria, you are routing for Alice.");
+    expect(out).toContain(SAMPLE_INDEX);
+    expect(out).not.toContain("{{ASSISTANT_NAME}}");
+    expect(out).not.toContain("{{PAGE_INDEX}}");
+  });
+
+  test("missing override file falls back to bundled prompt", () => {
+    const overridePath = join(tmpDir, "does-not-exist.md");
+    expect(resolveRouterPrompt(overridePath, STD_OPTS)).toEqual(
+      renderRouterPrompt(STD_OPTS),
+    );
+  });
+
+  test("empty override file falls back to bundled prompt", () => {
+    const overridePath = join(tmpDir, "empty.md");
+    writeFileSync(overridePath, "   \n\t\n", "utf-8");
+    expect(resolveRouterPrompt(overridePath, STD_OPTS)).toEqual(
+      renderRouterPrompt(STD_OPTS),
+    );
+  });
+
+  test("override that is a directory falls back to bundled prompt", () => {
+    // Pass the temp directory itself as the override path — lstat sees a
+    // directory, not a regular file, so the loader bails to bundled.
+    expect(resolveRouterPrompt(tmpDir, STD_OPTS)).toEqual(
+      renderRouterPrompt(STD_OPTS),
+    );
+  });
+
+  test("override applies neutral fallbacks for missing names", () => {
+    const overridePath = join(tmpDir, "neutral.md");
+    writeFileSync(
+      overridePath,
+      "Hi {{ASSISTANT_NAME}}, routing for {{USER_NAME}}.",
+      "utf-8",
+    );
+
+    const out = resolveRouterPrompt(overridePath, {
+      assistantName: null,
+      userName: null,
+      pageIndexBlock: "",
+    });
+    expect(out).toBe("Hi the assistant, routing for the user.");
   });
 });

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -16,7 +16,28 @@
  *     `[id] slug — summary (edges: a, b, c)` where edges are numeric IDs into
  *     the same list. The caller renders this so the prompt module stays
  *     stateless.
+ *
+ * Operators may replace the bundled body via
+ * `memory.v2.router.router_prompt_path` and {@link resolveRouterPrompt} — the
+ * same placeholder substitution applies to overrides.
  */
+
+import { lstatSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import { getLogger } from "../../../util/logger.js";
+import { getWorkspaceDir } from "../../../util/platform.js";
+
+const log = getLogger("memory-v2-router-prompt");
+
+/**
+ * Hard upper bound on the override file size. The bundled prompt is well
+ * under 4 KiB; 1 MiB is generous-enough for any reasonable hand-edit while
+ * still preventing pathological inputs from being slurped into memory on
+ * every router call.
+ */
+const MAX_PROMPT_BYTES = 1 * 1024 * 1024;
 
 /** Sentinel substituted with the assistant's display name at runtime. */
 const ASSISTANT_NAME_PLACEHOLDER = "{{ASSISTANT_NAME}}";
@@ -73,9 +94,99 @@ interface RenderRouterPromptOpts {
  * for trimming/formatting it.
  */
 export function renderRouterPrompt(opts: RenderRouterPromptOpts): string {
+  return substitutePlaceholders(ROUTER_PROMPT, opts);
+}
+
+/**
+ * Load the router prompt template, optionally overridden from the file
+ * referenced by `memory.v2.router.router_prompt_path`, then substitute the
+ * standard placeholders. Path-resolution rules mirror the consolidation
+ * prompt override: absolute paths used as-is, leading `~/` expanded to home,
+ * relative paths resolved under the workspace root.
+ *
+ * Failure handling is intentionally permissive — missing file, read error,
+ * oversized file, or empty/whitespace-only body all log a warning and fall
+ * back to the bundled prompt. Router selection must never break because of
+ * a bad override.
+ */
+export function resolveRouterPrompt(
+  overridePath: string | null,
+  opts: RenderRouterPromptOpts,
+): string {
+  if (overridePath === null) return renderRouterPrompt(opts);
+
+  const resolvedPath = resolveOverridePath(overridePath);
+  let contents: string;
+  try {
+    const stat = lstatSync(resolvedPath);
+    if (!stat.isFile()) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          reason: "not_regular_file",
+          fallback: "bundled",
+        },
+        "router prompt override is not a regular file; using bundled prompt",
+      );
+      return renderRouterPrompt(opts);
+    }
+    if (stat.size > MAX_PROMPT_BYTES) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          size: stat.size,
+          limit: MAX_PROMPT_BYTES,
+          reason: "oversized_override",
+          fallback: "bundled",
+        },
+        "router prompt override exceeds size limit; using bundled prompt",
+      );
+      return renderRouterPrompt(opts);
+    }
+    contents = readFileSync(resolvedPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    log.warn(
+      { configuredPath: overridePath, resolvedPath, code, fallback: "bundled" },
+      "router prompt override unreadable; using bundled prompt",
+    );
+    return renderRouterPrompt(opts);
+  }
+
+  if (contents.trim().length === 0) {
+    log.warn(
+      {
+        configuredPath: overridePath,
+        resolvedPath,
+        reason: "empty_override",
+        fallback: "bundled",
+      },
+      "router prompt override is empty; using bundled prompt",
+    );
+    return renderRouterPrompt(opts);
+  }
+
+  return substitutePlaceholders(contents, opts);
+}
+
+function substitutePlaceholders(
+  template: string,
+  opts: RenderRouterPromptOpts,
+): string {
   const assistant = opts.assistantName?.trim() || "the assistant";
   const user = opts.userName?.trim() || "the user";
-  return ROUTER_PROMPT.replaceAll(ASSISTANT_NAME_PLACEHOLDER, assistant)
+  return template
+    .replaceAll(ASSISTANT_NAME_PLACEHOLDER, assistant)
     .replaceAll(USER_NAME_PLACEHOLDER, user)
     .replaceAll(PAGE_INDEX_PLACEHOLDER, opts.pageIndexBlock);
+}
+
+function resolveOverridePath(overridePath: string): string {
+  if (overridePath.startsWith("~/")) {
+    return join(homedir(), overridePath.slice(2));
+  }
+  if (isAbsolute(overridePath)) return overridePath;
+  return join(getWorkspaceDir(), overridePath);
 }

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -48,7 +48,7 @@ import type {
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getPageIndex } from "./page-index.js";
-import { renderRouterPrompt } from "./prompts/router.js";
+import { resolveRouterPrompt } from "./prompts/router.js";
 import type { EverInjectedEntry } from "./types.js";
 
 const log = getLogger("memory-v2-router");
@@ -179,11 +179,14 @@ export async function runRouter(
     return emptyResult("no_provider");
   }
 
-  const systemPrompt = renderRouterPrompt({
-    assistantName: getAssistantName(),
-    userName: resolveUserName(workspaceDir),
-    pageIndexBlock: pageIndex.rendered,
-  });
+  const systemPrompt = resolveRouterPrompt(
+    config.memory?.v2?.router?.router_prompt_path ?? null,
+    {
+      assistantName: getAssistantName(),
+      userName: resolveUserName(workspaceDir),
+      pageIndexBlock: pageIndex.rendered,
+    },
+  );
 
   // Already-injected slugs that map back to a current index ID. Slugs whose
   // page has been deleted since the prior turn drop out silently — the model


### PR DESCRIPTION
## Summary
- Add `memory.v2.router.router_prompt_path` config field (nullable, default `null`).
- New `resolveRouterPrompt(overridePath, opts)` in `prompts/router.ts` mirrors `resolveConsolidationPrompt`: lstat → size check → read → fall back to bundled on any failure with a warn.
- `runRouter` now reads the configured path and threads it through; absent override is a no-op (bundled prompt as before).
- Schema test + prompt-resolver tests covering null, missing file, empty file, directory, override-applies-fallbacks-for-null-names.

## Test plan
- [ ] `bun test src/memory/v2/__tests__/prompts-router.test.ts` (19 tests, 6 new for resolver)
- [ ] `bun test src/config/schemas/__tests__/memory-v2.test.ts` (25 tests, 3 new for the field)
- [ ] `bun test src/memory/v2/__tests__/router.test.ts` regression check
- [ ] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->