### PR TITLE
fix(gateway): preserve Slack guardian channel casing

### DIFF
--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import type { SqliteValue } from "../db/assistant-db-proxy.js";
+
+import "./test-preload.js";
+
+let assistantDb: Database | null = null;
+
+function db(): Database {
+  if (!assistantDb) throw new Error("test DB not initialized");
+  return assistantDb;
+}
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  async assistantDbQuery(sql: string, bind: SqliteValue[] = []) {
+    return db()
+      .prepare(sql)
+      .all(...bind);
+  },
+  async assistantDbRun(sql: string, bind: SqliteValue[] = []) {
+    const result = db()
+      .prepare(sql)
+      .run(...bind);
+    return {
+      changes: result.changes,
+      lastInsertRowid: Number(result.lastInsertRowid),
+    };
+  },
+  async assistantDbExec(sql: string) {
+    db().exec(sql);
+  },
+}));
+
+const fakeGatewayTx = {
+  insert: () => ({
+    values: () => ({
+      onConflictDoUpdate: () => ({ run: () => {} }),
+    }),
+  }),
+};
+
+mock.module("../db/connection.js", () => ({
+  getGatewayDb: () => ({
+    transaction: (fn: (tx: typeof fakeGatewayTx) => void) => fn(fakeGatewayTx),
+  }),
+}));
+
+mock.module("../db/schema.js", () => ({
+  actorRefreshTokenRecords: {},
+  actorTokenRecords: {},
+  contacts: {},
+  contactChannels: {},
+}));
+
+const { createGuardianBinding } = await import("../auth/guardian-bootstrap.js");
+
+beforeEach(() => {
+  assistantDb = new Database(":memory:");
+  assistantDb.exec(`
+    CREATE TABLE contacts (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'contact',
+      principal_id TEXT,
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      verified_at INTEGER,
+      verified_via TEXT,
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER
+    );
+
+    CREATE UNIQUE INDEX idx_contact_channels_type_address
+      ON contact_channels(type, address);
+  `);
+});
+
+afterEach(() => {
+  assistantDb?.close();
+  assistantDb = null;
+});
+
+function seedGuardianContact(): void {
+  db()
+    .prepare(
+      `INSERT INTO contacts
+         (id, display_name, role, principal_id, notes, created_at, updated_at)
+       VALUES
+         ('guardian-contact', 'Example User', 'guardian', 'guardian-principal', 'guardian', 1, 1)`,
+    )
+    .run();
+}
+
+function seedSlackContactChannel(address: string): void {
+  db()
+    .prepare(
+      `INSERT INTO contacts
+         (id, display_name, role, principal_id, notes, created_at, updated_at)
+       VALUES
+         ('seed-contact', 'Example User', 'contact', NULL, NULL, 1, 1)`,
+    )
+    .run();
+  db()
+    .prepare(
+      `INSERT INTO contact_channels
+         (id, contact_id, type, address, external_user_id, external_chat_id,
+          is_primary, status, policy, created_at, updated_at)
+       VALUES
+         ('seed-channel', 'seed-contact', 'slack', ?, 'U123EXAMPLE',
+          'D123EXAMPLE', 0, 'unverified', 'allow', 1, 1)`,
+    )
+    .run(address);
+}
+
+describe("createGuardianBinding", () => {
+  test("claims a preseeded Slack channel for the guardian instead of inserting a duplicate", async () => {
+    seedGuardianContact();
+    seedSlackContactChannel("U123EXAMPLE");
+
+    const result = await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(result.contactId).toBe("guardian-contact");
+    expect(result.channelId).toBe("seed-channel");
+
+    const rows = db()
+      .query<
+        {
+          id: string;
+          contact_id: string;
+          address: string;
+          external_user_id: string;
+          status: string;
+          policy: string;
+          is_primary: number;
+        },
+        []
+      >("SELECT * FROM contact_channels WHERE type = 'slack'")
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "seed-channel",
+      contact_id: "guardian-contact",
+      address: "U123EXAMPLE",
+      external_user_id: "U123EXAMPLE",
+      status: "active",
+      policy: "allow",
+      is_primary: 1,
+    });
+  });
+
+  test("repairs an old lowercase Slack address by matching the preserved external user ID", async () => {
+    seedGuardianContact();
+    seedSlackContactChannel("u123example");
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    const rows = db()
+      .query<
+        {
+          id: string;
+          contact_id: string;
+          address: string;
+          external_user_id: string;
+          status: string;
+        },
+        []
+      >(
+        `SELECT id, contact_id, address, external_user_id, status
+         FROM contact_channels
+         WHERE type = 'slack'`,
+      )
+      .all();
+    expect(rows).toEqual([
+      {
+        id: "seed-channel",
+        contact_id: "guardian-contact",
+        address: "U123EXAMPLE",
+        external_user_id: "U123EXAMPLE",
+        status: "active",
+      },
+    ]);
+  });
+});

--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -128,6 +128,19 @@ function seedSlackContactChannel(address: string): void {
     .run(address);
 }
 
+function seedRevokedGuardianSlackChannel(): void {
+  db()
+    .prepare(
+      `INSERT INTO contact_channels
+         (id, contact_id, type, address, external_user_id, external_chat_id,
+          is_primary, status, policy, created_at, updated_at)
+       VALUES
+         ('guardian-channel', 'guardian-contact', 'slack', 'U123EXAMPLE',
+          'U123EXAMPLE', 'D123EXAMPLE', 1, 'revoked', 'deny', 1, 1)`,
+    )
+    .run();
+}
+
 describe("createGuardianBinding", () => {
   test("claims a preseeded Slack channel for the guardian instead of inserting a duplicate", async () => {
     seedGuardianContact();
@@ -207,6 +220,55 @@ describe("createGuardianBinding", () => {
         address: "U123EXAMPLE",
         external_user_id: "U123EXAMPLE",
         status: "active",
+      },
+    ]);
+  });
+
+  test("prefers the cased guardian channel over a lowercase seed duplicate", async () => {
+    seedGuardianContact();
+    seedRevokedGuardianSlackChannel();
+    seedSlackContactChannel("u123example");
+
+    const result = await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U123EXAMPLE",
+      deliveryChatId: "D123EXAMPLE",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+    });
+
+    expect(result.contactId).toBe("guardian-contact");
+    expect(result.channelId).toBe("guardian-channel");
+
+    const rows = db()
+      .query<
+        {
+          id: string;
+          contact_id: string;
+          address: string;
+          status: string;
+        },
+        []
+      >(
+        `SELECT id, contact_id, address, status
+         FROM contact_channels
+         WHERE type = 'slack'
+         ORDER BY id`,
+      )
+      .all();
+    expect(rows).toEqual([
+      {
+        id: "guardian-channel",
+        contact_id: "guardian-contact",
+        address: "U123EXAMPLE",
+        status: "active",
+      },
+      {
+        id: "seed-channel",
+        contact_id: "seed-contact",
+        address: "u123example",
+        status: "unverified",
       },
     ]);
   });

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -3,7 +3,10 @@
  * revoked or blocked channels.
  */
 
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import "./test-preload.js";
 
@@ -19,6 +22,10 @@ type ExistingRow = {
 
 let queryRows: ExistingRow[] = [];
 const runCalls: { sql: string; params: unknown[] }[] = [];
+const TEST_SOCKET_PATH = join(
+  tmpdir(),
+  `vellum-upsert-contact-channel-test-${process.pid}.sock`,
+);
 
 mock.module("../db/assistant-db-proxy.js", () => ({
   assistantDbQuery: async (_sql: string, _params: unknown[]) => queryRows,
@@ -50,17 +57,21 @@ mock.module("../verification/identity.js", () => ({
 }));
 
 mock.module("../ipc/socket-path.js", () => ({
-  resolveIpcSocketPath: () => ({ path: "/tmp/test.sock" }),
+  resolveIpcSocketPath: () => ({ path: TEST_SOCKET_PATH }),
 }));
 
 // Import after mocks
-const { upsertVerifiedContactChannel } = await import(
-  "../verification/contact-helpers.js"
-);
+const { upsertContactChannel, upsertVerifiedContactChannel } =
+  await import("../verification/contact-helpers.js");
 
 beforeEach(() => {
   queryRows = [];
   runCalls.length = 0;
+  writeFileSync(TEST_SOCKET_PATH, "");
+});
+
+afterEach(() => {
+  rmSync(TEST_SOCKET_PATH, { force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -169,5 +180,24 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
 
     const inserts = runCalls.filter((c) => c.sql.includes("INSERT"));
     expect(inserts).toHaveLength(2);
+  });
+});
+
+describe("upsertContactChannel — channel address casing", () => {
+  test("preserves Slack actor ID casing when seeding an inbound contact channel", async () => {
+    queryRows = [];
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "U123EXAMPLE",
+      externalChatId: "D123EXAMPLE",
+    });
+
+    const channelInsert = runCalls.find((c) =>
+      c.sql.includes("INSERT OR IGNORE INTO contact_channels"),
+    );
+    expect(channelInsert).toBeTruthy();
+    expect(channelInsert!.params[3]).toBe("U123EXAMPLE");
+    expect(channelInsert!.params[4]).toBe("U123EXAMPLE");
   });
 });

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -21,6 +21,7 @@ type ExistingRow = {
 };
 
 let queryRows: ExistingRow[] = [];
+const queryCalls: { sql: string; params: unknown[] }[] = [];
 const runCalls: { sql: string; params: unknown[] }[] = [];
 const TEST_SOCKET_PATH = join(
   tmpdir(),
@@ -28,7 +29,10 @@ const TEST_SOCKET_PATH = join(
 );
 
 mock.module("../db/assistant-db-proxy.js", () => ({
-  assistantDbQuery: async (_sql: string, _params: unknown[]) => queryRows,
+  assistantDbQuery: async (sql: string, params: unknown[]) => {
+    queryCalls.push({ sql, params });
+    return queryRows;
+  },
   assistantDbRun: async (sql: string, params: unknown[]) => {
     runCalls.push({ sql, params });
   },
@@ -66,6 +70,7 @@ const { upsertContactChannel, upsertVerifiedContactChannel } =
 
 beforeEach(() => {
   queryRows = [];
+  queryCalls.length = 0;
   runCalls.length = 0;
   writeFileSync(TEST_SOCKET_PATH, "");
 });
@@ -199,5 +204,13 @@ describe("upsertContactChannel — channel address casing", () => {
     expect(channelInsert).toBeTruthy();
     expect(channelInsert!.params[3]).toBe("U123EXAMPLE");
     expect(channelInsert!.params[4]).toBe("U123EXAMPLE");
+
+    expect(queryCalls[0]!.sql).toContain("CASE WHEN cc.address = ?");
+    expect(queryCalls[0]!.params).toEqual([
+      "slack",
+      "U123EXAMPLE",
+      "U123EXAMPLE",
+      "U123EXAMPLE",
+    ]);
   });
 });

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -94,6 +94,11 @@ interface GuardianLookupRow {
   principal_id: string | null;
 }
 
+interface ExistingChannelRow {
+  id: string;
+  contactId: string;
+}
+
 /**
  * Find the existing guardian contact for the "vellum" channel.
  * Mirrors assistant's `findGuardianForChannel("vellum")`.
@@ -180,7 +185,8 @@ export interface CreateGuardianBindingResult {
  *
  * Writes to both the assistant DB (via IPC proxy, primary) and gateway DB
  * (secondary). Uses upsert semantics: looks up an existing contact by
- * principalId and an existing channel by (contactId, type), updating if found.
+ * principalId, then claims any preseeded channel for the same actor before
+ * falling back to an existing guardian channel by (contactId, type).
  */
 export async function createGuardianBinding(
   params: CreateGuardianBindingParams,
@@ -200,22 +206,48 @@ export async function createGuardianBinding(
       [params.guardianPrincipalId],
     );
 
-    contactId = existingContacts[0]?.id ?? uuid();
+    const claimableChannels = await assistantDbQuery<ExistingChannelRow>(
+      `SELECT cc.id, cc.contact_id AS contactId
+       FROM contact_channels cc
+       WHERE cc.type = ?
+         AND cc.status != 'blocked'
+         AND (cc.address = ? OR cc.external_user_id = ?)
+       ORDER BY
+         CASE WHEN cc.external_user_id = ? THEN 0 ELSE 1 END,
+         CASE cc.status
+           WHEN 'active' THEN 0
+           WHEN 'unverified' THEN 1
+           ELSE 2
+         END,
+         cc.updated_at DESC
+       LIMIT 1`,
+      [
+        params.channel,
+        params.externalUserId,
+        params.externalUserId,
+        params.externalUserId,
+      ],
+    );
+
+    contactId =
+      existingContacts[0]?.id ?? claimableChannels[0]?.contactId ?? uuid();
 
     let existingChannels: { id: string }[] = [];
-    if (existingContacts[0]) {
+    if (!claimableChannels[0] && existingContacts[0]) {
       existingChannels = await assistantDbQuery<{ id: string }>(
         `SELECT id FROM contact_channels WHERE contact_id = ? AND type = ? LIMIT 1`,
         [contactId, params.channel],
       );
     }
 
-    channelId = existingChannels[0]?.id ?? uuid();
+    channelId = claimableChannels[0]?.id ?? existingChannels[0]?.id ?? uuid();
 
-    if (existingContacts[0]) {
+    if (existingContacts[0] || claimableChannels[0]) {
       await assistantDbRun(
-        `UPDATE contacts SET display_name = ?, updated_at = ? WHERE id = ?`,
-        [displayName, now, contactId],
+        `UPDATE contacts
+         SET display_name = ?, role = 'guardian', principal_id = ?, updated_at = ?
+         WHERE id = ?`,
+        [displayName, params.guardianPrincipalId, now, contactId],
       );
     } else {
       await assistantDbRun(
@@ -225,14 +257,17 @@ export async function createGuardianBinding(
       );
     }
 
-    if (existingChannels[0]) {
+    if (claimableChannels[0] || existingChannels[0]) {
       await assistantDbRun(
         `UPDATE contact_channels
-         SET address = ?, external_user_id = ?, external_chat_id = ?,
+         SET contact_id = ?, address = ?, external_user_id = ?, external_chat_id = ?,
+             is_primary = 1,
              status = 'active', policy = 'allow', verified_at = ?,
-             verified_via = ?, updated_at = ?
+             verified_via = ?, revoked_reason = NULL, blocked_reason = NULL,
+             updated_at = ?
          WHERE id = ?`,
         [
+          contactId,
           params.externalUserId,
           params.externalUserId,
           params.deliveryChatId,
@@ -287,7 +322,12 @@ export async function createGuardianBinding(
         })
         .onConflictDoUpdate({
           target: gwContacts.id,
-          set: { displayName, updatedAt: now },
+          set: {
+            displayName,
+            role: "guardian",
+            principalId: params.guardianPrincipalId,
+            updatedAt: now,
+          },
         })
         .run();
 
@@ -310,13 +350,18 @@ export async function createGuardianBinding(
         .onConflictDoUpdate({
           target: gwContactChannels.id,
           set: {
+            contactId,
             address: params.externalUserId,
             externalUserId: params.externalUserId,
             externalChatId: params.deliveryChatId,
+            isPrimary: true,
             status: "active",
             policy: "allow",
             verifiedAt: now,
             verifiedVia,
+            revokedReason: null,
+            blockedReason: null,
+            updatedAt: now,
           },
         })
         .run();

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -205,6 +205,7 @@ export async function createGuardianBinding(
       `SELECT id FROM contacts WHERE role = 'guardian' AND principal_id = ? LIMIT 1`,
       [params.guardianPrincipalId],
     );
+    const existingGuardianContactId = existingContacts[0]?.id;
 
     const claimableChannels = await assistantDbQuery<ExistingChannelRow>(
       `SELECT cc.id, cc.contact_id AS contactId
@@ -213,6 +214,8 @@ export async function createGuardianBinding(
          AND cc.status != 'blocked'
          AND (cc.address = ? OR cc.external_user_id = ?)
        ORDER BY
+         CASE WHEN cc.address = ? THEN 0 ELSE 1 END,
+         CASE WHEN cc.contact_id = ? THEN 0 ELSE 1 END,
          CASE WHEN cc.external_user_id = ? THEN 0 ELSE 1 END,
          CASE cc.status
            WHEN 'active' THEN 0
@@ -225,6 +228,8 @@ export async function createGuardianBinding(
         params.channel,
         params.externalUserId,
         params.externalUserId,
+        params.externalUserId,
+        existingGuardianContactId ?? "",
         params.externalUserId,
       ],
     );

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -113,8 +113,16 @@ export async function upsertVerifiedContactChannel(params: {
     `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
      FROM contact_channels cc
      WHERE cc.type = ? AND (cc.address = ? OR cc.external_user_id = ?)
+     ORDER BY
+       CASE WHEN cc.address = ? THEN 0 ELSE 1 END,
+       CASE cc.status
+         WHEN 'active' THEN 0
+         WHEN 'unverified' THEN 1
+         ELSE 2
+       END,
+       cc.updated_at DESC
      LIMIT 1`,
-    [sourceChannel, address, canonicalUserId],
+    [sourceChannel, address, canonicalUserId, address],
   );
 
   if (existing.length > 0) {
@@ -278,8 +286,16 @@ export async function upsertContactChannel(params: {
     `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
      FROM contact_channels cc
      WHERE cc.type = ? AND (cc.address = ? OR cc.external_user_id = ?)
+     ORDER BY
+       CASE WHEN cc.address = ? THEN 0 ELSE 1 END,
+       CASE cc.status
+         WHEN 'active' THEN 0
+         WHEN 'unverified' THEN 1
+         ELSE 2
+       END,
+       cc.updated_at DESC
      LIMIT 1`,
-    [sourceChannel, address, canonicalUserId],
+    [sourceChannel, address, canonicalUserId, address],
   );
 
   if (existing.length > 0) {

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -14,17 +14,26 @@ import { existsSync } from "node:fs";
 
 import { eq } from "drizzle-orm";
 
-import {
-  assistantDbQuery,
-  assistantDbRun,
-} from "../db/assistant-db-proxy.js";
+import { assistantDbQuery, assistantDbRun } from "../db/assistant-db-proxy.js";
 import { getGatewayDb } from "../db/connection.js";
-import { contactChannels as gwContactChannels, contacts as gwContacts } from "../db/schema.js";
+import {
+  contactChannels as gwContactChannels,
+  contacts as gwContacts,
+} from "../db/schema.js";
 import { getLogger } from "../logger.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { canonicalizeInboundIdentity } from "./identity.js";
 
 const log = getLogger("verification-contacts");
+
+function contactChannelAddress(
+  sourceChannel: string,
+  canonicalUserId: string,
+): string {
+  return sourceChannel === "slack"
+    ? canonicalUserId
+    : canonicalUserId.toLowerCase();
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,10 +101,10 @@ export async function upsertVerifiedContactChannel(params: {
   const canonicalUserId =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
     params.externalUserId;
-  const address = canonicalUserId.toLowerCase();
+  const address = contactChannelAddress(sourceChannel, canonicalUserId);
   const contactDisplayName = displayName ?? username ?? canonicalUserId;
 
-  // Check if a channel with this (type, address) already exists
+  // Check if a channel for this actor already exists.
   const existing = await assistantDbQuery<{
     channelId: string;
     contactId: string;
@@ -103,9 +112,9 @@ export async function upsertVerifiedContactChannel(params: {
   }>(
     `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
      FROM contact_channels cc
-     WHERE cc.type = ? AND cc.address = ?
+     WHERE cc.type = ? AND (cc.address = ? OR cc.external_user_id = ?)
      LIMIT 1`,
-    [sourceChannel, address],
+    [sourceChannel, address, canonicalUserId],
   );
 
   if (existing.length > 0) {
@@ -123,21 +132,24 @@ export async function upsertVerifiedContactChannel(params: {
     // Update existing channel
     await assistantDbRun(
       `UPDATE contact_channels
-       SET status = 'active', policy = 'allow',
+       SET address = ?,
+           status = 'active', policy = 'allow',
            external_user_id = ?, external_chat_id = ?,
            revoked_reason = NULL, blocked_reason = NULL,
            updated_at = ?
        WHERE id = ?`,
-      [canonicalUserId, externalChatId, now, row.channelId],
+      [address, canonicalUserId, externalChatId, now, row.channelId],
     );
 
     // Dual-write to gateway DB
     try {
       const gwDb = getGatewayDb();
-      gwDb.update(gwContactChannels)
+      gwDb
+        .update(gwContactChannels)
         .set({
           status: "active",
           policy: "allow",
+          address,
           externalUserId: canonicalUserId,
           externalChatId,
           revokedReason: null,
@@ -147,7 +159,10 @@ export async function upsertVerifiedContactChannel(params: {
         .where(eq(gwContactChannels.id, row.channelId))
         .run();
     } catch (gwErr) {
-      log.warn({ err: gwErr }, "Gateway DB contact channel update dual-write failed");
+      log.warn(
+        { err: gwErr },
+        "Gateway DB contact channel update dual-write failed",
+      );
     }
 
     return;
@@ -171,13 +186,23 @@ export async function upsertVerifiedContactChannel(params: {
        (id, contact_id, type, address, is_primary, external_user_id, external_chat_id,
         status, policy, interaction_count, created_at, updated_at)
      VALUES (?, ?, ?, ?, 0, ?, ?, 'active', 'allow', 0, ?, ?)`,
-    [channelId, contactId, sourceChannel, address, canonicalUserId, externalChatId, now, now],
+    [
+      channelId,
+      contactId,
+      sourceChannel,
+      address,
+      canonicalUserId,
+      externalChatId,
+      now,
+      now,
+    ],
   );
 
   // Dual-write to gateway DB
   try {
     const gwDb = getGatewayDb();
-    gwDb.insert(gwContacts)
+    gwDb
+      .insert(gwContacts)
       .values({
         id: contactId,
         displayName: contactDisplayName,
@@ -188,7 +213,8 @@ export async function upsertVerifiedContactChannel(params: {
       .onConflictDoNothing()
       .run();
 
-    gwDb.insert(gwContactChannels)
+    gwDb
+      .insert(gwContactChannels)
       .values({
         id: channelId,
         contactId,
@@ -241,7 +267,7 @@ export async function upsertContactChannel(params: {
   const canonicalUserId =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
     params.externalUserId;
-  const address = canonicalUserId.toLowerCase();
+  const address = contactChannelAddress(sourceChannel, canonicalUserId);
   const contactDisplayName = displayName ?? username ?? canonicalUserId;
 
   const existing = await assistantDbQuery<{
@@ -251,9 +277,9 @@ export async function upsertContactChannel(params: {
   }>(
     `SELECT cc.id AS channelId, cc.contact_id AS contactId, cc.status AS channelStatus
      FROM contact_channels cc
-     WHERE cc.type = ? AND cc.address = ?
+     WHERE cc.type = ? AND (cc.address = ? OR cc.external_user_id = ?)
      LIMIT 1`,
-    [sourceChannel, address],
+    [sourceChannel, address, canonicalUserId],
   );
 
   if (existing.length > 0) {
@@ -267,11 +293,12 @@ export async function upsertContactChannel(params: {
     );
     await assistantDbRun(
       `UPDATE contact_channels
-       SET external_user_id = ?,
+       SET address = ?,
+           external_user_id = ?,
            external_chat_id = COALESCE(?, external_chat_id),
            updated_at = ?
        WHERE id = ?`,
-      [canonicalUserId, externalChatId ?? null, now, row.channelId],
+      [address, canonicalUserId, externalChatId ?? null, now, row.channelId],
     );
 
     try {
@@ -279,6 +306,7 @@ export async function upsertContactChannel(params: {
       gwDb
         .update(gwContactChannels)
         .set({
+          address,
           externalUserId: canonicalUserId,
           ...(externalChatId ? { externalChatId } : {}),
           updatedAt: now,
@@ -286,7 +314,10 @@ export async function upsertContactChannel(params: {
         .where(eq(gwContactChannels.id, row.channelId))
         .run();
     } catch (gwErr) {
-      log.warn({ err: gwErr }, "Gateway DB contact channel update dual-write failed");
+      log.warn(
+        { err: gwErr },
+        "Gateway DB contact channel update dual-write failed",
+      );
     }
     return;
   }
@@ -305,7 +336,16 @@ export async function upsertContactChannel(params: {
        (id, contact_id, type, address, is_primary, external_user_id, external_chat_id,
         status, policy, interaction_count, created_at, updated_at)
      VALUES (?, ?, ?, ?, 0, ?, ?, 'unverified', 'allow', 0, ?, ?)`,
-    [channelId, contactId, sourceChannel, address, canonicalUserId, externalChatId ?? null, now, now],
+    [
+      channelId,
+      contactId,
+      sourceChannel,
+      address,
+      canonicalUserId,
+      externalChatId ?? null,
+      now,
+      now,
+    ],
   );
 
   try {
@@ -340,6 +380,9 @@ export async function upsertContactChannel(params: {
       .onConflictDoNothing()
       .run();
   } catch (gwErr) {
-    log.warn({ err: gwErr }, "Gateway DB contact channel create dual-write failed");
+    log.warn(
+      { err: gwErr },
+      "Gateway DB contact channel create dual-write failed",
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Preserve Slack actor ID casing when seeding contact channels.
- Have guardian binding claim an existing channel for the same actor before inserting a new guardian channel.
- Add regression coverage for preseeded Slack channel reuse and old lowercase address repair.

## Original prompt
The user asked to open a PR for GitHub issue #30322, specifically following their comment that the original cleanup-only suggestion felt like a band-aid. The requested direction was to prevent the duplicate outbound Slack guardian verification contact at the root by preserving casing during seeding and guardian binding.

Closes EPD-2725
Closes #30322
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->