### PR TITLE
fix(macos): remove duplicate Platform chip and Pick a provider badge

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -473,18 +473,7 @@ struct InferenceProfileEditor: View {
     }
 
     private var providerField: some View {
-        labeled(
-            "Provider",
-            accessory: {
-                if isProviderMissing {
-                    VBadge(
-                        label: "Pick a provider",
-                        tone: .warning,
-                        emphasis: .subtle
-                    )
-                }
-            }
-        ) {
+        labeled("Provider") {
             VDropdown(
                 placeholder: "Select a provider\u{2026}",
                 selection: Binding(

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -297,11 +297,13 @@ struct ProvidersSheet: View {
                 tone: .neutral,
                 emphasis: .subtle
             )
-            VBadge(
-                label: authTypeLabel(conn.auth.type),
-                tone: authTypeTone(conn.auth.type),
-                emphasis: .subtle
-            )
+            if !(conn.isManaged && conn.auth.type == "platform") {
+                VBadge(
+                    label: authTypeLabel(conn.auth.type),
+                    tone: authTypeTone(conn.auth.type),
+                    emphasis: .subtle
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove duplicate "Platform" chip in Provider Connections list: when a connection is both managed and has platform auth, the auth type badge is now suppressed since the managed badge already says "Platform"
- Remove the yellow "Pick a provider" warning badge from the New Profile editor's Provider field — the dropdown placeholder already communicates the same thing

## Original prompt
The Provider Connections view in the macOS client was showing two "Platform" chips for managed connections — one from the managed status and another from the auth type. The user asked to deduplicate by keeping only the right-side chip. Additionally, the "New Profile" form had an unnecessary yellow "Pick a provider" warning pill next to the Provider label that should be removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->