### PR TITLE
feat(daemon): ask_question tool

### DIFF
--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import type { QuestionPromptResult } from "../../permissions/question-prompter.js";
+import type { ToolContext } from "../types.js";
+import { AskQuestionTool } from "./ask-question-tool.js";
+
+type PromptParams = Parameters<
+  import("../../permissions/question-prompter.js").QuestionPrompter["prompt"]
+>[0];
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-1",
+    trustClass: "guardian",
+    toolUseId: "tu-1",
+    ...overrides,
+  };
+}
+
+function makeToolWithStub(result: QuestionPromptResult): {
+  tool: AskQuestionTool;
+  calls: PromptParams[];
+} {
+  const calls: PromptParams[] = [];
+  const tool = new AskQuestionTool(() => ({
+    async prompt(params: PromptParams) {
+      calls.push(params);
+      return result;
+    },
+  }));
+  return { tool, calls };
+}
+
+const validInput = {
+  question: "Which fruit?",
+  description: "Pick one to add to the smoothie.",
+  options: [
+    { id: "a", label: "Apple" },
+    { id: "b", label: "Banana", description: "Ripe" },
+  ],
+  freeTextPlaceholder: "Type a fruit",
+};
+
+describe("AskQuestionTool definition", () => {
+  test("exposes the expected schema shape", () => {
+    const def = new AskQuestionTool().getDefinition();
+    expect(def.name).toBe("ask_question");
+    expect(def.description).toContain("free-text fallback is always added");
+    expect(def.description).toContain("do not");
+    expect(def.description).toContain("'something else'");
+
+    const schema = def.input_schema as {
+      properties: Record<string, { type?: string; minItems?: number; maxItems?: number }>;
+      required: string[];
+    };
+    expect(schema.required).toEqual(["question", "options"]);
+    expect(schema.properties.options?.type).toBe("array");
+    expect(schema.properties.options?.minItems).toBe(2);
+    expect(schema.properties.options?.maxItems).toBe(4);
+  });
+});
+
+describe("AskQuestionTool.execute", () => {
+  test("forwards options unchanged to the prompter", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute(validInput, makeContext());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.conversationId).toBe("conv-1");
+    expect(calls[0]?.question).toBe(validInput.question);
+    expect(calls[0]?.description).toBe(validInput.description);
+    expect(calls[0]?.options).toEqual(validInput.options);
+    expect(calls[0]?.freeTextPlaceholder).toBe(validInput.freeTextPlaceholder);
+    expect(calls[0]?.toolUseId).toBe("tu-1");
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Option: a\nLabel: Apple");
+  });
+
+  test("formats option result with looked-up label", async () => {
+    const { tool } = makeToolWithStub({
+      decision: "option",
+      optionId: "b",
+    });
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.content).toBe("Option: b\nLabel: Banana");
+    expect(result.isError).toBe(false);
+  });
+
+  test("falls back to '(unknown)' label when optionId is not in options", async () => {
+    // Defensive: prompter never returns an out-of-band id, but the handler
+    // must not crash if it ever did. Verifies the lookup default branch.
+    const { tool } = makeToolWithStub({
+      decision: "option",
+      optionId: "ghost",
+    });
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.content).toBe("Option: ghost\nLabel: (unknown)");
+    expect(result.isError).toBe(false);
+  });
+
+  test("formats free-text result", async () => {
+    const { tool } = makeToolWithStub({
+      decision: "free_text",
+      text: "Cherry",
+    });
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.content).toBe("Free text: Cherry");
+    expect(result.isError).toBe(false);
+  });
+
+  test("timeout produces tool error", async () => {
+    const { tool } = makeToolWithStub({ decision: "timed_out" });
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("User did not respond within timeout");
+  });
+
+  test("aborted produces tool error", async () => {
+    const { tool } = makeToolWithStub({ decision: "aborted" });
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("Question aborted");
+  });
+
+  test("rejects input with fewer than 2 options", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const result = await tool.execute(
+      { ...validInput, options: [{ id: "a", label: "Apple" }] },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("invalid input");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects input with more than 4 options", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const result = await tool.execute(
+      {
+        ...validInput,
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+          { id: "c", label: "C" },
+          { id: "d", label: "D" },
+          { id: "e", label: "E" },
+        ],
+      },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects input with empty question", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const result = await tool.execute(
+      { ...validInput, question: "" },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("propagates abort signal into the prompter", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const ac = new AbortController();
+    await tool.execute(validInput, makeContext({ signal: ac.signal }));
+    expect(calls[0]?.signal).toBe(ac.signal);
+  });
+});

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+
+import { QuestionPrompter } from "../../permissions/question-prompter.js";
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+// ── Input schema ────────────────────────────────────────────────────
+// Runtime validation lives in Zod; the wire-level definition surfaced
+// to the LLM is the hand-written JSON Schema in getDefinition() below.
+// (The codebase does not currently use zod-to-json-schema for tool defs,
+// so the two are kept in sync manually.)
+
+const OptionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().optional(),
+});
+
+const InputSchema = z.object({
+  question: z.string().min(1),
+  description: z.string().optional(),
+  // 2–4 LLM-supplied options. The client renders a fixed 5th "Type
+  // something else" slot for free-text, so the model must keep the
+  // structured set to 4 or fewer.
+  options: z.array(OptionSchema).min(2).max(4),
+  freeTextPlaceholder: z.string().optional(),
+});
+
+export type AskQuestionInput = z.infer<typeof InputSchema>;
+
+// ── Tool description ────────────────────────────────────────────────
+
+const DESCRIPTION = [
+  "Ask the user a clarifying question with a small set of structured options.",
+  "Use when the request is ambiguous and a short multiple-choice prompt would",
+  "resolve it faster than free-form back-and-forth.",
+  "",
+  "Provide 2–4 options. A free-text fallback is always added by the UI — do not",
+  "include a 'something else' option yourself.",
+  "",
+  "Each option needs a stable `id` (the value the response carries back) and a",
+  "short human-readable `label`. Optional `description` adds one line of",
+  "context shown beneath the label.",
+].join("\n");
+
+// ── Tool ────────────────────────────────────────────────────────────
+
+export class AskQuestionTool implements Tool {
+  name = "ask_question";
+  description = DESCRIPTION;
+  category = "interaction";
+  defaultRiskLevel = RiskLevel.Low;
+
+  // Override hook for tests: lets a test replace the prompter factory
+  // without monkey-patching the module. Default factory wires the real
+  // broadcastMessage so the question reaches every connected client.
+  private prompterFactory: () => Pick<QuestionPrompter, "prompt">;
+
+  constructor(
+    prompterFactory: () => Pick<QuestionPrompter, "prompt"> = () =>
+      new QuestionPrompter({ broadcastMessage }),
+  ) {
+    this.prompterFactory = prompterFactory;
+  }
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          question: {
+            type: "string",
+            description: "The clarifying question shown to the user.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Optional one-line context shown beneath the question.",
+          },
+          options: {
+            type: "array",
+            minItems: 2,
+            maxItems: 4,
+            description:
+              "2–4 structured options. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  description:
+                    "Stable identifier for this option (returned verbatim in the response).",
+                },
+                label: {
+                  type: "string",
+                  description: "Short human-readable label.",
+                },
+                description: {
+                  type: "string",
+                  description:
+                    "Optional one-line context shown beneath the label.",
+                },
+              },
+              required: ["id", "label"],
+            },
+          },
+          freeTextPlaceholder: {
+            type: "string",
+            description:
+              "Optional placeholder text shown inside the free-text fallback input.",
+          },
+        },
+        required: ["question", "options"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const parsed = InputSchema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        content: `Invalid input: ${parsed.error.message}`,
+        isError: true,
+      };
+    }
+
+    const { question, description, options, freeTextPlaceholder } = parsed.data;
+
+    const prompter = this.prompterFactory();
+    const result = await prompter.prompt({
+      conversationId: context.conversationId,
+      question,
+      description,
+      options,
+      freeTextPlaceholder,
+      toolUseId: context.toolUseId,
+      signal: context.signal,
+    });
+
+    switch (result.decision) {
+      case "option": {
+        const chosen = options.find((o) => o.id === result.optionId);
+        const label = chosen?.label ?? "(unknown)";
+        return {
+          content: `Option: ${result.optionId}\nLabel: ${label}`,
+          isError: false,
+        };
+      }
+      case "free_text": {
+        return {
+          content: `Free text: ${result.text ?? ""}`,
+          isError: false,
+        };
+      }
+      case "timed_out":
+        return {
+          content: "User did not respond within timeout",
+          isError: true,
+        };
+      case "aborted":
+        return {
+          content: "Question aborted",
+          isError: true,
+        };
+    }
+  }
+}
+
+export const askQuestionTool = new AskQuestionTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -11,6 +11,7 @@ import {
   isCesSecureInstallEnabled,
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
+import { askQuestionTool } from "./ask-question/ask-question-tool.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
 import { runAuthenticatedCommandTool } from "./credential-execution/run-authenticated-command.js";
@@ -91,6 +92,7 @@ export const explicitTools: Tool[] = [
   recallTool,
   credentialStoreTool,
   notifyParentTool,
+  askQuestionTool,
   // NOTE: external skill tools (registered via registerExternalTools in
   // registry.ts) are intentionally NOT included here. `explicitTools` is a
   // module-level const whose value is fixed at first evaluation, so


### PR DESCRIPTION
## Summary
- Add ask_question LLM tool with 2–4 option Zod schema
- Handler forwards to QuestionPrompter and maps results to tool output
- Registered in tools/registry alongside other built-in tools

Part of plan: agent-question-ux.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->