### PR TITLE
feat(plugins): expose runtime bridge via globalThis for compiled-binary plugin loading

### DIFF
--- a/assistant/docs/plugins.md
+++ b/assistant/docs/plugins.md
@@ -104,7 +104,7 @@ export interface PluginManifest {
 
 | Field                | Required | Purpose                                                                                                                                                                                                                                                                                                        |
 | -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | yes      | Unique plugin identifier. Duplicate names fail registration. Used as the directory under `<workspaceDir>/plugins-data/<name>/` and the attribution tag in logs.                                                                                                                                                     |
+| `name`               | yes      | Unique plugin identifier. Duplicate names fail registration. Used as the directory under `<workspaceDir>/plugins-data/<name>/` and the attribution tag in logs.                                                                                                                                                |
 | `version`            | yes      | Plugin's own semver. Informational — the registry does not compare it.                                                                                                                                                                                                                                         |
 | `provides`           | no       | Reserved for future cross-plugin composition and not currently consumed by the assistant. Plugin authors may set this field, but no runtime code reads it yet — it is declared here so future cross-plugin work can land without a manifest version bump. Do not rely on it for any runtime behavior today.    |
 | `requires`           | yes      | Must include `pluginRuntime: "v1"` at minimum. The registry checks every entry against `ASSISTANT_API_VERSIONS` and refuses to register plugins that ask for a capability or version the assistant does not expose.                                                                                            |
@@ -179,11 +179,28 @@ Feature Flags" section for the full procedure.
 
 ## Registration
 
-A plugin's `register.ts` calls `registerPlugin()` at module load time:
+A plugin's `register.ts` calls `registerPlugin()` at module load time. The
+function is exposed via the `globalThis.__vellumPluginRuntime` bridge so the
+plugin file does not need to import from the daemon's source tree:
 
 ```typescript
-import { registerPlugin } from "<path-to-assistant>/src/plugins/registry.js";
 import type { Plugin } from "<path-to-assistant>/src/plugins/types.js";
+
+interface VellumPluginRuntime {
+  readonly version: 1;
+  readonly registerPlugin: (plugin: Plugin) => void;
+  readonly assistantEventHub: import("<path-to-assistant>/src/runtime/assistant-event-hub.js").AssistantEventHub;
+  readonly getSecureKeyAsync: (account: string) => Promise<string | undefined>;
+}
+
+const runtime = (globalThis as { __vellumPluginRuntime?: VellumPluginRuntime })
+  .__vellumPluginRuntime;
+if (!runtime || runtime.version !== 1) {
+  throw new Error(
+    "vellum plugin runtime not available — install a recent assistant build",
+  );
+}
+const { registerPlugin } = runtime;
 
 const myPlugin: Plugin = {
   manifest: {
@@ -199,6 +216,20 @@ const myPlugin: Plugin = {
 registerPlugin(myPlugin);
 ```
 
+**Why the bridge?** When the daemon is a `bun --compile` binary, its modules
+are bundled into the executable. Plugins that import the daemon's modules by
+absolute path (`/abs/path/to/assistant/src/plugins/registry.js`) reload fresh
+disk copies into a separate module graph, and any `registerPlugin()` call in
+the plugin lands in a registry the daemon never reads. The
+`globalThis.__vellumPluginRuntime` handle is the same instance the daemon's
+bundled code holds onto, so plugin registrations always reach the right
+place — whether the daemon was built with `bun --compile` or is running from
+source.
+
+Type-only imports (`import type { Plugin } from "..."`) remain free to use
+absolute paths to the assistant source — the TypeScript compiler erases them
+and they have no module-identity effect at runtime.
+
 **Rules:**
 
 - Exactly one `registerPlugin()` call per plugin. The registry rejects
@@ -210,6 +241,8 @@ registerPlugin(myPlugin);
   this plugin" — use `requiresFlag` or a guard inside `init()` instead.
 - The file runs before any lifecycle hooks. Keep it fast — heavy work
   belongs in `init()`.
+- The bridge is installed by the daemon before `loadUserPlugins()` runs, so
+  the global is always present when a plugin's module body executes.
 
 ## Middleware patterns
 

--- a/assistant/examples/plugins/echo/README.md
+++ b/assistant/examples/plugins/echo/README.md
@@ -30,49 +30,49 @@ For the full plugin authoring guide, see
 
 ## Install locally
 
-The assistant scans `~/.vellum/plugins/*` for subdirectories containing a
+The assistant scans `<workspaceDir>/plugins/*` (e.g.
+`~/.vellum/workspace/plugins/`) for subdirectories containing a
 `register.{ts,js}` file and dynamic-imports each one during assistant
 startup. Dropping (or symlinking) this directory in place is enough to
 enable it.
 
-### Option 1 — symlink from the repo (recommended)
+The plugin reads `registerPlugin` from `globalThis.__vellumPluginRuntime`,
+which the daemon attaches before scanning plugins. This works against both
+the `bun --compile`-bundled daemon binary AND a daemon running from
+source — no special install procedure required either way.
+
+### Option 1 — symlink from the repo (simplest in-repo dev)
 
 From the repo root:
 
 ```bash
-mkdir -p ~/.vellum/plugins
-ln -s "$(pwd)/assistant/examples/plugins/echo" ~/.vellum/plugins/echo
+mkdir -p ~/.vellum/workspace/plugins
+ln -s "$(pwd)/assistant/examples/plugins/echo" ~/.vellum/workspace/plugins/echo
 ```
 
 Symlinks let you edit the plugin in-place and restart the assistant to
-pick up changes. **This is the only zero-edit install path** — the
-`register.ts` in this directory uses relative imports
-(`../../../src/plugins/registry.js`) that resolve into the in-repo
-assistant sources, so the file must stay reachable at that relative
-location.
+pick up changes.
 
-### Option 2 — standalone copy (requires edits)
+### Option 2 — standalone copy
 
-If you want a fully isolated install that does not depend on a local
-vellum-assistant checkout, a plain `cp -R` of this directory into
-`~/.vellum/plugins/echo/` will **not** work as-is: the relative imports
-in `register.ts` resolve to `~/.vellum/src/plugins/...`, which does not
-exist. The assistant does not currently publish the plugin API as an npm
-package, so to copy-and-adapt this template into a standalone plugin you
-must rewrite the imports in `register.ts` to point at an absolute path
-inside a vellum-assistant checkout, for example:
+A plain `cp -R` of this directory into `~/.vellum/workspace/plugins/echo/`
+works for the runtime imports (which go through the global bridge), but
+the `import type` lines at the top of `register.ts` still resolve into
+the in-repo assistant source tree. If your standalone copy lives outside
+a vellum-assistant checkout, rewrite those `import type` paths to point
+at an absolute path inside any checkout — they're erased at compile time
+and have no module-identity effect at runtime:
 
 ```ts
 // before (repo-local):
-import { registerPlugin } from "../../../src/plugins/registry.js";
+import type { VellumPluginRuntime } from "../../../src/plugins/external-api.js";
+import type { Plugin } from "../../../src/plugins/types.js";
 // after (standalone, edit to your checkout path):
-import { registerPlugin } from "/path/to/vellum-assistant/assistant/src/plugins/registry.js";
+import type { VellumPluginRuntime } from "/path/to/vellum-assistant/assistant/src/plugins/external-api.js";
+import type { Plugin } from "/path/to/vellum-assistant/assistant/src/plugins/types.js";
 ```
 
-Apply the same rewrite to the `import type` line that pulls from
-`../../../src/plugins/types.js`. Until a published package exists, the
-symlink recipe above is simpler and more portable for day-to-day
-development.
+No runtime-import rewriting is needed — the bridge already handles that.
 
 ### Restart the assistant
 
@@ -113,7 +113,7 @@ original error still propagates.
 Remove the symlink (or the copied directory) and restart the assistant:
 
 ```bash
-rm ~/.vellum/plugins/echo
+rm ~/.vellum/workspace/plugins/echo
 vellum restart
 ```
 

--- a/assistant/examples/plugins/echo/register.ts
+++ b/assistant/examples/plugins/echo/register.ts
@@ -2,34 +2,26 @@
  * Echo plugin — observes every assistant pipeline and logs one structured
  * line per invocation to stderr.
  *
- * This plugin is bundled in the repository as an authoring reference. It is
- * not shipped with the assistant runtime; to try it locally, symlink this
- * directory into `~/.vellum/plugins/echo/` and restart the assistant. See
- * `README.md` in this directory for the full install recipe and
- * `assistant/docs/plugins.md` for general plugin authoring docs.
+ * Bundled in the repository as an authoring reference. To try it locally,
+ * symlink (or copy) this directory into `<workspaceDir>/plugins/echo/` and
+ * restart the assistant. See `README.md` in this directory for the install
+ * recipe and `assistant/docs/plugins.md` for general plugin authoring docs.
  *
- * ## IMPORTANT — imports below are REPO-LOCAL
+ * ## Runtime bridge
  *
- * The relative imports from `../../../src/plugins/...` resolve correctly
- * only while this file lives inside the vellum-assistant repo at
- * `assistant/examples/plugins/echo/`. The path walks back to
- * `assistant/src/plugins/` so the example compiles against the assistant's
- * in-repo types.
+ * The plugin reads `registerPlugin` from `globalThis.__vellumPluginRuntime`,
+ * a stable handle the daemon attaches at startup. This lets the same plugin
+ * file work whether the daemon is running from source (relative or absolute
+ * imports would resolve to the daemon's modules) or as a `bun --compile`
+ * binary (where absolute imports would load a disjoint disk copy with a
+ * separate registry instance). The bridge is documented in
+ * `assistant/src/plugins/external-api.ts`.
  *
- * If you copy (rather than symlink) this directory to
- * `~/.vellum/plugins/echo/`, these imports will fail because
- * `~/.vellum/src/plugins/...` does not exist. The assistant does not
- * currently publish the plugin API as an npm package, so the only
- * zero-edit install path is the symlink recipe (Option 1 in README.md).
- *
- * For a standalone copy that lives outside the repo, you must either:
- * - Point the imports at an absolute path into a vellum-assistant checkout
- *   (`/path/to/vellum-assistant/assistant/src/plugins/registry.js`), or
- * - Rewrite the plugin to consume only the public types you need and drop
- *   the direct registry import in favor of your own entry-point wiring.
- *
- * See README.md "Option 2 — standalone copy" for the recommended
- * standalone-template adaptation steps.
+ * Type imports below still come from the in-repo source tree. Types are
+ * erased at runtime, so they don't affect module identity — but they only
+ * resolve while this file lives inside the vellum-assistant checkout. For a
+ * standalone-copy install, rewrite the `import type` paths to absolute paths
+ * inside a checkout (or vendor only the types you need).
  *
  * ## Design
  *
@@ -48,7 +40,7 @@
  * user-plugin-loader contract (see `assistant/src/plugins/user-loader.ts`).
  */
 
-import { registerPlugin } from "../../../src/plugins/registry.js";
+import type { VellumPluginRuntime } from "../../../src/plugins/external-api.js";
 import type {
   CircuitBreakerArgs,
   CircuitBreakerResult,
@@ -80,6 +72,15 @@ import type {
   TurnArgs,
   TurnResult,
 } from "../../../src/plugins/types.js";
+
+const runtime = (globalThis as { __vellumPluginRuntime?: VellumPluginRuntime })
+  .__vellumPluginRuntime;
+if (!runtime || runtime.version !== 1) {
+  throw new Error(
+    "echo plugin: globalThis.__vellumPluginRuntime is missing or has an unexpected version — install a recent assistant build",
+  );
+}
+const { registerPlugin } = runtime;
 
 const PLUGIN_NAME = "echo";
 

--- a/assistant/src/__tests__/plugin-external-api.test.ts
+++ b/assistant/src/__tests__/plugin-external-api.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the `globalThis.__vellumPluginRuntime` bridge.
+ *
+ * The bridge exists so workspace-local plugins (`<workspaceDir>/plugins/*`)
+ * can register with the daemon's bundled module instances even when the
+ * daemon is a `bun --compile` binary. Absolute-path imports against a
+ * compiled binary load fresh disk copies into a disjoint module graph; the
+ * bridge sidesteps that by attaching a stable handle to globalThis.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getPluginRuntime,
+  installPluginRuntime,
+  uninstallPluginRuntimeForTests,
+} from "../plugins/external-api.js";
+import { registerPlugin } from "../plugins/registry.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+
+describe("plugin external-api bridge", () => {
+  beforeEach(() => {
+    uninstallPluginRuntimeForTests();
+  });
+
+  afterEach(() => {
+    uninstallPluginRuntimeForTests();
+  });
+
+  test("installs a runtime handle on globalThis", () => {
+    expect(getPluginRuntime()).toBeUndefined();
+    installPluginRuntime();
+    const runtime = getPluginRuntime();
+    expect(runtime).toBeDefined();
+    expect(runtime?.version).toBe(1);
+  });
+
+  test("exposes the canonical registerPlugin / hub / secrets references", () => {
+    installPluginRuntime();
+    const runtime = getPluginRuntime();
+    expect(runtime?.registerPlugin).toBe(registerPlugin);
+    expect(runtime?.assistantEventHub).toBe(assistantEventHub);
+    expect(runtime?.getSecureKeyAsync).toBe(getSecureKeyAsync);
+  });
+
+  test("plugins can read the runtime via the documented globalThis key", () => {
+    installPluginRuntime();
+    // Mirror the access pattern documented for plugin authors.
+    const runtime = (
+      globalThis as { __vellumPluginRuntime?: { version: number } }
+    ).__vellumPluginRuntime;
+    expect(runtime).toBeDefined();
+    expect(runtime?.version).toBe(1);
+  });
+
+  test("install is idempotent — repeat calls preserve the same handle", () => {
+    installPluginRuntime();
+    const first = getPluginRuntime();
+    installPluginRuntime();
+    installPluginRuntime();
+    expect(getPluginRuntime()).toBe(first);
+  });
+
+  test("getPluginRuntime returns undefined when the bridge is not installed", () => {
+    expect(getPluginRuntime()).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -54,6 +54,7 @@ import {
 } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
+import { installPluginRuntime } from "../plugins/external-api.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
 import { backfillGuardIfNeeded } from "../proactive-artifact/index.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -647,6 +648,12 @@ export async function runDaemon(): Promise<void> {
         }
       });
     }
+
+    // Install the `globalThis.__vellumPluginRuntime` bridge before scanning
+    // for user plugins. Plugins that touch the bridge from their module body
+    // would throw without this — see `plugins/external-api.ts` for the
+    // rationale (compiled-binary module identity).
+    installPluginRuntime();
 
     // Populate the registry with user plugins from `<workspaceDir>/plugins/*`
     // AFTER first-party plugins have already registered via their static

--- a/assistant/src/plugins/external-api.ts
+++ b/assistant/src/plugins/external-api.ts
@@ -1,0 +1,104 @@
+/**
+ * External plugin runtime — `globalThis.__vellumPluginRuntime` bridge.
+ *
+ * Workspace-local plugins (`<workspaceDir>/plugins/*`) get dynamic-imported by
+ * {@link loadUserPlugins}. They need to call `registerPlugin()` from their
+ * module body and they typically also want to read secrets, subscribe to
+ * runtime events, etc.
+ *
+ * Importing those symbols by absolute path
+ * (`/abs/path/to/assistant/src/plugins/registry.js`) works when the daemon is
+ * running from source — both the daemon and the dynamic-imported plugin
+ * resolve the same on-disk file and share module identity. It DOES NOT work
+ * when the daemon is a `bun --compile` binary: the daemon's modules are baked
+ * into the executable, and any absolute-path import re-loads a fresh disk
+ * copy. `registerPlugin()` then writes into a disjoint registry instance and
+ * the daemon never sees the plugin.
+ *
+ * The fix is to expose a single, stable handle on `globalThis` that plugins
+ * read at module-load time. The daemon's bundled modules attach themselves
+ * here once at startup; plugins consume the same instance regardless of how
+ * the daemon was built.
+ *
+ * Plugins use the bridge like this:
+ *
+ *   const runtime = (globalThis as { __vellumPluginRuntime?: ... })
+ *     .__vellumPluginRuntime;
+ *   if (!runtime || runtime.version !== 1) throw new Error("...");
+ *   const { registerPlugin, assistantEventHub, getSecureKeyAsync } = runtime;
+ *
+ * Type-only imports (`import type { Plugin } from "..."`) remain free to use
+ * absolute paths or workspace-local copies — the TypeScript compiler erases
+ * them and they have no module-identity effect at runtime.
+ *
+ * See `assistant/docs/plugins.md` for the full authoring contract and
+ * `assistant/examples/plugins/echo/register.ts` for a worked example.
+ */
+
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { registerPlugin } from "./registry.js";
+
+/**
+ * The handle plugins read from `globalThis.__vellumPluginRuntime`.
+ *
+ * `version` is the contract version. Plugins should assert against the
+ * version they were authored against and refuse to register if they see a
+ * different one — bumping it is a breaking change to the plugin surface.
+ *
+ * The field set is intentionally small: the most-commonly-needed symbols
+ * across both static (module-load-time) and dynamic (init-time) plugin
+ * lifecycle. Plugins that need richer runtime state can still receive it
+ * through {@link PluginInitContext} during `init()`.
+ */
+export interface VellumPluginRuntime {
+  readonly version: 1;
+  readonly registerPlugin: typeof registerPlugin;
+  readonly assistantEventHub: typeof assistantEventHub;
+  readonly getSecureKeyAsync: typeof getSecureKeyAsync;
+}
+
+/** Stable globalThis key. Don't rename — plugins reference it by string. */
+const RUNTIME_GLOBAL_KEY = "__vellumPluginRuntime" as const;
+
+interface GlobalWithRuntime {
+  [RUNTIME_GLOBAL_KEY]?: VellumPluginRuntime;
+}
+
+/**
+ * Install the plugin runtime bridge on `globalThis`. Idempotent — repeat
+ * calls are no-ops, so it's safe to invoke from tests that also touch the
+ * lifecycle path.
+ *
+ * Must be called BEFORE {@link loadUserPlugins} runs, otherwise plugins that
+ * touch `globalThis.__vellumPluginRuntime` in their module body will throw.
+ */
+export function installPluginRuntime(): void {
+  const g = globalThis as GlobalWithRuntime;
+  if (g[RUNTIME_GLOBAL_KEY]) return;
+  g[RUNTIME_GLOBAL_KEY] = {
+    version: 1,
+    registerPlugin,
+    assistantEventHub,
+    getSecureKeyAsync,
+  };
+}
+
+/**
+ * Read the installed runtime. Returns `undefined` if {@link installPluginRuntime}
+ * hasn't been called yet — plugins should treat this as a fatal error.
+ *
+ * Exposed mainly for tests and for the rare in-process consumer that wants
+ * to read the bridge from the same module graph that installed it.
+ */
+export function getPluginRuntime(): VellumPluginRuntime | undefined {
+  return (globalThis as GlobalWithRuntime)[RUNTIME_GLOBAL_KEY];
+}
+
+/**
+ * Tear down the runtime handle. Test-only — production code never uninstalls
+ * because the runtime lifetime is the daemon lifetime.
+ */
+export function uninstallPluginRuntimeForTests(): void {
+  delete (globalThis as GlobalWithRuntime)[RUNTIME_GLOBAL_KEY];
+}


### PR DESCRIPTION
## Summary

- Workspace plugins (`<workspaceDir>/plugins/*`) silently fail to register when the daemon is a `bun --compile` binary. Absolute-path imports re-load fresh disk copies into a disjoint module graph; `registerPlugin()` writes to a registry the daemon never reads.
- Fix: expose `globalThis.__vellumPluginRuntime` with stable `registerPlugin` / `assistantEventHub` / `getSecureKeyAsync` handles. Daemon installs once before `loadUserPlugins()` runs; plugins read from there instead of importing.
- Updates the echo example and `assistant/docs/plugins.md` to the new pattern. The "must symlink from repo" caveat is now limited to type-only imports (erased at runtime; no module-identity effect).

## Test plan

- [x] New unit test `plugin-external-api.test.ts` covers install/get/idempotency/teardown.
- [x] Existing plugin tests pass (`plugin-registry.test.ts`, `plugin-bootstrap.test.ts`).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->