### PR TITLE
feat: add `addReaction` and `listUsers` to Slack API client

### DIFF
--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -20,8 +20,10 @@ import type {
   SlackConversationsListResponse,
   SlackConversationsOpenResponse,
   SlackPostMessageResponse,
+  SlackReactionsAddResponse,
   SlackSearchMessagesResponse,
   SlackUserInfoResponse,
+  SlackUsersListResponse,
 } from "./types.js";
 
 const SLACK_API_BASE = "https://slack.com/api";
@@ -431,4 +433,29 @@ export async function searchMessages(
       page: String(page),
     },
   );
+}
+
+export async function addReaction(
+  connectionOrToken: OAuthConnection | string,
+  channel: string,
+  timestamp: string,
+  name: string,
+): Promise<SlackReactionsAddResponse> {
+  return request<SlackReactionsAddResponse>(
+    connectionOrToken,
+    "reactions.add",
+    undefined,
+    { channel, timestamp, name },
+  );
+}
+
+export async function listUsers(
+  connectionOrToken: OAuthConnection | string,
+  limit = 200,
+  cursor?: string,
+): Promise<SlackUsersListResponse> {
+  return request<SlackUsersListResponse>(connectionOrToken, "users.list", {
+    limit: String(limit),
+    cursor,
+  });
 }

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -110,3 +110,10 @@ export interface SlackConversationsOpenResponse extends SlackApiResponse {
 }
 
 export type SlackConversationMarkResponse = SlackApiResponse;
+
+export type SlackReactionsAddResponse = SlackApiResponse;
+
+export interface SlackUsersListResponse extends SlackApiResponse {
+  members: SlackUser[];
+  response_metadata?: { next_cursor?: string };
+}


### PR DESCRIPTION
## Summary
- Add `SlackReactionsAddResponse` and `SlackUsersListResponse` types
- Add `addReaction()` and `listUsers()` methods using existing rate-limit retry pattern
- Cherry-picked from the `alex-nork/use-slack-cli` feature branch

Part of plan: slack-skill-scripts.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->