### PR TITLE
[ATL-483] Teach CLI to tolerate sync_changed events

### DIFF
--- a/cli/src/__tests__/sync-events.test.ts
+++ b/cli/src/__tests__/sync-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { renderMarkdown } from "../commands/events.js";
+
+type AssistantEvent = Parameters<typeof renderMarkdown>[0];
+
+function makeEvent(message: AssistantEvent["message"]): AssistantEvent {
+  return {
+    id: "event-123",
+    assistantId: "assistant-123",
+    emittedAt: "2026-01-01T00:00:00.000Z",
+    message,
+  };
+}
+
+describe("sync_changed events", () => {
+  test("renders sync tags clearly in vellum events markdown output", () => {
+    const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      renderMarkdown(
+        makeEvent({
+          type: "sync_changed",
+          tags: ["assistant:self:avatar", "conversations:list"],
+        }),
+      );
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        "\n> **Sync changed:** `assistant:self:avatar`, `conversations:list`",
+      );
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  test("tolerates malformed sync tags without throwing", () => {
+    const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(() =>
+        renderMarkdown(
+          makeEvent({
+            type: "sync_changed",
+            tags: ["assistant:self:avatar", 42, null],
+          }),
+        ),
+      ).not.toThrow();
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        "\n> **Sync changed:** `assistant:self:avatar`",
+      );
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+});

--- a/cli/src/commands/events.ts
+++ b/cli/src/commands/events.ts
@@ -49,13 +49,14 @@ interface AssistantEvent {
     content?: string;
     message?: string;
     chunk?: string;
+    tags?: unknown;
     conversationId?: string;
     [key: string]: unknown;
   };
 }
 
 /** Render an event as human-readable markdown to stdout. */
-function renderMarkdown(event: AssistantEvent): void {
+export function renderMarkdown(event: AssistantEvent): void {
   const msg = event.message;
   switch (msg.type) {
     case "assistant_text_delta":
@@ -94,6 +95,17 @@ function renderMarkdown(event: AssistantEvent): void {
     case "user_message_echo":
       console.log(`\n**You:** ${msg.text}`);
       break;
+    case "sync_changed": {
+      const tags = Array.isArray(msg.tags)
+        ? msg.tags.filter((tag): tag is string => typeof tag === "string")
+        : [];
+      const renderedTags =
+        tags.length > 0
+          ? tags.map((tag) => `\`${tag}\``).join(", ")
+          : "(no tags)";
+      console.log(`\n> **Sync changed:** ${renderedTags}`);
+      break;
+    }
     default:
       // Silently skip events that don't have a markdown representation
       // (e.g. heartbeat comments, activity states, etc.)

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -333,6 +333,8 @@ interface SseEvent {
   allowedDomains?: string[];
   // message_complete fields
   source?: "main" | "aux";
+  // sync_changed fields
+  tags?: string[];
   [key: string]: unknown;
 }
 
@@ -1856,6 +1858,11 @@ function ChatApp({
                 hRef.setBusy(false);
                 break;
 
+              case "sync_changed":
+                // The interactive CLI does not currently keep any sync-tagged
+                // caches, so generic invalidations are intentionally ignored.
+                break;
+
               default:
                 // Ignore events we don't handle (activity state, traces, etc.)
                 break;
@@ -2265,15 +2272,7 @@ function ChatApp({
       // racing with SSE events that may arrive during the sendMessage await.
       h.showSpinner("Working...");
     },
-    [
-      runtimeUrl,
-      assistantId,
-      auth,
-      project,
-      zone,
-      cleanup,
-      ensureConnected,
-    ],
+    [runtimeUrl, assistantId, auth, project, zone, cleanup, ensureConnected],
   );
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
## Summary
- render `sync_changed` tags clearly in `vellum events` markdown output
- explicitly ignore generic sync invalidations in the interactive CLI TUI, since it does not own sync-tagged caches yet
- add focused tests for sync tag rendering and malformed tag tolerance

## Validation
- `bun test src/__tests__/sync-events.test.ts`
- `bunx prettier --check src/commands/events.ts src/components/DefaultMainScreen.tsx src/__tests__/sync-events.test.ts`
- `bunx tsc --noEmit`
- pre-commit hook: focused CLI Prettier + ESLint
- pre-push hook: focused CLI ESLint (hook still prints the existing package-scan shell warning, exits 0)

## Original prompt
We are rolling out stateless multi-client sync with a generic `sync_changed` SSE event. The CLI slice should be low-risk: event consumers should tolerate the new event, print it usefully where the CLI streams raw events, and avoid noisy errors or UI churn in the interactive screen.

Closes ATL-483
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->