### PR TITLE
Part of ATL-539: Remove Vercel credential proxy guidance from skills

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T16:12:45-04:00"
+      "updatedAt": "2026-05-12T11:33:20-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -921,7 +921,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-12T11:33:20-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -921,7 +921,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:33:20-04:00"
+      "updatedAt": "2026-05-12T11:41:15-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:33:20-04:00"
+      "updatedAt": "2026-05-12T11:36:47-04:00"
     },
     {
       "id": "discord-app-setup",

--- a/skills/deploy-fullstack-vercel/SKILL.md
+++ b/skills/deploy-fullstack-vercel/SKILL.md
@@ -21,12 +21,19 @@ Deploy a full-stack app with a React/Vite frontend and Python/FastAPI backend to
 
 ## Authentication
 
-Before deploying, check for a Vercel API credential:
+### Vellum App Publishing
 
-1. Run `credential_store list` and look for a `vercel/api_token` entry.
-2. If found with `injection_templates`, the credential can be used automatically via `network_mode: "proxied"` with `credential_ids`.
-3. If no credential exists, use `credential_store prompt` to ask the user for their Vercel API token. Direct them to https://vercel.com/account/tokens to create one.
-4. Fall back to the Vercel CLI only if no usable credential exists. Install with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+For publishing Vellum apps from the library, use the built-in `publish_page` tool. This is the preferred path — it uses the stored Vercel API token (`vercel/api_token`) via the brokered publish flow without exposing the token to shell commands.
+
+**The stored Vercel API token is reserved for brokered `publish_page` and `unpublish_page` actions only.** Do not pass it to `bash`, `curl`, Vercel CLI commands, or proxy credential injection. Do not use `network_mode: "proxied"` with `credential_ids` for Vercel deployments.
+
+### Custom Full-Stack Deployments
+
+For custom projects that need Vercel deployment (not Vellum app publishing):
+
+1. Use the Vercel CLI with user-mediated authentication: `vercel login` (opens browser for the user to authenticate interactively).
+2. Install the CLI with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+3. If the user does not want to use CLI auth, stop and ask them for an approved deployment path. Do not extract, inject, or shell with the stored API token.
 
 ## Deploying a Vellum App
 
@@ -91,7 +98,7 @@ Create a `vercel.json` in the dist directory:
 }
 ```
 
-Then deploy using the Vercel API credential (preferred) or CLI.
+Then deploy using the `publish_page` tool (preferred). For Vellum apps, use the built-in app publish flow rather than raw Vercel API calls from shell.
 
 ## Deploying a Custom Full-Stack Project
 
@@ -250,7 +257,7 @@ curl -s <deployed-url>/api/health
 
 ```bash
 bun install -g vercel        # Install
-vercel login                 # Authenticate (opens browser — last resort)
+vercel login                 # Authenticate (opens browser for user-mediated auth)
 vercel --yes --prod          # Deploy to production (skip prompts)
 vercel logs --project <name> # Check function logs
 ```

--- a/skills/deploy-fullstack-vercel/SKILL.md
+++ b/skills/deploy-fullstack-vercel/SKILL.md
@@ -31,8 +31,8 @@ For publishing Vellum apps from the library, use the built-in `publish_page` too
 
 For custom projects that need Vercel deployment (not Vellum app publishing):
 
-1. Use the Vercel CLI with user-mediated authentication: `vercel login` (opens browser for the user to authenticate interactively).
-2. Install the CLI with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+1. Install the Vercel CLI with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+2. Use `vercel login` to authenticate interactively (opens browser for the user).
 3. If the user does not want to use CLI auth, stop and ask them for an approved deployment path. Do not extract, inject, or shell with the stored API token.
 
 ## Deploying a Vellum App

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -83,6 +83,7 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
+  allowedDomains: []
 ```
 
 ### Channel Step 4: Done!
@@ -224,6 +225,7 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
+  allowedDomains: []
 ```
 
 **Verify:** `credential_store list` shows `api_token` for `vercel`.

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -83,7 +83,6 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
-  allowedDomains: ["api.vercel.com"]
 ```
 
 ### Channel Step 4: Done!
@@ -225,7 +224,6 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
-  allowedDomains: ["api.vercel.com"]
 ```
 
 **Verify:** `credential_store list` shows `api_token` for `vercel`.


### PR DESCRIPTION
## Summary
- Replace unsafe proxied bash credential injection instructions in deploy-fullstack-vercel skill
- Update vercel-token-setup skill to use restricted metadata (publish_page/unpublish_page only)
- Direct deployments to user-mediated Vercel CLI auth instead of stored token injection

Part of plan: atl-539-vercel-credential-injection.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->