### PR TITLE
feat(daemon): /model slash command for inference profile switching

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+} from "../config/loader.js";
 import {
   classifySlash,
   resolveSlash,
   type SlashContext,
 } from "../daemon/conversation-slash.js";
+import { getWorkspaceConfigPath } from "../util/platform.js";
 
 function makeSlashContext(overrides: Partial<SlashContext> = {}): SlashContext {
   return {
@@ -37,12 +44,12 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
       "/fork — Fork the current conversation into a new branch",
     ]);
-    expect(lines).not.toContain("/model — Switch the active model");
   });
 
   test("renders iOS command help with /fork", async () => {
@@ -53,6 +60,7 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -68,6 +76,7 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -80,6 +89,7 @@ describe("resolveSlash /commands interface-aware help", () => {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
     ]);
@@ -90,6 +100,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines).toEqual([
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
+      "/model — List or switch inference profile",
       "/models — List all available models",
     ]);
   });
@@ -213,4 +224,132 @@ describe("classifySlash is a pure classifier matching resolveSlash kinds", () =>
       expect(resolved.kind).toBe(kind);
     });
   }
+});
+
+// ── /model — inference profile switcher ────────────────────────────
+
+function writeFixtureConfig(config: Record<string, unknown>): void {
+  writeFileSync(getWorkspaceConfigPath(), JSON.stringify(config), "utf-8");
+  invalidateConfigCache();
+}
+
+describe("resolveSlash /model — inference profile switcher", () => {
+  beforeEach(() => {
+    writeFixtureConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            label: "Balanced",
+            description: "Default mix of speed and quality",
+          },
+          "cost-optimized": {
+            label: "Cost-optimized",
+            description: "Cheaper models, slower",
+          },
+          "short-context": {
+            label: "Short context",
+            status: "disabled",
+          },
+        },
+        profileOrder: ["balanced", "cost-optimized", "short-context"],
+        activeProfile: "balanced",
+      },
+    });
+  });
+
+  afterEach(() => {
+    invalidateConfigCache();
+  });
+
+  test("`/model` lists profiles with current marker, status, and description", async () => {
+    const result = await resolveSlash("/model");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toContain("Inference profiles:");
+    expect(result.message).toContain(
+      "`balanced` (Balanced) **[current]** — Default mix of speed and quality",
+    );
+    expect(result.message).toContain(
+      "`cost-optimized` (Cost-optimized) — Cheaper models, slower",
+    );
+    expect(result.message).toContain(
+      "`short-context` (Short context) *(disabled)*",
+    );
+    expect(result.message).toContain("Switch with `/model <name>`.");
+  });
+
+  test("`/model <name>` switches the active profile and writes config to disk", async () => {
+    const result = await resolveSlash("/model cost-optimized");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toBe(
+      "Switched to profile `cost-optimized` (Cost-optimized).",
+    );
+
+    const persisted = loadRawConfig() as {
+      llm?: { activeProfile?: string };
+    };
+    expect(persisted.llm?.activeProfile).toBe("cost-optimized");
+  });
+
+  test("`/model <unknown>` returns an error with available profile names", async () => {
+    const result = await resolveSlash("/model gemini");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toContain("Profile `gemini` not found.");
+    expect(result.message).toContain("`balanced`");
+    expect(result.message).toContain("`cost-optimized`");
+  });
+
+  test("`/model <disabled>` refuses to switch and points at Settings", async () => {
+    const result = await resolveSlash("/model short-context");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toBe(
+      "Profile `short-context` is disabled. Enable it in **Settings → Models & Services** first.",
+    );
+    // Disk should NOT have been written.
+    const persisted = loadRawConfig() as {
+      llm?: { activeProfile?: string };
+    };
+    expect(persisted.llm?.activeProfile).toBe("balanced");
+  });
+
+  test("`/model <current>` is a no-op with a friendly message", async () => {
+    const result = await resolveSlash("/model balanced");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toBe(
+      "Already using profile `balanced` (Balanced).",
+    );
+  });
+
+  test("`/model` with no profiles defined points at Settings", async () => {
+    writeFixtureConfig({
+      llm: { profiles: {}, profileOrder: [] },
+    });
+    const result = await resolveSlash("/model");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toBe(
+      "No inference profiles are defined. Use **Settings → Models & Services** to create one.",
+    );
+  });
+
+  test("`/model <name>` trims surrounding whitespace from the argument", async () => {
+    const result = await resolveSlash("/model   cost-optimized  ");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown kind");
+    expect(result.message).toBe(
+      "Switched to profile `cost-optimized` (Cost-optimized).",
+    );
+  });
+
+  test("`/models` (plural) is not parsed as a /model invocation", async () => {
+    // /models is a separate command handled elsewhere; this test guards the
+    // boundary so we don't accidentally swallow it as a typo'd /model.
+    expect(classifySlash("/models")).toBe("unknown");
+    // /models foo is passthrough (existing behavior).
+    expect(classifySlash("/models foo")).toBe("passthrough");
+  });
 });

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -1,5 +1,4 @@
 import { writeFileSync } from "node:fs";
-
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -126,8 +126,6 @@ type ModelCommandParse =
 function parseModelCommand(trimmed: string): ModelCommandParse | null {
   if (trimmed === "/model") return { kind: "list" };
   if (!trimmed.startsWith("/model ")) return null;
-  // Treat `/models` (which is a separate command) as not-a-/model invocation.
-  if (trimmed === "/models" || trimmed.startsWith("/models")) return null;
   const rest = trimmed.slice("/model ".length).trim();
   if (rest.length === 0) return { kind: "list" };
   return { kind: "switch", profileName: rest };

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -1,7 +1,12 @@
 import type { InterfaceId } from "../channels/types.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
-import { getConfig } from "../config/loader.js";
+import {
+  getConfig,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+} from "../config/loader.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
@@ -108,6 +113,122 @@ const DEPRECATED_MODEL_SHORTCUTS = new Set([
   "grok-multi",
 ]);
 
+// ── /model command (inference profile switcher) ──────────────────────
+
+type ModelCommandParse =
+  | { kind: "list" }
+  | { kind: "switch"; profileName: string };
+
+/**
+ * Parse `/model` and `/model <name>` forms. Returns `null` for any input
+ * that isn't a `/model` invocation (so the caller can fall through).
+ */
+function parseModelCommand(trimmed: string): ModelCommandParse | null {
+  if (trimmed === "/model") return { kind: "list" };
+  if (!trimmed.startsWith("/model ")) return null;
+  // Treat `/models` (which is a separate command) as not-a-/model invocation.
+  if (trimmed === "/models" || trimmed.startsWith("/models")) return null;
+  const rest = trimmed.slice("/model ".length).trim();
+  if (rest.length === 0) return { kind: "list" };
+  return { kind: "switch", profileName: rest };
+}
+
+function orderedProfileNames(
+  profiles: Record<string, { label?: string; description?: string; status?: "active" | "disabled" }>,
+  profileOrder: readonly string[] | undefined,
+): string[] {
+  const order = profileOrder ?? [];
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const name of order) {
+    if (profiles[name] != null && !seen.has(name)) {
+      ordered.push(name);
+      seen.add(name);
+    }
+  }
+  const tail = Object.keys(profiles)
+    .filter((n) => !seen.has(n))
+    .sort();
+  return [...ordered, ...tail];
+}
+
+async function resolveModelCommand(
+  parse: ModelCommandParse,
+): Promise<SlashResolution> {
+  const config = getConfig();
+  const profiles = (config.llm.profiles ?? {}) as Record<
+    string,
+    { label?: string; description?: string; status?: "active" | "disabled" }
+  >;
+  const profileNames = orderedProfileNames(profiles, config.llm.profileOrder);
+  const activeProfile = config.llm.activeProfile;
+
+  if (parse.kind === "list") {
+    if (profileNames.length === 0) {
+      return {
+        kind: "unknown",
+        message:
+          "No inference profiles are defined. Use **Settings → Models & Services** to create one.",
+      };
+    }
+    const lines = ["Inference profiles:\n"];
+    for (const name of profileNames) {
+      const profile = profiles[name];
+      const label = profile.label ?? name;
+      const isCurrent = name === activeProfile;
+      const isDisabled = profile.status === "disabled";
+      const marker = isCurrent ? " **[current]**" : "";
+      const disabled = isDisabled ? " *(disabled)*" : "";
+      const description = profile.description ? ` — ${profile.description}` : "";
+      lines.push(`  - \`${name}\` (${label})${marker}${disabled}${description}`);
+    }
+    lines.push("\nSwitch with `/model <name>`.");
+    return { kind: "unknown", message: lines.join("\n") };
+  }
+
+  const target = parse.profileName;
+  if (!(target in profiles)) {
+    const available = profileNames.map((n) => `\`${n}\``).join(", ");
+    const hint = available.length > 0 ? ` Available: ${available}.` : "";
+    return {
+      kind: "unknown",
+      message: `Profile \`${target}\` not found.${hint}`,
+    };
+  }
+  if (profiles[target].status === "disabled") {
+    return {
+      kind: "unknown",
+      message: `Profile \`${target}\` is disabled. Enable it in **Settings → Models & Services** first.`,
+    };
+  }
+  if (target === activeProfile) {
+    const label = profiles[target].label ?? target;
+    return {
+      kind: "unknown",
+      message: `Already using profile \`${target}\` (${label}).`,
+    };
+  }
+
+  // Write `llm.activeProfile` directly to the raw config file. We invalidate
+  // the in-process cache so the very next `getConfig()` reflects the switch;
+  // the file watcher will also pick this up but its debounce can lag a tick.
+  const raw = loadRawConfig();
+  const llm: Record<string, unknown> =
+    raw.llm != null && typeof raw.llm === "object" && !Array.isArray(raw.llm)
+      ? (raw.llm as Record<string, unknown>)
+      : {};
+  llm.activeProfile = target;
+  raw.llm = llm;
+  saveRawConfig(raw);
+  invalidateConfigCache();
+
+  const label = profiles[target].label ?? target;
+  return {
+    kind: "unknown",
+    message: `Switched to profile \`${target}\` (${label}).`,
+  };
+}
+
 // ── /models command ──────────────────────────────────────────────────
 
 async function resolveModelList(): Promise<SlashResolution> {
@@ -184,6 +305,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
   if (context) {
     fallbackLines.push("/context — Show conversation context usage");
   }
+  fallbackLines.push("/model — List or switch inference profile");
   fallbackLines.push("/models — List all available models");
   if (context) {
     fallbackLines.push("/status — Show conversation status and context usage");
@@ -196,6 +318,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -208,6 +331,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",
       "/context — Show conversation context usage",
+      "/model — List or switch inference profile",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -219,6 +343,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
     "/commands — List all available commands",
     "/compact — Force context compaction immediately",
     "/context — Show conversation context usage",
+    "/model — List or switch inference profile",
     "/models — List all available models",
     "/status — Show conversation status and context usage",
     "/btw — Ask a side question while the assistant is working",
@@ -238,10 +363,7 @@ export function classifySlash(
   content: string,
 ): "passthrough" | "compact" | "unknown" {
   const trimmed = content.trim();
-  if (
-    trimmed === "/model" ||
-    (trimmed.startsWith("/model ") && trimmed !== "/models")
-  ) {
+  if (parseModelCommand(trimmed) != null) {
     return "unknown";
   }
   const shortcutMatch = trimmed.match(/^\/([a-z0-9-]+)(\s|$)/i);
@@ -269,17 +391,11 @@ export async function resolveSlash(
   content: string,
   context?: SlashContext,
 ): Promise<SlashResolution> {
-  // Handle deprecated model-switching commands — direct users to Settings
+  // Handle `/model` — list profiles (no arg) or switch active profile.
   const trimmed = content.trim();
-  if (
-    trimmed === "/model" ||
-    (trimmed.startsWith("/model ") && trimmed !== "/models")
-  ) {
-    return {
-      kind: "unknown",
-      message:
-        "The `/model` command has been removed. Use **Settings → Models & Services** to change your model and provider.",
-    };
+  const modelParse = parseModelCommand(trimmed);
+  if (modelParse != null) {
+    return await resolveModelCommand(modelParse);
   }
 
   // Reject deprecated provider shortcut commands (/opus, /sonnet, /haiku, etc.)

--- a/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerSlashCommandPickerTests.swift
@@ -7,12 +7,14 @@ final class ComposerSlashCommandPickerTests: XCTestCase {
     func testPickerCommandsMatchSharedCatalogOrder() {
         XCTAssertEqual(
             SlashCommand.all.map(\.name),
-            ["commands", "compact", "models", "status", "btw", "fork"]
+            ["commands", "compact", "model", "models", "status", "btw", "fork"]
         )
     }
 
-    func testDeprecatedModelCommandIsNotInPickerCommands() {
-        XCTAssertFalse(SlashCommand.all.contains(where: { $0.name == "model" }))
+    func testModelCommandIsInPickerWithTrailingSpaceBehavior() throws {
+        let command = try XCTUnwrap(SlashCommand.all.first(where: { $0.name == "model" }))
+        XCTAssertEqual(command.selectedInputText, "/model ")
+        XCTAssertFalse(command.shouldAutoSendOnSelect)
     }
 
     func testBtwSelectionInsertsTrailingSpaceWithoutAutoSend() throws {

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -19,6 +19,7 @@ public enum ChatSlashCommandSelectionBehavior: Hashable {
 public enum ChatSlashCommandSendPathMatchRule: Hashable {
     case exact
     case commandWithArgument
+    case exactOrWithArgument
 }
 
 public struct ChatSlashCommandDescriptor: Hashable {
@@ -105,6 +106,17 @@ public enum ChatSlashCommandCatalog {
             pickerPlatforms: allPlatforms,
             helpBubblePlatforms: allPlatforms,
             sendPathPlatforms: allPlatforms
+        ),
+        ChatSlashCommandDescriptor(
+            name: "model",
+            description: "List or switch inference profile",
+            icon: "cpu",
+            selectionBehavior: .insertTrailingSpace,
+            sendPathMatchRule: .exactOrWithArgument,
+            pickerPlatforms: allPlatforms,
+            helpBubblePlatforms: allPlatforms,
+            sendPathPlatforms: allPlatforms,
+            refreshesModelMetadata: true
         ),
         ChatSlashCommandDescriptor(
             name: "models",
@@ -223,6 +235,16 @@ public enum ChatSlashCommandCatalog {
                 let argument = String(trimmed.dropFirst(slashName.count + 1))
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 return !argument.isEmpty
+            case .exactOrWithArgument:
+                if trimmed == slashName {
+                    return true
+                }
+                guard trimmed.hasPrefix("\(slashName) ") else {
+                    return false
+                }
+                let argument = String(trimmed.dropFirst(slashName.count + 1))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return !argument.isEmpty
             }
         }
     }
@@ -244,10 +266,6 @@ public enum ChatSlashCommandCatalog {
         }
 
         let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed == "/model" || (trimmed.hasPrefix("/model ") && trimmed != "/models") {
-            return true
-        }
-
         guard trimmed.hasPrefix("/") else { return false }
         guard let commandToken = trimmed.dropFirst().split(whereSeparator: \.isWhitespace).first else {
             return false

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -104,7 +104,7 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[1].text, "/status")
     }
 
-    func testModelsRefreshesMetadataButUnsupportedFormsDoNot() async {
+    func testModelAndModelsRefreshMetadataButUnsupportedFormsDoNot() async {
         settingsClient.modelInfoResponse = ModelInfoMessage(
             type: "model_info",
             model: "test-model",
@@ -131,7 +131,14 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
 
         await Task.yield()
         await Task.yield()
-        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 1)
+        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 2)
+
+        viewModel.inputText = "/model alpha"
+        viewModel.sendMessage()
+
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(settingsClient.fetchModelInfoCallCount, 3)
     }
 
     func testUnsupportedSlashFormsUseWorkspaceRefinementWhenSurfaceIsActive() {
@@ -187,12 +194,31 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 0)
     }
 
-    func testDeprecatedDaemonManagedSlashCommandsBypassWorkspaceRefinement() {
+    func testModelSlashCommandBypassesWorkspaceRefinement() {
+        viewModel.activeSurfaceId = "surface-1"
+        viewModel.isChatDockedToSide = false
+
+        let modelCommands = [
+            "/model",
+            "/model alpha",
+        ]
+
+        for command in modelCommands {
+            viewModel.isWorkspaceRefinementInFlight = false
+            viewModel.inputText = command
+            viewModel.sendMessage()
+
+            XCTAssertFalse(viewModel.isWorkspaceRefinementInFlight)
+        }
+
+        XCTAssertEqual(viewModel.messages.map(\.text), modelCommands)
+    }
+
+    func testDeprecatedProviderShortcutsBypassWorkspaceRefinement() {
         viewModel.activeSurfaceId = "surface-1"
         viewModel.isChatDockedToSide = false
 
         let deprecatedCommands = [
-            "/model",
             "/opus write a summary",
             "/OPUS write a summary",
         ]

--- a/clients/shared/Tests/SlashCommandCatalogTests.swift
+++ b/clients/shared/Tests/SlashCommandCatalogTests.swift
@@ -8,7 +8,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .picker
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testMacOSHelpOrderMatchesExpectedDesktopCommands() {
@@ -16,7 +16,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .macos,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testIOSHelpShowsForkAlongsideCommonCommands() {
@@ -24,7 +24,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .ios,
             surface: .helpBubble
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/models", "/status", "/btw", "/fork"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw", "/fork"])
     }
 
     func testIOSPickerOmitsForkCommand() {
@@ -32,7 +32,7 @@ final class SlashCommandCatalogTests: XCTestCase {
             for: .ios,
             surface: .picker
         ).map(\.slashName)
-        XCTAssertEqual(commands, ["/commands", "/compact", "/models", "/status", "/btw"])
+        XCTAssertEqual(commands, ["/commands", "/compact", "/model", "/models", "/status", "/btw"])
     }
 
     func testStatusDescriptionMatchesConversationCopy() {
@@ -52,25 +52,40 @@ final class SlashCommandCatalogTests: XCTestCase {
         XCTAssertEqual(descriptor?.selectionBehavior, .insertTrailingSpace)
     }
 
-    func testDeprecatedModelCommandIsNotDiscoverableInPickerOrHelp() {
+    func testModelCommandIsDiscoverableInPickerAndHelpBubble() {
         let pickerDescriptor = ChatSlashCommandCatalog.descriptor(
             forRawInput: "/model",
             platform: .macos,
             surface: .picker
         )
-        XCTAssertNil(pickerDescriptor)
+        XCTAssertEqual(pickerDescriptor?.name, "model")
+        XCTAssertEqual(
+            pickerDescriptor?.description,
+            "List or switch inference profile"
+        )
+        XCTAssertEqual(pickerDescriptor?.selectionBehavior, .insertTrailingSpace)
 
         let helpDescriptor = ChatSlashCommandCatalog.descriptor(
-            forRawInput: "/model opus",
+            forRawInput: "/model alpha",
             platform: .ios,
             surface: .helpBubble
         )
-        XCTAssertNil(helpDescriptor)
+        XCTAssertEqual(helpDescriptor?.name, "model")
     }
 
     func testSendPathRecognitionRequiresSupportedForms() {
         XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/commands",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/model",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/model alpha",
             platform: .macos,
             surface: .sendPath
         ))
@@ -122,9 +137,59 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
     }
 
+    func testModelMatchRuleDistinguishesModelAndModels() {
+        // `/model` (bare) and `/model <name>` resolve to the model descriptor.
+        XCTAssertEqual(
+            ChatSlashCommandCatalog.descriptor(
+                forRawInput: "/model",
+                platform: .macos,
+                surface: .sendPath
+            )?.name,
+            "model"
+        )
+        XCTAssertEqual(
+            ChatSlashCommandCatalog.descriptor(
+                forRawInput: "/model alpha",
+                platform: .macos,
+                surface: .sendPath
+            )?.name,
+            "model"
+        )
+        // `/models` must continue resolving to its own descriptor — the
+        // `/model` rule prefix must not steal it.
+        XCTAssertEqual(
+            ChatSlashCommandCatalog.descriptor(
+                forRawInput: "/models",
+                platform: .macos,
+                surface: .sendPath
+            )?.name,
+            "models"
+        )
+        // Empty argument after `/model ` is not a valid switch invocation,
+        // but the trimmed form `/model` still matches as a bare invocation.
+        XCTAssertEqual(
+            ChatSlashCommandCatalog.descriptor(
+                forRawInput: "/model    ",
+                platform: .macos,
+                surface: .sendPath
+            )?.name,
+            "model"
+        )
+    }
+
     func testSendPathRecognitionIsCaseSensitiveAndLowercaseOnly() {
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
             "/COMMANDS",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/MODEL",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/MODEL alpha",
             platform: .macos,
             surface: .sendPath
         ))
@@ -183,11 +248,33 @@ final class SlashCommandCatalogTests: XCTestCase {
         )
     }
 
-    func testDeprecatedDaemonManagedCommandsStillBypassWorkspaceRefinement() {
+    func testModelCommandBypassesWorkspaceRefinementInBothForms() {
+        // `/model` is now a real catalog command; bypass should be driven by
+        // catalog recognition, not the deprecated-shortcut fallback.
         XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
             forRawInput: "/model",
             platform: .macos
         ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: "/model alpha",
+            platform: .macos
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/model",
+            platform: .macos,
+            surface: .sendPath
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.isRecognizedSlashCommand(
+            "/model alpha",
+            platform: .macos,
+            surface: .sendPath
+        ))
+    }
+
+    func testDeprecatedProviderShortcutsStillBypassWorkspaceRefinement() {
+        // `/opus`, `/sonnet`, etc. are not in the catalog — they reach the
+        // daemon via the fallback bypass so it can return the deprecation
+        // message instead of letting them fall through as raw text.
         XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
             forRawInput: "/opus explain this",
             platform: .macos
@@ -196,9 +283,13 @@ final class SlashCommandCatalogTests: XCTestCase {
             forRawInput: "/OPUS explain this",
             platform: .macos
         ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldBypassWorkspaceRefinement(
+            forRawInput: "/sonnet",
+            platform: .macos
+        ))
 
         XCTAssertFalse(ChatSlashCommandCatalog.isRecognizedSlashCommand(
-            "/model",
+            "/opus explain this",
             platform: .macos,
             surface: .sendPath
         ))
@@ -209,9 +300,17 @@ final class SlashCommandCatalogTests: XCTestCase {
         ))
     }
 
-    func testModelMetadataRefreshOnlyForExactModelsCommand() {
+    func testModelMetadataRefreshOptsInForModelAndModelsCommands() {
         XCTAssertTrue(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
             forRawInput: "/models",
+            platform: .macos
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+            forRawInput: "/model",
+            platform: .macos
+        ))
+        XCTAssertTrue(ChatSlashCommandCatalog.shouldRefreshModelMetadata(
+            forRawInput: "/model alpha",
             platform: .macos
         ))
         XCTAssertFalse(ChatSlashCommandCatalog.shouldRefreshModelMetadata(


### PR DESCRIPTION
## Summary

Part 2 of the inference-providers two-part cleanup. [Part 1 (#30373)](https://github.com/vellum-ai/vellum-assistant/pull/30373) deleted the dead `setModel` handler and surfaces. This PR resurrects `/model` as a real chat slash command — switching the user-facing concept from "pick a model" to "pick a profile" (a profile is the new plumbing: `provider`, `model`, `effort`, `temperature`, etc.).

---

## Behavior

| Input | Result |
|---|---|
| `/model` (bare) | Lists profiles with **[current]** marker, `*(disabled)*` status, label, description. Footer: `Switch with \`/model <name>\`.` |
| `/model <name>` | Writes `llm.activeProfile = <name>` to raw config, invalidates in-process cache, confirms: `Switched to profile \`<name>\` (<label>).` |
| `/model <unknown>` | Error with available profile names |
| `/model <disabled>` | Refuses; pointer to Settings |
| `/model <current>` | No-op friendly message |
| No profiles defined | Pointer to Settings → Models & Services |

The deprecated `/opus`, `/sonnet`, `/haiku`, `/grok-beta`, `/grok-multi` shortcuts are untouched — they still route to the existing deprecation message.

---

## Changes

### `assistant/src/daemon/conversation-slash.ts`

- `parseModelCommand`: parses `/model` → `{ kind: "list" }` and `/model <name>` → `{ kind: "switch" }`. Explicitly excludes `/models`.
- `orderedProfileNames`: respects `profileOrder`, appends extras alphabetically.
- `resolveModelCommand`: dispatches list vs switch, handles disabled/current/unknown edge cases.
- `classifySlash` and `resolveSlash` route `/model` (any form) through `resolveModelCommand`.
- `resolveCommandsList` includes `/model — List or switch inference profile` in every interface branch.

### `clients/shared/Features/Chat/SlashCommandCatalog.swift`

- **New** `ChatSlashCommandSendPathMatchRule.exactOrWithArgument`: matches both `/model` and `/model <name>`.
- `/model` added to `allCommands` — visible on all platforms in picker, helpBubble, sendPath. Opts in to `refreshesModelMetadata`. Selection behavior: `insertTrailingSpace` (types `/model ` so the user can append a name).
- **Removed** the now-redundant `/model` hard-coded bypass in `shouldBypassWorkspaceRefinement` — catalog recognition handles it.

### Tests

**TypeScript:**
- 8 new `resolveSlash /model` tests covering list, switch, unknown, disabled, current, no-profiles, whitespace trimming, and `/models`-non-confusion.

**Swift (`SlashCommandCatalogTests`):**
- Picker / helpBubble order assertions updated to include `/model`.
- `testDeprecatedModelCommandIsNotDiscoverableInPickerOrHelp` → `testModelCommandIsDiscoverableInPickerAndHelpBubble` (flipped).
- New `testModelMatchRuleDistinguishesModelAndModels` — verifies bare `/model`, `/model <arg>`, and that `/models` still resolves to its own descriptor.
- Bypass tests split: `testModelCommandBypassesWorkspaceRefinementInBothForms` + `testDeprecatedProviderShortcutsStillBypassWorkspaceRefinement`.
- Model-metadata refresh test extended to cover `/model` and `/model alpha`.

**Swift (`ChatViewModelSlashCommandTests`):**
- `/model` and `/model alpha` now trigger `fetchModelInfo` (previously the test asserted they did NOT).
- Bypass test split into `testModelSlashCommandBypassesWorkspaceRefinement` + `testDeprecatedProviderShortcutsBypassWorkspaceRefinement`.

**Swift (`ComposerSlashCommandPickerTests`):**
- Picker order updated; `testDeprecatedModelCommandIsNotInPickerCommands` → `testModelCommandIsInPickerWithTrailingSpaceBehavior`.

---

## Test noise note (not blocking)

When the slash-related TS test files are run together in a single `bun test a b c d` invocation, two files (`conversation-slash-queue.test.ts`, `conversation-slash-unknown.test.ts`) fail due to Bun's process-global `mock.module` contamination between files. The CI runner (`scripts/test.sh`) gives each file its own Bun process, so this doesn't reproduce in CI. The new `conversation-slash-commands.test.ts` passes 38/38 in isolation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->