### PR TITLE
feat: add Slack channel cache and resolution daemon routes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15430,6 +15430,58 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+  /v1/use/slack/channels:
+    get:
+      operationId: use_slack_channels_get
+      summary: List cached Slack channels
+      description: Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/channels/{name}:
+    get:
+      operationId: use_slack_channels_by_name_get
+      summary: Resolve a Slack channel by name
+      description: Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/use/slack/channels/refresh:
+    post:
+      operationId: use_slack_channels_refresh_post
+      summary: Refresh Slack channel cache
+      description: Fetch all channels from the Slack API, rebuild the local cache, and return it.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/users/{query}:
+    get:
+      operationId: use_slack_users_by_query_get
+      summary: Resolve a Slack user by name or email
+      description: Resolve a display name or email address to a Slack user via the local cache.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: query
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/user-routes/inspect:
     post:
       operationId: userroutes_inspect_post

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -73,6 +73,7 @@ import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-prov
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as SLACK_CHANNEL_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
+import { ROUTES as SLACK_USE_ROUTES } from "./integrations/slack/use-slack-routes.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
 import { ROUTES as VERCEL_ROUTES } from "./integrations/vercel.js";
@@ -219,6 +220,7 @@ export const ROUTES: RouteDefinition[] = [
   ...SKILL_ROUTES,
   ...SLACK_CHANNEL_ROUTES,
   ...SLACK_SHARE_ROUTES,
+  ...SLACK_USE_ROUTES,
   ...STT_ROUTES,
   ...SUGGEST_TRUST_RULE_ROUTES,
   ...SUBAGENT_ROUTES,

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
@@ -1,0 +1,249 @@
+/**
+ * Slack channel and user cache for the `use slack` CLI.
+ *
+ * Caches are persisted as JSON files under `<dataDir>/slack-use/` so that
+ * channel/user resolution avoids redundant Slack API calls. The cache is
+ * rebuilt on demand (first miss or explicit refresh).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  listConversations,
+  listUsers,
+} from "../../../../messaging/providers/slack/client.js";
+import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { getDataDir } from "../../../../util/platform.js";
+import { NotFoundError } from "../../errors.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SlackChannelCache {
+  workspace: string;
+  refreshedAt: string;
+  channels: Record<string, { id: string; type: string }>;
+}
+
+export interface SlackUserCache {
+  workspace: string;
+  refreshedAt: string;
+  users: Record<string, { id: string; email?: string; displayName?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function channelCachePath(): string {
+  return join(getDataDir(), "slack-use", "channels.json");
+}
+
+function userCachePath(): string {
+  return join(getDataDir(), "slack-use", "users.json");
+}
+
+// ---------------------------------------------------------------------------
+// Channel cache I/O
+// ---------------------------------------------------------------------------
+
+export function loadChannelCache(): SlackChannelCache | undefined {
+  const p = channelCachePath();
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as SlackChannelCache;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveChannelCache(cache: SlackChannelCache): void {
+  const p = channelCachePath();
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(p, JSON.stringify(cache, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// User cache I/O
+// ---------------------------------------------------------------------------
+
+export function loadUserCache(): SlackUserCache | undefined {
+  const p = userCachePath();
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as SlackUserCache;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveUserCache(cache: SlackUserCache): void {
+  const p = userCachePath();
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(p, JSON.stringify(cache, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Channel resolution
+// ---------------------------------------------------------------------------
+
+function classifyConversation(conv: SlackConversation): string {
+  if (conv.is_im) return "dm";
+  if (conv.is_mpim) return "group";
+  if (conv.is_group) return "group";
+  return "channel";
+}
+
+/**
+ * Fetch all channels from the Slack API (paginating), rebuild the channel
+ * cache, persist it, and return it.
+ */
+export async function refreshChannelCache(
+  token: string,
+): Promise<SlackChannelCache> {
+  const channels: Record<string, { id: string; type: string }> = {};
+  let cursor: string | undefined;
+  do {
+    const resp = await listConversations(
+      token,
+      "public_channel,private_channel,mpim,im",
+      true,
+      200,
+      cursor,
+    );
+    for (const ch of resp.channels) {
+      const name = ch.name ?? ch.id;
+      channels[name] = {
+        id: ch.id,
+        type: classifyConversation(ch),
+      };
+    }
+    cursor = resp.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  const cache: SlackChannelCache = {
+    workspace: "default",
+    refreshedAt: new Date().toISOString(),
+    channels,
+  };
+  saveChannelCache(cache);
+  return cache;
+}
+
+/**
+ * Resolve a channel name or ID to a Slack channel ID.
+ *
+ * - If the input looks like a Slack channel ID (`C[A-Z0-9]+`), return it
+ *   directly without any API calls.
+ * - Otherwise check the local cache. On miss, refresh the cache from the
+ *   Slack API and try again.
+ * - Throws `NotFoundError` if the channel is not found after refresh.
+ */
+export async function resolveChannelId(
+  token: string,
+  nameOrId: string,
+): Promise<string> {
+  // Direct ID pass-through
+  if (/^C[A-Z0-9]+$/.test(nameOrId)) {
+    return nameOrId;
+  }
+
+  // Try cache first
+  let cache = loadChannelCache();
+  if (cache) {
+    const entry = cache.channels[nameOrId];
+    if (entry) return entry.id;
+  }
+
+  // Cache miss — refresh and retry
+  cache = await refreshChannelCache(token);
+  const entry = cache.channels[nameOrId];
+  if (entry) return entry.id;
+
+  throw new NotFoundError(`Slack channel not found: ${nameOrId}`);
+}
+
+// ---------------------------------------------------------------------------
+// User resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch all users from the Slack API (paginating), rebuild the user cache,
+ * persist it, and return it.
+ */
+export async function refreshUserCache(token: string): Promise<SlackUserCache> {
+  const users: Record<
+    string,
+    { id: string; email?: string; displayName?: string }
+  > = {};
+  let cursor: string | undefined;
+  do {
+    const resp = await listUsers(token, 200, cursor);
+    for (const member of resp.members) {
+      if (member.deleted) continue;
+
+      const displayName =
+        member.profile?.display_name ||
+        member.profile?.real_name ||
+        member.real_name ||
+        member.name;
+      const email = member.profile?.email;
+
+      // Key by display name (lowercased for case-insensitive lookup)
+      users[displayName.toLowerCase()] = {
+        id: member.id,
+        email,
+        displayName,
+      };
+
+      // Also key by email if available
+      if (email) {
+        users[email.toLowerCase()] = {
+          id: member.id,
+          email,
+          displayName,
+        };
+      }
+    }
+    cursor = resp.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  const cache: SlackUserCache = {
+    workspace: "default",
+    refreshedAt: new Date().toISOString(),
+    users,
+  };
+  saveUserCache(cache);
+  return cache;
+}
+
+/**
+ * Resolve a user by display name or email to a Slack user ID.
+ *
+ * Checks the local cache first (case-insensitive). On miss, refreshes the
+ * cache from the Slack API and retries. Throws `NotFoundError` if no match.
+ */
+export async function resolveUserId(
+  token: string,
+  nameOrEmail: string,
+): Promise<{ id: string; email?: string; displayName?: string }> {
+  const key = nameOrEmail.toLowerCase();
+
+  // Try cache first
+  let cache = loadUserCache();
+  if (cache) {
+    const entry = cache.users[key];
+    if (entry) return entry;
+  }
+
+  // Cache miss — refresh and retry
+  cache = await refreshUserCache(token);
+  const entry = cache.users[key];
+  if (entry) return entry;
+
+  throw new NotFoundError(`Slack user not found: ${nameOrEmail}`);
+}

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -1,0 +1,142 @@
+/**
+ * Route handlers for the `use slack` CLI.
+ *
+ * These endpoints expose channel/user resolution and cache management
+ * over the daemon IPC/HTTP interface so the CLI can perform Slack
+ * operations without embedding API logic.
+ */
+
+import { ServiceUnavailableError } from "../../errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
+import { resolveSlackToken } from "./token.js";
+import {
+  loadChannelCache,
+  refreshChannelCache,
+  resolveChannelId,
+  resolveUserId,
+} from "./use-slack-cache.js";
+
+// ---------------------------------------------------------------------------
+// GET use/slack/channels — list cached channels (auto-refresh on empty)
+// ---------------------------------------------------------------------------
+
+async function handleListChannels() {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  let cache = loadChannelCache();
+  if (!cache || Object.keys(cache.channels).length === 0) {
+    cache = await refreshChannelCache(token);
+  }
+
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/channels/refresh — force-refresh channel cache
+// ---------------------------------------------------------------------------
+
+async function handleRefreshChannels() {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const cache = await refreshChannelCache(token);
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// GET use/slack/channels/:name — resolve a single channel by name
+// ---------------------------------------------------------------------------
+
+async function handleGetChannel({ pathParams }: RouteHandlerArgs) {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const name = pathParams?.name ?? "";
+  const id = await resolveChannelId(token, name);
+
+  // Look up the full entry from cache for the type field
+  const cache = loadChannelCache();
+  const entry = cache
+    ? Object.entries(cache.channels).find(([, v]) => v.id === id)
+    : undefined;
+
+  return {
+    id,
+    name: entry ? entry[0] : name,
+    type: entry ? entry[1].type : "channel",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET use/slack/users/:query — resolve a user by display name or email
+// ---------------------------------------------------------------------------
+
+async function handleGetUser({ pathParams }: RouteHandlerArgs) {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const query = pathParams?.query ?? "";
+  const user = await resolveUserId(token, query);
+
+  return {
+    id: user.id,
+    displayName: user.displayName,
+    email: user.email,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "slack_use_channels_list",
+    endpoint: "use/slack/channels",
+    method: "GET",
+    summary: "List cached Slack channels",
+    description:
+      "Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.",
+    tags: ["integrations"],
+    handler: () => handleListChannels(),
+  },
+  {
+    operationId: "slack_use_channels_refresh",
+    endpoint: "use/slack/channels/refresh",
+    method: "POST",
+    summary: "Refresh Slack channel cache",
+    description:
+      "Fetch all channels from the Slack API, rebuild the local cache, and return it.",
+    tags: ["integrations"],
+    handler: () => handleRefreshChannels(),
+  },
+  {
+    operationId: "slack_use_channels_get",
+    endpoint: "use/slack/channels/:name",
+    method: "GET",
+    summary: "Resolve a Slack channel by name",
+    description:
+      "Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.",
+    tags: ["integrations"],
+    handler: handleGetChannel,
+  },
+  {
+    operationId: "slack_use_users_get",
+    endpoint: "use/slack/users/:query",
+    method: "GET",
+    summary: "Resolve a Slack user by name or email",
+    description:
+      "Resolve a display name or email address to a Slack user via the local cache.",
+    tags: ["integrations"],
+    handler: handleGetUser,
+  },
+];


### PR DESCRIPTION
## Summary
- Add `use-slack-cache.ts` with channel/user cache (local JSON files) and resolution helpers
- Add `use-slack-routes.ts` with channels list/refresh/get and users get routes
- Register new routes in the shared ROUTES array

Part of plan: use-slack-cli.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->