### PR TITLE
feat(daemon): question prompter and pending-interaction kind

### DIFF
--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  QuestionRequest,
+  ServerMessage,
+} from "../daemon/message-protocol.js";
+
+// Use a tiny timeout so the setTimeout branch fires quickly in tests
+const mockConfig = {
+  timeouts: { permissionTimeoutSec: 0.05 },
+};
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+// Use a real Map so QuestionPrompter can store and retrieve callbacks.
+const _piStore = new Map<string, { timer?: ReturnType<typeof setTimeout> }>();
+mock.module("../runtime/pending-interactions.js", () => ({
+  register: (id: string, entry: object) => _piStore.set(id, entry),
+  resolve: (id: string) => {
+    const e = _piStore.get(id);
+    if (e?.timer != null) clearTimeout(e.timer);
+    _piStore.delete(id);
+    return e;
+  },
+  get: (id: string) => _piStore.get(id),
+  getAll: () => [..._piStore.values()],
+  getByConversation: () => [],
+  getByKind: () => [],
+  removeByConversation: () => {},
+  clear: () => _piStore.clear(),
+}));
+
+const { QuestionPrompter } = await import("./question-prompter.js");
+
+function makePrompter() {
+  const sent: ServerMessage[] = [];
+  const prompter = new QuestionPrompter({
+    broadcastMessage: (msg) => sent.push(msg),
+  });
+  return { prompter, sent };
+}
+
+const baseParams = {
+  conversationId: "conv-1",
+  question: "Pick one",
+  options: [
+    { id: "a", label: "Apple" },
+    { id: "b", label: "Banana" },
+  ],
+};
+
+describe("QuestionPrompter", () => {
+  beforeEach(() => {
+    _piStore.clear();
+  });
+
+  test("happy path: option resolution", async () => {
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt(baseParams);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe("question_request");
+
+    const requestId = (sent[0] as QuestionRequest).requestId;
+    prompter.resolveQuestion(requestId, { kind: "option", optionId: "a" });
+
+    const result = await promise;
+    expect(result).toEqual({ decision: "option", optionId: "a" });
+    expect(prompter.hasPendingRequest(requestId)).toBe(false);
+  });
+
+  test("free-text resolution", async () => {
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt({
+      ...baseParams,
+      freeTextPlaceholder: "Type a fruit",
+    });
+
+    const req = sent[0] as QuestionRequest;
+    expect(req.freeTextPlaceholder).toBe("Type a fruit");
+
+    prompter.resolveQuestion(req.requestId, {
+      kind: "free_text",
+      text: "Cherry",
+    });
+
+    const result = await promise;
+    expect(result).toEqual({ decision: "free_text", text: "Cherry" });
+  });
+
+  test("timeout fires with decision: timed_out", async () => {
+    const { prompter } = makePrompter();
+    const result = await prompter.prompt(baseParams);
+    expect(result).toEqual({ decision: "timed_out" });
+  });
+
+  test("abort signal triggers decision: aborted", async () => {
+    const { prompter, sent } = makePrompter();
+    const ac = new AbortController();
+
+    const promise = prompter.prompt({ ...baseParams, signal: ac.signal });
+    const requestId = (sent[0] as QuestionRequest).requestId;
+    expect(prompter.hasPendingRequest(requestId)).toBe(true);
+
+    ac.abort();
+    const result = await promise;
+    expect(result).toEqual({ decision: "aborted" });
+    expect(prompter.hasPendingRequest(requestId)).toBe(false);
+  });
+
+  test("pre-aborted signal short-circuits before broadcasting", async () => {
+    const { prompter, sent } = makePrompter();
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await prompter.prompt({ ...baseParams, signal: ac.signal });
+    expect(result).toEqual({ decision: "aborted" });
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -1,0 +1,144 @@
+import { v4 as uuid } from "uuid";
+
+import { getConfig } from "../config/loader.js";
+import type {
+  QuestionOption,
+  QuestionRequest,
+  ServerMessage,
+} from "../daemon/message-protocol.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { AssistantError, ErrorCode } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("question-prompter");
+
+export interface QuestionPromptResult {
+  decision: "option" | "free_text" | "timed_out" | "aborted";
+  optionId?: string;
+  text?: string;
+}
+
+export interface QuestionPromptParams {
+  conversationId: string;
+  question: string;
+  description?: string;
+  options: QuestionOption[];
+  allowFreeText?: boolean;
+  freeTextPlaceholder?: string;
+  toolUseId?: string;
+  signal?: AbortSignal;
+}
+
+export type QuestionResponse =
+  | { kind: "option"; optionId: string }
+  | { kind: "free_text"; text: string };
+
+/**
+ * Broadcast an ask-question request to all connected clients and wait for the
+ * user's reply. Mirrors the {@link SecretPrompter} and {@link PermissionPrompter}
+ * patterns: lifecycle state (rpcResolve, rpcReject, timer) lives in
+ * pendingInteractions; this class only tracks ownership so dispose can scope
+ * cleanup to a single conversation.
+ *
+ * Timeout reuses `getConfig().timeouts.permissionTimeoutSec` (default 5 min) —
+ * questions are user-prompts in the same UX family as permission prompts and
+ * secret prompts, so they share the same idle-timeout knob.
+ */
+export class QuestionPrompter {
+  private ownedIds = new Set<string>();
+
+  constructor(
+    private deps: { broadcastMessage(msg: ServerMessage): void },
+  ) {}
+
+  async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
+    const {
+      conversationId,
+      question,
+      description,
+      options,
+      freeTextPlaceholder,
+      toolUseId,
+      signal,
+    } = params;
+
+    if (signal?.aborted) return { decision: "aborted" };
+
+    const requestId = uuid();
+
+    return new Promise((resolve, reject) => {
+      const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
+
+      const timer = setTimeout(() => {
+        pendingInteractions.resolve(requestId);
+        this.ownedIds.delete(requestId);
+        log.warn({ requestId, conversationId }, "Question prompt timed out");
+        resolve({ decision: "timed_out" });
+      }, timeoutMs);
+
+      pendingInteractions.register(requestId, {
+        conversationId,
+        kind: "question",
+        rpcResolve: resolve as (value: unknown) => void,
+        rpcReject: reject,
+        timer,
+        toolUseId,
+      });
+      this.ownedIds.add(requestId);
+
+      if (signal) {
+        const onAbort = () => {
+          if (this.ownedIds.has(requestId)) {
+            pendingInteractions.resolve(requestId);
+            this.ownedIds.delete(requestId);
+            resolve({ decision: "aborted" });
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      const msg: QuestionRequest = {
+        type: "question_request",
+        requestId,
+        question,
+        description,
+        options,
+        freeTextPlaceholder,
+        conversationId,
+        toolUseId,
+      };
+
+      this.deps.broadcastMessage(msg);
+    });
+  }
+
+  hasPendingRequest(requestId: string): boolean {
+    return this.ownedIds.has(requestId);
+  }
+
+  resolveQuestion(requestId: string, response: QuestionResponse): void {
+    if (!this.ownedIds.has(requestId)) {
+      log.warn({ requestId }, "No pending prompt for question response");
+      return;
+    }
+    const interaction = pendingInteractions.resolve(requestId);
+    this.ownedIds.delete(requestId);
+    const result: QuestionPromptResult =
+      response.kind === "option"
+        ? { decision: "option", optionId: response.optionId }
+        : { decision: "free_text", text: response.text };
+    (interaction?.rpcResolve as
+      | ((v: QuestionPromptResult) => void)
+      | undefined)?.(result);
+  }
+
+  dispose(): void {
+    for (const requestId of [...this.ownedIds]) {
+      const interaction = pendingInteractions.resolve(requestId);
+      this.ownedIds.delete(requestId);
+      interaction?.rpcReject?.(
+        new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),
+      );
+    }
+  }
+}

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -47,6 +47,7 @@ export interface PendingInteraction {
   kind:
     | "confirmation"
     | "secret"
+    | "question"
     | "host_bash"
     | "host_file"
     | "host_cu"


### PR DESCRIPTION
## Summary
- Add QuestionPrompter service following SecretPrompter/PermissionPrompter pattern
- Add 'question' to PendingInteraction kind union
- Tests cover option resolution, free-text, timeout, abort

Part of plan: agent-question-ux.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->