### PR TITLE
feat(daemon): question-response route handler

### DIFF
--- a/assistant/src/runtime/routes/__tests__/question-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/question-routes.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the `/v1/question-response` route in `question-routes.ts`.
+ *
+ * Covers:
+ *   - 200 OK + rpcResolve invoked with `{ decision: "option", optionId }`
+ *     on valid option body with a registered "question" interaction.
+ *   - 200 OK + rpcResolve invoked with `{ decision: "free_text", text }`
+ *     on valid free-text body.
+ *   - 404 when no pending interaction exists for the requestId.
+ *   - 400 when the request body fails zod validation.
+ *   - Cross-talk safety: a registered "confirmation" requestId returns 404
+ *     rather than being mis-resolved.
+ *   - The pending interaction is removed after a successful resolve.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import * as pendingInteractions from "../../pending-interactions.js";
+import { BadRequestError, NotFoundError } from "../errors.js";
+import { ROUTES as QUESTION_ROUTES } from "../question-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = QUESTION_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+const handler = findHandler("question_response");
+
+async function call(args: RouteHandlerArgs): Promise<unknown> {
+  return await handler(args);
+}
+
+beforeEach(() => {
+  pendingInteractions.clear();
+});
+
+afterEach(() => {
+  pendingInteractions.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/question-response", () => {
+  test("resolves a pending question with an option selection", async () => {
+    const resolved: unknown[] = [];
+    pendingInteractions.register("req-1", {
+      conversationId: "conv-1",
+      kind: "question",
+      rpcResolve: (value) => resolved.push(value),
+    });
+
+    const result = await call({
+      body: { requestId: "req-1", kind: "option", optionId: "yes" },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(resolved).toEqual([{ decision: "option", optionId: "yes" }]);
+    // Interaction deregistered after resolve.
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+
+  test("resolves a pending question with a free-text response", async () => {
+    const resolved: unknown[] = [];
+    pendingInteractions.register("req-2", {
+      conversationId: "conv-1",
+      kind: "question",
+      rpcResolve: (value) => resolved.push(value),
+    });
+
+    const result = await call({
+      body: { requestId: "req-2", kind: "free_text", text: "maybe" },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(resolved).toEqual([{ decision: "free_text", text: "maybe" }]);
+    expect(pendingInteractions.get("req-2")).toBeUndefined();
+  });
+
+  test("returns 404 when no pending interaction exists for the requestId", async () => {
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "missing", kind: "option", optionId: "a" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+    expect((thrown as NotFoundError).statusCode).toBe(404);
+  });
+
+  test("returns 400 when the request body fails validation", async () => {
+    // Missing optionId for kind: "option".
+    let thrown: unknown;
+    try {
+      await call({ body: { requestId: "req-3", kind: "option" } });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+    expect((thrown as BadRequestError).statusCode).toBe(400);
+  });
+
+  test("returns 400 when kind is an unknown discriminator value", async () => {
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "req-4", kind: "bogus", optionId: "x" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+  });
+
+  test("returns 400 when body is missing entirely", async () => {
+    let thrown: unknown;
+    try {
+      await call({});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+  });
+
+  test("cross-talk safe: confirmation requestId returns 404 instead of mis-resolving", async () => {
+    const resolved: unknown[] = [];
+    pendingInteractions.register("req-confirm", {
+      conversationId: "conv-1",
+      kind: "confirmation",
+      rpcResolve: (value) => resolved.push(value),
+    });
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "req-confirm", kind: "option", optionId: "yes" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(NotFoundError);
+    // The confirmation interaction was not touched.
+    expect(resolved).toEqual([]);
+    expect(pendingInteractions.get("req-confirm")?.kind).toBe("confirmation");
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -95,6 +95,7 @@ import { ROUTES as PLATFORM_ROUTES } from "./platform-routes.js";
 import { ROUTES as PLAYGROUND_ROUTES } from "./playground/index.js";
 import { ROUTES as PROFILER_ROUTES } from "./profiler-routes.js";
 import { ROUTES as PS_ROUTES } from "./ps-routes.js";
+import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "./schedule-routes.js";
@@ -209,6 +210,7 @@ export const ROUTES: RouteDefinition[] = [
   ...PLAYGROUND_ROUTES,
   ...PROFILER_ROUTES,
   ...PS_ROUTES,
+  ...QUESTION_ROUTES,
   ...RECORDING_ROUTES,
   ...RENAME_CONVERSATION_ROUTES,
   ...SCHEDULE_ROUTES,

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -1,0 +1,110 @@
+/**
+ * Route handler for resolving pending question prompts.
+ *
+ * POST /v1/question-response — a client (UI or remote channel) submits the
+ * user's selection (one of the supplied options, or free-text) for a pending
+ * ask-question interaction registered by {@link QuestionPrompter}.
+ *
+ * Mirrors `/v1/confirm` and `/v1/secret`: the request body is validated via
+ * zod, the pending interaction is looked up from the shared
+ * `pendingInteractions` map, and the caller's Promise is resolved with the
+ * appropriate `QuestionPromptResult` shape.
+ *
+ * Cross-talk safety: pending interactions of other kinds (`confirmation`,
+ * `secret`, host_*, etc.) return 404 here rather than being mis-resolved.
+ */
+import { z } from "zod";
+
+import type { QuestionPromptResult } from "../../permissions/question-prompter.js";
+import { getLogger } from "../../util/logger.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("question-routes");
+
+const QuestionResponseBody = z.discriminatedUnion("kind", [
+  z.object({
+    requestId: z.string(),
+    kind: z.literal("option"),
+    optionId: z.string(),
+  }),
+  z.object({
+    requestId: z.string(),
+    kind: z.literal("free_text"),
+    text: z.string(),
+  }),
+]);
+
+type QuestionResponseBody = z.infer<typeof QuestionResponseBody>;
+
+/**
+ * POST /v1/question-response — resolve a pending ask-question interaction.
+ */
+function handleQuestionResponse({ body }: RouteHandlerArgs) {
+  const parsed = QuestionResponseBody.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid question response body: ${parsed.error.message}`,
+    );
+  }
+
+  const response: QuestionResponseBody = parsed.data;
+  const { requestId } = response;
+
+  const interaction = pendingInteractions.get(requestId);
+  if (!interaction || interaction.kind !== "question") {
+    log.warn(
+      { requestId, foundKind: interaction?.kind },
+      "Question response for unknown or wrong-kind requestId",
+    );
+    throw new NotFoundError(
+      "No pending question interaction found for this requestId",
+    );
+  }
+
+  // Deregister now that we know we'll resolve — clears the prompter timer.
+  pendingInteractions.resolve(requestId);
+
+  const result: QuestionPromptResult =
+    response.kind === "option"
+      ? { decision: "option", optionId: response.optionId }
+      : { decision: "free_text", text: response.text };
+
+  log.info(
+    {
+      requestId,
+      decision: result.decision,
+      conversationId: interaction.conversationId,
+    },
+    "Question resolved",
+  );
+
+  (interaction.rpcResolve as
+    | ((value: QuestionPromptResult) => void)
+    | undefined)?.(result);
+
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "question_response",
+    endpoint: "question-response",
+    method: "POST",
+    handler: handleQuestionResponse,
+    requireGuardian: true,
+    summary: "Resolve a pending ask-question prompt",
+    description:
+      "Submit the user's response (option selection or free-text) for a pending question prompt by requestId.",
+    tags: ["approvals"],
+    requestBody: QuestionResponseBody,
+    responseBody: z.object({
+      success: z.boolean(),
+    }),
+  },
+];


### PR DESCRIPTION
## Summary
- Add POST /v1/question-response route to resolve pending question interactions
- Zod discriminated union body validates option vs free_text responses
- 404 on missing or wrong-kind pendingInteraction (cross-talk safe)

Part of plan: agent-question-ux.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->