### PR TITLE
Delay Slack thinking status until response text

### DIFF
--- a/assistant/src/__tests__/process-message-background-slack.test.ts
+++ b/assistant/src/__tests__/process-message-background-slack.test.ts
@@ -30,6 +30,14 @@ mock.module("../memory/conversation-disk-view.js", () => ({
   updateMetaFile: () => {},
 }));
 
+const broadcastMessages: unknown[] = [];
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: unknown) => {
+    broadcastMessages.push(msg);
+  },
+}));
+
 mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
   bridgeConfirmationRequestToGuardian: () => {},
 }));
@@ -240,6 +248,7 @@ describe("processMessageInBackground Slack option propagation", () => {
   beforeEach(() => {
     activeConversation = makeConversation();
     mergeConversationOptionsMock.mockClear();
+    broadcastMessages.length = 0;
   });
 
   test("passes Slack inbound metadata to persistence and exposes the runtime notice during the loop", async () => {
@@ -307,6 +316,43 @@ describe("processMessageInBackground Slack option propagation", () => {
 
     expect(activeConversation.__noticeCalls).toEqual([notice, undefined]);
     expect(activeConversation.__clientSenders).toHaveLength(2);
+  });
+
+  test("observes live agent events without replacing the broadcast emitter", async () => {
+    const observedMessages: unknown[] = [];
+
+    const processing = processMessage(
+      "conv-background-slack",
+      "Reply from Slack",
+      undefined,
+      {
+        onEvent: (msg) => {
+          observedMessages.push(msg);
+        },
+      },
+      "slack",
+      "slack",
+    );
+
+    await waitForRunAgentLoopCall();
+
+    const loopOnEvent = activeConversation.runAgentLoop.mock.calls[0][2] as
+      | ((msg: unknown) => void)
+      | undefined;
+    const delta = {
+      type: "assistant_text_delta",
+      text: "Working on it.",
+      conversationId: "conv-background-slack",
+    };
+    loopOnEvent?.(delta);
+
+    expect(broadcastMessages).toEqual([delta]);
+    expect(observedMessages).toEqual([delta]);
+
+    activeConversation.__loopDeferred.resolve();
+    await expect(processing).resolves.toEqual({
+      messageId: "persisted-user-message-id",
+    });
   });
 
   test("leaves non-Slack background persistence metadata absent", async () => {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -50,8 +50,36 @@ import {
   preactivateHostProxySkills,
   shouldAttachHostProxyForCapability,
 } from "./host-proxy-preactivation.js";
+import type { ServerMessage } from "./message-protocol.js";
 
 const log = getLogger("process-message");
+
+type ProcessMessageOptions = ConversationCreateOptions & {
+  /** Per-turn observer for live agent-loop events. Does not replace SSE broadcast. */
+  onEvent?: (msg: ServerMessage) => void;
+};
+
+function stripPerTurnObservers(
+  options?: ProcessMessageOptions,
+): ConversationCreateOptions | undefined {
+  if (!options) return undefined;
+  const { onEvent: _onEvent, ...conversationOptions } = options;
+  return conversationOptions;
+}
+
+function buildEventEmitter(
+  observer?: (msg: ServerMessage) => void,
+): (msg: ServerMessage) => void {
+  if (!observer) return broadcastMessage;
+  return (msg) => {
+    broadcastMessage(msg);
+    try {
+      observer(msg);
+    } catch (err) {
+      log.warn({ err, messageType: msg.type }, "Agent event observer failed");
+    }
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Turn-context resolution helpers
@@ -167,7 +195,9 @@ async function prepareConversationForMessage(
   // unconditionally when the capability is reachable — feature-flag gating
   // is enforced by the skill-projection layer via SKILL.md frontmatter, so
   // an attached proxy is harmless when the flag is off.
-  if (shouldAttachHostProxyForCapability("host_app_control", resolvedInterface)) {
+  if (
+    shouldAttachHostProxyForCapability("host_app_control", resolvedInterface)
+  ) {
     if (!conversation.isProcessing() || !conversation.hostAppControlProxy) {
       conversation.setHostAppControlProxy(
         new HostAppControlProxy(conversationId),
@@ -216,18 +246,20 @@ export async function processMessage(
   conversationId: string,
   content: string,
   attachmentIds?: string[],
-  options?: ConversationCreateOptions,
+  options?: ProcessMessageOptions,
   sourceChannel?: string,
   sourceInterface?: string,
 ): Promise<{ messageId: string }> {
+  const conversationOptions = stripPerTurnObservers(options);
   const { conversation, attachments } = await prepareConversationForMessage(
     conversationId,
     content,
     attachmentIds,
-    options,
+    conversationOptions,
     sourceChannel,
     sourceInterface,
   );
+  const emitEvent = buildEventEmitter(options?.onEvent);
 
   const serverInterfaceCtx = conversation.getTurnInterfaceContext();
   const slashContext = buildSlashContextForContent(content, {
@@ -413,16 +445,11 @@ export async function processMessage(
     conversation.setSlackRuntimeContextNotice(
       options?.slackRuntimeContextNotice,
     );
-    await conversation.runAgentLoop(
-      resolvedContent,
-      messageId,
-      broadcastMessage,
-      {
-        isInteractive: options?.isInteractive ?? false,
-        isUserMessage: true,
-        ...(options?.callSite ? { callSite: options.callSite } : {}),
-      },
-    );
+    await conversation.runAgentLoop(resolvedContent, messageId, emitEvent, {
+      isInteractive: options?.isInteractive ?? false,
+      isUserMessage: true,
+      ...(options?.callSite ? { callSite: options.callSite } : {}),
+    });
   } finally {
     conversation.setSlackRuntimeContextNotice(undefined);
     if (
@@ -448,18 +475,20 @@ export async function processMessageInBackground(
   conversationId: string,
   content: string,
   attachmentIds?: string[],
-  options?: ConversationCreateOptions,
+  options?: ProcessMessageOptions,
   sourceChannel?: string,
   sourceInterface?: string,
 ): Promise<{ messageId: string }> {
+  const conversationOptions = stripPerTurnObservers(options);
   const { conversation, attachments } = await prepareConversationForMessage(
     conversationId,
     content,
     attachmentIds,
-    options,
+    conversationOptions,
     sourceChannel,
     sourceInterface,
   );
+  const emitEvent = buildEventEmitter(options?.onEvent);
 
   const requestId = crypto.randomUUID();
   const persistMetadata = options?.slackInbound
@@ -478,7 +507,7 @@ export async function processMessageInBackground(
 
   conversation.setSlackRuntimeContextNotice(options?.slackRuntimeContextNotice);
   conversation
-    .runAgentLoop(content, messageId, broadcastMessage, {
+    .runAgentLoop(content, messageId, emitEvent, {
       isInteractive: options?.isInteractive ?? false,
       isUserMessage: true,
       ...(options?.callSite ? { callSite: options.callSite } : {}),

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const deliveredChannelReplies: Array<{
+  callbackUrl: string;
+  payload: Record<string, unknown>;
+}> = [];
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
@@ -20,6 +25,19 @@ mock.module("../../../memory/delivery-status.js", () => ({
   recordProcessingFailure: () => {},
 }));
 
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: async (
+    callbackUrl: string,
+    payload: Record<string, unknown>,
+  ) => {
+    deliveredChannelReplies.push({ callbackUrl, payload });
+    return { ok: true };
+  },
+}));
+
+mock.module("../channel-delivery-routes.js", () => ({
+  deliverReplyViaCallback: async () => {},
+}));
 
 import type { TrustContext } from "../../../daemon/trust-context.js";
 import {
@@ -31,6 +49,7 @@ import type { MessageProcessor } from "../../http-types.js";
 import {
   isBoundGuardianActor,
   processChannelMessageInBackground,
+  shouldStartSlackThinkingStatusForText,
 } from "./background-dispatch.js";
 
 describe("isBoundGuardianActor", () => {
@@ -150,5 +169,122 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     expect(getThreadTs(conversationId)).toBe(newThreadTs);
 
     clearThreadTs(conversationId);
+  });
+});
+
+describe("Slack thinking status timing", () => {
+  const trustCtx: TrustContext = {
+    trustClass: "guardian",
+    guardianExternalUserId: "guardian-1",
+    requesterExternalUserId: "guardian-1",
+  } as unknown as TrustContext;
+
+  const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 10));
+
+  beforeEach(() => {
+    deliveredChannelReplies.length = 0;
+  });
+
+  test("recognizes only deliverable text as a Slack thinking-status trigger", () => {
+    expect(shouldStartSlackThinkingStatusForText("")).toBe(false);
+    expect(shouldStartSlackThinkingStatusForText("   ")).toBe(false);
+    expect(shouldStartSlackThinkingStatusForText("<")).toBe(false);
+    expect(shouldStartSlackThinkingStatusForText("<no_response")).toBe(false);
+    expect(shouldStartSlackThinkingStatusForText("<no_response/>")).toBe(false);
+    expect(shouldStartSlackThinkingStatusForText("  <no_response />  ")).toBe(
+      false,
+    );
+    expect(shouldStartSlackThinkingStatusForText("Real response.")).toBe(true);
+    expect(
+      shouldStartSlackThinkingStatusForText("<no_response/>\nReal response."),
+    ).toBe(true);
+  });
+
+  test("does not set Slack thinking status for no_response text deltas", async () => {
+    const conversationId = "conv-no-response-status";
+    const channelId = "C-NO-RESPONSE";
+    const threadTs = "1700000000.000003";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<no_response/>",
+        conversationId,
+      });
+      return { messageId: "user-msg-no-response" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-no-response-status",
+      content: "ambient channel chatter",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    expect(deliveredChannelReplies).toEqual([]);
+  });
+
+  test("sets and clears Slack thinking status after real assistant text starts", async () => {
+    const conversationId = "conv-real-response-status";
+    const channelId = "C-REAL-RESPONSE";
+    const threadTs = "1700000000.000004";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<",
+        conversationId,
+      });
+      expect(deliveredChannelReplies).toEqual([]);
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "b>Working on it.",
+        conversationId,
+      });
+      return { messageId: "user-msg-real-response" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-real-response-status",
+      content: "please respond",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map((entry) => {
+      const status = entry.payload.assistantThreadStatus as
+        | { status?: string }
+        | undefined;
+      return status?.status;
+    });
+    expect(statuses).toEqual(["is thinking...", ""]);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -9,6 +9,7 @@
  */
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context.js";
 import { updateDeliveredSegmentCount } from "../../../memory/delivery-channels.js";
 import { linkMessage } from "../../../memory/delivery-crud.js";
@@ -135,13 +136,12 @@ export function processChannelMessageInBackground(
         )
       : undefined;
 
-    // Set Slack Assistants API "is thinking..." status indicator
-    const clearSlackThinkingStatus = shouldEmitSlackReaction(
+    const slackThinkingStatus = createSlackThinkingStatusController({
       sourceChannel,
       replyCallbackUrl,
-    )
-      ? setSlackThinkingStatus(replyCallbackUrl!, externalChatId, assistantId)
-      : undefined;
+      chatId: externalChatId,
+      assistantId,
+    });
     const stopApprovalWatcher = replyCallbackUrl
       ? startPendingApprovalPromptWatcher({
           conversationId,
@@ -226,6 +226,12 @@ export function processChannelMessageInBackground(
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
           ...(slackRuntimeContextNotice ? { slackRuntimeContextNotice } : {}),
           ...(slackInbound ? { slackInbound } : {}),
+          ...(slackThinkingStatus
+            ? {
+                onEvent: (msg: ServerMessage) =>
+                  slackThinkingStatus.observeEvent(msg),
+              }
+            : {}),
         },
         sourceChannel,
         sourceInterface,
@@ -274,7 +280,7 @@ export function processChannelMessageInBackground(
       recordProcessingFailure(eventId, err);
     } finally {
       stopTypingHeartbeat?.();
-      clearSlackThinkingStatus?.();
+      slackThinkingStatus?.stop();
       stopApprovalWatcher?.();
       stopTcApprovalNotifier?.();
     }
@@ -341,7 +347,36 @@ function startTelegramTypingHeartbeat(
 // Slack Assistants API thinking status indicator
 // ---------------------------------------------------------------------------
 
-function shouldEmitSlackReaction(
+type SlackThinkingStatusController = {
+  observeEvent: (msg: ServerMessage) => void;
+  stop: () => void;
+};
+
+const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/i;
+const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
+const NO_RESPONSE_SENTINEL_FORMS = [
+  "<no_response/>",
+  "<no_response />",
+  "<no_response>",
+] as const;
+
+function isPotentialNoResponsePrefix(text: string): boolean {
+  const lower = text.toLowerCase();
+  return NO_RESPONSE_SENTINEL_FORMS.some((sentinel) =>
+    sentinel.startsWith(lower),
+  );
+}
+
+export function shouldStartSlackThinkingStatusForText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (NO_RESPONSE_RE.test(trimmed)) return false;
+  if (isPotentialNoResponsePrefix(trimmed)) return false;
+
+  return trimmed.replace(NO_RESPONSE_INLINE_RE, "").trim().length > 0;
+}
+
+function shouldEmitSlackThinkingStatus(
   sourceChannel: ChannelId,
   replyCallbackUrl?: string,
 ): boolean {
@@ -351,6 +386,51 @@ function shouldEmitSlackReaction(
   } catch {
     return replyCallbackUrl.endsWith("/deliver/slack");
   }
+}
+
+function createSlackThinkingStatusController(params: {
+  sourceChannel: ChannelId;
+  replyCallbackUrl?: string;
+  chatId: string;
+  assistantId?: string;
+}): SlackThinkingStatusController | undefined {
+  const { sourceChannel, replyCallbackUrl, chatId, assistantId } = params;
+  if (
+    !replyCallbackUrl ||
+    !shouldEmitSlackThinkingStatus(sourceChannel, replyCallbackUrl)
+  ) {
+    return undefined;
+  }
+  const callbackUrl = replyCallbackUrl;
+
+  let stopped = false;
+  let clearSlackThinkingStatus: (() => void) | undefined;
+  let observedAssistantText = "";
+
+  const start = (): void => {
+    if (stopped || clearSlackThinkingStatus) return;
+    clearSlackThinkingStatus = setSlackThinkingStatus(
+      callbackUrl,
+      chatId,
+      assistantId,
+    );
+  };
+
+  return {
+    observeEvent(msg) {
+      if (stopped || clearSlackThinkingStatus) return;
+      if (msg.type !== "assistant_text_delta") return;
+
+      observedAssistantText += msg.text;
+      if (shouldStartSlackThinkingStatusForText(observedAssistantText)) {
+        start();
+      }
+    },
+    stop() {
+      stopped = true;
+      clearSlackThinkingStatus?.();
+    },
+  };
 }
 
 const SLACK_THINKING_MAX_DURATION_MS = 120_000;


### PR DESCRIPTION
## Summary
- Delay Slack Assistants API thinking status/reaction until live assistant text contains deliverable content.
- Keep <no_response/> and partial sentinel deltas silent while preserving normal event broadcast.
- Add regression coverage for Slack status timing and event observation.

## Original prompt
We traced Slack channel replies and found the thinking indicator starts before the assistant has decided whether to respond. The requested change was to show Slack typing/thinking status only once the assistant starts producing real text, and keep the channel silent when the model outputs the <no_response/> sentinel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->