### PR TITLE
feat(providers): add DeepSeek V4 Pro, V4 Flash, V3.2 Speciale via OpenRouter

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -236,8 +236,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.5,
           tiers: [
             {
-              inputTokenThreshold:
-                OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 10,
               outputPer1mTokens: 45,
               cacheReadPer1mTokens: 1,
@@ -261,8 +260,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           outputPer1mTokens: 180.0,
           tiers: [
             {
-              inputTokenThreshold:
-                OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 60,
               outputPer1mTokens: 270,
             },
@@ -286,8 +284,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.25,
           tiers: [
             {
-              inputTokenThreshold:
-                OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
               inputPer1mTokens: 5,
               outputPer1mTokens: 22.5,
               cacheReadPer1mTokens: 0.5,
@@ -695,6 +692,39 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: { inputPer1mTokens: 0.27, outputPer1mTokens: 1.1 },
+      },
+      {
+        id: "deepseek/deepseek-v4-pro",
+        displayName: "DeepSeek V4 Pro",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 384000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 0.435, outputPer1mTokens: 0.87 },
+      },
+      {
+        id: "deepseek/deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 384000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 0.14, outputPer1mTokens: 0.28 },
+      },
+      {
+        id: "deepseek/deepseek-v3.2-speciale",
+        displayName: "DeepSeek V3.2 Speciale",
+        contextWindowTokens: 163840,
+        maxOutputTokens: 163840,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: false,
+        pricing: { inputPer1mTokens: 0.287, outputPer1mTokens: 0.431 },
       },
       // Qwen
       {

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -633,6 +633,54 @@
           }
         },
         {
+          "id": "deepseek/deepseek-v4-pro",
+          "displayName": "DeepSeek V4 Pro",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 384000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.435,
+            "outputPer1mTokens": 0.87
+          }
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash",
+          "displayName": "DeepSeek V4 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 384000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.14,
+            "outputPer1mTokens": 0.28
+          }
+        },
+        {
+          "id": "deepseek/deepseek-v3.2-speciale",
+          "displayName": "DeepSeek V3.2 Speciale",
+          "contextWindowTokens": 163840,
+          "maxOutputTokens": 163840,
+          "defaultContextWindowTokens": 163840,
+          "longContextMode": "unsupported",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": false,
+          "pricing": {
+            "inputPer1mTokens": 0.287,
+            "outputPer1mTokens": 0.431
+          }
+        },
+        {
           "id": "qwen/qwen3.5-plus-02-15",
           "displayName": "Qwen 3.5 Plus",
           "contextWindowTokens": 131072,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -633,6 +633,54 @@
           }
         },
         {
+          "id": "deepseek/deepseek-v4-pro",
+          "displayName": "DeepSeek V4 Pro",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 384000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.435,
+            "outputPer1mTokens": 0.87
+          }
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash",
+          "displayName": "DeepSeek V4 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 384000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.14,
+            "outputPer1mTokens": 0.28
+          }
+        },
+        {
+          "id": "deepseek/deepseek-v3.2-speciale",
+          "displayName": "DeepSeek V3.2 Speciale",
+          "contextWindowTokens": 163840,
+          "maxOutputTokens": 163840,
+          "defaultContextWindowTokens": 163840,
+          "longContextMode": "unsupported",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": false,
+          "pricing": {
+            "inputPer1mTokens": 0.287,
+            "outputPer1mTokens": 0.431
+          }
+        },
+        {
           "id": "qwen/qwen3.5-plus-02-15",
           "displayName": "Qwen 3.5 Plus",
           "contextWindowTokens": 131072,


### PR DESCRIPTION
## Summary

Adds three new DeepSeek model entries to the OpenRouter section of the catalog plus the mirrored JSON projection.

| Slug | Context | Max output | Thinking | Tools | $/M in | $/M out |
|---|---|---|---|---|---|---|
| `deepseek/deepseek-v4-pro` | 1,048,576 | 384,000 | ✓ | ✓ | 0.435 | 0.87 |
| `deepseek/deepseek-v4-flash` | 1,048,576 | 384,000 | ✓ | ✓ | 0.14 | 0.28 |
| `deepseek/deepseek-v3.2-speciale` | 163,840 | 163,840 | ✓ | ✗ | 0.287 | 0.431 |

Specs sourced from `openrouter.ai/api/v1/models` on 2026-05-12.

## Notes for review

- **`supportsCaching: false` on all three** — matches precedent for non-Anthropic OpenRouter entries per #27138's design note ("caching isn't propagated through the router in this deployment"). OpenRouter does expose `input_cache_read` pricing upstream, but our router integration doesn't carry it through; flagging `true` here would mislead cost accounting.
- **V3.2 Speciale has `supportsToolUse: false`** — `tools`/`tool_choice` are not in OpenRouter's `supported_parameters` for that model. V4 Pro/Flash both list `tools`.
- **No platform billing rate-card entries needed** — OpenRouter is configured as a BYOK provider (`managed: false` in `MANAGED_PROVIDER_META`), so requests don't traverse the platform's runtime proxy and `BILLING_RUNTIME_TOKEN_RATE_CARDS["openrouter"]` is intentionally not configured.
- **Pre-existing prettier drift** on 3 unrelated OpenAI rows (lines 236/261/286, single `inputTokenThreshold:` collapsings) was fixed by the precommit hook running prettier on the file. Cosmetic.

## Companion PR needed

The platform repo vendors a copy of `meta/llm-provider-catalog.json` at `vellum-assistant-platform/web/src/lib/generated/llm-provider-catalog.json` (used by the web UI). After this PR merges, a follow-up PR in `vellum-assistant-platform` is needed to:

1. Copy the updated `meta/llm-provider-catalog.json` over.
2. Run `cd web && bun run sync:llm-model-catalog` to regenerate `web/src/lib/llm-model-catalog.ts`.

This is the established manual sync pattern (per the script comment "Drift between the vendored JSON and upstream is handled separately"). Without it, the web UI won't show the new DeepSeek entries.

## Test plan

- [x] `cd assistant && bun test src/__tests__/llm-catalog-parity.test.ts` — 14 pass / 948 assertions
- [x] `cd assistant && bunx tsc --noEmit` clean
- [x] Precommit hook (prettier + eslint + tsc) clean
- [ ] Smoke: route a chat through each new model once `OPENROUTER_API_KEY` is provisioned
- [ ] Companion PR in `vellum-assistant-platform` to mirror catalog → web UI

Closes JARVIS-783