### PR TITLE
fix: broaden channel ID regex, strip # prefix, reverse read order

### DIFF
--- a/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
@@ -147,8 +147,11 @@ export async function resolveChannelId(
   token: string,
   nameOrId: string,
 ): Promise<string> {
-  // Direct ID pass-through
-  if (/^C[A-Z0-9]+$/.test(nameOrId)) {
+  // Strip leading '#' so users can pass '#general' etc.
+  nameOrId = nameOrId.replace(/^#/, "");
+
+  // Direct ID pass-through (C = channel, D = DM, G = group)
+  if (/^[CDG][A-Z0-9]+$/.test(nameOrId)) {
     return nameOrId;
   }
 

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -245,6 +245,9 @@ async function handleRead({ body }: RouteHandlerArgs) {
     }));
   }
 
+  // Reverse so messages read chronologically (oldest first)
+  messages.reverse();
+
   return { channel: channelId, messages };
 }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for use-slack-cli.md.

**Gap 1:** Channel ID regex broadened from `^C[A-Z0-9]+$` to `^[CDG][A-Z0-9]+$` to handle DM and group channel IDs
**Gap 2:** Strip leading `#` from channel name arguments before resolution
**Gap 3:** Reverse messages from `conversationHistory` for chronological CLI output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->