### PR TITLE
ATL-539: Vercel credential injection hardening

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1597,6 +1597,95 @@ describe("bash network_mode=proxied — risk capped at medium", () => {
   });
 });
 
+describe("credentialed proxied bash — high risk escalation", () => {
+  beforeEach(() => {
+    mockRisk("low");
+    mockIpcResponse("get_global_thresholds", DEFAULT_GATEWAY_THRESHOLDS);
+    _clearGlobalCacheForTesting();
+    clearRiskCache();
+    testConfig.skills = { load: { extraDirs: [] } };
+  });
+
+  test("proxied bash with credential_ids sends credentialRefCount in IPC params", async () => {
+    mockRisk("high", {
+      reason:
+        "Proxied credential session — shell has access to injected credentials",
+    });
+    const result = await check(
+      "bash",
+      {
+        command: "curl https://api.example.com",
+        network_mode: "proxied",
+        credential_ids: ["cred-abc-123"],
+      },
+      "/tmp",
+    );
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("credential");
+  });
+
+  test("proxied bash with multiple credential_ids prompts with high risk", async () => {
+    mockRisk("high", {
+      reason:
+        "Proxied credential session — shell has access to injected credentials",
+    });
+    const result = await check(
+      "bash",
+      {
+        command: "ls",
+        network_mode: "proxied",
+        credential_ids: ["cred-1", "cred-2"],
+      },
+      "/tmp",
+    );
+    expect(result.decision).toBe("prompt");
+  });
+
+  test("proxied bash with empty credential_ids array does not escalate risk", async () => {
+    mockRisk("low");
+    const result = await check(
+      "bash",
+      {
+        command: "ls",
+        network_mode: "proxied",
+        credential_ids: [],
+      },
+      "/tmp",
+    );
+    // Empty array means no credential refs — follows normal proxied behavior
+    expect(result.decision).toBe("allow");
+  });
+
+  test("proxied bash with credential_ids containing empty strings does not escalate", async () => {
+    mockRisk("low");
+    const result = await check(
+      "bash",
+      {
+        command: "ls",
+        network_mode: "proxied",
+        credential_ids: ["", ""],
+      },
+      "/tmp",
+    );
+    // Empty strings are filtered out, so no credential refs
+    expect(result.decision).toBe("allow");
+  });
+
+  test("non-proxied bash with credential_ids follows normal flow", async () => {
+    mockRisk("low");
+    const result = await check(
+      "bash",
+      {
+        command: "ls",
+        credential_ids: ["cred-abc-123"],
+      },
+      "/tmp",
+    );
+    // Without proxied mode, credential refs don't affect IPC classification
+    expect(result.decision).toBe("allow");
+  });
+});
+
 describe("workspace mode — auto-allow workspace-scoped operations", () => {
   const workspaceDir = "/home/user/my-project";
 

--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -93,6 +93,7 @@ afterAll(() => {
 describe("shell tool credential ref resolution", () => {
   test("service/field ref resolves to UUID and reaches session creation", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
+      allowedTools: ["bash"],
       injectionTemplates: [
         {
           hostPattern: "*.fal.ai",
@@ -120,7 +121,9 @@ describe("shell tool credential ref resolution", () => {
   });
 
   test("UUID ref remains supported", async () => {
-    const meta = upsertCredentialMetadata("github", "token");
+    const meta = upsertCredentialMetadata("github", "token", {
+      allowedTools: ["bash"],
+    });
 
     await shellTool.execute(
       {
@@ -156,7 +159,9 @@ describe("shell tool credential ref resolution", () => {
   });
 
   test("mixed known+unknown refs fails fast (no partial execution)", async () => {
-    upsertCredentialMetadata("fal", "api_key");
+    upsertCredentialMetadata("fal", "api_key", {
+      allowedTools: ["bash"],
+    });
 
     const result = await shellTool.execute(
       {
@@ -175,7 +180,9 @@ describe("shell tool credential ref resolution", () => {
   });
 
   test("duplicate refs are deduped", async () => {
-    const meta = upsertCredentialMetadata("fal", "api_key");
+    const meta = upsertCredentialMetadata("fal", "api_key", {
+      allowedTools: ["bash"],
+    });
 
     await shellTool.execute(
       {
@@ -207,6 +214,91 @@ describe("shell tool credential ref resolution", () => {
 
     // Should not fail — credential resolution only happens in proxied mode
     expect(result.isError).toBeFalsy();
+    expect(mockGetOrStartSession).not.toHaveBeenCalled();
+  });
+
+  test("credential with allowedTools excluding bash is denied for proxied shell", async () => {
+    upsertCredentialMetadata("vercel", "api_token", {
+      allowedTools: ["publish_page"],
+      injectionTemplates: [
+        {
+          hostPattern: "api.vercel.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ],
+    });
+
+    const result = await shellTool.execute(
+      {
+        command: "curl https://api.vercel.com/v1/projects",
+        activity: "test",
+        network_mode: "proxied",
+        credential_ids: ["vercel/api_token"],
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("credential tool policy denied");
+    expect(result.content).toContain("not bash");
+    // Must not call getOrStartSession — policy denial happens before session creation
+    expect(mockGetOrStartSession).not.toHaveBeenCalled();
+  });
+
+  test("credential with allowedTools including bash starts proxied session", async () => {
+    const meta = upsertCredentialMetadata("deploy_svc", "api_key", {
+      allowedTools: ["bash"],
+      injectionTemplates: [
+        {
+          hostPattern: "*.deploy-svc.io",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ],
+    });
+
+    await shellTool.execute(
+      {
+        command: "echo deploy",
+        activity: "test",
+        network_mode: "proxied",
+        credential_ids: ["deploy_svc/api_key"],
+      },
+      ctx,
+    );
+
+    // Session should be created with the resolved credential ID
+    expect(mockGetOrStartSession).toHaveBeenCalledTimes(1);
+    const callArgs = mockGetOrStartSession.mock.calls[0];
+    expect(callArgs[1]).toEqual([meta.credentialId]);
+  });
+
+  test("mixed allowed and denied credentials fail the whole command before session creation", async () => {
+    upsertCredentialMetadata("allowed_svc", "token", {
+      allowedTools: ["bash"],
+    });
+    upsertCredentialMetadata("denied_svc", "token", {
+      allowedTools: ["publish_page"],
+    });
+
+    const result = await shellTool.execute(
+      {
+        command: "echo mixed",
+        activity: "test",
+        network_mode: "proxied",
+        credential_ids: ["allowed_svc/token", "denied_svc/token"],
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("credential tool policy denied");
+    expect(result.content).toContain("denied_svc/token");
+    expect(result.content).toContain("not bash");
+    // Must not call getOrStartSession — even one denied credential blocks the whole command
     expect(mockGetOrStartSession).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -136,6 +136,20 @@ mock.module("../tools/credentials/resolve.js", () => ({
   resolveCredentialRef: (ref: string) => ({ credentialId: ref }),
 }));
 
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadataById: (id: string) => ({
+    service: "test",
+    field: id,
+    allowedTools: ["bash"],
+    allowedDomains: [],
+  }),
+}));
+
+mock.module("../tools/credentials/tool-policy.js", () => ({
+  isToolAllowed: (toolName: string, allowedTools: string[]) =>
+    Array.isArray(allowedTools) && allowedTools.includes(toolName),
+}));
+
 mock.module("../tools/network/script-proxy/logging.js", () => ({
   buildCredentialRefTrace: (
     rawRefs: string[],

--- a/assistant/src/__tests__/vercel-config.test.ts
+++ b/assistant/src/__tests__/vercel-config.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+let secureKeyStore: Record<string, string> = {};
+
+// Track metadata upsert calls to verify policy
+let lastUpsertCall: {
+  service: string;
+  field: string;
+  policy: Record<string, unknown> | undefined;
+} | null = null;
+let metadataDeleted: { service: string; field: string } | null = null;
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) =>
+    secureKeyStore[account] ?? undefined,
+  setSecureKeyAsync: async (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKeyAsync: async (account: string) => {
+    if (account in secureKeyStore) {
+      delete secureKeyStore[account];
+      return "deleted" as const;
+    }
+    return "not-found" as const;
+  },
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  deleteCredentialMetadata: (service: string, field: string) => {
+    metadataDeleted = { service, field };
+    return true;
+  },
+  upsertCredentialMetadata: (
+    service: string,
+    field: string,
+    policy?: Record<string, unknown>,
+  ) => {
+    lastUpsertCall = { service, field, policy };
+    return {};
+  },
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  deleteVercelConfig,
+  getVercelConfig,
+  setVercelConfig,
+} from "../daemon/handlers/config-vercel.js";
+
+describe("Vercel config handler", () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+    lastUpsertCall = null;
+    metadataDeleted = null;
+  });
+
+  // -- setVercelConfig --
+
+  describe("setVercelConfig", () => {
+    test("stores token and returns success", async () => {
+      const result = await setVercelConfig("vl_test_token_123");
+
+      expect(result.success).toBe(true);
+      expect(result.hasToken).toBe(true);
+      expect(secureKeyStore[credentialKey("vercel", "api_token")]).toBe(
+        "vl_test_token_123",
+      );
+    });
+
+    test("metadata does not include bash in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).not.toContain("bash");
+    });
+
+    test("metadata does not include deploy in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).not.toContain("deploy");
+    });
+
+    test("metadata explicitly clears injection templates", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      expect(lastUpsertCall!.policy?.injectionTemplates).toBeNull();
+    });
+
+    test("publish_page and unpublish_page remain in allowedTools", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).toContain("publish_page");
+      expect(tools).toContain("unpublish_page");
+    });
+
+    test("allowedTools contains only publish_page and unpublish_page", async () => {
+      await setVercelConfig("vl_test_token_123");
+
+      expect(lastUpsertCall).not.toBeNull();
+      const tools = lastUpsertCall!.policy?.allowedTools as string[];
+      expect(tools).toEqual(["publish_page", "unpublish_page"]);
+    });
+
+    test("returns error when apiToken is not provided", async () => {
+      const result = await setVercelConfig(undefined);
+
+      expect(result.success).toBe(false);
+      expect(result.hasToken).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  // -- getVercelConfig --
+
+  describe("getVercelConfig", () => {
+    test("returns hasToken true when token exists", async () => {
+      secureKeyStore[credentialKey("vercel", "api_token")] = "some-token";
+      const result = await getVercelConfig();
+
+      expect(result.hasToken).toBe(true);
+      expect(result.success).toBe(true);
+    });
+
+    test("returns hasToken false when no token exists", async () => {
+      const result = await getVercelConfig();
+
+      expect(result.hasToken).toBe(false);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // -- deleteVercelConfig --
+
+  describe("deleteVercelConfig", () => {
+    test("removes both secure key and metadata", async () => {
+      secureKeyStore[credentialKey("vercel", "api_token")] = "token-to-delete";
+
+      const result = await deleteVercelConfig();
+
+      expect(result.success).toBe(true);
+      expect(result.hasToken).toBe(false);
+      // Secure key should be removed
+      expect(
+        secureKeyStore[credentialKey("vercel", "api_token")],
+      ).toBeUndefined();
+      // Metadata should be deleted
+      expect(metadataDeleted).toEqual({
+        service: "vercel",
+        field: "api_token",
+      });
+    });
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-080-restrict-vercel-api-token-metadata.test.ts
+++ b/assistant/src/__tests__/workspace-migration-080-restrict-vercel-api-token-metadata.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for workspace migration `080-restrict-vercel-api-token-metadata`.
+ *
+ * The migration rewrites Vercel API token credential metadata from
+ * the legacy vulnerable policy (bash in allowedTools, injection
+ * templates) to the hardened policy (publish_page + unpublish_page
+ * only, no injection templates).
+ *
+ * Cases covered:
+ *   1. Legacy vulnerable metadata -> repaired to target policy.
+ *   2. Already-migrated metadata -> no-op (file unchanged).
+ *   3. Missing metadata file -> no-op (no error).
+ *   4. Malformed JSON -> no-op (no error).
+ *   5. Unrelated credentials preserved during repair.
+ *   6. Unrecognized future schema version -> no-op.
+ *   7. No Vercel record present -> no-op.
+ *   8. Idempotent: second run on repaired file is a no-op.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { restrictVercelApiTokenMetadataMigration } from "../workspace/migrations/080-restrict-vercel-api-token-metadata.js";
+
+let workspaceDir: string;
+let metadataPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-080-test-"));
+  metadataPath = join(workspaceDir, "data", "credentials", "metadata.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeMetadata(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+  writeFileSync(metadataPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readMetadata(): Record<string, unknown> {
+  return JSON.parse(readFileSync(metadataPath, "utf-8"));
+}
+
+/** The legacy vulnerable Vercel credential record (pre-PR 2). */
+function makeLegacyVercelRecord(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    credentialId: "cred-vercel-123",
+    service: "vercel",
+    field: "api_token",
+    allowedTools: ["deploy", "publish_page", "bash"],
+    allowedDomains: [],
+    injectionTemplates: [
+      {
+        hostPattern: "api.vercel.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** The expected hardened Vercel credential record (post-migration). */
+function makeHardenedVercelRecord(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    credentialId: "cred-vercel-123",
+    service: "vercel",
+    field: "api_token",
+    allowedTools: ["publish_page", "unpublish_page"],
+    allowedDomains: [],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** An unrelated credential record (should never be touched). */
+function makeOtherRecord(): Record<string, unknown> {
+  return {
+    credentialId: "cred-other-456",
+    service: "slack",
+    field: "bot_token",
+    allowedTools: ["send_message"],
+    allowedDomains: ["slack.com"],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+describe("workspace migration 080-restrict-vercel-api-token-metadata", () => {
+  test("has the expected id and description", () => {
+    expect(restrictVercelApiTokenMetadataMigration.id).toBe(
+      "080-restrict-vercel-api-token-metadata",
+    );
+    expect(restrictVercelApiTokenMetadataMigration.description).toContain(
+      "Vercel",
+    );
+  });
+
+  test("repairs legacy vulnerable metadata to hardened policy", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    expect(result.version).toBe(5);
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(1);
+
+    const vercel = creds[0];
+    expect(vercel.service).toBe("vercel");
+    expect(vercel.field).toBe("api_token");
+    expect(vercel.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+    expect(vercel.allowedDomains).toEqual([]);
+    expect(vercel.injectionTemplates).toBeUndefined();
+    // updatedAt should have been bumped.
+    expect(vercel.updatedAt).not.toBe(1700000000000);
+    // createdAt should be preserved.
+    expect(vercel.createdAt).toBe(1700000000000);
+    // credentialId should be preserved.
+    expect(vercel.credentialId).toBe("cred-vercel-123");
+  });
+
+  test("already-migrated metadata is a no-op (file unchanged)", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeHardenedVercelRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+    const beforeStat = statSync(metadataPath);
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const after = readFileSync(metadataPath, "utf-8");
+    expect(after).toBe(before);
+    expect(statSync(metadataPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  test("missing metadata file is a no-op (no error, no file created)", () => {
+    expect(existsSync(metadataPath)).toBe(false);
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(existsSync(metadataPath)).toBe(false);
+  });
+
+  test("malformed JSON is a no-op (does not throw, leaves file alone)", () => {
+    mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+    writeFileSync(metadataPath, "{not valid json", "utf-8");
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("non-Vercel credentials are preserved unchanged during repair", () => {
+    const other = makeOtherRecord();
+    writeMetadata({
+      version: 5,
+      credentials: [other, makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(2);
+
+    // Other credential should be exactly unchanged.
+    const otherCred = creds.find((c) => c.service === "slack");
+    expect(otherCred).toBeDefined();
+    expect(otherCred!.allowedTools).toEqual(["send_message"]);
+    expect(otherCred!.allowedDomains).toEqual(["slack.com"]);
+    expect(otherCred!.updatedAt).toBe(1700000000000);
+
+    // Vercel credential should be repaired.
+    const vercelCred = creds.find((c) => c.service === "vercel");
+    expect(vercelCred).toBeDefined();
+    expect(vercelCred!.allowedTools).toEqual([
+      "publish_page",
+      "unpublish_page",
+    ]);
+    expect(vercelCred!.injectionTemplates).toBeUndefined();
+  });
+
+  test("unrecognized future schema version is a no-op", () => {
+    writeMetadata({
+      version: 99,
+      credentials: [makeLegacyVercelRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("no Vercel record present is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeOtherRecord()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("idempotent: second run on repaired file is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const afterFirst = readFileSync(metadataPath, "utf-8");
+    const afterFirstStat = statSync(metadataPath);
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const afterSecond = readFileSync(metadataPath, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(statSync(metadataPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeMetadata([1, 2, 3]);
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("file with no version field defaults to version 1 and processes", () => {
+    writeMetadata({
+      credentials: [makeLegacyVercelRecord()],
+    });
+
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    const vercel = creds.find((c) => c.service === "vercel");
+    expect(vercel!.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+    expect(vercel!.injectionTemplates).toBeUndefined();
+  });
+
+  test("down() is a no-op (security hardening cannot be reversed)", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeLegacyVercelRecord()],
+    });
+    restrictVercelApiTokenMetadataMigration.run(workspaceDir);
+    const after = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      restrictVercelApiTokenMetadataMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(after);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-081-backfill-bash-allowed-tools.test.ts
+++ b/assistant/src/__tests__/workspace-migration-081-backfill-bash-allowed-tools.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Tests for workspace migration `081-backfill-bash-allowed-tools-for-injection-credentials`.
+ *
+ * After migration 080 hardened the Vercel credential (removing its
+ * injectionTemplates and setting allowedTools to publish tools only),
+ * the shell.ts policy enforcement rejects proxied bash for every OTHER
+ * service whose allowedTools was never populated. This migration
+ * backfills `"bash"` into allowedTools for credentials that have
+ * non-empty injectionTemplates and empty/missing allowedTools.
+ *
+ * Cases covered:
+ *   1. Credential with injectionTemplates and empty allowedTools gets ["bash"] added.
+ *   2. Credential with injectionTemplates and existing populated allowedTools is NOT modified.
+ *   3. Credential without injectionTemplates is NOT modified.
+ *   4. Vercel credential (no injectionTemplates after migration 080) is NOT modified.
+ *   5. Missing metadata file -> no-op.
+ *   6. Malformed JSON -> no-op.
+ *   7. Idempotent: second run is a no-op.
+ *   8. Multiple qualifying credentials are all backfilled.
+ *   9. Unrecognized future schema version -> no-op.
+ *  10. Non-object root -> no-op.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backfillBashAllowedToolsForInjectionCredentialsMigration } from "../workspace/migrations/081-backfill-bash-allowed-tools-for-injection-credentials.js";
+
+let workspaceDir: string;
+let metadataPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-081-test-"));
+  metadataPath = join(workspaceDir, "data", "credentials", "metadata.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeMetadata(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+  writeFileSync(metadataPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readMetadata(): Record<string, unknown> {
+  return JSON.parse(readFileSync(metadataPath, "utf-8"));
+}
+
+/** A credential with injectionTemplates and empty allowedTools (needs backfill). */
+function makeSentryCredential(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    credentialId: "cred-sentry-123",
+    service: "sentry",
+    field: "auth_token",
+    allowedTools: [],
+    allowedDomains: [],
+    injectionTemplates: [
+      {
+        hostPattern: "sentry.io",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+/** A credential with injectionTemplates and missing allowedTools (needs backfill). */
+function makeResendCredential(): Record<string, unknown> {
+  return {
+    credentialId: "cred-resend-456",
+    service: "resend",
+    field: "api_key",
+    allowedDomains: [],
+    injectionTemplates: [
+      {
+        hostPattern: "api.resend.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+/** The Vercel credential after migration 080 (no injectionTemplates, populated allowedTools). */
+function makeHardenedVercelCredential(): Record<string, unknown> {
+  return {
+    credentialId: "cred-vercel-789",
+    service: "vercel",
+    field: "api_token",
+    allowedTools: ["publish_page", "unpublish_page"],
+    allowedDomains: [],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+/** A credential with populated allowedTools AND injectionTemplates (should NOT be modified). */
+function makeCredentialWithPopulatedAllowedTools(): Record<string, unknown> {
+  return {
+    credentialId: "cred-custom-101",
+    service: "custom_service",
+    field: "token",
+    allowedTools: ["custom_tool_a", "custom_tool_b"],
+    allowedDomains: [],
+    injectionTemplates: [
+      {
+        hostPattern: "custom.example.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Token ",
+      },
+    ],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+/** A credential with no injectionTemplates (should NOT be modified). */
+function makeCredentialWithoutInjectionTemplates(): Record<string, unknown> {
+  return {
+    credentialId: "cred-slack-202",
+    service: "slack",
+    field: "bot_token",
+    allowedTools: [],
+    allowedDomains: ["slack.com"],
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  };
+}
+
+describe("workspace migration 081-backfill-bash-allowed-tools-for-injection-credentials", () => {
+  test("has the expected id and description", () => {
+    expect(backfillBashAllowedToolsForInjectionCredentialsMigration.id).toBe(
+      "081-backfill-bash-allowed-tools-for-injection-credentials",
+    );
+    expect(
+      backfillBashAllowedToolsForInjectionCredentialsMigration.description,
+    ).toContain("bash");
+  });
+
+  test("credential with injectionTemplates and empty allowedTools gets bash added", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeSentryCredential()],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(1);
+
+    const sentry = creds[0];
+    expect(sentry.service).toBe("sentry");
+    expect(sentry.allowedTools).toEqual(["bash"]);
+    // injectionTemplates should be preserved (not removed).
+    expect(sentry.injectionTemplates).toBeDefined();
+    expect((sentry.injectionTemplates as unknown[]).length).toBeGreaterThan(0);
+    // updatedAt should have been bumped.
+    expect(sentry.updatedAt).not.toBe(1700000000000);
+    // createdAt should be preserved.
+    expect(sentry.createdAt).toBe(1700000000000);
+  });
+
+  test("credential with injectionTemplates and missing allowedTools gets bash added", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeResendCredential()],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    const resend = creds[0];
+    expect(resend.service).toBe("resend");
+    expect(resend.allowedTools).toEqual(["bash"]);
+  });
+
+  test("credential with injectionTemplates and existing populated allowedTools is NOT modified", () => {
+    const original = makeCredentialWithPopulatedAllowedTools();
+    writeMetadata({
+      version: 5,
+      credentials: [original],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const after = readFileSync(metadataPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("credential without injectionTemplates is NOT modified", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeCredentialWithoutInjectionTemplates()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const after = readFileSync(metadataPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("Vercel credential (no injectionTemplates after migration 080) is NOT modified", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeHardenedVercelCredential()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const after = readFileSync(metadataPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  test("missing metadata file is a no-op (no error, no file created)", () => {
+    expect(existsSync(metadataPath)).toBe(false);
+
+    expect(() =>
+      backfillBashAllowedToolsForInjectionCredentialsMigration.run(
+        workspaceDir,
+      ),
+    ).not.toThrow();
+
+    expect(existsSync(metadataPath)).toBe(false);
+  });
+
+  test("malformed JSON is a no-op (does not throw, leaves file alone)", () => {
+    mkdirSync(join(workspaceDir, "data", "credentials"), { recursive: true });
+    writeFileSync(metadataPath, "{not valid json", "utf-8");
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      backfillBashAllowedToolsForInjectionCredentialsMigration.run(
+        workspaceDir,
+      ),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("idempotent: second run on backfilled file is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeSentryCredential()],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+    const afterFirst = readFileSync(metadataPath, "utf-8");
+    const afterFirstStat = statSync(metadataPath);
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+    const afterSecond = readFileSync(metadataPath, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(statSync(metadataPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  test("multiple qualifying credentials are all backfilled", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [
+        makeSentryCredential(),
+        makeResendCredential(),
+        makeHardenedVercelCredential(),
+        makeCredentialWithPopulatedAllowedTools(),
+        makeCredentialWithoutInjectionTemplates(),
+      ],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    expect(creds).toHaveLength(5);
+
+    // Sentry: should be backfilled.
+    const sentry = creds.find((c) => c.service === "sentry");
+    expect(sentry!.allowedTools).toEqual(["bash"]);
+    expect(sentry!.updatedAt).not.toBe(1700000000000);
+
+    // Resend: should be backfilled.
+    const resend = creds.find((c) => c.service === "resend");
+    expect(resend!.allowedTools).toEqual(["bash"]);
+    expect(resend!.updatedAt).not.toBe(1700000000000);
+
+    // Vercel: NOT modified (no injectionTemplates, populated allowedTools).
+    const vercel = creds.find((c) => c.service === "vercel");
+    expect(vercel!.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+    expect(vercel!.updatedAt).toBe(1700000000000);
+
+    // Custom: NOT modified (populated allowedTools even though it has injectionTemplates).
+    const custom = creds.find((c) => c.service === "custom_service");
+    expect(custom!.allowedTools).toEqual(["custom_tool_a", "custom_tool_b"]);
+    expect(custom!.updatedAt).toBe(1700000000000);
+
+    // Slack: NOT modified (no injectionTemplates).
+    const slack = creds.find((c) => c.service === "slack");
+    expect(slack!.allowedTools).toEqual([]);
+    expect(slack!.updatedAt).toBe(1700000000000);
+  });
+
+  test("unrecognized future schema version is a no-op", () => {
+    writeMetadata({
+      version: 99,
+      credentials: [makeSentryCredential()],
+    });
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      backfillBashAllowedToolsForInjectionCredentialsMigration.run(
+        workspaceDir,
+      ),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeMetadata([1, 2, 3]);
+    const before = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      backfillBashAllowedToolsForInjectionCredentialsMigration.run(
+        workspaceDir,
+      ),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(before);
+  });
+
+  test("file with no version field defaults to version 1 and processes", () => {
+    writeMetadata({
+      credentials: [makeSentryCredential()],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+    const sentry = creds.find((c) => c.service === "sentry");
+    expect(sentry!.allowedTools).toEqual(["bash"]);
+  });
+
+  test("down() is a no-op", () => {
+    writeMetadata({
+      version: 5,
+      credentials: [makeSentryCredential()],
+    });
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+    const after = readFileSync(metadataPath, "utf-8");
+
+    expect(() =>
+      backfillBashAllowedToolsForInjectionCredentialsMigration.down(
+        workspaceDir,
+      ),
+    ).not.toThrow();
+
+    expect(readFileSync(metadataPath, "utf-8")).toBe(after);
+  });
+
+  test("post-080+081 scenario: Vercel has no bash, injection services have bash", () => {
+    // Simulate state after migration 080 has already run:
+    // - Vercel: hardened (no injectionTemplates, allowedTools = publish tools)
+    // - Sentry: still has injectionTemplates, empty allowedTools
+    writeMetadata({
+      version: 5,
+      credentials: [makeHardenedVercelCredential(), makeSentryCredential()],
+    });
+
+    backfillBashAllowedToolsForInjectionCredentialsMigration.run(workspaceDir);
+
+    const result = readMetadata();
+    const creds = result.credentials as Record<string, unknown>[];
+
+    // Vercel: should still have publish tools only, no bash.
+    const vercel = creds.find((c) => c.service === "vercel");
+    expect(vercel!.allowedTools).toEqual(["publish_page", "unpublish_page"]);
+
+    // Sentry: should now have bash.
+    const sentry = creds.find((c) => c.service === "sentry");
+    expect(sentry!.allowedTools).toEqual(["bash"]);
+  });
+});

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -54,6 +54,7 @@ const SLACK_INJECTION_TEMPLATES = [
 /** Ensure the bot token credential has injection templates for the proxy. */
 function ensureBotTokenInjectionTemplates(): void {
   upsertCredentialMetadata("slack_channel", "bot_token", {
+    allowedTools: ["bash"],
     allowedDomains: ["slack.com"],
     injectionTemplates: SLACK_INJECTION_TEMPLATES,
   });
@@ -62,6 +63,7 @@ function ensureBotTokenInjectionTemplates(): void {
 /** Ensure the user token credential has injection templates for the proxy. */
 function ensureUserTokenInjectionTemplates(): void {
   upsertCredentialMetadata("slack_channel", "user_token", {
+    allowedTools: ["bash"],
     allowedDomains: ["slack.com"],
     injectionTemplates: SLACK_INJECTION_TEMPLATES,
   });
@@ -209,7 +211,9 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      return currentErrorSnapshot("Failed to store bot token in secure storage");
+      return currentErrorSnapshot(
+        "Failed to store bot token in secure storage",
+      );
     }
 
     ensureBotTokenInjectionTemplates();
@@ -262,8 +266,7 @@ export async function setSlackChannelConfig(
           data.team_id !== metadata.teamId
         ) {
           shouldClear = true;
-          clearReason =
-            "User token from a different workspace was removed.";
+          clearReason = "User token from a different workspace was removed.";
         }
       } catch (err) {
         // Transient failure (DNS error, network blip, connection reset,
@@ -310,7 +313,9 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      return currentErrorSnapshot("Failed to store app token in secure storage");
+      return currentErrorSnapshot(
+        "Failed to store app token in secure storage",
+      );
     }
 
     upsertCredentialMetadata("slack_channel", "app_token", {});
@@ -344,9 +349,7 @@ export async function setSlackChannelConfig(
       userTeamId = data.team_id;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return currentErrorSnapshot(
-        `Failed to validate user token: ${message}`,
-      );
+      return currentErrorSnapshot(`Failed to validate user token: ${message}`);
     }
 
     // Cross-check: if a bot token has already been configured, the user token

--- a/assistant/src/daemon/handlers/config-vercel.ts
+++ b/assistant/src/daemon/handlers/config-vercel.ts
@@ -59,16 +59,9 @@ export async function setVercelConfig(
   }
 
   upsertCredentialMetadata("vercel", "api_token", {
-    allowedTools: ["deploy", "publish_page", "bash"],
+    allowedTools: ["publish_page", "unpublish_page"],
     allowedDomains: [],
-    injectionTemplates: [
-      {
-        hostPattern: "api.vercel.com",
-        injectionType: "header",
-        headerName: "Authorization",
-        valuePrefix: "Bearer ",
-      },
-    ],
+    injectionTemplates: null,
   });
 
   log.info("Vercel API token stored successfully");

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -289,6 +289,17 @@ function buildClassifyRiskParams(
 ): ClassifyRiskParams {
   // ── Bash/host_bash ──
   if (toolName === "bash" || toolName === "host_bash") {
+    // Count credential references attached to this invocation.
+    let credentialRefCount: number | undefined;
+    if (Array.isArray(input.credential_ids)) {
+      const validIds = (input.credential_ids as unknown[]).filter(
+        (id) => typeof id === "string" && id.length > 0,
+      );
+      if (validIds.length > 0) {
+        credentialRefCount = validIds.length;
+      }
+    }
+
     return {
       tool: toolName,
       command: getStringField(input, "command"),
@@ -297,6 +308,7 @@ function buildClassifyRiskParams(
       isContainerized: getIsContainerized(),
       networkMode:
         typeof input.network_mode === "string" ? input.network_mode : undefined,
+      credentialRefCount,
     };
   }
 

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -92,4 +92,6 @@ export interface ClassifyRiskParams {
   skillMetadata?: SkillMetadata;
   /** Tool registry default risk level for unknown tools. */
   registryDefaultRisk?: string;
+  /** Number of credential references attached to this tool invocation. */
+  credentialRefCount?: number;
 }

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -143,6 +143,7 @@ export async function handleSetTwilioCredentials({
   saveRawConfig({ ...raw, twilio });
 
   upsertCredentialMetadata("twilio", "account_sid", {
+    allowedTools: ["bash"],
     injectionTemplates: [
       {
         hostPattern: "api.twilio.com",

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -17,7 +17,9 @@ import {
   registerBackgroundTool,
   removeBackgroundTool,
 } from "../background-tool-registry.js";
+import { getCredentialMetadataById } from "../credentials/metadata-store.js";
 import { resolveCredentialRef } from "../credentials/resolve.js";
+import { isToolAllowed } from "../credentials/tool-policy.js";
 import {
   getOrStartSession,
   getSessionEnv,
@@ -214,6 +216,48 @@ class ShellTool implements Tool {
         },
         "Credential refs resolved",
       );
+
+      // -------------------------------------------------------------------
+      // Tool policy enforcement — deny any credential that does not
+      // explicitly allow "bash" in its allowedTools metadata. This check
+      // runs after resolution/dedup and before proxy session creation so
+      // that a denied credential never reaches getOrStartSession.
+      // -------------------------------------------------------------------
+      const deniedCredentials: { credentialId: string; reason: string }[] = [];
+      for (const credId of credentialIds) {
+        const meta = getCredentialMetadataById(credId);
+        if (!meta) {
+          // Should not happen — we just resolved these IDs — but fail-closed.
+          deniedCredentials.push({
+            credentialId: credId,
+            reason: "metadata not found",
+          });
+          continue;
+        }
+        if (!isToolAllowed("bash", meta.allowedTools)) {
+          const tools = meta.allowedTools ?? [];
+          deniedCredentials.push({
+            credentialId: credId,
+            reason:
+              tools.length === 0
+                ? `credential ${meta.service}/${meta.field} has no allowed tools`
+                : `credential ${meta.service}/${meta.field} allows [${tools.join(", ")}] but not bash`,
+          });
+        }
+      }
+      if (deniedCredentials.length > 0) {
+        log.warn(
+          { denied: deniedCredentials },
+          "Credential tool policy denied for proxied bash",
+        );
+        const reasons = deniedCredentials
+          .map((d) => `${d.credentialId}: ${d.reason}`)
+          .join("; ");
+        return {
+          content: `Error: credential tool policy denied — ${reasons}. Each credential must include "bash" in its allowed tools to be used in a proxied shell session.`,
+          isError: true,
+        };
+      }
     } else {
       credentialIds.push(...rawCredentialRefs);
     }

--- a/assistant/src/workspace/migrations/080-restrict-vercel-api-token-metadata.ts
+++ b/assistant/src/workspace/migrations/080-restrict-vercel-api-token-metadata.ts
@@ -1,0 +1,182 @@
+/**
+ * Workspace migration `080-restrict-vercel-api-token-metadata`.
+ *
+ * Repairs legacy Vercel API token credential metadata that was stored
+ * with overly permissive policy (e.g. `bash` in allowedTools and
+ * injection templates targeting `api.vercel.com`). Rewrites the
+ * Vercel record to the hardened policy:
+ *
+ *   - `allowedTools: ["publish_page", "unpublish_page"]`
+ *   - `allowedDomains: []`
+ *   - `injectionTemplates` removed
+ *
+ * Behaviour:
+ *   - Missing metadata file -> no-op.
+ *   - Malformed JSON -> log and no-op.
+ *   - Unrecognized future schema version -> no-op.
+ *   - No `vercel`/`api_token` credential record -> no-op.
+ *   - Already matches target policy -> no-op (no rewrite, no updatedAt bump).
+ *   - Non-Vercel credential records are never modified.
+ *
+ * Idempotent: running twice produces no second write. The runner's
+ * checkpoint also prevents re-runs, but this in-file guard keeps the
+ * migration safe even if the checkpoint is wiped.
+ *
+ * This migration never touches secure secret values — only the
+ * metadata policy fields.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-080-restrict-vercel-api-token-metadata",
+);
+
+const METADATA_RELATIVE_PATH = join("data", "credentials", "metadata.json");
+
+/** Known on-disk schema versions we can safely handle. */
+const KNOWN_VERSIONS = new Set([1, 2, 3, 4, 5]);
+
+/** The hardened target policy for the Vercel API token. */
+const TARGET_ALLOWED_TOOLS = ["publish_page", "unpublish_page"];
+const TARGET_ALLOWED_DOMAINS: string[] = [];
+
+export const restrictVercelApiTokenMetadataMigration: WorkspaceMigration = {
+  id: "080-restrict-vercel-api-token-metadata",
+  description:
+    "Restrict existing Vercel API token metadata to publish tools only",
+
+  run(workspaceDir: string): void {
+    const metadataPath = join(workspaceDir, METADATA_RELATIVE_PATH);
+    if (!existsSync(metadataPath)) {
+      return;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(metadataPath, "utf-8");
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to read credentials metadata; skipping migration",
+      );
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to parse credentials metadata JSON; skipping migration",
+      );
+      return;
+    }
+
+    if (!isPlainObject(parsed)) {
+      log.warn(
+        { path: metadataPath },
+        "Credentials metadata is not an object; skipping migration",
+      );
+      return;
+    }
+
+    // Respect unrecognized future schema versions — do not touch the file.
+    const version = typeof parsed.version === "number" ? parsed.version : 1;
+    if (!KNOWN_VERSIONS.has(version)) {
+      log.info(
+        { version, path: metadataPath },
+        "Credentials metadata has unrecognized version; skipping migration",
+      );
+      return;
+    }
+
+    const credentials = Array.isArray(parsed.credentials)
+      ? parsed.credentials
+      : [];
+
+    // Find the Vercel API token record.
+    const vercelIdx = credentials.findIndex(
+      (c: unknown) =>
+        isPlainObject(c) && c.service === "vercel" && c.field === "api_token",
+    );
+
+    if (vercelIdx === -1) {
+      // No Vercel credential — nothing to repair.
+      return;
+    }
+
+    const vercelRecord = credentials[vercelIdx] as Record<string, unknown>;
+
+    // Check if already matches target policy.
+    if (alreadyMatchesTarget(vercelRecord)) {
+      return;
+    }
+
+    // Rewrite the Vercel record to the target policy.
+    vercelRecord.allowedTools = TARGET_ALLOWED_TOOLS;
+    vercelRecord.allowedDomains = TARGET_ALLOWED_DOMAINS;
+    delete vercelRecord.injectionTemplates;
+    vercelRecord.updatedAt = Date.now();
+
+    try {
+      writeFileSync(metadataPath, JSON.stringify(parsed, null, 2), "utf-8");
+      log.info(
+        { path: metadataPath },
+        "Repaired Vercel API token metadata to hardened policy",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path: metadataPath },
+        "Failed to write repaired credentials metadata; leaving prior file in place",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Cannot recover the original vulnerable policy — and we would not
+    // want to even if we could. This is a security hardening migration.
+  },
+};
+
+/**
+ * Returns true when the Vercel record already matches the target
+ * hardened policy, meaning no rewrite is necessary.
+ */
+function alreadyMatchesTarget(record: Record<string, unknown>): boolean {
+  const tools = record.allowedTools;
+  const domains = record.allowedDomains;
+
+  if (!Array.isArray(tools) || tools.length !== TARGET_ALLOWED_TOOLS.length) {
+    return false;
+  }
+  const sortedTools = [...tools].sort();
+  const sortedTarget = [...TARGET_ALLOWED_TOOLS].sort();
+  for (let i = 0; i < sortedTools.length; i++) {
+    if (sortedTools[i] !== sortedTarget[i]) return false;
+  }
+
+  if (!Array.isArray(domains) || domains.length !== 0) {
+    return false;
+  }
+
+  // injectionTemplates must be absent or undefined.
+  if (
+    "injectionTemplates" in record &&
+    record.injectionTemplates !== undefined &&
+    record.injectionTemplates !== null
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/081-backfill-bash-allowed-tools-for-injection-credentials.ts
+++ b/assistant/src/workspace/migrations/081-backfill-bash-allowed-tools-for-injection-credentials.ts
@@ -1,0 +1,160 @@
+/**
+ * Workspace migration `081-backfill-bash-allowed-tools-for-injection-credentials`.
+ *
+ * After migration 080 stripped Vercel's injection templates and locked
+ * its `allowedTools` to `["publish_page", "unpublish_page"]`, the new
+ * shell.ts credential policy enforcement (`isToolAllowed("bash", meta.allowedTools)`)
+ * would reject every other service that legitimately uses proxied bash
+ * via injection templates — because their `allowedTools` was never populated.
+ *
+ * This migration backfills `"bash"` into `allowedTools` for any credential
+ * that:
+ *   1. Has a non-empty `injectionTemplates` array (i.e., it uses proxied bash).
+ *   2. Has empty or missing `allowedTools`.
+ *
+ * Credentials that already have populated `allowedTools` (like the
+ * now-hardened Vercel credential) are NOT touched.
+ *
+ * Behaviour:
+ *   - Missing metadata file -> no-op.
+ *   - Malformed JSON -> log and no-op.
+ *   - Unrecognized future schema version -> no-op.
+ *   - No qualifying credentials -> no-op (no rewrite).
+ *   - Already backfilled -> no-op (idempotent).
+ *
+ * Idempotent: running twice produces no second write.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-081-backfill-bash-allowed-tools-for-injection-credentials",
+);
+
+const METADATA_RELATIVE_PATH = join("data", "credentials", "metadata.json");
+
+/** Known on-disk schema versions we can safely handle. */
+const KNOWN_VERSIONS = new Set([1, 2, 3, 4, 5]);
+
+export const backfillBashAllowedToolsForInjectionCredentialsMigration: WorkspaceMigration =
+  {
+    id: "081-backfill-bash-allowed-tools-for-injection-credentials",
+    description:
+      "Backfill bash into allowedTools for credentials with injection templates",
+
+    run(workspaceDir: string): void {
+      const metadataPath = join(workspaceDir, METADATA_RELATIVE_PATH);
+      if (!existsSync(metadataPath)) {
+        return;
+      }
+
+      let raw: string;
+      try {
+        raw = readFileSync(metadataPath, "utf-8");
+      } catch (err) {
+        log.warn(
+          { err, path: metadataPath },
+          "Failed to read credentials metadata; skipping migration",
+        );
+        return;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) {
+        log.warn(
+          { err, path: metadataPath },
+          "Failed to parse credentials metadata JSON; skipping migration",
+        );
+        return;
+      }
+
+      if (!isPlainObject(parsed)) {
+        log.warn(
+          { path: metadataPath },
+          "Credentials metadata is not an object; skipping migration",
+        );
+        return;
+      }
+
+      // Respect unrecognized future schema versions — do not touch the file.
+      const version = typeof parsed.version === "number" ? parsed.version : 1;
+      if (!KNOWN_VERSIONS.has(version)) {
+        log.info(
+          { version, path: metadataPath },
+          "Credentials metadata has unrecognized version; skipping migration",
+        );
+        return;
+      }
+
+      const credentials = Array.isArray(parsed.credentials)
+        ? parsed.credentials
+        : [];
+
+      let modified = false;
+
+      for (const cred of credentials) {
+        if (!isPlainObject(cred)) continue;
+
+        // Only target credentials with non-empty injectionTemplates.
+        if (!hasNonEmptyInjectionTemplates(cred)) continue;
+
+        // Only target credentials with empty or missing allowedTools.
+        if (hasPopulatedAllowedTools(cred)) continue;
+
+        // Backfill "bash" into allowedTools.
+        cred.allowedTools = ["bash"];
+        cred.updatedAt = Date.now();
+        modified = true;
+      }
+
+      if (!modified) {
+        return;
+      }
+
+      try {
+        writeFileSync(metadataPath, JSON.stringify(parsed, null, 2), "utf-8");
+        log.info(
+          { path: metadataPath },
+          "Backfilled bash into allowedTools for credentials with injection templates",
+        );
+      } catch (err) {
+        log.warn(
+          { err, path: metadataPath },
+          "Failed to write backfilled credentials metadata; leaving prior file in place",
+        );
+      }
+    },
+
+    down(_workspaceDir: string): void {
+      // This is a forward-only data repair. Rolling back would re-break
+      // proxied bash for affected services.
+    },
+  };
+
+/**
+ * Returns true when the credential has a non-empty `injectionTemplates` array.
+ */
+function hasNonEmptyInjectionTemplates(
+  record: Record<string, unknown>,
+): boolean {
+  const templates = record.injectionTemplates;
+  return Array.isArray(templates) && templates.length > 0;
+}
+
+/**
+ * Returns true when the credential has a populated (non-empty) `allowedTools` array.
+ */
+function hasPopulatedAllowedTools(record: Record<string, unknown>): boolean {
+  const tools = record.allowedTools;
+  return Array.isArray(tools) && tools.length > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -77,6 +77,7 @@ import { dropServicesInferenceModeMigration } from "./076-drop-services-inferenc
 import { seedMemoryRouterCallsiteMigration } from "./077-seed-memory-router-callsite.js";
 import { releaseNotesTavilyWebSearchMigration } from "./078-release-notes-tavily-web-search.js";
 import { homeFeedNotificationOnlyMigration } from "./079-home-feed-notification-only.js";
+import { restrictVercelApiTokenMetadataMigration } from "./080-restrict-vercel-api-token-metadata.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -165,4 +166,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedMemoryRouterCallsiteMigration,
   releaseNotesTavilyWebSearchMigration,
   homeFeedNotificationOnlyMigration,
+  restrictVercelApiTokenMetadataMigration,
 ];

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -78,6 +78,7 @@ import { seedMemoryRouterCallsiteMigration } from "./077-seed-memory-router-call
 import { releaseNotesTavilyWebSearchMigration } from "./078-release-notes-tavily-web-search.js";
 import { homeFeedNotificationOnlyMigration } from "./079-home-feed-notification-only.js";
 import { restrictVercelApiTokenMetadataMigration } from "./080-restrict-vercel-api-token-metadata.js";
+import { backfillBashAllowedToolsForInjectionCredentialsMigration } from "./081-backfill-bash-allowed-tools-for-injection-credentials.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -167,4 +168,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesTavilyWebSearchMigration,
   homeFeedNotificationOnlyMigration,
   restrictVercelApiTokenMetadataMigration,
+  backfillBashAllowedToolsForInjectionCredentialsMigration,
 ];

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -349,6 +349,82 @@ describe("skill classification", () => {
   });
 });
 
+// ── Credentialed proxied bash ───────────────────────────────────────────────
+
+describe("credentialed proxied bash", () => {
+  test("credentialed proxied bash returns high risk even for simple curl", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "curl https://api.example.com",
+      networkMode: "proxied",
+      credentialRefCount: 1,
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("credential");
+  });
+
+  test("credentialed proxied bash returns high risk for low-risk command", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      networkMode: "proxied",
+      credentialRefCount: 2,
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("credential");
+  });
+
+  test("proxied bash without credential refs keeps existing medium cap for high-risk command", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "rm -rf /",
+      networkMode: "proxied",
+    });
+    // rm -rf / is high risk but gets capped to medium for non-credentialed proxied bash
+    expect(result.risk).toBe("medium");
+  });
+
+  test("proxied bash without credential refs keeps low risk for low-risk command", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      networkMode: "proxied",
+    });
+    expect(result.risk).toBe("low");
+  });
+
+  test("credentialRefCount=0 does not escalate risk", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      networkMode: "proxied",
+      credentialRefCount: 0,
+    });
+    expect(result.risk).toBe("low");
+  });
+
+  test("non-proxied bash with credential refs follows normal risk flow", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      credentialRefCount: 1,
+    });
+    // Without proxied mode, credential refs don't affect classification
+    expect(result.risk).toBe("low");
+  });
+
+  test("host_bash with proxied + credential refs is not affected (host_bash skips proxied cap)", async () => {
+    const result = await classify({
+      tool: "host_bash",
+      command: "rm -rf /",
+      networkMode: "proxied",
+      credentialRefCount: 1,
+    });
+    // host_bash is never affected by proxied risk logic
+    expect(result.risk).toBe("high");
+  });
+});
+
 // ── Unknown tool fallback ───────────────────────────────────────────────────
 
 describe("unknown tool fallback", () => {

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -73,6 +73,8 @@ const ClassifyRiskSchema = z.object({
     .optional(),
   /** Tool registry default risk level for unknown tools. */
   registryDefaultRisk: z.string().optional(),
+  /** Number of credential references attached to this tool invocation. */
+  credentialRefCount: z.number().int().nonnegative().optional(),
 });
 
 type ClassifyRiskParams = z.infer<typeof ClassifyRiskSchema>;
@@ -358,17 +360,26 @@ export async function handleClassifyRisk(
         });
       }
 
-      // Proxied bash risk cap: when running through the credential proxy,
-      // cap High → Medium so proxied commands don't trigger unnecessary prompts.
+      // Proxied bash risk classification:
+      // - When credentials are attached (credentialRefCount > 0), escalate to
+      //   high risk regardless of the underlying assessment. Credentialed
+      //   proxied shell sessions carry elevated risk and must not be
+      //   downgraded by the general proxied-bash cap.
+      // - For non-credentialed proxied bash, cap High → Medium so proxied
+      //   commands don't trigger unnecessary prompts.
       // Only applies to sandboxed "bash" — host_bash runs on the host machine
       // and should not have its risk capped.
       let finalRisk = assessment.riskLevel;
-      if (
-        tool === "bash" &&
-        params.networkMode === "proxied" &&
-        finalRisk === "high"
-      ) {
-        finalRisk = "medium";
+      let finalReason = assessment.reason;
+      const credentialRefCount = params.credentialRefCount ?? 0;
+      if (tool === "bash" && params.networkMode === "proxied") {
+        if (credentialRefCount > 0) {
+          finalRisk = "high";
+          finalReason =
+            "Proxied credential session — shell has access to injected credentials";
+        } else if (finalRisk === "high") {
+          finalRisk = "medium";
+        }
       }
 
       // Collect resolved paths for directory-scoped rule enforcement.
@@ -380,7 +391,7 @@ export async function handleClassifyRisk(
 
       return {
         risk: finalRisk,
-        reason: assessment.reason,
+        reason: finalReason,
         scopeOptions: assessment.scopeOptions,
         allowlistOptions: assessment.allowlistOptions,
         actionKeys,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -94,7 +94,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "document-writer",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "macos-automation",
@@ -453,7 +453,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:24:05-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "outlook",
@@ -515,7 +515,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "restaurant-reservation",
@@ -571,7 +571,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "slack",
@@ -627,7 +627,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:22:28-04:00"
+      "updatedAt": "2026-05-12T12:30:42-04:00"
     },
     {
       "id": "tasks",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -636,7 +636,8 @@
       "metadata": {
         "emoji": "💳"
       },
-      "compatibility": "Designed for Vellum personal assistants"
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-05-12T11:01:33-07:00"
     },
     {
       "id": "tasks",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:36:47-04:00"
+      "updatedAt": "2026-05-12T11:43:38-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -94,7 +94,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-09T20:06:44-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "document-writer",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-24T15:56:45-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "macos-automation",
@@ -453,7 +453,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-03T13:09:26-05:00"
+      "updatedAt": "2026-05-12T12:24:05-04:00"
     },
     {
       "id": "outlook",
@@ -515,7 +515,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-30T11:22:01-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "restaurant-reservation",
@@ -571,7 +571,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-30T20:13:09-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "slack",
@@ -627,7 +627,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T04:55:50-04:00"
+      "updatedAt": "2026-05-12T12:22:28-04:00"
     },
     {
       "id": "tasks",
@@ -921,7 +921,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:41:15-04:00"
+      "updatedAt": "2026-05-12T11:43:38-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T16:12:45-04:00"
+      "updatedAt": "2026-05-12T11:36:47-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -921,7 +921,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-12T11:41:15-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/deploy-fullstack-vercel/SKILL.md
+++ b/skills/deploy-fullstack-vercel/SKILL.md
@@ -21,12 +21,19 @@ Deploy a full-stack app with a React/Vite frontend and Python/FastAPI backend to
 
 ## Authentication
 
-Before deploying, check for a Vercel API credential:
+### Vellum App Publishing
 
-1. Run `credential_store list` and look for a `vercel/api_token` entry.
-2. If found with `injection_templates`, the credential can be used automatically via `network_mode: "proxied"` with `credential_ids`.
-3. If no credential exists, use `credential_store prompt` to ask the user for their Vercel API token. Direct them to https://vercel.com/account/tokens to create one.
-4. Fall back to the Vercel CLI only if no usable credential exists. Install with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+For publishing Vellum apps from the library, use the built-in `publish_page` tool. This is the preferred path — it uses the stored Vercel API token (`vercel/api_token`) via the brokered publish flow without exposing the token to shell commands.
+
+**The stored Vercel API token is reserved for brokered `publish_page` and `unpublish_page` actions only.** Do not pass it to `bash`, `curl`, Vercel CLI commands, or proxy credential injection. Do not use `network_mode: "proxied"` with `credential_ids` for Vercel deployments.
+
+### Custom Full-Stack Deployments
+
+For custom projects that need Vercel deployment (not Vellum app publishing):
+
+1. Install the Vercel CLI with `bun install -g vercel` (not npm — npm is not available in the sandbox).
+2. Use `vercel login` to authenticate interactively (opens browser for the user).
+3. If the user does not want to use CLI auth, stop and ask them for an approved deployment path. Do not extract, inject, or shell with the stored API token.
 
 ## Deploying a Vellum App
 
@@ -91,7 +98,7 @@ Create a `vercel.json` in the dist directory:
 }
 ```
 
-Then deploy using the Vercel API credential (preferred) or CLI.
+Then deploy using the `publish_page` tool (preferred). For Vellum apps, use the built-in app publish flow rather than raw Vercel API calls from shell.
 
 ## Deploying a Custom Full-Stack Project
 
@@ -250,7 +257,7 @@ curl -s <deployed-url>/api/health
 
 ```bash
 bun install -g vercel        # Install
-vercel login                 # Authenticate (opens browser — last resort)
+vercel login                 # Authenticate (opens browser for user-mediated auth)
 vercel --yes --prod          # Deploy to production (skip prompts)
 vercel logs --project <name> # Check function logs
 ```

--- a/skills/discord-app-setup/scripts/store-bot-token.ts
+++ b/skills/discord-app-setup/scripts/store-bot-token.ts
@@ -25,6 +25,8 @@ async function storeVellum(): Promise<void> {
     "Paste the bot token from the Bot tab of your Discord application. Discord shows it only once.",
     "--allowed-domains",
     "discord.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/linear-app-setup/SKILL.md
+++ b/skills/linear-app-setup/SKILL.md
@@ -59,6 +59,7 @@ credential_store:
   placeholder: "lin_api_xxxxxxxxxx"
   description: "API key for your Linear app (used to authenticate API requests)"
   allowed_domains: ["api.linear.app"]
+  allowed_tools: ["bash"]
   injection_templates:
     - hostPattern: "api.linear.app"
       injectionType: header

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -101,13 +101,15 @@ Run with `python3 /path/to/script.py` on the user's machine (`host_bash`). The u
 ### 3. Store Tokens
 
 After the OAuth flow, read tokens from `/tmp/oura_tokens.json` and store them:
-- `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix)
+
+- `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix) and `allowed_tools: ["bash"]`
 - `refresh_token` — store in credential vault for token refresh
 - Tokens expire in ~30 days. Set a reminder to refresh before expiry.
 
 ### 4. Verify Connection
 
 Test with the personal info endpoint:
+
 ```bash
 curl -s -H "Authorization: Bearer $TOKEN" "https://api.ouraring.com/v2/usercollection/personal_info"
 ```
@@ -116,21 +118,22 @@ curl -s -H "Authorization: Bearer $TOKEN" "https://api.ouraring.com/v2/usercolle
 
 All endpoints use `GET https://api.ouraring.com/v2/usercollection/{type}` with query params `start_date` and `end_date` (YYYY-MM-DD format).
 
-| Endpoint | Data | Notes |
-|----------|------|-------|
-| `/v2/usercollection/daily_sleep` | Sleep score, duration, efficiency, stages | Best checked after user's typical wake time |
-| `/v2/usercollection/sleep` | Detailed sleep periods with HR, HRV, movement | Raw sleep period data |
-| `/v2/usercollection/daily_readiness` | Readiness score, HRV balance, recovery | Good morning check-in metric |
-| `/v2/usercollection/daily_activity` | Steps, calories, movement, inactivity | Activity summary |
-| `/v2/usercollection/heartrate` | Continuous HR (use `start_datetime`/`end_datetime` in ISO format) | Can be large — limit date range |
-| `/v2/usercollection/daily_spo2` | Blood oxygen levels | Nightly average |
-| `/v2/usercollection/daily_stress` | Stress score and recovery | Daytime stress tracking |
-| `/v2/usercollection/workout` | Detected workouts with HR, calories | Auto-detected or manual |
-| `/v2/usercollection/personal_info` | Age, weight, height, email | Good connection test |
+| Endpoint                             | Data                                                              | Notes                                       |
+| ------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------- |
+| `/v2/usercollection/daily_sleep`     | Sleep score, duration, efficiency, stages                         | Best checked after user's typical wake time |
+| `/v2/usercollection/sleep`           | Detailed sleep periods with HR, HRV, movement                     | Raw sleep period data                       |
+| `/v2/usercollection/daily_readiness` | Readiness score, HRV balance, recovery                            | Good morning check-in metric                |
+| `/v2/usercollection/daily_activity`  | Steps, calories, movement, inactivity                             | Activity summary                            |
+| `/v2/usercollection/heartrate`       | Continuous HR (use `start_datetime`/`end_datetime` in ISO format) | Can be large — limit date range             |
+| `/v2/usercollection/daily_spo2`      | Blood oxygen levels                                               | Nightly average                             |
+| `/v2/usercollection/daily_stress`    | Stress score and recovery                                         | Daytime stress tracking                     |
+| `/v2/usercollection/workout`         | Detected workouts with HR, calories                               | Auto-detected or manual                     |
+| `/v2/usercollection/personal_info`   | Age, weight, height, email                                        | Good connection test                        |
 
 ## Token Refresh
 
 Tokens expire after 30 days. Refresh with:
+
 ```bash
 curl -s -X POST "https://api.ouraring.com/oauth/token" \
   -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"

--- a/skills/resend-setup/scripts/store-api-key.ts
+++ b/skills/resend-setup/scripts/store-api-key.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Your Resend API key for sending emails",
     "--allowed-domains",
     "api.resend.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/sentry-app-setup/scripts/store-token.ts
+++ b/skills/sentry-app-setup/scripts/store-token.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Auth token from your Sentry internal integration (found on the integration's details page under Tokens)",
     "--allowed-domains",
     "sentry.io",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/stripe-app-setup/scripts/store-key.ts
+++ b/skills/stripe-app-setup/scripts/store-key.ts
@@ -23,6 +23,8 @@ async function storeVellum(): Promise<void> {
     "Restricted API key from your Stripe Dashboard (Developers > API keys). Starts with rk_live_ or rk_test_.",
     "--allowed-domains",
     "api.stripe.com",
+    "--allowed-tools",
+    "bash",
     "--injection-templates",
     JSON.stringify([
       {

--- a/skills/vercel-token-setup/SKILL.md
+++ b/skills/vercel-token-setup/SKILL.md
@@ -83,7 +83,7 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
-  allowedDomains: ["api.vercel.com"]
+  allowedDomains: []
 ```
 
 ### Channel Step 4: Done!
@@ -225,7 +225,7 @@ credential_store store:
   field: "api_token"
   value: "<the token the user provided>"
   allowedTools: ["publish_page", "unpublish_page"]
-  allowedDomains: ["api.vercel.com"]
+  allowedDomains: []
 ```
 
 **Verify:** `credential_store list` shows `api_token` for `vercel`.


### PR DESCRIPTION
## Summary
Closes the credential-boundary vulnerability where the Vercel API token was stored with an `api.vercel.com` Authorization injection template and was usable by the generic `bash` tool. Enforces credential `allowedTools` policy before proxied shell sessions, restricts Vercel metadata to publish-only, migrates existing metadata, updates deployment skills, and escalates risk classification.

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs (non-Vercel credential setup paths needed `allowedTools: ["bash"]`)

## PRs merged into feature branch
- #30384: Enforce credential policy before proxied bash sessions
- #30381: Restrict new Vercel token metadata to publish tools
- #30383: Escalate credentialed proxied bash risk
- #30389: Repair existing Vercel credential metadata
- #30388: Remove Vercel credential proxy guidance from skills

### Fix PRs
- #30393: Backfill bash allowedTools for injection-template credentials (migration 081)
- #30396: Add bash to allowedTools for non-Vercel credential setup scripts
- #30400: Add bash to allowedTools for Slack credential creation

Part of plan: atl-539-vercel-credential-injection.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->