### PR TITLE
refactor: extract `resolveSlackToken` from share.ts into shared slack helpers

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -235,6 +235,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/avatar-routes.ts", // avatar generate route reads platform_base_url from credential store
       "cli/commands/keys.ts", // CLI provider key management
       "cli/commands/oauth/connect.ts", // CLI OAuth connect stored-secret verification
+      "runtime/routes/integrations/slack/token.ts", // shared Slack token resolver (bot/user token lookup for CLI use routes)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -12,9 +12,6 @@ import {
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
-import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
-import { credentialKey } from "../../../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import {
   BadRequestError,
@@ -23,49 +20,9 @@ import {
   ServiceUnavailableError,
 } from "../../errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
+import { resolveSlackToken } from "./token.js";
 
 const log = getLogger("slack-share");
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve a Slack token for the Share UI, mirroring the read/write auth split
- * in `messaging/providers/slack/adapter.ts`.
- *
- * For Socket Mode installs (tokens stored under `credential/slack_channel/*`),
- * prefer the user OAuth token (xoxp-) for reads when present — this lets the
- * channel picker surface channels the user belongs to but the bot doesn't.
- * Fall back to the bot token (xoxb-) otherwise.
- *
- * Writes MUST always use the bot token so posted messages come from the bot
- * identity, never the user. Passing `user_token` to chat.postMessage would
- * post as the user — unambiguously wrong for Share UI behavior.
- *
- * For legacy OAuth installs (no Socket Mode tokens), fall back to the OAuth
- * connection's access_token, which is the bot token in Slack's OAuth v2 flow.
- */
-async function resolveSlackToken(
-  mode: "read" | "write",
-): Promise<string | undefined> {
-  const botToken = await getSecureKeyAsync(
-    credentialKey("slack_channel", "bot_token"),
-  );
-  if (botToken) {
-    if (mode === "read") {
-      const userToken = await getSecureKeyAsync(
-        credentialKey("slack_channel", "user_token"),
-      );
-      return userToken ?? botToken;
-    }
-    return botToken;
-  }
-
-  const conn = getConnectionByProvider("slack");
-  if (!conn) return undefined;
-  return await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
-}
 
 // ---------------------------------------------------------------------------
 // GET /v1/slack/channels
@@ -179,15 +136,11 @@ export async function handleShareToSlackChannel({
   };
 
   if (!appId || !channelId) {
-    throw new BadRequestError(
-      "Missing required fields: appId, channelId",
-    );
+    throw new BadRequestError("Missing required fields: appId, channelId");
   }
 
   if (typeof appId !== "string" || typeof channelId !== "string") {
-    throw new BadRequestError(
-      "Fields appId and channelId must be strings",
-    );
+    throw new BadRequestError("Fields appId and channelId must be strings");
   }
 
   if (message !== undefined && typeof message !== "string") {
@@ -245,8 +198,7 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "slack/channels",
     method: "GET",
     summary: "List Slack channels",
-    description:
-      "List Slack channels, groups, and DMs for the channel picker.",
+    description: "List Slack channels, groups, and DMs for the channel picker.",
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: () => handleListSlackChannels(),

--- a/assistant/src/runtime/routes/integrations/slack/token.ts
+++ b/assistant/src/runtime/routes/integrations/slack/token.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared Slack token resolution.
+ *
+ * Extracted from share.ts so that multiple route modules (share, use-slack)
+ * can reuse the same auth logic.
+ */
+
+import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
+import { credentialKey } from "../../../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+
+/**
+ * Resolve a Slack token for the Share UI, mirroring the read/write auth split
+ * in `messaging/providers/slack/adapter.ts`.
+ *
+ * For Socket Mode installs (tokens stored under `credential/slack_channel/*`),
+ * prefer the user OAuth token (xoxp-) for reads when present — this lets the
+ * channel picker surface channels the user belongs to but the bot doesn't.
+ * Fall back to the bot token (xoxb-) otherwise.
+ *
+ * Writes MUST always use the bot token so posted messages come from the bot
+ * identity, never the user. Passing `user_token` to chat.postMessage would
+ * post as the user — unambiguously wrong for Share UI behavior.
+ *
+ * For legacy OAuth installs (no Socket Mode tokens), fall back to the OAuth
+ * connection's access_token, which is the bot token in Slack's OAuth v2 flow.
+ */
+export async function resolveSlackToken(
+  mode: "read" | "write",
+): Promise<string | undefined> {
+  const botToken = await getSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  if (botToken) {
+    if (mode === "read") {
+      const userToken = await getSecureKeyAsync(
+        credentialKey("slack_channel", "user_token"),
+      );
+      return userToken ?? botToken;
+    }
+    return botToken;
+  }
+
+  const conn = getConnectionByProvider("slack");
+  if (!conn) return undefined;
+  return await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
+}


### PR DESCRIPTION
## Summary
- Create `token.ts` with the shared `resolveSlackToken(mode)` function
- Update `share.ts` to import from the new module instead of defining locally
- No behavior change — pure extraction for reuse by upcoming `use slack` routes

Part of plan: use-slack-cli.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->