### PR TITLE
refactor(macos): conditionally replace send button with stop during generation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -465,129 +465,52 @@ struct ComposerView: View, Equatable {
 
             Spacer()
 
-            // Right side: attach, stop/voice/mic, send
-            if isAssistantBusy && !hasPendingConfirmation {
-                VButton(
-                    label: "Stop generation",
-                    iconOnly: VIcon.square.rawValue,
-                    style: .primary,
-                    iconSize: composerActionButtonSize,
-                    action: onStop
-                )
-            } else if inputText.isEmpty && !hasPendingConfirmation {
-                if !isAssistantBusy {
-                    VButton(
-                        label: "Attach file",
-                        iconOnly: VIcon.paperclip.rawValue,
-                        style: .ghost,
-                        iconSize: composerActionButtonSize,
-                        action: { onAttach() }
-                    )
-                    .vTooltip("Attach file")
-                }
+            // Right side: attach, voice/mic, stop-or-send
 
-                if onVoiceModeToggle != nil {
-                    VButton(
-                        label: "Voice mode",
-                        iconOnly: VIcon.audioWaveform.rawValue,
-                        style: .ghost,
-                        iconSize: composerActionButtonSize,
-                        action: { onVoiceModeToggle?() }
-                    )
-                    .vTooltip("Live voice conversation")
-                }
+            VButton(
+                label: "Attach file",
+                iconOnly: VIcon.paperclip.rawValue,
+                style: .ghost,
+                iconSize: composerActionButtonSize,
+                action: { onAttach() }
+            )
+            .vTooltip("Attach file")
 
+            if inputText.isEmpty && onVoiceModeToggle != nil {
                 VButton(
-                    label: isRecording ? "Stop recording" : "Dictate",
-                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
+                    label: "Voice mode",
+                    iconOnly: VIcon.audioWaveform.rawValue,
                     style: .ghost,
                     iconSize: composerActionButtonSize,
-                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                    action: { onVoiceModeToggle?() }
                 )
-                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
+                .vTooltip("Live voice conversation")
+            }
 
-                if !isRecording {
+            VButton(
+                label: isRecording ? "Stop recording" : "Dictate",
+                iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
+                style: .ghost,
+                iconSize: composerActionButtonSize,
+                action: { (onDictateToggle ?? onMicrophoneToggle)() }
+            )
+            .vTooltip(isRecording ? "Stop recording" : micTooltipText)
+
+            if !isRecording {
+                if isAssistantBusy && !canSend && !hasPendingConfirmation {
+                    VButton(
+                        label: "Stop generation",
+                        iconOnly: VIcon.square.rawValue,
+                        style: .primary,
+                        iconSize: composerActionButtonSize,
+                        action: onStop
+                    )
+                } else {
                     VButton(
                         label: "Send message",
                         iconOnly: VIcon.arrowUp.rawValue,
                         style: .primary,
-                        isDisabled: !canSend,
-                        iconSize: composerActionButtonSize
-                    ) {
-                        composerFocus = true
-                        performSendAction()
-                    }
-                    .vTooltip("Type a message to send")
-                }
-            } else if !hasPendingConfirmation {
-                VButton(
-                    label: "Attach file",
-                    iconOnly: VIcon.paperclip.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { onAttach() }
-                )
-                .vTooltip("Attach file")
-
-                VButton(
-                    label: isRecording ? "Stop recording" : "Dictate",
-                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
-                )
-                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
-
-                if !isRecording {
-                    VButton(
-                        label: "Send message",
-                        iconOnly: VIcon.arrowUp.rawValue,
-                        style: .primary,
-                        isDisabled: !canSend,
-                        iconSize: composerActionButtonSize
-                    ) {
-                        composerFocus = true
-                        performSendAction()
-                    }
-                    .vTooltip(canSend ? "Send" : "Type a message to send")
-                }
-            } else {
-                // Pending confirmation
-                VButton(
-                    label: "Attach file",
-                    iconOnly: VIcon.paperclip.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { onAttach() }
-                )
-                .vTooltip("Attach file")
-
-                if onVoiceModeToggle != nil {
-                    VButton(
-                        label: "Voice mode",
-                        iconOnly: VIcon.audioWaveform.rawValue,
-                        style: .ghost,
-                        iconSize: composerActionButtonSize,
-                        action: { onVoiceModeToggle?() }
-                    )
-                    .vTooltip("Live voice conversation")
-                }
-
-                VButton(
-                    label: isRecording ? "Stop recording" : "Dictate",
-                    iconOnly: isRecording ? VIcon.circleStop.rawValue : VIcon.mic.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { (onDictateToggle ?? onMicrophoneToggle)() }
-                )
-                .vTooltip(isRecording ? "Stop recording" : micTooltipText)
-
-                if !isRecording {
-                    VButton(
-                        label: "Send message",
-                        iconOnly: VIcon.arrowUp.rawValue,
-                        style: .primary,
-                        isDisabled: !canSend,
+                        isDisabled: !canSend && !isAssistantBusy,
                         iconSize: composerActionButtonSize
                     ) {
                         composerFocus = true

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -510,7 +510,7 @@ struct ComposerView: View, Equatable {
                         label: "Send message",
                         iconOnly: VIcon.arrowUp.rawValue,
                         style: .primary,
-                        isDisabled: !canSend && !isAssistantBusy,
+                        isDisabled: !canSend && (!isAssistantBusy || hasPendingConfirmation),
                         iconSize: composerActionButtonSize
                     ) {
                         composerFocus = true


### PR DESCRIPTION
Replaces the dedicated stop-only state in the composer action bar with a conditional stop/send toggle. Previously, when the assistant was busy the composer hid all controls (attach, voice mode, mic) and showed only a stop button. Now all controls remain visible during generation, and only the trailing button switches between stop and send based on whether the user has typed input.

**Trailing button logic:**
- Assistant busy + no sendable input → **stop** button
- Assistant busy + user has typed input → **send** button (enabled, for message queueing)
- Assistant idle + no input → **send** button (disabled)
- Assistant idle + has input → **send** button (enabled)
- Pending confirmation + busy + no input → **send** button (disabled, prevents accidental approval)

This also eliminates ~80 lines of duplicated button declarations across four if/else branches, consolidating into a flat structure.

---

## Prompt / plan

User requested: remove the extra stop button during assistant busy state; conditionally replace send with stop. Stop shows when busy with no input, send shows when user is typing (even during generation for queueing), and send is disabled only when idle with no input.

## Test plan

- CI skips macOS builds — **must be verified locally in Xcode**
- No unit tests affected (view-only change)
- Manual testing needed for all states: idle empty, idle with input, busy empty, busy with input, pending confirmation, recording

## Human review checklist

- [ ] **Build in Xcode** — CI cannot verify Swift compilation
- [ ] **Verify attach/mic visible during generation** — these were previously hidden when assistant was busy; now always visible. Confirm this is the intended UX, and that attaching files mid-generation doesn't cause race conditions in the attachment pipeline.
- [ ] **Verify voice mode button during pending confirmation** — old code showed voice mode unconditionally in pending-confirmation state; new code gates it on `inputText.isEmpty`. Confirm this is acceptable.
- [ ] **Verify send disabled logic `!canSend && (!isAssistantBusy || hasPendingConfirmation)`** — send is enabled when assistant is busy + user has input (for queueing), but stays disabled during pending confirmation with no input to prevent accidental approval via the generic Send button.
- [ ] **Verify message queueing still works** — typing during generation should show an enabled send button that queues the message.
- [ ] **Verify stop button returns after clearing input** — when the user deletes typed text while assistant is still busy, the stop button should reappear in place of send.

Link to Devin session: https://app.devin.ai/sessions/e7e86980a49240858ecd9879202f442a
Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->