### PR TITLE
[ATL-478] Add stateless sync publisher

### DIFF
--- a/assistant/src/runtime/sync/sync-publisher.test.ts
+++ b/assistant/src/runtime/sync/sync-publisher.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
+import type { AssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishSyncInvalidation } from "./sync-publisher.js";
+
+describe("sync publisher", () => {
+  test("publishes a deduped sync_changed event", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      const message = await publishSyncInvalidation([
+        SYNC_TAGS.assistantAvatar,
+        SYNC_TAGS.assistantAvatar,
+        SYNC_TAGS.assistantIdentity,
+      ]);
+
+      expect(message).toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantAvatar, SYNC_TAGS.assistantIdentity],
+      });
+      expect(received).toHaveLength(1);
+      expect(received[0].message).toEqual(message);
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("rejects empty tag lists before publishing", async () => {
+    await expect(publishSyncInvalidation([])).rejects.toThrow();
+  });
+
+  test("does not fail the caller when live publish fails", async () => {
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: () => {
+        throw new Error("subscriber failed");
+      },
+    });
+
+    try {
+      await expect(
+        publishSyncInvalidation([SYNC_TAGS.assistantAvatar]),
+      ).resolves.toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantAvatar],
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+});

--- a/assistant/src/runtime/sync/sync-publisher.test.ts
+++ b/assistant/src/runtime/sync/sync-publisher.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, test } from "bun:test";
 
 import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
 import type { AssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for sync publisher test condition");
+}
 
 describe("sync publisher", () => {
   test("publishes a deduped sync_changed event", async () => {
@@ -22,6 +33,8 @@ describe("sync publisher", () => {
         SYNC_TAGS.assistantIdentity,
       ]);
 
+      await waitFor(() => received.length === 1);
+
       expect(message).toEqual({
         type: "sync_changed",
         tags: [SYNC_TAGS.assistantAvatar, SYNC_TAGS.assistantIdentity],
@@ -38,9 +51,11 @@ describe("sync publisher", () => {
   });
 
   test("does not fail the caller when live publish fails", async () => {
+    let callbackCalled = false;
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: () => {
+        callbackCalled = true;
         throw new Error("subscriber failed");
       },
     });
@@ -52,6 +67,37 @@ describe("sync publisher", () => {
         type: "sync_changed",
         tags: [SYNC_TAGS.assistantAvatar],
       });
+      await waitFor(() => callbackCalled);
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("preserves ordering with previously queued server events", async () => {
+    const receivedTypes: string[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: async (event) => {
+        if (event.message.type === "conversation_list_invalidated") {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        receivedTypes.push(event.message.type);
+      },
+    });
+
+    try {
+      broadcastMessage({
+        type: "conversation_list_invalidated",
+        reason: "created",
+      });
+      await publishSyncInvalidation([SYNC_TAGS.conversationsList]);
+
+      await waitFor(() => receivedTypes.length === 2);
+
+      expect(receivedTypes).toEqual([
+        "conversation_list_invalidated",
+        "sync_changed",
+      ]);
     } finally {
       subscription.dispose();
     }

--- a/assistant/src/runtime/sync/sync-publisher.ts
+++ b/assistant/src/runtime/sync/sync-publisher.ts
@@ -4,8 +4,7 @@ import {
   type SyncInvalidationTag,
 } from "../../daemon/message-types/sync.js";
 import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 
 const log = getLogger("sync-publisher");
 
@@ -14,7 +13,7 @@ export async function publishSyncInvalidation(
 ): Promise<SyncChangedMessage> {
   const message = buildSyncChangedMessage(tags);
   try {
-    await assistantEventHub.publish(buildAssistantEvent(message));
+    broadcastMessage(message);
   } catch (err) {
     log.warn({ err, tags: message.tags }, "Failed to publish sync_changed");
   }

--- a/assistant/src/runtime/sync/sync-publisher.ts
+++ b/assistant/src/runtime/sync/sync-publisher.ts
@@ -1,0 +1,22 @@
+import type { SyncChangedMessage } from "../../daemon/message-types/sync.js";
+import {
+  buildSyncChangedMessage,
+  type SyncInvalidationTag,
+} from "../../daemon/message-types/sync.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+
+const log = getLogger("sync-publisher");
+
+export async function publishSyncInvalidation(
+  tags: SyncInvalidationTag[],
+): Promise<SyncChangedMessage> {
+  const message = buildSyncChangedMessage(tags);
+  try {
+    await assistantEventHub.publish(buildAssistantEvent(message));
+  } catch (err) {
+    log.warn({ err, tags: message.tags }, "Failed to publish sync_changed");
+  }
+  return message;
+}


### PR DESCRIPTION
## Summary
- Add `publishSyncInvalidation(tags)` for broadcasting generic sync tag invalidations.
- Dedupe tags through the existing `buildSyncChangedMessage` contract helper.
- Log and swallow live publish failures so a successful state mutation is not failed by SSE fanout.

## V1 scope
This remains stateless: no `sync_changes` table, no cursors, no catch-up routes, and no client storage changes.

Part of ATL-478.

## Validation
- `bun test --preload ./src/__tests__/test-preload.ts src/runtime/sync/sync-publisher.test.ts`
- `bun run lint src/runtime/sync/sync-publisher.ts src/runtime/sync/sync-publisher.test.ts`
- `bunx tsc --noEmit`
- Pre-push assistant typecheck and ESLint passed