### PR TITLE
fix(macos): label VDropdown onChange in ProvidersSheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -557,10 +557,11 @@ struct ProvidersSheet: View {
                             placeholder: "Select a credential\u{2026}",
                             selection: $editorDraft.credential,
                             options: options,
-                            menuWidth: 360
-                        ) { newValue in
-                            Task { await loadMaskedValue(for: newValue) }
-                        }
+                            menuWidth: 360,
+                            onChange: { newValue in
+                                Task { await loadMaskedValue(for: newValue) }
+                            }
+                        )
                     }
 
                     if isCreatingNewCredential {


### PR DESCRIPTION
## Summary

- Label the unlabeled trailing closure on the credential-picker `VDropdown` call in `ProvidersSheet.swift` with `onChange:` to silence Swift 6's `[#TrailingClosureMatching]` deprecation warning.

## Original prompt

Fix the Swift compiler `[#TrailingClosureMatching]` warning emitted while compiling `ProvidersSheet.swift` (line 561), where a backward-matched unlabeled trailing closure on a `VDropdown(...)` call needed to be relabeled with the explicit `onChange:` argument per Swift 6's tightened trailing-closure rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->