### PR TITLE
Emit config and sounds sync tags

### DIFF
--- a/assistant/src/__tests__/config-sounds-sync.test.ts
+++ b/assistant/src/__tests__/config-sounds-sync.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import {
+  publishConfigChanged,
+  publishSoundsConfigUpdated,
+} from "../runtime/sync/resource-sync-events.js";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for config/sounds sync event");
+}
+
+describe("config and sounds sync events", () => {
+  test("config changes emit legacy config event and sync tag", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      publishConfigChanged();
+      await waitFor(() => received.length === 2);
+
+      expect(received.map((event) => event.message.type)).toEqual([
+        "config_changed",
+        "sync_changed",
+      ]);
+      expect(received[1].message).toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantConfig],
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("sounds config changes emit legacy sounds event and sync tag", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      publishSoundsConfigUpdated();
+      await waitFor(() => received.length === 2);
+
+      expect(received.map((event) => event.message.type)).toEqual([
+        "sounds_config_updated",
+        "sync_changed",
+      ]);
+      expect(received[1].message).toEqual({
+        type: "sync_changed",
+        tags: [SYNC_TAGS.assistantSounds],
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+});

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -16,7 +16,9 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import {
   publishAvatarChanged,
+  publishConfigChanged,
   publishIdentityChanged,
+  publishSoundsConfigUpdated,
 } from "../runtime/sync/resource-sync-events.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -193,11 +195,11 @@ export class DaemonServer {
   }
 
   private broadcastConfigChanged(): void {
-    broadcastMessage({ type: "config_changed" });
+    publishConfigChanged();
   }
 
   private broadcastSoundsConfigUpdated(): void {
-    broadcastMessage({ type: "sounds_config_updated" });
+    publishSoundsConfigUpdated();
   }
 
   private broadcastAvatarUpdated(): void {

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -23,3 +23,13 @@ export function publishIdentityChanged(fields: IdentityFields): void {
   });
   void publishSyncInvalidation([SYNC_TAGS.assistantIdentity]);
 }
+
+export function publishConfigChanged(): void {
+  broadcastMessage({ type: "config_changed" });
+  void publishSyncInvalidation([SYNC_TAGS.assistantConfig]);
+}
+
+export function publishSoundsConfigUpdated(): void {
+  broadcastMessage({ type: "sounds_config_updated" });
+  void publishSyncInvalidation([SYNC_TAGS.assistantSounds]);
+}


### PR DESCRIPTION
## Summary
- emit generic sync_changed invalidations for assistant config and sounds changes
- preserve legacy config_changed and sounds_config_updated events during rollout
- add focused tests for event ordering and tag payloads

## Original prompt
After daemon PR 3 landed, we identified a small daemon slice worth inserting before conversation sync tags: config and sounds already have legacy SSE events but were not yet emitting generic sync tags. This PR completes that settings-sync bridge by adding assistant:self:config and assistant:self:sounds invalidations while keeping backwards-compatible legacy events.

## Tests
- bun test src/__tests__/config-sounds-sync.test.ts src/runtime/sync/sync-publisher.test.ts
- bun run typecheck
- bun run lint -- src/__tests__/config-sounds-sync.test.ts src/runtime/sync/resource-sync-events.ts src/daemon/server.ts
- bunx prettier --check src/__tests__/config-sounds-sync.test.ts src/runtime/sync/resource-sync-events.ts src/daemon/server.ts

Note: Linear issue creation for this inserted slice failed in the connector, so no ATL issue is attached yet.