### PR TITLE
fix(macos): unbreak macOS tests after inferenceMode removal

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -788,24 +788,4 @@ final class InferenceProfileEditorTests: XCTestCase {
         _ = editor.body
         XCTAssertEqual(cancelCalls, 0)
     }
-
-    // MARK: - Provider dropdown filtering
-
-    func testManagedModeShowsOnlyManagedCapableProviders() {
-        store.inferenceMode = "managed"
-        let (editor, _) = makeEditor(profile: InferenceProfile(name: "draft"))
-        XCTAssertEqual(
-            Set(editor.availableProviderIds),
-            Set(["anthropic", "openai", "gemini"])
-        )
-        XCTAssertFalse(editor.availableProviderIds.contains("openrouter"))
-    }
-
-    func testYourOwnModeShowsAllCatalogProviders() {
-        store.inferenceMode = "your-own"
-        let (editor, _) = makeEditor(profile: InferenceProfile(name: "draft"))
-        XCTAssertTrue(editor.availableProviderIds.contains("openrouter"),
-            "your-own mode should expose all catalog providers including openrouter")
-        XCTAssertEqual(editor.availableProviderIds.count, store.dynamicProviderIds.count)
-    }
 }

--- a/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
@@ -110,7 +110,7 @@ final class ProviderConnectionClientTests: XCTestCase {
     func testListReturnsEmptyWhenClientReturnsEmpty() async {
         mock.listResponse = []
         let result = await mock.listProviderConnections(provider: nil)
-        XCTAssertEqual(result, [])
+        XCTAssertEqual(result?.count, 0)
         XCTAssertEqual(mock.listCallCount, 1)
         XCTAssertNil(mock.listProviderArg as Any? as? String)
     }


### PR DESCRIPTION
## Summary
- Delete two `InferenceProfileEditorTests` cases that referenced `SettingsStore.inferenceMode`, removed in #30231 along with the managed-only branch of `availableProviderIds`.
- Replace `XCTAssertEqual(result, [])` in `ProviderConnectionClientTests` with `XCTAssertEqual(result?.count, 0)` — the generated `ProviderConnection` struct is `Codable, Sendable` but not `Equatable`.

## Original prompt
Fix the macOS Tests CI job (run 25645467173) that broke on `main` after #30231 landed. The build failed with `value of type 'SettingsStore' has no member 'inferenceMode'` at `InferenceProfileEditorTests.swift:795,805` and `XCTAssertEqual ... requires that 'ProviderConnection' conform to 'Equatable'` at `ProviderConnectionClientTests.swift:113`. Scope this fix to those two failures only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->