### PR TITLE
test(credentials): allow plugins/external-api.ts to import secure-keys

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -226,6 +226,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path
+      "plugins/external-api.ts", // globalThis runtime bridge that exposes getSecureKeyAsync to dynamically-imported workspace plugins (compiled-binary plugin loading)
       "inbound/platform-callback-registration.ts", // managed credential lookup for platform base URL, assistant ID, and API key
       "tts/providers/elevenlabs-provider.ts", // ElevenLabs TTS API key lookup
       "tts/providers/deepgram-provider.ts", // Deepgram TTS API key lookup


### PR DESCRIPTION
## Summary
- Add \`plugins/external-api.ts\` to the \`ALLOWED_IMPORTERS\` set in \`credential-security-invariants.test.ts\`.
- The file is the globalThis runtime bridge introduced in #30424 that legitimately exposes \`getSecureKeyAsync\` to dynamically-imported workspace plugins so compiled-binary daemons share module identity with plugin code.

## Original prompt
Fix the specific CI issue in the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/25758078026/job/75651746066. The \`credential-security-invariants.test.ts\` test was failing because the new \`plugins/external-api.ts\` (from PR #30424 — globalThis plugin runtime bridge) imports \`secure-keys\` but wasn't listed in the test's allowlist of authorized importers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->