### PR TITLE
Part of ATL-539: Repair existing Vercel credential metadata

### DIFF
--- a/assistant/src/__tests__/workspace-migration-080-restrict-vercel-api-token-metadata.test.ts
+++ b/assistant/src/__tests__/workspace-migration-080-restrict-vercel-api-token-metadata.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for workspace migration `080-restrict-vercel-api-token-metadata`.
+ *
+ * The migration rewrites Vercel API token credential metadata from
+ * the legacy vulnerable policy (bash in allowedTools, injection
+ * templates) to the hardened policy (publish_page + unpublish_page
+ * only, no injection templates).
+ *
+ * Cases covered:
+ *   1. Legacy vulnerable metadata -> repaired to target policy.
+ *   2. Already-migrated metadata -> no-op (file unchanged).
+ *   3. Missing metadata file -> no-op (no error).
+ *   4. Malformed JSON -> no-op (no error).
+ *   5. Unrelated credentials preserved during repair.
+ *   6. Unrecognized future schema version -> no-op.
+ *   7. No Vercel record present -> no-op.
+ *   8. Idempotent: second run on repaired file is a no-op.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { restrictVercelApiTokenMetadataMigration } from "../workspace/migrations/080-restrict-vercel-api-token-metadata.js";
+
+let workspaceDir: string;
+let metadataPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-080-test-"));
+  metadataPath = join(workspaceDir, "data", "credentials", "metadata.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeMetadata(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+  writeFileSync(metadataPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readMetadata(): Record<string, unknown> {
+  return JSON.parse(readFileSync(metadataPath, "utf-8"));
+}
+
+/** The legacy vulnerable Vercel credential record (pre-PR 2). */
+function makeLegacyVercelRecord(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    credentialId: "cred-vercel-123",
+    service: "vercel",
+    field: "api_token",
+    allowedTools: ["deploy", "publish_page", "bash"],
+    allowedDomains: [],
+    injectionTemplates: [
+      {
+        hostPattern: "api.vercel.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** The expected hardened Vercel credential record (post-migration). */
+function makeHardenedVercelRecord(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    credentialId: "cred-vercel-123",
+    service: "vercel",
+    field: "api_token",
+    allowedTools: ["publish_page", "unpublish_page"],
+    allowedDomains: [],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** An unrelated credential record (should never be touched). */
+function makeOtherRecord(): Record<string, unknown> {
+  return {
+    credentialId: "cred-other-456",
+    service: "slack",
+    field: "bot_token",
+    allowedTools: ["send_message"],
+    allowedDomains: ["slack.com"],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+describe("workspace migration 080-restrict-vercel-api-token-metadata", () => {
+  test("has the expected id and description", () => {
+    expect(restrictVercelApiTokenMetadataMigration.id).toBe(
+      "080-restrict-vercel-api-token-metadata",
+    );
+    expect(restrictVercelApiTokenMetadataMigration.description).toContain(
+      "Vercel",
+    );
+  });
+
+  test("repairs legacy vulnerable metadata to hardened policy", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    expect(result.version).toBe(5);
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(1);
+
+    const vercel = creds[0];
+    expect(vercel.service).toBe("vercel");
+    expect(vercel.field).toBe("api_token");
+    expect(vercel.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+    expect(vercel.allowedDomains).toEqual([]);
+    expect(vercel.injectionTemplates).toBeUndefined();
+    // updatedAt should have been bumped.
+    expect(vercel.updatedAt).not.toBe(1700000000000);
+    // createdAt should be preserved.
+    expect(vercel.createdAt).toBe(1700000000000);
+    // credentialId should be preserved.
+    expect(vercel.credentialId).toBe("cred-vercel-123");
+  });
+
+  test("already-migrated metadata is a no-op (file unchanged)", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeHardenedVercelRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+    const beforeStat = statSync(metadataPath);
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const after = readFileSync(metadataPath, "utf-8");
+    expect(after).toBe(before);
+    expect(statSync(metadataPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  test("missing metadata file is a no-op (no error, no file created)", () => {
+    expect(existsSync(metadataPath)).toBe(false);
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(existsSync(metadataPath)).toBe(false);
+  });
+
+  test("malformed JSON is a no-op (does not throw, leaves file alone)", () => {
+    mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+    writeFileSync(metadataPath, "{not valid json", "utf-8");
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("non-Vercel credentials are preserved unchanged during repair", () => {
+    const other = makeOtherRecord();
+    writeMetadata({
+      version: 5,
+      credentials: [other, makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(2);
+
+    // Other credential should be exactly unchanged.
+    const otherCred = creds.find((c) => c.service === "slack");
+    expect(otherCred).toBeDefined();
+    expect(otherCred!.allowedTools).toEqual(["send_message"]);
+    expect(otherCred!.allowedDomains).toEqual(["slack.com"]);
+    expect(otherCred!.updatedAt).toBe(1700000000000);
+
+    // Vercel credential should be repaired.
+    const vercelCred = creds.find((c) => c.service === "vercel");
+    expect(vercelCred).toBeDefined();
+    expect(vercelCred!.allowedTools).toEqual([
+      "publish_page",
+      "unpublish_page",
+    ]);
+    expect(vercelCred!.injectionTemplates).toBeUndefined();
+  });
+
+  test("unrecognized future schema version is a no-op", () => {
+    writeMetadata({
+      version: 99,
+      credentials: [makeLegacyVercelRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("no Vercel record present is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeOtherRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("idempotent: second run on repaired file is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const afterFirst = readFileSync(metadataPath, "utf-8");
+    const afterFirstStat = statSync(metadataPath);
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const afterSecond = readFileSync(metadataPath, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(statSync(metadataPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeMetadata([1, 2, 3]);
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("file with no version field defaults to version 1 and processes", () => {
+    writeMetadata({
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    const vercel = creds.find((c) => c.service === "vercel");
+    expect(vercel!.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+    expect(vercel!.injectionTemplates).toBeUndefined();
+  });
+
+  test("down() is a no-op (security hardening cannot be reversed)", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const after = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(after);
+  });
+});

--- a/assistant/src/workspace/migrations/080-restrict-vercel-api-token-metadata.ts
+++ b/assistant/src/workspace/migrations/080-restrict-vercel-api-token-metadata.ts
@@ -1,0 +1,182 @@
+/**
+ * Workspace migration `080-restrict-vercel-api-token-metadata`.
+ *
+ * Repairs legacy Vercel API token credential metadata that was stored
+ * with overly permissive policy (e.g. `bash` in allowedTools and
+ * injection templates targeting `api.vercel.com`). Rewrites the
+ * Vercel record to the hardened policy:
+ *
+ *   - `allowedTools: ["publish_page", "unpublish_page"]`
+ *   - `allowedDomains: []`
+ *   - `injectionTemplates` removed
+ *
+ * Behaviour:
+ *   - Missing metadata file -> no-op.
+ *   - Malformed JSON -> log and no-op.
+ *   - Unrecognized future schema version -> no-op.
+ *   - No `vercel`/`api_token` credential record -> no-op.
+ *   - Already matches target policy -> no-op (no rewrite, no updatedAt bump).
+ *   - Non-Vercel credential records are never modified.
+ *
+ * Idempotent: running twice produces no second write. The runner's
+ * checkpoint also prevents re-runs, but this in-file guard keeps the
+ * migration safe even if the checkpoint is wiped.
+ *
+ * This migration never touches secure secret values — only the
+ * metadata policy fields.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-080-restrict-vercel-api-token-metadata",
+);
+
+const METADATA_RELATIVE_PATH = join("data", "credentials", "metadata.json");
+
+/** Known on-disk schema versions we can safely handle. */
+const KNOWN_VERSIONS = new Set([1, 2, 3, 4, 5]);
+
+/** The hardened target policy for the Vercel API token. */
+const TARGET_ALLOWED_TOOLS = ["publish_page", "unpublish_page"];
+const TARGET_ALLOWED_DOMAINS: string[] = [];
+
+export const restrictVercelApiTokenMetadataMigration: WorkspaceMigration = {
+  id: "080-restrict-vercel-api-token-metadata",
+  description:
+    "Restrict existing Vercel API token metadata to publish tools only",
+
+  run(workspaceDir: string): void {
+    const metadataPath = join(workspaceDir, METADATA_RELATIVE_PATH);
+    if (!existsSync(metadataPath)) {
+      return;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(metadataPath, "utf-8");
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to read credentials metadata; skipping migration",
+      );
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to parse credentials metadata JSON; skipping migration",
+      );
+      return;
+    }
+
+    if (!isPlainObject(parsed)) {
+      log.warn(
+        { path: metadataPath },
+        "Credentials metadata is not an object; skipping migration",
+      );
+      return;
+    }
+
+    // Respect unrecognized future schema versions — do not touch the file.
+    const version = typeof parsed.version === "number" ? parsed.version : 1;
+    if (!KNOWN_VERSIONS.has(version)) {
+      log.info(
+        { version, path: metadataPath },
+        "Credentials metadata has unrecognized version; skipping migration",
+      );
+      return;
+    }
+
+    const credentials = Array.isArray(parsed.credentials)
+      ? parsed.credentials
+      : [];
+
+    // Find the Vercel API token record.
+    const vercelIdx = credentials.findIndex(
+      (c: unknown) =>
+        isPlainObject(c) && c.service === "vercel" && c.field === "api_token",
+    );
+
+    if (vercelIdx === -1) {
+      // No Vercel credential — nothing to repair.
+      return;
+    }
+
+    const vercelRecord = credentials[vercelIdx] as Record<string, unknown>;
+
+    // Check if already matches target policy.
+    if (alreadyMatchesTarget(vercelRecord)) {
+      return;
+    }
+
+    // Rewrite the Vercel record to the target policy.
+    vercelRecord.allowedTools = TARGET_ALLOWED_TOOLS;
+    vercelRecord.allowedDomains = TARGET_ALLOWED_DOMAINS;
+    delete vercelRecord.injectionTemplates;
+    vercelRecord.updatedAt = Date.now();
+
+    try {
+      writeFileSync(metadataPath, JSON.stringify(parsed, null, 2), "utf-8");
+      log.info(
+        { path: metadataPath },
+        "Repaired Vercel API token metadata to hardened policy",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to write repaired credentials metadata; leaving prior file in place",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Cannot recover the original vulnerable policy — and we would not
+    // want to even if we could. This is a security hardening migration.
+  },
+};
+
+/**
+ * Returns true when the Vercel record already matches the target
+ * hardened policy, meaning no rewrite is necessary.
+ */
+function alreadyMatchesTarget(record: Record<string, unknown>): boolean {
+  const tools = record.allowedTools;
+  const domains = record.allowedDomains;
+
+  if (!Array.isArray(tools) || tools.length !== TARGET_ALLOWED_TOOLS.length) {
+    return false;
+  }
+  const sortedTools = [...tools].sort();
+  const sortedTarget = [...TARGET_ALLOWED_TOOLS].sort();
+  for (let i = 0; i < sortedTools.length; i++) {
+    if (sortedTools[i] !== sortedTarget[i]) return false;
+  }
+
+  if (!Array.isArray(domains) || domains.length !== 0) {
+    return false;
+  }
+
+  // injectionTemplates must be absent or undefined.
+  if (
+    "injectionTemplates" in record &&
+    record.injectionTemplates !== undefined &&
+    record.injectionTemplates !== null
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -77,6 +77,7 @@ import { dropServicesInferenceModeMigration } from "./076-drop-services-inferenc
 import { seedMemoryRouterCallsiteMigration } from "./077-seed-memory-router-callsite.js";
 import { releaseNotesTavilyWebSearchMigration } from "./078-release-notes-tavily-web-search.js";
 import { homeFeedNotificationOnlyMigration } from "./079-home-feed-notification-only.js";
+import { restrictVercelApiTokenMetadataMigration } from "./080-restrict-vercel-api-token-metadata.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -165,4 +166,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedMemoryRouterCallsiteMigration,
   releaseNotesTavilyWebSearchMigration,
   homeFeedNotificationOnlyMigration,
+  restrictVercelApiTokenMetadataMigration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration 080 to rewrite legacy Vercel API token metadata
- Restricts allowedTools to publish_page/unpublish_page, clears injectionTemplates
- Idempotent: no-ops if metadata already matches target policy

Part of plan: atl-539-vercel-credential-injection.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->