### PR TITLE
fix(test): mock findMostRecentRetrospectiveFor in disk-pressure test

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -113,6 +113,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   deleteConversation: mock(() => ({ memoryIds: [] })),
   deleteLastExchange: mock(() => 0),
   findAnalysisConversationFor: mock(() => null),
+  findMostRecentRetrospectiveFor: mock(() => null),
   forkConversation: mock(() => ({ id: "conv-fork" })),
   getConversationOverrideProfile: () => undefined,
   getConversationOverrideProfileFromRow: () => undefined,


### PR DESCRIPTION
## Summary

- PR #30331 added `findMostRecentRetrospectiveFor` to `conversation-crud.ts` and imported it from `memory-retrospective-job.ts`.
- `background-workers-disk-pressure.test.ts` mocks the whole `conversation-crud.js` module, so missing the new export caused a static-import error when the jobs worker transitively pulled in the retrospective handler.
- Add `findMostRecentRetrospectiveFor: mock(() => null)` to the mock so the import resolves and the test suite runs cleanly.

## Original prompt

Main CI was failing on `src/__tests__/background-workers-disk-pressure.test.ts` with `SyntaxError: Export named 'findMostRecentRetrospectiveFor' not found in module '.../assistant/src/memory/conversation-crud.ts'`. The export exists in the real module, but the test mocks the whole module — the mock needs to include any export consumed by transitively-loaded code. Same pattern as the earlier fix in PR #30311.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->