### PR TITLE
feat(daemon): types for ask-question message

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -235,6 +235,27 @@ export interface SecretRequest {
   allowOneTimeSend?: boolean;
 }
 
+export interface QuestionOption {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface QuestionRequest {
+  type: "question_request";
+  requestId: string;
+  question: string;
+  description?: string;
+  /** LLM-supplied options, capped at 4. The client always renders a fixed
+   *  5th "Type something else" slot wired to a free-text response — so this
+   *  array never represents the full choice set the user sees. */
+  options: QuestionOption[];
+  /** Optional placeholder shown in the free-text input. */
+  freeTextPlaceholder?: string;
+  conversationId?: string;
+  toolUseId?: string;
+}
+
 export interface MessageComplete {
   type: "message_complete";
   conversationId?: string;
@@ -430,6 +451,7 @@ export type _MessagesServerMessages =
   | ToolResult
   | ConfirmationRequest
   | SecretRequest
+  | QuestionRequest
   | MessageComplete
   | ErrorMessage
   | MessageQueued


### PR DESCRIPTION
## Summary
- Add QuestionRequest/QuestionOption types to daemon message-types
- Wire QuestionRequest into the ServerMessage discriminated union

Part of plan: agent-question-ux.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->