### PR TITLE
feat(pkb): emphasize remember and drop workspace-file nudge

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -5,9 +5,8 @@ import { buildPkbReminder } from "./pkb-reminder-builder.js";
 // Byte-for-byte fixture of the base PKB reminder.
 const BASE_REMINDER =
   "<system_reminder>" +
-  "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+  "\n**CRITICAL:** Call `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-  "\nRead any unread workspace files that look even partially relevant." +
   "\n</system_reminder>";
 
 describe("buildPkbReminder", () => {
@@ -19,9 +18,8 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(["projects/alpha.md"]);
     const expected =
       "<system_reminder>" +
-      "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+      "\n**CRITICAL:** Call `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-      "\nRead any unread workspace files that look even partially relevant." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
       "\n</system_reminder>";
@@ -40,9 +38,8 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(hints);
     const expected =
       "<system_reminder>" +
-      "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+      "\n**CRITICAL:** Call `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-      "\nRead any unread workspace files that look even partially relevant." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- a.md" +
       "\n- sub/b.md" +

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -1,7 +1,6 @@
 const BODY =
-  "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
-  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-  "\nRead any unread workspace files that look even partially relevant.";
+  "\n**CRITICAL:** Call `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing.";
 
 /**
  * Render the PKB system_reminder text, optionally with a bulleted list of


### PR DESCRIPTION
## Summary
- Prefix the `remember` instruction in the PKB system reminder with `**CRITICAL:**` so it gets stronger attention than the surrounding lines.
- Drop the "Read any unread workspace files that look even partially relevant" line — the `recall` instruction already covers workspace lookups and the extra nudge encouraged unnecessary file reads.
- Update the byte-for-byte fixture in `pkb-reminder-builder.test.ts` to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->