### PR TITLE
[ATL-478] Add stateless sync invalidation contract

### DIFF
--- a/assistant/src/__tests__/sync-message-contract.test.ts
+++ b/assistant/src/__tests__/sync-message-contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSyncChangedMessage,
+  conversationMessagesSyncTag,
+  type ServerMessage,
+  SYNC_TAGS,
+  SyncChangedMessageSchema,
+} from "../daemon/message-protocol.js";
+
+describe("sync message contract", () => {
+  test("sync_changed is assignable to ServerMessage", () => {
+    const message: ServerMessage = {
+      type: "sync_changed",
+      tags: [SYNC_TAGS.assistantAvatar],
+    };
+
+    expect(message).toEqual({
+      type: "sync_changed",
+      tags: [SYNC_TAGS.assistantAvatar],
+    });
+  });
+
+  test("buildSyncChangedMessage dedupes tags", () => {
+    const message = buildSyncChangedMessage([
+      SYNC_TAGS.assistantAvatar,
+      SYNC_TAGS.assistantAvatar,
+      conversationMessagesSyncTag("conversation-123"),
+    ]);
+
+    expect(message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.assistantAvatar,
+        "conversation:conversation-123:messages",
+      ],
+    });
+  });
+
+  test("schema rejects malformed sync_changed payloads", () => {
+    expect(() =>
+      SyncChangedMessageSchema.parse({
+        type: "sync_changed",
+        tags: [],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      SyncChangedMessageSchema.parse({
+        type: "sync_changed",
+        tags: [""],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      SyncChangedMessageSchema.parse({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantAvatar],
+        cursor: 1,
+      }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -43,6 +43,7 @@ export * from "./message-types/shared.js";
 export * from "./message-types/skills.js";
 export * from "./message-types/subagents.js";
 export * from "./message-types/surfaces.js";
+export * from "./message-types/sync.js";
 export * from "./message-types/upgrades.js";
 export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
@@ -131,6 +132,7 @@ import type {
   _SurfacesClientMessages,
   _SurfacesServerMessages,
 } from "./message-types/surfaces.js";
+import type { _SyncInvalidationServerMessages } from "./message-types/sync.js";
 import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
 import type {
   _WorkItemsClientMessages,
@@ -190,6 +192,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _SyncInvalidationServerMessages
   | _HomeServerMessages
   | _HostAppControlServerMessages
   | _HostBashServerMessages

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const SYNC_TAGS = {
+  assistantAvatar: "assistant:self:avatar",
+  assistantIdentity: "assistant:self:identity",
+  assistantConfig: "assistant:self:config",
+  assistantSounds: "assistant:self:sounds",
+  conversationsList: "conversations:list",
+} as const;
+
+export type KnownSyncInvalidationTag =
+  (typeof SYNC_TAGS)[keyof typeof SYNC_TAGS];
+
+export type ConversationSyncInvalidationTag =
+  | `conversation:${string}:messages`
+  | `conversation:${string}:metadata`;
+
+export type SyncInvalidationTag =
+  | KnownSyncInvalidationTag
+  | ConversationSyncInvalidationTag
+  | (string & {});
+
+export interface SyncChangedMessage {
+  type: "sync_changed";
+  tags: SyncInvalidationTag[];
+}
+
+export const SyncInvalidationTagSchema = z.string().min(1);
+
+export const SyncChangedMessageSchema = z
+  .object({
+    type: z.literal("sync_changed"),
+    tags: z.array(SyncInvalidationTagSchema).min(1),
+  })
+  .strict();
+
+export function conversationMessagesSyncTag(
+  conversationId: string,
+): ConversationSyncInvalidationTag {
+  return `conversation:${conversationId}:messages`;
+}
+
+export function conversationMetadataSyncTag(
+  conversationId: string,
+): ConversationSyncInvalidationTag {
+  return `conversation:${conversationId}:metadata`;
+}
+
+export function buildSyncChangedMessage(
+  tags: SyncInvalidationTag[],
+): SyncChangedMessage {
+  const dedupedTags = Array.from(new Set(tags));
+  const parsed = SyncChangedMessageSchema.parse({
+    type: "sync_changed",
+    tags: dedupedTags,
+  });
+  return parsed as SyncChangedMessage;
+}
+
+export type _SyncInvalidationServerMessages = SyncChangedMessage;


### PR DESCRIPTION
## Summary
- Add a minimal `sync_changed` server event contract for stateless tag invalidation.
- Define the first sync tag vocabulary and conversation tag helpers.
- Wire the sync message domain into the aggregate `ServerMessage` union.

## V1 scope
This intentionally avoids durable sync catch-up machinery: no `sync_changes` table, no cursor fields, no `/sync/state`, and no `/sync/changes`.

Part of ATL-478.

## Validation
- `bun test --preload ./src/__tests__/test-preload.ts src/__tests__/sync-message-contract.test.ts`
- `bun run lint src/daemon/message-protocol.ts src/daemon/message-types/sync.ts src/__tests__/sync-message-contract.test.ts`
- `bunx tsc --noEmit`
- Pre-push assistant typecheck and ESLint passed