### PR TITLE
fix(macos): surface real errors from self-signed cert auto-creation

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -324,19 +324,55 @@ keyUsage = critical, digitalSignature
 extendedKeyUsage = critical, codeSigning
 basicConstraints = critical, CA:false
 CERTEOF
-                if openssl req -x509 -newkey rsa:2048 \
+                # Run each step separately so we can surface the real error
+                # if one fails (instead of swallowing stderr from all three).
+                _cert_step=""
+                _cert_ok=true
+                if ! openssl req -x509 -newkey rsa:2048 \
                     -keyout "$_CERT_DIR/key.pem" -out "$_CERT_DIR/cert.pem" \
-                    -days 3650 -nodes -config "$_CERT_DIR/cert.conf" 2>/dev/null && \
-                   openssl pkcs12 -export -in "$_CERT_DIR/cert.pem" \
+                    -days 3650 -nodes -config "$_CERT_DIR/cert.conf" \
+                    2>"$_CERT_DIR/openssl-req.err"; then
+                    _cert_step="openssl req (cert generation)"
+                    _cert_ok=false
+                elif ! openssl pkcs12 -export -in "$_CERT_DIR/cert.pem" \
                     -inkey "$_CERT_DIR/key.pem" -out "$_CERT_DIR/cert.p12" \
-                    -passout pass: 2>/dev/null && \
-                   security import "$_CERT_DIR/cert.p12" \
+                    -passout pass: 2>"$_CERT_DIR/openssl-p12.err"; then
+                    _cert_step="openssl pkcs12 -export (p12 conversion)"
+                    _cert_ok=false
+                elif ! security import "$_CERT_DIR/cert.p12" \
                     -k ~/Library/Keychains/login.keychain-db \
-                    -T /usr/bin/codesign -P "" 2>/dev/null; then
+                    -T /usr/bin/codesign -P "" \
+                    2>"$_CERT_DIR/security-import.err"; then
+                    _cert_step="security import (keychain import)"
+                    _cert_ok=false
+                fi
+
+                if $_cert_ok; then
                     echo "Certificate '$_CERT_CN' created and imported into login keychain."
                     echo ""
                 else
                     echo "Warning: Failed to create self-signed certificate." >&2
+                    echo "  Failed at: $_cert_step" >&2
+                    case "$_cert_step" in
+                        openssl*req*)
+                            if [ -s "$_CERT_DIR/openssl-req.err" ]; then
+                                sed 's/^/    /' "$_CERT_DIR/openssl-req.err" >&2
+                            fi
+                            ;;
+                        openssl*pkcs12*)
+                            if [ -s "$_CERT_DIR/openssl-p12.err" ]; then
+                                sed 's/^/    /' "$_CERT_DIR/openssl-p12.err" >&2
+                            fi
+                            ;;
+                        security*import*)
+                            if [ -s "$_CERT_DIR/security-import.err" ]; then
+                                sed 's/^/    /' "$_CERT_DIR/security-import.err" >&2
+                            fi
+                            echo "" >&2
+                            echo "  Common cause: login keychain is locked. Try:" >&2
+                            echo "    security unlock-keychain ~/Library/Keychains/login.keychain-db" >&2
+                            ;;
+                    esac
                     echo "         You may need to create one manually or install an Apple Development cert." >&2
                     echo ""
                 fi


### PR DESCRIPTION
## Summary
- The auto-cert fallback in `clients/macos/build.sh` silently swallowed stderr from `openssl req`, `openssl pkcs12 -export`, and `security import`, so failures produced only a generic "Failed to create self-signed certificate" message with no actionable info.
- Each step now runs separately with stderr captured into per-step log files. On failure, the script prints which step failed and the captured error output.
- The most common failure mode (locked login keychain causing `security import` to fail) now suggests `security unlock-keychain ~/Library/Keychains/login.keychain-db` directly.

## Why this matters
This fallback was added in #29840 to handle macOS 26+'s Launch Constraint enforcement (ad-hoc signed apps with security entitlements get killed on launch). It's intentionally a last resort — almost every dev should land on an Apple Development cert from Xcode and never hit this path. But when they do hit it (fresh machine, no Xcode sign-in, nuked keychain), the silent failure mode left them stuck with a launch-crashing app and no diagnostic.

## Files Changed
- `clients/macos/build.sh` — replaced the chained `&& ... 2>/dev/null` block with sequential steps that capture stderr per-step and surface it on failure.

## Testing
- `bash -n clients/macos/build.sh` confirms syntax is valid.
- The happy path is unchanged: same "Certificate '...' created and imported into login keychain." output on success.
- Failure path now prints e.g. `Failed at: security import (keychain import)` followed by the indented captured stderr, plus the unlock hint when the failing step is `security import`.

## Original prompt
In `clients/macos/build.sh`, the auto-cert creation block (around lines 327-342) silently swallows stderr from all three commands (\`openssl req\`, \`openssl pkcs12 -export\`, \`security import\`) with \`2>/dev/null\`, so when it fails users only see a generic 'Failed to create self-signed certificate' warning with no actionable info.

Fix: capture stderr from each step into a temp log, and on failure print the real error output and identify which step failed (cert generation, pkcs12 export, or keychain import). Keep the existing happy-path output unchanged. Also keep the existing follow-up guidance lines.

Context for why this matters: this fallback exists because macOS 26+ rejects ad-hoc signed apps with security entitlements (Launch Constraint Violation). The fallback is intentionally last-resort — most devs should have an Apple Development cert from Xcode and never hit it — but when they do hit it, the silent failure mode makes debugging impossible. PR #29840 introduced this code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->