### PR TITLE
fix: include bash in allowedTools for non-Vercel credential creation

### DIFF
--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -143,6 +143,7 @@ export async function handleSetTwilioCredentials({
   saveRawConfig({ ...raw, twilio });
 
   upsertCredentialMetadata("twilio", "account_sid", {
+    allowedTools: ["bash"],
     injectionTemplates: [
       {
         hostPattern: "api.twilio.com",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -453,7 +453,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:24:05-04:00"
     },
     {
       "id": "outlook",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:36:47-04:00"
+      "updatedAt": "2026-05-12T11:43:38-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -921,7 +921,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:41:15-04:00"
+      "updatedAt": "2026-05-12T11:43:38-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -94,7 +94,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-09T20:06:44-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "document-writer",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-24T15:56:45-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "macos-automation",
@@ -453,7 +453,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-03T13:09:26-05:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "outlook",
@@ -515,7 +515,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-30T11:22:01-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "restaurant-reservation",
@@ -571,7 +571,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-30T20:13:09-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "slack",
@@ -627,7 +627,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T04:55:50-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "tasks",

--- a/skills/discord-app-setup/scripts/store-bot-token.ts
+++ b/skills/discord-app-setup/scripts/store-bot-token.ts
@@ -25,6 +25,8 @@ async function storeVellum(): Promise<void> {
     "Paste the bot token from the Bot tab of your Discord application. Discord shows it only once.",
     "--allowed-domains",
     "discord.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/linear-app-setup/SKILL.md
+++ b/skills/linear-app-setup/SKILL.md
@@ -59,6 +59,7 @@ credential_store:
   placeholder: "lin_api_xxxxxxxxxx"
   description: "API key for your Linear app (used to authenticate API requests)"
   allowed_domains: ["api.linear.app"]
+  allowed_tools: ["bash"]
   injection_templates:
     - hostPattern: "api.linear.app"
       injectionType: header

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -101,6 +101,7 @@ Run with `python3 /path/to/script.py` on the user's machine (`host_bash`). The u
 ### 3. Store Tokens
 
 After the OAuth flow, read tokens from `/tmp/oura_tokens.json` and store them:
+
 - `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix) and `allowed_tools: ["bash"]`
 - `refresh_token` — store in credential vault for token refresh
 - Tokens expire in ~30 days. Set a reminder to refresh before expiry.
@@ -108,6 +109,7 @@ After the OAuth flow, read tokens from `/tmp/oura_tokens.json` and store them:
 ### 4. Verify Connection
 
 Test with the personal info endpoint:
+
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" "https://api.ouraring.com/v2/usercollection/personal_info"
 ```
@@ -116,21 +118,22 @@ curl -s -H "Authorization: Bearer $TOKEN" "https://api.ouraring.com/v2/usercolle
 
 All endpoints use `GET https://api.ouraring.com/v2/usercollection/{type}` with query params `start_date` and `end_date` (YYYY-MM-DD format).
 
-| Endpoint | Data | Notes |
-|----------|------|-------|
-| `/v2/usercollection/daily_sleep` | Sleep score, duration, efficiency, stages | Best checked after user's typical wake time |
-| `/v2/usercollection/sleep` | Detailed sleep periods with HR, HRV, movement | Raw sleep period data |
-| `/v2/usercollection/daily_readiness` | Readiness score, HRV balance, recovery | Good morning check-in metric |
-| `/v2/usercollection/daily_activity` | Steps, calories, movement, inactivity | Activity summary |
-| `/v2/usercollection/heartrate` | Continuous HR (use `start_datetime`/`end_datetime` in ISO format) | Can be large — limit date range |
-| `/v2/usercollection/daily_spo2` | Blood oxygen levels | Nightly average |
-| `/v2/usercollection/daily_stress` | Stress score and recovery | Daytime stress tracking |
-| `/v2/usercollection/workout` | Detected workouts with HR, calories | Auto-detected or manual |
-| `/v2/usercollection/personal_info` | Age, weight, height, email | Good connection test |
+| Endpoint                             | Data                                                              | Notes                                       |
+| ------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------- |
+| `/v2/usercollection/daily_sleep`     | Sleep score, duration, efficiency, stages                         | Best checked after user's typical wake time |
+| `/v2/usercollection/sleep`           | Detailed sleep periods with HR, HRV, movement                     | Raw sleep period data                       |
+| `/v2/usercollection/daily_readiness` | Readiness score, HRV balance, recovery                            | Good morning check-in metric                |
+| `/v2/usercollection/daily_activity`  | Steps, calories, movement, inactivity                             | Activity summary                            |
+| `/v2/usercollection/heartrate`       | Continuous HR (use `start_datetime`/`end_datetime` in ISO format) | Can be large — limit date range             |
+| `/v2/usercollection/daily_spo2`      | Blood oxygen levels                                               | Nightly average                             |
+| `/v2/usercollection/daily_stress`    | Stress score and recovery                                         | Daytime stress tracking                     |
+| `/v2/usercollection/workout`         | Detected workouts with HR, calories                               | Auto-detected or manual                     |
+| `/v2/usercollection/personal_info`   | Age, weight, height, email                                        | Good connection test                        |
 
 ## Token Refresh
 
 Tokens expire after 30 days. Refresh with:
+
 ```bash
 curl -s -X POST "https://api.ouraring.com/oauth/token" \
   -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -101,7 +101,7 @@ Run with `python3 /path/to/script.py` on the user's machine (`host_bash`). The u
 ### 3. Store Tokens
 
 After the OAuth flow, read tokens from `/tmp/oura_tokens.json` and store them:
-- `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix)
+- `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix) and `allowed_tools: ["bash"]`
 - `refresh_token` — store in credential vault for token refresh
 - Tokens expire in ~30 days. Set a reminder to refresh before expiry.
 

--- a/skills/resend-setup/scripts/store-api-key.ts
+++ b/skills/resend-setup/scripts/store-api-key.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Your Resend API key for sending emails",
     "--allowed-domains",
     "api.resend.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/sentry-app-setup/scripts/store-token.ts
+++ b/skills/sentry-app-setup/scripts/store-token.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Auth token from your Sentry internal integration (found on the integration's details page under Tokens)",
     "--allowed-domains",
     "sentry.io",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/stripe-app-setup/scripts/store-key.ts
+++ b/skills/stripe-app-setup/scripts/store-key.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Restricted API key from your Stripe Dashboard (Developers > API keys). Starts with rk_live_ or rk_test_.",
     "--allowed-domains",
     "api.stripe.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {


### PR DESCRIPTION
## Summary
Fixes forward-compatibility gap from ATL-539 plan review.

**Gap:** New credential setups for non-Vercel services don't include allowedTools: ['bash'], so they'd be blocked by the new shell.ts policy enforcement
**What was expected:** New credential setups should include bash in allowedTools when injection templates are present
**What was found:** Setup scripts and SKILL.md instructions omit allowedTools, defaulting to [] which blocks proxied bash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->