### PR TITLE
feat: update Slack SKILL.md with resolution scripts and rich API access guidance

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -584,7 +584,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T19:20:00-04:00"
+      "updatedAt": "2026-05-12T19:31:26Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,70 +8,142 @@ metadata:
     display-name: "Slack"
 ---
 
-You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via the `bash` tool with credential proxy — there are no dedicated Slack tools.
+You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via `assistant oauth request --provider slack` -- there are no dedicated Slack tools.
+
+## Resolution Scripts
+
+Use these scripts to resolve Slack channel and user names to IDs. Results are cached locally so repeated lookups are free (no API calls).
+
+| Command                                                          | Description                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------ |
+| `bun skills/slack/scripts/slack-resolve.ts channel <name>`       | Resolve a channel name to its ID                 |
+| `bun skills/slack/scripts/slack-resolve.ts user <name-or-email>` | Resolve a user display name or email to their ID |
+| `bun skills/slack/scripts/slack-resolve.ts channels [--refresh]` | List all cached channels, or refresh the cache   |
+
+All scripts return JSON:
+
+- **Success**: `{ "ok": true, "data": { "id": "C...", "name": "general", ... } }`
+- **Failure**: `{ "ok": false, "error": "..." }`
+
+The cache is stored locally under `~/.vellum/workspace/data/slack-skill/`. On first use the script fetches all channels/users from Slack and caches them. Subsequent lookups read from the cache with no API calls. Pass `--refresh` to force a refresh.
 
 ## Making Slack API Calls
 
-Use `bash` with these parameters:
+Use `assistant oauth request --provider slack` to call any Slack Web API method. Auth is handled transparently -- the provider injects the bot token automatically.
 
-- **`network_mode`**: `"proxied"`
-- **`credential_ids`**: `["slack_channel/bot_token"]`
+General pattern:
 
-The proxy intercepts requests to `slack.com` and injects the bot token as a `Bearer` header automatically. You never see or handle the token directly.
-
-Example — list channels:
-
-```
-bash {
-  command: "curl -s https://slack.com/api/conversations.list?types=public_channel,private_channel | jq ."
-  network_mode: "proxied"
-  credential_ids: ["slack_channel/bot_token"]
-  activity: "to list your Slack channels"
-}
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C123","text":"Hello world"}' \
+  https://slack.com/api/chat.postMessage --json
 ```
 
-Refer to https://api.slack.com/methods for available endpoints. The bot token scopes configured in the Slack app manifest determine what's accessible.
+The model knows the full Slack API from training data. Refer to https://api.slack.com/methods for the complete list of available endpoints.
 
-## Common Operations
+### Send a message
 
-### Reading messages
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C0123456789","text":"Hello from the assistant!"}' \
+  https://slack.com/api/chat.postMessage --json
+```
 
-- `conversations.list` — list channels
-- `conversations.history` — read recent messages in a channel
-- `conversations.replies` — read a full thread
-- `users.info` — resolve user IDs to display names
+### Read channel history
 
-### Sending messages
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C0123456789","limit":20}' \
+  https://slack.com/api/conversations.history --json
+```
 
-- `chat.postMessage` — send a message to a channel or DM
-- `chat.update` — edit a message the bot previously sent
-- `chat.delete` — delete a message the bot previously sent
+### Read thread replies
 
-### Reacting & managing
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C0123456789","ts":"1716000000.000001"}' \
+  https://slack.com/api/conversations.replies --json
+```
 
-- `reactions.add` — add an emoji reaction
-- `conversations.join` — join a public channel
-- `conversations.leave` — leave a channel
-- `search.messages` — search across the workspace
+### Add a reaction
 
-### Channel scanning
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C0123456789","timestamp":"1716000000.000001","name":"thumbsup"}' \
+  https://slack.com/api/reactions.add --json
+```
 
-When the user asks to scan or catch up on Slack:
+### Send with blocks (rich formatting)
 
-1. Call `conversations.list` to get active channels, then `conversations.history` for each
-2. Present an overview first: channel names, message counts, top threads
-3. Offer to drill into specific threads with `conversations.replies`
-4. Summarize with attribution: who said what, decisions made, open questions
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{
+    "channel":"C0123456789",
+    "text":"Fallback text",
+    "blocks":[
+      {"type":"header","text":{"type":"plain_text","text":"Weekly Update"}},
+      {"type":"section","text":{"type":"mrkdwn","text":"*Project Alpha*: on track\n*Project Beta*: needs review"}}
+    ]
+  }' \
+  https://slack.com/api/chat.postMessage --json
+```
+
+### Upload a file
+
+File uploads use a multi-step flow: get an upload URL, upload the file, then complete the upload.
+
+```bash
+# Step 1: Get an upload URL
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"filename":"notes.txt","length":42}' \
+  https://slack.com/api/files.getUploadURLExternal --json
+
+# Step 2: Upload file content to the returned upload_url (use curl directly)
+# Step 3: Complete the upload
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"files":[{"id":"FILE_ID","title":"Meeting Notes"}],"channel_id":"C0123456789"}' \
+  https://slack.com/api/files.completeUploadExternal --json
+```
+
+### Search messages
+
+```bash
+assistant oauth request --provider slack \
+  "https://slack.com/api/search.messages?query=project+launch+in%3A%23general" --json
+```
+
+### Open a DM
+
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"users":"U0123456789"}' \
+  https://slack.com/api/conversations.open --json
+```
+
+## Typical Workflow
+
+1. **Resolve the channel**: `bun skills/slack/scripts/slack-resolve.ts channel general` to get the channel ID.
+2. **Call the API**: Use `assistant oauth request --provider slack` with that ID for the actual operation (send, read, react, etc.).
+3. **For DMs**: Use `bun skills/slack/scripts/slack-resolve.ts user <name>` to get the user ID, then `conversations.open` to get the DM channel ID, then `chat.postMessage` to send the message.
 
 ## User Resolution
 
 When you need to send a DM or look up a Slack user by name, check contacts first to avoid redundant API calls:
 
-1. **Before calling `users.list`**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage`.
+1. **Before calling the resolve script**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage` via `assistant oauth request --provider slack`.
 
    When `contact_search` returns notes for the recipient, use them to inform the message's tone, formality, and content. Contact notes capture relationship context and communication preferences that should shape how you write to this person.
 
-2. **After resolving via API**: When you had to call `users.list` or `conversations.open` to resolve a user, save the contact with `contact_upsert` so you can find them by name next time. External Slack IDs (user ID, DM channel ID) are cached automatically by the messaging layer and should not be passed through `contact_upsert`.
+2. **After resolving via script**: When you had to use `slack-resolve.ts user` or `conversations.open` to resolve a user, save the contact with `contact_upsert` so you can find them by name next time. External Slack IDs (user ID, DM channel ID) are cached automatically by the messaging layer and should not be passed through `contact_upsert`.
 
 ## Privacy Rules
 
@@ -83,26 +155,33 @@ When you need to send a DM or look up a Slack user by name, check contacts first
 - Public channel content can be shared with attribution ("From #channel: ...")
 - Always confirm with the user before sending content to any destination
 
-## Delivery Notes
-
-- For rich content (digests, reports, formatted summaries): use the Slack API directly via `chat.postMessage` with blocks
-- For short alerts: `assistant notifications send` via `bash` is fine — it lets the notification router pick the best channel
-- For scheduled tasks: always include an explicit Slack API call to deliver results, otherwise output only lives in the conversation log
-
 ## Threading
 
-When responding to messages from Slack channels, replies should be threaded. Pass `thread_ts` to `chat.postMessage` to reply in a thread rather than posting a new top-level message.
+When responding to messages from Slack channels, replies should be threaded. Pass `thread_ts` to `chat.postMessage` to reply in a thread rather than posting a new top-level message:
+
+```bash
+assistant oauth request --provider slack \
+  -X POST \
+  -d '{"channel":"C0123456789","text":"Replying in thread","thread_ts":"1716000000.000001"}' \
+  https://slack.com/api/chat.postMessage --json
+```
 
 ## Connection
 
-Before making any Slack API calls, verify that Slack is connected. If not connected, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow. Do NOT improvise setup instructions — the `slack-app-setup` skill is the single source of truth. Slack uses Socket Mode and does not require redirect URLs or any OAuth flow.
+Before making any Slack API calls, verify that Slack is connected. If not connected, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow. Do NOT improvise setup instructions -- the `slack-app-setup` skill is the single source of truth. Slack uses Socket Mode and does not require redirect URLs or any OAuth flow.
 
 ## Error Handling
 
-If a Slack API call fails due to missing or invalid credentials — for example, an error indicating that `slack_channel/bot_token` is not found, the credential is missing, or the token is invalid — do NOT attempt to fix the credentials manually. Instead, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow to set up or reconnect Slack. Tell the user something like "Slack needs to be reconnected" and start the setup skill.
+If a Slack API call fails due to missing or invalid credentials -- for example, an error indicating that the token is missing or invalid -- do NOT attempt to fix the credentials manually. Instead, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow to set up or reconnect Slack. Tell the user something like "Slack needs to be reconnected" and start the setup skill.
 
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to check Slack, start scanning immediately.
 - **Keep it human.** Never mention OAuth, tokens, APIs, proxies, or credential IDs. If something isn't working, say "Slack needs to be reconnected."
 - **Show progress.** When scanning multiple channels, tell the user what you're doing.
+
+## Delivery Notes
+
+- For rich content (digests, reports, formatted summaries): use `chat.postMessage` with blocks via `assistant oauth request --provider slack`
+- For short alerts: `assistant notifications send` via `bash` is fine -- it lets the notification router pick the best channel
+- For scheduled tasks: always include an explicit Slack API call to deliver results, otherwise output only lives in the conversation log


### PR DESCRIPTION
## Summary
- Replace proxied curl pattern with `assistant oauth request --provider slack`
- Document resolution scripts for channel/user lookup with caching
- Add rich API examples: send, read, react, blocks, files, search
- Lean into the model — scripts for resolution only, raw API for everything else

Part of plan: slack-skill-scripts.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->