### PR TITLE
feat: add `assistant use slack` CLI namespace with send, read, react, channels, users

### DIFF
--- a/assistant/eslint-rules/cli-no-daemon-internals.js
+++ b/assistant/eslint-rules/cli-no-daemon-internals.js
@@ -15,22 +15,27 @@ const ALLOWED_PREFIXES = {
     // imports independently, so this can't be used to smuggle daemon
     // internals through a sibling re-export.
     "./",
-    // IPC client at depth-1 and depth-2.
+    // IPC client at depth-1, depth-2, and depth-3.
     "../../ipc/cli-client",
     "../../../ipc/cli-client",
+    "../../../../ipc/cli-client",
     // Status command's daemon-down fallback needs socket path + platform.
     "../../ipc/socket-path",
     "../../util/platform",
-    // Logger / output at depth-1 and depth-2.
+    // Logger / output at depth-1, depth-2, and depth-3.
     "../logger",
     "../output",
     "../../logger",
     "../../output",
-    // Shared CLI lib / utils at depth-1 and depth-2.
+    "../../../logger",
+    "../../../output",
+    // Shared CLI lib / utils at depth-1, depth-2, and depth-3.
     "../lib/",
     "../../lib/",
+    "../../../lib/",
     "../utils/",
     "../../utils/",
+    "../../../utils/",
     // Environment access for commands that need to read VELLUM_* env vars
     // before issuing IPC calls (e.g. email, domain).
     "../../config/env",

--- a/assistant/src/cli/commands/use/index.ts
+++ b/assistant/src/cli/commands/use/index.ts
@@ -6,7 +6,7 @@ import { registerSlackCommand } from "./slack/index.js";
 export function registerUseCommand(program: Command): void {
   registerCommand(program, {
     name: "use",
-    transport: "local",
+    transport: "ipc",
     description: "Use third-party integrations (Slack, Linear, etc.)",
     build: (use) => {
       use.addHelpText(

--- a/assistant/src/cli/commands/use/index.ts
+++ b/assistant/src/cli/commands/use/index.ts
@@ -1,0 +1,28 @@
+import type { Command } from "commander";
+
+import { registerCommand } from "../../lib/register-command.js";
+import { registerSlackCommand } from "./slack/index.js";
+
+export function registerUseCommand(program: Command): void {
+  registerCommand(program, {
+    name: "use",
+    transport: "local",
+    description: "Use third-party integrations (Slack, Linear, etc.)",
+    build: (use) => {
+      use.addHelpText(
+        "after",
+        `
+Third-party integration commands. Each integration is a subcommand
+group with its own set of operations. Integrations require prior
+configuration via 'assistant oauth' or 'assistant credentials'.
+
+Examples:
+  $ assistant use slack send --channel general --text "hello"
+  $ assistant use slack read --channel general --limit 5
+  $ assistant use slack channels list`,
+      );
+
+      registerSlackCommand(use);
+    },
+  });
+}

--- a/assistant/src/cli/commands/use/slack/channels.ts
+++ b/assistant/src/cli/commands/use/slack/channels.ts
@@ -1,0 +1,149 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:channels");
+
+interface ChannelCache {
+  channels: Record<string, { id: string; type: string }>;
+  refreshedAt: string;
+}
+
+interface ChannelEntry {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export function registerChannelsCommand(slack: Command): void {
+  const channels = slack
+    .command("channels")
+    .description("List, refresh, or look up Slack channels");
+
+  channels.addHelpText(
+    "after",
+    `
+Manage the local Slack channel cache. Channels are cached locally after
+the first fetch to avoid repeated API calls. Use 'refresh' to rebuild
+the cache from the Slack API.
+
+Examples:
+  $ assistant use slack channels list
+  $ assistant use slack channels refresh
+  $ assistant use slack channels get team-jarvis`,
+  );
+
+  channels
+    .command("list")
+    .description("List cached Slack channels")
+    .addHelpText(
+      "after",
+      `
+Returns the locally cached channel list. If the cache is empty, it is
+auto-populated from the Slack API on first call.
+
+Examples:
+  $ assistant use slack channels list
+  general        C01234567  channel
+  team-jarvis    C01234568  channel
+  random         C01234569  channel
+
+  $ assistant use slack channels list --json
+  {"channels":{"general":{"id":"C01234567","type":"channel"},...},"refreshedAt":"..."}`,
+    )
+    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      const r = await cliIpcCall<ChannelCache>("slack_use_channels_list", {});
+      if (!r.ok) return exitFromIpcResult(r, cmd);
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, r.result);
+      } else {
+        const cache = r.result!;
+        const entries = Object.entries(cache.channels);
+        if (entries.length === 0) {
+          log.info("No channels found.");
+        } else {
+          // Find the longest channel name for alignment
+          const maxName = Math.max(...entries.map(([name]) => name.length));
+          for (const [name, info] of entries) {
+            log.info(`${name.padEnd(maxName + 2)} ${info.id}  ${info.type}`);
+          }
+          log.info(
+            `\n${entries.length} channel(s) (cached at ${cache.refreshedAt})`,
+          );
+        }
+      }
+    });
+
+  channels
+    .command("refresh")
+    .description("Rebuild the local channel cache from the Slack API")
+    .addHelpText(
+      "after",
+      `
+Fetches all channels from the Slack API and rebuilds the local cache.
+Use this after channels are created or renamed in Slack.
+
+Examples:
+  $ assistant use slack channels refresh
+  Refreshed 42 channels
+
+  $ assistant use slack channels refresh --json
+  {"channels":{...},"refreshedAt":"..."}`,
+    )
+    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      const r = await cliIpcCall<ChannelCache>(
+        "slack_use_channels_refresh",
+        {},
+      );
+      if (!r.ok) return exitFromIpcResult(r, cmd);
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, r.result);
+      } else {
+        const count = Object.keys(r.result!.channels).length;
+        log.info(`Refreshed ${count} channel(s)`);
+      }
+    });
+
+  channels
+    .command("get <name>")
+    .description("Resolve a Slack channel by name or ID")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Channel name (e.g. "general", "#team-jarvis") or raw Slack channel ID
+
+Resolves a channel name or ID to a structured object with the channel's
+Slack ID, name, and type. Uses the local cache, auto-refreshing if needed.
+
+Examples:
+  $ assistant use slack channels get general
+  Name: general
+  ID:   C01234567
+  Type: channel
+
+  $ assistant use slack channels get C01234567 --json
+  {"id":"C01234567","name":"general","type":"channel"}`,
+    )
+    .action(
+      async (name: string, _opts: Record<string, unknown>, cmd: Command) => {
+        const r = await cliIpcCall<ChannelEntry>("slack_use_channels_get", {
+          pathParams: { name },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const ch = r.result!;
+          log.info(`Name: ${ch.name}`);
+          log.info(`ID:   ${ch.id}`);
+          log.info(`Type: ${ch.type}`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/index.ts
+++ b/assistant/src/cli/commands/use/slack/index.ts
@@ -1,0 +1,43 @@
+import type { Command } from "commander";
+
+import { registerCommand } from "../../../lib/register-command.js";
+import { registerChannelsCommand } from "./channels.js";
+import { registerReactCommand } from "./react.js";
+import { registerReadCommand } from "./read.js";
+import { registerSendCommand } from "./send.js";
+import { registerUsersCommand } from "./users.js";
+
+export function registerSlackCommand(parent: Command): void {
+  registerCommand(parent, {
+    name: "slack",
+    transport: "ipc",
+    description: "Send, read, and react to Slack messages",
+    build: (slack) => {
+      slack.option("--json", "Machine-readable compact JSON output");
+
+      slack.addHelpText(
+        "after",
+        `
+Slack integration requires a configured Slack token. Set one up via
+'assistant oauth connect slack' or 'assistant credentials set slack-token'.
+
+Channel arguments accept a channel name (with or without #) or a raw
+Slack channel ID. User arguments accept an email address or display name.
+
+Examples:
+  $ assistant use slack send --channel team-jarvis --text "hello"
+  $ assistant use slack read --channel general --limit 10 --since 2h
+  $ assistant use slack react --channel general --ts 1715123456.000100 --emoji thumbsup
+  $ assistant use slack channels list
+  $ assistant use slack channels refresh
+  $ assistant use slack users get user@example.com`,
+      );
+
+      registerSendCommand(slack);
+      registerReadCommand(slack);
+      registerReactCommand(slack);
+      registerChannelsCommand(slack);
+      registerUsersCommand(slack);
+    },
+  });
+}

--- a/assistant/src/cli/commands/use/slack/react.ts
+++ b/assistant/src/cli/commands/use/slack/react.ts
@@ -1,0 +1,64 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:react");
+
+export function registerReactCommand(slack: Command): void {
+  slack
+    .command("react")
+    .description("Add an emoji reaction to a Slack message")
+    .requiredOption(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .requiredOption(
+      "--ts <message-ts>",
+      "Timestamp of the message to react to — visible in 'assistant use slack read --json' output",
+    )
+    .requiredOption(
+      "--emoji <name>",
+      'Emoji name without colons (e.g. "thumbsup", not ":thumbsup:")',
+    )
+    .addHelpText(
+      "after",
+      `
+Add an emoji reaction to a specific message in a Slack channel.
+Surrounding colons on the emoji name are stripped automatically.
+
+Arguments:
+  --channel   Channel name or Slack channel ID (required)
+  --ts        Message timestamp to react to (required)
+  --emoji     Emoji name, e.g. "thumbsup", "rocket", "eyes" (required)
+
+Examples:
+  $ assistant use slack react --channel general --ts 1715123456.000100 --emoji thumbsup
+  Reacted with :thumbsup: to message
+
+  $ assistant use slack react --channel team-jarvis --ts 1715123456.000100 --emoji rocket --json
+  {"ok":true}`,
+    )
+    .action(
+      async (
+        opts: { channel: string; ts: string; emoji: string },
+        cmd: Command,
+      ) => {
+        const { channel, ts, emoji } = opts;
+
+        const r = await cliIpcCall<{ ok: boolean }>("slack_use_react", {
+          body: { channel, ts, emoji },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          log.info(
+            `Reacted with :${emoji.replace(/^:/, "").replace(/:$/, "")}: to message`,
+          );
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/read.ts
+++ b/assistant/src/cli/commands/use/slack/read.ts
@@ -1,0 +1,102 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:read");
+
+interface ReadResponse {
+  channel: string;
+  messages: Array<{
+    ts: string;
+    user?: string;
+    text: string;
+    thread_ts?: string;
+  }>;
+}
+
+export function registerReadCommand(slack: Command): void {
+  slack
+    .command("read")
+    .description("Read messages from a Slack channel or thread")
+    .requiredOption(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .option("--limit <n>", "Maximum number of messages to return", "20")
+    .option(
+      "--since <ts-or-offset>",
+      'Only show messages since this point — a Slack timestamp (e.g. "1234567890.123456") or relative offset ("2h", "30m", "1d")',
+    )
+    .option("--thread <ts>", "Read replies in a specific thread")
+    .addHelpText(
+      "after",
+      `
+Read recent messages from a Slack channel. When --thread is given,
+reads replies in that thread instead of top-level messages.
+
+The --since option accepts either a raw Slack timestamp or a relative
+offset: "2h" (2 hours ago), "30m" (30 minutes ago), "1d" (1 day ago).
+
+Arguments:
+  --channel   Channel name (e.g. "general") or Slack channel ID (required)
+  --limit     Max messages to return (default: 20)
+  --since     Filter to messages after this point
+  --thread    Parent message timestamp to read thread replies
+
+Examples:
+  $ assistant use slack read --channel general
+  [1715123456.000100] <U123> hello world
+  [1715123456.000200] <U456> hi there
+
+  $ assistant use slack read --channel team-jarvis --limit 5 --since 2h
+  [1715123456.000100] <U123> recent message
+
+  $ assistant use slack read --channel general --thread 1715123456.000100
+  [1715123456.000100] <U123> original message
+  [1715123456.000200] <U456> thread reply
+
+  $ assistant use slack read --channel general --json
+  {"channel":"C123","messages":[...]}`,
+    )
+    .action(
+      async (
+        opts: {
+          channel: string;
+          limit?: string;
+          since?: string;
+          thread?: string;
+        },
+        cmd: Command,
+      ) => {
+        const { channel, limit, since, thread } = opts;
+
+        const r = await cliIpcCall<ReadResponse>("slack_use_read", {
+          body: {
+            channel,
+            limit: parseInt(limit ?? "20", 10),
+            since,
+            thread,
+          },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const messages = r.result!.messages;
+          if (messages.length === 0) {
+            log.info("No messages found.");
+          } else {
+            for (const msg of messages) {
+              const threadIndicator = msg.thread_ts ? " [thread]" : "";
+              log.info(
+                `[${msg.ts}] <${msg.user ?? "unknown"}> ${msg.text}${threadIndicator}`,
+              );
+            }
+          }
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/send.ts
+++ b/assistant/src/cli/commands/use/slack/send.ts
@@ -1,0 +1,89 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:send");
+
+interface SendResponse {
+  ok: boolean;
+  channel: string;
+  ts: string;
+}
+
+export function registerSendCommand(slack: Command): void {
+  slack
+    .command("send")
+    .description("Send a message to a Slack channel or user DM")
+    .requiredOption("--text <message>", "Message text to send")
+    .option(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .option(
+      "--user <id-or-email>",
+      "User ID or email for a direct message — run 'assistant use slack users get <query>' to resolve",
+    )
+    .option("--thread <ts>", "Thread timestamp to reply in")
+    .addHelpText(
+      "after",
+      `
+Send a message to a Slack channel or open a DM with a user. Exactly
+one of --channel or --user must be provided.
+
+When --thread is given, the message is posted as a threaded reply.
+
+Arguments:
+  --text       The message body (required)
+  --channel    Channel name (e.g. "general", "#team-jarvis") or Slack ID
+  --user       User email or Slack user ID — opens a DM conversation
+  --thread     Parent message timestamp for threading
+
+Examples:
+  $ assistant use slack send --channel team-jarvis --text "hello"
+  Message sent to team-jarvis (ts: 1715123456.000100)
+
+  $ assistant use slack send --user user@example.com --text "hey!"
+  Message sent to user@example.com (ts: 1715123456.000200)
+
+  $ assistant use slack send --channel general --text "reply" --thread 1715123456.000100
+  Message sent to general (ts: 1715123456.000300)
+
+  $ assistant use slack send --channel general --text "hello" --json
+  {"ok":true,"channel":"C123","ts":"1715123456.000100"}`,
+    )
+    .action(
+      async (
+        opts: {
+          text: string;
+          channel?: string;
+          user?: string;
+          thread?: string;
+        },
+        cmd: Command,
+      ) => {
+        const { text, channel, user, thread } = opts;
+
+        if ((channel && user) || (!channel && !user)) {
+          log.error(
+            "Exactly one of --channel or --user must be provided. Use --channel for a channel message or --user for a DM.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        const r = await cliIpcCall<SendResponse>("slack_use_send", {
+          body: { channel, user, text, thread },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const target = channel ?? user;
+          log.info(`Message sent to ${target} (ts: ${r.result!.ts})`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/users.ts
+++ b/assistant/src/cli/commands/use/slack/users.ts
@@ -1,0 +1,66 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:users");
+
+interface UserEntry {
+  id: string;
+  displayName: string;
+  email: string;
+}
+
+export function registerUsersCommand(slack: Command): void {
+  const users = slack.command("users").description("Look up Slack users");
+
+  users.addHelpText(
+    "after",
+    `
+Resolve Slack users by email address or display name.
+
+Examples:
+  $ assistant use slack users get user@example.com
+  $ assistant use slack users get "Jane Smith"`,
+  );
+
+  users
+    .command("get <query>")
+    .description("Resolve a Slack user by email or display name")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  query   Email address or display name to search for
+
+Resolves a user from the local Slack user cache. The query is matched
+against email addresses and display names.
+
+Examples:
+  $ assistant use slack users get user@example.com
+  Name:  Jane Smith
+  ID:    U01234567
+  Email: user@example.com
+
+  $ assistant use slack users get "Jane Smith" --json
+  {"id":"U01234567","displayName":"Jane Smith","email":"user@example.com"}`,
+    )
+    .action(
+      async (query: string, _opts: Record<string, unknown>, cmd: Command) => {
+        const r = await cliIpcCall<UserEntry>("slack_use_users_get", {
+          pathParams: { query },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const user = r.result!;
+          log.info(`Name:  ${user.displayName}`);
+          log.info(`ID:    ${user.id}`);
+          log.info(`Email: ${user.email}`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -47,6 +47,7 @@ import { registerTrustCommand } from "./commands/trust.js";
 import { registerTtsCommand } from "./commands/tts.js";
 import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
+import { registerUseCommand } from "./commands/use/index.js";
 import { registerWatchersCommand } from "./commands/watchers.js";
 import { registerWebhooksCommand } from "./commands/webhooks.js";
 import { log } from "./logger.js";
@@ -117,6 +118,7 @@ Examples:
   registerTtsCommand(program);
   registerUiCommand(program);
   registerUsageCommand(program);
+  registerUseCommand(program);
   registerWatchersCommand(program);
   registerWebhooksCommand(program);
 

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -224,6 +224,17 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "ui",
   "ui request",
   "ui confirm",
+  "use",
+  "use slack",
+  "use slack send",
+  "use slack read",
+  "use slack react",
+  "use slack channels",
+  "use slack channels list",
+  "use slack channels refresh",
+  "use slack channels get",
+  "use slack users",
+  "use slack users get",
   "usage",
   "usage totals",
   "usage daily",
@@ -407,7 +418,8 @@ const riskOverrides: AssistantRiskOverride[] = [
   {
     path: "inference providers connections create",
     risk: "medium",
-    reason: "Inserts a provider_connection row referenced by inference profiles",
+    reason:
+      "Inserts a provider_connection row referenced by inference profiles",
   },
   {
     path: "inference providers connections update",
@@ -417,7 +429,8 @@ const riskOverrides: AssistantRiskOverride[] = [
   {
     path: "inference providers connections delete",
     risk: "medium",
-    reason: "Deletes a provider_connection row; refuses unless --force when profiles still reference it",
+    reason:
+      "Deletes a provider_connection row; refuses unless --force when profiles still reference it",
   },
   { path: "llm send", risk: "medium" },
   {
@@ -500,6 +513,22 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "task queue remove", risk: "medium" },
   { path: "task queue run", risk: "medium" },
   { path: "tts synthesize", risk: "medium" },
+  {
+    path: "use slack send",
+    risk: "medium",
+    reason: "Sends a message to a Slack channel or DM",
+  },
+  {
+    path: "use slack react",
+    risk: "medium",
+    reason: "Adds an emoji reaction to a Slack message",
+  },
+  {
+    path: "use slack channels refresh",
+    risk: "low",
+    reason:
+      "Rebuilds local channel cache from Slack API — read-only external call",
+  },
   { path: "watchers create", risk: "medium" },
   { path: "watchers update", risk: "medium" },
   { path: "watchers delete", risk: "medium" },


### PR DESCRIPTION
## Summary
- Create `assistant use` top-level namespace for third-party integrations
- Add `assistant use slack` with send, read, react, channels, and users subcommands
- All commands support `--json` for programmatic use
- Human-readable output formatting for each command
- Comprehensive help text with examples
- Gateway risk registry updated with all new command paths and risk overrides

Part of plan: use-slack-cli.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->