### PR TITLE
fix(macos): add missing return in InferenceProfilesSheet.profileRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -255,7 +255,7 @@ struct InferenceProfilesSheet: View {
     /// the user always owns (mirrors `ProvidersSheet`'s connection row).
     private func profileRow(_ profile: InferenceProfile) -> some View {
         let isActive = profile.status != "disabled"
-        HStack(alignment: .center, spacing: VSpacing.md) {
+        return HStack(alignment: .center, spacing: VSpacing.md) {
             VIconView(.gripVertical, size: 14)
                 .foregroundStyle(VColor.contentTertiary)
                 .frame(width: 18, height: 28)


### PR DESCRIPTION
## Summary
- Add explicit `return` keyword to `profileRow(_:)` in `InferenceProfilesSheet.swift` to fix Swift build error
- The function has a `let` binding before the view expression, so Swift can't use single-expression return type inference — needs the explicit `return`

## Original prompt
Fix the macOS build error in CI where `InferenceProfilesSheet.swift:250` fails with "function declares an opaque return type, but has no return statements in its body from which to infer an underlying type". The root cause is a `let` binding before the `HStack` view expression preventing Swift's single-expression return inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->