### PR TITLE
fix(approvals): prevent cross-chat guardian reply hijacking on Slack

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockDeliveryScopedRequests: { id: string }[] = [];
+let mockIdentityRequests: { id: string }[] = [];
+let routeGuardianReplyCalls: unknown[] = [];
+let deliverChannelReplyCalls: unknown[][] = [];
+
+mock.module("../../../memory/canonical-guardian-store.js", () => ({
+  listPendingCanonicalGuardianRequestsByDestinationChat: () =>
+    mockDeliveryScopedRequests,
+  listCanonicalGuardianRequests: () => mockIdentityRequests,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: (url: unknown, payload: unknown, token: unknown) => {
+    deliverChannelReplyCalls.push([url, payload, token]);
+    return Promise.resolve({ ok: true });
+  },
+}));
+
+mock.module("../../guardian-reply-router.js", () => ({
+  routeGuardianReply: (ctx: unknown) => {
+    routeGuardianReplyCalls.push(ctx);
+    return Promise.resolve({
+      consumed: false,
+      decisionApplied: false,
+      type: "not_consumed",
+    });
+  },
+}));
+
+// Import after mocks are installed
+const { handleGuardianReplyIntercept } =
+  await import("./guardian-reply-intercept.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(
+  overrides: Partial<Parameters<typeof handleGuardianReplyIntercept>[0]> = {},
+) {
+  return {
+    isDuplicate: false,
+    trimmedContent: "hello",
+    hasCallbackData: false,
+    callbackData: undefined,
+    rawSenderId: "user-42",
+    canonicalSenderId: "user-42",
+    canonicalAssistantId: "self",
+    sourceChannel: "slack" as const,
+    conversationExternalId: "chat-123",
+    conversationId: "conv-abc",
+    eventId: "evt-1",
+    replyCallbackUrl: "https://gateway/reply",
+    trustClass: "guardian",
+    guardianPrincipalId: "principal-1",
+    approvalConversationGenerator: undefined,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleGuardianReplyIntercept", () => {
+  beforeEach(() => {
+    mockDeliveryScopedRequests = [];
+    mockIdentityRequests = [];
+    routeGuardianReplyCalls = [];
+    deliverChannelReplyCalls = [];
+  });
+
+  test("passes empty pendingRequestIds when Slack guardian sends message in non-delivery chat", async () => {
+    // No delivery-scoped requests for this chat
+    mockDeliveryScopedRequests = [];
+    // Identity-based lookup would find a pending request in a different chat
+    mockIdentityRequests = [{ id: "identity-req" }];
+
+    await handleGuardianReplyIntercept(makeParams({ sourceChannel: "slack" }));
+
+    expect(routeGuardianReplyCalls).toHaveLength(1);
+    const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
+    // Must be [] (empty array), NOT undefined — blocks identity fallback
+    expect(ctx.pendingRequestIds).toEqual([]);
+  });
+
+  test("preserves identity fallback for non-Slack channels when no deliveries exist", async () => {
+    // No delivery-scoped requests for this chat
+    mockDeliveryScopedRequests = [];
+    mockIdentityRequests = [{ id: "identity-req" }];
+
+    await handleGuardianReplyIntercept(
+      makeParams({ sourceChannel: "telegram" }),
+    );
+
+    expect(routeGuardianReplyCalls).toHaveLength(1);
+    const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
+    // Must be undefined — identity-based fallback stays active
+    expect(ctx.pendingRequestIds).toBeUndefined();
+  });
+
+  test("includes identity-unioned pendingRequestIds when Slack guardian is in delivery chat", async () => {
+    mockDeliveryScopedRequests = [{ id: "delivered-req" }];
+    mockIdentityRequests = [
+      { id: "delivered-req" },
+      { id: "identity-only-req" },
+    ];
+
+    await handleGuardianReplyIntercept(makeParams({ sourceChannel: "slack" }));
+
+    expect(routeGuardianReplyCalls).toHaveLength(1);
+    const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
+    const ids = ctx.pendingRequestIds as string[];
+    expect(ids).toContain("delivered-req");
+    expect(ids).toContain("identity-only-req");
+  });
+
+  test("skips intercept for non-guardian trust class", async () => {
+    const result = await handleGuardianReplyIntercept(
+      makeParams({ trustClass: "unknown" }),
+    );
+
+    expect(routeGuardianReplyCalls).toHaveLength(0);
+    expect(result).toEqual({
+      response: null,
+      skipApprovalInterception: false,
+    });
+  });
+
+  test("skips intercept when replyCallbackUrl is missing", async () => {
+    const result = await handleGuardianReplyIntercept(
+      makeParams({ replyCallbackUrl: undefined }),
+    );
+
+    expect(routeGuardianReplyCalls).toHaveLength(0);
+    expect(result).toEqual({
+      response: null,
+      skipApprovalInterception: false,
+    });
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -101,8 +101,22 @@ export async function handleGuardianReplyIntercept(
   // When delivery-scoped matches exist, union them with any identity-
   // based pending requests so that requests without delivery rows (e.g.
   // tool_approval requests created inline) are not silently excluded.
-  // Pass undefined (not []) when there are zero combined results so the
-  // router's own identity-based fallback stays active.
+  //
+  // On Slack, when no delivery-scoped results exist for the current
+  // chat, pass [] (empty array) instead of undefined. This prevents the
+  // router's identity-based fallback from intercepting unrelated
+  // messages in other channels/threads — a cross-chat hijacking vector
+  // unique to Slack where a single guardian is active in many threaded
+  // contexts. Explicit callbacks (apr:<id>:<action>) and request codes
+  // still work cross-chat because they carry specific request
+  // identifiers and bypass the pendingRequests list.
+  //
+  // Non-Slack channels (Telegram, WhatsApp) keep undefined so the
+  // identity-based fallback stays active. On those channels, delivery
+  // rows are created asynchronously (fire-and-forget .then()) so the
+  // guardian can reply before the row is persisted. Cross-chat
+  // contamination is unlikely there because each chat is a distinct
+  // conversation with no thread concept.
   const deliveryScopedPendingRequests =
     listPendingCanonicalGuardianRequestsByDestinationChat(
       sourceChannel,
@@ -121,6 +135,10 @@ export async function handleGuardianReplyIntercept(
       deliveryIds.add(r.id);
     }
     pendingRequestIds = [...deliveryIds];
+  } else if (sourceChannel === "slack") {
+    // Block identity-based fallback on Slack to prevent cross-chat
+    // NL/free-text interception. See comment above for rationale.
+    pendingRequestIds = [];
   }
 
   const routerResult = await routeGuardianReply({
@@ -168,13 +186,13 @@ export async function handleGuardianReplyIntercept(
     }
 
     return {
-      response: ({
+      response: {
         accepted: true,
         duplicate: false,
         eventId,
         canonicalRouter: routerResult.type,
         requestId: routerResult.requestId,
-      }),
+      },
       skipApprovalInterception: false,
     };
   }


### PR DESCRIPTION
## Summary
- Block identity-based pending request fallback on Slack when no delivery exists for the current chat
- Add Slack-only guard so Telegram/WhatsApp retain identity fallback (delivery row race condition safety)
- Add unit tests for guardian-reply-intercept covering cross-chat, delivery-chat, and guard conditions

Part of plan: slack-approval-hijack.md (PR 1 of 1)

Closes JARVIS-650
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->