### PR TITLE
fix(gateway): add assistant-scoped trust-rule mutation routes

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1296,6 +1296,57 @@ async function main() {
       auth: "edge",
       handler: (req, params) => handleTrustRulesDelete(req, params[0]),
     },
+
+    // ── Trust rules v3 — assistant-scoped variants ──
+    // Mirror the flat /v1/trust-rules routes for clients that use
+    // GatewayHTTPClient's auto-prefix (Swift TrustRuleClient and
+    // vellum-assistant-platform's web/src/lib/trust-rules/api.ts), which build
+    // URLs like /v1/assistants/<id>/trust-rules/. Without these, the request
+    // falls through to the runtime-proxy catch-all and the daemon serves 404
+    // on mutations (the daemon HTTP handlers were stripped by #28784).
+    //
+    // Trust rules are gateway-global, so the assistant id is matched and
+    // discarded. Same precedent as the assistant-scoped /v1/assistants/.../
+    // contacts DELETE route above.
+    {
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/?$/,
+      method: "GET",
+      auth: "edge",
+      handler: (req) => handleTrustRulesList(req),
+    },
+    {
+      // Must appear before the create entry and before the /:id catch-all
+      // so the literal /suggest segment is matched first.
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/suggest\/?$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRulesSuggest(req),
+    },
+    {
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/?$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRulesCreate(req),
+    },
+    {
+      // Reset must be registered before the /:id catch-all regex.
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/reset\/?$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req, params) => handleTrustRulesReset(req, params[0]),
+    },
+    {
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/?$/,
+      method: "PATCH",
+      auth: "edge",
+      handler: (req, params) => handleTrustRulesUpdate(req, params[0]),
+    },
+    {
+      path: /^\/v1\/assistants\/[^/]+\/trust-rules\/([^/]+)\/?$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) => handleTrustRulesDelete(req, params[0]),
+    },
   ];
 
   // Runtime proxy catch-all — must be last so specific routes are checked first.


### PR DESCRIPTION
## Bug

Users have been seeing **"Failed to Save Rule — Trust rule v3 request failed (HTTP 404)"** since May 4, 2026. Reported on Discord today.

## Timeline

- **#28784** (Apr 29) stripped the daemon's `trust_rules_create / update / remove / reset` HTTP handlers. The 404 started here but was silent because `TrustRuleClient.swift` used `try?`.
- **#29464** (May 4) replaced `try?` with `do-catch + .alert(...)`, surfacing the latent 404 to users.

## Root cause

Both clients use `GatewayHTTPClient`, which auto-prepends `assistants/<assistantId>/`:

- macOS `TrustRuleClient.swift`
- web `vellum-assistant-platform/web/src/lib/trust-rules/api.ts`

So every mutation call lands on `/v1/assistants/<id>/trust-rules[/:ruleId[/reset]]`.

The gateway only registers **flat** `/v1/trust-rules/*` routes. Scoped requests fall through to the runtime-proxy catch-all → daemon, which after #28784 only handles GET-list and 404s on the mutations.

Trust rules are gateway-global; the assistant id is in the URL only because clients prefix it. The same shape already exists for contacts:

```ts
// gateway/src/index.ts — pre-existing
path: /^\/v1\/assistants\/[^/]+\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
method: "DELETE",
```

## Fix

Add six assistant-scoped sibling routes mirroring the flat ones. Each scoped route discards the assistant id and reuses the same handler.

| Method | Path                                                       | Handler                       |
| ------ | ---------------------------------------------------------- | ----------------------------- |
| GET    | `/v1/assistants/<id>/trust-rules`                          | `handleTrustRulesList`        |
| POST   | `/v1/assistants/<id>/trust-rules/suggest`                  | `handleTrustRulesSuggest`     |
| POST   | `/v1/assistants/<id>/trust-rules`                          | `handleTrustRulesCreate`      |
| POST   | `/v1/assistants/<id>/trust-rules/<ruleId>/reset`           | `handleTrustRulesReset`       |
| PATCH  | `/v1/assistants/<id>/trust-rules/<ruleId>`                 | `handleTrustRulesUpdate`      |
| DELETE | `/v1/assistants/<id>/trust-rules/<ruleId>`                 | `handleTrustRulesDelete`      |

Ordering mirrors the flat block (list → suggest → create → reset → update → delete) so the literal `/suggest` and `/<id>/reset` are matched before the `/<id>` PATCH/DELETE catch-alls.

## Why gateway routes and not daemon routes

The previous attempt (#30328) re-added the routes on the **daemon**, which was the wrong layer — the daemon's old handlers just round-tripped back to the gateway. Trust rules live on the gateway; the right fix is to teach the gateway about both URL shapes the clients use.

## Why not migrate clients to flat paths instead

Either works. Gateway-side fix unblocks the user-visible 404 today without a coordinated client release across macOS, web, and Django. Both client repos can be retired off the scoped paths later as a cleanup; this PR is the minimum to stop the user-visible regression.

## What's NOT in this PR

- No client-side changes. `TrustRuleClient.swift` and `web/src/lib/trust-rules/api.ts` still use the scoped paths (the contacts precedent does the same).
- No daemon cleanup. `assistant/src/runtime/routes/trust-rules-routes.ts` `handleList` is still used by the CLI `trust list` IPC (`assistant/src/cli/commands/trust.ts:78`). Leave it as a separate follow-up if we want to remove it.
- No new OpenAPI schema entry. The scoped variants are documented as a runtime-only client compat layer, same as the contacts assistant-scoped DELETE. The schema-guard test ignores bare `[^/]+` patterns. Happy to add schema entries if reviewers prefer.

## Verification

- `bun test gateway/src/http/routes/trust-rules.suggest.test.ts` — 10/10 pass
- `bun test gateway/src/__tests__/route-schema-guard.test.ts` — 5/5 pass
- `bun run typecheck` (gateway) — clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->