### PR TITLE
docs(contributing): point new engineers to .claude/README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ bun run typecheck
 
 ### Using AI coding assistants
 
-If you use Claude Code, see [.claude/README.md](.claude/README.md) for setup (shared slash commands, fast mode, typical workflow). Other tools have their own configs under `.codex/`, `.agents/`, etc.
+If you use Claude Code, see [.claude/README.md](.claude/README.md) for setup (shared slash commands, fast mode, typical workflow).
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ bun run lint
 bun run typecheck
 ```
 
+### Using AI coding assistants
+
+If you use Claude Code, see [.claude/README.md](.claude/README.md) for setup (shared slash commands, fast mode, typical workflow). Other tools have their own configs under `.codex/`, `.agents/`, etc.
+
 ## Project structure
 
 | Directory | What it is |


### PR DESCRIPTION
## Summary

- Add a short subsection to `CONTRIBUTING.md` pointing developers at [.claude/README.md](.claude/README.md) for Claude Code setup.
- Keeps tool-specific guidance (claude-skills setup, `/fast`, typical workflow) out of the general contribution guide while making it discoverable.

## Why

The Claude Code human-facing setup steps currently live only in `.claude/README.md`. New engineers don't naturally look inside `.claude/` (it reads as "Claude's directory") and `CONTRIBUTING.md` had no mention of AI tooling at all. A one-line breadcrumb is the smallest change that closes the gap without coupling the contribution guide to any specific tool.

## What this PR does not do

- Does **not** move content out of `.claude/README.md` — that file remains the single source of truth for Claude-specific setup.
- Does **not** require Claude Code (or any AI assistant) for contributing — the pointer is opt-in.

## Prompt / plan

Asked Claude Opus 4.7 to audit the repo's AI-tooling docs and recommend any changes for fresh-clone discoverability. The audit found everything already wired correctly (CLAUDE.md → AGENTS.md symlinks committed as git mode 120000, `.claude/`/`.codex/`/`.agents/` all tracked) — the only gap was that `.claude/README.md` setup instructions weren't surfaced from any human-facing doc. This PR is the minimal fix.

## Test plan

- [ ] Render `CONTRIBUTING.md` on GitHub and confirm the new "Using AI coding assistants" subsection renders correctly under "Development setup".
- [ ] Click the [.claude/README.md](.claude/README.md) link from the rendered file and confirm it resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)