### PR TITLE
feat(macos): group subagents into collapsible inline container

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -149,6 +149,7 @@ import type {
 export interface SubagentEvent {
   type: "subagent_event";
   subagentId: string;
+  conversationId: string;
   event: ServerMessage;
 }
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -230,7 +230,10 @@ export class SubagentManager {
         config.systemPromptOverride ??
         buildSubagentSystemPrompt({ ...config, id: subagentId }, role);
     }
-    const maxTokens = resolveCallSiteConfig("subagentSpawn", appConfig.llm).maxTokens;
+    const maxTokens = resolveCallSiteConfig(
+      "subagentSpawn",
+      appConfig.llm,
+    ).maxTokens;
     const workingDir = getSandboxWorkingDir();
 
     // ── Initialise state ────────────────────────────────────────────
@@ -270,6 +273,7 @@ export class SubagentManager {
       managed.parentSendToClient({
         type: "subagent_event",
         subagentId,
+        conversationId: config.parentConversationId,
         event: msg,
       } as ServerMessage);
     };

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -252,17 +252,17 @@ struct MessageCellView: View, Equatable {
             .id(message.id)
         }
 
-        ForEach(subagentsByParent[message.id] ?? []) { subagent in
+        if let subagents = subagentsByParent[message.id], !subagents.isEmpty {
             HStack(spacing: 0) {
-                SubagentEventsReader(
+                SubagentGroupContainer(
+                    subagents: subagents,
                     store: subagentDetailStore,
-                    subagent: subagent,
-                    onAbort: { onAbortSubagent?(subagent.id) },
-                    onTap: { onSubagentTap?(subagent.id) }
+                    onAbort: { id in onAbortSubagent?(id) },
+                    onTap: { id in onSubagentTap?(id) }
                 )
                 Spacer(minLength: 0)
             }
-            .id("subagent-\(subagent.id)")
+            .id("subagent-group-\(message.id)")
         }
 
         if showAnchoredThinkingIndicator {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -256,7 +256,6 @@ struct MessageCellView: View, Equatable {
             HStack(spacing: 0) {
                 SubagentGroupContainer(
                     subagents: subagents,
-                    store: subagentDetailStore,
                     onAbort: { id in onAbortSubagent?(id) },
                     onTap: { id in onSubagentTap?(id) }
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -143,11 +143,15 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar,
+                hideInlineAvatar: hideInlineAvatar || hasSubagents,
                 searchQuery: searchQuery
             )
             .equatable()
         }
+    }
+
+    private var hasSubagents: Bool {
+        subagentsByParent[message.id]?.isEmpty == false
     }
 
     @ViewBuilder
@@ -161,6 +165,27 @@ struct MessageCellView: View, Equatable {
             Spacer(minLength: 0)
         }
         .id("thinking-indicator")
+    }
+
+    @ViewBuilder
+    private var subagentInlineAvatar: some View {
+        let appearance = AvatarAppearanceManager.shared
+        let avatarSize = ConversationAvatarFollower.avatarSize
+        HStack {
+            if appearance.customAvatarImage != nil {
+                VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+            } else if let bodyShape = appearance.characterBodyShape,
+                      let eyeStyle = appearance.characterEyeStyle,
+                      let color = appearance.characterColor {
+                AnimatedAvatarView(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color,
+                                   size: avatarSize, blinkEnabled: true, pokeEnabled: true,
+                                   isStreaming: message.isStreaming)
+                    .frame(width: avatarSize, height: avatarSize)
+            } else {
+                VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+            }
+            Spacer()
+        }
     }
 
     var body: some View {
@@ -239,7 +264,7 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar,
+                hideInlineAvatar: hideInlineAvatar || hasSubagents,
                 searchQuery: searchQuery
             )
             .equatable()
@@ -262,6 +287,10 @@ struct MessageCellView: View, Equatable {
                 Spacer(minLength: 0)
             }
             .id("subagent-group-\(message.id)")
+
+            if isLatestAssistantMessage && !hideInlineAvatar {
+                subagentInlineAvatar
+            }
         }
 
         if showAnchoredThinkingIndicator {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -357,6 +357,8 @@ struct MessageListContentView: View, Equatable {
 
             if let anchorMessage = pinnedTurnPartition.anchorMessage,
                let anchorRow = rowsByMessageId[anchorMessage.id] {
+                orphanSubagentGroup()
+
                 PinnedLatestTurnSection(
                     contentView: self,
                     partition: pinnedTurnPartition,
@@ -476,7 +478,6 @@ private struct PinnedLatestTurnSection: View {
 
     private var hasResponseContent: Bool {
         contentView.showsStandaloneLatestEdgeActivity
-            || !contentView.state.orphanSubagents.isEmpty
             || !partition.responseItems.isEmpty
     }
 
@@ -548,8 +549,6 @@ private struct PinnedLatestTurnSection: View {
                     isFlipped: false
                 )
             }
-
-            contentView.orphanSubagentGroup(isFlipped: false)
 
             contentView.latestEdgeActivityRow(isFlipped: false)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -173,7 +173,6 @@ struct MessageListContentView: View, Equatable {
             HStack(spacing: 0) {
                 SubagentGroupContainer(
                     subagents: state.orphanSubagents,
-                    store: subagentDetailStore,
                     onAbort: { id in onAbortSubagent?(id) },
                     onTap: { id in onSubagentTap?(id) }
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -168,20 +168,22 @@ struct MessageListContentView: View, Equatable {
     }
 
     @ViewBuilder
-    fileprivate func orphanSubagentRow(_ subagent: SubagentInfo, isFlipped: Bool = true) -> some View {
-        HStack(spacing: 0) {
-            SubagentEventsReader(
-                store: subagentDetailStore,
-                subagent: subagent,
-                onAbort: { onAbortSubagent?(subagent.id) },
-                onTap: { onSubagentTap?(subagent.id) }
-            )
-            Spacer(minLength: 0)
-        }
-        .id("subagent-\(subagent.id)")
-        .transition(.opacity)
-        .if(isFlipped) { view in
-            view.flipped()
+    fileprivate func orphanSubagentGroup(isFlipped: Bool = true) -> some View {
+        if !state.orphanSubagents.isEmpty {
+            HStack(spacing: 0) {
+                SubagentGroupContainer(
+                    subagents: state.orphanSubagents,
+                    store: subagentDetailStore,
+                    onAbort: { id in onAbortSubagent?(id) },
+                    onTap: { id in onSubagentTap?(id) }
+                )
+                Spacer(minLength: 0)
+            }
+            .id("orphan-subagent-group")
+            .transition(.opacity)
+            .if(isFlipped) { view in
+                view.flipped()
+            }
         }
     }
 
@@ -381,9 +383,7 @@ struct MessageListContentView: View, Equatable {
                 latestEdgeSentinel()
                 latestEdgeActivityRow()
 
-                ForEach(state.orphanSubagents) { subagent in
-                    orphanSubagentRow(subagent)
-                }
+                orphanSubagentGroup()
 
                 // ── Messages ──
                 ForEach(displayedItems.reversed()) { item in
@@ -550,9 +550,7 @@ private struct PinnedLatestTurnSection: View {
                 )
             }
 
-            ForEach(contentView.state.orphanSubagents) { subagent in
-                contentView.orphanSubagentRow(subagent, isFlipped: false)
-            }
+            contentView.orphanSubagentGroup(isFlipped: false)
 
             contentView.latestEdgeActivityRow(isFlipped: false)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -167,25 +167,6 @@ struct MessageListContentView: View, Equatable {
         }
     }
 
-    @ViewBuilder
-    fileprivate func orphanSubagentGroup(isFlipped: Bool = true) -> some View {
-        if !state.orphanSubagents.isEmpty {
-            HStack(spacing: 0) {
-                SubagentGroupContainer(
-                    subagents: state.orphanSubagents,
-                    onAbort: { id in onAbortSubagent?(id) },
-                    onTap: { id in onSubagentTap?(id) }
-                )
-                Spacer(minLength: 0)
-            }
-            .id("orphan-subagent-group")
-            .transition(.opacity)
-            .if(isFlipped) { view in
-                view.flipped()
-            }
-        }
-    }
-
     // MARK: - Transcript row rendering
 
     /// Renders a single transcript row (either a real message cell or the
@@ -357,7 +338,6 @@ struct MessageListContentView: View, Equatable {
 
             if let anchorMessage = pinnedTurnPartition.anchorMessage,
                let anchorRow = rowsByMessageId[anchorMessage.id] {
-                orphanSubagentGroup()
 
                 PinnedLatestTurnSection(
                     contentView: self,
@@ -383,8 +363,6 @@ struct MessageListContentView: View, Equatable {
                 // at the visual bottom. Place current-activity indicators here.
                 latestEdgeSentinel()
                 latestEdgeActivityRow()
-
-                orphanSubagentGroup()
 
                 // ── Messages ──
                 ForEach(displayedItems.reversed()) { item in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -27,39 +27,12 @@ struct SubagentDetailPanel: View {
     /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
 
-    /// Raw panel width measured from the pinnedContent area. Used to
-    /// apply an explicit `.frame(width:)` constraint on the pinned body
-    /// so its content cannot exceed the panel bounds. VSidePanel's
-    /// VStack only *proposes* this width — it does not enforce it — so
-    /// without the hard constraint the pinned body can overflow.
-    @State private var pinnedAreaWidth: CGFloat = 0
-
     var body: some View {
         VSidePanel(title: subagentInfo?.label ?? "Subagent", titleFont: VFont.titleSmall, onClose: onClose, pinnedContent: {
-            // Measure the raw panel width so we can enforce it as a
-            // hard constraint on pinnedBody. VSidePanel's VStack only
-            // *proposes* this width to children; it does not clamp
-            // them, so without an explicit frame the pinned content
-            // can exceed the panel bounds.
-            Color.clear
-                .frame(height: 0)
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.width
-                } action: { newWidth in
-                    pinnedAreaWidth = newWidth
-                }
-
             pinnedBody
-                .frame(width: pinnedAreaWidth > 0 ? pinnedAreaWidth : nil, alignment: .leading)
-                .clipped()
 
             Divider().background(VColor.borderBase)
         }) {
-            // Measure the usable content width after VSidePanel applies
-            // contentPadding + containerRelativeFrame. This probe lives
-            // inside the scroll content closure so panelContentWidth
-            // reflects the actual available width for child views, not
-            // the raw panel width.
             Color.clear
                 .frame(height: 0)
                 .onGeometryChange(for: CGFloat.self) { proxy in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -20,19 +20,24 @@ struct SubagentDetailPanel: View {
     private var events: [SubagentEventItem] { state?.events ?? [] }
     private var isRunning: Bool { subagentInfo?.status == .running || subagentInfo?.status == .pending }
 
-    /// Available width measured from the panel's proposed layout width (not
-    /// from rendered content). Used to gate content rendering until the
-    /// layout has a valid width, and forwarded to
+    /// Usable content width inside VSidePanel's scroll area (panel width
+    /// minus `contentPadding`). Measured by a zero-height probe inside the
+    /// scroll content closure and forwarded to
     /// `MarkdownSegmentView.maxContentWidth` so markdown wraps to the panel
     /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
 
     var body: some View {
         VSidePanel(title: subagentInfo?.label ?? "Subagent", titleFont: VFont.titleSmall, onClose: onClose, pinnedContent: {
-            // Measure the panel's proposed width with a zero-height
-            // invisible view before rendering any content. This prevents
-            // the first-frame overflow where content renders at an
-            // unconstrained width before the panel's layout settles.
+            pinnedBody
+
+            Divider().background(VColor.borderBase)
+        }) {
+            // Measure the usable content width after VSidePanel applies
+            // contentPadding + containerRelativeFrame. This probe lives
+            // inside the scroll content closure so panelContentWidth
+            // reflects the actual available width for child views, not
+            // the raw panel width.
             Color.clear
                 .frame(height: 0)
                 .onGeometryChange(for: CGFloat.self) { proxy in
@@ -41,22 +46,14 @@ struct SubagentDetailPanel: View {
                     panelContentWidth = newWidth
                 }
 
-            if panelContentWidth > 0 {
-                pinnedBody
-
-                Divider().background(VColor.borderBase)
-            }
-        }) {
-            if panelContentWidth > 0 {
-                if events.isEmpty {
-                    VEmptyState(
-                        title: "No events yet",
-                        subtitle: "Events will appear as the subagent runs",
-                        icon: "waveform.path"
-                    )
-                } else {
-                    eventList
-                }
+            if events.isEmpty {
+                VEmptyState(
+                    title: "No events yet",
+                    subtitle: "Events will appear as the subagent runs",
+                    icon: "waveform.path"
+                )
+            } else if panelContentWidth > 0 {
+                eventList
             }
         }
         .onAppear {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -27,9 +27,31 @@ struct SubagentDetailPanel: View {
     /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
 
+    /// Raw panel width measured from the pinnedContent area. Used to
+    /// apply an explicit `.frame(width:)` constraint on the pinned body
+    /// so its content cannot exceed the panel bounds. VSidePanel's
+    /// VStack only *proposes* this width — it does not enforce it — so
+    /// without the hard constraint the pinned body can overflow.
+    @State private var pinnedAreaWidth: CGFloat = 0
+
     var body: some View {
         VSidePanel(title: subagentInfo?.label ?? "Subagent", titleFont: VFont.titleSmall, onClose: onClose, pinnedContent: {
+            // Measure the raw panel width so we can enforce it as a
+            // hard constraint on pinnedBody. VSidePanel's VStack only
+            // *proposes* this width to children; it does not clamp
+            // them, so without an explicit frame the pinned content
+            // can exceed the panel bounds.
+            Color.clear
+                .frame(height: 0)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    pinnedAreaWidth = newWidth
+                }
+
             pinnedBody
+                .frame(width: pinnedAreaWidth > 0 ? pinnedAreaWidth : nil, alignment: .leading)
+                .clipped()
 
             Divider().background(VColor.borderBase)
         }) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -20,105 +20,42 @@ struct SubagentDetailPanel: View {
     private var events: [SubagentEventItem] { state?.events ?? [] }
     private var isRunning: Bool { subagentInfo?.status == .running || subagentInfo?.status == .pending }
 
-    /// Available width for event content, measured from the panel's proposed
-    /// layout width (not from rendered content). Forwarded to
+    /// Available width measured from the panel's proposed layout width (not
+    /// from rendered content). Used to gate content rendering until the
+    /// layout has a valid width, and forwarded to
     /// `MarkdownSegmentView.maxContentWidth` so markdown wraps to the panel
     /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
 
     var body: some View {
         VSidePanel(title: subagentInfo?.label ?? "Subagent", titleFont: VFont.titleSmall, onClose: onClose, pinnedContent: {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Status + abort row
-                HStack {
-                    statusBadge
-                    Spacer()
-                    if isRunning {
-                        Button(action: { onAbort?() }) {
-                            HStack(spacing: VSpacing.xxs) {
-                                VIconView(.square, size: 8)
-                                Text("Abort")
-                                    .font(VFont.labelDefault)
-                            }
-                            .foregroundStyle(VColor.systemNegativeStrong)
-                            .padding(.horizontal, VSpacing.sm)
-                            .padding(.vertical, VSpacing.xxs)
-                            .background(
-                                RoundedRectangle(cornerRadius: VRadius.pill)
-                                    .fill(VColor.systemNegativeStrong.opacity(0.12))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Abort subagent")
-                    }
+            // Measure the panel's proposed width with a zero-height
+            // invisible view before rendering any content. This prevents
+            // the first-frame overflow where content renders at an
+            // unconstrained width before the panel's layout settles.
+            Color.clear
+                .frame(height: 0)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    panelContentWidth = newWidth
                 }
 
-                // Objective
-                if let objective, !objective.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("OBJECTIVE")
-                            .font(VFont.labelSmall)
-                            .foregroundStyle(VColor.contentTertiary)
-                        Text(objective)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentSecondary)
-                    }
-                }
+            if panelContentWidth > 0 {
+                pinnedBody
 
-                // Usage metrics row
-                if let usage {
-                    usageMetrics(usage)
-                }
-
-                // Error banner
-                if let error = subagentInfo?.error, !error.isEmpty {
-                    HStack(alignment: .top, spacing: VSpacing.xs) {
-                        VIconView(.triangleAlert, size: 11)
-                            .foregroundStyle(VColor.systemNegativeStrong)
-                        Text(error)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.systemNegativeStrong)
-                    }
-                    .padding(VSpacing.sm)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(VColor.systemNegativeStrong.opacity(0.08))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: VRadius.md)
-                                    .strokeBorder(VColor.systemNegativeStrong.opacity(0.2), lineWidth: 1)
-                            )
-                    )
-                }
+                Divider().background(VColor.borderBase)
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.lg)
-
-            Divider().background(VColor.borderBase)
         }) {
-            if events.isEmpty {
-                VEmptyState(
-                    title: "No events yet",
-                    subtitle: "Events will appear as the subagent runs",
-                    icon: "waveform.path"
-                )
-            } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Captures the *proposed* (container) width independently
-                    // of event content. Color.clear fills exactly the proposed
-                    // width — it cannot overflow — so this avoids a feedback
-                    // loop where overflowing content inflates the measurement.
-                    Color.clear
-                        .frame(height: 0)
-                        .onGeometryChange(for: CGFloat.self) { proxy in
-                            proxy.size.width
-                        } action: { newWidth in
-                            panelContentWidth = newWidth
-                        }
-
-                    if panelContentWidth > 0 {
-                        eventList
-                    }
+            if panelContentWidth > 0 {
+                if events.isEmpty {
+                    VEmptyState(
+                        title: "No events yet",
+                        subtitle: "Events will appear as the subagent runs",
+                        icon: "waveform.path"
+                    )
+                } else {
+                    eventList
                 }
             }
         }
@@ -128,6 +65,77 @@ struct SubagentDetailPanel: View {
                 onRequestDetail?()
             }
         }
+    }
+
+    // MARK: - Pinned Content
+
+    @ViewBuilder
+    private var pinnedBody: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Status + abort row
+            HStack {
+                statusBadge
+                Spacer()
+                if isRunning {
+                    Button(action: { onAbort?() }) {
+                        HStack(spacing: VSpacing.xxs) {
+                            VIconView(.square, size: 8)
+                            Text("Abort")
+                                .font(VFont.labelDefault)
+                        }
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.pill)
+                                .fill(VColor.systemNegativeStrong.opacity(0.12))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Abort subagent")
+                }
+            }
+
+            // Objective
+            if let objective, !objective.isEmpty {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("OBJECTIVE")
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text(objective)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+            }
+
+            // Usage metrics row
+            if let usage {
+                usageMetrics(usage)
+            }
+
+            // Error banner
+            if let error = subagentInfo?.error, !error.isEmpty {
+                HStack(alignment: .top, spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 11)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                    Text(error)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+                .padding(VSpacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.systemNegativeStrong.opacity(0.08))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .strokeBorder(VColor.systemNegativeStrong.opacity(0.2), lineWidth: 1)
+                        )
+                )
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.lg)
     }
 
     // MARK: - Event List

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -20,11 +20,10 @@ struct SubagentDetailPanel: View {
     private var events: [SubagentEventItem] { state?.events ?? [] }
     private var isRunning: Bool { subagentInfo?.status == .running || subagentInfo?.status == .pending }
 
-    /// Observed width of the event-list container, forwarded to
-    /// `MarkdownSegmentView.maxContentWidth` so long markdown wraps to the
-    /// panel instead of `VSpacing.chatBubbleMaxWidth` (wider than the panel).
-    /// Safe to observe here — the container's width is driven by the enclosing
-    /// ScrollView, not by child content, so there is no feedback loop.
+    /// Available width for event content, measured from the panel's proposed
+    /// layout width (not from rendered content). Forwarded to
+    /// `MarkdownSegmentView.maxContentWidth` so markdown wraps to the panel
+    /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
 
     var body: some View {
@@ -104,12 +103,23 @@ struct SubagentDetailPanel: View {
                     icon: "waveform.path"
                 )
             } else {
-                eventList
-                    .onGeometryChange(for: CGFloat.self) { proxy in
-                        proxy.size.width
-                    } action: { newWidth in
-                        panelContentWidth = newWidth
+                VStack(alignment: .leading, spacing: 0) {
+                    // Captures the *proposed* (container) width independently
+                    // of event content. Color.clear fills exactly the proposed
+                    // width — it cannot overflow — so this avoids a feedback
+                    // loop where overflowing content inflates the measurement.
+                    Color.clear
+                        .frame(height: 0)
+                        .onGeometryChange(for: CGFloat.self) { proxy in
+                            proxy.size.width
+                        } action: { newWidth in
+                            panelContentWidth = newWidth
+                        }
+
+                    if panelContentWidth > 0 {
+                        eventList
                     }
+                }
             }
         }
         .onAppear {

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -9,6 +9,8 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
     @ViewBuilder public let pinnedContent: () -> PinnedContent
     @ViewBuilder public let content: () -> Content
 
+    @State private var scrollViewWidth: CGFloat = 0
+
     public init(title: String, titleFont: Font = VFont.titleLarge, uppercased: Bool = false, contentPadding: EdgeInsets = EdgeInsets(top: VSpacing.lg, leading: VSpacing.lg, bottom: VSpacing.lg, trailing: VSpacing.lg), onClose: (() -> Void)? = nil, @ViewBuilder pinnedContent: @escaping () -> PinnedContent, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
         self.titleFont = titleFont
@@ -43,24 +45,30 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             // Scrollable content — lower priority so pinnedContent's
             // own ScrollView (e.g. TraceTimelineView) isn't starved.
             //
-            // `.containerRelativeFrame(.horizontal)` (rather than
-            // `.frame(maxWidth: .infinity, alignment: .top)`) sizes the
-            // padded content to the ScrollView's visible width without
-            // emitting `_FlexFrameLayout`. A FlexFrame here would query
-            // `explicitAlignment` recursively on every descendant — when
-            // `content()` is a `LazyVStack` of streaming events the
-            // cascade walks every realized cell on every layout pass,
-            // O(n × depth), which has caused multi-second hangs in
-            // sibling surfaces (see clients/macos/AGENTS.md
-            // "No `_FlexFrameLayout` ... in LazyVStack" and the
-            // matching `.containerRelativeFrame` adoption in
-            // `HomeDetailPanel`).
+            // The content width is measured from the ScrollView's actual
+            // frame via onGeometryChange and applied as a fixed-width
+            // `.frame(width:)`. This avoids two pitfalls:
             //
-            // Reference: https://developer.apple.com/documentation/swiftui/view/containerrelativeframe(_:alignment:)
+            //  1. `.frame(maxWidth: .infinity)` emits `_FlexFrameLayout`
+            //     which queries `explicitAlignment` recursively on every
+            //     descendant — when `content()` is a `LazyVStack` of
+            //     streaming events the cascade walks every realized cell
+            //     on every layout pass, O(n × depth), causing hangs.
+            //
+            //  2. `.containerRelativeFrame(.horizontal)` can resolve to
+            //     the window instead of the ScrollView in certain layout
+            //     hierarchies (e.g. when the ScrollView is inside a
+            //     VStack with `.frame(width:)` from VSplitView), making
+            //     the content wider than the panel.
             ScrollView {
                 content()
                     .padding(contentPadding)
-                    .containerRelativeFrame(.horizontal, alignment: .top)
+                    .frame(width: scrollViewWidth > 0 ? scrollViewWidth : nil, alignment: .top)
+            }
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { newWidth in
+                scrollViewWidth = newWidth
             }
             .layoutPriority(-1)
         }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -35,7 +35,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                 dragDivider(availableWidth: availableWidth)
 
                 panel
-                    .frame(width: panelWidth)
+                    .frame(width: panelWidth, alignment: .topLeading)
                     .animation(nil, value: panelWidth)  // Disable animation on width changes
                     .background(VColor.surfaceBase)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -62,7 +62,7 @@ struct ChatGallerySection: View {
                 // MARK: - SubagentStatusChip
                 GallerySectionHeader(
                     title: "SubagentStatusChip",
-                    description: "Status chip and conversation view for subagent progress. Includes SubagentConversationView."
+                    description: "Status chip and group container for subagent progress."
                 )
 
                 VCard {
@@ -95,36 +95,31 @@ struct ChatGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        Text("SubagentConversationView")
+                        Text("SubagentGroupContainer")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentSecondary)
 
-                        SubagentConversationView(
-                            subagent: SubagentInfo(id: "t-1", label: "Research Agent", status: .running),
-                            events: [
-                                SubagentEventItem(timestamp: Date(), kind: .toolUse(name: "web_search"), content: "SwiftUI adaptive colors"),
-                                SubagentEventItem(timestamp: Date(), kind: .text, content: "Found several relevant resources on adaptive color tokens.")
+                        SubagentGroupContainer(
+                            subagents: [
+                                SubagentInfo(id: "g-running-1", label: "Research Agent", status: .running),
+                                SubagentInfo(id: "g-running-2", label: "Code Review Agent", status: .running),
+                                SubagentInfo(id: "g-running-3", label: "Deploy Agent", status: .pending)
                             ]
                         )
 
-                        SubagentConversationView(
-                            subagent: SubagentInfo(id: "t-2", label: "Code Review Agent", status: .completed),
-                            events: [
-                                SubagentEventItem(timestamp: Date(), kind: .text, content: "All checks passed. No issues found."),
-                                SubagentEventItem(timestamp: Date(), kind: .text, content: "LGTM — ready to merge.")
+                        SubagentGroupContainer(
+                            subagents: [
+                                SubagentInfo(id: "g-done-1", label: "Research Agent", status: .completed),
+                                SubagentInfo(id: "g-done-2", label: "Code Review Agent", status: .completed),
+                                SubagentInfo(id: "g-done-3", label: "Deploy Agent", status: .failed)
                             ]
                         )
 
-                        SubagentConversationView(
-                            subagent: SubagentInfo(id: "t-3", label: "Deploy Agent", status: .failed),
-                            events: [
-                                SubagentEventItem(timestamp: Date(), kind: .error, content: "Connection timed out after 30s")
+                        SubagentGroupContainer(
+                            subagents: [
+                                SubagentInfo(id: "g-all-done-1", label: "Research Agent", status: .completed),
+                                SubagentInfo(id: "g-all-done-2", label: "Cleanup Agent", status: .completed)
                             ]
-                        )
-
-                        SubagentConversationView(
-                            subagent: SubagentInfo(id: "t-4", label: "Cleanup Agent", status: .aborted),
-                            events: []
                         )
                     }
                 }

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -249,6 +249,236 @@ public struct SubagentEventsReader: View {
     }
 }
 
+// MARK: - Subagent Group Container
+
+/// Collapsible container that groups multiple subagents into a single inline
+/// transcript element. Modeled after `AssistantProgressView`'s expandable
+/// card pattern: a header summarizes the group ("3 subagents running") and
+/// expanding reveals individual rows. Tapping a row opens its detail panel.
+public struct SubagentGroupContainer: View {
+    let subagents: [SubagentInfo]
+    let store: SubagentDetailStore
+    var onAbort: ((String) -> Void)?
+    var onTap: ((String) -> Void)?
+
+    @State private var isExpanded: Bool
+
+    public init(
+        subagents: [SubagentInfo],
+        store: SubagentDetailStore,
+        onAbort: ((String) -> Void)? = nil,
+        onTap: ((String) -> Void)? = nil
+    ) {
+        self.subagents = subagents
+        self.store = store
+        self.onAbort = onAbort
+        self.onTap = onTap
+        // Auto-expand when any subagent is still active.
+        _isExpanded = State(initialValue: !subagents.allSatisfy(\.isTerminal))
+    }
+
+    private var allTerminal: Bool { subagents.allSatisfy(\.isTerminal) }
+
+    private var failedCount: Int {
+        subagents.filter { $0.status == .failed || $0.status == .aborted }.count
+    }
+
+    private var headlineText: String {
+        let count = subagents.count
+        if allTerminal {
+            if failedCount > 0 {
+                return "Completed \(count) subagent\(count == 1 ? "" : "s") (\(failedCount) failed)"
+            }
+            return "Completed \(count) subagent\(count == 1 ? "" : "s")"
+        }
+        let running = subagents.filter({ !$0.isTerminal }).count
+        return "\(running) subagent\(running == 1 ? "" : "s") running"
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerRow
+
+            if isExpanded {
+                expandedContent
+                    .padding(.bottom, VSpacing.xs)
+            }
+        }
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .animation(VAnimation.fast, value: isExpanded)
+        .textSelection(.disabled)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Subagent group: \(headlineText)")
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        Button(action: {
+            withAnimation(VAnimation.fast) {
+                isExpanded.toggle()
+            }
+        }) {
+            HStack(spacing: VSpacing.sm) {
+                if allTerminal {
+                    VIconView(failedCount > 0 ? .triangleAlert : .circleCheck, size: 12)
+                        .foregroundStyle(failedCount > 0 ? VColor.systemNegativeStrong : VColor.primaryBase)
+                } else {
+                    VBusyIndicator(size: 8)
+                }
+
+                Text(headlineText)
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                VIconView(isExpanded ? .chevronUp : .chevronDown, size: 9)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(isExpanded ? "Collapse subagent list" : "Expand subagent list")
+    }
+
+    // MARK: - Expanded Content
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(subagents) { subagent in
+                SubagentGroupRow(
+                    subagent: subagent,
+                    onAbort: { onAbort?(subagent.id) },
+                    onTap: { onTap?(subagent.id) }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Subagent Group Row
+
+/// A single subagent row within a `SubagentGroupContainer`. Shows the
+/// subagent's label with a status indicator. Tapping opens the detail panel.
+public struct SubagentGroupRow: View {
+    let subagent: SubagentInfo
+    var onAbort: (() -> Void)?
+    var onTap: (() -> Void)?
+
+    @State private var isHovered: Bool = false
+
+    private var isRunning: Bool { !subagent.isTerminal }
+
+    private var statusColor: Color {
+        switch subagent.status {
+        case .completed: return VColor.systemPositiveStrong
+        case .failed, .aborted: return VColor.systemNegativeStrong
+        default: return VColor.systemPositiveStrong
+        }
+    }
+
+    private var statusIcon: VIcon {
+        switch subagent.status {
+        case .completed: return .circleCheck
+        case .failed: return .circleX
+        case .aborted: return .circleStop
+        default: return .circleDot
+        }
+    }
+
+    private var statusLabel: String {
+        switch subagent.status {
+        case .completed: return "Completed"
+        case .failed: return "Failed"
+        case .aborted: return "Aborted"
+        case .running: return "Working…"
+        case .awaitingInput: return "Awaiting input"
+        case .pending: return "Pending"
+        case .unknown: return ""
+        }
+    }
+
+    public init(subagent: SubagentInfo, onAbort: (() -> Void)? = nil, onTap: (() -> Void)? = nil) {
+        self.subagent = subagent
+        self.onAbort = onAbort
+        self.onTap = onTap
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(statusIcon, size: 9)
+                .foregroundStyle(statusColor)
+
+            Text(subagent.label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentDefault)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if isRunning {
+                SubagentAnimatedDots()
+            }
+
+            Spacer(minLength: VSpacing.xs)
+
+            if !isRunning {
+                Text(statusLabel)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            if isRunning, let onAbort {
+                VIconView(.x, size: 9)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(VSpacing.xs)
+                    .contentShape(Rectangle())
+                    .highPriorityGesture(TapGesture().onEnded { onAbort() })
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Abort subagent")
+            }
+
+            VIconView(.chevronRight, size: 9)
+                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentTertiary)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(isHovered ? VColor.surfaceActive : Color.clear)
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
+        .onHover { isHovered = $0 }
+        .pointerCursor()
+        .accessibilityLabel("Subagent: \(subagent.label), \(statusLabel)")
+        .accessibilityHint("Opens subagent detail panel")
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+// MARK: - Shared Animated Dots
+
+/// Reusable animated dots indicator for subagent running state.
+private struct SubagentAnimatedDots: View {
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(VColor.contentSecondary)
+                    .frame(width: 4, height: 4)
+                    .phaseAnimator([0, 1, 2]) { content, phase in
+                        content.opacity(phase == index ? 1.0 : 0.3)
+                    } animation: { _ in
+                        .easeInOut(duration: 0.4)
+                    }
+            }
+        }
+    }
+}
+
 // MARK: - L-Shaped Connector
 
 /// Draws a smooth L-shaped path: vertical line down from top-left, then curves

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -1,254 +1,5 @@
 import SwiftUI
 
-/// Slack-style conversation indicator for a subagent, rendered below the parent message.
-///
-/// Looks like Slack's "3 replies  Last reply 2m ago" bar with:
-/// - A vertical connecting line on the left linking it visually to the parent message
-/// - Subagent icon, label, status, reply preview, and reply count
-/// - Clicking opens the conversation detail in the side panel (like Slack opens a conversation panel)
-///
-/// This replaces SubagentStatusChip with richer conversation-style affordances.
-public struct SubagentConversationView: View {
-    let subagent: SubagentInfo
-    let events: [SubagentEventItem]
-    var onAbort: (() -> Void)?
-    var onTap: (() -> Void)?
-
-    @State private var isHovered: Bool = false
-
-    private var isRunning: Bool { !subagent.isTerminal }
-
-    private var statusColor: Color {
-        switch subagent.status {
-        case .completed: return VColor.systemPositiveStrong
-        case .failed, .aborted: return VColor.systemNegativeStrong
-        default: return VColor.systemPositiveStrong
-        }
-    }
-
-    private var statusIcon: VIcon {
-        switch subagent.status {
-        case .completed: return .circleCheck
-        case .failed: return .circleX
-        case .aborted: return .circleStop
-        default: return .circleDot
-        }
-    }
-
-    /// Count of visible steps (text + toolUse + error, excluding toolResults).
-    private var replyCount: Int {
-        events.filter { if case .toolResult = $0.kind { return false }; return true }.count
-    }
-
-    /// Preview text from the last meaningful event.
-    private var lastReplyPreview: String? {
-        let meaningful = events.reversed().first { event in
-            switch event.kind {
-            case .toolResult: return false
-            default: return true
-            }
-        }
-        guard let event = meaningful else { return nil }
-        switch event.kind {
-        case .text:
-            let line = event.content.components(separatedBy: .newlines).first ?? event.content
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            return trimmed.count > 60 ? String(trimmed.prefix(57)) + "..." : trimmed
-        case .toolUse(let name):
-            return toolActionDescription(name: name, input: event.content)
-        case .error:
-            let line = event.content.components(separatedBy: .newlines).first ?? event.content
-            return line.count > 60 ? String(line.prefix(57)) + "..." : line
-        default:
-            return nil
-        }
-    }
-
-    public init(subagent: SubagentInfo, events: [SubagentEventItem], onAbort: (() -> Void)? = nil, onTap: (() -> Void)? = nil) {
-        self.subagent = subagent
-        self.events = events
-        self.onAbort = onAbort
-        self.onTap = onTap
-    }
-
-    public var body: some View {
-        conversationContent(phase: 0)
-            .textSelection(.disabled)
-    }
-
-    @ViewBuilder
-    private func conversationContent(phase: Int) -> some View {
-        HStack(alignment: .center, spacing: 0) {
-            // L-shaped connector: vertical line from parent → curves right into the conversation bar
-            LConnector()
-                .stroke(statusColor.opacity(0.4), style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                .frame(width: 14, height: 28)
-                .padding(.trailing, VSpacing.xs)
-
-            // Conversation indicator content
-            conversationBar(phase: phase)
-        }
-    }
-
-    // MARK: - Conversation Bar
-
-    private func conversationBar(phase: Int) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            // Label (clickable, turns blue on hover like Slack)
-            Text(subagent.label)
-                .font(VFont.labelDefault)
-                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentDefault)
-
-            // Status icon
-            VIconView(statusIcon, size: 9)
-                .foregroundStyle(statusColor)
-
-            // Animated dots while running
-            if isRunning {
-                animatedDots(phase: phase)
-            }
-
-            Spacer(minLength: VSpacing.xs)
-
-            // Reply count (like Slack's "3 replies")
-            if replyCount > 0 {
-                Text("\(replyCount) repl\(replyCount == 1 ? "y" : "ies")")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(isHovered ? VColor.primaryBase : VColor.systemPositiveStrong)
-            } else if isRunning {
-                Text("Working...")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .italic()
-            }
-
-            // Abort button
-            if isRunning, let onAbort {
-                VIconView(.x, size: 9)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .padding(VSpacing.xs)
-                    .contentShape(Rectangle())
-                    .highPriorityGesture(TapGesture().onEnded { onAbort() })
-                    .accessibilityAddTraits(.isButton)
-                    .accessibilityLabel("Abort subagent")
-            }
-
-            // View conversation arrow
-            VIconView(.chevronRight, size: 9)
-                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentTertiary)
-        }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(isHovered ? VColor.surfaceOverlay.opacity(0.5) : VColor.surfaceOverlay.opacity(0.2))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .strokeBorder(isHovered ? statusColor.opacity(0.3) : Color.clear, lineWidth: 1)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { onTap?() }
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .pointerCursor()
-        .accessibilityLabel("Conversation: \(subagent.label)")
-        .accessibilityHint("Opens conversation detail panel")
-        .accessibilityAddTraits(.isButton)
-    }
-
-    // MARK: - Animated Dots
-
-    private func animatedDots(phase _: Int) -> some View {
-        HStack(spacing: 2) {
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(VColor.contentSecondary)
-                    .frame(width: 4, height: 4)
-                    .phaseAnimator([0, 1, 2]) { content, phase in
-                        content.opacity(phase == index ? 1.0 : 0.3)
-                    } animation: { _ in
-                        .easeInOut(duration: 0.4)
-                    }
-            }
-        }
-    }
-
-    // MARK: - Tool Helpers
-
-    private func toolActionDescription(name: String, input: String) -> String {
-        let shortInput: String = {
-            guard !input.isEmpty else { return "" }
-            let lastComponent = URL(fileURLWithPath: input).lastPathComponent
-            return lastComponent.isEmpty ? input : lastComponent
-        }()
-
-        switch name.lowercased() {
-        case "read", "file_read":
-            return shortInput.isEmpty ? "Read a file" : "Read \(shortInput)"
-        case "edit", "file_edit":
-            return shortInput.isEmpty ? "Edited a file" : "Edited \(shortInput)"
-        case "write", "file_write":
-            return shortInput.isEmpty ? "Created a file" : "Created \(shortInput)"
-        case "bash":
-            return input.isEmpty ? "Ran a command" : "Ran \(truncated(input, to: 50))"
-        case "glob":
-            return input.isEmpty ? "Searched for files" : "Found \(truncated(input, to: 50))"
-        case "grep":
-            return input.isEmpty ? "Searched files" : "Searched for \"\(truncated(input, to: 40))\""
-        case "web_search", "websearch":
-            return input.isEmpty ? "Searched the web" : "Searched \"\(truncated(input, to: 40))\""
-        case "web_fetch", "webfetch":
-            if let host = URL(string: input)?.host { return "Fetched \(host)" }
-            return "Fetched a URL"
-        case "task":
-            return input.isEmpty ? "Ran an agent" : "Ran agent: \(truncated(input, to: 40))"
-        default:
-            return name
-                .replacingOccurrences(of: "_", with: " ")
-                .split(separator: " ")
-                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-                .joined(separator: " ")
-        }
-    }
-
-    private func truncated(_ s: String, to length: Int) -> String {
-        s.count > length ? String(s.prefix(length - 1)) + "…" : s
-    }
-}
-
-// MARK: - Subagent Events Reader
-
-/// Thin wrapper that isolates `SubagentDetailStore` observation from the
-/// parent `MessageListView`. Each reader resolves the per-subagent
-/// `SubagentState` and reads its `events` property, so observation is
-/// per-subagent: only this reader invalidates when this subagent's data
-/// changes. The parent message list is untouched.
-public struct SubagentEventsReader: View {
-    var store: SubagentDetailStore
-    let subagent: SubagentInfo
-    var onAbort: (() -> Void)?
-    var onTap: (() -> Void)?
-
-    public init(store: SubagentDetailStore, subagent: SubagentInfo, onAbort: (() -> Void)? = nil, onTap: (() -> Void)? = nil) {
-        self.store = store
-        self.subagent = subagent
-        self.onAbort = onAbort
-        self.onTap = onTap
-    }
-
-    public var body: some View {
-        let state = store.subagentStates[subagent.id]
-        SubagentConversationView(
-            subagent: subagent,
-            events: state?.events ?? [],
-            onAbort: onAbort,
-            onTap: onTap
-        )
-    }
-}
-
 // MARK: - Subagent Group Container
 
 /// Collapsible container that groups multiple subagents into a single inline
@@ -257,7 +8,6 @@ public struct SubagentEventsReader: View {
 /// expanding reveals individual rows. Tapping a row opens its detail panel.
 public struct SubagentGroupContainer: View {
     let subagents: [SubagentInfo]
-    let store: SubagentDetailStore
     var onAbort: ((String) -> Void)?
     var onTap: ((String) -> Void)?
 
@@ -265,15 +15,12 @@ public struct SubagentGroupContainer: View {
 
     public init(
         subagents: [SubagentInfo],
-        store: SubagentDetailStore,
         onAbort: ((String) -> Void)? = nil,
         onTap: ((String) -> Void)? = nil
     ) {
         self.subagents = subagents
-        self.store = store
         self.onAbort = onAbort
         self.onTap = onTap
-        // Auto-expand when any subagent is still active.
         _isExpanded = State(initialValue: !subagents.allSatisfy(\.isTerminal))
     }
 
@@ -308,6 +55,11 @@ public struct SubagentGroupContainer: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .animation(VAnimation.fast, value: isExpanded)
         .textSelection(.disabled)
+        .onChange(of: allTerminal) { _, isTerminal in
+            if isTerminal {
+                withAnimation(VAnimation.fast) { isExpanded = false }
+            }
+        }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Subagent group: \(headlineText)")
     }
@@ -441,6 +193,7 @@ public struct SubagentGroupRow: View {
                     .highPriorityGesture(TapGesture().onEnded { onAbort() })
                     .accessibilityAddTraits(.isButton)
                     .accessibilityLabel("Abort subagent")
+                    .accessibilityAction { onAbort() }
             }
 
             VIconView(.chevronRight, size: 9)
@@ -456,6 +209,7 @@ public struct SubagentGroupRow: View {
         .accessibilityLabel("Subagent: \(subagent.label), \(statusLabel)")
         .accessibilityHint("Opens subagent detail panel")
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onTap?() }
     }
 }
 
@@ -479,24 +233,4 @@ private struct SubagentAnimatedDots: View {
     }
 }
 
-// MARK: - L-Shaped Connector
 
-/// Draws a smooth L-shaped path: vertical line down from top-left, then curves
-/// right toward the conversation bar. Uses a quarter-circle arc for a polished look.
-private struct LConnector: Shape {
-    func path(in rect: CGRect) -> Path {
-        let radius: CGFloat = 6
-        var path = Path()
-        path.move(to: CGPoint(x: 1, y: 0))
-        path.addLine(to: CGPoint(x: 1, y: rect.midY - radius))
-        path.addArc(
-            center: CGPoint(x: 1 + radius, y: rect.midY - radius),
-            radius: radius,
-            startAngle: .degrees(180),
-            endAngle: .degrees(90),
-            clockwise: true
-        )
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
-        return path
-    }
-}

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -199,8 +199,7 @@ public struct SubagentGroupRow: View {
             VIconView(.chevronRight, size: 9)
                 .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentTertiary)
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm + VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs + VSpacing.xs))
         .background(isHovered ? VColor.surfaceActive : Color.clear)
         .contentShape(Rectangle())
         .onTapGesture { onTap?() }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2839,6 +2839,7 @@ public struct SubagentAbortMessage: Encodable, Sendable {
 /// Wire type: `"subagent_event"`
 public struct SubagentEventMessage: Decodable, Sendable {
     public let subagentId: String
+    public let conversationId: String?
     public let event: ServerMessage
 }
 


### PR DESCRIPTION
Replaces per-subagent individual rows with a single collapsible `SubagentGroupContainer` that renders inline in the chat transcript, and fixes four layout bugs in the subagent detail side panel and message rendering.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/66911b66bc364b7abb305795ddd59467
