### PR TITLE
fix(test): mock missing memory-retrospective exports in disk-pressure test

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -107,6 +107,7 @@ mock.module("../memory/conversation-crud.js", () => ({
     return { id: "conv-1", ...opts };
   },
   countConversationsByScheduleJobId: mock(() => 0),
+  countMessagesAfter: mock(() => 0),
   deleteMessageById: mock(() => {}),
   clearAll: mock(() => ({ conversations: 0, messages: 0 })),
   deleteConversation: mock(() => ({ memoryIds: [] })),
@@ -126,6 +127,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getLastUserTimestampBefore: () => null,
   getMessageById: () => null,
   getMessages: () => [],
+  getMessagesAfter: () => [],
   getMessagesPaginated: () => ({ messages: [], hasMore: false }),
   getTurnTimeBounds: () => null,
   getConversation: () => null,
@@ -175,6 +177,7 @@ mock.module("../memory/jobs-store.js", () => ({
   SLOW_LLM_JOB_TYPES: [],
   upsertAutoAnalysisJob: mock(() => "job-auto-analysis"),
   upsertDebouncedJob: mock(() => "job-debounced"),
+  upsertMemoryRetrospectiveJob: mock(() => "job-memory-retrospective"),
 }));
 
 const mockMaybeRunDbMaintenance = mock(() => {});


### PR DESCRIPTION
## Summary
- Add \`upsertMemoryRetrospectiveJob\` to the mocked \`jobs-store.js\` module.
- Add \`countMessagesAfter\` and \`getMessagesAfter\` to the mocked \`conversation-crud.js\` module.
- Restores green CI on main — the new exports were added by the memory-retrospective feature (#30310) and are loaded transitively via \`jobs-worker → backfill → indexer → memory-retrospective-{enqueue,trigger-check}\`.

## Original prompt
Fix the specific CI issue in the failing \`Test\` job on https://github.com/vellum-ai/vellum-assistant/actions/runs/25696004142 — \`background-workers-disk-pressure.test.ts\` failed at module load with \"Export named 'upsertMemoryRetrospectiveJob' not found\" after #30310 landed. Scope the fix to this one job only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->