### PR TITLE
fix(provider): repair orphan web_search_tool_result blocks before send

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -807,7 +807,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
   test("orphaned server_tool_use gets synthetic web_search_tool_result injected", async () => {
     // When stream is interrupted, server_tool_use may be stored without its
-    // paired web_search_tool_result. repairOrphanedServerToolUse should inject
+    // paired web_search_tool_result. repairOrphanedServerToolBlocks should inject
     // a synthetic error web_search_tool_result after the orphan so the model
     // knows the search failed (rather than silently returning zero results).
     const messages: Message[] = [
@@ -1133,7 +1133,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
   test("paired server_tool_use is not modified by repair", async () => {
     // When server_tool_use has its matching web_search_tool_result,
-    // repairOrphanedServerToolUse should not inject anything.
+    // repairOrphanedServerToolBlocks should not inject anything.
     const messages: Message[] = [
       userMsg("search"),
       {
@@ -1176,6 +1176,96 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     );
     expect(wsResults).toHaveLength(1);
     expect(wsResults[0].tool_use_id).toBe("srvtoolu_paired");
+  });
+
+  test("orphaned web_search_tool_result with no preceding server_tool_use gets downgraded to text", async () => {
+    // The inverse of the orphan server_tool_use case. A
+    // web_search_tool_result whose tool_use_id has no matching server_tool_use
+    // in the same assistant message would trip Anthropic's
+    // "messages.N.content.M: unexpected tool_use_id" error. Downgrading the
+    // orphan to a text block preserves the titles/URLs for the model and
+    // keeps the request valid.
+    const messages: Message[] = [
+      userMsg("Tell me more"),
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_orphaned",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "Example",
+                encrypted_content: "enc_abc",
+              },
+            ],
+          },
+        ],
+      },
+      userMsg("Thanks"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string; tool_use_id?: string }>;
+    }>;
+
+    // No web_search_tool_result block survives anywhere in the dispatched
+    // request — the orphan must be downgraded so Anthropic doesn't 400.
+    const allBlocks = sent.flatMap((m) => m.content);
+    expect(allBlocks.every((b) => b.type !== "web_search_tool_result")).toBe(
+      true,
+    );
+
+    // The downgrade text references the orphan id and the result's URL so
+    // the model retains context.
+    const assistantMsg = sent[1];
+    expect(assistantMsg.role).toBe("assistant");
+    const downgraded = assistantMsg.content.find(
+      (b) => b.type === "text" && b.text?.includes("srvtoolu_orphaned"),
+    );
+    expect(downgraded).toBeDefined();
+    expect(downgraded!.text).toContain("https://example.com");
+  });
+
+  test("orphaned web_search_tool_result with no content array still downgrades cleanly", async () => {
+    const messages: Message[] = [
+      userMsg("status?"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_empty",
+            content: {
+              type: "web_search_tool_result_error",
+              error_code: "unavailable",
+            },
+          },
+        ],
+      },
+      userMsg("ok"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+    }>;
+
+    const allBlocks = sent.flatMap((m) => m.content);
+    expect(allBlocks.every((b) => b.type !== "web_search_tool_result")).toBe(
+      true,
+    );
+    const downgraded = sent[1].content.find(
+      (b) => b.type === "text" && b.text?.includes("srvtoolu_empty"),
+    );
+    expect(downgraded).toBeDefined();
+    expect(downgraded!.text).toContain("results unavailable");
   });
 
   test("assistant message with only unknown blocks gets placeholder text", async () => {

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -724,6 +724,95 @@ describe("repairHistory", () => {
     expect(userMsg.content.every((b) => b.type !== "tool_result")).toBe(true);
   });
 
+  test("downgrades orphan web_search_tool_result in assistant message to text", () => {
+    // Inverse of the orphan-server_tool_use case. A web_search_tool_result
+    // in an assistant message whose tool_use_id has no preceding
+    // server_tool_use in the same message would 400 at the API. Downgrade
+    // to text so the model still sees the search results.
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "search" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here's what I found." },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_orphan",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "Example",
+                encrypted_content: "enc_abc",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(0);
+
+    const assistantMsg = repaired[1];
+    expect(
+      assistantMsg.content.every((b) => b.type !== "web_search_tool_result"),
+    ).toBe(true);
+    const downgraded = assistantMsg.content.find(
+      (b) =>
+        b.type === "text" &&
+        (b as { text: string }).text.includes("srvtoolu_orphan"),
+    );
+    expect(downgraded).toBeDefined();
+  });
+
+  test("repairs both orphan directions within the same assistant message", () => {
+    // server_tool_use without a result AND a stray wsr from a different id —
+    // both must be repaired in one pass.
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_missing_result",
+            name: "web_search",
+            input: { query: "alpha" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "stu_no_use",
+            content: [
+              { type: "web_search_result", url: "https://x.test", title: "X" },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.missingToolResultsInserted).toBe(1);
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+
+    const assistantMsg = repaired[1];
+    // Synthetic result inserted immediately after the orphan server_tool_use.
+    const blockTypes = assistantMsg.content.map((b) => b.type);
+    expect(blockTypes[0]).toBe("server_tool_use");
+    expect(blockTypes[1]).toBe("web_search_tool_result");
+    expect(
+      (assistantMsg.content[1] as { tool_use_id: string }).tool_use_id,
+    ).toBe("stu_missing_result");
+    // The orphan wsr is downgraded to text.
+    expect(blockTypes[2]).toBe("text");
+    expect((assistantMsg.content[2] as { text: string }).text).toContain(
+      "stu_no_use",
+    );
+  });
+
   test("downgrades type-mismatched web_search_tool_result for tool_use", () => {
     // A web_search_tool_result paired with a regular tool_use ID is a type mismatch
     const messages: Message[] = [

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -68,11 +68,14 @@ export function repairHistory(messages: Message[]): RepairResult {
         }
       }
 
-      // Ensure every server_tool_use has a paired web_search_tool_result
-      // in the same assistant message (handles interrupted streams).
-      // Synthetic results are inserted IMMEDIATELY AFTER their corresponding
-      // server_tool_use block — not appended to the end — so that
-      // ensureToolPairing's split at tool_use boundaries cannot separate them.
+      // Pair server-side tool blocks within the same assistant message.
+      // Server tools (e.g. web_search) emit server_tool_use + matching
+      // web_search_tool_result. Either side can go missing — the synthetic
+      // result is inserted IMMEDIATELY AFTER the orphan server_tool_use (not
+      // appended to the end) so ensureToolPairing's split at tool_use
+      // boundaries cannot separate the pair. An orphan
+      // web_search_tool_result (no preceding server_tool_use) is downgraded
+      // to text — Anthropic rejects the request otherwise.
       const serverToolIds = new Set(
         cleanedContent
           .filter(
@@ -91,11 +94,35 @@ export function repairHistory(messages: Message[]): RepairResult {
           orphanedServerIds.add(id);
         }
       }
+      const orphanedWebSearchResultIds = new Set<string>();
+      for (const id of matchedServerIds) {
+        if (!serverToolIds.has(id)) {
+          orphanedWebSearchResultIds.add(id);
+        }
+      }
 
       let repairedContent: ContentBlock[];
-      if (orphanedServerIds.size > 0) {
+      if (orphanedServerIds.size > 0 || orphanedWebSearchResultIds.size > 0) {
         repairedContent = [];
         for (const block of cleanedContent) {
+          if (
+            block.type === "web_search_tool_result" &&
+            orphanedWebSearchResultIds.has(
+              (block as { tool_use_id: string }).tool_use_id,
+            )
+          ) {
+            repairedContent.push(
+              downgradeResult(
+                block as {
+                  type: "web_search_tool_result";
+                  tool_use_id: string;
+                  content: unknown;
+                },
+              ),
+            );
+            stats.orphanToolResultsDowngraded++;
+            continue;
+          }
           repairedContent.push(block);
           if (
             block.type === "server_tool_use" &&

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -390,9 +390,11 @@ function isServerToolUseBlock(
 }
 
 /** Type-guard for web_search_tool_result blocks. */
-function isWebSearchToolResultBlock(
-  block: unknown,
-): block is { type: "web_search_tool_result"; tool_use_id: string } {
+function isWebSearchToolResultBlock(block: unknown): block is {
+  type: "web_search_tool_result";
+  tool_use_id: string;
+  content: unknown;
+} {
   return (
     typeof block === "object" &&
     block != null &&
@@ -401,52 +403,85 @@ function isWebSearchToolResultBlock(
 }
 
 /**
- * Repair orphaned server_tool_use blocks within assistant messages.
- * Server-side tools (e.g. web_search) are self-paired: the assistant message
- * should contain both server_tool_use and its matching web_search_tool_result.
- * When the stream is interrupted or the API returns a partial response, the
- * web_search_tool_result may be missing. This function injects a synthetic
- * error result for any orphaned server_tool_use block.
+ * Repair orphaned server-side tool blocks within assistant messages. Server-
+ * side tools (e.g. web_search) are self-paired: the assistant message should
+ * contain both server_tool_use and its matching web_search_tool_result. Either
+ * side can go missing — a partial stream may drop the result, or a downstream
+ * step (history reload, message split, compaction) may drop the use block.
+ * Both cases trigger an Anthropic 400 on the next request, so this function
+ * handles both directions:
+ *
+ *   - server_tool_use without paired result: inject a synthetic error result.
+ *   - web_search_tool_result without paired server_tool_use: downgrade to a
+ *     text block describing what was found so the model retains context.
  */
-function repairOrphanedServerToolUse(
+function repairOrphanedServerToolBlocks(
   messages: Anthropic.MessageParam[],
 ): Anthropic.MessageParam[] {
   return messages.map((msg) => {
     if (msg.role !== "assistant") return msg;
     const content = Array.isArray(msg.content) ? msg.content : [];
 
-    // Collect server_tool_use IDs and web_search_tool_result IDs in this message
     const serverToolUseIds = new Set<string>();
-    const pairedResultIds = new Set<string>();
+    const webSearchResultIds = new Set<string>();
     for (const block of content) {
       if (isServerToolUseBlock(block)) {
         serverToolUseIds.add(block.id);
       }
       if (isWebSearchToolResultBlock(block)) {
-        pairedResultIds.add(block.tool_use_id);
+        webSearchResultIds.add(block.tool_use_id);
       }
     }
 
-    // Find orphaned server_tool_use blocks (no matching web_search_tool_result)
-    const orphanedIds: string[] = [];
+    const orphanServerToolUseIds = new Set<string>();
     for (const id of serverToolUseIds) {
-      if (!pairedResultIds.has(id)) {
-        orphanedIds.push(id);
-      }
+      if (!webSearchResultIds.has(id)) orphanServerToolUseIds.add(id);
+    }
+    const orphanWebSearchResultIds = new Set<string>();
+    for (const id of webSearchResultIds) {
+      if (!serverToolUseIds.has(id)) orphanWebSearchResultIds.add(id);
     }
 
-    if (orphanedIds.length === 0) return msg;
+    if (
+      orphanServerToolUseIds.size === 0 &&
+      orphanWebSearchResultIds.size === 0
+    ) {
+      return msg;
+    }
 
-    log.warn(
-      { orphanedIds, blockCount: content.length },
-      "Injecting synthetic web_search_tool_result for orphaned server_tool_use blocks",
-    );
+    if (orphanServerToolUseIds.size > 0) {
+      log.warn(
+        {
+          orphanedIds: Array.from(orphanServerToolUseIds),
+          blockCount: content.length,
+        },
+        "Injecting synthetic web_search_tool_result for orphaned server_tool_use blocks",
+      );
+    }
+    if (orphanWebSearchResultIds.size > 0) {
+      log.warn(
+        {
+          orphanedIds: Array.from(orphanWebSearchResultIds),
+          blockCount: content.length,
+        },
+        "Downgrading orphaned web_search_tool_result blocks to text",
+      );
+    }
 
-    // Insert a synthetic error web_search_tool_result after each orphaned server_tool_use
     const repairedContent: Anthropic.ContentBlockParam[] = [];
     for (const block of content) {
+      if (
+        isWebSearchToolResultBlock(block) &&
+        orphanWebSearchResultIds.has(block.tool_use_id)
+      ) {
+        repairedContent.push({
+          type: "text",
+          text: formatOrphanedWebSearchResultAsText(block),
+        });
+        continue;
+      }
       repairedContent.push(block);
-      if (isServerToolUseBlock(block) && orphanedIds.includes(block.id)) {
+      if (isServerToolUseBlock(block) && orphanServerToolUseIds.has(block.id)) {
         repairedContent.push({
           type: "web_search_tool_result",
           tool_use_id: block.id,
@@ -460,6 +495,38 @@ function repairOrphanedServerToolUse(
 
     return { role: msg.role, content: repairedContent };
   });
+}
+
+function formatOrphanedWebSearchResultAsText(block: {
+  tool_use_id: string;
+  content: unknown;
+}): string {
+  const header = `[Orphaned web_search results (tool_use_id=${block.tool_use_id}):`;
+  if (!Array.isArray(block.content)) {
+    return `${header} (results unavailable)]`;
+  }
+  const entries: string[] = [];
+  for (const r of block.content) {
+    if (
+      typeof r !== "object" ||
+      r == null ||
+      (r as { type?: string }).type !== "web_search_result"
+    ) {
+      continue;
+    }
+    const title =
+      typeof (r as { title?: unknown }).title === "string"
+        ? (r as { title: string }).title
+        : "(untitled)";
+    const url =
+      typeof (r as { url?: unknown }).url === "string"
+        ? (r as { url: string }).url
+        : "";
+    const idx = entries.length + 1;
+    entries.push(url ? `${idx}. ${title}\n   ${url}` : `${idx}. ${title}`);
+  }
+  const body = entries.length > 0 ? entries.join("\n") : "(no results)";
+  return `${header}\n${body}]`;
 }
 
 /**
@@ -859,7 +926,9 @@ export class AnthropicProvider implements Provider {
       // assistant messages have original thinking with valid signatures
       // — the API accepts them. No provider-side stripping needed.
 
-      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
+      sentMessages = ensureToolPairing(
+        repairOrphanedServerToolBlocks(formatted),
+      );
       const {
         effort,
         speed,


### PR DESCRIPTION
## Summary

- Anthropic was rejecting requests with `messages.N.content.M: unexpected tool_use_id found in web_search_tool_result blocks: srvtoolu_… Each web_search_tool_result block must have a corresponding server_tool_use block before it`. The two repair gates that should have caught this only handled the inverse direction (orphan `server_tool_use`), so a stray `web_search_tool_result` was passed through to the API unchanged.
- Extend `repairOrphanedServerToolUse` (renamed to `repairOrphanedServerToolBlocks`) in `assistant/src/providers/anthropic/client.ts` and the assistant-message branch of `repairHistory` in `assistant/src/daemon/history-repair.ts` so that an orphan `web_search_tool_result` is downgraded to a text block describing what was found, preserving titles/URLs for the model.
- Adds regression tests in both `anthropic-provider.test.ts` and `history-repair.test.ts` covering the orphan-wsr direction.

## Original prompt

A 400 surfaced in a live Velissa conversation showing `messages.3.content.8: unexpected tool_use_id found in web_search_tool_result blocks: srvtoolu_01LUaUhE3o8iM5vCu9nAWmhp` and Sidd asked me to figure out what happened. Investigation traced the failure to asymmetric repair logic: both the API-gate repair in `anthropic/client.ts` and the upstream `history-repair.ts` only fixed orphan `server_tool_use` blocks, never the inverse (orphan `web_search_tool_result`). Whatever upstream path produced the orphan — stream interruption, message split between an assistant turn's blocks, or a persistence/reload edge — the orphan reached Anthropic unchanged. This PR makes both repair gates symmetric so any future orphan in either direction is fixed before the request goes out; the upstream root cause can be chased separately via the new downgrade log line.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->