### PR TITLE
test(skills): align install tests with catalogOnly flag

### DIFF
--- a/assistant/src/cli/commands/__tests__/skills.test.ts
+++ b/assistant/src/cli/commands/__tests__/skills.test.ts
@@ -41,7 +41,11 @@ mock.module("../../../ipc/cli-client.js", () => ({
     const next = mockIpcResults.shift();
     return next ?? { ok: true, result: { skills: [] } };
   },
-  exitFromIpcResult: (r: { ok: boolean; error?: string; statusCode?: number }) => {
+  exitFromIpcResult: (r: {
+    ok: boolean;
+    error?: string;
+    statusCode?: number;
+  }) => {
     process.exitCode = r.statusCode ?? 1;
   },
 }));
@@ -137,7 +141,9 @@ describe("skills list", () => {
 
     expect(ipcCalls).toHaveLength(1);
     expect(ipcCalls[0]!.method).toBe("listSkills");
-    expect((ipcCalls[0]!.params as { queryParams: unknown }).queryParams).toEqual({});
+    expect(
+      (ipcCalls[0]!.params as { queryParams: unknown }).queryParams,
+    ).toEqual({});
   });
 
   test("IPC failure sets exitCode 1", async () => {
@@ -151,11 +157,7 @@ describe("skills list", () => {
   test("--json IPC failure emits ok:false with error to stdout, exitCode set", async () => {
     mockIpcResults = [{ ok: false, error: "Connection refused" }];
 
-    const { exitCode, stdout } = await runCommand([
-      "skills",
-      "list",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCommand(["skills", "list", "--json"]);
 
     // Machine readers expect JSON on both success and failure paths.
     const parsed = JSON.parse(stdout);
@@ -196,9 +198,11 @@ describe("skills inspect", () => {
 
     expect(ipcCalls).toHaveLength(1);
     expect(ipcCalls[0]!.method).toBe("skillsLocalInspect");
-    expect((ipcCalls[0]!.params as { pathParams: unknown }).pathParams).toEqual({
-      id: "weather",
-    });
+    expect((ipcCalls[0]!.params as { pathParams: unknown }).pathParams).toEqual(
+      {
+        id: "weather",
+      },
+    );
   });
 
   test("IPC failure sets exitCode 1", async () => {
@@ -210,9 +214,7 @@ describe("skills inspect", () => {
   });
 
   test("--json IPC failure emits ok:false with error to stdout, exitCode set", async () => {
-    mockIpcResults = [
-      { ok: false, error: "Skill not found", statusCode: 404 },
-    ];
+    mockIpcResults = [{ ok: false, error: "Skill not found", statusCode: 404 }];
 
     const { exitCode, stdout } = await runCommand([
       "skills",
@@ -239,9 +241,11 @@ describe("skills uninstall", () => {
 
     expect(ipcCalls).toHaveLength(1);
     expect(ipcCalls[0]!.method).toBe("deleteSkill");
-    expect((ipcCalls[0]!.params as { pathParams: unknown }).pathParams).toEqual({
-      id: "weather",
-    });
+    expect((ipcCalls[0]!.params as { pathParams: unknown }).pathParams).toEqual(
+      {
+        id: "weather",
+      },
+    );
   });
 
   test("IPC failure sets exitCode 1", async () => {
@@ -253,9 +257,7 @@ describe("skills uninstall", () => {
   });
 
   test("--json IPC failure emits ok:false with error to stdout, exitCode set", async () => {
-    mockIpcResults = [
-      { ok: false, error: "Not found", statusCode: 404 },
-    ];
+    mockIpcResults = [{ ok: false, error: "Not found", statusCode: 404 }];
 
     const { exitCode, stdout } = await runCommand([
       "skills",
@@ -283,11 +285,14 @@ describe("skills install", () => {
     // No preflight via listSkills — the daemon's installSkill handler does
     // its own catalog lookup. Preflighting via listSkills(include=catalog)
     // would falsely "not found" when a community skill shadows a catalog id.
+    // catalogOnly:true restricts to bundled+catalog skills; community installs
+    // use `skills add` instead.
     expect(ipcCalls).toHaveLength(1);
     expect(ipcCalls[0]!.method).toBe("installSkill");
     expect((ipcCalls[0]!.params as { body: unknown }).body).toEqual({
       slug: "weather",
       overwrite: false,
+      catalogOnly: true,
     });
   });
 
@@ -315,6 +320,7 @@ describe("skills install", () => {
     expect((ipcCalls[0]!.params as { body: unknown }).body).toEqual({
       slug: "weather",
       overwrite: true,
+      catalogOnly: true,
     });
   });
 
@@ -408,9 +414,7 @@ describe("skills add", () => {
   });
 
   test("--json IPC failure emits ok:false with error to stdout, exitCode set", async () => {
-    mockIpcResults = [
-      { ok: false, error: "Not a valid skills.sh source" },
-    ];
+    mockIpcResults = [{ ok: false, error: "Not a valid skills.sh source" }];
 
     const { exitCode, stdout } = await runCommand([
       "skills",


### PR DESCRIPTION
## Summary
- Update two `skills install` test cases to expect `catalogOnly: true` in the IPC body, matching the implementation in `assistant/src/cli/commands/skills.ts:438`.
- Fixes the failing job https://github.com/vellum-ai/vellum-assistant/actions/runs/25645484337/job/75273497930.

## Original prompt
Fix the specific CI issue in the linked failing job. The failure was in `src/cli/commands/__tests__/skills.test.ts` — two `skills install` tests asserted the IPC body equals `{ slug, overwrite }`, but the implementation also sends `catalogOnly: true` (intentional, to keep `skills install` catalog-only and route community installs through `skills add`). The implementation behavior is correct; tests just weren't updated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->