### PR TITLE
[ATL-479] Emit avatar and identity sync tags

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1635,7 +1635,7 @@ paths:
     post:
       operationId: avatar_notifyupdated_post
       summary: Notify avatar updated
-      description: Publish an avatar_updated SSE event to connected clients.
+      description: Publish avatar change notifications to connected clients.
       tags:
         - avatar
       responses:

--- a/assistant/src/__tests__/avatar-identity-sync.test.ts
+++ b/assistant/src/__tests__/avatar-identity-sync.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { ROUTES as AVATAR_ROUTES } from "../runtime/routes/avatar-routes.js";
+import { publishIdentityChanged } from "../runtime/sync/resource-sync-events.js";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for avatar/identity sync event");
+}
+
+describe("avatar and identity sync events", () => {
+  test("notify_avatar_updated emits legacy avatar event and sync tag", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      const route = AVATAR_ROUTES.find(
+        (candidate) => candidate.operationId === "notify_avatar_updated",
+      );
+      expect(route).toBeDefined();
+
+      await route!.handler({});
+      await waitFor(() => received.length === 2);
+
+      expect(received.map((event) => event.message.type)).toEqual([
+        "avatar_updated",
+        "sync_changed",
+      ]);
+      expect(received[1].message).toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantAvatar],
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("identity changes emit legacy identity event and sync tag", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      publishIdentityChanged({
+        name: "Sage",
+        role: "Assistant",
+        personality: "Calm",
+        emoji: ":sparkles:",
+        home: "San Francisco",
+      });
+      await waitFor(() => received.length === 2);
+
+      expect(received.map((event) => event.message.type)).toEqual([
+        "identity_changed",
+        "sync_changed",
+      ]);
+      expect(received[0].message).toMatchObject({
+        type: "identity_changed",
+        name: "Sage",
+      });
+      expect(received[1].message).toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantIdentity],
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+});

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -14,13 +14,14 @@ import { syncIdentityNameToPlatform } from "../platform/sync-identity.js";
 import { initializeProviders } from "../providers/registry.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
+import {
+  publishAvatarChanged,
+  publishIdentityChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
-import {
-  getAvatarImagePath,
-  getWorkspacePromptPath,
-} from "../util/platform.js";
+import { getWorkspacePromptPath } from "../util/platform.js";
 import {
   AppSourceWatcher,
   setEnsureAppSourceWatcher,
@@ -164,14 +165,7 @@ export class DaemonServer {
         ? readFileSync(identityPath, "utf-8")
         : "";
       const fields = parseIdentityFields(content);
-      broadcastMessage({
-        type: "identity_changed",
-        name: fields.name,
-        role: fields.role,
-        personality: fields.personality,
-        emoji: fields.emoji,
-        home: fields.home,
-      });
+      publishIdentityChanged(fields);
 
       // Best-effort sync of the assistant name to the platform record.
       if (fields.name) {
@@ -207,10 +201,7 @@ export class DaemonServer {
   }
 
   private broadcastAvatarUpdated(): void {
-    broadcastMessage({
-      type: "avatar_updated",
-      avatarPath: getAvatarImagePath(),
-    });
+    publishAvatarChanged();
   }
 
   /**

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -26,8 +26,7 @@ import {
   getAvatarImagePath,
   getWorkspaceDir,
 } from "../../util/platform.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishAvatarChanged } from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   RouteError,
@@ -36,20 +35,6 @@ import {
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("avatar-routes");
-
-function publishAvatarUpdated(): void {
-  const avatarPath = getAvatarImagePath();
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "avatar_updated",
-        avatarPath,
-      }),
-    )
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish avatar_updated event");
-    });
-}
 
 function handleGetCharacterComponents() {
   return getCharacterComponents();
@@ -84,7 +69,7 @@ function handleRenderFromTraits({ body }: RouteHandlerArgs) {
   }
 
   updateIdentityAvatarSection(null, log);
-  publishAvatarUpdated();
+  publishAvatarChanged();
   return { ok: true };
 }
 
@@ -124,7 +109,7 @@ async function handleGenerateAvatar({ body }: RouteHandlerArgs) {
   }
 
   updateIdentityAvatarSection(null, log);
-  publishAvatarUpdated();
+  publishAvatarChanged();
   return { ok: true, message: result.content };
 }
 
@@ -140,7 +125,10 @@ function handleSetAvatar({ body }: RouteHandlerArgs) {
   // pass /etc/passwd or other host paths and exfiltrate via avatar_get.
   const workspaceDir = getWorkspaceDir();
   const normalized = resolve(imagePath);
-  if (normalized !== workspaceDir && !normalized.startsWith(workspaceDir + "/")) {
+  if (
+    normalized !== workspaceDir &&
+    !normalized.startsWith(workspaceDir + "/")
+  ) {
     throw new BadRequestError(
       "imagePath must resolve inside the workspace directory",
     );
@@ -154,7 +142,7 @@ function handleSetAvatar({ body }: RouteHandlerArgs) {
   copyFileSync(normalized, avatarPath);
 
   updateIdentityAvatarSection(null, log);
-  publishAvatarUpdated();
+  publishAvatarChanged();
   return { ok: true };
 }
 
@@ -184,16 +172,14 @@ function handleRemoveAvatar(_args: RouteHandlerArgs) {
     "Default character avatar (no custom image set)",
     log,
   );
-  publishAvatarUpdated();
+  publishAvatarChanged();
   return { ok: true, hadAvatar: true };
 }
 
 function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
-  const format = (
-    queryParams?.format ??
+  const format = (queryParams?.format ??
     (body as Record<string, unknown>)?.format ??
-    "path"
-  ) as string;
+    "path") as string;
 
   if (format !== "path" && format !== "base64") {
     throw new BadRequestError(
@@ -301,11 +287,11 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "avatar/notify-updated",
     method: "POST",
     handler: () => {
-      publishAvatarUpdated();
+      publishAvatarChanged();
       return { ok: true };
     },
     summary: "Notify avatar updated",
-    description: "Publish an avatar_updated SSE event to connected clients.",
+    description: "Publish avatar change notifications to connected clients.",
     tags: ["avatar"],
     responseBody: z.object({
       ok: z.boolean(),
@@ -350,8 +336,7 @@ export const ROUTES: RouteDefinition[] = [
     method: "GET",
     handler: handleGetAvatar,
     summary: "Get current avatar",
-    description:
-      "Retrieve the current avatar as a file path or base64 string.",
+    description: "Retrieve the current avatar as a file path or base64 string.",
     tags: ["avatar"],
     queryParams: [
       {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -51,6 +51,7 @@ import { getLogger } from "../../util/logger.js";
 import { getAvatarImagePath, getWorkspaceDir } from "../../util/platform.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishAvatarChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { resolveWorkspacePath } from "./workspace-utils.js";
@@ -94,16 +95,7 @@ async function handleGenerateAvatar({ body = {} }: RouteHandlerArgs) {
 
     const avatarPath = getAvatarImagePath();
 
-    assistantEventHub
-      .publish(
-        buildAssistantEvent({
-          type: "avatar_updated",
-          avatarPath,
-        }),
-      )
-      .catch((err) => {
-        log.warn({ err }, "Failed to publish avatar_updated event");
-      });
+    publishAvatarChanged();
 
     return { ok: true, avatarPath };
   } catch (err) {

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -1,0 +1,25 @@
+import type { IdentityFields } from "../../daemon/handlers/identity.js";
+import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
+import { getAvatarImagePath } from "../../util/platform.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
+import { publishSyncInvalidation } from "./sync-publisher.js";
+
+export function publishAvatarChanged(): void {
+  broadcastMessage({
+    type: "avatar_updated",
+    avatarPath: getAvatarImagePath(),
+  });
+  void publishSyncInvalidation([SYNC_TAGS.assistantAvatar]);
+}
+
+export function publishIdentityChanged(fields: IdentityFields): void {
+  broadcastMessage({
+    type: "identity_changed",
+    name: fields.name,
+    role: fields.role,
+    personality: fields.personality,
+    emoji: fields.emoji,
+    home: fields.home,
+  });
+  void publishSyncInvalidation([SYNC_TAGS.assistantIdentity]);
+}


### PR DESCRIPTION
## Summary
- add a shared avatar/identity sync publisher that emits legacy events followed by sync_changed tags
- wire avatar routes, settings avatar generation, and daemon config watchers through the shared publisher
- add focused tests for avatar and identity sync event ordering/tag payloads

## Tests
- bun test src/__tests__/avatar-identity-sync.test.ts src/runtime/sync/sync-publisher.test.ts
- bun run typecheck
- bun run lint -- src/__tests__/avatar-identity-sync.test.ts src/runtime/sync/resource-sync-events.ts src/runtime/routes/avatar-routes.ts src/runtime/routes/settings-routes.ts src/daemon/server.ts
- bunx prettier --check src/__tests__/avatar-identity-sync.test.ts src/runtime/sync/resource-sync-events.ts src/runtime/routes/avatar-routes.ts src/runtime/routes/settings-routes.ts src/daemon/server.ts

Linear: ATL-479