### PR TITLE
fix(macos): title-case profile name when label is missing or blank

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -95,8 +95,41 @@ public struct InferenceProfile: Hashable, Identifiable {
     public var isDisabled: Bool { status == "disabled" }
 
     /// Label for pickers and list rows. Prefers the explicit `label`
-    /// (e.g. "Quality") and falls back to `name`.
-    public var displayName: String { label ?? name }
+    /// (e.g. "Quality") and falls back to a title-cased rendering of
+    /// `name` when `label` is missing or blank.
+    ///
+    /// Treating empty / whitespace-only `label` as missing — not just `nil`
+    /// — keeps the fallback robust against any code path that might set
+    /// `label = ""` without going through the JSON decoder's normalization.
+    /// The title-case step makes the fallback presentable since `name` is a
+    /// stable identifier and is typically kebab- or snake-cased
+    /// (e.g. `"quality-optimized"` → `"Quality Optimized"`).
+    public var displayName: String {
+        if let label, !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return label
+        }
+        return Self.titleCased(name)
+    }
+
+    /// Renders a profile identifier as a human-readable label by splitting
+    /// on common separators (`-`, `_`, whitespace) and capitalising the
+    /// first character of each part. Returns the input unchanged when no
+    /// non-separator parts remain (e.g. an empty string or `"---"`).
+    ///
+    /// Examples:
+    /// - `"balanced"` → `"Balanced"`
+    /// - `"quality-optimized"` → `"Quality Optimized"`
+    /// - `"custom_balanced"` → `"Custom Balanced"`
+    static func titleCased(_ identifier: String) -> String {
+        let separators = CharacterSet(charactersIn: "-_").union(.whitespacesAndNewlines)
+        let parts = identifier
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+        guard !parts.isEmpty else { return identifier }
+        return parts
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
 
     /// Optional secondary text for list row subtitles.
     public var subtitle: String? { profileDescription }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -12,7 +12,7 @@ final class ChatProfilePickerTests: XCTestCase {
         let profiles = [InferenceProfile(name: "balanced")]
         XCTAssertEqual(
             ChatProfilePicker.label(current: nil, profiles: profiles, activeProfile: "balanced"),
-            "Default (balanced)"
+            "Default (Balanced)"
         )
     }
 
@@ -23,7 +23,7 @@ final class ChatProfilePickerTests: XCTestCase {
         ]
         XCTAssertEqual(
             ChatProfilePicker.label(current: "quality-optimized", profiles: profiles, activeProfile: "balanced"),
-            "quality-optimized"
+            "Quality Optimized"
         )
     }
 
@@ -31,7 +31,7 @@ final class ChatProfilePickerTests: XCTestCase {
         let profiles = [InferenceProfile(name: "cost-optimized")]
         XCTAssertEqual(
             ChatProfilePicker.label(current: nil, profiles: profiles, activeProfile: "cost-optimized"),
-            "Default (cost-optimized)"
+            "Default (Cost Optimized)"
         )
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -222,9 +222,29 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertFalse(profile.isManaged)
     }
 
-    func testDisplayNameFallsBackToNameWhenLabelIsNil() {
+    func testDisplayNameFallsBackToTitleCasedNameWhenLabelIsNil() {
         let profile = InferenceProfile(name: "my-profile")
-        XCTAssertEqual(profile.displayName, "my-profile")
+        XCTAssertEqual(profile.displayName, "My Profile")
+    }
+
+    func testDisplayNameFallsBackToTitleCasedNameWhenLabelIsEmptyString() {
+        let profile = InferenceProfile(name: "quality-optimized", label: "")
+        XCTAssertEqual(profile.displayName, "Quality Optimized")
+    }
+
+    func testDisplayNameFallsBackToTitleCasedNameWhenLabelIsWhitespace() {
+        let profile = InferenceProfile(name: "custom-balanced", label: "   ")
+        XCTAssertEqual(profile.displayName, "Custom Balanced")
+    }
+
+    func testTitleCasedHandlesCommonIdentifierShapes() {
+        XCTAssertEqual(InferenceProfile.titleCased("balanced"), "Balanced")
+        XCTAssertEqual(InferenceProfile.titleCased("quality-optimized"), "Quality Optimized")
+        XCTAssertEqual(InferenceProfile.titleCased("custom_balanced"), "Custom Balanced")
+        XCTAssertEqual(InferenceProfile.titleCased("custom-quality-optimized"), "Custom Quality Optimized")
+        XCTAssertEqual(InferenceProfile.titleCased("  spaced  name  "), "Spaced Name")
+        XCTAssertEqual(InferenceProfile.titleCased("---"), "---")
+        XCTAssertEqual(InferenceProfile.titleCased(""), "")
     }
 
     func testSubtitleIsNilWhenDescriptionIsNil() {


### PR DESCRIPTION
Closes LUM-1519.

## Prompt / plan

`InferenceProfile.displayName` is read by the chat composer pill, the
profile list, the default-profile dropdown, the composer settings menu,
and a handful of accessibility labels. It fell back to the raw `name`
identifier whenever `label` was nil. On Cloud, the platform-overlay
seeds profiles without populating `label` (`assistant/src/config/seed-inference-profiles.ts`
short-circuits re-seeding under `isPlatform` once a profile entry
exists), so freshly hatched assistants showed kebab-case identifiers
like `quality-optimized` — or nothing at all if the label happened to
be an empty string rather than nil — in spots that should read
"Quality Optimized".

Make the fallback empty-aware (treat `""` and whitespace as missing,
not just `nil`) and title-case the `name` when it fires. The `name`
field itself stays untouched; it's the stable identifier used as the
profile key in lookups, the conversation override, and call-site
overrides.

Noa is separately addressing the underlying data issue (why `label` is
blank for new assistants on Cloud); this PR is the UI-side hardening
explicitly requested in the ticket.

### What changed

- `clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift`
  - `displayName` now returns `label` only when it is non-nil and
    non-empty after trimming; otherwise it returns
    `Self.titleCased(name)`.
  - Adds `static func titleCased(_:)` which splits on `-`, `_`, and
    whitespace, capitalises the first character of each non-empty part,
    and joins with single spaces. Falls through to the input unchanged
    when no usable parts remain (e.g. `"---"`).

### Why this is safe

- Pure UI display change. No wire format, persistence, IPC, or
  NotificationCenter payload touches the change.
- No cross-component skew: the daemon, gateway, and platform never see
  the rendered string. Old daemon + new macOS and new daemon + old
  macOS both behave identically since this lives entirely inside the
  macOS client's render path.
- All existing call sites of `displayName` (profile list rows,
  `ChatProfilePicker.label`, `InferenceServiceCard` dropdown options,
  `ComposerSettingsMenu` profile picker, accessibility labels in
  `InferenceProfilesSheet`) benefit transparently — no call-site
  changes needed.

### Alternatives considered

- **Mutate `name` at decode time so it's pre-formatted.** Rejected:
  `name` is the stable identifier used as a profile key in
  `activeProfile` lookups, `id`, call-site overrides, and conversation
  override fields. Display formatting must remain a derived view-only
  concern.
- **Add a fallback at each call site.** Rejected: at least five call
  sites depend on `displayName`. Centralising in the computed property
  keeps the convention enforceable and the test surface narrow.
- **Use `String.capitalized` directly.** Rejected:
  `"quality-optimized".capitalized` returns `"Quality-Optimized"`
  because Foundation's [`capitalized`](https://developer.apple.com/documentation/swift/string/capitalized)
  treats `-` and `_` as part of a word, not a separator.
- **Backend backfill mirroring [#30412](https://github.com/vellum-ai/vellum-assistant/pull/30412)
  (provider connections).** Out of scope per the ticket — Noa is
  handling the root-cause data issue separately. UI hardening also
  guards against future label-blank scenarios.
- **Extract a shared `String` extension and DRY up with
  `MessageInspectorSummaryFormatters.titleCasedProviderLabel`.**
  Considered but explicitly de-scoped for this PR per request: the
  ticket asks for the minimal UI fallback while the data root cause is
  being fixed separately. The provider-label helper lives in a
  different domain (inspector summary) and a follow-up consolidation
  is safer once both call sites have settled.

## Test plan

- Updates the existing `InferenceProfile` `displayName` tests in
  `InferenceProfileTests.swift` to expect the title-cased fallback:
  - nil label → title-cased name
  - empty-string label → title-cased name
  - whitespace-only label → title-cased name
- Adds `testTitleCasedHandlesCommonIdentifierShapes` covering
  `balanced`, `quality-optimized`, `custom_balanced`,
  `custom-quality-optimized`, surrounding/repeated whitespace, all
  separators (`---`), and empty input.
- Updates the affected `ChatProfilePickerTests` cases that previously
  encoded the raw-kebab fallback (`"Default (balanced)"`,
  `"quality-optimized"`, `"Default (cost-optimized)"`) to the
  title-cased output.
- CI doesn't build macOS — Xcode build/test must be verified locally
  before merging.

## Root cause analysis

1. **How did the code get into this state?** `displayName` was added
   as `label ?? name` when the label/source/description fields
   landed. At the time, every seeded profile included a `label`, so
   the fallback was only ever exercised by ad-hoc user-created
   profiles where the kebab `name` was acceptable.
2. **What mistakes or decisions led to it?** The fallback path was
   never explicitly designed for the platform-overlay case where
   `label` is missing. The decoder normalises `""` to nil, which
   masked the empty-string scenario in unit tests and meant the gap
   only surfaced once the Cloud platform started serving
   label-less profiles.
3. **Were there warning signs we missed?** [#30412](https://github.com/vellum-ai/vellum-assistant/pull/30412)
   fixed the same symptom for provider connections (label blank,
   editor renders empty) by backfilling `label = name`. The same
   pattern across the codebase suggests a generalised "always have a
   sensible display fallback when label is missing" convention is
   missing.
4. **What can we do to prevent this pattern from recurring?** Any
   identifier field paired with a user-friendly `label` should
   compute a display value that is presentable even when `label` is
   absent. Title-casing the identifier is the cheap, reliable
   default.
5. **Should we add a guideline to AGENTS.md?** Not yet. Two data
   points (`InferenceProfile`, provider connections) is suggestive
   but not enough to warrant a project-wide rule; a follow-up that
   factors out a shared `titleCasedIdentifier` extension would be the
   right time to codify the convention.

## References

- Apple — [`String.capitalized`](https://developer.apple.com/documentation/swift/string/capitalized)
  (why we can't use it directly: keeps `-` and `_` as part of a word)
- Apple — [`CharacterSet`](https://developer.apple.com/documentation/foundation/characterset)
- Apple refs checked (2026-05-12): `String.capitalized`, `CharacterSet.union(_:)`, `String.components(separatedBy:)`

Link to Devin session: https://app.devin.ai/sessions/bac5a01cf5be4de69e79e16034b50cfb
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->