### PR TITLE
docs(glossary): sync GLOSSARY.md with public docs (Guardian→Creator)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -2,13 +2,13 @@
 
 Words shape perception. The language we use defines how people think about what we're building. This glossary establishes shared meaning across the company so that when we say a word, everyone understands the same thing.
 
-This is the canonical, repo-level reference. The same definitions are surfaced in the public docs at <https://www.vellum.ai/docs/glossary>.
+This file mirrors the public glossary at <https://www.vellum.ai/docs/glossary>. If they diverge, the public docs are canonical.
 
 ---
 
 ### App
 
-An interactive experience an assistant builds for their guardian. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need — often one that's recurring or benefits from visuals.
+An interactive experience an assistant builds for their creator. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need – often one that's recurring or benefits from visuals.
 
 ### Assistant
 
@@ -16,11 +16,11 @@ A specific instance of a Personal Intelligence. Every assistant has their own na
 
 ### Avatar
 
-The assistant's visual identity. Avatars are part of what makes each assistant distinct. They are chosen or generated during the hatching process and can evolve over time.
+The assistant's visual identity. Avatars are part of what makes each assistant distinct. They are chosen or generated when an assistant is created and can evolve over time.
 
 ### Channel
 
-A communication medium through which a guardian or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
+A communication medium through which a creator or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
 
 ### Client
 
@@ -28,67 +28,59 @@ A device or application used to interact with the assistant. The Vellum macOS ap
 
 ### Contact
 
-A named entity that the guardian has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-guardian entities interact with an assistant.
+A named entity that the creator has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-creator entities interact with an assistant.
 
 ### Credential Vault
 
-Where secrets that the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant may read from the vault to perform tasks, but the guardian controls what goes in, and controls when they are accessed.
+Where secrets the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant reads from the vault to perform tasks; access is mediated by trust rules the creator defines, which can require explicit approval, allow specific patterns autonomously, or deny entirely.
 
-> Note: internally this is currently called the "credential executor."
+*Note: internally this is currently called the "credential executor."*
+
+### Creator
+
+The person who guides and is responsible for an assistant. The creator grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the creator. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. The relationship between a person and their Vellum Assistant is something different: they are its creator, not a user of it.
 
 ### Gateway
 
-The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the guardian can. This boundary is architecturally enforced, not just through policy.
-
-### Guardian
-
-The person who raises, guides, and is responsible for an assistant. The guardian grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the guardian. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. But the relationship between a person and their Vellum Assistant is guardianship, not usage.
-
-### Hatch
-
-The act of creating a new assistant. Not "sign up," "onboard," or "provision." Hatching is the beginning of a relationship.
+The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the creator can. This boundary is architecturally enforced, not just through policy.
 
 ### Heartbeat
 
-The assistant's own pulse: a regular moment when they check in on themselves, on their guardian, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
+The assistant's own pulse: a regular moment when they check in on themselves, on their creator, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
 
 ### Home
 
-Where the assistant lives. This could be the Vellum managed platform, a Mac Mini, a Docker container, a desktop app, or other infrastructure. The assistant's home determines their networking, security boundary, capabilities, and resources available to them.
+Where the assistant runs: Vellum's managed platform, a self-hosted machine, a Docker container, or a local daemon on a desktop. The home determines the assistant's networking, security boundary, capabilities, and available resources. Distinct from a client, which is how the creator reaches the assistant.
 
 ### Memory
 
-Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their guardian — their preferences, their history, the world around them — and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
+Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their creator – their preferences, their history, the world around them – and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
 
 ### Open Source
 
-At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Guardians can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
+At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Creators can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
 
-The exception is the platform — the multi-tenant infrastructure that hosts assistants for guardians who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
+The exception is the platform – the multi-tenant infrastructure that hosts assistants for creators who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
 
 ### Personal Intelligence
 
-The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their guardian's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their guardian first and foremost.
+The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their creator's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their creator first and foremost.
 
 ### Personality
 
-The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the guardian explicitly and co-evolved through ongoing interaction.
+The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the creator explicitly and co-evolved through ongoing interaction.
 
 ### Platform
 
 Vellum's managed infrastructure that hosts and runs assistants. The platform is a SaaS tool, and people who use it are users. It exists as a bridge to bootstrap the Personal Intelligence experience for those who value convenience. We actively invest in the platform, and are committed to always supporting self-hosting. Never use "platform" to describe the assistant.
 
-### Raise
-
-The ongoing process of teaching, customizing, and growing an assistant. Emphasizes that the relationship deepens over time. Not "configure," "set up," or "train."
-
 ### Schedule
 
-A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the guardian to ask. This is one way the assistant moves from reactive to proactive.
+A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the creator to ask. This is one way the assistant moves from reactive to proactive.
 
 ### Self-host
 
-Running your assistant on your own computer or infrastructure. It gives guardians the opportunity to have full ownership, full control, and full privacy.
+Running your assistant on your own computer/infrastructure. It gives creators the opportunity to have full ownership, full control, and full privacy.
 
 ### Skill
 
@@ -96,7 +88,7 @@ A capability the assistant can learn and use. Skills are modular and can be adde
 
 ### Species
 
-The type of assistant runtime. Vellum assistants are one species; other species (like OpenClaw) may exist on different runtimes. Species determines the underlying architecture, available capabilities, and behavioral patterns of an assistant.
+The kind of assistant a creator builds. Different organizations may build different species of assistant on shared infrastructure: Vellum builds one species; OpenClaw and Hermes Agents are examples of others. The species sets the assistant's underlying architecture, capabilities, and behavioral patterns. A creator could in principle have assistants of multiple species.
 
 ### Teleport
 
@@ -104,15 +96,17 @@ Moving an assistant from one home to another. For example, migrating from the Ve
 
 ### Trust Rules
 
-Policies governing what assistants can do autonomously without the guardian's consent. The guardian sets trust rules; the gateway enforces them. For example, the guardian can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
+Policies governing what assistants can do autonomously without the creator's consent. The creator sets trust rules; the gateway enforces them. For example, the creator can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
 
 ### User
 
-A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. That relationship is guardianship. A person can be a guardian of a Vellum assistant without being a user of the Vellum Platform.
+A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. They are a creator, not a user. A person can be a creator of a Vellum assistant without being a user of the Vellum Platform.
 
 ### Vellum Doctor
 
-Vellum's customer support tool. The Doctor helps guardians troubleshoot issues, diagnose problems, and nurse their assistant back to health. The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one guardian travels to another. The Doctor does not have access to a guardian's assistant by default and must be granted explicit access by the guardian for each session.
+Vellum's customer support tool. The Doctor helps creators troubleshoot issues, diagnose problems, and nurse their assistant back to health.
+
+The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one creator travels to another. The Doctor does not have access to a creator's assistant by default and must be granted explicit access by the creator for each session.
 
 ### Widget
 
@@ -120,4 +114,4 @@ A UI element that the assistant renders within a conversation. Cards, forms, tab
 
 ### Workspace
 
-The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the guardian's file system.
+The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the creator's file system.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -2,7 +2,7 @@
 
 Words shape perception. The language we use defines how people think about what we're building. This glossary establishes shared meaning across the company so that when we say a word, everyone understands the same thing.
 
-This file mirrors the public glossary at <https://www.vellum.ai/docs/glossary>. If they diverge, the public docs are canonical.
+This file is the canonical source for Vellum's glossary. The public glossary at <https://www.vellum.ai/docs/glossary> mirrors it. If they diverge, this file wins – propagate changes here first, then to docs.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings `GLOSSARY.md` into sync with the agreed Vellum vocabulary (Guardian→Creator, drop Hatch/Raise + a few rewordings).

Backstory: I shipped the rename in [vellum-assistant-platform#6364](https://github.com/vellum-ai/vellum-assistant-platform/pull/6364) on 2026-05-10 (constitution + public glossary), but never propagated it back to this file. This PR closes that drift.

**Canonicality:** this file (`GLOSSARY.md` in `vellum-assistant`) is the source of truth. The public glossary at <https://www.vellum.ai/docs/glossary> mirrors it. Going forward, vocabulary changes get made here first, then propagated to `web/src/components/marketing/DocsPage/GlossaryContent.tsx` in `vellum-assistant-platform`.

## Changes

**Entries removed (no longer in our vocabulary):**
- `Guardian` — replaced conceptually by `Creator`
- `Hatch` — dropped from glossary; the `vellum hatch` CLI command still exists
- `Raise` — dropped from glossary

**Entry added:**
- `Creator` — replaces `Guardian` with reworded definition

**Reworded:**
- `Credential Vault` — definition now references trust-rule mediation explicitly
- `Home` — tighter wording, adds "distinct from a client" callout
- `Species` — reframes around "kind a creator builds" with OpenClaw + Hermes Agents as examples
- `User` — flows directly into the creator framing

**Mechanical rename across remaining entries:** every `guardian` reference → `creator`. Affects App, Avatar, Channel, Contact, Gateway, Heartbeat, Memory, Open Source, Personal Intelligence, Personality, Schedule, Self-host, Trust Rules, Vellum Doctor, Workspace.

**Cosmetic:**
- Em-dashes (`—`) → en-dashes (`–`) — matches the docs source
- Intro paragraph trimmed
- Canonicality note flipped to assert repo as source of truth

## What's NOT in this PR

Verified via `grep` — `guardian`, `hatch`, and `raise` still appear in the repo, but only as:

- **API symbols / code identifiers:** `/v1/guardian/init`, `guardian-bootstrap.ts`, `guardian-refresh.ts`, `GUARDIAN_BOOTSTRAP_SECRET`, `guardianPrincipalId`, etc. (concentrated in `gateway/`)
- **CLI command names:** `vellum hatch`
- **READMEs / AGENTS.md** documenting the above

Renaming any of those is a structurally bigger change than a vocab-doc sync. Out of scope for this PR; would be a separate effort if/when we want to bring code symbols in line with the agreed vocabulary.

## Verification

- `grep -in 'guardian\|hatch\|raise' GLOSSARY.md` → no matches
- `grep -c '—' GLOSSARY.md` → 0 (em-dashes eliminated)
- Heading count: 28 → 26 (Guardian/Hatch/Raise removed, Creator added)
- Diff: +27 / -33 lines

Markdown-only change, no code paths touched, no CI risk beyond doc linting.
