### PR TITLE
[codex] Add Enter submit to secure credential prompt

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -173,14 +173,6 @@ struct SecretPromptView: View {
     @State private var saved = false
     @State private var isSending = false
 
-    private var trimmedSecretValue: String {
-        secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var canSave: Bool {
-        !saved && !isSending && !trimmedSecretValue.isEmpty
-    }
-
     private var hasContext: Bool {
         purpose != nil
             || !(allowedTools ?? []).isEmpty
@@ -265,7 +257,7 @@ struct SecretPromptView: View {
                         VButton(label: isSending ? "Saving..." : "Save", style: .primary, accessibilityID: "secure-credential-save") {
                             submitSave()
                         }
-                        .disabled(!canSave)
+                        .disabled(isSending || secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         .accessibilityLabel("Save")
                     }
 
@@ -274,9 +266,18 @@ struct SecretPromptView: View {
                             VIconView(.triangleAlert, size: 10)
                                 .foregroundStyle(VColor.systemNegativeHover)
                             VButton(label: isSending ? "Sending..." : "Send Once (not saved)", style: .outlined) {
-                                submitSendOnce()
+                                let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                guard !trimmed.isEmpty else { return }
+                                isSending = true
+                                Task {
+                                    let success = await onSendOnce(trimmed)
+                                    isSending = false
+                                    if success {
+                                        withAnimation(VAnimation.standard) { saved = true }
+                                    }
+                                }
                             }
-                            .disabled(!canSave)
+                            .disabled(isSending || secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         }
                     }
                 }
@@ -291,43 +292,14 @@ struct SecretPromptView: View {
         .frame(maxHeight: 600)
         .vPanelBackground()
         .clipShape(RoundedRectangle(cornerRadius: VRadius.window))
-        .background {
-            Button("") { submitSave() }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSave)
-                .opacity(0)
-                .frame(width: 0, height: 0)
-                .accessibilityHidden(true)
-            Button("") {
-                Task { await onCancel() }
-            }
-                .keyboardShortcut(.cancelAction)
-                .disabled(isSending)
-                .opacity(0)
-                .frame(width: 0, height: 0)
-                .accessibilityHidden(true)
-        }
     }
 
     private func submitSave() {
-        guard canSave else { return }
-        let value = trimmedSecretValue
+        let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSending else { return }
         isSending = true
         Task {
-            let success = await onSave(value)
-            isSending = false
-            if success {
-                withAnimation(VAnimation.standard) { saved = true }
-            }
-        }
-    }
-
-    private func submitSendOnce() {
-        guard canSave else { return }
-        let value = trimmedSecretValue
-        isSending = true
-        Task {
-            let success = await onSendOnce(value)
+            let success = await onSave(trimmed)
             isSending = false
             if success {
                 withAnimation(VAnimation.standard) { saved = true }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -173,6 +173,14 @@ struct SecretPromptView: View {
     @State private var saved = false
     @State private var isSending = false
 
+    private var trimmedSecretValue: String {
+        secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSave: Bool {
+        !saved && !isSending && !trimmedSecretValue.isEmpty
+    }
+
     private var hasContext: Bool {
         purpose != nil
             || !(allowedTools ?? []).isEmpty
@@ -218,6 +226,7 @@ struct SecretPromptView: View {
                     placeholder: placeholder,
                     text: $secretValue,
                     isSecure: true,
+                    onSubmit: { submitSave() },
                     font: VFont.bodyMediumDefault
                 )
                 .accessibilityIdentifier("secure-credential-input")
@@ -254,18 +263,9 @@ struct SecretPromptView: View {
                         .disabled(isSending)
                         .accessibilityLabel("Cancel")
                         VButton(label: isSending ? "Saving..." : "Save", style: .primary, accessibilityID: "secure-credential-save") {
-                            let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                            guard !trimmed.isEmpty else { return }
-                            isSending = true
-                            Task {
-                                let success = await onSave(trimmed)
-                                isSending = false
-                                if success {
-                                    withAnimation(VAnimation.standard) { saved = true }
-                                }
-                            }
+                            submitSave()
                         }
-                        .disabled(isSending || secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(!canSave)
                         .accessibilityLabel("Save")
                     }
 
@@ -274,18 +274,9 @@ struct SecretPromptView: View {
                             VIconView(.triangleAlert, size: 10)
                                 .foregroundStyle(VColor.systemNegativeHover)
                             VButton(label: isSending ? "Sending..." : "Send Once (not saved)", style: .outlined) {
-                                let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                                guard !trimmed.isEmpty else { return }
-                                isSending = true
-                                Task {
-                                    let success = await onSendOnce(trimmed)
-                                    isSending = false
-                                    if success {
-                                        withAnimation(VAnimation.standard) { saved = true }
-                                    }
-                                }
+                                submitSendOnce()
                             }
-                            .disabled(isSending || secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            .disabled(!canSave)
                         }
                     }
                 }
@@ -300,6 +291,48 @@ struct SecretPromptView: View {
         .frame(maxHeight: 600)
         .vPanelBackground()
         .clipShape(RoundedRectangle(cornerRadius: VRadius.window))
+        .background {
+            Button("") { submitSave() }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+            Button("") {
+                Task { await onCancel() }
+            }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isSending)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func submitSave() {
+        guard canSave else { return }
+        let value = trimmedSecretValue
+        isSending = true
+        Task {
+            let success = await onSave(value)
+            isSending = false
+            if success {
+                withAnimation(VAnimation.standard) { saved = true }
+            }
+        }
+    }
+
+    private func submitSendOnce() {
+        guard canSave else { return }
+        let value = trimmedSecretValue
+        isSending = true
+        Task {
+            let success = await onSendOnce(value)
+            isSending = false
+            if success {
+                withAnimation(VAnimation.standard) { saved = true }
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Adds keyboard submission support to the macOS secure credential prompt so pressing Enter saves the credential when the secure input has a non-empty value.

## Details

The secure credential modal already had a Save button, but the secure text field did not wire its submit action to the same save path. This centralizes Save and Send Once submission handling, reuses the same disabled-state guard, and adds hidden default/cancel shortcut buttons so Return and Escape route through the prompt consistently.

## Validation

- `swift build --target VellumAssistantLib`