### PR TITLE
fix(memory-retrospective): inherit state and dedup context across forks

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -45,6 +45,11 @@ import {
 } from "../memory/graph/graph-memory-state-store.js";
 import { getRequestLogsByMessageId } from "../memory/llm-request-log-store.js";
 import {
+  bumpRetrospectiveLastRunAt,
+  getRetrospectiveState,
+  upsertRetrospectiveState,
+} from "../memory/memory-retrospective-state.js";
+import {
   activationState,
   channelInboundEvents,
   conversationAssistantAttentionState,
@@ -53,6 +58,7 @@ import {
   externalConversationBindings,
   llmRequestLogs,
   memoryJobs,
+  memoryRetrospectiveState,
   toolInvocations,
 } from "../memory/schema.js";
 import { hydrate as hydrateActivationState } from "../memory/v2/activation-store.js";
@@ -66,6 +72,7 @@ function resetTables(): void {
   db.delete(conversationAssistantAttentionState).run();
   db.delete(activationState).run();
   db.delete(conversationGraphMemoryState).run();
+  db.delete(memoryRetrospectiveState).run();
   db.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   db.delete(memoryJobs).run();
@@ -601,5 +608,136 @@ describe("forkConversation", () => {
     const db = getDb();
     expect(await hydrateActivationState(db, fork.id)).toBeNull();
     expect(loadGraphMemoryState(fork.id)).toBeNull();
+  });
+});
+
+describe("forkConversation + memory_retrospective_state", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("does not seed state when the source has none", async () => {
+    const source = createConversation("Untouched thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(getRetrospectiveState(fork.id)).toBeNull();
+  });
+
+  test("maps the source pointer when it falls within the copied range", async () => {
+    const source = createConversation("In-range thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const processedMessage = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "user", "Message 3", undefined, {
+      skipIndexing: true,
+    });
+
+    upsertRetrospectiveState({
+      conversationId: source.id,
+      lastProcessedMessageId: processedMessage.id,
+      lastRunAt: 1_700_000_000_000,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkState = getRetrospectiveState(fork.id);
+    const forkMessages = getMessages(fork.id);
+    const mappedProcessedId = forkMessages.find((m) => {
+      const md = parseMetadata(m.metadata) as {
+        forkSourceMessageId?: string;
+      } | null;
+      return md?.forkSourceMessageId === processedMessage.id;
+    })?.id;
+
+    expect(mappedProcessedId).toBeDefined();
+    expect(forkState).not.toBeNull();
+    expect(forkState?.lastProcessedMessageId).toBe(mappedProcessedId);
+    expect(forkState?.lastRunAt).toBe(1_700_000_000_000);
+  });
+
+  test("clamps to the last copied message when the source pointer is past the fork boundary", async () => {
+    const source = createConversation("Past-boundary thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    const branchPoint = await addMessage(
+      source.id,
+      "assistant",
+      "Message 2",
+      undefined,
+      { skipIndexing: true },
+    );
+    const pastBoundaryMessage = await addMessage(
+      source.id,
+      "user",
+      "Message 3",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "assistant", "Message 4", undefined, {
+      skipIndexing: true,
+    });
+
+    upsertRetrospectiveState({
+      conversationId: source.id,
+      lastProcessedMessageId: pastBoundaryMessage.id,
+      lastRunAt: 1_700_000_000_000,
+    });
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: branchPoint.id,
+    });
+    const forkState = getRetrospectiveState(fork.id);
+    const forkMessages = getMessages(fork.id);
+    const lastForkedMessageId = forkMessages.at(-1)?.id;
+
+    expect(forkMessages).toHaveLength(2);
+    expect(forkState?.lastProcessedMessageId).toBe(lastForkedMessageId);
+    expect(forkState?.lastRunAt).toBe(1_700_000_000_000);
+  });
+
+  test("preserves the empty-string sentinel from a failure-only source", async () => {
+    const source = createConversation("Failure-only thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    bumpRetrospectiveLastRunAt(source.id, 1_700_000_000_000);
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkState = getRetrospectiveState(fork.id);
+
+    expect(forkState?.lastProcessedMessageId).toBe("");
+    expect(forkState?.lastRunAt).toBe(1_700_000_000_000);
+  });
+
+  test("copies lastRunAt so the cooldown gate inherits from the source", async () => {
+    const source = createConversation("Cooldown thread");
+    const message = await addMessage(
+      source.id,
+      "user",
+      "Message 1",
+      undefined,
+      { skipIndexing: true },
+    );
+    upsertRetrospectiveState({
+      conversationId: source.id,
+      lastProcessedMessageId: message.id,
+      lastRunAt: 1_700_000_000_000,
+    });
+
+    const fork = forkConversation({ conversationId: source.id });
+
+    expect(getRetrospectiveState(fork.id)?.lastRunAt).toBe(1_700_000_000_000);
   });
 });

--- a/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
+++ b/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createConversation,
+  findMostRecentRetrospectiveFor,
+} from "../conversation-crud.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { MEMORY_RETROSPECTIVE_SOURCE } from "../memory-retrospective-constants.js";
+import { conversations } from "../schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+}
+
+function setForkParent(conversationId: string, parentId: string): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ forkParentConversationId: parentId })
+    .where(eq(conversations.id, conversationId))
+    .run();
+}
+
+function setCreatedAt(conversationId: string, createdAt: number): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ createdAt })
+    .where(eq(conversations.id, conversationId))
+    .run();
+}
+
+function createRetro(parentId: string, createdAt: number): { id: string } {
+  const retro = createConversation({
+    title: "retro",
+    source: MEMORY_RETROSPECTIVE_SOURCE,
+  });
+  setForkParent(retro.id, parentId);
+  setCreatedAt(retro.id, createdAt);
+  return { id: retro.id };
+}
+
+describe("findMostRecentRetrospectiveFor", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("returns null when no retrospective exists anywhere in the fork chain", () => {
+    const conv = createConversation("conv");
+    expect(findMostRecentRetrospectiveFor(conv.id)).toBeNull();
+  });
+
+  test("returns a direct retrospective rooted at the conversation", () => {
+    const conv = createConversation("conv");
+    const retro = createRetro(conv.id, 1_000);
+
+    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({ id: retro.id });
+  });
+
+  test("returns the most recently created retrospective when multiple exist at the same level", () => {
+    const conv = createConversation("conv");
+    createRetro(conv.id, 1_000);
+    const newer = createRetro(conv.id, 2_000);
+    createRetro(conv.id, 500);
+
+    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({ id: newer.id });
+  });
+
+  test("walks up the fork chain when the current conversation has no retros", () => {
+    const parent = createConversation("parent");
+    const parentRetro = createRetro(parent.id, 1_000);
+
+    const fork = createConversation("fork");
+    setForkParent(fork.id, parent.id);
+
+    expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
+      id: parentRetro.id,
+    });
+  });
+
+  test("prefers the fork's own retros over the parent's", () => {
+    const parent = createConversation("parent");
+    createRetro(parent.id, 5_000);
+
+    const fork = createConversation("fork");
+    setForkParent(fork.id, parent.id);
+    const forkRetro = createRetro(fork.id, 1_000);
+
+    expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
+      id: forkRetro.id,
+    });
+  });
+
+  test("walks multiple levels (fork-of-fork) until it finds a retro", () => {
+    const grandparent = createConversation("grandparent");
+    const grandparentRetro = createRetro(grandparent.id, 1_000);
+
+    const parent = createConversation("parent");
+    setForkParent(parent.id, grandparent.id);
+
+    const fork = createConversation("fork");
+    setForkParent(fork.id, parent.id);
+
+    expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
+      id: grandparentRetro.id,
+    });
+  });
+
+  test("returns null when the entire fork chain has no retros", () => {
+    const grandparent = createConversation("grandparent");
+    const parent = createConversation("parent");
+    setForkParent(parent.id, grandparent.id);
+    const fork = createConversation("fork");
+    setForkParent(fork.id, parent.id);
+
+    expect(findMostRecentRetrospectiveFor(fork.id)).toBeNull();
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -49,6 +49,8 @@ import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { getDb, getSqliteFrom } from "./db-connection.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
+import { MEMORY_RETROSPECTIVE_SOURCE } from "./memory-retrospective-constants.js";
+import { forkRetrospectiveState } from "./memory-retrospective-state.js";
 import { rawExec, rawGet, rawRun } from "./raw-query.js";
 import {
   channelInboundEvents,
@@ -442,28 +444,51 @@ export function findAnalysisConversationFor(
  * `<already_remembered>` block — bounded source-of-truth for "what the
  * prior pass already saved" that scales as the source conversation grows.
  *
- * Returns `null` when no prior retrospective exists yet (first run).
+ * Walks up `forkParentConversationId` when no retrospective exists at the
+ * current level. This lets a forked conversation inherit dedup context from
+ * its source's most recent retro on the fork's *first* retrospective —
+ * otherwise the fork would re-save every fact the source already retro'd.
+ * Once the fork accumulates its own retros, those are found at the first
+ * iteration and we never walk up.
+ *
+ * Returns `null` when no prior retrospective exists anywhere in the fork
+ * chain (true first-run case).
  *
  * Hits `idx_conversations_fork_parent_conversation_id` for the
  * `forkParentConversationId` lookup.
  */
+const MAX_FORK_CHAIN_DEPTH = 16;
+
 export function findMostRecentRetrospectiveFor(
   parentConversationId: string,
 ): { id: string } | null {
   const db = getDb();
-  const row = db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.source, "memory-retrospective"),
-        eq(conversations.forkParentConversationId, parentConversationId),
-      ),
-    )
-    .orderBy(desc(conversations.createdAt))
-    .limit(1)
-    .get();
-  return row ? { id: row.id } : null;
+  let currentId: string | null = parentConversationId;
+  for (let depth = 0; depth < MAX_FORK_CHAIN_DEPTH && currentId; depth++) {
+    const row = db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.source, MEMORY_RETROSPECTIVE_SOURCE),
+          eq(conversations.forkParentConversationId, currentId),
+        ),
+      )
+      .orderBy(desc(conversations.createdAt))
+      .limit(1)
+      .get();
+    if (row) return { id: row.id };
+
+    const parent = db
+      .select({
+        forkParentConversationId: conversations.forkParentConversationId,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, currentId))
+      .get();
+    currentId = parent?.forkParentConversationId ?? null;
+  }
+  return null;
 }
 
 /**
@@ -705,6 +730,13 @@ export function forkConversation(params: {
     // in-context tracker the parent had at fork time.
     forkActivationState(db, sourceConversation.id, fc.id);
     forkGraphMemoryState(sourceConversation.id, fc.id);
+    forkRetrospectiveState({
+      database: db,
+      sourceConversationId: sourceConversation.id,
+      forkedConversationId: fc.id,
+      forkedMessageIds,
+      lastCopiedSourceMessageId: messagesToCopy.at(-1)?.id ?? null,
+    });
 
     return fc;
   });

--- a/assistant/src/memory/memory-retrospective-state.ts
+++ b/assistant/src/memory/memory-retrospective-state.ts
@@ -15,7 +15,7 @@
 
 import { eq } from "drizzle-orm";
 
-import { getDb } from "./db-connection.js";
+import { type DrizzleDb, getDb } from "./db-connection.js";
 import { memoryRetrospectiveState } from "./schema.js";
 
 export interface MemoryRetrospectiveState {
@@ -59,6 +59,78 @@ export function upsertRetrospectiveState(args: MemoryRetrospectiveState): void {
       set: {
         lastProcessedMessageId: args.lastProcessedMessageId,
         lastRunAt: args.lastRunAt,
+      },
+    })
+    .run();
+}
+
+/**
+ * Carry the source conversation's retrospective state into a forked child so
+ * the fork doesn't re-process content the parent already covered. Synchronous
+ * so it can run inside the bun:sqlite transaction wrapping `forkConversation`.
+ *
+ * Mapping for `lastProcessedMessageId`:
+ *
+ *   - source has no state row → no-op (child inherits "first run" semantics
+ *     and `findMostRecentRetrospectiveFor` walks the fork chain instead).
+ *   - source pointer is the `""` sentinel (failed-only attempts, never
+ *     succeeded) → child pointer is also `""`.
+ *   - source pointer is within the copied range (`forkedMessageIds` has it) →
+ *     child pointer is the mapped forked message ID.
+ *   - source pointer is past the fork boundary (not in `forkedMessageIds`) →
+ *     child pointer is the last copied message's mapped ID. All copied
+ *     messages have already been retro'd by the source, so the child should
+ *     wait for new post-fork messages before its first retro fires.
+ *
+ * `lastRunAt` is copied verbatim — the cooldown gate inherits from source.
+ */
+export function forkRetrospectiveState(args: {
+  database: DrizzleDb;
+  sourceConversationId: string;
+  forkedConversationId: string;
+  forkedMessageIds: Map<string, string>;
+  lastCopiedSourceMessageId: string | null;
+}): void {
+  const {
+    database,
+    sourceConversationId,
+    forkedConversationId,
+    forkedMessageIds,
+    lastCopiedSourceMessageId,
+  } = args;
+
+  const sourceRow = database
+    .select()
+    .from(memoryRetrospectiveState)
+    .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
+    .get();
+  if (!sourceRow) return;
+
+  let forkedPointer = "";
+  if (sourceRow.lastProcessedMessageId !== "") {
+    const mapped = forkedMessageIds.get(sourceRow.lastProcessedMessageId);
+    if (mapped !== undefined) {
+      forkedPointer = mapped;
+    } else if (lastCopiedSourceMessageId !== null) {
+      // Source pointer is past the fork boundary — everything copied has
+      // already been processed by the source, so clamp to the last copied
+      // message so the fork waits for new post-fork messages.
+      forkedPointer = forkedMessageIds.get(lastCopiedSourceMessageId) ?? "";
+    }
+  }
+
+  database
+    .insert(memoryRetrospectiveState)
+    .values({
+      conversationId: forkedConversationId,
+      lastProcessedMessageId: forkedPointer,
+      lastRunAt: sourceRow.lastRunAt,
+    })
+    .onConflictDoUpdate({
+      target: memoryRetrospectiveState.conversationId,
+      set: {
+        lastProcessedMessageId: forkedPointer,
+        lastRunAt: sourceRow.lastRunAt,
       },
     })
     .run();


### PR DESCRIPTION
## Summary

- Forked conversations now inherit \`memory_retrospective_state\` from their source so the fork's first retrospective doesn't re-process the entire copied transcript.
- \`findMostRecentRetrospectiveFor\` walks up the fork chain via \`forkParentConversationId\`, so a fork's first retro sees the source's most recent retro in \`<already_remembered>\` instead of starting with an empty dedup context (which was causing duplicate \`remember\` calls).

## Original prompt

User asked whether retrospective triggers reset cross-trigger (they do — the message-count is derived from \`lastProcessedMessageId\`). Follow-up question: \"what happens in forked conversations?\" Investigation found that \`POST /v1/conversations/fork\` produces a child A' with a fresh ID and no state row, so A''s first retro re-processes everything; and \`findMostRecentRetrospectiveFor\` couldn't reach retros rooted at A, leaving \`<already_remembered>\` empty and producing duplicate \`remember\` calls. Two orthogonal fixes: copy state at fork time + walk the fork chain on the dedup lookup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->