### PR TITLE
fix(ci): add missing mock exports for memory-retrospective in disk-pressure test

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -109,6 +109,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   countConversationsByScheduleJobId: mock(() => 0),
   deleteMessageById: mock(() => {}),
   clearAll: mock(() => ({ conversations: 0, messages: 0 })),
+  countMessagesAfter: mock(() => 0),
   deleteConversation: mock(() => ({ memoryIds: [] })),
   deleteLastExchange: mock(() => 0),
   findAnalysisConversationFor: mock(() => null),
@@ -126,6 +127,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getLastUserTimestampBefore: () => null,
   getMessageById: () => null,
   getMessages: () => [],
+  getMessagesAfter: () => [],
   getMessagesPaginated: () => ({ messages: [], hasMore: false }),
   getTurnTimeBounds: () => null,
   getConversation: () => null,
@@ -175,6 +177,7 @@ mock.module("../memory/jobs-store.js", () => ({
   SLOW_LLM_JOB_TYPES: [],
   upsertAutoAnalysisJob: mock(() => "job-auto-analysis"),
   upsertDebouncedJob: mock(() => "job-debounced"),
+  upsertMemoryRetrospectiveJob: mock(() => "job-retrospective"),
 }));
 
 const mockMaybeRunDbMaintenance = mock(() => {});


### PR DESCRIPTION
## Prompt / plan

PR #30310 added `upsertMemoryRetrospectiveJob` to `jobs-store.ts` and `countMessagesAfter`/`getMessagesAfter` to `conversation-crud.ts`, but did not update the `mock.module()` calls in `background-workers-disk-pressure.test.ts`. Bun's ES module resolver rejects named imports that the mock does not provide, causing the test to fail with:

```
SyntaxError: Export named 'upsertMemoryRetrospectiveJob' not found in module '.../assistant/src/memory/jobs-store.ts'.
```

This adds the three missing exports to the existing mocks.

## Test plan

- `bun test src/__tests__/background-workers-disk-pressure.test.ts` — all 5 tests pass (previously 0 pass, 1 error)
- Pre-push hook: typecheck, lint, and related tests all green

Link to Devin session: https://app.devin.ai/sessions/46959a3af4484bf19a3bf90e5a3b2a89
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->