### PR TITLE
feat(search): add Tavily as a web search provider

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -134,6 +134,17 @@ describe("AssistantConfigSchema", () => {
     expect(result.auditLog).toEqual({ retentionDays: 0 });
   });
 
+  test("accepts Tavily as a web search provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        "web-search": { mode: "your-own", provider: "tavily" },
+      },
+    });
+
+    expect(result.services["web-search"].provider).toBe("tavily");
+    expect(result.services["web-search"].mode).toBe("your-own");
+  });
+
   test("accepts valid complete config", () => {
     const input = {
       llm: {

--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -136,6 +136,7 @@ mock.module("../config/loader.js", () => ({
     "fireworks",
     "brave",
     "perplexity",
+    "tavily",
   ],
   getConfig: () => mockConfig,
   getConfigReadOnly: () => mockConfig,

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -50,6 +50,7 @@ mock.module("../config/loader.js", () => ({
     "openrouter",
     "brave",
     "perplexity",
+    "tavily",
   ],
 }));
 

--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -43,6 +43,17 @@ describe("WebSearchTool", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain("No web search API key configured");
     });
+
+    test("returns error when no API key is configured (tavily)", async () => {
+      delete process.env.TAVILY_API_KEY;
+      const result = await executeWebSearch(
+        { query: "test" },
+        undefined,
+        "tavily",
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("No web search API key configured");
+    });
   });
 
   describe("input validation", () => {
@@ -508,6 +519,159 @@ describe("WebSearchTool", () => {
       expect(result.content).toContain("Network unreachable");
     });
   });
+
+  describe("Tavily API responses", () => {
+    test("formats results", async () => {
+      const mockResponse = {
+        results: [
+          {
+            title: "Tavily Result",
+            url: "https://example.com/tavily",
+            content: "A Tavily search snippet.",
+            score: 0.9234,
+          },
+        ],
+      };
+
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as unknown as typeof fetch;
+
+      const result = await executeWebSearch(
+        { query: "test" },
+        "tvly-key",
+        "tavily",
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Tavily Result");
+      expect(result.content).toContain("https://example.com/tavily");
+      expect(result.content).toContain("A Tavily search snippet");
+      expect(result.content).toContain("Score: 0.923");
+    });
+
+    test("handles empty response", async () => {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as unknown as typeof fetch;
+
+      const result = await executeWebSearch(
+        { query: "noresults" },
+        "tvly-key",
+        "tavily",
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("No results found");
+    });
+
+    test("maps count and freshness into Tavily request body", async () => {
+      let capturedHeaders: Record<string, string> = {};
+      let capturedBody: Record<string, unknown> = {};
+      globalThis.fetch = (async (_url: string, init: RequestInit) => {
+        capturedHeaders = Object.fromEntries(
+          Object.entries(init.headers as Record<string, string>),
+        );
+        capturedBody = JSON.parse(init.body as string);
+        return new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
+
+      await executeWebSearch(
+        { query: "test query", count: 50, freshness: "pw" },
+        "tvly-my-key",
+        "tavily",
+      );
+      expect(capturedHeaders.Authorization).toBe("Bearer tvly-my-key");
+      expect(capturedHeaders["Content-Type"]).toBe("application/json");
+      expect(capturedBody.query).toBe("test query");
+      expect(capturedBody.search_depth).toBe("advanced");
+      expect(capturedBody.max_results).toBe(20);
+      expect(capturedBody.time_range).toBe("week");
+    });
+
+    test("omits invalid freshness values", async () => {
+      let capturedBody: Record<string, unknown> = {};
+      globalThis.fetch = (async (_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string);
+        return new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
+
+      await executeWebSearch(
+        { query: "test query", freshness: "invalid" },
+        "tvly-my-key",
+        "tavily",
+      );
+      expect(capturedBody.time_range).toBeUndefined();
+    });
+
+    test("handles 401 unauthorized", async () => {
+      globalThis.fetch = (async () =>
+        new Response("Unauthorized", {
+          status: 401,
+        })) as unknown as typeof fetch;
+
+      const result = await executeWebSearch(
+        { query: "test" },
+        "bad-key",
+        "tavily",
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Invalid or expired");
+    });
+
+    test("retries on 429 and succeeds", async () => {
+      let callCount = 0;
+      globalThis.fetch = (async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response("Too Many Requests", { status: 429 });
+        }
+        return new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "Found it",
+                url: "https://example.com/found",
+                content: "Found it with Tavily",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch;
+
+      const result = await executeWebSearch(
+        { query: "test" },
+        "tvly-key",
+        "tavily",
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Found it with Tavily");
+      expect(callCount).toBe(3);
+    });
+
+    test("handles network errors", async () => {
+      globalThis.fetch = (async () => {
+        throw new Error("Network unreachable");
+      }) as unknown as typeof fetch;
+
+      const result = await executeWebSearch(
+        { query: "test" },
+        "tvly-key",
+        "tavily",
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Network unreachable");
+    });
+  });
 });
 
 interface BraveSearchResult {
@@ -527,6 +691,17 @@ interface PerplexityResponse {
   citations?: string[];
 }
 
+interface TavilySearchResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  score?: number;
+}
+
+interface TavilySearchResponse {
+  results?: TavilySearchResult[];
+}
+
 /**
  * Helper that exercises the web search logic directly, bypassing module
  * registration concerns. This replicates the core execute path from
@@ -535,7 +710,7 @@ interface PerplexityResponse {
 async function executeWebSearch(
   input: Record<string, unknown>,
   apiKey?: string,
-  provider: "brave" | "perplexity" = "brave",
+  provider: "brave" | "perplexity" | "tavily" = "brave",
 ): Promise<{ content: string; isError: boolean }> {
   const query = input.query;
   if (!query || typeof query !== "string") {
@@ -548,13 +723,17 @@ async function executeWebSearch(
   if (!apiKey) {
     return {
       content:
-        "Error: No web search API key configured. Set it via `keys set perplexity <key>` or `keys set brave <key>`, or configure it from the Settings page under API Keys.",
+        "Error: No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, or `keys set tavily <key>`, or configure it from the Settings page under API Keys.",
       isError: true,
     };
   }
 
   if (provider === "perplexity") {
     return executePerplexitySearchHelper(query as string, apiKey);
+  }
+
+  if (provider === "tavily") {
+    return executeTavilySearchHelper(input, query as string, apiKey);
   }
 
   return executeBraveSearchHelper(input, query as string, apiKey);
@@ -757,6 +936,128 @@ async function executePerplexitySearchHelper(
     return {
       content:
         "Error: Perplexity rate limit exceeded after retries. Try again shortly.",
+      isError: true,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { content: `Error: Web search failed: ${msg}`, isError: true };
+  }
+}
+
+function tavilyTimeRangeForFreshness(
+  freshness: string | undefined,
+): "day" | "week" | "month" | "year" | undefined {
+  switch (freshness) {
+    case "pd":
+      return "day";
+    case "pw":
+      return "week";
+    case "pm":
+      return "month";
+    case "py":
+      return "year";
+    default:
+      return undefined;
+  }
+}
+
+async function executeTavilySearchHelper(
+  input: Record<string, unknown>,
+  query: string,
+  apiKey: string,
+): Promise<{ content: string; isError: boolean }> {
+  const count =
+    typeof input.count === "number"
+      ? Math.min(20, Math.max(1, Math.round(input.count)))
+      : 10;
+  const timeRange = tavilyTimeRangeForFreshness(
+    typeof input.freshness === "string" ? input.freshness : undefined,
+  );
+  const body: Record<string, unknown> = {
+    query,
+    search_depth: "advanced",
+    max_results: count,
+  };
+  if (timeRange) body.time_range = timeRange;
+
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 1;
+
+  try {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response = await fetch("https://api.tavily.com/search", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "X-Client-Source": "vellum-assistant",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (response.ok) {
+        const data = (await response.json()) as TavilySearchResponse;
+        const results = data.results ?? [];
+
+        if (results.length === 0) {
+          return {
+            content: `No results found for "${query}".`,
+            isError: false,
+          };
+        }
+
+        const lines: string[] = [`Web search results for "${query}":\n`];
+
+        for (let i = 0; i < results.length; i++) {
+          const r = results[i];
+          const title = r.title?.trim() || r.url?.trim() || "Untitled result";
+          lines.push(`${i + 1}. ${title}`);
+          if (r.url) lines.push(`   URL: ${r.url}`);
+          if (r.content) lines.push(`   ${r.content}`);
+          if (typeof r.score === "number") {
+            lines.push(`   Score: ${r.score.toFixed(3)}`);
+          }
+          lines.push("");
+        }
+
+        return { content: lines.join("\n"), isError: false };
+      }
+
+      await response.text();
+
+      if (response.status === 401 || response.status === 403) {
+        return {
+          content: "Error: Invalid or expired Tavily API key",
+          isError: true,
+        };
+      }
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const retryAfter = response.headers.get("retry-after");
+        const delayMs =
+          retryAfter && !isNaN(Number(retryAfter))
+            ? Number(retryAfter) * 1000
+            : BASE_DELAY_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      if (response.status === 429) {
+        return {
+          content:
+            "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
+          isError: true,
+        };
+      }
+      return {
+        content: `Error: Tavily Search API returned status ${response.status}`,
+        isError: true,
+      };
+    }
+
+    return {
+      content:
+        "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
       isError: true,
     };
   } catch (err) {

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -20,6 +20,7 @@ const VALID_IMAGE_GEN_PROVIDERS = ["gemini", "openai"] as const;
 const VALID_WEB_SEARCH_PROVIDERS = [
   "perplexity",
   "brave",
+  "tavily",
   "inference-provider-native",
 ] as const;
 

--- a/assistant/src/providers/__tests__/provider-env-vars.test.ts
+++ b/assistant/src/providers/__tests__/provider-env-vars.test.ts
@@ -34,6 +34,7 @@ describe("getLlmProviderEnvVar", () => {
   test("returns undefined for search providers (out of scope)", () => {
     expect(getLlmProviderEnvVar("brave")).toBeUndefined();
     expect(getLlmProviderEnvVar("perplexity")).toBeUndefined();
+    expect(getLlmProviderEnvVar("tavily")).toBeUndefined();
   });
 
   test("returns undefined for unknown provider", () => {
@@ -48,6 +49,10 @@ describe("getSearchProviderEnvVar", () => {
 
   test("returns PERPLEXITY_API_KEY for perplexity", () => {
     expect(getSearchProviderEnvVar("perplexity")).toBe("PERPLEXITY_API_KEY");
+  });
+
+  test("returns TAVILY_API_KEY for tavily", () => {
+    expect(getSearchProviderEnvVar("tavily")).toBe("TAVILY_API_KEY");
   });
 
   test("returns undefined for LLM providers (out of scope)", () => {
@@ -69,6 +74,7 @@ describe("getAnyProviderEnvVar", () => {
   test("returns search env var for search providers", () => {
     expect(getAnyProviderEnvVar("brave")).toBe("BRAVE_API_KEY");
     expect(getAnyProviderEnvVar("perplexity")).toBe("PERPLEXITY_API_KEY");
+    expect(getAnyProviderEnvVar("tavily")).toBe("TAVILY_API_KEY");
   });
 
   test("returns undefined for ollama (keyless LLM provider)", () => {

--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -39,4 +39,10 @@ describe("API_KEY_PROVIDERS", () => {
     expect(API_KEY_PROVIDERS).toContain("openai");
     expect(API_KEY_PROVIDERS).toContain("gemini");
   });
+
+  test("includes search providers", () => {
+    expect(API_KEY_PROVIDERS).toContain("brave");
+    expect(API_KEY_PROVIDERS).toContain("perplexity");
+    expect(API_KEY_PROVIDERS).toContain("tavily");
+  });
 });

--- a/assistant/src/providers/provider-env-vars.ts
+++ b/assistant/src/providers/provider-env-vars.ts
@@ -23,6 +23,7 @@ import { PROVIDER_CATALOG } from "./model-catalog.js";
 const SEARCH_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   brave: "BRAVE_API_KEY",
   perplexity: "PERPLEXITY_API_KEY",
+  tavily: "TAVILY_API_KEY",
 };
 
 export function getLlmProviderEnvVar(providerId: string): string | undefined {

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -7,7 +7,8 @@
  * 1. **LLM providers** -- derived from `PROVIDER_CATALOG`
  *    (`model-catalog.ts`). Adding a provider to the catalog automatically
  *    extends the API-key-addressable set.
- * 2. **Search providers** -- statically declared (`brave`, `perplexity`);
+ * 2. **Search providers** -- statically declared (`brave`, `perplexity`,
+ *    `tavily`);
  *    no catalog module exists for search providers yet.
  * 3. **STT providers** -- dynamically derived from the canonical STT
  *    provider catalog by reading credential-provider names.
@@ -39,8 +40,8 @@ import { listCredentialProviderNames as listSttCredentialProviderNames } from ".
  * about the set of bare-name credential-store keys accepted by
  * `assistant keys ...`.
  *
- * Search providers (`brave`, `perplexity`) have no catalog module yet and
- * remain statically declared below.
+ * Search providers (`brave`, `perplexity`, `tavily`) have no catalog module
+ * yet and remain statically declared below.
  */
 const LLM_API_KEY_PROVIDERS: readonly string[] = PROVIDER_CATALOG.map(
   (p) => p.id,
@@ -51,7 +52,7 @@ const LLM_API_KEY_PROVIDERS: readonly string[] = PROVIDER_CATALOG.map(
  * catalog is introduced, replace this array with a catalog-derived
  * computation analogous to the TTS logic below.
  */
-const SEARCH_API_KEY_PROVIDERS = ["brave", "perplexity"] as const;
+const SEARCH_API_KEY_PROVIDERS = ["brave", "perplexity", "tavily"] as const;
 
 const LLM_AND_SEARCH_API_KEY_PROVIDERS: readonly string[] = [
   ...LLM_API_KEY_PROVIDERS,

--- a/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
+++ b/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
@@ -40,18 +40,19 @@ const STORE_PATH = join(TEST_DIR, "keys.enc");
  * Regression test for the env-var fallback in `getProviderKeyAsync`.
  *
  * PR #27126 introduced `getLlmProviderEnvVar` which is LLM-scoped only.
- * After that PR, calls like `getProviderKeyAsync("brave")` and
- * `getProviderKeyAsync("perplexity")` stopped resolving the env var when
- * the secure store was empty, breaking web-search for users with
- * env-var-sourced Brave/Perplexity keys. The fix (this PR) routes the
- * fallback through `getAnyProviderEnvVar` which consults both the LLM
- * catalog and the search-provider map.
+ * After that PR, calls like `getProviderKeyAsync("brave")`,
+ * `getProviderKeyAsync("perplexity")`, and other search-provider keys stopped
+ * resolving the env var when the secure store was empty, breaking web-search
+ * for users with env-var-sourced search keys. The fix routes the fallback
+ * through `getAnyProviderEnvVar` which consults both the LLM catalog and the
+ * search-provider map.
  */
 describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
   const SAVED_ENV: Record<string, string | undefined> = {};
   const MANAGED_VARS = [
     "BRAVE_API_KEY",
     "PERPLEXITY_API_KEY",
+    "TAVILY_API_KEY",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
   ];
@@ -95,6 +96,11 @@ describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
   test("returns PERPLEXITY_API_KEY from process.env when secure store is empty", async () => {
     process.env.PERPLEXITY_API_KEY = "pplx-env-test";
     expect(await getProviderKeyAsync("perplexity")).toBe("pplx-env-test");
+  });
+
+  test("returns TAVILY_API_KEY from process.env when secure store is empty", async () => {
+    process.env.TAVILY_API_KEY = "tavily-env-test";
+    expect(await getProviderKeyAsync("tavily")).toBe("tavily-env-test");
   });
 
   test("returns ANTHROPIC_API_KEY from process.env when secure store is empty (LLM regression)", async () => {

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 let mockWebSearchProvider: string | undefined = "perplexity";
 let mockBraveSecureKey: string | undefined;
 let mockPerplexitySecureKey: string | undefined;
+let mockTavilySecureKey: string | undefined;
 
 // Capture the registered tool
 let capturedTool: any = null;
@@ -26,6 +27,7 @@ mock.module("../../../security/secure-keys.js", () => ({
   getProviderKeyAsync: async (provider: string) => {
     if (provider === "brave") return mockBraveSecureKey;
     if (provider === "perplexity") return mockPerplexitySecureKey;
+    if (provider === "tavily") return mockTavilySecureKey;
     return undefined;
   },
 }));
@@ -52,6 +54,7 @@ describe("web_search tool", () => {
     mockWebSearchProvider = "perplexity";
     mockBraveSecureKey = undefined;
     mockPerplexitySecureKey = undefined;
+    mockTavilySecureKey = undefined;
   });
 
   afterEach(() => {
@@ -347,6 +350,125 @@ describe("web_search tool", () => {
     expect(callCount).toBe(4);
   });
 
+  // ---- Tavily provider ----------------------------------------------------
+
+  test("executes Tavily search successfully", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-test-key";
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "Tavily Result 1",
+              url: "https://example.com/tavily-1",
+              content: "First Tavily result",
+              score: 0.91,
+            },
+            {
+              title: "Tavily Result 2",
+              url: "https://example.com/tavily-2",
+              content: "Second Tavily result",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "what is TypeScript" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Tavily Result 1");
+    expect(result.content).toContain("https://example.com/tavily-1");
+    expect(result.content).toContain("Score: 0.910");
+  });
+
+  test("Tavily sends correct request format", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-test-key";
+    let capturedUrl = "";
+    let capturedBody: any = null;
+    let capturedHeaders: any = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(init?.body as string);
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    await execute({ query: "test query", count: 50, freshness: "pm" });
+    expect(capturedUrl).toContain("api.tavily.com/search");
+    expect(capturedBody.query).toBe("test query");
+    expect(capturedBody.search_depth).toBe("advanced");
+    expect(capturedBody.max_results).toBe(20);
+    expect(capturedBody.time_range).toBe("month");
+    expect(capturedHeaders.get("authorization")).toBe("Bearer tvly-test-key");
+  });
+
+  test("Tavily skips invalid freshness values", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    let capturedBody: any = null;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    await execute({ query: "test", freshness: "invalid" });
+    expect(capturedBody.time_range).toBeUndefined();
+  });
+
+  test("Tavily returns no results message when response is empty", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const result = await execute({ query: "obscure query" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("No results found");
+  });
+
+  test("Tavily handles 401/403 auth errors", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "bad-key";
+    globalThis.fetch = (async () => {
+      return new Response("Unauthorized", { status: 401 });
+    }) as any;
+
+    const result = await execute({ query: "test" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Invalid or expired Tavily API key");
+  });
+
+  test("Tavily handles 429 rate limit after max retries", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      return new Response("Too Many Requests", {
+        status: 429,
+        headers: { "retry-after": "0" },
+      });
+    }) as any;
+
+    const result = await execute({ query: "test" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("rate limit exceeded");
+    expect(callCount).toBe(4);
+  });
+
   // ---- Provider fallback --------------------------------------------------
 
   test("falls back from perplexity to brave when perplexity has no key", async () => {
@@ -376,6 +498,40 @@ describe("web_search tool", () => {
         JSON.stringify({
           choices: [{ message: { content: "fallback result" } }],
         }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "fallback test" });
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toContain("perplexity");
+  });
+
+  test("falls back to tavily when earlier providers have no key", async () => {
+    mockWebSearchProvider = "perplexity";
+    mockTavilySecureKey = "tvly-fallback-key";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as any;
+
+    const result = await execute({ query: "fallback test" });
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toContain("tavily");
+  });
+
+  test("falls back from tavily to perplexity when tavily has no key", async () => {
+    mockWebSearchProvider = "tavily";
+    mockPerplexitySecureKey = "pplx-fallback-key";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "fallback" } }] }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
     }) as any;

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -17,8 +17,15 @@ const log = getLogger("web-search");
 
 const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
 const PERPLEXITY_API_URL = "https://api.perplexity.ai/chat/completions";
+const TAVILY_API_URL = "https://api.tavily.com/search";
 
-type WebSearchProvider = "perplexity" | "brave";
+type WebSearchProvider = "perplexity" | "brave" | "tavily";
+
+const WEB_SEARCH_FALLBACK_ORDER: readonly WebSearchProvider[] = [
+  "perplexity",
+  "brave",
+  "tavily",
+];
 
 interface BraveSearchResult {
   title: string;
@@ -42,6 +49,20 @@ interface PerplexityResponse {
   citations?: string[];
 }
 
+interface TavilySearchResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  score?: number;
+  raw_content?: string | null;
+  favicon?: string;
+}
+
+interface TavilySearchResponse {
+  query?: string;
+  results?: TavilySearchResult[];
+}
+
 function getWebSearchProvider(): WebSearchProvider {
   const config = getConfig();
   const configured = config.services["web-search"].provider ?? "perplexity";
@@ -58,8 +79,20 @@ async function getApiKey(
     return (await getProviderKeyAsync("brave")) ?? undefined;
   }
 
+  if (provider === "tavily") {
+    return (await getProviderKeyAsync("tavily")) ?? undefined;
+  }
+
   // Perplexity
   return (await getProviderKeyAsync("perplexity")) ?? undefined;
+}
+
+function fallbackProvidersFor(
+  provider: WebSearchProvider,
+): readonly WebSearchProvider[] {
+  return WEB_SEARCH_FALLBACK_ORDER.filter(
+    (candidate) => candidate !== provider,
+  );
 }
 
 const CITATION_INSTRUCTION =
@@ -116,6 +149,54 @@ function formatPerplexityResults(
   }
 
   return lines.join("\n");
+}
+
+function formatTavilyResults(
+  data: TavilySearchResponse,
+  query: string,
+): string {
+  const results = data.results ?? [];
+
+  if (results.length === 0) {
+    return `No results found for "${query}".`;
+  }
+
+  const lines: string[] = [`Web search results for "${query}":\n`];
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const title = r.title?.trim() || r.url?.trim() || "Untitled result";
+    lines.push(`${i + 1}. ${title}`);
+    if (r.url) {
+      lines.push(`   URL: ${r.url}`);
+    }
+    if (r.content) {
+      lines.push(`   ${r.content}`);
+    }
+    if (typeof r.score === "number") {
+      lines.push(`   Score: ${r.score.toFixed(3)}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function tavilyTimeRangeForFreshness(
+  freshness: string | undefined,
+): "day" | "week" | "month" | "year" | undefined {
+  switch (freshness) {
+    case "pd":
+      return "day";
+    case "pw":
+      return "week";
+    case "pm":
+      return "month";
+    case "py":
+      return "year";
+    default:
+      return undefined;
+  }
 }
 
 async function executeBraveSearch(
@@ -281,6 +362,91 @@ async function executePerplexitySearch(
   };
 }
 
+async function executeTavilySearch(
+  query: string,
+  count: number,
+  freshness: string | undefined,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<ToolExecutionResult> {
+  const timeRange = tavilyTimeRangeForFreshness(freshness);
+  const body: Record<string, unknown> = {
+    query,
+    search_depth: "advanced",
+    max_results: count,
+  };
+  if (timeRange) {
+    body.time_range = timeRange;
+  }
+
+  for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
+    const response = await fetch(TAVILY_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "X-Client-Source": "vellum-assistant",
+      },
+      body: JSON.stringify(body),
+      signal,
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as TavilySearchResponse;
+      return {
+        content:
+          wrapUntrustedContent(formatTavilyResults(data, query), {
+            source: "search",
+            sourceDetail: "tavily",
+          }) + CITATION_INSTRUCTION,
+        isError: false,
+      };
+    }
+
+    await response.text();
+
+    if (response.status === 401 || response.status === 403) {
+      return {
+        content: "Error: Invalid or expired Tavily API key",
+        isError: true,
+      };
+    }
+
+    if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
+      const delayMs = getHttpRetryDelay(
+        response,
+        attempt,
+        DEFAULT_BASE_DELAY_MS,
+      );
+      log.warn(
+        { attempt: attempt + 1, delayMs },
+        "Tavily Search rate limited, retrying",
+      );
+      await sleep(delayMs);
+      continue;
+    }
+
+    log.warn({ status: response.status }, "Tavily Search API error");
+    if (response.status === 429) {
+      return {
+        content:
+          "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
+        isError: true,
+      };
+    }
+    return {
+      content: `Error: Tavily Search API returned status ${response.status}`,
+      isError: true,
+    };
+  }
+
+  return {
+    content:
+      "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
+    isError: true,
+  };
+}
+
 class WebSearchTool implements Tool {
   name = "web_search";
   description =
@@ -302,7 +468,7 @@ class WebSearchTool implements Tool {
           count: {
             type: "number",
             description:
-              "Number of results to return (1-20, default 10). Only used with Brave provider.",
+              "Number of results to return (1-20, default 10). Used with Brave and Tavily providers.",
           },
           offset: {
             type: "number",
@@ -312,7 +478,7 @@ class WebSearchTool implements Tool {
           freshness: {
             type: "string",
             description:
-              'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Only used with Brave provider.',
+              'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Used with Brave and Tavily providers.',
           },
         },
         required: ["query"],
@@ -335,22 +501,27 @@ class WebSearchTool implements Tool {
     let provider = getWebSearchProvider();
     let apiKey = await getApiKey(provider);
 
-    // Fallback: if the configured provider has no key, try the other provider
+    // Fallback: if the configured provider has no key, try other BYOK search
+    // providers in a stable order. This preserves existing installs that only
+    // configured one search-provider key while still allowing new providers to
+    // be selected explicitly.
     if (!apiKey) {
-      const fallback: WebSearchProvider =
-        provider === "perplexity" ? "brave" : "perplexity";
-      const fallbackKey = await getApiKey(fallback);
-      if (fallbackKey) {
+      for (const fallback of fallbackProvidersFor(provider)) {
+        const fallbackKey = await getApiKey(fallback);
+        if (!fallbackKey) continue;
         log.info(
           { from: provider, to: fallback },
           "Configured web search provider has no API key, falling back",
         );
         provider = fallback;
         apiKey = fallbackKey;
-      } else {
+        break;
+      }
+
+      if (!apiKey) {
         return {
           content:
-            "Error: No web search API key configured. Set it via `keys set perplexity <key>` or `keys set brave <key>`, or configure it from the Settings page under API Keys.",
+            "Error: No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, or `keys set tavily <key>`, or configure it from the Settings page under API Keys.",
           isError: true,
         };
       }
@@ -374,6 +545,22 @@ class WebSearchTool implements Tool {
           query,
           count,
           offset,
+          freshness,
+          apiKey,
+          context.signal,
+        );
+      }
+
+      if (provider === "tavily") {
+        const count =
+          typeof input.count === "number"
+            ? Math.min(20, Math.max(1, Math.round(input.count)))
+            : 10;
+        const freshness =
+          typeof input.freshness === "string" ? input.freshness : undefined;
+        return await executeTavilySearch(
+          query,
+          count,
           freshness,
           apiKey,
           context.signal,

--- a/assistant/src/workspace/migrations/078-release-notes-tavily-web-search.ts
+++ b/assistant/src/workspace/migrations/078-release-notes-tavily-web-search.ts
@@ -1,0 +1,66 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-078-release-notes-tavily-web-search",
+);
+
+const MIGRATION_ID = "078-release-notes-tavily-web-search";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Tavily web search
+
+Tavily is now available as a web search provider. Add your Tavily API key in
+Settings → Models & Services, or run \`assistant keys set tavily <key>\`, then
+select Tavily for Web Search.
+`;
+
+export const releaseNotesTavilyWebSearchMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description: "Append release notes for Tavily web search to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info(
+        { path: updatesPath },
+        "Appended Tavily web search release note",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append Tavily web search release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -75,6 +75,7 @@ import { dropDeprecatedSecretDetectionKeysMigration } from "./074-drop-deprecate
 import { memoryV2Bm25BDefaultReembedMigration } from "./075-memory-v2-bm25-b-default-reembed.js";
 import { dropServicesInferenceModeMigration } from "./076-drop-services-inference-mode.js";
 import { seedMemoryRouterCallsiteMigration } from "./077-seed-memory-router-callsite.js";
+import { releaseNotesTavilyWebSearchMigration } from "./078-release-notes-tavily-web-search.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -161,4 +162,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   memoryV2Bm25BDefaultReembedMigration,
   dropServicesInferenceModeMigration,
   seedMemoryRouterCallsiteMigration,
+  releaseNotesTavilyWebSearchMigration,
 ];

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -3,7 +3,7 @@
  *
  * Two sources are merged into a single combined map:
  *
- *   1. Search-provider env vars — hardcoded below (Brave, Perplexity).
+ *   1. Search-provider env vars — hardcoded below (Brave, Perplexity, Tavily).
  *   2. LLM-provider env vars — sourced from `PROVIDER_CATALOG` in
  *      `assistant/src/providers/model-catalog.ts` via a locally-maintained
  *      mirror (the CLI does not import from `assistant/src/`; drift is caught
@@ -29,6 +29,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
 export const SEARCH_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   brave: "BRAVE_API_KEY",
   perplexity: "PERPLEXITY_API_KEY",
+  tavily: "TAVILY_API_KEY",
 };
 
 /**

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -45,6 +45,7 @@ enum APIKeyManager {
         "openai",
         "openrouter",
         "perplexity",
+        "tavily",
     ]
 
     /// Provider identifiers whose API keys are synced to the daemon as

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -144,6 +144,7 @@ struct SettingsPanel: View {
 
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
+    @State private var tavilyKeyText: String = ""
     @State private var imageGenKeyText: String = ""
     @State private var embeddingKeyText: String = ""
 
@@ -559,6 +560,7 @@ struct SettingsPanel: View {
                 authManager: authManager,
                 perplexityKeyText: $perplexityKeyText,
                 braveKeyText: $braveKeyText,
+                tavilyKeyText: $tavilyKeyText,
                 showToast: showToast
             )
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -65,6 +65,7 @@ public final class SettingsStore: ObservableObject {
     @Published var apiKeySaving: Bool = false
     @Published var braveKeySaveError: String?
     @Published var perplexityKeySaveError: String?
+    @Published var tavilyKeySaveError: String?
     @Published var imageGenKeySaveError: String?
     @Published var imageGenKeySaving: Bool = false
 
@@ -312,12 +313,13 @@ public final class SettingsStore: ObservableObject {
     @Published var yourOwnOAuthConnectingAppId: String? = nil
     @Published var yourOwnOAuthProviderMetadata: [String: OAuthProviderMetadata] = [:]
 
-    static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave"]
+    static let availableWebSearchProviders = ["inference-provider-native", "perplexity", "brave", "tavily"]
 
     static let webSearchProviderDisplayNames: [String: String] = [
         "inference-provider-native": "Provider Native",
         "perplexity": "Perplexity",
         "brave": "Brave",
+        "tavily": "Tavily",
     ]
 
     // MARK: - Managed Assistant Recovery Mode State
@@ -981,6 +983,35 @@ public final class SettingsStore: ObservableObject {
         Task {
             let deleted = await APIKeyManager.deleteKey(for: "perplexity")
             if !deleted { addDeletionTombstone(type: "api_key", name: "perplexity") }
+        }
+    }
+
+    func saveTavilyKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        tavilyKeySaveError = nil
+        removeDeletionTombstone(type: "api_key", name: "tavily")
+        Task {
+            let result = await APIKeyManager.setKey(trimmed, for: "tavily")
+            if result.success {
+                let _: Void = APIKeyManager.deleteKey(for: "tavily")
+                scheduleRoutingSourceRefresh()
+                onSuccess?()
+            } else if let error = result.error {
+                tavilyKeySaveError = error
+                if !result.isTransient {
+                    let _: Void = APIKeyManager.deleteKey(for: "tavily")
+                }
+            }
+        }
+    }
+
+    func clearTavilyKey() {
+        APIKeyManager.deleteKey(for: "tavily")
+        scheduleRoutingSourceRefresh()
+        Task {
+            let deleted = await APIKeyManager.deleteKey(for: "tavily")
+            if !deleted { addDeletionTombstone(type: "api_key", name: "tavily") }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -9,13 +9,14 @@ import VellumAssistantShared
 /// - **Managed + Your Own inference**: Message that managed web search is not yet available.
 /// - **Your Own**: Provider picker + API key. Provider Native is available whenever the
 ///   inference provider supports native web search (e.g. Anthropic, OpenAI), regardless of
-///   inference mode. Perplexity and Brave are always available as key-based alternatives.
+///   inference mode. Perplexity, Brave, and Tavily are always available as key-based alternatives.
 @MainActor
 struct WebSearchServiceCard: View {
     @ObservedObject var store: SettingsStore
     var authManager: AuthManager
     @Binding var perplexityKeyText: String
     @Binding var braveKeyText: String
+    @Binding var tavilyKeyText: String
     var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
@@ -28,6 +29,8 @@ struct WebSearchServiceCard: View {
     @State private var perplexityHasKey = false
     /// Whether the Brave provider has a stored API key (fetched per-component).
     @State private var braveHasKey = false
+    /// Whether the Tavily provider has a stored API key (fetched per-component).
+    @State private var tavilyHasKey = false
     /// Tail of the serial chain of in-flight `services.web-search.provider` PATCHes.
     /// Both the auto-fallback writes in `onChange` and the explicit `save()` write
     /// go through `enqueueProviderWrite` — chaining on this task guarantees the
@@ -43,8 +46,32 @@ struct WebSearchServiceCard: View {
         draftProvider == "brave"
     }
 
+    private var isTavily: Bool {
+        draftProvider == "tavily"
+    }
+
     private var needsAPIKey: Bool {
-        isPerplexity || isBrave
+        isPerplexity || isBrave || isTavily
+    }
+
+    private var selectedProviderHasKey: Bool {
+        if isPerplexity { return perplexityHasKey }
+        if isBrave { return braveHasKey }
+        if isTavily { return tavilyHasKey }
+        return false
+    }
+
+    private var selectedProviderKeyText: Binding<String> {
+        if isPerplexity { return $perplexityKeyText }
+        if isBrave { return $braveKeyText }
+        return $tavilyKeyText
+    }
+
+    private var selectedProviderKeyError: String? {
+        if isPerplexity { return store.perplexityKeySaveError }
+        if isBrave { return store.braveKeySaveError }
+        if isTavily { return store.tavilyKeySaveError }
+        return nil
     }
 
     private var isLoggedIn: Bool {
@@ -57,8 +84,8 @@ struct WebSearchServiceCard: View {
     /// regardless of whether inference is managed or your-own.
     private var availableProviders: [String] {
         store.isNativeWebSearchCapable(store.selectedInferenceProvider, model: store.selectedModel)
-            ? ["inference-provider-native", "perplexity", "brave"]
-            : ["perplexity", "brave"]
+            ? ["inference-provider-native", "perplexity", "brave", "tavily"]
+            : ["perplexity", "brave", "tavily"]
     }
 
     /// True when the user has made changes worth saving.
@@ -80,6 +107,8 @@ struct WebSearchServiceCard: View {
                 return !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             } else if isBrave {
                 return !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            } else if isTavily {
+                return !tavilyKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
             return false
         }()
@@ -113,17 +142,9 @@ struct WebSearchServiceCard: View {
                             hasChanges: hasChanges,
                             onSave: { save() },
                             onReset: {
-                                if isPerplexity {
-                                    store.clearPerplexityKey()
-                                    perplexityHasKey = false
-                                    perplexityKeyText = ""
-                                } else if isBrave {
-                                    store.clearBraveKey()
-                                    braveHasKey = false
-                                    braveKeyText = ""
-                                }
+                                clearSelectedProviderKey()
                             },
-                            showReset: isPerplexity ? perplexityHasKey : braveHasKey
+                            showReset: selectedProviderHasKey
                         )
                     } else {
                         PickerWithInlineSave(
@@ -144,6 +165,7 @@ struct WebSearchServiceCard: View {
         .task {
             perplexityHasKey = await APIKeyManager.hasKey(for: "perplexity")
             braveHasKey = await APIKeyManager.hasKey(for: "brave")
+            tavilyHasKey = await APIKeyManager.hasKey(for: "tavily")
         }
         .onChange(of: store.webSearchMode) { _, newValue in
             draftMode = newValue
@@ -157,8 +179,8 @@ struct WebSearchServiceCard: View {
             // does not support native web search while provider-native is selected.
             // Persist the fix so the daemon's services.web-search.provider does
             // not remain pinned to "inference-provider-native" while the new
-            // provider can't support it — otherwise getWebSearchProvider falls
-            // back to Perplexity and breaks search for users without a key.
+            // provider can't support it — otherwise the custom web_search tool
+            // takes over and may route through an unintended key-based provider.
             if draftProvider == "inference-provider-native" && !store.isNativeWebSearchCapable(newProvider, model: store.selectedModel) {
                 draftProvider = "perplexity"
                 if store.webSearchProvider == "inference-provider-native" {
@@ -230,9 +252,9 @@ struct WebSearchServiceCard: View {
     private var apiKeySection: some View {
         APIKeyTextField(
             label: "API Key",
-            hasKey: isPerplexity ? perplexityHasKey : braveHasKey,
-            text: isPerplexity ? $perplexityKeyText : $braveKeyText,
-            errorMessage: isPerplexity ? store.perplexityKeySaveError : store.braveKeySaveError,
+            hasKey: selectedProviderHasKey,
+            text: selectedProviderKeyText,
+            errorMessage: selectedProviderKeyError,
             maxWidth: 400
         )
     }
@@ -255,22 +277,46 @@ struct WebSearchServiceCard: View {
                 _ = await store.setWebSearchProvider(capturedProvider).value
             }
 
-            if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                store.savePerplexityKey(perplexityKeyText, onSuccess: { [self] in
-                    perplexityHasKey = true
-                })
-                perplexityKeyText = ""
-            }
-            if isBrave && !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                store.saveBraveKey(braveKeyText, onSuccess: { [self] in
-                    braveHasKey = true
-                })
-                braveKeyText = ""
-            }
+            saveSelectedProviderKeyIfNeeded()
         }
 
         // Update initial provider to reflect persisted state
         initialProvider = draftProvider
+    }
+
+    private func saveSelectedProviderKeyIfNeeded() {
+        if isPerplexity && !perplexityKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.savePerplexityKey(perplexityKeyText, onSuccess: { [self] in
+                perplexityHasKey = true
+            })
+            perplexityKeyText = ""
+        } else if isBrave && !braveKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.saveBraveKey(braveKeyText, onSuccess: { [self] in
+                braveHasKey = true
+            })
+            braveKeyText = ""
+        } else if isTavily && !tavilyKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.saveTavilyKey(tavilyKeyText, onSuccess: { [self] in
+                tavilyHasKey = true
+            })
+            tavilyKeyText = ""
+        }
+    }
+
+    private func clearSelectedProviderKey() {
+        if isPerplexity {
+            store.clearPerplexityKey()
+            perplexityHasKey = false
+            perplexityKeyText = ""
+        } else if isBrave {
+            store.clearBraveKey()
+            braveHasKey = false
+            braveKeyText = ""
+        } else if isTavily {
+            store.clearTavilyKey()
+            tavilyHasKey = false
+            tavilyKeyText = ""
+        }
     }
 
     /// Serializes provider PATCHes by chaining each new write onto the tail of

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
@@ -225,7 +225,7 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
     func testNonNativeWebSearchCapableProviderFallsBackToPerplexity() {
         // When the inference provider doesn't support native web search,
         // isNativeWebSearchCapable should return false, indicating the UI
-        // should enforce fallback to perplexity or brave.
+        // should enforce fallback to a key-based provider such as Perplexity, Brave, or Tavily.
         XCTAssertFalse(store.isNativeWebSearchCapable("gemini", model: "gemini-2.5-pro"))
         XCTAssertFalse(store.isNativeWebSearchCapable("ollama", model: "llama3"))
         XCTAssertFalse(store.isNativeWebSearchCapable("fireworks", model: "accounts/fireworks/models/kimi-k2"))


### PR DESCRIPTION
## Prompt / plan

Add [Tavily](https://tavily.com) as a third built-in web search provider, alongside the existing Brave and Perplexity options. Tavily is a search API designed specifically for LLM/agent workflows - relevance-scored results, LLM-optimized snippets, and a `time_range` filter that maps cleanly onto the existing `freshness` parameter.

Approach: mirror the Brave/Perplexity wiring at every layer rather than introducing a parallel abstraction, so future provider additions remain a mechanical change.

Touched layers:
- **Config schema** — `services.web-search.provider` accepts `"tavily"` (`assistant/src/config/schemas/services.ts`).
- **Secret catalog & env vars** — `tavily` added to the static search-provider list and `TAVILY_API_KEY` registered in both the assistant and CLI env-var mirrors (`provider-secret-catalog.ts`, `provider-env-vars.ts`, `cli/src/shared/provider-env-vars.ts`).
- **Web search tool** (`assistant/src/tools/network/web-search.ts`):
  - New `executeTavilySearch` that POSTs to `https://api.tavily.com/search` with `search_depth: "advanced"` and `max_results`.
  - `freshness` (`pd`/`pw`/`pm`/`py`) translated to Tavily's `time_range` (`day`/`week`/`month`/`year`).
  - Same retry/backoff semantics as the Brave path for 429s; 401/403 surface as "invalid or expired API key".
  - Sends `X-Client-Source: vellum-assistant` so Tavily-side traffic is attributable to this client.
  - Fallback chain refactored from a binary `perplexity ↔ brave` swap into an ordered `WEB_SEARCH_FALLBACK_ORDER = ["perplexity", "brave", "tavily"]` so existing installs that only configured one search key keep working when they opt into a new provider.
- **Workspace migration `078-release-notes-tavily-web-search`** appends a one-time marker-gated note to `UPDATES.md` so existing users learn the option exists.
- **macOS settings UI** — `WebSearchServiceCard` lists Tavily in the provider picker, `SettingsStore` gets `saveTavilyKey`/`clearTavilyKey` mirroring the Brave/Perplexity methods, and `APIKeyManager.syncableProviders` includes `tavily`. Per-provider conditional ladders in `WebSearchServiceCard` were collapsed into `selectedProviderHasKey` / `selectedProviderKeyText` / `selectedProviderKeyError` helpers — cleaner with three providers than three parallel `if` chains.

Notes for reviewers:
- The fallback order is stable (`perplexity → brave → tavily`); a user who selects Tavily but hasn't set a key will silently fall back to an already-configured provider rather than error. This preserves current behavior for users adopting Tavily later.
- The `X-Client-Source` header is non-functional from the client's perspective - it just lets Tavily attribute traffic from this distribution.

## Test plan

- `cd assistant && bun run test` — added unit tests in `assistant/src/tools/network/__tests__/web-search.test.ts` and `assistant/src/__tests__/web-search.test.ts` covering Tavily request shape, response formatting, freshness → time_range mapping, 401/403/429 handling, retry/backoff, and the multi-provider fallback chain. Provider catalog/env-var tests updated for the new `tavily` entry.
- `cd cli && bun run test` — CLI env-var mirror test updated.
- `bun run lint && bun run typecheck` in `assistant/` and `cli/`.
- macOS app: launched via `./clients/macos/build.sh run`, added a Tavily key from Settings → Models & Services, selected Tavily as the web search provider, and ran a search via the assistant to confirm end-to-end

---

Closes #30289 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->