### PR TITLE
fix: include bash in allowedTools for Slack credential creation

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -54,6 +54,7 @@ const SLACK_INJECTION_TEMPLATES = [
 /** Ensure the bot token credential has injection templates for the proxy. */
 function ensureBotTokenInjectionTemplates(): void {
   upsertCredentialMetadata("slack_channel", "bot_token", {
+    allowedTools: ["bash"],
     allowedDomains: ["slack.com"],
     injectionTemplates: SLACK_INJECTION_TEMPLATES,
   });
@@ -62,6 +63,7 @@ function ensureBotTokenInjectionTemplates(): void {
 /** Ensure the user token credential has injection templates for the proxy. */
 function ensureUserTokenInjectionTemplates(): void {
   upsertCredentialMetadata("slack_channel", "user_token", {
+    allowedTools: ["bash"],
     allowedDomains: ["slack.com"],
     injectionTemplates: SLACK_INJECTION_TEMPLATES,
   });
@@ -209,7 +211,9 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      return currentErrorSnapshot("Failed to store bot token in secure storage");
+      return currentErrorSnapshot(
+        "Failed to store bot token in secure storage",
+      );
     }
 
     ensureBotTokenInjectionTemplates();
@@ -262,8 +266,7 @@ export async function setSlackChannelConfig(
           data.team_id !== metadata.teamId
         ) {
           shouldClear = true;
-          clearReason =
-            "User token from a different workspace was removed.";
+          clearReason = "User token from a different workspace was removed.";
         }
       } catch (err) {
         // Transient failure (DNS error, network blip, connection reset,
@@ -310,7 +313,9 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      return currentErrorSnapshot("Failed to store app token in secure storage");
+      return currentErrorSnapshot(
+        "Failed to store app token in secure storage",
+      );
     }
 
     upsertCredentialMetadata("slack_channel", "app_token", {});
@@ -344,9 +349,7 @@ export async function setSlackChannelConfig(
       userTeamId = data.team_id;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return currentErrorSnapshot(
-        `Failed to validate user token: ${message}`,
-      );
+      return currentErrorSnapshot(`Failed to validate user token: ${message}`);
     }
 
     // Cross-check: if a bot token has already been configured, the user token


### PR DESCRIPTION
## Summary
Fixes forward-compatibility gap from ATL-539 plan review (round 3).

**Gap:** config-slack-channel.ts creates credentials with injectionTemplates but no allowedTools, blocking proxied bash for new Slack setups
**Fix:** Added allowedTools: ["bash"] to both ensureBotTokenInjectionTemplates and ensureUserTokenInjectionTemplates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->