### PR TITLE
feat: assistant use slack CLI (JARVIS-787)

### DIFF
--- a/assistant/eslint-rules/cli-no-daemon-internals.js
+++ b/assistant/eslint-rules/cli-no-daemon-internals.js
@@ -15,22 +15,27 @@ const ALLOWED_PREFIXES = {
     // imports independently, so this can't be used to smuggle daemon
     // internals through a sibling re-export.
     "./",
-    // IPC client at depth-1 and depth-2.
+    // IPC client at depth-1, depth-2, and depth-3.
     "../../ipc/cli-client",
     "../../../ipc/cli-client",
+    "../../../../ipc/cli-client",
     // Status command's daemon-down fallback needs socket path + platform.
     "../../ipc/socket-path",
     "../../util/platform",
-    // Logger / output at depth-1 and depth-2.
+    // Logger / output at depth-1, depth-2, and depth-3.
     "../logger",
     "../output",
     "../../logger",
     "../../output",
-    // Shared CLI lib / utils at depth-1 and depth-2.
+    "../../../logger",
+    "../../../output",
+    // Shared CLI lib / utils at depth-1, depth-2, and depth-3.
     "../lib/",
     "../../lib/",
+    "../../../lib/",
     "../utils/",
     "../../utils/",
+    "../../../utils/",
     // Environment access for commands that need to read VELLUM_* env vars
     // before issuing IPC calls (e.g. email, domain).
     "../../config/env",

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15430,6 +15430,58 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+  /v1/use/slack/channels:
+    get:
+      operationId: use_slack_channels_get
+      summary: List cached Slack channels
+      description: Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/channels/{name}:
+    get:
+      operationId: use_slack_channels_by_name_get
+      summary: Resolve a Slack channel by name
+      description: Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/use/slack/channels/refresh:
+    post:
+      operationId: use_slack_channels_refresh_post
+      summary: Refresh Slack channel cache
+      description: Fetch all channels from the Slack API, rebuild the local cache, and return it.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+  /v1/use/slack/users/{query}:
+    get:
+      operationId: use_slack_users_by_query_get
+      summary: Resolve a Slack user by name or email
+      description: Resolve a display name or email address to a Slack user via the local cache.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: query
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/user-routes/inspect:
     post:
       operationId: userroutes_inspect_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15466,6 +15466,94 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/use/slack/react:
+    post:
+      operationId: use_slack_react_post
+      summary: Add a reaction to a Slack message
+      description: Add an emoji reaction to a message. Strips surrounding colons from the emoji name if present.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                ts:
+                  type: string
+                emoji:
+                  type: string
+              required:
+                - channel
+                - ts
+                - emoji
+              additionalProperties: false
+  /v1/use/slack/read:
+    post:
+      operationId: use_slack_read_post
+      summary: Read Slack messages
+      description:
+        Read messages from a Slack channel or thread. Supports limit, since (Slack timestamp or relative offset
+        like "2h", "30m", "1d"), and thread replies.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                limit:
+                  type: number
+                since:
+                  type: string
+                thread:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/use/slack/send:
+    post:
+      operationId: use_slack_send_post
+      summary: Send a Slack message
+      description:
+        Send a message to a Slack channel or user DM. Exactly one of channel or user must be set. Supports
+        threading via the thread parameter.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                user:
+                  type: string
+                text:
+                  type: string
+                thread:
+                  type: string
+              required:
+                - text
+              additionalProperties: false
   /v1/use/slack/users/{query}:
     get:
       operationId: use_slack_users_by_query_get

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -235,6 +235,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/avatar-routes.ts", // avatar generate route reads platform_base_url from credential store
       "cli/commands/keys.ts", // CLI provider key management
       "cli/commands/oauth/connect.ts", // CLI OAuth connect stored-secret verification
+      "runtime/routes/integrations/slack/token.ts", // shared Slack token resolver (bot/user token lookup for CLI use routes)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/cli/commands/use/index.ts
+++ b/assistant/src/cli/commands/use/index.ts
@@ -1,0 +1,28 @@
+import type { Command } from "commander";
+
+import { registerCommand } from "../../lib/register-command.js";
+import { registerSlackCommand } from "./slack/index.js";
+
+export function registerUseCommand(program: Command): void {
+  registerCommand(program, {
+    name: "use",
+    transport: "ipc",
+    description: "Use third-party integrations (Slack, Linear, etc.)",
+    build: (use) => {
+      use.addHelpText(
+        "after",
+        `
+Third-party integration commands. Each integration is a subcommand
+group with its own set of operations. Integrations require prior
+configuration via 'assistant oauth' or 'assistant credentials'.
+
+Examples:
+  $ assistant use slack send --channel general --text "hello"
+  $ assistant use slack read --channel general --limit 5
+  $ assistant use slack channels list`,
+      );
+
+      registerSlackCommand(use);
+    },
+  });
+}

--- a/assistant/src/cli/commands/use/slack/channels.ts
+++ b/assistant/src/cli/commands/use/slack/channels.ts
@@ -1,0 +1,149 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:channels");
+
+interface ChannelCache {
+  channels: Record<string, { id: string; type: string }>;
+  refreshedAt: string;
+}
+
+interface ChannelEntry {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export function registerChannelsCommand(slack: Command): void {
+  const channels = slack
+    .command("channels")
+    .description("List, refresh, or look up Slack channels");
+
+  channels.addHelpText(
+    "after",
+    `
+Manage the local Slack channel cache. Channels are cached locally after
+the first fetch to avoid repeated API calls. Use 'refresh' to rebuild
+the cache from the Slack API.
+
+Examples:
+  $ assistant use slack channels list
+  $ assistant use slack channels refresh
+  $ assistant use slack channels get team-jarvis`,
+  );
+
+  channels
+    .command("list")
+    .description("List cached Slack channels")
+    .addHelpText(
+      "after",
+      `
+Returns the locally cached channel list. If the cache is empty, it is
+auto-populated from the Slack API on first call.
+
+Examples:
+  $ assistant use slack channels list
+  general        C01234567  channel
+  team-jarvis    C01234568  channel
+  random         C01234569  channel
+
+  $ assistant use slack channels list --json
+  {"channels":{"general":{"id":"C01234567","type":"channel"},...},"refreshedAt":"..."}`,
+    )
+    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      const r = await cliIpcCall<ChannelCache>("slack_use_channels_list", {});
+      if (!r.ok) return exitFromIpcResult(r, cmd);
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, r.result);
+      } else {
+        const cache = r.result!;
+        const entries = Object.entries(cache.channels);
+        if (entries.length === 0) {
+          log.info("No channels found.");
+        } else {
+          // Find the longest channel name for alignment
+          const maxName = Math.max(...entries.map(([name]) => name.length));
+          for (const [name, info] of entries) {
+            log.info(`${name.padEnd(maxName + 2)} ${info.id}  ${info.type}`);
+          }
+          log.info(
+            `\n${entries.length} channel(s) (cached at ${cache.refreshedAt})`,
+          );
+        }
+      }
+    });
+
+  channels
+    .command("refresh")
+    .description("Rebuild the local channel cache from the Slack API")
+    .addHelpText(
+      "after",
+      `
+Fetches all channels from the Slack API and rebuilds the local cache.
+Use this after channels are created or renamed in Slack.
+
+Examples:
+  $ assistant use slack channels refresh
+  Refreshed 42 channels
+
+  $ assistant use slack channels refresh --json
+  {"channels":{...},"refreshedAt":"..."}`,
+    )
+    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      const r = await cliIpcCall<ChannelCache>(
+        "slack_use_channels_refresh",
+        {},
+      );
+      if (!r.ok) return exitFromIpcResult(r, cmd);
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, r.result);
+      } else {
+        const count = Object.keys(r.result!.channels).length;
+        log.info(`Refreshed ${count} channel(s)`);
+      }
+    });
+
+  channels
+    .command("get <name>")
+    .description("Resolve a Slack channel by name or ID")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Channel name (e.g. "general", "#team-jarvis") or raw Slack channel ID
+
+Resolves a channel name or ID to a structured object with the channel's
+Slack ID, name, and type. Uses the local cache, auto-refreshing if needed.
+
+Examples:
+  $ assistant use slack channels get general
+  Name: general
+  ID:   C01234567
+  Type: channel
+
+  $ assistant use slack channels get C01234567 --json
+  {"id":"C01234567","name":"general","type":"channel"}`,
+    )
+    .action(
+      async (name: string, _opts: Record<string, unknown>, cmd: Command) => {
+        const r = await cliIpcCall<ChannelEntry>("slack_use_channels_get", {
+          pathParams: { name },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const ch = r.result!;
+          log.info(`Name: ${ch.name}`);
+          log.info(`ID:   ${ch.id}`);
+          log.info(`Type: ${ch.type}`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/index.ts
+++ b/assistant/src/cli/commands/use/slack/index.ts
@@ -1,0 +1,43 @@
+import type { Command } from "commander";
+
+import { registerCommand } from "../../../lib/register-command.js";
+import { registerChannelsCommand } from "./channels.js";
+import { registerReactCommand } from "./react.js";
+import { registerReadCommand } from "./read.js";
+import { registerSendCommand } from "./send.js";
+import { registerUsersCommand } from "./users.js";
+
+export function registerSlackCommand(parent: Command): void {
+  registerCommand(parent, {
+    name: "slack",
+    transport: "ipc",
+    description: "Send, read, and react to Slack messages",
+    build: (slack) => {
+      slack.option("--json", "Machine-readable compact JSON output");
+
+      slack.addHelpText(
+        "after",
+        `
+Slack integration requires a configured Slack token. Set one up via
+'assistant oauth connect slack' or 'assistant credentials set slack-token'.
+
+Channel arguments accept a channel name (with or without #) or a raw
+Slack channel ID. User arguments accept an email address or display name.
+
+Examples:
+  $ assistant use slack send --channel team-jarvis --text "hello"
+  $ assistant use slack read --channel general --limit 10 --since 2h
+  $ assistant use slack react --channel general --ts 1715123456.000100 --emoji thumbsup
+  $ assistant use slack channels list
+  $ assistant use slack channels refresh
+  $ assistant use slack users get user@example.com`,
+      );
+
+      registerSendCommand(slack);
+      registerReadCommand(slack);
+      registerReactCommand(slack);
+      registerChannelsCommand(slack);
+      registerUsersCommand(slack);
+    },
+  });
+}

--- a/assistant/src/cli/commands/use/slack/react.ts
+++ b/assistant/src/cli/commands/use/slack/react.ts
@@ -1,0 +1,64 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:react");
+
+export function registerReactCommand(slack: Command): void {
+  slack
+    .command("react")
+    .description("Add an emoji reaction to a Slack message")
+    .requiredOption(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .requiredOption(
+      "--ts <message-ts>",
+      "Timestamp of the message to react to — visible in 'assistant use slack read --json' output",
+    )
+    .requiredOption(
+      "--emoji <name>",
+      'Emoji name without colons (e.g. "thumbsup", not ":thumbsup:")',
+    )
+    .addHelpText(
+      "after",
+      `
+Add an emoji reaction to a specific message in a Slack channel.
+Surrounding colons on the emoji name are stripped automatically.
+
+Arguments:
+  --channel   Channel name or Slack channel ID (required)
+  --ts        Message timestamp to react to (required)
+  --emoji     Emoji name, e.g. "thumbsup", "rocket", "eyes" (required)
+
+Examples:
+  $ assistant use slack react --channel general --ts 1715123456.000100 --emoji thumbsup
+  Reacted with :thumbsup: to message
+
+  $ assistant use slack react --channel team-jarvis --ts 1715123456.000100 --emoji rocket --json
+  {"ok":true}`,
+    )
+    .action(
+      async (
+        opts: { channel: string; ts: string; emoji: string },
+        cmd: Command,
+      ) => {
+        const { channel, ts, emoji } = opts;
+
+        const r = await cliIpcCall<{ ok: boolean }>("slack_use_react", {
+          body: { channel, ts, emoji },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          log.info(
+            `Reacted with :${emoji.replace(/^:/, "").replace(/:$/, "")}: to message`,
+          );
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/read.ts
+++ b/assistant/src/cli/commands/use/slack/read.ts
@@ -1,0 +1,102 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:read");
+
+interface ReadResponse {
+  channel: string;
+  messages: Array<{
+    ts: string;
+    user?: string;
+    text: string;
+    thread_ts?: string;
+  }>;
+}
+
+export function registerReadCommand(slack: Command): void {
+  slack
+    .command("read")
+    .description("Read messages from a Slack channel or thread")
+    .requiredOption(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .option("--limit <n>", "Maximum number of messages to return", "20")
+    .option(
+      "--since <ts-or-offset>",
+      'Only show messages since this point — a Slack timestamp (e.g. "1234567890.123456") or relative offset ("2h", "30m", "1d")',
+    )
+    .option("--thread <ts>", "Read replies in a specific thread")
+    .addHelpText(
+      "after",
+      `
+Read recent messages from a Slack channel. When --thread is given,
+reads replies in that thread instead of top-level messages.
+
+The --since option accepts either a raw Slack timestamp or a relative
+offset: "2h" (2 hours ago), "30m" (30 minutes ago), "1d" (1 day ago).
+
+Arguments:
+  --channel   Channel name (e.g. "general") or Slack channel ID (required)
+  --limit     Max messages to return (default: 20)
+  --since     Filter to messages after this point
+  --thread    Parent message timestamp to read thread replies
+
+Examples:
+  $ assistant use slack read --channel general
+  [1715123456.000100] <U123> hello world
+  [1715123456.000200] <U456> hi there
+
+  $ assistant use slack read --channel team-jarvis --limit 5 --since 2h
+  [1715123456.000100] <U123> recent message
+
+  $ assistant use slack read --channel general --thread 1715123456.000100
+  [1715123456.000100] <U123> original message
+  [1715123456.000200] <U456> thread reply
+
+  $ assistant use slack read --channel general --json
+  {"channel":"C123","messages":[...]}`,
+    )
+    .action(
+      async (
+        opts: {
+          channel: string;
+          limit?: string;
+          since?: string;
+          thread?: string;
+        },
+        cmd: Command,
+      ) => {
+        const { channel, limit, since, thread } = opts;
+
+        const r = await cliIpcCall<ReadResponse>("slack_use_read", {
+          body: {
+            channel,
+            limit: parseInt(limit ?? "20", 10),
+            since,
+            thread,
+          },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const messages = r.result!.messages;
+          if (messages.length === 0) {
+            log.info("No messages found.");
+          } else {
+            for (const msg of messages) {
+              const threadIndicator = msg.thread_ts ? " [thread]" : "";
+              log.info(
+                `[${msg.ts}] <${msg.user ?? "unknown"}> ${msg.text}${threadIndicator}`,
+              );
+            }
+          }
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/send.ts
+++ b/assistant/src/cli/commands/use/slack/send.ts
@@ -1,0 +1,89 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:send");
+
+interface SendResponse {
+  ok: boolean;
+  channel: string;
+  ts: string;
+}
+
+export function registerSendCommand(slack: Command): void {
+  slack
+    .command("send")
+    .description("Send a message to a Slack channel or user DM")
+    .requiredOption("--text <message>", "Message text to send")
+    .option(
+      "--channel <name-or-id>",
+      "Channel name or ID — run 'assistant use slack channels list' to find it",
+    )
+    .option(
+      "--user <id-or-email>",
+      "User ID or email for a direct message — run 'assistant use slack users get <query>' to resolve",
+    )
+    .option("--thread <ts>", "Thread timestamp to reply in")
+    .addHelpText(
+      "after",
+      `
+Send a message to a Slack channel or open a DM with a user. Exactly
+one of --channel or --user must be provided.
+
+When --thread is given, the message is posted as a threaded reply.
+
+Arguments:
+  --text       The message body (required)
+  --channel    Channel name (e.g. "general", "#team-jarvis") or Slack ID
+  --user       User email or Slack user ID — opens a DM conversation
+  --thread     Parent message timestamp for threading
+
+Examples:
+  $ assistant use slack send --channel team-jarvis --text "hello"
+  Message sent to team-jarvis (ts: 1715123456.000100)
+
+  $ assistant use slack send --user user@example.com --text "hey!"
+  Message sent to user@example.com (ts: 1715123456.000200)
+
+  $ assistant use slack send --channel general --text "reply" --thread 1715123456.000100
+  Message sent to general (ts: 1715123456.000300)
+
+  $ assistant use slack send --channel general --text "hello" --json
+  {"ok":true,"channel":"C123","ts":"1715123456.000100"}`,
+    )
+    .action(
+      async (
+        opts: {
+          text: string;
+          channel?: string;
+          user?: string;
+          thread?: string;
+        },
+        cmd: Command,
+      ) => {
+        const { text, channel, user, thread } = opts;
+
+        if ((channel && user) || (!channel && !user)) {
+          log.error(
+            "Exactly one of --channel or --user must be provided. Use --channel for a channel message or --user for a DM.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        const r = await cliIpcCall<SendResponse>("slack_use_send", {
+          body: { channel, user, text, thread },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const target = channel ?? user;
+          log.info(`Message sent to ${target} (ts: ${r.result!.ts})`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/use/slack/users.ts
+++ b/assistant/src/cli/commands/use/slack/users.ts
@@ -1,0 +1,66 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../../ipc/cli-client.js";
+import { getCliLogger } from "../../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../../output.js";
+
+const log = getCliLogger("use:slack:users");
+
+interface UserEntry {
+  id: string;
+  displayName: string;
+  email: string;
+}
+
+export function registerUsersCommand(slack: Command): void {
+  const users = slack.command("users").description("Look up Slack users");
+
+  users.addHelpText(
+    "after",
+    `
+Resolve Slack users by email address or display name.
+
+Examples:
+  $ assistant use slack users get user@example.com
+  $ assistant use slack users get "Jane Smith"`,
+  );
+
+  users
+    .command("get <query>")
+    .description("Resolve a Slack user by email or display name")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  query   Email address or display name to search for
+
+Resolves a user from the local Slack user cache. The query is matched
+against email addresses and display names.
+
+Examples:
+  $ assistant use slack users get user@example.com
+  Name:  Jane Smith
+  ID:    U01234567
+  Email: user@example.com
+
+  $ assistant use slack users get "Jane Smith" --json
+  {"id":"U01234567","displayName":"Jane Smith","email":"user@example.com"}`,
+    )
+    .action(
+      async (query: string, _opts: Record<string, unknown>, cmd: Command) => {
+        const r = await cliIpcCall<UserEntry>("slack_use_users_get", {
+          pathParams: { query },
+        });
+        if (!r.ok) return exitFromIpcResult(r, cmd);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, r.result);
+        } else {
+          const user = r.result!;
+          log.info(`Name:  ${user.displayName}`);
+          log.info(`ID:    ${user.id}`);
+          log.info(`Email: ${user.email}`);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -47,6 +47,7 @@ import { registerTrustCommand } from "./commands/trust.js";
 import { registerTtsCommand } from "./commands/tts.js";
 import { registerUiCommand } from "./commands/ui.js";
 import { registerUsageCommand } from "./commands/usage.js";
+import { registerUseCommand } from "./commands/use/index.js";
 import { registerWatchersCommand } from "./commands/watchers.js";
 import { registerWebhooksCommand } from "./commands/webhooks.js";
 import { log } from "./logger.js";
@@ -117,6 +118,7 @@ Examples:
   registerTtsCommand(program);
   registerUiCommand(program);
   registerUsageCommand(program);
+  registerUseCommand(program);
   registerWatchersCommand(program);
   registerWebhooksCommand(program);
 

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -20,8 +20,10 @@ import type {
   SlackConversationsListResponse,
   SlackConversationsOpenResponse,
   SlackPostMessageResponse,
+  SlackReactionsAddResponse,
   SlackSearchMessagesResponse,
   SlackUserInfoResponse,
+  SlackUsersListResponse,
 } from "./types.js";
 
 const SLACK_API_BASE = "https://slack.com/api";
@@ -431,4 +433,29 @@ export async function searchMessages(
       page: String(page),
     },
   );
+}
+
+export async function addReaction(
+  connectionOrToken: OAuthConnection | string,
+  channel: string,
+  timestamp: string,
+  name: string,
+): Promise<SlackReactionsAddResponse> {
+  return request<SlackReactionsAddResponse>(
+    connectionOrToken,
+    "reactions.add",
+    undefined,
+    { channel, timestamp, name },
+  );
+}
+
+export async function listUsers(
+  connectionOrToken: OAuthConnection | string,
+  limit = 200,
+  cursor?: string,
+): Promise<SlackUsersListResponse> {
+  return request<SlackUsersListResponse>(connectionOrToken, "users.list", {
+    limit: String(limit),
+    cursor,
+  });
 }

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -110,3 +110,10 @@ export interface SlackConversationsOpenResponse extends SlackApiResponse {
 }
 
 export type SlackConversationMarkResponse = SlackApiResponse;
+
+export type SlackReactionsAddResponse = SlackApiResponse;
+
+export interface SlackUsersListResponse extends SlackApiResponse {
+  members: SlackUser[];
+  response_metadata?: { next_cursor?: string };
+}

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -73,6 +73,7 @@ import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-prov
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as SLACK_CHANNEL_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
+import { ROUTES as SLACK_USE_ROUTES } from "./integrations/slack/use-slack-routes.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
 import { ROUTES as VERCEL_ROUTES } from "./integrations/vercel.js";
@@ -219,6 +220,7 @@ export const ROUTES: RouteDefinition[] = [
   ...SKILL_ROUTES,
   ...SLACK_CHANNEL_ROUTES,
   ...SLACK_SHARE_ROUTES,
+  ...SLACK_USE_ROUTES,
   ...STT_ROUTES,
   ...SUGGEST_TRUST_RULE_ROUTES,
   ...SUBAGENT_ROUTES,

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -12,9 +12,6 @@ import {
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
-import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
-import { credentialKey } from "../../../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import {
   BadRequestError,
@@ -23,49 +20,9 @@ import {
   ServiceUnavailableError,
 } from "../../errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
+import { resolveSlackToken } from "./token.js";
 
 const log = getLogger("slack-share");
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve a Slack token for the Share UI, mirroring the read/write auth split
- * in `messaging/providers/slack/adapter.ts`.
- *
- * For Socket Mode installs (tokens stored under `credential/slack_channel/*`),
- * prefer the user OAuth token (xoxp-) for reads when present — this lets the
- * channel picker surface channels the user belongs to but the bot doesn't.
- * Fall back to the bot token (xoxb-) otherwise.
- *
- * Writes MUST always use the bot token so posted messages come from the bot
- * identity, never the user. Passing `user_token` to chat.postMessage would
- * post as the user — unambiguously wrong for Share UI behavior.
- *
- * For legacy OAuth installs (no Socket Mode tokens), fall back to the OAuth
- * connection's access_token, which is the bot token in Slack's OAuth v2 flow.
- */
-async function resolveSlackToken(
-  mode: "read" | "write",
-): Promise<string | undefined> {
-  const botToken = await getSecureKeyAsync(
-    credentialKey("slack_channel", "bot_token"),
-  );
-  if (botToken) {
-    if (mode === "read") {
-      const userToken = await getSecureKeyAsync(
-        credentialKey("slack_channel", "user_token"),
-      );
-      return userToken ?? botToken;
-    }
-    return botToken;
-  }
-
-  const conn = getConnectionByProvider("slack");
-  if (!conn) return undefined;
-  return await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
-}
 
 // ---------------------------------------------------------------------------
 // GET /v1/slack/channels
@@ -179,15 +136,11 @@ export async function handleShareToSlackChannel({
   };
 
   if (!appId || !channelId) {
-    throw new BadRequestError(
-      "Missing required fields: appId, channelId",
-    );
+    throw new BadRequestError("Missing required fields: appId, channelId");
   }
 
   if (typeof appId !== "string" || typeof channelId !== "string") {
-    throw new BadRequestError(
-      "Fields appId and channelId must be strings",
-    );
+    throw new BadRequestError("Fields appId and channelId must be strings");
   }
 
   if (message !== undefined && typeof message !== "string") {
@@ -245,8 +198,7 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "slack/channels",
     method: "GET",
     summary: "List Slack channels",
-    description:
-      "List Slack channels, groups, and DMs for the channel picker.",
+    description: "List Slack channels, groups, and DMs for the channel picker.",
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: () => handleListSlackChannels(),

--- a/assistant/src/runtime/routes/integrations/slack/token.ts
+++ b/assistant/src/runtime/routes/integrations/slack/token.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared Slack token resolution.
+ *
+ * Extracted from share.ts so that multiple route modules (share, use-slack)
+ * can reuse the same auth logic.
+ */
+
+import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
+import { credentialKey } from "../../../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
+
+/**
+ * Resolve a Slack token for the Share UI, mirroring the read/write auth split
+ * in `messaging/providers/slack/adapter.ts`.
+ *
+ * For Socket Mode installs (tokens stored under `credential/slack_channel/*`),
+ * prefer the user OAuth token (xoxp-) for reads when present — this lets the
+ * channel picker surface channels the user belongs to but the bot doesn't.
+ * Fall back to the bot token (xoxb-) otherwise.
+ *
+ * Writes MUST always use the bot token so posted messages come from the bot
+ * identity, never the user. Passing `user_token` to chat.postMessage would
+ * post as the user — unambiguously wrong for Share UI behavior.
+ *
+ * For legacy OAuth installs (no Socket Mode tokens), fall back to the OAuth
+ * connection's access_token, which is the bot token in Slack's OAuth v2 flow.
+ */
+export async function resolveSlackToken(
+  mode: "read" | "write",
+): Promise<string | undefined> {
+  const botToken = await getSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  if (botToken) {
+    if (mode === "read") {
+      const userToken = await getSecureKeyAsync(
+        credentialKey("slack_channel", "user_token"),
+      );
+      return userToken ?? botToken;
+    }
+    return botToken;
+  }
+
+  const conn = getConnectionByProvider("slack");
+  if (!conn) return undefined;
+  return await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
+}

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
@@ -1,0 +1,249 @@
+/**
+ * Slack channel and user cache for the `use slack` CLI.
+ *
+ * Caches are persisted as JSON files under `<dataDir>/slack-use/` so that
+ * channel/user resolution avoids redundant Slack API calls. The cache is
+ * rebuilt on demand (first miss or explicit refresh).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import {
+  listConversations,
+  listUsers,
+} from "../../../../messaging/providers/slack/client.js";
+import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { getDataDir } from "../../../../util/platform.js";
+import { NotFoundError } from "../../errors.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SlackChannelCache {
+  workspace: string;
+  refreshedAt: string;
+  channels: Record<string, { id: string; type: string }>;
+}
+
+export interface SlackUserCache {
+  workspace: string;
+  refreshedAt: string;
+  users: Record<string, { id: string; email?: string; displayName?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function channelCachePath(): string {
+  return join(getDataDir(), "slack-use", "channels.json");
+}
+
+function userCachePath(): string {
+  return join(getDataDir(), "slack-use", "users.json");
+}
+
+// ---------------------------------------------------------------------------
+// Channel cache I/O
+// ---------------------------------------------------------------------------
+
+export function loadChannelCache(): SlackChannelCache | undefined {
+  const p = channelCachePath();
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as SlackChannelCache;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveChannelCache(cache: SlackChannelCache): void {
+  const p = channelCachePath();
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(p, JSON.stringify(cache, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// User cache I/O
+// ---------------------------------------------------------------------------
+
+export function loadUserCache(): SlackUserCache | undefined {
+  const p = userCachePath();
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as SlackUserCache;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveUserCache(cache: SlackUserCache): void {
+  const p = userCachePath();
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(p, JSON.stringify(cache, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Channel resolution
+// ---------------------------------------------------------------------------
+
+function classifyConversation(conv: SlackConversation): string {
+  if (conv.is_im) return "dm";
+  if (conv.is_mpim) return "group";
+  if (conv.is_group) return "group";
+  return "channel";
+}
+
+/**
+ * Fetch all channels from the Slack API (paginating), rebuild the channel
+ * cache, persist it, and return it.
+ */
+export async function refreshChannelCache(
+  token: string,
+): Promise<SlackChannelCache> {
+  const channels: Record<string, { id: string; type: string }> = {};
+  let cursor: string | undefined;
+  do {
+    const resp = await listConversations(
+      token,
+      "public_channel,private_channel,mpim,im",
+      true,
+      200,
+      cursor,
+    );
+    for (const ch of resp.channels) {
+      const name = ch.name ?? ch.id;
+      channels[name] = {
+        id: ch.id,
+        type: classifyConversation(ch),
+      };
+    }
+    cursor = resp.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  const cache: SlackChannelCache = {
+    workspace: "default",
+    refreshedAt: new Date().toISOString(),
+    channels,
+  };
+  saveChannelCache(cache);
+  return cache;
+}
+
+/**
+ * Resolve a channel name or ID to a Slack channel ID.
+ *
+ * - If the input looks like a Slack channel ID (`C[A-Z0-9]+`), return it
+ *   directly without any API calls.
+ * - Otherwise check the local cache. On miss, refresh the cache from the
+ *   Slack API and try again.
+ * - Throws `NotFoundError` if the channel is not found after refresh.
+ */
+export async function resolveChannelId(
+  token: string,
+  nameOrId: string,
+): Promise<string> {
+  // Direct ID pass-through
+  if (/^C[A-Z0-9]+$/.test(nameOrId)) {
+    return nameOrId;
+  }
+
+  // Try cache first
+  let cache = loadChannelCache();
+  if (cache) {
+    const entry = cache.channels[nameOrId];
+    if (entry) return entry.id;
+  }
+
+  // Cache miss — refresh and retry
+  cache = await refreshChannelCache(token);
+  const entry = cache.channels[nameOrId];
+  if (entry) return entry.id;
+
+  throw new NotFoundError(`Slack channel not found: ${nameOrId}`);
+}
+
+// ---------------------------------------------------------------------------
+// User resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch all users from the Slack API (paginating), rebuild the user cache,
+ * persist it, and return it.
+ */
+export async function refreshUserCache(token: string): Promise<SlackUserCache> {
+  const users: Record<
+    string,
+    { id: string; email?: string; displayName?: string }
+  > = {};
+  let cursor: string | undefined;
+  do {
+    const resp = await listUsers(token, 200, cursor);
+    for (const member of resp.members) {
+      if (member.deleted) continue;
+
+      const displayName =
+        member.profile?.display_name ||
+        member.profile?.real_name ||
+        member.real_name ||
+        member.name;
+      const email = member.profile?.email;
+
+      // Key by display name (lowercased for case-insensitive lookup)
+      users[displayName.toLowerCase()] = {
+        id: member.id,
+        email,
+        displayName,
+      };
+
+      // Also key by email if available
+      if (email) {
+        users[email.toLowerCase()] = {
+          id: member.id,
+          email,
+          displayName,
+        };
+      }
+    }
+    cursor = resp.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  const cache: SlackUserCache = {
+    workspace: "default",
+    refreshedAt: new Date().toISOString(),
+    users,
+  };
+  saveUserCache(cache);
+  return cache;
+}
+
+/**
+ * Resolve a user by display name or email to a Slack user ID.
+ *
+ * Checks the local cache first (case-insensitive). On miss, refreshes the
+ * cache from the Slack API and retries. Throws `NotFoundError` if no match.
+ */
+export async function resolveUserId(
+  token: string,
+  nameOrEmail: string,
+): Promise<{ id: string; email?: string; displayName?: string }> {
+  const key = nameOrEmail.toLowerCase();
+
+  // Try cache first
+  let cache = loadUserCache();
+  if (cache) {
+    const entry = cache.users[key];
+    if (entry) return entry;
+  }
+
+  // Cache miss — refresh and retry
+  cache = await refreshUserCache(token);
+  const entry = cache.users[key];
+  if (entry) return entry;
+
+  throw new NotFoundError(`Slack user not found: ${nameOrEmail}`);
+}

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-cache.ts
@@ -147,8 +147,11 @@ export async function resolveChannelId(
   token: string,
   nameOrId: string,
 ): Promise<string> {
-  // Direct ID pass-through
-  if (/^C[A-Z0-9]+$/.test(nameOrId)) {
+  // Strip leading '#' so users can pass '#general' etc.
+  nameOrId = nameOrId.replace(/^#/, "");
+
+  // Direct ID pass-through (C = channel, D = DM, G = group)
+  if (/^[CDG][A-Z0-9]+$/.test(nameOrId)) {
     return nameOrId;
   }
 

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -245,6 +245,9 @@ async function handleRead({ body }: RouteHandlerArgs) {
     }));
   }
 
+  // Reverse so messages read chronologically (oldest first)
+  messages.reverse();
+
   return { channel: channelId, messages };
 }
 

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -6,7 +6,16 @@
  * operations without embedding API logic.
  */
 
-import { ServiceUnavailableError } from "../../errors.js";
+import { z } from "zod";
+
+import {
+  addReaction,
+  conversationHistory,
+  conversationReplies,
+  conversationsOpen,
+  postMessage,
+} from "../../../../messaging/providers/slack/client.js";
+import { BadRequestError, ServiceUnavailableError } from "../../errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
 import { resolveSlackToken } from "./token.js";
 import {
@@ -95,6 +104,189 @@ async function handleGetUser({ pathParams }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// POST use/slack/send — send a message to a channel or DM
+// ---------------------------------------------------------------------------
+
+async function handleSend({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const user = body?.user as string | undefined;
+  const text = body?.text as string | undefined;
+  const thread = body?.thread as string | undefined;
+
+  if (!text) {
+    throw new BadRequestError("text is required");
+  }
+
+  if ((channel && user) || (!channel && !user)) {
+    throw new BadRequestError("Exactly one of channel or user must be set");
+  }
+
+  const writeToken = await resolveSlackToken("write");
+  if (!writeToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  let targetChannelId: string;
+
+  if (channel) {
+    const readToken = await resolveSlackToken("read");
+    if (!readToken) {
+      throw new ServiceUnavailableError("No Slack token configured");
+    }
+    targetChannelId = await resolveChannelId(readToken, channel);
+  } else {
+    // DM — resolve user then open a conversation
+    const readToken = await resolveSlackToken("read");
+    if (!readToken) {
+      throw new ServiceUnavailableError("No Slack token configured");
+    }
+    const resolved = await resolveUserId(readToken, user!);
+    const dmResp = await conversationsOpen(writeToken, resolved.id);
+    targetChannelId = dmResp.channel.id;
+  }
+
+  const resp = await postMessage(writeToken, targetChannelId, text, {
+    threadTs: thread,
+  });
+  return { ok: true, channel: resp.channel, ts: resp.ts };
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/read — read messages from a channel or thread
+// ---------------------------------------------------------------------------
+
+async function handleRead({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const limit = body?.limit as number | undefined;
+  const since = body?.since as string | undefined;
+  const thread = body?.thread as string | undefined;
+
+  if (!channel) {
+    throw new BadRequestError("channel is required");
+  }
+
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const channelId = await resolveChannelId(token, channel);
+
+  // Parse `since` into a Slack timestamp (oldest)
+  let oldest: string | undefined;
+  if (since) {
+    if (/^\d+\.\d+$/.test(since)) {
+      // Already a Slack timestamp
+      oldest = since;
+    } else if (/^\d+[hmd]$/.test(since)) {
+      // Relative offset: e.g. "2h", "30m", "1d"
+      const value = parseInt(since.slice(0, -1), 10);
+      const unit = since.slice(-1);
+      let offsetMs: number;
+      switch (unit) {
+        case "h":
+          offsetMs = value * 60 * 60 * 1000;
+          break;
+        case "m":
+          offsetMs = value * 60 * 1000;
+          break;
+        case "d":
+          offsetMs = value * 24 * 60 * 60 * 1000;
+          break;
+        default:
+          throw new BadRequestError(
+            `Invalid since unit: ${unit}. Use h, m, or d`,
+          );
+      }
+      const ts = (Date.now() - offsetMs) / 1000;
+      oldest = `${Math.floor(ts)}.000000`;
+    } else {
+      throw new BadRequestError(
+        'Invalid since format. Use a Slack timestamp (e.g. "1234567890.123456") or a relative offset (e.g. "2h", "30m", "1d")',
+      );
+    }
+  }
+
+  let messages: Array<{
+    ts: string;
+    user?: string;
+    text: string;
+    thread_ts?: string;
+  }>;
+
+  if (thread) {
+    const resp = await conversationReplies(
+      token,
+      channelId,
+      thread,
+      limit ?? 50,
+      undefined,
+      oldest,
+    );
+    messages = resp.messages.map((m) => ({
+      ts: m.ts,
+      user: m.user,
+      text: m.text,
+      thread_ts: m.thread_ts,
+    }));
+  } else {
+    const resp = await conversationHistory(
+      token,
+      channelId,
+      limit ?? 50,
+      undefined,
+      oldest,
+    );
+    messages = resp.messages.map((m) => ({
+      ts: m.ts,
+      user: m.user,
+      text: m.text,
+      thread_ts: m.thread_ts,
+    }));
+  }
+
+  return { channel: channelId, messages };
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/react — add a reaction to a message
+// ---------------------------------------------------------------------------
+
+async function handleReact({ body }: RouteHandlerArgs) {
+  const channel = body?.channel as string | undefined;
+  const ts = body?.ts as string | undefined;
+  let emoji = body?.emoji as string | undefined;
+
+  if (!channel) {
+    throw new BadRequestError("channel is required");
+  }
+  if (!ts) {
+    throw new BadRequestError("ts is required");
+  }
+  if (!emoji) {
+    throw new BadRequestError("emoji is required");
+  }
+
+  // Strip surrounding colons if present (e.g. ":thumbsup:" -> "thumbsup")
+  emoji = emoji.replace(/^:/, "").replace(/:$/, "");
+
+  const writeToken = await resolveSlackToken("write");
+  if (!writeToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const readToken = await resolveSlackToken("read");
+  if (!readToken) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const channelId = await resolveChannelId(readToken, channel);
+  await addReaction(writeToken, channelId, ts, emoji);
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -107,6 +299,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: () => handleListChannels(),
   },
   {
@@ -117,6 +310,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Fetch all channels from the Slack API, rebuild the local cache, and return it.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: () => handleRefreshChannels(),
   },
   {
@@ -127,6 +321,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: handleGetChannel,
   },
   {
@@ -137,6 +332,57 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Resolve a display name or email address to a Slack user via the local cache.",
     tags: ["integrations"],
+    requirePolicyEnforcement: true,
     handler: handleGetUser,
+  },
+  {
+    operationId: "slack_use_send",
+    endpoint: "use/slack/send",
+    method: "POST",
+    summary: "Send a Slack message",
+    description:
+      "Send a message to a Slack channel or user DM. Exactly one of channel or user must be set. Supports threading via the thread parameter.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string().optional(),
+      user: z.string().optional(),
+      text: z.string(),
+      thread: z.string().optional(),
+    }),
+    handler: handleSend,
+  },
+  {
+    operationId: "slack_use_read",
+    endpoint: "use/slack/read",
+    method: "POST",
+    summary: "Read Slack messages",
+    description:
+      'Read messages from a Slack channel or thread. Supports limit, since (Slack timestamp or relative offset like "2h", "30m", "1d"), and thread replies.',
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string(),
+      limit: z.number().optional(),
+      since: z.string().optional(),
+      thread: z.string().optional(),
+    }),
+    handler: handleRead,
+  },
+  {
+    operationId: "slack_use_react",
+    endpoint: "use/slack/react",
+    method: "POST",
+    summary: "Add a reaction to a Slack message",
+    description:
+      "Add an emoji reaction to a message. Strips surrounding colons from the emoji name if present.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    requestBody: z.object({
+      channel: z.string(),
+      ts: z.string(),
+      emoji: z.string(),
+    }),
+    handler: handleReact,
   },
 ];

--- a/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
+++ b/assistant/src/runtime/routes/integrations/slack/use-slack-routes.ts
@@ -1,0 +1,142 @@
+/**
+ * Route handlers for the `use slack` CLI.
+ *
+ * These endpoints expose channel/user resolution and cache management
+ * over the daemon IPC/HTTP interface so the CLI can perform Slack
+ * operations without embedding API logic.
+ */
+
+import { ServiceUnavailableError } from "../../errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../../types.js";
+import { resolveSlackToken } from "./token.js";
+import {
+  loadChannelCache,
+  refreshChannelCache,
+  resolveChannelId,
+  resolveUserId,
+} from "./use-slack-cache.js";
+
+// ---------------------------------------------------------------------------
+// GET use/slack/channels — list cached channels (auto-refresh on empty)
+// ---------------------------------------------------------------------------
+
+async function handleListChannels() {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  let cache = loadChannelCache();
+  if (!cache || Object.keys(cache.channels).length === 0) {
+    cache = await refreshChannelCache(token);
+  }
+
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// POST use/slack/channels/refresh — force-refresh channel cache
+// ---------------------------------------------------------------------------
+
+async function handleRefreshChannels() {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const cache = await refreshChannelCache(token);
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// GET use/slack/channels/:name — resolve a single channel by name
+// ---------------------------------------------------------------------------
+
+async function handleGetChannel({ pathParams }: RouteHandlerArgs) {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const name = pathParams?.name ?? "";
+  const id = await resolveChannelId(token, name);
+
+  // Look up the full entry from cache for the type field
+  const cache = loadChannelCache();
+  const entry = cache
+    ? Object.entries(cache.channels).find(([, v]) => v.id === id)
+    : undefined;
+
+  return {
+    id,
+    name: entry ? entry[0] : name,
+    type: entry ? entry[1].type : "channel",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET use/slack/users/:query — resolve a user by display name or email
+// ---------------------------------------------------------------------------
+
+async function handleGetUser({ pathParams }: RouteHandlerArgs) {
+  const token = await resolveSlackToken("read");
+  if (!token) {
+    throw new ServiceUnavailableError("No Slack token configured");
+  }
+
+  const query = pathParams?.query ?? "";
+  const user = await resolveUserId(token, query);
+
+  return {
+    id: user.id,
+    displayName: user.displayName,
+    email: user.email,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "slack_use_channels_list",
+    endpoint: "use/slack/channels",
+    method: "GET",
+    summary: "List cached Slack channels",
+    description:
+      "Return the cached channel list. Auto-refreshes from the Slack API if the cache is empty.",
+    tags: ["integrations"],
+    handler: () => handleListChannels(),
+  },
+  {
+    operationId: "slack_use_channels_refresh",
+    endpoint: "use/slack/channels/refresh",
+    method: "POST",
+    summary: "Refresh Slack channel cache",
+    description:
+      "Fetch all channels from the Slack API, rebuild the local cache, and return it.",
+    tags: ["integrations"],
+    handler: () => handleRefreshChannels(),
+  },
+  {
+    operationId: "slack_use_channels_get",
+    endpoint: "use/slack/channels/:name",
+    method: "GET",
+    summary: "Resolve a Slack channel by name",
+    description:
+      "Resolve a channel name (or raw Slack ID) to a structured channel object via the local cache.",
+    tags: ["integrations"],
+    handler: handleGetChannel,
+  },
+  {
+    operationId: "slack_use_users_get",
+    endpoint: "use/slack/users/:query",
+    method: "GET",
+    summary: "Resolve a Slack user by name or email",
+    description:
+      "Resolve a display name or email address to a Slack user via the local cache.",
+    tags: ["integrations"],
+    handler: handleGetUser,
+  },
+];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -224,6 +224,17 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "ui",
   "ui request",
   "ui confirm",
+  "use",
+  "use slack",
+  "use slack send",
+  "use slack read",
+  "use slack react",
+  "use slack channels",
+  "use slack channels list",
+  "use slack channels refresh",
+  "use slack channels get",
+  "use slack users",
+  "use slack users get",
   "usage",
   "usage totals",
   "usage daily",
@@ -407,7 +418,8 @@ const riskOverrides: AssistantRiskOverride[] = [
   {
     path: "inference providers connections create",
     risk: "medium",
-    reason: "Inserts a provider_connection row referenced by inference profiles",
+    reason:
+      "Inserts a provider_connection row referenced by inference profiles",
   },
   {
     path: "inference providers connections update",
@@ -417,7 +429,8 @@ const riskOverrides: AssistantRiskOverride[] = [
   {
     path: "inference providers connections delete",
     risk: "medium",
-    reason: "Deletes a provider_connection row; refuses unless --force when profiles still reference it",
+    reason:
+      "Deletes a provider_connection row; refuses unless --force when profiles still reference it",
   },
   { path: "llm send", risk: "medium" },
   {
@@ -500,6 +513,22 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "task queue remove", risk: "medium" },
   { path: "task queue run", risk: "medium" },
   { path: "tts synthesize", risk: "medium" },
+  {
+    path: "use slack send",
+    risk: "medium",
+    reason: "Sends a message to a Slack channel or DM",
+  },
+  {
+    path: "use slack react",
+    risk: "medium",
+    reason: "Adds an emoji reaction to a Slack message",
+  },
+  {
+    path: "use slack channels refresh",
+    risk: "low",
+    reason:
+      "Rebuilds local channel cache from Slack API — read-only external call",
+  },
   { path: "watchers create", risk: "medium" },
   { path: "watchers update", risk: "medium" },
   { path: "watchers delete", risk: "medium" },


### PR DESCRIPTION
## Summary
Add `assistant use slack` CLI — a new `use` namespace for third-party integrations, starting with Slack. Provides send, read, react, channel resolution with local caching, and user resolution via a single CLI command per action.

**Before:** 3-5 hand-rolled API calls per Slack interaction (paginate channels, resolve IDs, construct auth, post).
**After:** 1 CLI call + 1 Slack API call. Channel IDs cached locally — zero API calls for resolution after first lookup.

### Commands
- `assistant use slack send --channel <name> --text <msg>` — send to channel or DM
- `assistant use slack read --channel <name> --limit <n>` — fetch recent messages
- `assistant use slack react --channel <name> --ts <ts> --emoji <name>` — add reaction
- `assistant use slack channels list|refresh|get` — manage channel cache
- `assistant use slack users get <query>` — resolve user by name or email

## Self-review result
GAPS FOUND — 3 gaps fixed in 1 fix PR:
1. Channel ID regex broadened to handle D/G-prefixed IDs
2. Strip `#` prefix from channel name arguments
3. Reverse message order for chronological CLI output

## PRs merged into feature branch
- #30370: feat: add `addReaction` and `listUsers` to Slack API client
- #30371: refactor: extract `resolveSlackToken` from share.ts into shared slack helpers
- #30376: feat: add Slack channel cache and resolution daemon routes
- #30379: feat: add Slack send, read, and react daemon routes
- #30390: feat: add `assistant use slack` CLI namespace with send, read, react, channels, users

### Fix PRs
- #30394: fix: broaden channel ID regex, strip # prefix, reverse read order

Part of plan: use-slack-cli.md

Closes JARVIS-787
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->