### PR TITLE
feat: add Slack send, read, and react daemon routes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15466,6 +15466,40 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/use/slack/react:
+    post:
+      operationId: use_slack_react_post
+      summary: Add a reaction to a Slack message
+      description: Add an emoji reaction to a message. Strips surrounding colons from the emoji name if present.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/read:
+    post:
+      operationId: use_slack_read_post
+      summary: Read Slack messages
+      description:
+        Read messages from a Slack channel or thread. Supports limit, since (Slack timestamp or relative offset
+        like "2h", "30m", "1d"), and thread replies.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/send:
+    post:
+      operationId: use_slack_send_post
+      summary: Send a Slack message
+      description:
+        Send a message to a Slack channel or user DM. Exactly one of channel or user must be set. Supports
+        threading via the thread parameter.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/use/slack/users/{query}:
     get:
       operationId: use_slack_users_by_query_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15476,6 +15476,24 @@ paths:
       responses:
         "200":
           description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                ts:
+                  type: string
+                emoji:
+                  type: string
+              required:
+                - channel
+                - ts
+                - emoji
+              additionalProperties: false
   /v1/use/slack/read:
     post:
       operationId: use_slack_read_post
@@ -15488,6 +15506,24 @@ paths:
       responses:
         "200":
           description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                limit:
+                  type: number
+                since:
+                  type: string
+                thread:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
   /v1/use/slack/send:
     post:
       operationId: use_slack_send_post
@@ -15500,6 +15536,24 @@ paths:
       responses:
         "200":
           description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                user:
+                  type: string
+                text:
+                  type: string
+                thread:
+                  type: string
+              required:
+                - text
+              additionalProperties: false
   /v1/use/slack/users/{query}:
     get:
       operationId: use_slack_users_by_query_get

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -6,7 +6,14 @@
  * operations without embedding API logic.
  */
 
-import { ServiceUnavailableError } from "../../errors.js";
+import {
+  addReaction,
+  conversationHistory,
+  conversationReplies,
+  conversationsOpen,
+  postMessage,
+} from "../../../../messaging/providers/slack/client.js";
+import { BadRequestError, ServiceUnavailableError } from "../../errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
 import { resolveSlackToken } from "./token.js";
 import {
@@ -95,6 +102,189 @@ async function handleGetUser({ pathParams }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// POST use/slack/send — send a message to a channel or DM
+// ---------------------------------------------------------------------------
+
+async function handleSend({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const user = body?.user as string | undefined;
+  const text = body?.text as string | undefined;
+  const thread = body?.thread as string | undefined;
+
+  if (!text) {
+    throw new BadRequestError("text is required");
+  }
+
+  if ((channel && user) || (!channel && !user)) {
+    throw new BadRequestError("Exactly one of channel or user must be set");
+  }
+
+  const writeToken = await resolveSlackToken("write");
+  if (!writeToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  let targetChannelId: string;
+
+  if (channel) {
+    const readToken = await resolveSlackToken("read");
+    if (!readToken) {
+      throw new ServiceUnavailableError("No Slack token configured");
+    }
+    targetChannelId = await resolveChannelId(readToken, channel);
+  } else {
+    // DM — resolve user then open a conversation
+    const readToken = await resolveSlackToken("read");
+    if (!readToken) {
+      throw new ServiceUnavailableError("No Slack token configured");
+    }
+    const resolved = await resolveUserId(readToken, user!);
+    const dmResp = await conversationsOpen(writeToken, resolved.id);
+    targetChannelId = dmResp.channel.id;
+  }
+
+  const resp = await postMessage(writeToken, targetChannelId, text, {
+    threadTs: thread,
+  });
+  return { ok: true, channel: resp.channel, ts: resp.ts };
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/read — read messages from a channel or thread
+// ---------------------------------------------------------------------------
+
+async function handleRead({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const limit = body?.limit as number | undefined;
+  const since = body?.since as string | undefined;
+  const thread = body?.thread as string | undefined;
+
+  if (!channel) {
+    throw new BadRequestError("channel is required");
+  }
+
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const channelId = await resolveChannelId(token, channel);
+
+  // Parse `since` into a Slack timestamp (oldest)
+  let oldest: string | undefined;
+  if (since) {
+    if (/^\d+\.\d+$/.test(since)) {
+      // Already a Slack timestamp
+      oldest = since;
+    } else if (/^\d+[hmd]$/.test(since)) {
+      // Relative offset: e.g. "2h", "30m", "1d"
+      const value = parseInt(since.slice(0, -1), 10);
+      const unit = since.slice(-1);
+      let offsetMs: number;
+      switch (unit) {
+        case "h":
+          offsetMs = value * 60 * 60 * 1000;
+          break;
+        case "m":
+          offsetMs = value * 60 * 1000;
+          break;
+        case "d":
+          offsetMs = value * 24 * 60 * 60 * 1000;
+          break;
+        default:
+          throw new BadRequestError(
+            `Invalid since unit: ${unit}. Use h, m, or d`,
+          );
+      }
+      const ts = (Date.now() - offsetMs) / 1000;
+      oldest = `${Math.floor(ts)}.000000`;
+    } else {
+      throw new BadRequestError(
+        'Invalid since format. Use a Slack timestamp (e.g. "1234567890.123456") or a relative offset (e.g. "2h", "30m", "1d")',
+      );
+    }
+  }
+
+  let messages: Array<{
+    ts: string;
+    user?: string;
+    text: string;
+    thread_ts?: string;
+  }>;
+
+  if (thread) {
+    const resp = await conversationReplies(
+      token,
+      channelId,
+      thread,
+      limit ?? 50,
+      undefined,
+      oldest,
+    );
+    messages = resp.messages.map((m) => ({
+      ts: m.ts,
+      user: m.user,
+      text: m.text,
+      thread_ts: m.thread_ts,
+    }));
+  } else {
+    const resp = await conversationHistory(
+      token,
+      channelId,
+      limit ?? 50,
+      undefined,
+      oldest,
+    );
+    messages = resp.messages.map((m) => ({
+      ts: m.ts,
+      user: m.user,
+      text: m.text,
+      thread_ts: m.thread_ts,
+    }));
+  }
+
+  return { channel: channelId, messages };
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/react — add a reaction to a message
+// ---------------------------------------------------------------------------
+
+async function handleReact({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const ts = body?.ts as string | undefined;
+  let emoji = body?.emoji as string | undefined;
+
+  if (!channel) {
+    throw new BadRequestError("channel is required");
+  }
+  if (!ts) {
+    throw new BadRequestError("ts is required");
+  }
+  if (!emoji) {
+    throw new BadRequestError("emoji is required");
+  }
+
+  // Strip surrounding colons if present (e.g. ":thumbsup:" -> "thumbsup")
+  emoji = emoji.replace(/^:/, "").replace(/:$/, "");
+
+  const writeToken = await resolveSlackToken("write");
+  if (!writeToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const readToken = await resolveSlackToken("read");
+  if (!readToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const channelId = await resolveChannelId(readToken, channel);
+  await addReaction(writeToken, channelId, ts, emoji);
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -138,5 +328,35 @@ export const ROUTES: RouteDefinition[] = [
       "Resolve a display name or email address to a Slack user via the local cache.",
     tags: ["integrations"],
     handler: handleGetUser,
+  },
+  {
+    operationId: "slack_use_send",
+    endpoint: "use/slack/send",
+    method: "POST",
+    summary: "Send a Slack message",
+    description:
+      "Send a message to a Slack channel or user DM. Exactly one of channel or user must be set. Supports threading via the thread parameter.",
+    tags: ["integrations"],
+    handler: handleSend,
+  },
+  {
+    operationId: "slack_use_read",
+    endpoint: "use/slack/read",
+    method: "POST",
+    summary: "Read Slack messages",
+    description:
+      'Read messages from a Slack channel or thread. Supports limit, since (Slack timestamp or relative offset like "2h", "30m", "1d"), and thread replies.',
+    tags: ["integrations"],
+    handler: handleRead,
+  },
+  {
+    operationId: "slack_use_react",
+    endpoint: "use/slack/react",
+    method: "POST",
+    summary: "Add a reaction to a Slack message",
+    description:
+      "Add an emoji reaction to a message. Strips surrounding colons from the emoji name if present.",
+    tags: ["integrations"],
+    handler: handleReact,
   },
 ];

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -6,6 +6,8 @@
  * operations without embedding API logic.
  */
 
+import { z } from "zod";
+
 import {
   addReaction,
   conversationHistory,
@@ -297,6 +299,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: () => handleListChannels(),
   },
   {
@@ -307,6 +310,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Fetch all channels from the Slack API, rebuild the local cache, and return it.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: () => handleRefreshChannels(),
   },
   {
@@ -317,6 +321,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: handleGetChannel,
   },
   {
@@ -327,6 +332,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a display name or email address to a Slack user via the local cache.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: handleGetUser,
   },
   {
@@ -337,6 +343,13 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Send a message to a Slack channel or user DM. Exactly one of channel or user must be set. Supports threading via the thread parameter.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string().optional(),
+      user: z.string().optional(),
+      text: z.string(),
+      thread: z.string().optional(),
+    }),
     handler: handleSend,
   },
   {
@@ -347,6 +360,13 @@ export const ROUTES: RouteDefinition[] = [
     description:
       'Read messages from a Slack channel or thread. Supports limit, since (Slack timestamp or relative offset like "2h", "30m", "1d"), and thread replies.',
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string(),
+      limit: z.number().optional(),
+      since: z.string().optional(),
+      thread: z.string().optional(),
+    }),
     handler: handleRead,
   },
   {
@@ -357,6 +377,12 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Add an emoji reaction to a message. Strips surrounding colons from the emoji name if present.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string(),
+      ts: z.string(),
+      emoji: z.string(),
+    }),
     handler: handleReact,
   },
 ];


### PR DESCRIPTION
## Summary
- Add `slack_use_send` route (POST) with channel/DM resolution and thread support
- Add `slack_use_read` route (POST) with limit, since offset, and thread replies
- Add `slack_use_react` route (POST) with emoji colon stripping

Part of plan: use-slack-cli.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->