### PR TITLE
fix(daemon): pass structured referencedBy in 409 conflict details

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -630,6 +630,7 @@ export class RuntimeHttpServer {
             err.code as HttpErrorCode,
             err.message,
             err.statusCode,
+            err.details,
           );
         }
         throw err;

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -77,8 +77,8 @@ export class UnprocessableEntityError extends RouteError {
 }
 
 export class ConflictError extends RouteError {
-  constructor(message: string) {
-    super(message, "CONFLICT", 409);
+  constructor(message: string, details?: unknown) {
+    super(message, "CONFLICT", 409, details);
     this.name = "ConflictError";
   }
 }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -135,6 +135,7 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   if ((config.llm?.default as Record<string, unknown> | undefined)?.provider_connection === name) {
     throw new ConflictError(
       `Connection "${name}" is referenced by llm.default. Update llm.default.provider_connection before deleting.`,
+      { referencedBy: ["llm.default"] },
     );
   }
 
@@ -155,6 +156,7 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
     if (result.error.code === "has_references") {
       throw new ConflictError(
         `Connection "${name}" is referenced by ${result.error.count} profile(s): ${referencingProfiles.join(", ")}.`,
+        { referencedBy: referencingProfiles },
       );
     }
     throw new BadRequestError("Delete failed.");


### PR DESCRIPTION
## Summary

- **`ConflictError` now accepts optional `details`** — aligns with the base `RouteError` constructor that already supports it
- **HTTP adapter forwards `err.details`** — previously `httpError()` was called without `err.details`, so any structured payload on a `RouteError` was silently dropped from the wire response
- **Delete provider-connection handler includes `{ referencedBy: [...] }` in conflict details** — the Swift client's `parseConflictRefs` (merged in #30231) already checks `error.details.referencedBy` first, but the daemon wasn't sending it

Follow-up to #30231 — these changes were pushed to the PR branch but the PR was merged before they landed.

## Test plan

- [x] `bun test src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts` — 28/28 pass (tests assert on `message` and `instanceof`, unaffected by the additive `details` field)
- [x] Existing `ConflictError` callers unaffected (`details` parameter is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->