### PR TITLE
feat: add Slack API client library for skill scripts

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -584,7 +584,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T10:19:18-04:00"
+      "updatedAt": "2026-05-12T14:09:41-04:00"
     },
     {
       "id": "slack-app-setup",
@@ -637,7 +637,7 @@
         "emoji": "💳"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T09:13:37-07:00"
+      "updatedAt": "2026-05-12T11:01:33-07:00"
     },
     {
       "id": "tasks",

--- a/skills/slack/scripts/lib/common.ts
+++ b/skills/slack/scripts/lib/common.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+
+/**
+ * Shared utilities for slack skill scripts.
+ * Provides CLI argument parsing, JSON output helpers, and common patterns.
+ */
+
+/** Parse `--key value` and `--flag` CLI arguments. */
+export function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      result[key] = true;
+    } else {
+      result[key] = next;
+      i++;
+    }
+  }
+  return result;
+}
+
+/** Write JSON to stdout. */
+export function printJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data) + "\n");
+}
+
+/** Write `{ ok: false, error: message }` to stdout and exit. */
+export function printError(message: string): void {
+  printJson({ ok: false, error: message });
+  process.exit(1);
+}
+
+/** Write `{ ok: true, data }` to stdout. */
+export function ok(data: unknown): void {
+  printJson({ ok: true, data });
+}
+
+/** Extract a required string argument or call `printError`. */
+export function requireArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    printError(`Missing required argument: --${name}`);
+    // printError calls process.exit(1), but TypeScript doesn't know that
+    throw new Error("unreachable");
+  }
+  return value;
+}
+
+/** Extract an optional string argument. */
+export function optionalArg(
+  args: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const value = args[name];
+  if (value === undefined || value === true) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Split comma-separated values, trim whitespace. */
+export function parseCsv(value: string): string[] {
+  return value.split(",").map((s) => s.trim());
+}

--- a/skills/slack/scripts/lib/slack-client.ts
+++ b/skills/slack/scripts/lib/slack-client.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+
+/**
+ * Authenticated Slack API client.
+ * Uses `assistant oauth request` under the hood for portable OAuth.
+ */
+
+export interface SlackRequestOptions {
+  method?: string;
+  path: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  account?: string;
+  headers?: Record<string, string>;
+}
+
+export interface SlackResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+/** A Slack channel (public or private). */
+export interface SlackChannel {
+  id: string;
+  name: string;
+  type: string;
+  isPrivate: boolean;
+}
+
+/** A Slack user. */
+export interface SlackUser {
+  id: string;
+  name: string;
+  displayName?: string;
+  email?: string;
+}
+
+/** A Slack message. */
+export interface SlackMessage {
+  ts: string;
+  user?: string;
+  text: string;
+  threadTs?: string;
+}
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1_000;
+const IDEMPOTENT_METHODS = new Set([
+  "GET",
+  "HEAD",
+  "PUT",
+  "DELETE",
+  "OPTIONS",
+  "PATCH",
+]);
+
+/**
+ * Execute an authenticated Slack API request via `assistant oauth request`.
+ * Retries 429 and 5xx errors with exponential backoff for idempotent methods.
+ */
+export async function slackRequest<T = unknown>(
+  opts: SlackRequestOptions,
+): Promise<SlackResponse<T>> {
+  const method = (opts.method ?? "GET").toUpperCase();
+  const canRetry = IDEMPOTENT_METHODS.has(method);
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const args: string[] = [
+      "assistant",
+      "oauth",
+      "request",
+      "--provider",
+      "slack",
+    ];
+
+    args.push("-X", method);
+
+    if (opts.body !== undefined) {
+      args.push("-d", JSON.stringify(opts.body));
+      args.push("-H", "Content-Type: application/json");
+    }
+
+    if (opts.headers) {
+      for (const [key, value] of Object.entries(opts.headers)) {
+        args.push("-H", `${key}: ${value}`);
+      }
+    }
+
+    if (opts.account) {
+      args.push("--account", opts.account);
+    }
+
+    let path = `https://slack.com/api${opts.path}`;
+    if (opts.query && Object.keys(opts.query).length > 0) {
+      const qs = new URLSearchParams(opts.query).toString();
+      path += "?" + qs;
+    }
+
+    args.push(path);
+    args.push("--json");
+
+    let proc: ReturnType<typeof Bun.spawn>;
+    try {
+      proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    } catch (err) {
+      throw new Error(
+        `Failed to spawn assistant oauth request: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    let result: {
+      ok: boolean;
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+    };
+    try {
+      result = JSON.parse(stdout);
+    } catch (err) {
+      if (exitCode !== 0) {
+        throw new Error(
+          `assistant oauth request failed (exit ${exitCode}): ${stderr || stdout}`,
+        );
+      }
+      throw new Error(
+        `Failed to parse assistant oauth request output: ${err instanceof Error ? err.message : String(err)}. stdout: ${stdout}`,
+      );
+    }
+
+    // Retry on 429 (rate limit) and 5xx (server error) for idempotent methods
+    const isRetryable =
+      result.status === 429 || (result.status >= 500 && result.status < 600);
+    if (canRetry && isRetryable && attempt < MAX_RETRIES) {
+      const retryAfter = result.headers?.["retry-after"];
+      const delayMs = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+      await new Promise((r) => setTimeout(r, delayMs));
+      continue;
+    }
+
+    return {
+      ok: result.ok,
+      status: result.status,
+      data: result.body as T,
+    };
+  }
+
+  // Should not be reached, but satisfy TypeScript
+  throw new Error("Retry loop exhausted without returning");
+}
+
+/** Convenience wrapper for GET requests. */
+export async function slackGet<T = unknown>(
+  path: string,
+  query?: Record<string, string>,
+  account?: string,
+): Promise<SlackResponse<T>> {
+  return slackRequest<T>({ method: "GET", path, query, account });
+}
+
+/** Convenience wrapper for POST requests. */
+export async function slackPost<T = unknown>(
+  path: string,
+  body: unknown,
+  account?: string,
+): Promise<SlackResponse<T>> {
+  return slackRequest<T>({ method: "POST", path, body, account });
+}


### PR DESCRIPTION
## Summary
- Add `common.ts` with shared arg parsing and output utilities
- Add `slack-client.ts` with authenticated Slack API client using `assistant oauth request`
- Follows the gcal/gmail skill script patterns

Part of plan: slack-skill-scripts.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->