### PR TITLE
feat(assistant): observe SSE subscriber shed under backpressure

### DIFF
--- a/assistant/src/__tests__/assistant-events-sse-shed.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-shed.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for SSE subscriber shed-on-backpressure observability.
+ *
+ * Verifies that when `controller.desiredSize <= 0`, the SSE route invokes
+ * the injected shed reporter with the correct reason and per-subscriber
+ * context. Both shed sites are covered: the event-callback path (slow
+ * subscriber + publishes filling the queue) and the heartbeat-timer path
+ * (slow subscriber with no published events). The healthy path asserts
+ * no shed report fires.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import {
+  handleSubscribeAssistantEvents,
+  type SseShedReason,
+  type SseSubscriberInstrumentation,
+} from "../runtime/routes/events-routes.js";
+
+initializeDb();
+
+function clearTables() {
+  const db = getDb();
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM conversations");
+}
+
+interface ShedReport {
+  reason: SseShedReason;
+  events_delivered: number;
+  heartbeats_sent: number;
+  client_id: string | null;
+  interface_id: string | null;
+  conversation_key: string | null;
+  subscription_age_ms: number;
+}
+
+function makeReporterCaptor(): {
+  reports: ShedReport[];
+  reporter: (reason: SseShedReason, inst: SseSubscriberInstrumentation) => void;
+} {
+  const reports: ShedReport[] = [];
+  return {
+    reports,
+    reporter: (reason, inst) => {
+      reports.push({
+        reason,
+        events_delivered: inst.eventsDelivered,
+        heartbeats_sent: inst.heartbeatsSent,
+        client_id: inst.clientId,
+        interface_id: inst.interfaceId,
+        conversation_key: inst.conversationKey,
+        subscription_age_ms: Date.now() - inst.subscribedAtMs,
+      });
+    },
+  };
+}
+
+const SSE_HIGH_WATER_MARK = 16;
+
+describe("SSE route — backpressure shed observability", () => {
+  beforeEach(clearTables);
+
+  test("invokes shedReporter with reason=callback_backpressure when publishes saturate the queue", async () => {
+    const hub = new AssistantEventHub();
+    const { reports, reporter } = makeReporterCaptor();
+    const ac = new AbortController();
+
+    handleSubscribeAssistantEvents(
+      {
+        queryParams: { conversationKey: "shed-cb-test" },
+        abortSignal: ac.signal,
+      },
+      { hub, shedReporter: reporter },
+    );
+    expect(hub.subscriberCount()).toBe(1);
+
+    // Saturate the stream's bounded queue without reading from it.
+    // start() already enqueued the immediate heartbeat (queue=1), so
+    // publishing `SSE_HIGH_WATER_MARK` events triggers the shed on the
+    // final publish when desiredSize hits 0.
+    for (let i = 0; i < SSE_HIGH_WATER_MARK; i += 1) {
+      await hub.publish(buildAssistantEvent({ type: "pong" }));
+    }
+
+    expect(hub.subscriberCount()).toBe(0);
+    expect(reports.length).toBe(1);
+    expect(reports[0]?.reason).toBe("callback_backpressure");
+    expect(reports[0]?.events_delivered).toBe(SSE_HIGH_WATER_MARK - 1);
+    expect(reports[0]?.conversation_key).toBe("shed-cb-test");
+    expect(typeof reports[0]?.subscription_age_ms).toBe("number");
+
+    ac.abort();
+  });
+
+  test("invokes shedReporter with reason=heartbeat_backpressure when the heartbeat tick finds desiredSize<=0", async () => {
+    const hub = new AssistantEventHub();
+    const { reports, reporter } = makeReporterCaptor();
+    const ac = new AbortController();
+
+    handleSubscribeAssistantEvents(
+      {
+        queryParams: { conversationKey: "shed-hb-test" },
+        abortSignal: ac.signal,
+      },
+      { hub, heartbeatIntervalMs: 20, shedReporter: reporter },
+    );
+    expect(hub.subscriberCount()).toBe(1);
+
+    // Fill the queue up to its limit without sending the publish that
+    // would shed via the callback path.
+    for (let i = 0; i < SSE_HIGH_WATER_MARK - 1; i += 1) {
+      await hub.publish(buildAssistantEvent({ type: "pong" }));
+    }
+    expect(reports.length).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(reports.length).toBe(1);
+    expect(reports[0]?.reason).toBe("heartbeat_backpressure");
+    expect(reports[0]?.conversation_key).toBe("shed-hb-test");
+
+    ac.abort();
+  });
+
+  test("does not invoke shedReporter when a reader drains the stream", async () => {
+    const hub = new AssistantEventHub();
+    const { reports, reporter } = makeReporterCaptor();
+    const ac = new AbortController();
+
+    const stream = handleSubscribeAssistantEvents(
+      {
+        queryParams: { conversationKey: "shed-healthy-test" },
+        abortSignal: ac.signal,
+      },
+      { hub, heartbeatIntervalMs: 1_000, shedReporter: reporter },
+    );
+
+    const reader = stream.getReader();
+    void reader.read();
+
+    for (let i = 0; i < 32; i += 1) {
+      await hub.publish(buildAssistantEvent({ type: "pong" }));
+      void reader.read();
+    }
+
+    expect(reports.length).toBe(0);
+
+    ac.abort();
+    void reader.cancel();
+  });
+
+  test("captures client identity in the shed instrumentation context", async () => {
+    const hub = new AssistantEventHub();
+    const { reports, reporter } = makeReporterCaptor();
+    const ac = new AbortController();
+
+    handleSubscribeAssistantEvents(
+      {
+        queryParams: { conversationKey: "shed-client-test" },
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-interface-id": "macos",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub, shedReporter: reporter },
+    );
+
+    for (let i = 0; i < SSE_HIGH_WATER_MARK; i += 1) {
+      await hub.publish(buildAssistantEvent({ type: "pong" }));
+    }
+
+    expect(reports.length).toBe(1);
+    expect(reports[0]?.client_id).toBe("client-abc");
+    expect(reports[0]?.interface_id).toBe("macos");
+
+    ac.abort();
+  });
+});

--- a/assistant/src/__tests__/assistant-events-sse-shed.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-shed.test.ts
@@ -15,6 +15,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
+  buildSseShedSentryContext,
   handleSubscribeAssistantEvents,
   type SseShedReason,
   type SseSubscriberInstrumentation,
@@ -90,6 +91,9 @@ describe("SSE route — backpressure shed observability", () => {
     expect(reports.length).toBe(1);
     expect(reports[0]?.reason).toBe("callback_backpressure");
     expect(reports[0]?.events_delivered).toBe(SSE_HIGH_WATER_MARK - 1);
+    // The initial heartbeat enqueued by start() must be counted so the
+    // reported queue depth matches what was actually pushed.
+    expect(reports[0]?.heartbeats_sent).toBe(1);
     expect(reports[0]?.conversation_key).toBe("shed-cb-test");
     expect(typeof reports[0]?.subscription_age_ms).toBe("number");
 
@@ -179,5 +183,50 @@ describe("SSE route — backpressure shed observability", () => {
     expect(reports[0]?.interface_id).toBe("macos");
 
     ac.abort();
+  });
+});
+
+describe("buildSseShedSentryContext", () => {
+  const inst: SseSubscriberInstrumentation = {
+    subscribedAtMs: 1_000,
+    eventsDelivered: 7,
+    heartbeatsSent: 3,
+    clientId: "client-xyz",
+    interfaceId: "macos",
+    // Channel-backed conversation key embedding a phone number.
+    conversationKey: "asst:self:whatsapp:447123456789",
+  };
+  const elDelay = { mean_ms: 1.2, p99_ms: 3.4, max_ms: 5.6 };
+
+  test("omits conversation_key so Sentry contexts do not leak PII", () => {
+    const ctx = buildSseShedSentryContext(
+      "callback_backpressure",
+      inst,
+      elDelay,
+      2_500,
+    );
+    expect(ctx).not.toHaveProperty("conversation_key");
+    expect(ctx).not.toHaveProperty("conversationKey");
+    expect(JSON.stringify(ctx)).not.toContain("447123456789");
+  });
+
+  test("preserves non-PII per-subscriber and runtime fields", () => {
+    const ctx = buildSseShedSentryContext(
+      "heartbeat_backpressure",
+      inst,
+      elDelay,
+      2_500,
+    );
+    expect(ctx).toMatchObject({
+      reason: "heartbeat_backpressure",
+      subscription_age_ms: 1_500,
+      events_delivered: 7,
+      heartbeats_sent: 3,
+      client_id: "client-xyz",
+      interface_id: "macos",
+      event_loop_delay_mean_ms: 1.2,
+      event_loop_delay_p99_ms: 3.4,
+      event_loop_delay_max_ms: 5.6,
+    });
   });
 });

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -12,6 +12,10 @@ The single HTTP send endpoint is `POST /v1/messages`. Key behaviors:
 
 Do NOT add new send endpoints. All message ingress should go through `POST /v1/messages` (HTTP).
 
+### SSE backpressure shedding must be observable
+
+SSE handlers built on `ReadableStream` shed slow subscribers when `controller.desiredSize <= 0` to keep daemon memory bounded. Every shed site must emit a log line + Sentry capture so the daemon-side shed can be time-correlated with the client-side idle watchdog (otherwise stalls are invisible from both sides). See [WHATWG Streams — Backpressure](https://streams.spec.whatwg.org/#pipe-chains) and [Node `monitorEventLoopDelay`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions).
+
 ### GET handler idempotency
 
 GET handlers must be safe and side-effect-free — they must not enqueue background jobs, mutate database state, or trigger writes. If a feature needs server-initiated work in response to a client request, use an explicit POST endpoint or a push-based flow (SSE event → client refetch). See [RFC 9110 §9.2.1 — Safe Methods](https://httpwg.org/specs/rfc9110.html#safe.methods).

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -100,7 +100,7 @@ function ensureEventLoopDelayMonitorStarted(): void {
   }
 }
 
-interface EventLoopDelaySnapshot {
+export interface EventLoopDelaySnapshot {
   mean_ms: number | null;
   p99_ms: number | null;
   max_ms: number | null;
@@ -145,6 +145,37 @@ export type SseShedReporter = (
 ) => void;
 
 /**
+ * Build the structured payload sent to Sentry when an SSE subscriber is
+ * shed under backpressure.
+ *
+ * The conversation key is deliberately excluded: for channel-backed
+ * conversations (WhatsApp, Telegram, etc.) the key embeds external
+ * identifiers — phone numbers, chat IDs — and Sentry contexts are not
+ * run through the PII redactor in `instrument.ts` (only
+ * `exception.values`, `breadcrumbs`, and `extra` are). Correlation
+ * with the client-side `sse_watchdog_fired` event is achieved via the
+ * `client_id` tag + timestamp instead.
+ */
+export function buildSseShedSentryContext(
+  reason: SseShedReason,
+  inst: SseSubscriberInstrumentation,
+  elDelay: EventLoopDelaySnapshot,
+  nowMs: number,
+): Record<string, unknown> {
+  return {
+    reason,
+    subscription_age_ms: nowMs - inst.subscribedAtMs,
+    events_delivered: inst.eventsDelivered,
+    heartbeats_sent: inst.heartbeatsSent,
+    client_id: inst.clientId,
+    interface_id: inst.interfaceId,
+    event_loop_delay_mean_ms: elDelay.mean_ms,
+    event_loop_delay_p99_ms: elDelay.p99_ms,
+    event_loop_delay_max_ms: elDelay.max_ms,
+  };
+}
+
+/**
  * Report a backpressure-shed event from an SSE subscriber to logs and Sentry.
  *
  * SSE subscribers are shed when `controller.desiredSize <= 0`: the consumer
@@ -160,19 +191,16 @@ export type SseShedReporter = (
  */
 const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
   const elDelay = sampleEventLoopDelay();
-  const context = {
+  const sentryContext = buildSseShedSentryContext(
     reason,
-    subscription_age_ms: Date.now() - inst.subscribedAtMs,
-    events_delivered: inst.eventsDelivered,
-    heartbeats_sent: inst.heartbeatsSent,
-    client_id: inst.clientId,
-    interface_id: inst.interfaceId,
-    conversation_key: inst.conversationKey,
-    event_loop_delay_mean_ms: elDelay.mean_ms,
-    event_loop_delay_p99_ms: elDelay.p99_ms,
-    event_loop_delay_max_ms: elDelay.max_ms,
-  };
-  log.warn(context, "sse subscriber shed under backpressure");
+    inst,
+    elDelay,
+    Date.now(),
+  );
+  log.warn(
+    { ...sentryContext, conversation_key: inst.conversationKey },
+    "sse subscriber shed under backpressure",
+  );
 
   try {
     Sentry.withScope((scope) => {
@@ -180,7 +208,7 @@ const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
       scope.setTag("sse_shed_reason", reason);
       if (inst.clientId) scope.setTag("client_id", inst.clientId);
       if (inst.interfaceId) scope.setTag("interface_id", inst.interfaceId);
-      scope.setContext("sse_shed", context);
+      scope.setContext("sse_shed", sentryContext);
       Sentry.captureMessage(`sse_subscriber_shed:${reason}`);
     });
   } catch {
@@ -366,6 +394,7 @@ export function handleSubscribeAssistantEvents(
         }
 
         controller.enqueue(encoder.encode(formatSseHeartbeat()));
+        instrumentation.heartbeatsSent += 1;
 
         heartbeatTimer = setInterval(() => {
           try {

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -18,6 +18,9 @@
  *   handles registration, touch (heartbeat), and unregistration (dispose).
  */
 
+import { type IntervalHistogram, monitorEventLoopDelay } from "node:perf_hooks";
+
+import * as Sentry from "@sentry/node";
 import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
@@ -45,6 +48,147 @@ const log = getLogger("events-routes");
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
 
 /**
+ * Resolution of the event-loop delay histogram, per
+ * https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions.
+ * A 20 ms resolution gives sub-tick visibility while keeping overhead near zero.
+ */
+const EVENT_LOOP_DELAY_RESOLUTION_MS = 20;
+
+/**
+ * How often we reset the cumulative event-loop delay histogram so subsequent
+ * percentile snapshots reflect recent behavior rather than the entire process
+ * lifetime. Matches the default window used by `@fastify/under-pressure` and
+ * `prom-client` for runtime-pressure metrics.
+ */
+const EVENT_LOOP_DELAY_RESET_INTERVAL_MS = 60_000;
+
+let eventLoopDelay: IntervalHistogram | null = null;
+let eventLoopResetTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Lazily start a cumulative event-loop delay histogram on the first SSE
+ * subscriber, and schedule a periodic reset so percentile readings stay
+ * meaningful across long-lived daemon processes.
+ *
+ * Guarded with try/catch because `node:perf_hooks.monitorEventLoopDelay`
+ * was a stub in some older Bun versions; if the runtime ever regresses,
+ * we still emit the shed log + Sentry capture without lag stats rather
+ * than crashing the SSE handler.
+ */
+function ensureEventLoopDelayMonitorStarted(): void {
+  if (eventLoopDelay !== null) return;
+  try {
+    const histogram = monitorEventLoopDelay({
+      resolution: EVENT_LOOP_DELAY_RESOLUTION_MS,
+    });
+    histogram.enable();
+    eventLoopDelay = histogram;
+    eventLoopResetTimer = setInterval(() => {
+      try {
+        histogram.reset();
+      } catch {
+        if (eventLoopResetTimer) {
+          clearInterval(eventLoopResetTimer);
+          eventLoopResetTimer = null;
+        }
+      }
+    }, EVENT_LOOP_DELAY_RESET_INTERVAL_MS);
+    eventLoopResetTimer.unref?.();
+  } catch (err) {
+    log.warn({ err }, "failed to start event-loop delay monitor");
+    eventLoopDelay = null;
+  }
+}
+
+interface EventLoopDelaySnapshot {
+  mean_ms: number | null;
+  p99_ms: number | null;
+  max_ms: number | null;
+}
+
+function nsToMs(ns: number): number | null {
+  if (!Number.isFinite(ns)) return null;
+  // Round to the nearest microsecond, then express in ms (3 decimal places).
+  return Math.round(ns / 1e3) / 1e3;
+}
+
+function sampleEventLoopDelay(): EventLoopDelaySnapshot {
+  const histogram = eventLoopDelay;
+  if (histogram === null) {
+    return { mean_ms: null, p99_ms: null, max_ms: null };
+  }
+  try {
+    return {
+      mean_ms: nsToMs(histogram.mean),
+      p99_ms: nsToMs(histogram.percentile(99)),
+      max_ms: nsToMs(histogram.max),
+    };
+  } catch {
+    return { mean_ms: null, p99_ms: null, max_ms: null };
+  }
+}
+
+export interface SseSubscriberInstrumentation {
+  subscribedAtMs: number;
+  eventsDelivered: number;
+  heartbeatsSent: number;
+  clientId: string | null;
+  interfaceId: string | null;
+  conversationKey: string | null;
+}
+
+export type SseShedReason = "callback_backpressure" | "heartbeat_backpressure";
+
+export type SseShedReporter = (
+  reason: SseShedReason,
+  inst: SseSubscriberInstrumentation,
+) => void;
+
+/**
+ * Report a backpressure-shed event from an SSE subscriber to logs and Sentry.
+ *
+ * SSE subscribers are shed when `controller.desiredSize <= 0`: the consumer
+ * has stopped reading and the stream's bounded queue is full. From the
+ * daemon's side this looks identical to a hung client — and the visible
+ * symptom on the client side is the 45 s idle-watchdog firing (Sentry
+ * issue `sse_watchdog_fired`). Surfacing the shed lets us time-correlate
+ * the two sides and attribute stalls to either backpressure or another
+ * cause (network drop, event-loop starvation, etc.).
+ *
+ * The Sentry call uses level="warning" intentionally: a shed is a
+ * saturation event, not an internal error.
+ */
+const defaultSseShedReporter: SseShedReporter = (reason, inst) => {
+  const elDelay = sampleEventLoopDelay();
+  const context = {
+    reason,
+    subscription_age_ms: Date.now() - inst.subscribedAtMs,
+    events_delivered: inst.eventsDelivered,
+    heartbeats_sent: inst.heartbeatsSent,
+    client_id: inst.clientId,
+    interface_id: inst.interfaceId,
+    conversation_key: inst.conversationKey,
+    event_loop_delay_mean_ms: elDelay.mean_ms,
+    event_loop_delay_p99_ms: elDelay.p99_ms,
+    event_loop_delay_max_ms: elDelay.max_ms,
+  };
+  log.warn(context, "sse subscriber shed under backpressure");
+
+  try {
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning");
+      scope.setTag("sse_shed_reason", reason);
+      if (inst.clientId) scope.setTag("client_id", inst.clientId);
+      if (inst.interfaceId) scope.setTag("interface_id", inst.interfaceId);
+      scope.setContext("sse_shed", context);
+      Sentry.captureMessage(`sse_subscriber_shed:${reason}`);
+    });
+  } catch {
+    // Never let a telemetry failure break the SSE path.
+  }
+};
+
+/**
  * Stream assistant events as Server-Sent Events.
  *
  * Query params:
@@ -63,12 +207,15 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
  *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 7 s).
+ *   shedReporter      -- override the callback invoked when a subscriber is shed
+ *                        under backpressure (defaults to log + Sentry capture).
  */
 export function handleSubscribeAssistantEvents(
   args: RouteHandlerArgs,
   options?: {
     hub?: AssistantEventHub;
     heartbeatIntervalMs?: number;
+    shedReporter?: SseShedReporter;
   },
 ): ReadableStream<Uint8Array> {
   const { queryParams, headers, abortSignal } = args;
@@ -108,6 +255,7 @@ export function handleSubscribeAssistantEvents(
   const hub = options?.hub ?? assistantEventHub;
   const heartbeatIntervalMs =
     options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const shedReporter = options?.shedReporter ?? defaultSseShedReporter;
 
   const ALL_CAPABILITIES: HostProxyCapability[] = [
     "host_bash",
@@ -134,6 +282,17 @@ export function handleSubscribeAssistantEvents(
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let sub!: AssistantEventSubscription;
 
+  const instrumentation: SseSubscriberInstrumentation = {
+    subscribedAtMs: Date.now(),
+    eventsDelivered: 0,
+    heartbeatsSent: 0,
+    clientId,
+    interfaceId,
+    conversationKey: conversationKey ?? null,
+  };
+
+  ensureEventLoopDelayMonitorStarted();
+
   function cleanup() {
     if (heartbeatTimer) {
       clearInterval(heartbeatTimer);
@@ -151,11 +310,13 @@ export function handleSubscribeAssistantEvents(
     if (!controller) return;
     try {
       if (controller.desiredSize != null && controller.desiredSize <= 0) {
+        shedReporter("callback_backpressure", instrumentation);
         sub.dispose();
         cleanup();
         return;
       }
       controller.enqueue(encoder.encode(formatSseFrame(event)));
+      instrumentation.eventsDelivered += 1;
     } catch {
       sub.dispose();
       cleanup();
@@ -209,6 +370,7 @@ export function handleSubscribeAssistantEvents(
         heartbeatTimer = setInterval(() => {
           try {
             if (controller.desiredSize != null && controller.desiredSize <= 0) {
+              shedReporter("heartbeat_backpressure", instrumentation);
               sub.dispose();
               cleanup();
               return;
@@ -217,6 +379,7 @@ export function handleSubscribeAssistantEvents(
               hub.touchClient(clientId);
             }
             controller.enqueue(encoder.encode(formatSseHeartbeat()));
+            instrumentation.heartbeatsSent += 1;
           } catch {
             sub.dispose();
             cleanup();


### PR DESCRIPTION
## Summary

Surface daemon-side SSE backpressure shedding as a `level="warning"` Sentry event with a runtime-pressure snapshot attached, so stalls observed by the client-side idle watchdog can be diagnosed from the server side instead of guessed at. No wire-format or behavior change.

Concretely, the two existing shed sites in `handleSubscribeAssistantEvents` — the per-event callback and the keep-alive heartbeat tick — now invoke a shed reporter before disposing the subscription. The default reporter emits a structured `log.warn` and a Sentry `captureMessage("sse_subscriber_shed:<reason>")` with the shed reason, per-subscriber stats, client identity, and an event-loop-delay histogram snapshot from `node:perf_hooks.monitorEventLoopDelay`.

## Test plan

- `bun test src/__tests__/assistant-events-sse-shed.test.ts src/__tests__/assistant-events-sse-hardening.test.ts` → 16/16 pass
- `bun run lint` → clean
- `bunx tsc --noEmit` → clean

Link to Devin session: https://app.devin.ai/sessions/8a3ce390e6e24deba0fac01d1b4a001e
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->