### PR TITLE
perf(design-system): hoist NSColor bridging out of adaptiveColor hot path (LUM-709)

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -26,13 +26,39 @@ public extension Color {
 
 // MARK: - Adaptive Color Helper
 
+/// Hoisted out of the dynamic-provider closure so each invocation reuses one
+/// shared array reference instead of allocating a fresh `[NSAppearance.Name]`
+/// every time AppKit asks the color for a component value.
+private let adaptiveColorAppearanceMatchList: [NSAppearance.Name] = [.darkAqua, .aqua]
+
 /// Creates a `Color` that automatically resolves to `light` or `dark` based on
 /// the current system / window appearance.
+///
+/// The light and dark `Color` arguments are bridged to `NSColor` once at
+/// token-init time, each under the appropriate drawing appearance via
+/// `NSAppearance.performAsCurrentDrawingAppearance(_:)`, so the dynamic
+/// provider closure only has to pick between two captured references on each
+/// invocation. AppKit calls the provider whenever a method on the color needs
+/// component values (per Apple's NSColor(name:dynamicProvider:) docs), which
+/// is the SwiftUI render hot path, so the body needs to stay trivial.
 public func adaptiveColor(light: Color, dark: Color) -> Color {
-    Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
-        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        return isDark ? NSColor(dark) : NSColor(light)
+    let lightNS = resolveSwiftUIColor(light, appearance: .aqua)
+    let darkNS = resolveSwiftUIColor(dark, appearance: .darkAqua)
+    return Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: adaptiveColorAppearanceMatchList) == .darkAqua ? darkNS : lightNS
     }))
+}
+
+/// Resolve a SwiftUI `Color` to a concrete `NSColor` under a specific
+/// appearance. Used to pre-bridge the light/dark branches of `adaptiveColor`
+/// so that nested adaptive arguments (e.g. `VColor.surfaceOverlay.opacity(…)`)
+/// resolve their own inner dynamic providers in the correct branch instead of
+/// whatever ambient drawing appearance happens to be set at token-init time.
+private func resolveSwiftUIColor(_ color: Color, appearance name: NSAppearance.Name) -> NSColor {
+    guard let target = NSAppearance(named: name) else { return NSColor(color) }
+    var resolved: NSColor!
+    target.performAsCurrentDrawingAppearance { resolved = NSColor(color) }
+    return resolved
 }
 
 // MARK: - Canonical Semantic Tokens


### PR DESCRIPTION
## Prompt / plan

Investigate [LUM-709](https://linear.app/vellum/issue/LUM-709) (`App Hang during view rendering — culprit adaptiveColor`), which Sentry attributes to the dynamic-provider closure in `clients/shared/DesignSystem/Tokens/ColorTokens.swift` — the largest active hang in the macOS backlog (33 events / 13 users on `vellum-macos@0.8.0`, last seen 2026-05-11). [LUM-468](https://linear.app/vellum/issue/LUM-468) is the duplicate-fingerprint partner where the watchdog catches `_allocateUninitializedArray<T>` inside the same closure.

After investigation we considered: (A) asset-catalog migration, (B) hoist out of the closure, (C) drop `bestMatch` for `appearance.name`, (D) `\.colorScheme`-env per view, (E) notification-observer cache, (F) custom `ShapeStyle`. Recommendation approved: **Option B** — targeted hot-path fix without disturbing `VTheme.applyTheme`'s `NSApp.appearance`-based theme machinery or the ~3,926 `VColor.X` consumer call sites. Asset catalog remains the right long-term Apple-recommended pattern but is a separate workstream.

## What changed

`adaptiveColor(light:dark:)` previously did three things on every closure invocation:

1. allocated a fresh `[NSAppearance.Name]` literal (`[.darkAqua, .aqua]`) — the `_allocateUninitializedArray<T>` leaf in LUM-468,
2. called `appearance.bestMatch(from:)`,
3. ran `NSColor(SwiftUI.Color)` on whichever branch matched — the `NSColor` thunk culprit in event `d40d12be…`.

AppKit invokes the dynamic provider whenever any method on the color needs component values (`currentDrawingAppearance`, `alphaComponent`, `cgColor`, etc., per [Apple's `NSColor.init(name:dynamicProvider:)` docs](https://developer.apple.com/documentation/appkit/nscolor/init(name:dynamicprovider:))) — i.e. on every SwiftUI render/layout pass that touches a design token. With ~56 adaptive tokens × multiple component queries per token per render pass, this dominates main-thread time and crosses the 2-second app-hang watchdog.

This PR:
- Moves the match-list literal to a module-level `private let`, so the closure no longer allocates a fresh `[NSAppearance.Name]` per invocation.
- Pre-bridges the light/dark `Color` arguments to `NSColor` once at token-init time, each under the appropriate drawing appearance via [`NSAppearance.performAsCurrentDrawingAppearance(_:)`](https://developer.apple.com/documentation/appkit/nsappearance/performascurrentdrawingappearance(_:)). The closure body reduces to one `bestMatch` + ternary picking between two captured references — the shape Apple's `NSColor.init(name:dynamicProvider:)` docs use as the canonical example.
- Wraps the pre-bridge in `performAsCurrentDrawingAppearance` so that `MeadowTokens` entries which compose nested adaptive arguments (`VColor.surfaceOverlay.opacity(…)`, `VColor.surfaceBase.opacity(…)`, `VColor.surfaceActive.opacity(…)`) still resolve their inner dynamic providers in the correct branch's appearance instead of whatever ambient appearance happens to be set at module-init time.

Diff is +29/-3 in one file.

## Why this is safe

- `VTheme.applyTheme(_:)` mutates `NSApp.appearance` (and each window's `appearance`) to implement the user's Light/Dark/System override. That mechanism propagates the chosen appearance into `currentDrawingAppearance` at draw time, which the (still-dynamic) outer `NSColor` consumes via `bestMatch`. Behavior is preserved end-to-end — per-window dark mode, system theme switching, and the user's manual setting all still work.
- The pre-bridged `NSColor`s are immutable and captured by reference in the closure. `NSColor` is documented thread-safe.
- For the 53 plain tokens in `ColorTokens.swift` (whose arguments are `Color(hex:)` / `Color(.sRGB, …)` — appearance-independent), the pre-bridge produces the same `NSColor` regardless of drawing appearance.
- For the 3 nested-adaptive `MeadowTokens` entries (`panelBackground`, `panelBorder`, and the captionText egg-glow pair), `performAsCurrentDrawingAppearance` ensures each branch resolves its inner dynamic provider under the right appearance.
- No new caches with mutable state, no cross-`@Observable`-store reads, no new `Layout` types — none of the failure modes from recent perf PRs in this area (#28691 LUM-1167, #29898) apply.
- Wire/protocol impact: **none.** This is a purely internal SwiftUI render-path change inside the macOS client. No IPC payloads, gateway endpoints, SSE schemas, or `NotificationCenter` contracts are touched — safe under both `old macOS + new platform` and `new macOS + old platform` skews.

## Test plan

- **CI:** `bunx tsc`, repo lint, design-token guardrail (`clients/scripts/check-design-tokens.sh` — passes locally; we don't change any token values).
- **Local Xcode build required** before merge — the repo has no macOS build in CI (no Xcode runner), so `public`-API access-level issues and AppKit/SwiftUI compile errors only surface in a local build. The diff is small and access levels are unchanged (`adaptiveColor` stays `public`, new helpers are `private`).
- **Visual verification** in Component Gallery under both Light and Dark appearance, plus toggling `VTheme.applyTheme("light"/"dark"/"system")` while the gallery is open, to confirm:
  - All token swatches render at their previous values.
  - `MeadowTokens.panelBackground` / `panelBorder` / `captionText` still pick the right `VColor.surface*` opacity in dark mode (these are the nested-adaptive cases the `performAsCurrentDrawingAppearance` wrapper is designed to preserve).
- **Post-merge Sentry validation:** monitor [LUM-709 fingerprint](https://sentry.io/organizations/vellum/issues/7385828098/) and [LUM-468](https://sentry.io/organizations/vellum/issues/7365112548/) volume on the next release. The recommendation memo predicts a ≥30% drop on the next release if the closure was the dominant cost. If volume stays flat, the closure was hot but not dominant, and the bigger architectural follow-up (asset-catalog migration) should be scoped.

## Root cause analysis

1. **How did the code get into this state?** The function was introduced in [#2957](https://github.com/vellum-ai/vellum-assistant/pull/2957) ("feat: add light theme support, redesign onboarding, and use full-window panels", 2026-02-15, Anita Kirkovska) when the design system gained light-theme support. The closure body is functionally correct — it just inlines the per-call work that Apple's documented example does once. Untouched since.
2. **What mistakes or decisions led to it?** Apple's [`NSColor.init(name:dynamicProvider:)` docs](https://developer.apple.com/documentation/appkit/nscolor/init(name:dynamicprovider:)) say the value is "calculated on first use," which reads as if AppKit will cache. The clarification underneath ("When methods on a color need component values, AppKit calls the provider with `currentDrawingAppearance`") is easy to miss — and in practice means the closure is the SwiftUI render hot path. The original implementation reasonably assumed it would only fire on theme changes.
3. **Were there warning signs we missed?** LUM-468 (`_allocateUninitializedArray<T>` inside `adaptiveColor`'s closure) has been live since at least 2026-03; the team treated it as a duplicate of LUM-709 once both surfaced. The `_allocateUninitializedArray<T>` leaf was the strongest signal that the closure body was running far more often than expected — anything per-call allocating on the render hot path warrants a closer look.
4. **What can prevent recurrence?** The pattern to internalize: **bodies of `NSColor(name:dynamicProvider:)` / `UIColor(dynamicProvider:)` closures should be trivially fast** (precomputed-reference selection only) because AppKit/UIKit invoke them on every component-getter call during draw — they are not memoized for you. The same rule applies to any other AppKit/UIKit "provider" closure that AppKit calls during layout/render (e.g. `NSTextStorage` attribute providers, `CAMetalLayer.drawableSize` blocks).
5. **Should we add a guideline to `clients/AGENTS.md`?** Yes — a one-sentence note in the existing "Performance and Resource Management → View Bodies and Rendering" section is enough, since that section already establishes the "view-graph hot path must stay trivial" principle. Proposed addition (not in this PR; happy to fold in if reviewers want):

   > **Dynamic `NSColor` / `UIColor` provider closures are part of the render hot path.** AppKit/UIKit invoke `NSColor(name:dynamicProvider:)` and `UIColor(dynamicProvider:)` blocks on every component-getter call during draw, *not* only on appearance change. Hoist allocations and `NSColor(SwiftUI.Color)` bridging out of the closure and capture precomputed `NSColor` references — the body should be a trivial branch on `appearance`. Ref: [Apple `NSColor.init(name:dynamicProvider:)`](https://developer.apple.com/documentation/appkit/nscolor/init(name:dynamicprovider:)).

Apple refs checked (2026-05-11):
- [`NSColor.init(name:dynamicProvider:)`](https://developer.apple.com/documentation/appkit/nscolor/init(name:dynamicprovider:))
- [`NSAppearance.performAsCurrentDrawingAppearance(_:)`](https://developer.apple.com/documentation/appkit/nsappearance/performascurrentdrawingappearance(_:))
- [`NSAppearance` overview](https://developer.apple.com/documentation/appkit/nsappearance)
- [`Color` overview](https://developer.apple.com/documentation/swiftui/color)

Closes LUM-709
Resolves duplicate fingerprint LUM-468

Link to Devin session: https://app.devin.ai/sessions/27fcd477b2c84786b37accab3c37b9a6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->