### PR TITLE
Emit conversation message sync tags

### DIFF
--- a/assistant/src/__tests__/conversation-message-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-message-sync-tags.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  conversationMessagesSyncTag,
+  type SyncChangedMessage,
+} from "../daemon/message-types/sync.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  assistantEventHub,
+  broadcastMessage,
+} from "../runtime/assistant-event-hub.js";
+import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
+import { waitFor } from "./helpers/wait-for.js";
+
+async function captureEvents(
+  action: () => void | Promise<unknown>,
+  expectedCount: number,
+): Promise<AssistantEvent[]> {
+  const received: AssistantEvent[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      received.push(event);
+    },
+  });
+  try {
+    await action();
+    await waitFor(() => received.length >= expectedCount, {
+      message: "Timed out waiting for conversation message sync tag event",
+    });
+    return received;
+  } finally {
+    subscription.dispose();
+  }
+}
+
+function syncMessages(events: AssistantEvent[]): SyncChangedMessage[] {
+  return events
+    .map((event) => event.message)
+    .filter(
+      (message): message is SyncChangedMessage =>
+        message.type === "sync_changed",
+    );
+}
+
+describe("conversation message sync tags", () => {
+  test("message-history publisher emits the conversation messages tag", async () => {
+    const received = await captureEvents(() => {
+      publishConversationMessagesChanged("conversation-123");
+    }, 1);
+
+    expect(syncMessages(received)).toEqual([
+      {
+        type: "sync_changed",
+        tags: [conversationMessagesSyncTag("conversation-123")],
+      },
+    ]);
+  });
+
+  test("callers can sequence user echo before the message-history tag", async () => {
+    const received = await captureEvents(() => {
+      broadcastMessage({
+        type: "user_message_echo",
+        conversationId: "conversation-123",
+        text: "Hello from another client",
+        messageId: "message-123",
+      });
+      publishConversationMessagesChanged("conversation-123");
+    }, 2);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "user_message_echo",
+      "sync_changed",
+    ]);
+    expect(syncMessages(received)).toEqual([
+      {
+        type: "sync_changed",
+        tags: [conversationMessagesSyncTag("conversation-123")],
+      },
+    ]);
+  });
+
+  test("token deltas do not emit message-history sync tags", async () => {
+    const received = await captureEvents(() => {
+      broadcastMessage({
+        type: "assistant_text_delta",
+        conversationId: "conversation-123",
+        text: "partial",
+      });
+    }, 1);
+
+    expect(received.map((event) => event.message.type)).toEqual([
+      "assistant_text_delta",
+    ]);
+    expect(syncMessages(received)).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -6,6 +6,10 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import {
+  conversationMessagesSyncTag,
+  type SyncChangedMessage,
+} from "../daemon/message-types/sync.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -272,6 +276,8 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { Conversation } from "../daemon/conversation.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { waitFor } from "./helpers/wait-for.js";
 
 type ConversationWithWorkspaceDeps = Conversation & {
   getWorkspaceGitService?: (_workspaceDir: string) => {
@@ -340,6 +346,25 @@ function resolveRun(index: number) {
   });
   run.onEvent({ type: "message_complete", message: assistantMsg });
   run.resolve([...run.messages, assistantMsg]);
+}
+
+function syncChangedMessages(): {
+  messages: SyncChangedMessage[];
+  dispose: () => void;
+} {
+  const messages: SyncChangedMessage[] = [];
+  const subscription = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      if (event.message.type === "sync_changed") {
+        messages.push(event.message);
+      }
+    },
+  });
+  return {
+    messages,
+    dispose: () => subscription.dispose(),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -484,5 +509,35 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
 
     resolveRun(2);
     await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test("/compact failure still emits message-history sync after persisting the user message", async () => {
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    conversation.forceCompact = async () => {
+      throw new Error("compaction failed");
+    };
+
+    const sync = syncChangedMessages();
+    try {
+      await expect(
+        conversation.processMessage("/compact", [], () => {}, "req-compact"),
+      ).rejects.toThrow("compaction failed");
+
+      await waitFor(
+        () =>
+          sync.messages.some(
+            (message) =>
+              message.tags.length === 1 &&
+              message.tags[0] === conversationMessagesSyncTag("conv-1"),
+          ),
+        {
+          message:
+            "Timed out waiting for /compact failure message-history sync tag",
+        },
+      );
+    } finally {
+      sync.dispose();
+    }
   });
 });

--- a/assistant/src/__tests__/process-message-background-slack.test.ts
+++ b/assistant/src/__tests__/process-message-background-slack.test.ts
@@ -145,6 +145,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { conversationMessagesSyncTag } from "../daemon/message-types/sync.js";
 import {
   processMessage,
   processMessageInBackground,
@@ -346,7 +347,13 @@ describe("processMessageInBackground Slack option propagation", () => {
     };
     loopOnEvent?.(delta);
 
-    expect(broadcastMessages).toEqual([delta]);
+    expect(broadcastMessages).toEqual([
+      {
+        type: "sync_changed",
+        tags: [conversationMessagesSyncTag("conv-background-slack")],
+      },
+      delta,
+    ]);
     expect(observedMessages).toEqual([delta]);
 
     activeConversation.__loopDeferred.resolve();

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -124,6 +124,7 @@ import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { UsageActor } from "../usage/actors.js";
@@ -1113,6 +1114,7 @@ export async function runAgentLoopImpl(
     }
 
     const state = createEventHandlerState();
+    let persistedErrorAssistantMessage = false;
 
     // Register confirmation outcome tracker so the agent loop can link
     // confirmation decisions to tool_use_ids for persistence.
@@ -2825,6 +2827,7 @@ export async function runAgentLoopImpl(
         buildPluginTurnContext(ctx, reqId),
         DEFAULT_TIMEOUTS.persistence,
       );
+      persistedErrorAssistantMessage = true;
       newMessages.push(errorAssistantMessage);
       // Do NOT send assistant_text_delta here — handleProviderError already
       // emitted a conversation_error event for this same error text, and the
@@ -2900,6 +2903,15 @@ export async function runAgentLoopImpl(
         convForDisk.createdAt,
       );
     };
+    const publishLoopMessagesChanged = (): void => {
+      if (
+        state.lastAssistantMessageId ||
+        state.persistedToolUseIds.size > 0 ||
+        persistedErrorAssistantMessage
+      ) {
+        publishConversationMessagesChanged(ctx.conversationId);
+      }
+    };
 
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
@@ -2919,6 +2931,7 @@ export async function runAgentLoopImpl(
         type: "generation_cancelled",
         conversationId: ctx.conversationId,
       });
+      publishLoopMessagesChanged();
     } else {
       // Resolve attachments (only when not cancelled — this is expensive async I/O)
       const attachmentResult = await resolveAssistantAttachments(
@@ -2959,6 +2972,7 @@ export async function runAgentLoopImpl(
           type: "generation_cancelled",
           conversationId: ctx.conversationId,
         });
+        publishLoopMessagesChanged();
       } else if (yieldedForHandoff) {
         ctx.traceEmitter.emit(
           "generation_handoff",
@@ -2987,6 +3001,7 @@ export async function runAgentLoopImpl(
             ? { displayMessageId: clientDisplayMessageId }
             : {}),
         });
+        publishLoopMessagesChanged();
       } else {
         ctx.emitActivityState("idle", "message_complete", "global", reqId);
         ctx.traceEmitter.emit(
@@ -3013,6 +3028,7 @@ export async function runAgentLoopImpl(
             ? { displayMessageId: clientDisplayMessageId }
             : {}),
         });
+        publishLoopMessagesChanged();
 
         // Proactive artifact: fire once when the processed turn was the 4th user message.
         // Only trigger for real user-authored turns (not subagent/system messages).

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -772,6 +772,18 @@ export async function runAgentLoopImpl(
 
   ctx.profiler.startRequest();
   let turnStarted = false;
+  const state = createEventHandlerState();
+  let persistedErrorAssistantMessage = false;
+
+  const publishLoopMessagesChanged = (): void => {
+    if (
+      state.lastAssistantMessageId ||
+      state.persistedToolUseIds.size > 0 ||
+      persistedErrorAssistantMessage
+    ) {
+      publishConversationMessagesChanged(ctx.conversationId);
+    }
+  };
 
   // Populate Sentry scope with conversation-specific tags so any exception
   // captured during this turn (e.g. inside agent/loop.ts) can be
@@ -1112,9 +1124,6 @@ export async function runAgentLoopImpl(
         compactedThisTurn = true;
       }
     }
-
-    const state = createEventHandlerState();
-    let persistedErrorAssistantMessage = false;
 
     // Register confirmation outcome tracker so the agent loop can link
     // confirmation decisions to tool_use_ids for persistence.
@@ -2903,16 +2912,6 @@ export async function runAgentLoopImpl(
         convForDisk.createdAt,
       );
     };
-    const publishLoopMessagesChanged = (): void => {
-      if (
-        state.lastAssistantMessageId ||
-        state.persistedToolUseIds.size > 0 ||
-        persistedErrorAssistantMessage
-      ) {
-        publishConversationMessagesChanged(ctx.conversationId);
-      }
-    };
-
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
     // so the client can re-enable the UI without delay.
@@ -3114,6 +3113,7 @@ export async function runAgentLoopImpl(
         type: "generation_cancelled",
         conversationId: ctx.conversationId,
       });
+      publishLoopMessagesChanged();
     } else {
       ctx.emitActivityState("idle", "error_terminal", "global", reqId);
       const message = err instanceof Error ? err.message : String(err);
@@ -3138,6 +3138,7 @@ export async function runAgentLoopImpl(
         errorCategory: classified.errorCategory,
       });
       onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
+      publishLoopMessagesChanged();
     }
   } finally {
     if (turnStarted) {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -31,6 +31,7 @@ import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
+import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { persistQueuedMessageBody } from "./conversation-messaging.js";
 import type {
@@ -570,6 +571,7 @@ async function drainSingleMessage(
         type: "message_complete",
         conversationId: conversation.conversationId,
       });
+      publishConversationMessagesChanged(conversation.conversationId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(
@@ -602,6 +604,7 @@ async function drainSingleMessage(
 
   // /compact — force context compaction, persist exchange, continue draining.
   if (slashResult.kind === "compact") {
+    let persistedCompactMessage = false;
     try {
       const drainProvenance = provenanceFromTrustContext(
         conversation.trustContext,
@@ -630,6 +633,7 @@ async function drainSingleMessage(
         JSON.stringify(cleanUserMsg.content),
         drainChannelMeta,
       );
+      persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
 
       conversation.emitActivityState(
@@ -666,7 +670,11 @@ async function drainSingleMessage(
         type: "message_complete",
         conversationId: conversation.conversationId,
       });
+      publishConversationMessagesChanged(conversation.conversationId);
     } catch (err) {
+      if (persistedCompactMessage) {
+        publishConversationMessagesChanged(conversation.conversationId);
+      }
       const message = err instanceof Error ? err.message : String(err);
       log.error(
         {
@@ -762,6 +770,7 @@ async function drainSingleMessage(
     requestId: next.requestId,
     clientMessageId: next.clientMessageId,
   });
+  publishConversationMessagesChanged(conversation.conversationId);
 
   // Set the active surface for the dequeued message so runAgentLoop can inject context
   conversation.currentActiveSurfaceId = next.activeSurfaceId;
@@ -1087,6 +1096,7 @@ async function drainBatch(
       requestId: qm.requestId,
       clientMessageId: qm.clientMessageId,
     });
+    publishConversationMessagesChanged(conversation.conversationId);
 
     // Persist succeeded. Update last-successful markers so a later tail
     // failure won't overwrite them.
@@ -1446,6 +1456,7 @@ export async function processMessage(
       type: "message_complete",
       conversationId: conversation.conversationId,
     });
+    publishConversationMessagesChanged(conversation.conversationId);
     return persisted.id;
   }
 
@@ -1517,6 +1528,7 @@ export async function processMessage(
         type: "message_complete",
         conversationId: conversation.conversationId,
       });
+      publishConversationMessagesChanged(conversation.conversationId);
       return persisted.id;
     } finally {
       conversation.processing = false;
@@ -1557,6 +1569,7 @@ export async function processMessage(
       undefined,
       displayContent,
     );
+    publishConversationMessagesChanged(conversation.conversationId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     onEvent({

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1463,6 +1463,7 @@ export async function processMessage(
   // /compact — force context compaction, persist exchange, return message ID.
   if (slashResult.kind === "compact") {
     conversation.processing = true;
+    let persistedCompactMessage = false;
     try {
       const pmTurnCtx = conversation.getTurnChannelContext();
       const pmInterfaceCtx = conversation.getTurnInterfaceContext();
@@ -1492,6 +1493,7 @@ export async function processMessage(
         JSON.stringify(cleanUserMsg.content),
         pmChannelMeta,
       );
+      persistedCompactMessage = true;
       conversation.messages.push(cleanUserMsg);
 
       conversation.emitActivityState(
@@ -1530,6 +1532,11 @@ export async function processMessage(
       });
       publishConversationMessagesChanged(conversation.conversationId);
       return persisted.id;
+    } catch (err) {
+      if (persistedCompactMessage) {
+        publishConversationMessagesChanged(conversation.conversationId);
+      }
+      throw err;
     } finally {
       conversation.processing = false;
       await drainQueue(conversation);

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -30,6 +30,7 @@ import {
 import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import { buildSlackMetaForPersistence } from "./conversation-messaging.js";
@@ -368,6 +369,7 @@ export async function processMessage(
       serverChannelMeta,
     );
     conversation.getMessages().push(assistantMsg);
+    publishConversationMessagesChanged(conversationId);
     return { messageId: persisted.id };
   }
 
@@ -421,6 +423,7 @@ export async function processMessage(
       compactChannelMeta,
     );
     conversation.getMessages().push(assistantMsg);
+    publishConversationMessagesChanged(conversationId);
     return { messageId: persisted.id };
   }
 
@@ -436,6 +439,7 @@ export async function processMessage(
     requestId,
     persistMetadata,
   );
+  publishConversationMessagesChanged(conversationId);
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);
@@ -500,6 +504,7 @@ export async function processMessageInBackground(
     requestId,
     persistMetadata,
   );
+  publishConversationMessagesChanged(conversationId);
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);

--- a/assistant/src/proactive-artifact/aux-message-injector.ts
+++ b/assistant/src/proactive-artifact/aux-message-injector.ts
@@ -8,7 +8,10 @@
 
 import { createAssistantMessage } from "../agent/message-types.js";
 import { findConversation } from "../daemon/conversation-store.js";
-import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import {
+  conversationMessagesSyncTag,
+  SYNC_TAGS,
+} from "../daemon/message-types/sync.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import type { BroadcastFn } from "../notifications/adapters/macos.js";
 import { getLogger } from "../util/logger.js";
@@ -74,6 +77,9 @@ export async function injectAuxAssistantMessage(params: {
   });
   params.broadcastMessage({
     type: "sync_changed",
-    tags: [SYNC_TAGS.conversationsList],
+    tags: [
+      SYNC_TAGS.conversationsList,
+      conversationMessagesSyncTag(params.conversationId),
+    ],
   });
 }

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import {
+  conversationMessagesSyncTag,
+  SYNC_TAGS,
+} from "../daemon/message-types/sync.js";
 
 // ── Mock state ──────────────────────────────────────────────────────────
 
@@ -740,7 +743,10 @@ describe("injectAuxAssistantMessage", () => {
     const syncMsg = broadcastCalls.find((c) => c.type === "sync_changed");
     expect(syncMsg).toEqual({
       type: "sync_changed",
-      tags: [SYNC_TAGS.conversationsList],
+      tags: [
+        SYNC_TAGS.conversationsList,
+        conversationMessagesSyncTag("conv-inject-1"),
+      ],
     });
   });
 
@@ -837,7 +843,13 @@ describe("injectAuxAssistantMessage", () => {
       broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
     ).toHaveLength(1);
     expect(broadcastCalls.filter((c) => c.type === "sync_changed")).toEqual([
-      { type: "sync_changed", tags: [SYNC_TAGS.conversationsList] },
+      {
+        type: "sync_changed",
+        tags: [
+          SYNC_TAGS.conversationsList,
+          conversationMessagesSyncTag("conv-inject-3"),
+        ],
+      },
     ]);
   });
 
@@ -866,7 +878,13 @@ describe("injectAuxAssistantMessage", () => {
       broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
     ).toHaveLength(1);
     expect(broadcastCalls.filter((c) => c.type === "sync_changed")).toEqual([
-      { type: "sync_changed", tags: [SYNC_TAGS.conversationsList] },
+      {
+        type: "sync_changed",
+        tags: [
+          SYNC_TAGS.conversationsList,
+          conversationMessagesSyncTag("conv-inject-4"),
+        ],
+      },
     ]);
   });
 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -113,7 +113,10 @@ import type {
 } from "../http-types.js";
 import { resolveLocalTrustContext } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { publishConversationListAndMetadataChanged } from "../sync/resource-sync-events.js";
+import {
+  publishConversationListAndMetadataChanged,
+  publishConversationMessagesChanged,
+} from "../sync/resource-sync-events.js";
 import {
   resolveTrustContext,
   withSourceChannel,
@@ -339,6 +342,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
       });
       onEvent({ type: "message_complete", conversationId: conversationId });
     }
+    publishConversationMessagesChanged(conversationId);
   } catch (err) {
     log.warn(
       { err, conversationId },
@@ -1519,6 +1523,7 @@ export async function handleSendMessage(
           conversationId,
         });
         broadcastMessage({ type: "message_complete", conversationId });
+        publishConversationMessagesChanged(conversationId);
         conversation.processing = false;
         silentlyWithLog(
           conversation.drainQueue(),
@@ -1822,6 +1827,7 @@ export async function handleSendMessage(
           type: "message_complete",
           conversationId: conversationId,
         });
+        publishConversationMessagesChanged(conversationId);
         conversation.processing = false;
         silentlyWithLog(conversation.drainQueue(), "slash-command queue drain");
       }, 0);
@@ -1896,7 +1902,9 @@ export async function handleSendMessage(
           conversationId,
         });
         broadcastMessage({ type: "message_complete", conversationId });
+        publishConversationMessagesChanged(conversationId);
       } catch (err) {
+        publishConversationMessagesChanged(conversationId);
         log.error({ err, conversationId }, "Compact command failed");
         broadcastMessage({
           type: "conversation_error",
@@ -1944,6 +1952,7 @@ export async function handleSendMessage(
     requestId,
     clientMessageId,
   });
+  publishConversationMessagesChanged(mapping.conversationId);
 
   // Fire-and-forget the agent loop; events flow to the hub via broadcastMessage.
   conversation

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1869,6 +1869,7 @@ export async function handleSendMessage(
     // forceCompact() makes an LLM call that can exceed the client's
     // HTTP timeout on large contexts, causing a false "Failed to send".
     (async () => {
+      let assistantMessagePersisted = false;
       try {
         broadcastMessage({
           type: "user_message_echo",
@@ -1877,6 +1878,7 @@ export async function handleSendMessage(
           messageId: persisted.id,
           clientMessageId,
         });
+        publishConversationMessagesChanged(conversationId);
         conversation.emitActivityState(
           "thinking",
           "context_compacting",
@@ -1894,6 +1896,7 @@ export async function handleSendMessage(
           JSON.stringify(assistantMsg.content),
           channelMeta,
         );
+        assistantMessagePersisted = true;
         conversation.getMessages().push(assistantMsg);
 
         broadcastMessage({
@@ -1904,7 +1907,9 @@ export async function handleSendMessage(
         broadcastMessage({ type: "message_complete", conversationId });
         publishConversationMessagesChanged(conversationId);
       } catch (err) {
-        publishConversationMessagesChanged(conversationId);
+        if (assistantMessagePersisted) {
+          publishConversationMessagesChanged(conversationId);
+        }
         log.error({ err, conversationId }, "Compact command failed");
         broadcastMessage({
           type: "conversation_error",

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -1,6 +1,7 @@
 import type { IdentityFields } from "../../daemon/handlers/identity.js";
 import type { ConversationListInvalidatedReason } from "../../daemon/message-types/conversations.js";
 import {
+  conversationMessagesSyncTag,
   conversationMetadataSyncTag,
   SYNC_TAGS,
 } from "../../daemon/message-types/sync.js";
@@ -46,6 +47,12 @@ export function publishConversationListChanged(
     reason,
   });
   void publishSyncInvalidation([SYNC_TAGS.conversationsList]);
+}
+
+export function publishConversationMessagesChanged(
+  conversationId: string,
+): void {
+  void publishSyncInvalidation([conversationMessagesSyncTag(conversationId)]);
 }
 
 export function publishConversationListAndMetadataChanged(


### PR DESCRIPTION
## Summary
- add a conversation message-history sync publisher for `conversation:<id>:messages`
- emit message-history invalidations after durable user-message writes, assistant turn completion/cancel/handoff, slash/compact fast paths, channel process-message paths, and proactive auxiliary assistant message injection
- keep message-history tags separate from list/metadata tags and avoid emitting them for token deltas

## Tests
- `bun test src/__tests__/conversation-message-sync-tags.test.ts src/runtime/sync/sync-publisher.test.ts`
- `bun test src/proactive-artifact/job.test.ts`
- `bun test src/__tests__/conversation-sync-tags.test.ts`
- `bun test src/__tests__/process-message-background-slack.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`