### PR TITLE
fix(proactive-artifact): scope transcript to triggering conversation

### DIFF
--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -51,9 +51,15 @@ mock.module("../providers/provider-send-message.js", () => ({
 
 // rawAll mock
 let rawAllRows: Array<{ role: string; content: string }> = [];
+let rawAllLastSql = "";
+let rawAllLastArgs: unknown[] = [];
 
 mock.module("../memory/raw-query.js", () => ({
-  rawAll: () => rawAllRows,
+  rawAll: (sql: string, ...args: unknown[]) => {
+    rawAllLastSql = sql;
+    rawAllLastArgs = args;
+    return rawAllRows;
+  },
   rawRun: () => 0,
 }));
 
@@ -279,6 +285,8 @@ function resetState() {
   copyResponse = "";
   providerSendCalls = [];
   rawAllRows = [];
+  rawAllLastSql = "";
+  rawAllLastArgs = [];
   bootstrapCalls = [];
   processMessageCalls = [];
   processMessageShouldThrow = false;
@@ -645,7 +653,7 @@ describe("runProactiveArtifactJob", () => {
   });
 
   describe("Transcript collection", () => {
-    test("dual-condition transcript query uses userMessageCutoff and assistantMessageId", async () => {
+    test("transcript query is scoped to the triggering conversation", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = decisionNo;
 
@@ -656,8 +664,8 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
-      // The rawAll mock captures all calls; verify the decision was called
-      // (proving transcript was collected and passed to decision)
+      expect(rawAllLastSql).toContain("AND m.conversation_id = ?");
+      expect(rawAllLastArgs).toEqual(["conv-1", 5000, "asst-msg-99"]);
       expect(
         providerSendCalls.some(
           (c) => c.callSite === "proactiveArtifactDecision",

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -57,12 +57,16 @@ export async function runProactiveArtifactJob(params: {
   let buildSucceeded = false;
   try {
     // ── Collect transcript (bounded) ────────────────────────────────
+    // The trigger window is workspace-wide, but raw transcript context sent to
+    // the LLM must stay scoped to the conversation that fired the job.
     const rows = rawAll<{ role: string; content: string }>(
       `SELECT m.role, m.content FROM messages m
        JOIN conversations c ON m.conversation_id = c.id
        WHERE c.conversation_type = 'standard'
+         AND m.conversation_id = ?
          AND (m.created_at <= ? OR m.id = ?)
        ORDER BY m.created_at ASC`,
+      params.conversationId,
       params.userMessageCutoff,
       params.assistantMessageId ?? "",
     );

--- a/assistant/src/proactive-artifact/trigger-state.test.ts
+++ b/assistant/src/proactive-artifact/trigger-state.test.ts
@@ -123,6 +123,15 @@ describe("trigger-state", () => {
       expect(getUserMessageCountUpTo(350)).toBe(3);
     });
 
+    test("counts user messages across standard conversations", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      expect(getUserMessageCountUpTo(400)).toBe(4);
+    });
+
     test("caps at 11 due to LIMIT", () => {
       for (let i = 1; i <= 15; i++) {
         seedUserMessage(i * 100);

--- a/assistant/src/proactive-artifact/trigger-state.ts
+++ b/assistant/src/proactive-artifact/trigger-state.ts
@@ -16,6 +16,10 @@ function guardPath(): string {
 
 /**
  * Count user messages in standard conversations with created_at <= beforeOrAt.
+ * This is intentionally cross-conversation: a user who starts a new thread
+ * early should still enter the proactive artifact trigger window. The job
+ * separately scopes raw transcript context to the triggering conversation.
+ *
  * LIMIT caps scan cost since we only care about thresholds up to TRIGGER_MAX.
  */
 export function getUserMessageCountUpTo(beforeOrAt: number): number {


### PR DESCRIPTION
## Summary

- Scope proactive artifact transcript collection to the triggering conversation before sending context to the LLM provider.
- Keep the proactive artifact trigger count intentionally cross-conversation so early new-thread usage still enters the trigger window.
- Add regression coverage for both behaviors.

## Root Cause

`runProactiveArtifactJob` accepted a `conversationId`, but its transcript SQL only filtered on `conversation_type = 'standard'` and a message timestamp cutoff. That allowed raw transcript content from other standard conversations to enter the artifact decision/build prompts.

## Validation

- `PATH="$HOME/.bun/bin:$PATH" bun test src/proactive-artifact/job.test.ts src/proactive-artifact/trigger-state.test.ts`
- Commit hook: formatting, targeted lint, assistant type-check
- Pre-push hook: assistant type-check and targeted lint

Closes ATL-451