### PR TITLE
Emit generic sync tags for conversation metadata

### DIFF
--- a/assistant/src/__tests__/conversation-inference-profile-route.test.ts
+++ b/assistant/src/__tests__/conversation-inference-profile-route.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../daemon/message-types/sync.js";
 import { makeMockLogger } from "./helpers/mock-logger.js";
+import { waitFor } from "./helpers/wait-for.js";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -63,6 +68,7 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
       type: string;
       conversationId?: string;
       profile?: string | null;
+      tags?: string[];
     }> = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
@@ -74,6 +80,10 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
             event.message.type === "conversation_inference_profile_updated"
               ? event.message.profile
               : undefined,
+          tags:
+            event.message.type === "sync_changed"
+              ? event.message.tags
+              : undefined,
         });
       },
     });
@@ -84,7 +94,9 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
       headers: {},
     });
 
-    await Promise.resolve();
+    await waitFor(() => received.length === 2, {
+      message: "Timed out waiting for inference profile route event",
+    });
 
     expect(result).toMatchObject({
       conversationId: conversation.id,
@@ -98,6 +110,16 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
         type: "conversation_inference_profile_updated",
         conversationId: conversation.id,
         profile: "quality-optimized",
+        tags: undefined,
+      },
+      {
+        type: "sync_changed",
+        conversationId: undefined,
+        profile: undefined,
+        tags: [
+          SYNC_TAGS.conversationsList,
+          conversationMetadataSyncTag(conversation.id),
+        ],
       },
     ]);
 
@@ -125,14 +147,17 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
       body: { profile: "balanced" },
       headers: {},
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getConversation(conversation.id)?.inferenceProfile).toBe("balanced");
 
-    const received: Array<{ profile?: string | null }> = [];
+    const received: Array<{ profile?: string | null; tags?: string[] }> = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
         if (event.message.type === "conversation_inference_profile_updated") {
           received.push({ profile: event.message.profile });
+        } else if (event.message.type === "sync_changed") {
+          received.push({ tags: event.message.tags });
         }
       },
     });
@@ -143,14 +168,24 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
       headers: {},
     });
 
-    await Promise.resolve();
+    await waitFor(() => received.length === 2, {
+      message: "Timed out waiting for inference profile route event",
+    });
 
     expect(result).toMatchObject({
       conversationId: conversation.id,
       profile: null,
     });
     expect(getConversation(conversation.id)?.inferenceProfile).toBeNull();
-    expect(received).toEqual([{ profile: null }]);
+    expect(received).toEqual([
+      { profile: null },
+      {
+        tags: [
+          SYNC_TAGS.conversationsList,
+          conversationMetadataSyncTag(conversation.id),
+        ],
+      },
+    ]);
 
     subscription.dispose();
   });
@@ -163,6 +198,7 @@ describe("PUT /v1/conversations/:id/inference-profile", () => {
       body: { profile: "balanced" },
       headers: {},
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const updatedAtAfterSet = getConversation(conversation.id)?.updatedAt;
 
     const received: Array<{ profile?: string | null }> = [];

--- a/assistant/src/__tests__/conversation-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-sync-tags.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../daemon/message-types/sync.js";
+import {
+  projectAssistantMessage,
+  recordConversationSeenSignal,
+} from "../memory/conversation-attention-store.js";
+import { createConversation } from "../memory/conversation-crud.js";
+import { getDb, resetDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { ROUTES as CONVERSATION_LIST_ROUTES } from "../runtime/routes/conversation-list-routes.js";
+import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../runtime/routes/conversation-management-routes.js";
+import type { RouteDefinition } from "../runtime/routes/types.js";
+import { waitFor } from "./helpers/wait-for.js";
+
+initializeDb();
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM conversation_assistant_attention_state");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function findRoute(
+  routes: RouteDefinition[],
+  operationId: string,
+): RouteDefinition {
+  const route = routes.find(
+    (candidate) => candidate.operationId === operationId,
+  );
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+async function captureEvents(
+  action: () => void | Promise<unknown>,
+  expectedCount: number,
+): Promise<AssistantEvent[]> {
+  const received: AssistantEvent[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      received.push(event);
+    },
+  });
+  try {
+    await action();
+    await waitFor(() => received.length >= expectedCount, {
+      message: "Timed out waiting for conversation sync tag event",
+    });
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+describe("conversation sync tags", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  afterAll(() => {
+    resetDb();
+  });
+
+  test("rename emits legacy title/list events and conversation metadata sync tags", async () => {
+    const conversation = createConversation("Old title");
+    const route = findRoute(
+      CONVERSATION_MANAGEMENT_ROUTES,
+      "renameConversation",
+    );
+
+    const received = await captureEvents(() => {
+      route.handler({
+        pathParams: { id: conversation.id },
+        body: { name: "New title" },
+      });
+    }, 3);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "conversation_title_updated",
+      "conversation_list_invalidated",
+      "sync_changed",
+    ]);
+    expect(received[2]!.message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMetadataSyncTag(conversation.id),
+      ],
+    });
+  });
+
+  test("create emits legacy list invalidation and list/metadata sync tags", async () => {
+    const route = findRoute(
+      CONVERSATION_MANAGEMENT_ROUTES,
+      "createConversation",
+    );
+    let conversationId: string | undefined;
+
+    const received = await captureEvents(async () => {
+      const result = (await route.handler({
+        body: { conversationKey: "sync-create-test" },
+      })) as { id: string };
+      conversationId = result.id;
+    }, 2);
+
+    expect(conversationId).toBeDefined();
+    expect(received.map((event) => event.message.type)).toEqual([
+      "conversation_list_invalidated",
+      "sync_changed",
+    ]);
+    expect(received[1]!.message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMetadataSyncTag(conversationId!),
+      ],
+    });
+  });
+
+  test("reorder emits list invalidation and metadata sync tags for touched conversations", async () => {
+    const first = createConversation("First");
+    const second = createConversation("Second");
+    const route = findRoute(
+      CONVERSATION_MANAGEMENT_ROUTES,
+      "reorderConversations",
+    );
+
+    const received = await captureEvents(() => {
+      route.handler({
+        body: {
+          updates: [
+            { conversationId: first.id, displayOrder: 1, isPinned: true },
+            { conversationId: second.id, displayOrder: 2, isPinned: false },
+          ],
+        },
+      });
+    }, 2);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "conversation_list_invalidated",
+      "sync_changed",
+    ]);
+    expect(received[1]!.message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMetadataSyncTag(first.id),
+        conversationMetadataSyncTag(second.id),
+      ],
+    });
+  });
+
+  test("record seen emits list invalidation and metadata sync tags for the touched conversation", async () => {
+    const conversation = createConversation("Attention");
+    projectAssistantMessage({
+      conversationId: conversation.id,
+      messageId: "assistant-message-1",
+      messageAt: 1_700_000_000_000,
+    });
+    const route = findRoute(CONVERSATION_LIST_ROUTES, "recordConversationSeen");
+
+    const received = await captureEvents(() => {
+      route.handler({
+        body: {
+          conversationId: conversation.id,
+          sourceChannel: "vellum",
+          signalType: "macos_conversation_opened",
+          confidence: "explicit",
+          source: "test",
+        },
+      });
+    }, 2);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "conversation_list_invalidated",
+      "sync_changed",
+    ]);
+    expect(received[1]!.message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMetadataSyncTag(conversation.id),
+      ],
+    });
+  });
+
+  test("mark unread emits list invalidation and metadata sync tags for the touched conversation", async () => {
+    const conversation = createConversation("Attention");
+    projectAssistantMessage({
+      conversationId: conversation.id,
+      messageId: "assistant-message-1",
+      messageAt: 1_700_000_000_000,
+    });
+    recordConversationSeenSignal({
+      conversationId: conversation.id,
+      sourceChannel: "vellum",
+      signalType: "macos_conversation_opened",
+      confidence: "explicit",
+      source: "test",
+    });
+    const route = findRoute(CONVERSATION_LIST_ROUTES, "markConversationUnread");
+
+    const received = await captureEvents(() => {
+      route.handler({
+        body: {
+          conversationId: conversation.id,
+        },
+      });
+    }, 2);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "conversation_list_invalidated",
+      "sync_changed",
+    ]);
+    expect(received[1]!.message).toEqual({
+      type: "sync_changed",
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMetadataSyncTag(conversation.id),
+      ],
+    });
+  });
+});

--- a/assistant/src/__tests__/helpers/wait-for.ts
+++ b/assistant/src/__tests__/helpers/wait-for.ts
@@ -1,0 +1,21 @@
+export async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  options: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    message?: string;
+  } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 500;
+  const intervalMs = options.intervalMs ?? 5;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(options.message ?? "Timed out waiting for test condition");
+}

--- a/assistant/src/__tests__/inference-profile-reaper.test.ts
+++ b/assistant/src/__tests__/inference-profile-reaper.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "./helpers/mock-logger.js";
+import { waitFor } from "./helpers/wait-for.js";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -86,8 +87,9 @@ describe("inference-profile-session-reaper", () => {
     });
 
     tickInferenceProfileReaper();
-    // Allow microtasks (promise callbacks) to settle
-    await Promise.resolve();
+    await waitFor(() => publishedEvents.length === 2, {
+      message: "Timed out waiting for inference profile reaper event",
+    });
 
     // Expired rows should be cleared
     expect(getConversation(conv1.id)?.inferenceProfile).toBeNull();

--- a/assistant/src/__tests__/inference-profile-session-handler.test.ts
+++ b/assistant/src/__tests__/inference-profile-session-handler.test.ts
@@ -19,8 +19,10 @@ mock.module("../util/logger.js", () => ({
 // Stub the event hub so tests don't need a running event bus.
 // Exposed as a `mock(...)` so individual tests can assert publish calls.
 const publishMock = mock(async () => {});
+const broadcastMessageMock = mock(() => {});
 mock.module("../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: { publish: publishMock },
+  broadcastMessage: broadcastMessageMock,
 }));
 
 // Stub buildAssistantEvent to be an identity pass-through for the event object
@@ -51,7 +53,10 @@ mock.module("../config/loader.js", () => ({
 // Real DB — same pattern as conversation-crud-inference-profile.test.ts
 // ---------------------------------------------------------------------------
 
-import { createConversation, getConversation } from "../memory/conversation-crud.js";
+import {
+  createConversation,
+  getConversation,
+} from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 
@@ -83,6 +88,7 @@ describe("setInferenceProfileSession", () => {
     mockProfiles = { balanced: {}, "cost-optimized": {} };
     mockMaxTtl = undefined; // reset to default 43200
     publishMock.mockClear();
+    broadcastMessageMock.mockClear();
   });
 
   test("open with ttlSeconds=600 — returns UUID sessionId and expiresAt ≈ now + 600_000", async () => {
@@ -139,7 +145,9 @@ describe("setInferenceProfileSession", () => {
     expect(result.ttlSeconds).toBe(43200);
     expect(result.expiresAt).not.toBeNull();
     expect(result.expiresAt!).toBeGreaterThanOrEqual(before + 43200 * 1000);
-    expect(result.expiresAt!).toBeLessThanOrEqual(Date.now() + 43200 * 1000 + 1000);
+    expect(result.expiresAt!).toBeLessThanOrEqual(
+      Date.now() + 43200 * 1000 + 1000,
+    );
   });
 
   test("open over active session — replaced carries prior session info", async () => {
@@ -208,6 +216,7 @@ describe("setInferenceProfileSession", () => {
     const updatedAtBefore = before?.updatedAt;
 
     publishMock.mockClear();
+    broadcastMessageMock.mockClear();
     const result = await setInferenceProfileSession({
       conversationId: conv.id,
       profile: null,
@@ -221,7 +230,7 @@ describe("setInferenceProfileSession", () => {
 
     // No event was published — this is the load-bearing assertion for the
     // idempotency guard (Codex P2 on PR #29913).
-    expect(publishMock).not.toHaveBeenCalled();
+    expect(broadcastMessageMock).not.toHaveBeenCalled();
 
     // No DB write occurred — `updatedAt` is unchanged.
     const after = getConversation(conv.id);
@@ -240,6 +249,7 @@ describe("setInferenceProfileSession", () => {
     });
 
     publishMock.mockClear();
+    broadcastMessageMock.mockClear();
     const result = await setInferenceProfileSession({
       conversationId: conv.id,
       profile: null,
@@ -250,8 +260,8 @@ describe("setInferenceProfileSession", () => {
     // though the sticky profile was cleared.
     expect(result.replaced).toBeNull();
 
-    // The clear DID happen — DB row reflects it and an event was published.
-    expect(publishMock).toHaveBeenCalledTimes(1);
+    // The clear DID happen — DB row reflects it and legacy+sync events were published.
+    expect(broadcastMessageMock).toHaveBeenCalledTimes(2);
     const row = getConversation(conv.id);
     expect(row?.inferenceProfile).toBeNull();
   });
@@ -265,7 +275,9 @@ describe("setInferenceProfileSession", () => {
         profile: "nonexistent-profile",
         ttlSeconds: 300,
       }),
-    ).rejects.toThrow('Profile "nonexistent-profile" is not defined in llm.profiles');
+    ).rejects.toThrow(
+      'Profile "nonexistent-profile" is not defined in llm.profiles',
+    );
   });
 
   test("open with ttlSeconds=null — expiresAt=null, sessionId=null, profile kept", async () => {

--- a/assistant/src/__tests__/inference-profile-session-ipc.test.ts
+++ b/assistant/src/__tests__/inference-profile-session-ipc.test.ts
@@ -15,6 +15,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: { publish: async () => {} },
+  broadcastMessage: () => {},
 }));
 
 mock.module("../runtime/assistant-event.js", () => ({
@@ -43,9 +44,15 @@ import { ROUTES } from "../runtime/routes/inference-profile-session-routes.js";
 
 initializeDb();
 
-const openRoute = ROUTES.find((r) => r.operationId === "inference_profile_open")!;
-const closeRoute = ROUTES.find((r) => r.operationId === "inference_profile_close")!;
-const listRoute = ROUTES.find((r) => r.operationId === "inference_profile_list")!;
+const openRoute = ROUTES.find(
+  (r) => r.operationId === "inference_profile_open",
+)!;
+const closeRoute = ROUTES.find(
+  (r) => r.operationId === "inference_profile_close",
+)!;
+const listRoute = ROUTES.find(
+  (r) => r.operationId === "inference_profile_list",
+)!;
 
 function clearTables(): void {
   const db = getDb();
@@ -77,7 +84,9 @@ describe("inference_profile_open IPC op", () => {
       replaced: null,
     });
     expect((result as { sessionId: string }).sessionId).not.toBeNull();
-    expect((result as { expiresAt: number }).expiresAt).toBeGreaterThan(Date.now());
+    expect((result as { expiresAt: number }).expiresAt).toBeGreaterThan(
+      Date.now(),
+    );
   });
 
   test("opens a sticky session (no ttlSeconds) — sessionId=null, expiresAt=null", async () => {
@@ -145,7 +154,10 @@ describe("inference_profile_close IPC op", () => {
     const result = (await closeRoute.handler({
       body: { conversationId: conv.id },
       headers: {},
-    })) as { noop: boolean; closed: { profile: string; sessionId: string } | null };
+    })) as {
+      noop: boolean;
+      closed: { profile: string; sessionId: string } | null;
+    };
 
     expect(result.noop).toBe(false);
     expect(result.closed).not.toBeNull();

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -202,6 +202,10 @@ import type {
 } from "./message-protocol.js";
 import type { MemoryRecalled } from "./message-types/memory.js";
 import type { ConfirmationStateChanged } from "./message-types/messages.js";
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "./message-types/sync.js";
 import { parseActualTokensFromError } from "./parse-actual-tokens-from-error.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 import type { TrustContext } from "./trust-context.js";
@@ -870,6 +874,13 @@ export async function runAgentLoopImpl(
             type: "conversation_title_updated",
             conversationId: ctx.conversationId,
             title,
+          });
+          onEvent({
+            type: "sync_changed",
+            tags: [
+              SYNC_TAGS.conversationsList,
+              conversationMetadataSyncTag(ctx.conversationId),
+            ],
           });
         },
       };
@@ -3055,6 +3066,13 @@ export async function runAgentLoopImpl(
             type: "conversation_title_updated",
             conversationId: ctx.conversationId,
             title,
+          });
+          onEvent({
+            type: "sync_changed",
+            tags: [
+              SYNC_TAGS.conversationsList,
+              conversationMetadataSyncTag(ctx.conversationId),
+            ],
           });
         },
         signal: abortController.signal,

--- a/assistant/src/proactive-artifact/aux-message-injector.ts
+++ b/assistant/src/proactive-artifact/aux-message-injector.ts
@@ -8,6 +8,7 @@
 
 import { createAssistantMessage } from "../agent/message-types.js";
 import { findConversation } from "../daemon/conversation-store.js";
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import type { BroadcastFn } from "../notifications/adapters/macos.js";
 import { getLogger } from "../util/logger.js";
@@ -70,5 +71,9 @@ export async function injectAuxAssistantMessage(params: {
   params.broadcastMessage({
     type: "conversation_list_invalidated",
     reason: "reordered",
+  });
+  params.broadcastMessage({
+    type: "sync_changed",
+    tags: [SYNC_TAGS.conversationsList],
   });
 }

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+
 // ── Mock state ──────────────────────────────────────────────────────────
 
 // Provider mock
@@ -691,7 +693,7 @@ describe("runProactiveArtifactJob", () => {
 });
 
 describe("injectAuxAssistantMessage", () => {
-  test("idle conversation: persists with skipIndexing, pushes to getMessages(), broadcasts delta + complete(aux) + list_invalidated", async () => {
+  test("idle conversation: persists with skipIndexing, pushes to getMessages(), broadcasts delta + complete(aux) + list sync", async () => {
     const messages: unknown[] = [];
     mockConversations.set("conv-inject-1", {
       processing: false,
@@ -714,7 +716,7 @@ describe("injectAuxAssistantMessage", () => {
     // Pushed to in-memory messages
     expect(messages).toHaveLength(1);
 
-    // Broadcasts: delta, complete(aux), list_invalidated
+    // Broadcasts: delta, complete(aux), list invalidation + sync tag
     const deltaMsg = broadcastCalls.find(
       (c) => c.type === "assistant_text_delta",
     );
@@ -734,6 +736,12 @@ describe("injectAuxAssistantMessage", () => {
     );
     expect(listMsg).toBeDefined();
     expect(listMsg!.reason).toBe("reordered");
+
+    const syncMsg = broadcastCalls.find((c) => c.type === "sync_changed");
+    expect(syncMsg).toEqual({
+      type: "sync_changed",
+      tags: [SYNC_TAGS.conversationsList],
+    });
   });
 
   test("processing → idle: waits for processing to become false before persisting", async () => {
@@ -824,13 +832,16 @@ describe("injectAuxAssistantMessage", () => {
       broadcastCalls.filter((c) => c.type === "message_complete"),
     ).toHaveLength(0);
 
-    // But list_invalidated IS sent (always sent regardless of processing state)
+    // But list invalidation + sync tag ARE sent regardless of processing state.
     expect(
       broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
     ).toHaveLength(1);
+    expect(broadcastCalls.filter((c) => c.type === "sync_changed")).toEqual([
+      { type: "sync_changed", tags: [SYNC_TAGS.conversationsList] },
+    ]);
   });
 
-  test("inactive/unloaded conversation: persists + list_invalidated only", async () => {
+  test("inactive/unloaded conversation: persists + list sync only", async () => {
     // No conversation in the store
     await injectAuxAssistantMessage({
       conversationId: "conv-inject-4",
@@ -850,10 +861,13 @@ describe("injectAuxAssistantMessage", () => {
       broadcastCalls.filter((c) => c.type === "message_complete"),
     ).toHaveLength(0);
 
-    // But list_invalidated IS sent
+    // But list invalidation + sync tag ARE sent
     expect(
       broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
     ).toHaveLength(1);
+    expect(broadcastCalls.filter((c) => c.type === "sync_changed")).toEqual([
+      { type: "sync_changed", tags: [SYNC_TAGS.conversationsList] },
+    ]);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -23,6 +23,7 @@ mock.module("../../assistant-event-hub.js", () => ({
     publish: async () => {},
     subscribe: () => () => {},
   },
+  broadcastMessage: () => {},
 }));
 
 import { getDb } from "../../../memory/db-connection.js";
@@ -114,7 +115,10 @@ function seedConversation(id: string): void {
 describe("PUT /v1/conversations/:id/inference-profile", () => {
   beforeEach(() => {
     clearConversations();
-    configLlmProfiles = { fast: { model: "model-a" }, slow: { model: "model-b" } };
+    configLlmProfiles = {
+      fast: { model: "model-a" },
+      slow: { model: "model-b" },
+    };
   });
 
   test("PUT with ttlSeconds=600 → response includes sessionId (UUID), expiresAt, ttlSeconds=600", async () => {

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -28,12 +28,11 @@ import { getBindingsForConversations } from "../../memory/external-conversation-
 import { listGroups } from "../../memory/group-crud.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   buildConversationDetailResponse,
   serializeConversationSummary,
 } from "../services/conversation-serializer.js";
+import { publishConversationListAndMetadataChanged } from "../sync/resource-sync-events.js";
 import {
   BadRequestError,
   InternalError,
@@ -52,22 +51,6 @@ function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
   if (!id) throw new NotFoundError(`Unknown conversation: ${rawId}`);
   return id;
-}
-
-function publishListInvalidated(): void {
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "conversation_list_invalidated",
-        reason: "seen_changed",
-      }),
-    )
-    .catch((err) => {
-      log.warn(
-        { err },
-        "Failed to publish conversation_list_invalidated (seen_changed)",
-      );
-    });
 }
 
 // ---------------------------------------------------------------------------
@@ -159,7 +142,7 @@ function handleRecordSeen({ body = {} }: RouteHandlerArgs) {
     });
 
     if (wasUnseen) {
-      publishListInvalidated();
+      publishConversationListAndMetadataChanged("seen_changed", conversationId);
     }
 
     return { ok: true };
@@ -179,7 +162,7 @@ function handleMarkUnread({ body = {} }: RouteHandlerArgs) {
   try {
     const changed = markConversationUnread(conversationId);
     if (changed) {
-      publishListInvalidated();
+      publishConversationListAndMetadataChanged("seen_changed", conversationId);
     }
     return { ok: true };
   } catch (err) {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -27,7 +27,6 @@ import {
   switchConversation,
   undoLastMessage,
 } from "../../daemon/handlers/conversations.js";
-import type { ConversationListInvalidatedReason } from "../../daemon/message-types/conversations.js";
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import {
   archiveConversation,
@@ -49,9 +48,12 @@ import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import { buildConversationDetailResponse } from "../services/conversation-serializer.js";
+import {
+  publishConversationListAndMetadataChanged,
+  publishConversationListChanged,
+  publishConversationTitleChanged,
+} from "../sync/resource-sync-events.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import { setInferenceProfileSession } from "./inference-profile-session-handler.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -66,24 +68,6 @@ function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
   if (!id) throw new NotFoundError(`Conversation ${rawId} not found`);
   return id;
-}
-
-function publishListInvalidated(
-  reason: ConversationListInvalidatedReason,
-): void {
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "conversation_list_invalidated",
-        reason,
-      }),
-    )
-    .catch((err) => {
-      log.warn(
-        { err },
-        `Failed to publish conversation_list_invalidated (${reason})`,
-      );
-    });
 }
 
 function cancelScheduleIfLast(conversationId: string): void {
@@ -108,6 +92,7 @@ function handleCreateConversation({ body = {} }: RouteHandlerArgs) {
   });
   if (result.created) {
     updateConversationTitle(result.conversationId, "New Conversation");
+    publishConversationListAndMetadataChanged("created", result.conversationId);
   }
   log.info(
     {
@@ -151,6 +136,7 @@ async function handleForkConversation({ body = {} }: RouteHandlerArgs) {
         `Forked conversation ${forkedConversation.id} could not be loaded`,
       );
     }
+    publishConversationListAndMetadataChanged("created", forkedConversation.id);
     return { conversation: detail.conversation };
   } catch (err) {
     if (err instanceof UserError) {
@@ -217,25 +203,7 @@ function handleRenameConversation({
   }
   updateConversationTitle(pathParams.id!, name, 0);
 
-  assistantEventHub
-    .publish(
-      buildAssistantEvent(
-        {
-          type: "conversation_title_updated",
-          conversationId: pathParams.id!,
-          title: name,
-        },
-        pathParams.id!,
-      ),
-    )
-    .catch((err) => {
-      log.warn(
-        { err, conversationId: pathParams.id },
-        "Failed to publish conversation_title_updated",
-      );
-    });
-
-  publishListInvalidated("renamed");
+  publishConversationTitleChanged(pathParams.id!, name);
 
   return { ok: true };
 }
@@ -249,6 +217,7 @@ function handleClearAllConversations({ headers = {} }: RouteHandlerArgs) {
     );
   }
   clearAllConversations();
+  publishConversationListChanged("deleted");
   return undefined;
 }
 
@@ -279,6 +248,7 @@ function handleWipeConversation({ pathParams = {} }: RouteHandlerArgs) {
     },
     "Wiped conversation and reverted memory changes",
   );
+  publishConversationListAndMetadataChanged("deleted", resolvedId);
   return {
     wiped: true,
     unsupersededItems: 0,
@@ -308,7 +278,7 @@ function handleDeleteConversation({ pathParams = {} }: RouteHandlerArgs) {
   }
   log.info({ conversationId: resolvedId }, "Deleted conversation");
 
-  publishListInvalidated("deleted");
+  publishConversationListAndMetadataChanged("deleted", resolvedId);
 
   return undefined;
 }
@@ -319,6 +289,7 @@ function handleArchiveConversation({ pathParams = {} }: RouteHandlerArgs) {
   if (!archived) {
     throw new NotFoundError(`Conversation ${pathParams.id} not found`);
   }
+  publishConversationListAndMetadataChanged("reordered", resolvedId);
   return { ok: true, conversationId: resolvedId };
 }
 
@@ -328,6 +299,7 @@ function handleUnarchiveConversation({ pathParams = {} }: RouteHandlerArgs) {
   if (!unarchived) {
     throw new NotFoundError(`Conversation ${pathParams.id} not found`);
   }
+  publishConversationListAndMetadataChanged("reordered", resolvedId);
   return { ok: true, conversationId: resolvedId };
 }
 
@@ -387,7 +359,10 @@ function handleReorderConversations({ body = {} }: RouteHandlerArgs) {
       groupId: u.groupId,
     })),
   );
-  publishListInvalidated("reordered");
+  publishConversationListAndMetadataChanged(
+    "reordered",
+    updates.map((u) => u.conversationId),
+  );
   return { ok: true };
 }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -101,7 +101,6 @@ import {
   getWorkspacePromptPath,
 } from "../../util/platform.js";
 import { silentlyWithLog } from "../../util/silently.js";
-import { buildAssistantEvent } from "../assistant-event.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { routeGuardianReply } from "../guardian-reply-router.js";
@@ -114,6 +113,7 @@ import type {
 } from "../http-types.js";
 import { resolveLocalTrustContext } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
+import { publishConversationListAndMetadataChanged } from "../sync/resource-sync-events.js";
 import {
   resolveTrustContext,
   withSourceChannel,
@@ -1293,16 +1293,10 @@ export async function handleSendMessage(
   // that other clients don't yet know about.
   if (mapping.conversationType === "standard") {
     if (!hasMessages(mapping.conversationId)) {
-      smDeps.assistantEventHub
-        .publish(
-          buildAssistantEvent({
-            type: "conversation_list_invalidated",
-            reason: "created",
-          }),
-        )
-        .catch((err) => {
-          log.warn({ err }, "Failed to publish conversation_list_invalidated");
-        });
+      publishConversationListAndMetadataChanged(
+        "created",
+        mapping.conversationId,
+      );
     }
   }
 

--- a/assistant/src/runtime/routes/group-routes.ts
+++ b/assistant/src/runtime/routes/group-routes.ts
@@ -18,6 +18,7 @@ import {
   reorderGroups,
   updateGroup,
 } from "../../memory/group-crud.js";
+import { publishConversationListChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -47,6 +48,7 @@ function handleCreateGroup({ body = {} }: RouteHandlerArgs) {
   }
   try {
     const group = createGroup(name);
+    publishConversationListChanged("created");
     return serializeGroup(group);
   } catch (err) {
     if (
@@ -90,6 +92,7 @@ function handleUpdateGroup({ pathParams = {}, body = {} }: RouteHandlerArgs) {
   if (!updated) {
     throw new NotFoundError("Group not found");
   }
+  publishConversationListChanged("reordered");
   return serializeGroup(updated);
 }
 
@@ -103,6 +106,7 @@ function handleDeleteGroup({ pathParams = {} }: RouteHandlerArgs) {
     throw new ForbiddenError("System groups cannot be deleted");
   }
   deleteGroup(groupId);
+  publishConversationListChanged("reordered");
 }
 
 function handleReorderGroups({ body = {} }: RouteHandlerArgs) {
@@ -131,6 +135,7 @@ function handleReorderGroups({ body = {} }: RouteHandlerArgs) {
     }
   }
   reorderGroups(updates);
+  publishConversationListChanged("reordered");
   return { ok: true };
 }
 

--- a/assistant/src/runtime/routes/inference-profile-session-handler.ts
+++ b/assistant/src/runtime/routes/inference-profile-session-handler.ts
@@ -21,12 +21,8 @@ import {
   setConversationInferenceProfileSession,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishConversationInferenceProfileChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
-
-const log = getLogger("inference-profile-session-handler");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -120,25 +116,12 @@ export async function setInferenceProfileSession({
       };
     }
     setConversationInferenceProfileSession(resolvedId, null, null, null);
-    await assistantEventHub
-      .publish(
-        buildAssistantEvent(
-          {
-            type: "conversation_inference_profile_updated",
-            conversationId: resolvedId,
-            profile: null,
-            sessionId: null,
-            expiresAt: null,
-          },
-          resolvedId,
-        ),
-      )
-      .catch((err) => {
-        log.warn(
-          { err, conversationId: resolvedId },
-          "Failed to publish conversation_inference_profile_updated event",
-        );
-      });
+    publishConversationInferenceProfileChanged({
+      conversationId: resolvedId,
+      profile: null,
+      sessionId: null,
+      expiresAt: null,
+    });
     return {
       conversationId: resolvedId,
       profile: null,
@@ -201,25 +184,12 @@ export async function setInferenceProfileSession({
     newExpiresAt ?? null,
   );
 
-  await assistantEventHub
-    .publish(
-      buildAssistantEvent(
-        {
-          type: "conversation_inference_profile_updated",
-          conversationId: resolvedId,
-          profile,
-          sessionId: newSessionId ?? null,
-          expiresAt: newExpiresAt ?? null,
-        },
-        resolvedId,
-      ),
-    )
-    .catch((err) => {
-      log.warn(
-        { err, conversationId: resolvedId },
-        "Failed to publish conversation_inference_profile_updated event",
-      );
-    });
+  publishConversationInferenceProfileChanged({
+    conversationId: resolvedId,
+    profile,
+    sessionId: newSessionId ?? null,
+    expiresAt: newExpiresAt ?? null,
+  });
 
   return {
     conversationId: resolvedId,
@@ -307,6 +277,9 @@ export function listInferenceProfileSessionsWithRemaining(
 }> {
   return listActiveInferenceProfileSessions(conversationId).map((row) => ({
     ...row,
-    remainingSeconds: Math.max(0, Math.floor((row.expiresAt - Date.now()) / 1000)),
+    remainingSeconds: Math.max(
+      0,
+      Math.floor((row.expiresAt - Date.now()) / 1000),
+    ),
   }));
 }

--- a/assistant/src/runtime/routes/inference-profile-session-reaper.ts
+++ b/assistant/src/runtime/routes/inference-profile-session-reaper.ts
@@ -13,8 +13,7 @@
 
 import { clearExpiredInferenceProfiles } from "../../memory/conversation-crud.js";
 import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishConversationInferenceProfileChanged } from "../sync/resource-sync-events.js";
 
 const log = getLogger("inference-profile-session-reaper");
 
@@ -38,25 +37,12 @@ export function tickInferenceProfileReaper(): void {
   const now = Date.now();
   const cleared = clearExpiredInferenceProfiles(now);
   for (const { conversationId } of cleared) {
-    assistantEventHub
-      .publish(
-        buildAssistantEvent(
-          {
-            type: "conversation_inference_profile_updated",
-            conversationId,
-            profile: null,
-            sessionId: null,
-            expiresAt: null,
-          },
-          conversationId,
-        ),
-      )
-      .catch((err) => {
-        log.warn(
-          { err, conversationId },
-          "Failed to publish inference profile expiry event",
-        );
-      });
+    publishConversationInferenceProfileChanged({
+      conversationId,
+      profile: null,
+      sessionId: null,
+      expiresAt: null,
+    });
   }
   if (cleared.length > 0) {
     log.info(

--- a/assistant/src/runtime/routes/rename-conversation-routes.ts
+++ b/assistant/src/runtime/routes/rename-conversation-routes.ts
@@ -13,9 +13,7 @@ import {
   getConversation,
   updateConversationTitle,
 } from "../../memory/conversation-crud.js";
-import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishConversationTitleChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -23,8 +21,6 @@ const RenameConversationBody = z.object({
   conversationId: z.string().min(1),
   title: z.string().min(1),
 });
-
-const log = getLogger("rename-conversation-routes");
 
 export const ROUTES: RouteDefinition[] = [
   {
@@ -50,34 +46,7 @@ export const ROUTES: RouteDefinition[] = [
 
       updateConversationTitle(conversationId, title, 0);
 
-      assistantEventHub
-        .publish(
-          buildAssistantEvent(
-            {
-              type: "conversation_title_updated",
-              conversationId,
-              title,
-            },
-            conversationId,
-          ),
-        )
-        .catch((err) => {
-          log.warn({ err }, "Failed to publish conversation_title_updated");
-        });
-
-      assistantEventHub
-        .publish(
-          buildAssistantEvent({
-            type: "conversation_list_invalidated",
-            reason: "renamed",
-          }),
-        )
-        .catch((err) => {
-          log.warn(
-            { err },
-            "Failed to publish conversation_list_invalidated for rename",
-          );
-        });
+      publishConversationTitleChanged(conversationId, title);
 
       return { ok: true };
     },

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -1,5 +1,9 @@
 import type { IdentityFields } from "../../daemon/handlers/identity.js";
-import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
+import type { ConversationListInvalidatedReason } from "../../daemon/message-types/conversations.js";
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../../daemon/message-types/sync.js";
 import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
@@ -32,4 +36,71 @@ export function publishConfigChanged(): void {
 export function publishSoundsConfigUpdated(): void {
   broadcastMessage({ type: "sounds_config_updated" });
   void publishSyncInvalidation([SYNC_TAGS.assistantSounds]);
+}
+
+export function publishConversationListChanged(
+  reason: ConversationListInvalidatedReason,
+): void {
+  broadcastMessage({
+    type: "conversation_list_invalidated",
+    reason,
+  });
+  void publishSyncInvalidation([SYNC_TAGS.conversationsList]);
+}
+
+export function publishConversationListAndMetadataChanged(
+  reason: ConversationListInvalidatedReason,
+  conversationIds: string | string[],
+): void {
+  const ids = Array.isArray(conversationIds)
+    ? conversationIds
+    : [conversationIds];
+  broadcastMessage({
+    type: "conversation_list_invalidated",
+    reason,
+  });
+  void publishSyncInvalidation([
+    SYNC_TAGS.conversationsList,
+    ...ids.map((conversationId) => conversationMetadataSyncTag(conversationId)),
+  ]);
+}
+
+export function publishConversationTitleChanged(
+  conversationId: string,
+  title: string,
+): void {
+  broadcastMessage(
+    {
+      type: "conversation_title_updated",
+      conversationId,
+      title,
+    },
+    conversationId,
+  );
+  void publishSyncInvalidation([
+    SYNC_TAGS.conversationsList,
+    conversationMetadataSyncTag(conversationId),
+  ]);
+}
+
+export function publishConversationInferenceProfileChanged(params: {
+  conversationId: string;
+  profile: string | null;
+  sessionId?: string | null;
+  expiresAt?: number | null;
+}): void {
+  broadcastMessage(
+    {
+      type: "conversation_inference_profile_updated",
+      conversationId: params.conversationId,
+      profile: params.profile,
+      sessionId: params.sessionId,
+      expiresAt: params.expiresAt,
+    },
+    params.conversationId,
+  );
+  void publishSyncInvalidation([
+    SYNC_TAGS.conversationsList,
+    conversationMetadataSyncTag(params.conversationId),
+  ]);
 }


### PR DESCRIPTION
## Summary
- add shared conversation sync helpers that pair legacy conversation events with sync_changed
- emit conversations:list and conversation:<id>:metadata for create, rename, delete, archive, reorder, group, and inference-profile changes
- cover auto-title and proactive artifact list invalidations
- add focused tests for legacy event plus sync tag emission

## Scope
- keeps legacy conversation_list_invalidated, conversation_title_updated, and conversation_inference_profile_updated events in place
- defers durable conversation:<id>:messages invalidation to the next daemon slice

## Verification
- cd assistant && bun run typecheck
- cd assistant && bun run lint
- cd assistant && bun test src/__tests__/conversation-sync-tags.test.ts
- cd assistant && bun test src/__tests__/conversation-inference-profile-route.test.ts
- cd assistant && bun test src/__tests__/inference-profile-session-handler.test.ts
- cd assistant && bun test src/__tests__/inference-profile-reaper.test.ts
- cd assistant && bun test src/__tests__/inference-profile-session-ipc.test.ts src/runtime/routes/__tests__/conversation-management-routes.test.ts
- cd assistant && bun test src/runtime/sync/sync-publisher.test.ts src/__tests__/avatar-identity-sync.test.ts
- cd assistant && bun test src/proactive-artifact/job.test.ts

## Notes
- bun run lint:circular still reports the repo's existing circular dependency set; this PR avoids adding daemon -> runtime sync cycles.
- src/__tests__/send-endpoint-busy.test.ts currently fails locally with EADDRINUSE on port 0 before exercising this change.