### PR TITLE
fix(search): harden Tavily provider UI guards and add 403 test coverage

### DIFF
--- a/assistant/src/security/secret-patterns.ts
+++ b/assistant/src/security/secret-patterns.ts
@@ -130,4 +130,7 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
 
   // -- Perplexity --
   { label: "Perplexity API Key", regex: /pplx-[A-Za-z0-9]{40,}/ },
+
+  // -- Tavily --
+  { label: "Tavily API Key", regex: /tvly-[A-Za-z0-9]{20,}/ },
 ];

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -439,11 +439,11 @@ describe("web_search tool", () => {
     expect(result.content).toContain("No results found");
   });
 
-  test("Tavily handles 401/403 auth errors", async () => {
+  test.each([401, 403])("Tavily handles %d auth error", async (status) => {
     mockWebSearchProvider = "tavily";
     mockTavilySecureKey = "bad-key";
     globalThis.fetch = (async () => {
-      return new Response("Unauthorized", { status: 401 });
+      return new Response("Auth error", { status });
     }) as any;
 
     const result = await execute({ query: "test" });

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -58,12 +58,15 @@ struct WebSearchServiceCard: View {
         if isPerplexity { return perplexityHasKey }
         if isBrave { return braveHasKey }
         if isTavily { return tavilyHasKey }
+        assertionFailure("selectedProviderHasKey called for non-key provider: \(draftProvider)")
         return false
     }
 
     private var selectedProviderKeyText: Binding<String> {
         if isPerplexity { return $perplexityKeyText }
         if isBrave { return $braveKeyText }
+        if isTavily { return $tavilyKeyText }
+        assertionFailure("selectedProviderKeyText called for non-key provider: \(draftProvider)")
         return $tavilyKeyText
     }
 
@@ -71,6 +74,7 @@ struct WebSearchServiceCard: View {
         if isPerplexity { return store.perplexityKeySaveError }
         if isBrave { return store.braveKeySaveError }
         if isTavily { return store.tavilyKeySaveError }
+        assertionFailure("selectedProviderKeyError called for non-key provider: \(draftProvider)")
         return nil
     }
 


### PR DESCRIPTION
## Summary

- Replace silent fallback defaults in `WebSearchServiceCard.swift` computed properties (`selectedProviderHasKey`, `selectedProviderKeyText`, `selectedProviderKeyError`) with `assertionFailure` guards — crashes in debug if a new provider is added without updating these, gracefully degrades in release.
- Add `403` auth error test coverage for the Tavily provider using a parameterized `test.each` to avoid duplicating the existing `401` test.
- Add `tvly-` prefix to `PREFIX_PATTERNS` in `secret-patterns.ts` so Tavily API keys are detected and redacted by the secret scanning pipeline.

## Original prompt

During review of PR #30295 (Tavily web search provider), two minor issues were flagged: the `selectedProviderKeyText` computed property silently fell through to `$tavilyKeyText` as a catch-all default (fragile if a 4th provider is added), and the Tavily test suite only covered `401` auth errors despite the code handling both `401` and `403`. Codex review additionally flagged a missing `tvly-` prefix in the secret-pattern catalog, creating a potential secret-leak gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)