### PR TITLE
Part of ATL-539: Restrict new Vercel token metadata to publish tools

### DIFF
--- a/assistant/src/__tests__/vercel-config.test.ts
+++ b/assistant/src/__tests__/vercel-config.test.ts
@@ -92,12 +92,11 @@ describe("Vercel config handler", () => {
       expect(tools).not.toContain("deploy");
     });
 
-    test("metadata has no injection templates", async () => {
+    test("metadata explicitly clears injection templates", async () => {
       await setVercelConfig("vl_test_token_123");
 
       expect(lastUpsertCall).not.toBeNull();
-      // injectionTemplates should not be present in the policy at all
-      expect(lastUpsertCall!.policy).not.toHaveProperty("injectionTemplates");
+      expect(lastUpsertCall!.policy?.injectionTemplates).toBeNull();
     });
 
     test("publish_page and unpublish_page remain in allowedTools", async () => {

--- a/assistant/src/__tests__/vercel-config.test.ts
+++ b/assistant/src/__tests__/vercel-config.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+let secureKeyStore: Record<string, string> = {};
+
+// Track metadata upsert calls to verify policy
+let lastUpsertCall: {
+  service: string;
+  field: string;
+  policy: Record<string, unknown> | undefined;
+} | null = null;
+let metadataDeleted: { service: string; field: string } | null = null;
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) =>
+    secureKeyStore[account] ?? undefined,
+  setSecureKeyAsync: async (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKeyAsync: async (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return "deleted" as const;
+    }
+    return "not-found" as const;
+  },
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  deleteCredentialMetadata: (service: string, field: string) => {
+    metadataDeleted = { service, field };
+    return true;
+  },
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    policy?: Record<string, unknown>,
+  ) => {
+    lastUpsertCall = { service, field, policy };
+    return {};
+  },
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  deleteVercelConfig,
+  getVercelConfig,
+  setVercelConfig,
+} from "../daemon/handlers/config-vercel.js";
+
+describe("Vercel config handler", () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    lastUpsertCall = null;
+    metadataDeleted = null;
+  });
+
+  // -- setVercelConfig --
+
+  describe("setVercelConfig", () => {
+    test("stores token and returns success", async () => {
+      const result = await setVercelConfig("vl_test_token_123");
+
+      expect(result.success).toBe(true);
+      expect(result.hasToken).toBe(true);
+      expect(secureKeyStore[credentialKey("vercel", "api_token")]).toBe(
+        "vl_test_token_123",
+      );
+    });
+
+    test("metadata does not include bash in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).not.toContain("bash");
+    });
+
+    test("metadata does not include deploy in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).not.toContain("deploy");
+    });
+
+    test("metadata has no injection templates", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      // injectionTemplates should not be present in the policy at all
+      expect(lastUpsertCall!.policy).not.toHaveProperty("injectionTemplates");
+    });
+
+    test("publish_page and unpublish_page remain in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).toContain("publish_page");
+      expect(tools).toContain("unpublish_page");
+    });
+
+    test("allowedTools contains only publish_page and unpublish_page", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).toEqual(["publish_page", "unpublish_page"]);
+    });
+
+    test("returns error when apiToken is not provided", async () => {
+      const result = await setVercelConfig(undefined);
+
+      expect(result.success).toBe(false);
+      expect(result.hasToken).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  // -- getVercelConfig --
+
+  describe("getVercelConfig", () => {
+    test("returns hasToken true when token exists", async () => {
+      secureKeyStore[credentialKey("vercel", "api_token")] = "some-token";
+      const result = await getVercelConfig();
+
+      expect(result.hasToken).toBe(true);
+      expect(result.success).toBe(true);
+    });
+
+    test("returns hasToken false when no token exists", async () => {
+      const result = await getVercelConfig();
+
+      expect(result.hasToken).toBe(false);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // -- deleteVercelConfig --
+
+  describe("deleteVercelConfig", () => {
+    test("removes both secure key and metadata", async () => {
+      secureKeyStore[credentialKey("vercel", "api_token")] = "token-to-delete";
+
+      const result = await deleteVercelConfig();
+
+      expect(result.success).toBe(true);
+      expect(result.hasToken).toBe(false);
+      // Secure key should be removed
+      expect(
+        secureKeyStore[credentialKey("vercel", "api_token")],
+      ).toBeUndefined();
+      // Metadata should be deleted
+      expect(metadataDeleted).toEqual({
+        service: "vercel",
+        field: "api_token",
+      });
+    });
+  });
+});

--- a/assistant/src/daemon/handlers/config-vercel.ts
+++ b/assistant/src/daemon/handlers/config-vercel.ts
@@ -61,6 +61,7 @@ export async function setVercelConfig(
   upsertCredentialMetadata("vercel", "api_token", {
     allowedTools: ["publish_page", "unpublish_page"],
     allowedDomains: [],
+    injectionTemplates: null,
   });
 
   log.info("Vercel API token stored successfully");

--- a/assistant/src/daemon/handlers/config-vercel.ts
+++ b/assistant/src/daemon/handlers/config-vercel.ts
@@ -59,16 +59,8 @@ export async function setVercelConfig(
   }
 
   upsertCredentialMetadata("vercel", "api_token", {
-    allowedTools: ["deploy", "publish_page", "bash"],
+    allowedTools: ["publish_page", "unpublish_page"],
     allowedDomains: [],
-    injectionTemplates: [
-      {
-        hostPattern: "api.vercel.com",
-        injectionType: "header",
-        headerName: "Authorization",
-        valuePrefix: "Bearer ",
-      },
-    ],
   });
 
   log.info("Vercel API token stored successfully");


### PR DESCRIPTION
## Summary
- Change setVercelConfig to write allowedTools limited to publish_page and unpublish_page
- Remove injection templates and overly broad deploy capability from Vercel metadata
- Add tests verifying new metadata excludes bash and proxy injection paths

Part of plan: atl-539-vercel-credential-injection.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->