### PR TITLE
feat(macos): add Discord community nudge (settings card + chat banner)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -112,6 +112,11 @@ public enum AppURLs {
     /// literal is a known-valid absolute URL.
     public static let repositoryURL = URL(string: "https://github.com/vellum-ai/vellum-assistant")!
 
+    /// Discord community invite — linked from the Settings "Discord" card and
+    /// the in-chat Discord community banner. Force-unwrap is safe: the literal
+    /// is a known-valid absolute URL.
+    public static let discordInviteURL = URL(string: "https://discord.gg/ZABd9V2zM8")!
+
     // MARK: - Helpers
 
     /// Build a docs URL by appending a path to the (possibly env-overridden) base.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -114,6 +114,19 @@ struct ChatView: View {
     @State private var dragEndLocalMonitor: Any?
     @State private var dragEndGlobalMonitor: Any?
 
+    // MARK: - Discord Community Nudge
+    @Environment(\.openURL) private var openURL
+    @AppStorage(DiscordNudge.joinedKey) private var discordJoined: Bool = false
+    @AppStorage(DiscordNudge.bannerDismissedKey) private var discordBannerDismissed: Bool = false
+    @AppStorage(GitHubNudge.starredKey) private var githubStarred: Bool = false
+
+    private var shouldShowDiscordBanner: Bool {
+        !discordJoined
+            && !discordBannerDismissed
+            && githubStarred
+            && (conversationManager?.conversations.count ?? 0) >= 2
+    }
+
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
     @State private var searchQuery = ""
@@ -437,6 +450,22 @@ struct ChatView: View {
                         onResumeAssistant: { onResumeAssistant?() },
                         onOpenSSHSettings: { onOpenSSHSettings?() },
                         isExiting: isRecoveryModeExiting
+                    )
+                }
+                .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
+            }
+
+            if shouldShowDiscordBanner {
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    DiscordCommunityBanner(
+                        onJoin: {
+                            discordJoined = true
+                            openURL(AppURLs.discordInviteURL)
+                        },
+                        onDismiss: {
+                            discordBannerDismissed = true
+                        }
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -124,7 +124,7 @@ struct ChatView: View {
         !discordJoined
             && !discordBannerDismissed
             && githubStarred
-            && (conversationManager?.conversations.count ?? 0) >= 2
+            && (conversationManager?.listStore.hasMultipleConversations ?? false)
     }
 
     // MARK: - In-Chat Search (Cmd+F)

--- a/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
@@ -49,6 +49,7 @@ struct DiscordCommunityBanner: View {
                     .foregroundStyle(VColor.contentTertiary)
             }
             .buttonStyle(.plain)
+            .pointerCursor()
             .accessibilityLabel("Dismiss Discord banner")
         }
         .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Inline banner promoting the Vellum Discord community, rendered above the
+/// composer in ChatView. Follows the same visual pattern as
+/// `RecoveryModeBanner` and `MissingApiKeyBanner`: anchored at the bottom
+/// of the message list with a rounded-top card.
+///
+/// Shown when:
+/// - User has not joined Discord (`app.discordNudge.joined` is false)
+/// - User has not dismissed the banner (`app.discordNudge.bannerDismissed` is false)
+/// - User has starred the GitHub repo (GitHub nudge resolved)
+/// - User has at least 2 conversations
+struct DiscordCommunityBanner: View {
+    let onJoin: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                discordIcon
+                    .padding(.top, 1)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Join our community!")
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(VColor.contentEmphasized)
+
+                    Text("Talk to the team — share feedback, request features, get answers faster.")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+                .layoutPriority(1)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    onDismiss()
+                } label: {
+                    VIconView(.x, size: 14)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss Discord banner")
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(
+                    label: "Join Discord",
+                    style: .primary
+                ) {
+                    onJoin()
+                }
+                .accessibilityLabel("Join Discord community")
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceActive)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: VRadius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: VRadius.lg
+            )
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .accessibilityElement(children: .contain)
+    }
+
+    /// Discord logo loaded from the bundled integration assets.
+    /// Falls back to a generic message icon if the asset is unavailable.
+    private var discordIcon: some View {
+        Group {
+            if let nsImage = IntegrationLogoBundle.bundledImage(providerKey: "discord") {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 16, height: 16)
+            } else {
+                VIconView(.messagesSquare, size: 14)
+            }
+        }
+        .foregroundStyle(VColor.primaryBase)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DiscordCommunityBanner.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Inline banner promoting the Vellum Discord community, rendered above the
-/// composer in ChatView. Follows the same visual pattern as
-/// `RecoveryModeBanner` and `MissingApiKeyBanner`: anchored at the bottom
-/// of the message list with a rounded-top card.
+/// Compact inline banner promoting the Vellum Discord community, rendered
+/// above the composer in ChatView. Single-row layout: icon + text on the
+/// left, "Join Discord" button + dismiss on the right.
 ///
 /// Shown when:
 /// - User has not joined Discord (`app.discordNudge.joined` is false)
@@ -16,46 +15,44 @@ struct DiscordCommunityBanner: View {
     let onDismiss: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                discordIcon
-                    .padding(.top, 1)
-                    .accessibilityHidden(true)
+        HStack(spacing: VSpacing.sm) {
+            discordIcon
+                .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Join our community!")
-                        .font(VFont.bodySmallEmphasised)
-                        .foregroundStyle(VColor.contentEmphasized)
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Join our community!")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentEmphasized)
 
-                    Text("Talk to the team — share feedback, request features, get answers faster.")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                }
-                .layoutPriority(1)
-
-                Spacer(minLength: 0)
-
-                Button {
-                    onDismiss()
-                } label: {
-                    VIconView(.x, size: 14)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss Discord banner")
+                Text("Talk to the team — share feedback, request features, get answers faster")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
             }
+            .layoutPriority(1)
 
-            HStack(spacing: VSpacing.sm) {
-                VButton(
-                    label: "Join Discord",
-                    style: .primary
-                ) {
-                    onJoin()
-                }
-                .accessibilityLabel("Join Discord community")
+            Spacer(minLength: 0)
+
+            VButton(
+                label: "Join Discord",
+                style: .primary,
+                size: .compact
+            ) {
+                onJoin()
             }
+            .accessibilityLabel("Join Discord community")
+
+            Button {
+                onDismiss()
+            } label: {
+                VIconView(.x, size: 14)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss Discord banner")
         }
-        .padding(VSpacing.lg)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
         .background(VColor.surfaceActive)
         .clipShape(
             UnevenRoundedRectangle(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -240,6 +240,9 @@ final class ConversationListStore {
     /// True when at least one conversation exists.
     private(set) var hasAnyConversations: Bool = false
 
+    /// True when at least two conversations exist (Discord nudge threshold).
+    private(set) var hasMultipleConversations: Bool = false
+
     /// True when at least one non-archived conversation exists (sidebar loading gate).
     private(set) var hasAnyVisibleConversations: Bool = false
 
@@ -290,6 +293,7 @@ final class ConversationListStore {
             setIfChanged(\.visibleConversations, to: [])
             setIfChanged(\.unseenVisibleConversationCount, to: 0)
             setIfChanged(\.hasAnyConversations, to: false)
+            setIfChanged(\.hasMultipleConversations, to: false)
             setIfChanged(\.hasAnyVisibleConversations, to: false)
             setIfChanged(\.unseenScheduledCount, to: 0)
             setIfChanged(\.conversationsByLocalId, to: [:])
@@ -314,6 +318,7 @@ final class ConversationListStore {
         setIfChanged(\.unseenVisibleConversationCount, to: nextUnseenCount)
 
         setIfChanged(\.hasAnyConversations, to: true)
+        setIfChanged(\.hasMultipleConversations, to: conversations.count >= 2)
         setIfChanged(\.hasAnyVisibleConversations, to: !nextVisible.isEmpty)
 
         let nextScheduledUnseen = nextVisible.count {

--- a/clients/macos/vellum-assistant/Features/Settings/DiscordCommunitySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DiscordCommunitySettingsCard.swift
@@ -36,7 +36,7 @@ struct DiscordCommunitySettingsCard: View {
                 }
                 VButton(
                     label: "Join Discord",
-                    leftIcon: VIcon.messagesSquare.rawValue,
+                    leftIcon: VIcon.discord.rawValue,
                     style: .primary
                 ) {
                     joined = true

--- a/clients/macos/vellum-assistant/Features/Settings/DiscordCommunitySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DiscordCommunitySettingsCard.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// `@AppStorage` keys for the Discord community nudge. Persisted to
+/// `UserDefaults.standard`. The key names mirror the web app's
+/// `app.discordNudge.*` `localStorage` keys as a per-platform naming
+/// convention; the two stores are separate.
+enum DiscordNudge {
+    static let joinedKey = "app.discordNudge.joined"
+    static let bannerDismissedKey = "app.discordNudge.bannerDismissed"
+}
+
+/// Settings card promoting the Vellum Discord community. Always visible
+/// (no dismissal) — a permanent home for the community link in Settings,
+/// matching the `OpenSourceSettingsCard` pattern.
+struct DiscordCommunitySettingsCard: View {
+    @AppStorage(DiscordNudge.joinedKey) private var joined: Bool = false
+    @Environment(\.openURL) private var openURL
+
+    private static let benefits: [(icon: VIcon, text: String)] = [
+        (.messagesSquare, "Talk directly with the team"),
+        (.star, "Share feedback and request features"),
+        (.circleCheck, "Get answers faster from the community"),
+    ]
+
+    var body: some View {
+        SettingsCard(
+            title: "Join our community!",
+            subtitle: "Talk to the team — share feedback, request features, get answers faster."
+        ) {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    ForEach(Self.benefits, id: \.text) { benefit in
+                        DiscordBenefitRow(icon: benefit.icon, text: benefit.text)
+                    }
+                }
+                VButton(
+                    label: "Join Discord",
+                    leftIcon: VIcon.messagesSquare.rawValue,
+                    style: .primary
+                ) {
+                    joined = true
+                    openURL(AppURLs.discordInviteURL)
+                }
+            }
+        }
+    }
+}
+
+/// One row of a `DiscordCommunitySettingsCard` benefit list — icon swatch +
+/// description sentence. Mirrors the `BenefitRow` in `OpenSourceSettingsCard`.
+private struct DiscordBenefitRow: View {
+    let icon: VIcon
+    let text: String
+
+    var body: some View {
+        HStack(spacing: VSpacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(VColor.surfaceBase)
+                    .frame(width: 28, height: 28)
+                icon.image(size: 14)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            .accessibilityHidden(true)
+            Text(text)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -103,6 +103,7 @@ struct SettingsGeneralTab: View {
             }
             SettingsAppearanceTab(store: store)
             OpenSourceSettingsCard()
+            DiscordCommunitySettingsCard()
             if !lockfileAssistants.isEmpty {
                 retireAssistantSection
             }

--- a/clients/shared/DesignSystem/Tokens/IconTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/IconTokens.swift
@@ -243,6 +243,7 @@ public enum VIcon: String, CaseIterable, Sendable {
     case gitBranch = "lucide-git-branch"
     case gitPullRequest = "lucide-git-pull-request"
     case github = "lucide-github"
+    case discord = "simpleicons-discord"
     case compass = "lucide-compass"
     case house = "lucide-house"
     case zoomIn = "lucide-zoom-in"
@@ -258,9 +259,16 @@ public enum VIcon: String, CaseIterable, Sendable {
 
     // MARK: - Image Resolution
 
-    /// URL of the PDF file inside the resource bundle's `LucideIcons` directory.
+    /// URL of the PDF file inside the resource bundle. Lucide icons live in
+    /// `LucideIcons/`; brand icons prefixed with `simpleicons-` resolve from
+    /// `IntegrationLogos/` using the provider key (e.g. `simpleicons-discord`
+    /// → `IntegrationLogos/discord.pdf`).
     private var pdfURL: URL? {
-        Bundle.vellumShared.url(forResource: rawValue, withExtension: "pdf", subdirectory: "LucideIcons")
+        if rawValue.hasPrefix("simpleicons-") {
+            let providerKey = String(rawValue.dropFirst("simpleicons-".count))
+            return Bundle.vellumShared.url(forResource: providerKey, withExtension: "pdf", subdirectory: "IntegrationLogos")
+        }
+        return Bundle.vellumShared.url(forResource: rawValue, withExtension: "pdf", subdirectory: "LucideIcons")
     }
 
     /// SwiftUI `Image` resolved from the vendored PDF.


### PR DESCRIPTION
Adds a Discord community nudge to the macOS client with two surfaces: an always-visible settings card and a compact in-chat banner above the composer. The banner uses a single-row horizontal layout (icon + title/subtitle on the left, "Join Discord" button + dismiss on the right) matching the web app's design.

The banner is gated on: user hasn't joined, hasn't dismissed, GitHub repo is starred, and has ≥2 conversations. The conversation threshold uses a reactive cached scalar (`hasMultipleConversations`) on `ConversationListStore` to ensure SwiftUI observes changes correctly, since the `conversations` array is `@ObservationIgnored`.

**Note:** CI skips macOS builds — requires local Xcode verification.

## Prompt / plan
Implement Discord community nudge surfaces for macOS matching the web app's cascading nudge pattern. Settings card always visible; banner gated on prerequisites.

## Test plan
- CI passes (non-macOS checks)
- Local Xcode build verification required (CI has no macOS runner)
- Manual verification: banner appears after starring GitHub repo and having 2+ conversations, dismiss/join actions persist via @AppStorage

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e0e2e037d85c4af0a585b17a4fe1871f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->