### PR TITLE
fix(macos): add missing AppKit import to ConversationManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import UserNotifications
 import VellumAssistantShared


### PR DESCRIPTION
## Prompt / plan

Fix CI build failure ([run #10613](https://github.com/vellum-ai/vellum-assistant/actions/runs/25700655675)) caused by `cannot find 'NSApp' in scope` in `ConversationManager.swift` after the SwiftUI import was removed in PR #30316.

## Root cause analysis

**What happened:** PR #30316 (commit `3a8556fcc1`) removed `import SwiftUI` from `ConversationManager.swift` as part of an import cleanup sub-commit ("Drop unused SwiftUI imports from ConversationListStore and ConversationManager"). The rationale was correct for `ConversationListStore.swift` (no AppKit symbols), but `ConversationManager.swift` uses `NSApp.isActive` in three places:

- **Line 468** — voice response notification suppression when app is active
- **Line 507** — turn-complete notification suppression when app is active
- **Line 1381** — mark-as-seen gating (only mark seen when app is active)

On macOS, `import SwiftUI` transitively imports AppKit, which provides `NSApp` (`NSApplication.shared`). Removing SwiftUI removed the transitive AppKit dependency.

**How it got into this state:** The import cleanup assumed that if no SwiftUI *types* or *property wrappers* were used, the import was unused. It didn't account for `NSApp` being an AppKit symbol provided transitively through SwiftUI.

**Warning signs missed:** The `NSApp` references were plain identifiers, not prefixed with any framework module name, making them easy to miss in a grep for "SwiftUI" usage. A build verification would have caught this, but macOS CI runs post-merge on the `ci-main-macos.yaml` workflow, not on PRs (unless the `preview` label is applied).

**Prevention:** When removing framework imports, always check for transitive dependencies — especially `import SwiftUI` on macOS, which brings in AppKit. A quick `grep -n 'NS[A-Z]'` on the file would catch AppKit symbol usage.

## Fix

Add `import AppKit` to `ConversationManager.swift`. This is the minimal, targeted import:

- The file genuinely has no SwiftUI dependencies — restoring `import SwiftUI` would over-import
- `import AppKit` is the convention used by other files in the same directory that need AppKit symbols without SwiftUI (e.g., `ConversationRestorer.swift`, `DocumentManager.swift`, `MainWindow.swift`, `ThreadWindowManager.swift`)
- `NSApp.isActive` is the [Apple-documented API](https://developer.apple.com/documentation/appkit/nsapplication/isactive) for checking app activation state — no alternative API is needed

## Architectural verification

`ConversationManager` is the app-layer facade (per its own docstring) wiring three focused `@Observable` stores with macOS-specific dependencies. It already imports `UserNotifications` for `UNNotificationRequest`/`UNMutableNotificationContent`. The `NSApp.isActive` checks are:

1. **Correct**: suppress macOS notifications when the user is looking at the app (standard UX pattern, used in 12 places across the macOS client)
2. **Well-placed**: notification suppression logic belongs in the facade, not in the individual stores or callers
3. **No deeper architectural issue**: this is not a case of wrong abstraction layer — ConversationManager is explicitly the macOS app-layer coordinator

## Alternatives not taken

| Alternative | Why rejected |
|---|---|
| Restore `import SwiftUI` | Over-imports; file has no SwiftUI types. Neighboring files use `import AppKit` for AppKit-only needs. |
| Replace `NSApp.isActive` with `NSRunningApplication.current.isActive` | Would still require `import AppKit`; `NSApp` is the idiomatic shorthand and [Apple-documented](https://developer.apple.com/documentation/appkit/nsapplication/isactive). Used in 12 places across the macOS client. |
| Extract notification logic to a separate service | Over-engineering for 3 call sites in a file designed to be the app-layer facade. |
| Push `isActive` check to callers | Worse encapsulation — notification suppression is an implementation detail of the notification-posting methods. |

## Test plan

- CI (`ci-main-macos.yaml`) verifies the macOS build and test suite pass with this import.
- No behavioral change — purely restoring a symbol that was previously available transitively.

Link to Devin session: https://app.devin.ai/sessions/1f873484a81e4c6e8e493c8f31eb865a
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->