### PR TITLE
fix(compaction): never skip user-forced /compact

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -74,7 +74,7 @@ describe("ContextWindowManager", () => {
     expect(result.reason).toBe("below compaction threshold");
   });
 
-  test("explains forced compaction skip when conversation already fits target", async () => {
+  test("explains forced compaction skip when only one user turn exists", async () => {
     const provider = createProvider(() => {
       throw new Error("summarizer should not be called");
     });
@@ -86,6 +86,10 @@ describe("ContextWindowManager", () => {
         targetBudgetRatio: 0.5,
       }),
     });
+    // Only one user turn — there is nothing earlier to summarize, so
+    // forced compaction must still skip but report a clear reason
+    // instead of "conversation already fits within the compaction
+    // target". `force=true` is honored everywhere else.
     const history = [message("user", "hello"), message("assistant", "hi")];
 
     const result = await manager.maybeCompact(history, undefined, {
@@ -95,8 +99,151 @@ describe("ContextWindowManager", () => {
     expect(result.compacted).toBe(false);
     expect(result.messages).toEqual(history);
     expect(result.reason).toBe(
+      "only one user turn — nothing earlier to compact",
+    );
+  });
+
+  test("forced compaction summarizes when adjustForToolPairs would walk boundary to summary", async () => {
+    let summaryCalls = 0;
+    const provider = createProvider(() => {
+      summaryCalls += 1;
+      return {
+        content: [{ type: "text", text: "## Summary\n- rescue path ran" }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 25 },
+        stopReason: "end_turn",
+      };
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 10_000,
+        targetBudgetRatio: 0.5,
+      }),
+    });
+    // Conversation starts with consecutive `assistant(tool_use)` →
+    // `user(tool_result + text)` pairs. `collectUserTurnStartIndexes`
+    // includes the mixed user messages (not tool_result-only), so the
+    // earliest `userTurnStarts` entry is the message containing
+    // `tool_result(tool-1)`. Once the projection-optimism clamp
+    // decrements the keep boundary to that user turn,
+    // `adjustForToolPairs` walks the boundary back through the
+    // tool_use/tool_result chain to index 0 — under the old code that
+    // routed `/compact` through the "already fits" skip path. With the
+    // rescue, summarization runs and orphan `tool_result` blocks are
+    // stripped from the kept region.
+    const history: Message[] = [
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-1", name: "x", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tool-1", content: "result1" },
+          { type: "text", text: "u1" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-2", name: "x", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tool-2", content: "result2" },
+          { type: "text", text: "u2" },
+        ],
+      },
+      message("assistant", "a3"),
+      message("user", "u3"),
+      message("assistant", "a4"),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      precomputedEstimate: 50_000,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summaryCalls).toBe(1);
+    expect(result.reason).not.toBe(
       "conversation already fits within the compaction target",
     );
+    expect(result.reason).not.toBe(
+      "truncated tool results without summarization",
+    );
+    expect(result.compactedMessages).toBeGreaterThan(0);
+
+    // The kept region must not contain orphan tool_result blocks whose
+    // tool_use lives in the compacted region — the LLM API would reject
+    // such messages on the next agent turn.
+    const keptToolUseIds = new Set<string>();
+    for (const msg of result.messages) {
+      if (msg.role !== "assistant") continue;
+      for (const block of msg.content) {
+        if (
+          (block.type === "tool_use" || block.type === "server_tool_use") &&
+          "id" in block
+        ) {
+          keptToolUseIds.add((block as { id: string }).id);
+        }
+      }
+    }
+    for (const msg of result.messages) {
+      if (msg.role !== "user") continue;
+      for (const block of msg.content) {
+        if (
+          (block.type === "tool_result" ||
+            block.type === "web_search_tool_result") &&
+          "tool_use_id" in block
+        ) {
+          expect(keptToolUseIds.has(block.tool_use_id as string)).toBe(true);
+        }
+      }
+    }
+  });
+
+  test("forced compaction summarizes when compactable count is below MIN guard", async () => {
+    let summaryCalls = 0;
+    const provider = createProvider(() => {
+      summaryCalls += 1;
+      return {
+        content: [{ type: "text", text: "## Summary\n- min-bypass ran" }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 25 },
+        stopReason: "end_turn",
+      };
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 10_000,
+        targetBudgetRatio: 0.5,
+      }),
+    });
+    // Two user turns separated by a single assistant message — the
+    // smallest realistic conversation where a forced compaction has
+    // anything to summarize. After the projection clamp + rescue, the
+    // compactable region is at most one user turn (the first one),
+    // which can fall below `MIN_COMPACTABLE_PERSISTED_MESSAGES`. The
+    // bypass must let summarization run instead of returning
+    // "insufficient compactable persisted messages".
+    const history: Message[] = [message("user", "u1"), message("user", "u2")];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      precomputedEstimate: 50_000,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summaryCalls).toBe(1);
+    expect(result.reason).not.toBe(
+      "insufficient compactable persisted messages",
+    );
+    expect(result.compactedMessages).toBeGreaterThan(0);
   });
 
   test("forced compaction summarizes when projection fits but real usage exceeds target", async () => {
@@ -2106,10 +2253,7 @@ describe("extractTailAssistantText", () => {
   });
 
   test("returns null when no assistant text is present", () => {
-    const messages: Message[] = [
-      message("user", "u1"),
-      message("user", "u2"),
-    ];
+    const messages: Message[] = [message("user", "u1"), message("user", "u2")];
     expect(extractTailAssistantText(messages)).toBeNull();
   });
 

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -501,13 +501,45 @@ export class ContextWindowManager {
       };
     }
 
-    const keepPlan = this.pickKeepBoundary(messages, userTurnStarts, {
+    const keepPlanInitial = this.pickKeepBoundary(messages, userTurnStarts, {
       minKeepRecentUserTurns: options?.minKeepRecentUserTurns,
       targetInputTokensOverride: options?.targetInputTokensOverride,
       conversationOriginChannel: options?.conversationOriginChannel,
       force: options?.force,
       previousEstimatedInputTokens,
     });
+    // Under force (user-explicit `/compact`), never route through the
+    // "already fits" / "truncated tool results without summarization"
+    // early-return — those are no-op responses to a direct user command.
+    // The boundary can collapse to the summary in two cases the
+    // projection-optimism clamp in pickKeepBoundary does not cover:
+    //   1. `adjustForToolPairs` walked the boundary back through a
+    //      tool_use/tool_result chain at the start of the conversation.
+    //   2. The binary search settled below `userTurnStarts.length` (so
+    //      the clamp at the top of pickKeepBoundary did not fire) but
+    //      `adjustForToolPairs` still walked the resulting boundary
+    //      backwards past `summaryOffset`.
+    // Rescue: restore the binary search's intended keep depth (capped at
+    // `length - 1` so we always summarize at least one turn) and bypass
+    // `adjustForToolPairs`. The kept region's first message may then
+    // contain a `tool_result` whose matching `tool_use` lives in the
+    // compacted region; we strip such orphans below before assembling
+    // the final messages array so the next agent turn does not fail
+    // when sending to the LLM.
+    const forceRescueApplied =
+      options?.force === true &&
+      keepPlanInitial.keepFromIndex <= summaryOffset &&
+      userTurnStarts.length >= 2;
+    const safeKeepTurns = Math.max(
+      1,
+      Math.min(keepPlanInitial.keepTurns, userTurnStarts.length - 1),
+    );
+    const keepPlan = forceRescueApplied
+      ? {
+          keepFromIndex: userTurnStarts[userTurnStarts.length - safeKeepTurns],
+          keepTurns: safeKeepTurns,
+        }
+      : keepPlanInitial;
     if (keepPlan.keepFromIndex <= summaryOffset) {
       // All turns fit after truncation projection, but the real in-memory
       // messages may still contain un-truncated tool results. Apply truncation
@@ -524,6 +556,14 @@ export class ContextWindowManager {
             toolTokenBudget: this.toolTokenBudget,
           })
         : previousEstimatedInputTokens;
+      // Under force with only one user turn, the rescue above could not
+      // fire — there is nothing earlier to summarize. Surface that
+      // explicitly instead of "conversation already fits..." so the user
+      // knows why `/compact` did not produce a summary.
+      const noSummarizationReason =
+        options?.force && userTurnStarts.length < 2
+          ? "only one user turn — nothing earlier to compact"
+          : "conversation already fits within the compaction target";
       return {
         messages: truncatedMessages,
         compacted: didTruncate,
@@ -540,7 +580,7 @@ export class ContextWindowManager {
         summaryText: existingSummary ?? "",
         reason: didTruncate
           ? "truncated tool results without summarization"
-          : "conversation already fits within the compaction target",
+          : noSummarizationReason,
       };
     }
 
@@ -658,9 +698,15 @@ export class ContextWindowManager {
       };
     }
 
+    // `severePressure` already bypasses this guard to keep context from
+    // overflowing. Forced compaction also bypasses: when the user
+    // explicitly types `/compact` we must summarize whatever is
+    // available rather than return "insufficient compactable persisted
+    // messages" — that is a no-op response to a direct user command.
     if (
       compactedPersistedMessages < MIN_COMPACTABLE_PERSISTED_MESSAGES &&
-      !severePressure
+      !severePressure &&
+      !options?.force
     ) {
       return {
         messages,
@@ -741,7 +787,14 @@ export class ContextWindowManager {
         messages.slice(keepPlan.keepFromIndex),
         COMPACTION_TOOL_RESULT_MAX_CHARS,
       );
-    const compactedMessages = [summaryMessage, ...truncatedKeptMessages];
+    // The force-rescue boundary bypasses `adjustForToolPairs`, so the
+    // kept region may contain `tool_result` blocks whose matching
+    // `tool_use` is in the (now-compacted) prefix. Strip those orphans
+    // so the next agent turn does not fail with an LLM API error.
+    const keptMessages = forceRescueApplied
+      ? stripOrphanToolResults(truncatedKeptMessages)
+      : truncatedKeptMessages;
+    const compactedMessages = [summaryMessage, ...keptMessages];
     const estimatedInputTokens = estimatePromptTokens(
       compactedMessages,
       this.systemPrompt,
@@ -1276,6 +1329,53 @@ function adjustForToolPairs(
   return idx;
 }
 
+/**
+ * Strip `tool_result` blocks whose matching `tool_use` is not present in
+ * the message array. Used by the force-rescue path in `_maybeCompact`
+ * which bypasses `adjustForToolPairs` to honor user-explicit `/compact`
+ * commands — the kept region's first user message can otherwise contain
+ * an orphan `tool_result`, which the LLM API rejects.
+ *
+ * A user message that contains only orphan `tool_result` blocks is
+ * dropped entirely; partial messages keep the surviving content blocks.
+ */
+function stripOrphanToolResults(messages: Message[]): Message[] {
+  const knownToolUseIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content) {
+      if (
+        (block.type === "tool_use" || block.type === "server_tool_use") &&
+        "id" in block
+      ) {
+        knownToolUseIds.add((block as { id: string }).id);
+      }
+    }
+  }
+
+  return messages.flatMap((msg) => {
+    if (msg.role !== "user") return [msg];
+    let stripped = false;
+    const filtered = msg.content.filter((block) => {
+      if (
+        (block.type === "tool_result" ||
+          block.type === "web_search_tool_result") &&
+        "tool_use_id" in block
+      ) {
+        const id = (block as { tool_use_id: string }).tool_use_id;
+        if (!knownToolUseIds.has(id)) {
+          stripped = true;
+          return false;
+        }
+      }
+      return true;
+    });
+    if (!stripped) return [msg];
+    if (filtered.length === 0) return [];
+    return [{ ...msg, content: filtered }];
+  });
+}
+
 export function getSummaryFromContextMessage(
   message: Message | undefined,
 ): string | null {
@@ -1339,7 +1439,11 @@ export function extractTailAssistantText(
     if (text.length === 0) continue;
     if (text.length <= maxChars) return text;
     // Keep the END — most recent narration wins.
-    const truncated = safeStringSlice(text, text.length - maxChars, text.length);
+    const truncated = safeStringSlice(
+      text,
+      text.length - maxChars,
+      text.length,
+    );
     return `[...truncated] ${truncated}`;
   }
   return null;


### PR DESCRIPTION
## Summary

- User-typed `/compact` could no-op with "conversation already fits within the compaction target" even when context was at ~67% of the window (the reported symptom: indicator yellow, /compact ignored, then auto-compaction triggered shortly after).
- Three failure modes slipped past the existing projection-optimism clamp: `adjustForToolPairs` walking the boundary to 0 through a tool_use/tool_result chain, the binary search settling below `userTurnStarts.length`, and `MIN_COMPACTABLE_PERSISTED_MESSAGES` blocking force on young conversations.
- Under force, `_maybeCompact` now restores the binary search's intended keep depth (capped at `length - 1`), bypasses `adjustForToolPairs`, strips orphan `tool_result` blocks via a new `stripOrphanToolResults` helper, and bypasses the MIN guard. The single-user-turn case still skips but with an honest reason.

## Original prompt

A user reported `/compact` getting silently ignored at ~67% context usage ("indicator was yellow and about 3/4 full"); the system reported "Context compaction skipped — conversation already fits within the compaction target" and auto-compaction triggered shortly after. The principle: when the user explicitly types `/compact`, we must never skip — always produce a real summarization or a deterministic, informative error. The fix targets three adjacent failure modes in \`assistant/src/context/window-manager.ts:511\` and \`:661\` that the existing projection-optimism clamp at line 904 does not cover.

## Test plan

- [x] \`cd assistant && bun test src/__tests__/context-window-manager.test.ts\` — 63 pass, including three new regression tests covering (a) \`adjustForToolPairs\` walking the boundary to summary, (b) below-MIN compactable count under force, (c) the existing projection-fits-but-real-usage-exceeds case.
- [x] \`cd assistant && bunx tsc --noEmit\` — clean.
- [ ] Manual: send \`/compact\` in the app with context in the 60–80% range and confirm a summary is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->