### PR TITLE
refactor(daemon): delete dead setModel surfaces

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -10793,30 +10793,6 @@ paths:
       responses:
         "200":
           description: Successful response
-    put:
-      operationId: model_put
-      summary: Set LLM model
-      description: Change the active LLM model and optionally its provider.
-      tags:
-        - config
-      responses:
-        "200":
-          description: Successful response
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                modelId:
-                  type: string
-                provider:
-                  type: string
-                  description: Optional provider override
-              required:
-                - modelId
-              additionalProperties: false
   /v1/model/image-gen:
     put:
       operationId: model_imagegen_put

--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -1,32 +1,4 @@
 /**
- * Safely set a nested field on a raw config object's `llm.default` map.
- *
- * Ensures the `llm` and `llm.default` objects exist before writing, so
- * callers don't need to guard against undefined intermediate keys.
- *
- * Example: `setLlmDefaultField(raw, "model", "claude-sonnet-4-6")`
- * produces `raw.llm.default.model = "claude-sonnet-4-6"`.
- */
-export function setLlmDefaultField(
-  raw: Record<string, unknown>,
-  field: string,
-  value: unknown,
-): void {
-  const llm: Record<string, unknown> =
-    raw.llm != null && typeof raw.llm === "object" && !Array.isArray(raw.llm)
-      ? (raw.llm as Record<string, unknown>)
-      : {};
-  const existing = llm.default;
-  const defaultBlock: Record<string, unknown> =
-    existing != null && typeof existing === "object" && !Array.isArray(existing)
-      ? (existing as Record<string, unknown>)
-      : {};
-  defaultBlock[field] = value;
-  llm.default = defaultBlock;
-  raw.llm = llm;
-}
-
-/**
  * Safely set a nested field on a raw config object's `services` map.
  *
  * Ensures the `services` and service-level objects exist before writing,

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -4,35 +4,12 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import {
-  setLlmDefaultField,
-  setServiceField,
-} from "../../config/raw-config-utils.js";
-import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
+import { setServiceField } from "../../config/raw-config-utils.js";
 import { providerForImageModelPrefix } from "../../media/types.js";
 import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
-import {
-  isModelInCatalog,
-  PROVIDER_CATALOG,
-} from "../../providers/model-catalog.js";
-import { getProviderDefaultModel } from "../../providers/model-intents.js";
-import {
-  getConfiguredProviders,
-  isProviderAvailable,
-} from "../../providers/provider-availability.js";
-import { initializeProviders } from "../../providers/registry.js";
-import {
-  conversationEntries,
-  deleteConversation,
-} from "../conversation-store.js";
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { getConfiguredProviders } from "../../providers/provider-availability.js";
 import { CONFIG_RELOAD_DEBOUNCE_MS, log } from "./shared.js";
-
-/** Reverse lookup: model ID → provider, derived from PROVIDER_CATALOG. */
-const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
-  PROVIDER_CATALOG.flatMap((provider) =>
-    provider.models.map(({ id }) => [id, provider.id]),
-  ),
-);
 
 // ---------------------------------------------------------------------------
 // Shared business logic (transport-agnostic)
@@ -101,7 +78,7 @@ export async function getModelInfo(): Promise<ModelInfo> {
 }
 
 /**
- * Minimal interface for the side-effects needed by setModel / setImageGenModel.
+ * Minimal interface for the side-effects needed by setImageGenModel.
  * Keeps the business logic decoupled from transport-specific server context.
  */
 export interface ModelSetContext {
@@ -109,104 +86,6 @@ export interface ModelSetContext {
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
   debounceTimers: { schedule(key: string, fn: () => void, ms: number): void };
-}
-
-/**
- * Set the active model. Returns the resulting ModelInfo, or throws on failure.
- * The caller is responsible for sending the response to the client.
- *
- * When `explicitProvider` is supplied, it takes precedence over automatic
- * provider inference from the model ID. If the provider changes and the
- * current model doesn't belong to the new provider's catalog, the model
- * is auto-reset to the provider's default.
- */
-export async function setModel(
-  modelId: string,
-  ctx: ModelSetContext,
-  explicitProvider?: string,
-): Promise<ModelInfo> {
-  const validProviders = new Set<string>(VALID_INFERENCE_PROVIDERS);
-
-  // Validate explicit provider against allowlist
-  if (explicitProvider && !validProviders.has(explicitProvider)) {
-    throw new Error(
-      `Invalid provider "${explicitProvider}". Valid providers: ${[...validProviders].join(", ")}`,
-    );
-  }
-
-  // Resolve provider: explicit > MODEL_TO_PROVIDER lookup > current
-  const current = getConfig();
-  const resolvedCurrent = resolveCallSiteConfig("mainAgent", current.llm);
-  const resolvedProvider =
-    explicitProvider ??
-    MODEL_TO_PROVIDER[modelId] ??
-    resolvedCurrent.provider;
-
-  // Auto-reset model when provider changes and current modelId doesn't
-  // belong to the new provider's catalog.
-  if (
-    resolvedProvider !== resolvedCurrent.provider &&
-    !isModelInCatalog(resolvedProvider, modelId)
-  ) {
-    modelId = getProviderDefaultModel(resolvedProvider);
-  }
-
-  // No-op guard: skip expensive reinitialization when nothing changed
-  if (
-    modelId === resolvedCurrent.model &&
-    resolvedProvider === resolvedCurrent.provider
-  ) {
-    return await getModelInfo();
-  }
-
-  // Validate provider availability (secure key, env var, or managed proxy) before switching
-  if (!(await isProviderAvailable(resolvedProvider))) {
-    // Return current model_info so the client resyncs its optimistic state
-    return await getModelInfo();
-  }
-
-  // Use raw config to avoid persisting env-var API keys to disk
-  const raw = loadRawConfig();
-  setLlmDefaultField(raw, "model", modelId);
-  setLlmDefaultField(raw, "provider", resolvedProvider);
-
-  // Suppress the file watcher callback — setModel already does
-  // the full reload sequence; a redundant watcher-triggered reload
-  // would incorrectly evict sessions created after this method returns.
-  const wasSuppressed = ctx.suppressConfigReload;
-  ctx.setSuppressConfigReload(true);
-  try {
-    saveRawConfig(raw);
-  } catch (err) {
-    ctx.setSuppressConfigReload(wasSuppressed);
-    throw err;
-  }
-  ctx.debounceTimers.schedule(
-    "__suppress_reset__",
-    () => {
-      ctx.setSuppressConfigReload(false);
-    },
-    CONFIG_RELOAD_DEBOUNCE_MS,
-  );
-
-  // Re-initialize provider with the new model so LLM calls use it
-  const config = getConfig();
-  await initializeProviders(config);
-
-  // Evict idle conversations immediately; mark busy ones as stale so they
-  // get recreated with the new provider once they finish processing.
-  for (const [id, conversation] of conversationEntries()) {
-    if (!conversation.isProcessing()) {
-      conversation.dispose();
-      deleteConversation(id);
-    } else {
-      conversation.markStale();
-    }
-  }
-
-  ctx.updateConfigFingerprint();
-
-  return await getModelInfo();
 }
 
 /**

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -138,12 +138,6 @@ export interface ModelGetRequest {
   type: "model_get";
 }
 
-export interface ModelSetRequest {
-  type: "model_set";
-  model: string;
-  provider?: string;
-}
-
 export interface ImageGenModelSetRequest {
   type: "image_gen_model_set";
   model: string;
@@ -607,7 +601,6 @@ export type _ConversationsClientMessages =
   | CancelRequest
   | DeleteQueuedMessage
   | ModelGetRequest
-  | ModelSetRequest
   | ImageGenModelSetRequest
   | UndoRequest
   | UsageRequest

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -4,7 +4,6 @@
  * context inspection, and queued message deletion.
  *
  * GET    /v1/model                      — current model info
- * PUT    /v1/model                      — set model
  * PUT    /v1/model/image-gen            — set image-gen model
  * GET    /v1/config/embeddings          — current embedding config
  * PUT    /v1/config/embeddings          — set embedding provider/model
@@ -34,7 +33,6 @@ import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
 import { ProfileEntry } from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
-import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
 import {
   getEmbeddingConfigInfo,
@@ -44,7 +42,6 @@ import {
   getModelInfo,
   type ModelSetContext,
   setImageGenModel,
-  setModel,
 } from "../../daemon/handlers/config-model.js";
 import {
   getMessageContent,
@@ -75,7 +72,6 @@ import {
 } from "./llm-context-normalization.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
 const validEmbeddingProviderSet = new Set<string>(
   VALID_MEMORY_EMBEDDING_PROVIDERS,
 );
@@ -245,33 +241,6 @@ function getModelSetContext(): ModelSetContext {
 
 async function handleGetModel() {
   return getModelInfo();
-}
-
-async function handleSetModel({ body }: RouteHandlerArgs) {
-  if (!body || typeof body !== "object") {
-    throw new BadRequestError("Request body is required");
-  }
-  const { modelId, provider } = body as {
-    modelId?: string;
-    provider?: string;
-  };
-  if (!modelId || typeof modelId !== "string") {
-    throw new BadRequestError("Missing required field: modelId");
-  }
-  if (
-    provider !== undefined &&
-    (typeof provider !== "string" || !validProviderSet.has(provider))
-  ) {
-    throw new BadRequestError(
-      `Invalid provider "${provider}". Valid providers: ${[...validProviderSet].join(", ")}`,
-    );
-  }
-  try {
-    return await setModel(modelId, getModelSetContext(), provider);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new InternalError(`Failed to set model: ${message}`);
-  }
 }
 
 async function handleSetImageGenModel({ body }: RouteHandlerArgs) {
@@ -481,7 +450,7 @@ async function commitConfigWrite(
   // second time - starting with providers.clear() which races with the
   // explicit reinit below. The watcher also fires onConversationEvict(),
   // which would evict all cached conversations on every write. Mirror the
-  // suppress/reset pattern used in setModel (config-model.ts).
+  // suppress/reset pattern used in setImageGenModel (config-model.ts).
   const configWatcher = getConfigWatcher();
   const wasSuppressed = configWatcher.suppressConfigReload;
   configWatcher.suppressConfigReload = true;
@@ -891,20 +860,6 @@ export const ROUTES: RouteDefinition[] = [
       "Return the active LLM model ID, provider, and available models.",
     tags: ["config"],
     handler: handleGetModel,
-  },
-  {
-    operationId: "model_set",
-    endpoint: "model",
-    method: "PUT",
-    policyKey: "model",
-    summary: "Set LLM model",
-    description: "Change the active LLM model and optionally its provider.",
-    tags: ["config"],
-    requestBody: z.object({
-      modelId: z.string(),
-      provider: z.string().describe("Optional provider override").optional(),
-    }),
-    handler: handleSetModel,
   },
   {
     operationId: "model_image_gen_set",

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -121,10 +121,6 @@ final class MockSettingsClient: SettingsClientProtocol {
         return modelInfoResponse
     }
 
-    func setModel(model: String, provider: String? = nil) async -> ModelInfoMessage? {
-        nil
-    }
-
     func setImageGenModel(modelId: String) async -> ModelInfoMessage? {
         setImageGenModelCalls.append(modelId)
         return setImageGenModelResponse

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1550,29 +1550,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         bootstrapConversation(userMessage: nil, attachments: nil)
     }
 
-    // MARK: - Model
-
-    /// Switch the active model via the gateway.
-    public func setModel(_ modelId: String) {
-        // Ensure the message loop is running so we receive downstream events.
-        // VMs restored with an existing conversationId may not have started it yet.
-        if messageLoopTask == nil {
-            startMessageLoop()
-        }
-        Task {
-            let info = await SettingsClient().setModel(model: modelId)
-            if let model = info?.model {
-                self.selectedModel = model
-            }
-            if let providers = info?.configuredProviders {
-                self.configuredProviders = Set(providers)
-            }
-            if let allProviders = info?.allProviders, !allProviders.isEmpty {
-                self.providerCatalog = allProviders
-            }
-        }
-    }
-
     // MARK: - Actions
 
     public func sendSurfaceAction(surfaceId: String, actionId: String, data: [String: AnyCodable]? = nil) {

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2860,18 +2860,6 @@ public struct ModelInfo: Codable, Sendable {
     }
 }
 
-public struct ModelSetRequest: Codable, Sendable {
-    public let type: String
-    public let model: String
-    public let provider: String?
-
-    public init(type: String, model: String, provider: String? = nil) {
-        self.type = type
-        self.model = model
-        self.provider = provider
-    }
-}
-
 public struct NavigateSettings: Codable, Sendable {
     public let type: String
     public let tab: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2636,16 +2636,6 @@ extension ModelGetRequest {
     }
 }
 
-/// Set the active model.
-/// Backed by generated `ModelSetRequest`.
-public typealias ModelSetRequestMessage = ModelSetRequest
-
-extension ModelSetRequest {
-    public init(model: String) {
-        self.init(type: "model_set", model: model)
-    }
-}
-
 /// Set the active image generation model.
 /// Backed by generated `ImageGenModelSetRequest`.
 public typealias ImageGenModelSetRequestMessage = ImageGenModelSetRequest

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -12,7 +12,6 @@ public protocol SettingsClientProtocol {
     func saveVercelConfig(apiToken: String) async -> VercelApiConfigResponseMessage?
     func deleteVercelConfig() async -> VercelApiConfigResponseMessage?
     func fetchModelInfo() async -> ModelInfoMessage?
-    func setModel(model: String, provider: String?) async -> ModelInfoMessage?
     func setImageGenModel(modelId: String) async -> ModelInfoMessage?
     func fetchEmbeddingConfig() async -> EmbeddingConfigMessage?
     func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage?
@@ -126,25 +125,6 @@ public struct SettingsClient: SettingsClientProtocol {
             return try JSONDecoder().decode(ModelInfoMessage.self, from: patched)
         } catch {
             log.error("fetchModelInfo error: \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
-    }
-
-    public func setModel(model: String, provider: String? = nil) async -> ModelInfoMessage? {
-        do {
-            var body: [String: Any] = ["modelId": model]
-            if let provider { body["provider"] = provider }
-            let response = try await GatewayHTTPClient.put(
-                path: "model", json: body, timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("setModel failed (HTTP \(response.statusCode))")
-                return nil
-            }
-            let patched = injectType("model_info", into: response.data)
-            return try JSONDecoder().decode(ModelInfoMessage.self, from: patched)
-        } catch {
-            log.error("setModel error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -17,8 +17,6 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
             return modelInfoResponse
         }
 
-        func setModel(model: String, provider: String?) async -> ModelInfoMessage? { nil }
-
         func setImageGenModel(modelId: String) async -> ModelInfoMessage? { nil }
 
         func fetchEmbeddingConfig() async -> EmbeddingConfigMessage? { nil }


### PR DESCRIPTION
## Summary

The model picker was retired from both macOS and web UIs during the inference-providers iter1/2/3 cascade (May 11). The `setModel` daemon handler and its companion surfaces had **zero live callers**: the Swift `ChatViewModel.setModel(_:)` was orphaned (never invoked from any UI), the macOS `InferenceServiceCard` now exposes a Default Profile picker instead of a model picker, and the web `ModelsServicesPage` never called `PUT /v1/model` at all.

## Removed

| Surface | File |
|---|---|
| `setModel()` handler + dead imports + `MODEL_TO_PROVIDER` const | `assistant/src/daemon/handlers/config-model.ts` |
| `handleSetModel` + `PUT /v1/model` route | `assistant/src/runtime/routes/conversation-query-routes.ts` |
| `ModelSetRequest` IPC type | `assistant/src/daemon/message-types/conversations.ts` |
| Swift `SettingsClient.setModel` (protocol + impl) | `clients/shared/Network/SettingsClient.swift` |
| Orphan `ChatViewModel.setModel(_:)` | `clients/shared/Features/Chat/ChatViewModel.swift` |
| Generated `ModelSetRequest` struct | `clients/shared/Network/Generated/GeneratedAPITypes.swift` |
| `ModelSetRequestMessage` typealias | `clients/shared/Network/MessageTypes.swift` |
| Two test mock stubs | `MockSettingsClient`, `ChatViewModelSlashCommandTests` |

## Kept (still live)

- `getModelInfo` / `GET /v1/model` — populates current-model display
- `setImageGenModel` / `PUT /v1/model/image-gen` — separate image-gen path
- `/model` chat-slash classifier deprecation message — retained as a breadcrumb until the slash command is resurrected as a profile switcher (follow-up)

## Verification

- `tsc --noEmit` clean
- `bun run generate:openapi` rerun; OpenAPI spec drops 24 lines (the `put` block under `/v1/model`)
- Route tests (48), slash-command tests, config-model-image-provider tests, config-set-route, managed-profile-guard — all pass in isolation
- Pre-existing bun global-state bleed causes 4 failures only in combined runs; each file passes alone. Not introduced by this PR.

## Stats

10 files, -273 lines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->