### PR TITLE
feat(memory-v2): flip router prompt error asymmetry

### DIFF
--- a/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
+++ b/assistant/src/memory/v2/__tests__/__snapshots__/prompts-router.test.ts.snap
@@ -5,7 +5,7 @@ exports[`renderRouterPrompt — determinism & snapshot stability snapshot of fix
 
 You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
 
-Pick up to a handful of concept pages whose contents would meaningfully help Aria respond well on this turn. Abstain (return an empty list) when nothing in the index is clearly relevant — over-injection is worse than missing a page, because the always-on essentials/threads/recent/buffer block is already in context and you must not duplicate that material here.
+Pick the concept pages whose contents would help Aria respond well on this turn. Lean toward inclusion when in doubt — missing a relevant page is a worse error than surfacing a few unused ones, because the assistant can ignore extras but can't summon context that wasn't loaded. Abstain (return an empty list) only when nothing in the index plausibly bears on the turn.
 
 Index format. Each line of the index has the shape:
 

--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -166,14 +166,15 @@ describe("renderRouterPrompt — content expectations", () => {
     expect(out).toContain("<now>");
   });
 
-  test("warns against duplicating the always-on essentials block", () => {
+  test("biases toward inclusion when in doubt", () => {
     const out = renderRouterPrompt({
       assistantName: "Aria",
       userName: "Alice",
       pageIndexBlock: SAMPLE_INDEX,
     });
 
-    expect(out.toLowerCase()).toContain("essentials");
+    expect(out.toLowerCase()).toContain("lean toward inclusion");
+    expect(out.toLowerCase()).toContain("missing a relevant page");
   });
 });
 

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -62,7 +62,7 @@ const ROUTER_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOL
 
 You will be shown the recent conversation, a \`<now>\` marker for the current time, an \`<already_injected_ids>\` block listing pages picked on the previous turn, and a \`# Concept Page Index\` listing every routable page on this workspace.
 
-Pick up to a handful of concept pages whose contents would meaningfully help ${ASSISTANT_NAME_PLACEHOLDER} respond well on this turn. Abstain (return an empty list) when nothing in the index is clearly relevant — over-injection is worse than missing a page, because the always-on essentials/threads/recent/buffer block is already in context and you must not duplicate that material here.
+Pick the concept pages whose contents would help ${ASSISTANT_NAME_PLACEHOLDER} respond well on this turn. Lean toward inclusion when in doubt — missing a relevant page is a worse error than surfacing a few unused ones, because the assistant can ignore extras but can't summon context that wasn't loaded. Abstain (return an empty list) only when nothing in the index plausibly bears on the turn.
 
 Index format. Each line of the index has the shape:
 

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -93,7 +93,7 @@ const ROUTER_TOOL_NAME = "select_pages_to_inject";
 function buildRouterTool(maxPageIds: number): ToolDefinition {
   return {
     name: ROUTER_TOOL_NAME,
-    description: `Choose up to ${maxPageIds} concept page IDs to inject for the next reply. Return [] if nothing in the index is relevant — abstaining is encouraged when the turn is small-talk or already adequately covered by already_injected_ids.`,
+    description: `Choose up to ${maxPageIds} concept page IDs to inject for the next reply. Lean toward inclusion when in doubt — missing a relevant page is a worse error than surfacing unused ones. Return [] only when nothing in the index plausibly bears on the turn.`,
     input_schema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
- Replace \"over-injection is worse than missing a page\" with \"missing a relevant page is a worse error than surfacing unused ones\" in both the bundled prompt and the tool description.
- Drop the unactionable reference to \"essentials/threads/recent/buffer\" — the router never sees those blocks.
- Regenerate the prompt snapshot; update the matching assertion to look for the new wording.

## Test plan
- [ ] \`bun test src/memory/v2/__tests__/prompts-router.test.ts\` (19, +1 snapshot)
- [ ] \`bun test src/memory/v2/__tests__/router.test.ts\` (15, no regressions)
- [ ] \`bunx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->