### PR TITLE
Simplify Stripe Link CLI install guidance

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -637,7 +637,7 @@
         "emoji": "💳"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:01:33-07:00"
+      "updatedAt": "2026-05-12T12:31:01-06:00"
     },
     {
       "id": "tasks",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:43:38-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -94,7 +94,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "document-writer",
@@ -314,7 +314,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "macos-automation",
@@ -453,7 +453,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "outlook",
@@ -515,7 +515,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "restaurant-reservation",
@@ -571,7 +571,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "slack",
@@ -627,7 +627,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:30:42-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "stripe-link-wallet",
@@ -931,7 +931,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T11:43:38-04:00"
+      "updatedAt": "2026-05-12T14:56:19-04:00"
     },
     {
       "id": "voice-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -637,7 +637,7 @@
         "emoji": "💳"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T12:31:01-06:00"
+      "updatedAt": "2026-05-12T16:13:34-06:00"
     },
     {
       "id": "tasks",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -637,7 +637,7 @@
         "emoji": "💳"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T16:13:34-06:00"
+      "updatedAt": "2026-05-12T16:18:15-06:00"
     },
     {
       "id": "tasks",

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -47,10 +47,14 @@ Whenever **any** flow (MCP tool, API call, web request, or otherwise) produces a
 ## Step 0: Check installation and auth
 
 ```bash
-command -v link-cli >/dev/null && link-cli auth status --format json
+if command -v link-cli >/dev/null; then
+  link-cli auth status --format json
+else
+  bunx @stripe/link-cli auth status --format json
+fi
 ```
 
-- Command missing — fall to **Setup: use `bunx`**.
+- `link-cli` missing — use `bunx @stripe/link-cli` for Step 0 and every command below.
 - Exit 0 but `"authenticated": false` — fall to **Setup: login**.
 - Authenticated — proceed to the requested flow.
 - `"update"` key present in auth status — mention the update to the user but don't block on it.

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -12,7 +12,7 @@ Spend on the user's behalf using the [Stripe Link CLI](https://github.com/stripe
 
 ## Required tools
 
-- `bash` for all `link-cli` invocations. The CLI runs fine in the sandbox pod; use `host_bash` only if a specific flow genuinely requires host-level access (e.g. reading a local file the user has on their machine).
+- `bash` for all `link-cli` invocations. Use `host_bash` only if a specific flow genuinely requires host-level access (e.g. reading a local file the user has on their machine).
 
 ## Hard constraints
 
@@ -61,21 +61,11 @@ command -v link-cli >/dev/null && link-cli auth status --format json
 
 ### If `link-cli` is missing
 
-First, determine your deployment context:
+Install it, then re-run Step 0:
 
-- **Pod/cloud hosted** (e.g. hostname looks like a Kubernetes pod, `/workspace` is a mounted volume): don't install — the container layer is ephemeral and a global install won't survive pod restarts or new shells. Invoke the CLI per call with `bunx`:
-  ```bash
-  bunx @stripe/link-cli <subcommand>
-  ```
-  In every example below, substitute `bunx @stripe/link-cli` wherever you see `link-cli`.
-- **Locally hosted** (`bash` and `host_bash` are the same machine): ask the user to install it - don't silently modify their system:
-  > Stripe's Link CLI isn't installed. Run this once and I can take it from there:
-  >
-  > ```bash
-  > npm install -g @stripe/link-cli
-  > ```
-  >
-  > Tell me when it's done.
+```bash
+npm install -g @stripe/link-cli
+```
 
 ### If installed but not authenticated
 
@@ -270,15 +260,15 @@ link-cli spend-request cancel <id> --format json
 
 ## Error handling
 
-| Error / condition                       | Action                                                                                                                        |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `link-cli` not found                    | In a pod/cloud sandbox, invoke via `bunx @stripe/link-cli` per call (no install needed). Locally, ask the user to install it. |
-| Not authenticated                       | Run `auth login --client-name "<your assistant name>"` (see Setup)                                                            |
-| `POLLING_TIMEOUT` on retrieve           | Report to user; offer cancel or fresh spend request                                                                           |
-| SPT payment fails (402 again after pay) | SPT is consumed — create a new spend request                                                                                  |
-| `amount` > 50000                        | Tell user the cap is $500 per transaction                                                                                     |
-| `context` < 100 chars                   | Expand it before retrying                                                                                                     |
-| Card file already exists                | Use `--force` to overwrite, or pick a different path                                                                          |
+| Error / condition                       | Action                                                                 |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| `link-cli` not found                    | Install it with `npm install -g @stripe/link-cli`, then re-run Step 0. |
+| Not authenticated                       | Run `auth login --client-name "<your assistant name>"` (see Setup)     |
+| `POLLING_TIMEOUT` on retrieve           | Report to user; offer cancel or fresh spend request                    |
+| SPT payment fails (402 again after pay) | SPT is consumed — create a new spend request                           |
+| `amount` > 50000                        | Tell user the cap is \$500 per transaction                             |
+| `context` < 100 chars                   | Expand it before retrying                                              |
+| Card file already exists                | Use `--force` to overwrite, or pick a different path                   |
 
 ---
 

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -50,7 +50,7 @@ Whenever **any** flow (MCP tool, API call, web request, or otherwise) produces a
 command -v link-cli >/dev/null && link-cli auth status --format json
 ```
 
-- Command missing — fall to **Setup: install**.
+- Command missing — fall to **Setup: use `bunx`**.
 - Exit 0 but `"authenticated": false` — fall to **Setup: login**.
 - Authenticated — proceed to the requested flow.
 - `"update"` key present in auth status — mention the update to the user but don't block on it.
@@ -61,11 +61,13 @@ command -v link-cli >/dev/null && link-cli auth status --format json
 
 ### If `link-cli` is missing
 
-Install it, then re-run Step 0:
+Invoke the CLI on demand with `bunx`:
 
 ```bash
-npm install -g @stripe/link-cli
+bunx @stripe/link-cli <subcommand>
 ```
+
+In every example below, substitute `bunx @stripe/link-cli` wherever you see `link-cli`.
 
 ### If installed but not authenticated
 
@@ -260,15 +262,15 @@ link-cli spend-request cancel <id> --format json
 
 ## Error handling
 
-| Error / condition                       | Action                                                                 |
-| --------------------------------------- | ---------------------------------------------------------------------- |
-| `link-cli` not found                    | Install it with `npm install -g @stripe/link-cli`, then re-run Step 0. |
-| Not authenticated                       | Run `auth login --client-name "<your assistant name>"` (see Setup)     |
-| `POLLING_TIMEOUT` on retrieve           | Report to user; offer cancel or fresh spend request                    |
-| SPT payment fails (402 again after pay) | SPT is consumed — create a new spend request                           |
-| `amount` > 50000                        | Tell user the cap is \$500 per transaction                             |
-| `context` < 100 chars                   | Expand it before retrying                                              |
-| Card file already exists                | Use `--force` to overwrite, or pick a different path                   |
+| Error / condition                       | Action                                                                                              |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `link-cli` not found                    | Invoke it with `bunx @stripe/link-cli` and substitute that prefix wherever examples use `link-cli`. |
+| Not authenticated                       | Run `auth login --client-name "<your assistant name>"` (see Setup)                                  |
+| `POLLING_TIMEOUT` on retrieve           | Report to user; offer cancel or fresh spend request                                                 |
+| SPT payment fails (402 again after pay) | SPT is consumed — create a new spend request                                                        |
+| `amount` > 50000                        | Tell user the cap is \$500 per transaction                                                          |
+| `context` < 100 chars                   | Expand it before retrying                                                                           |
+| Card file already exists                | Use `--force` to overwrite, or pick a different path                                                |
 
 ---
 


### PR DESCRIPTION
## Summary

- Simplified the Stripe Link wallet install instructions to use a single install command.
- Removed pod/local environment branching from the skill text and matching error guidance.

## Original prompt

The request was to clean up the recently merged Stripe Link wallet skill based on the Slack thread about dependency installation. The skill should not ask the assistant to inspect whether it is running in a pod, cloud environment, or local machine before installing dependencies; it should simply install what it needs and leave permission policy to the harness or user rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->