### PR TITLE
fix: clear domain restrictions when saving Vercel API token

### DIFF
--- a/assistant/src/daemon/handlers/config-vercel.ts
+++ b/assistant/src/daemon/handlers/config-vercel.ts
@@ -60,6 +60,7 @@ export async function setVercelConfig(
 
   upsertCredentialMetadata("vercel", "api_token", {
     allowedTools: ["deploy", "publish_page", "bash"],
+    allowedDomains: [],
     injectionTemplates: [
       {
         hostPattern: "api.vercel.com",


### PR DESCRIPTION
## Summary
- `setVercelConfig` didn't pass `allowedDomains` to `upsertCredentialMetadata`, so domain restrictions from a previous credential store save (e.g. `["vercel.com", "api.vercel.com"]`) persisted across re-saves
- The broker rejects server-side credential usage when `allowedDomains` is non-empty, blocking `publish_page` with: "has domain restrictions and cannot be used server-side"
- Fix: explicitly pass `allowedDomains: []` to clear stale domain restrictions when saving via the config endpoint

## Context
Companion PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/6541

## Test plan
- [ ] Store a Vercel token via the assistant credential store with domain restrictions, then re-save via the config endpoint — verify domain restrictions are cleared
- [ ] Deploy an app to Vercel after re-saving — verify the publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->