### PR TITLE
[codex] Reconcile loaded macOS chat history

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -97,11 +97,16 @@ final class ConversationManager: ConversationRestorerDelegate {
     /// message POST includes it for assistant personalization.
     var preChatContext: PreChatOnboardingContext?
 
-    // MARK: - Notification Catch-Up
+    // MARK: - History Catch-Up
 
-    /// Daemon conversation IDs that need a notification catch-up (history fetch)
-    /// once the associated ChatViewModel finishes its current send/think cycle.
-    @ObservationIgnored private var pendingNotificationCatchUpIds: Set<String> = []
+    private struct PendingHistoryCatchUp {
+        let requiresLoadedHistory: Bool
+    }
+
+    /// Daemon conversation IDs that need a history catch-up once the associated
+    /// ChatViewModel finishes an observed send/think/queue or history-load block.
+    @ObservationIgnored private var pendingHistoryCatchUpsByDaemonId: [String: PendingHistoryCatchUp] = [:]
+    @ObservationIgnored private var pendingHistoryCatchUpRetryTasks: [String: Task<Void, Never>] = [:]
 
     // MARK: - App-Layer Callbacks
 
@@ -244,7 +249,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         wireStoreCallbacks()
 
         activityStore.onBusyToIdle = { [weak self] conversationId in
-            self?.drainPendingNotificationCatchUp(for: conversationId)
+            self?.drainPendingHistoryCatchUp(for: conversationId)
         }
         activityStore.onAssistantActivityChange = { [weak self] conversationId, previousSnapshot, currentSnapshot in
             self?.handleAssistantMessageArrival(conversationId: conversationId, previousSnapshot: previousSnapshot, currentSnapshot: currentSnapshot)
@@ -408,6 +413,10 @@ final class ConversationManager: ConversationRestorerDelegate {
 
     func appendConversations(from response: ConversationListResponseMessage) {
         listStore.appendConversations(from: response)
+    }
+
+    func reconcileLoadedConversationHistory(localId: UUID, daemonConversationId: String) {
+        requestHistoryCatchUp(localId: localId, daemonConversationId: daemonConversationId, requiresLoadedHistory: true)
     }
 
     func mergeAssistantAttention(from item: ConversationListResponseItem, intoConversationAt index: Int) {
@@ -1089,7 +1098,7 @@ final class ConversationManager: ConversationRestorerDelegate {
 
     func refreshActiveConversation() {
         guard let conversationId = activeConversation?.conversationId else { return }
-        activeViewModel?.prepareForNotificationCatchUp()
+        activeViewModel?.prepareForLatestHistoryReconciliation()
         conversationRestorer.requestReconnectHistory(conversationId: conversationId)
     }
 
@@ -1404,12 +1413,8 @@ final class ConversationManager: ConversationRestorerDelegate {
         }
         listStore.conversations[idx] = conversation
 
-        if let vm = selectionStore.chatViewModels[localId], !vm.isThinking, !vm.isSending {
-            pendingNotificationCatchUpIds.remove(daemonConversationId)
-            vm.prepareForNotificationCatchUp()
-            conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
-        } else if selectionStore.chatViewModels[localId] != nil {
-            pendingNotificationCatchUpIds.insert(daemonConversationId)
+        if selectionStore.chatViewModels[localId] != nil {
+            requestHistoryCatchUp(localId: localId, daemonConversationId: daemonConversationId)
         }
     }
 
@@ -1608,14 +1613,90 @@ final class ConversationManager: ConversationRestorerDelegate {
         activityStore.unsubscribeAll(for: id)
     }
 
-    // MARK: - Notification Catch-Up
+    // MARK: - History Catch-Up
 
-    private func drainPendingNotificationCatchUp(for conversationId: UUID) {
+    private func requestHistoryCatchUp(
+        localId: UUID,
+        daemonConversationId: String,
+        requiresLoadedHistory: Bool = false
+    ) {
+        guard let vm = selectionStore.chatViewModels[localId] else { return }
+        if requiresLoadedHistory, !vm.isHistoryLoaded {
+            guard vm.isLoadingHistory else {
+                clearPendingHistoryCatchUp(daemonConversationId)
+                return
+            }
+            queuePendingHistoryCatchUp(
+                daemonConversationId: daemonConversationId,
+                requiresLoadedHistory: requiresLoadedHistory,
+                retryAfterDelayFor: localId
+            )
+            return
+        }
+        if requiresLoadedHistory, vm.isLoadingHistory || vm.isLoadingMoreMessages {
+            queuePendingHistoryCatchUp(
+                daemonConversationId: daemonConversationId,
+                requiresLoadedHistory: requiresLoadedHistory,
+                retryAfterDelayFor: localId
+            )
+            return
+        }
+        guard !isHistoryCatchUpBlockedByObservedActivity(vm) else {
+            queuePendingHistoryCatchUp(
+                daemonConversationId: daemonConversationId,
+                requiresLoadedHistory: requiresLoadedHistory
+            )
+            return
+        }
+        clearPendingHistoryCatchUp(daemonConversationId)
+        vm.prepareForLatestHistoryReconciliation()
+        conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
+    }
+
+    private func drainPendingHistoryCatchUp(for conversationId: UUID) {
         guard let daemonId = listStore.conversations.first(where: { $0.id == conversationId })?.conversationId,
-              pendingNotificationCatchUpIds.remove(daemonId) != nil,
-              let vm = selectionStore.chatViewModels[conversationId] else { return }
-        vm.prepareForNotificationCatchUp()
-        conversationRestorer.requestReconnectHistory(conversationId: daemonId)
+              let pending = pendingHistoryCatchUpsByDaemonId[daemonId] else { return }
+        guard selectionStore.chatViewModels[conversationId] != nil else {
+            clearPendingHistoryCatchUp(daemonId)
+            return
+        }
+        requestHistoryCatchUp(
+            localId: conversationId,
+            daemonConversationId: daemonId,
+            requiresLoadedHistory: pending.requiresLoadedHistory
+        )
+    }
+
+    private func isHistoryCatchUpBlockedByObservedActivity(_ vm: ChatViewModel) -> Bool {
+        vm.isSending || vm.isThinking || vm.pendingQueuedCount > 0
+    }
+
+    private func queuePendingHistoryCatchUp(
+        daemonConversationId: String,
+        requiresLoadedHistory: Bool,
+        retryAfterDelayFor localId: UUID? = nil
+    ) {
+        let existing = pendingHistoryCatchUpsByDaemonId[daemonConversationId]
+        pendingHistoryCatchUpsByDaemonId[daemonConversationId] = PendingHistoryCatchUp(
+            requiresLoadedHistory: (existing?.requiresLoadedHistory ?? true) && requiresLoadedHistory
+        )
+        guard let localId else { return }
+        schedulePendingHistoryCatchUpRetry(daemonConversationId: daemonConversationId, localId: localId)
+    }
+
+    private func clearPendingHistoryCatchUp(_ daemonConversationId: String) {
+        pendingHistoryCatchUpsByDaemonId.removeValue(forKey: daemonConversationId)
+        pendingHistoryCatchUpRetryTasks.removeValue(forKey: daemonConversationId)?.cancel()
+    }
+
+    private func schedulePendingHistoryCatchUpRetry(daemonConversationId: String, localId: UUID) {
+        guard pendingHistoryCatchUpRetryTasks[daemonConversationId] == nil else { return }
+        pendingHistoryCatchUpRetryTasks[daemonConversationId] = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled, let self else { return }
+            self.pendingHistoryCatchUpRetryTasks.removeValue(forKey: daemonConversationId)
+            self.drainPendingHistoryCatchUp(for: localId)
+        }
     }
 
     // MARK: - Managed Key Reprovisioning

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -29,6 +29,10 @@ protocol ConversationRestorerDelegate: AnyObject {
     func isConversationArchived(_ conversationId: String) -> Bool
     func restoreLastActiveConversation()
     func appendConversations(from response: ConversationListResponseMessage)
+    /// Queue a latest-history reconciliation for an already-loaded conversation.
+    /// Used when a conversation-list refresh shows that another client advanced
+    /// the conversation while this client may have missed the live SSE event.
+    func reconcileLoadedConversationHistory(localId: UUID, daemonConversationId: String)
     /// Returns an existing ChatViewModel matching the given conversation ID, if any.
     func existingChatViewModel(forConversationId conversationId: String) -> ChatViewModel?
     /// Merge daemon attention metadata into an existing conversation, allowing the
@@ -88,6 +92,11 @@ final class ConversationRestorer {
     /// NotificationCenter observer token for `NSApplication.didBecomeActiveNotification`.
     /// Kept for the lifetime of the restorer to catch every activation.
     private var appDidBecomeActiveObserver: NSObjectProtocol?
+    /// Last `lastMessageAt` observed in a list response for loaded conversations.
+    /// This prevents app activation/list invalidation refreshes from repeatedly
+    /// fetching the same latest history page when the server-side latest message
+    /// has not changed.
+    private var observedListLastMessageAtByConversationId: [String: Int] = [:]
 
     weak var delegate: ConversationRestorerDelegate?
 
@@ -421,6 +430,11 @@ final class ConversationRestorer {
                 // arrived).
                 delegate.applyAssistantAttention(from: session, into: &existing)
                 snapshot[existingIdx] = existing
+                requestLoadedHistoryReconciliationIfNeeded(
+                    localId: existing.id,
+                    daemonConversationId: session.id,
+                    serverLastMessageAtMillis: session.lastMessageAt
+                )
                 continue
             }
 
@@ -568,6 +582,22 @@ final class ConversationRestorer {
         guard let delegate else { return }
         guard let index = delegate.conversations.firstIndex(where: { $0.conversationId == response.conversationId }) else { return }
         delegate.conversations[index].title = response.title
+    }
+
+    private func requestLoadedHistoryReconciliationIfNeeded(
+        localId: UUID,
+        daemonConversationId: String,
+        serverLastMessageAtMillis: Int?
+    ) {
+        guard let serverLastMessageAtMillis else { return }
+        guard observedListLastMessageAtByConversationId[daemonConversationId] != serverLastMessageAtMillis else {
+            return
+        }
+        observedListLastMessageAtByConversationId[daemonConversationId] = serverLastMessageAtMillis
+        delegate?.reconcileLoadedConversationHistory(
+            localId: localId,
+            daemonConversationId: daemonConversationId
+        )
     }
 
     // MARK: - Invalidation Debounce

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -18,6 +18,7 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     var activatedConversationId: UUID?
     var createConversationCallCount = 0
     var archivedConversationIds: Set<String> = []
+    var loadedHistoryReconciliationRequests: [(localId: UUID, daemonConversationId: String)] = []
     private let connectionManager: GatewayConnectionManager
     private let eventStreamClient: EventStreamClient
 
@@ -76,6 +77,10 @@ final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
 
     func appendConversations(from response: ConversationListResponseMessage) {
         // no-op for tests
+    }
+
+    func reconcileLoadedConversationHistory(localId: UUID, daemonConversationId: String) {
+        loadedHistoryReconciliationRequests.append((localId, daemonConversationId))
     }
 
     func applyAssistantAttention(
@@ -755,6 +760,40 @@ struct ConversationRestorerTests {
         // AND mutable metadata (lastInteractedAt) was refreshed from the server
         let expectedDate = Date(timeIntervalSince1970: TimeInterval(5000) / 1000.0)
         #expect(conversationAfter?.lastInteractedAt == expectedDate)
+    }
+
+    @Test @MainActor
+    func refreshRequestsLatestHistoryReconciliationWhenLatestMessageTimestampChanges() {
+        let dc = GatewayConnectionManager()
+        let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
+        let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
+        restorer.delegate = delegate
+
+        let conversation = ConversationModel(title: "Chat A", conversationId: "sa")
+        delegate.conversations = [conversation]
+
+        let firstRefresh = makeConversationListResponse(conversationDicts: [[
+            "id": "sa",
+            "title": "Chat A",
+            "updatedAt": 2_000,
+            "lastMessageAt": 2_000,
+        ]])
+        restorer.handleConversationListResponse(firstRefresh)
+
+        #expect(delegate.loadedHistoryReconciliationRequests.count == 1)
+        #expect(delegate.loadedHistoryReconciliationRequests.first?.localId == conversation.id)
+        #expect(delegate.loadedHistoryReconciliationRequests.first?.daemonConversationId == "sa")
+
+        restorer.handleConversationListResponse(firstRefresh)
+        #expect(delegate.loadedHistoryReconciliationRequests.count == 1)
+
+        restorer.handleConversationListResponse(makeConversationListResponse(conversationDicts: [[
+            "id": "sa",
+            "title": "Chat A",
+            "updatedAt": 3_000,
+            "lastMessageAt": 3_000,
+        ]]))
+        #expect(delegate.loadedHistoryReconciliationRequests.count == 2)
     }
 
     /// Verifies that a default-titled conversation gets its title updated

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1370,19 +1370,24 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         }
     }
 
-    // MARK: - Notification Catch-Up
+    // MARK: - History Catch-Up
 
-    /// Prepare the view model for a notification catch-up history fetch.
+    /// Prepare the view model for a latest-history reconciliation fetch.
     ///
     /// Sets `needsReconnectCatchUp` so the next `populateFromHistory` call uses
-    /// the smart merge path (server-authoritative list + preserved unsent locals)
-    /// instead of the prepend-older-only path which would drop the new message.
+    /// the server-authoritative merge path instead of the prepend-older-only
+    /// path, which is only safe for initial history races.
+    public func prepareForLatestHistoryReconciliation() {
+        needsReconnectCatchUp = true
+    }
+
+    /// Prepare the view model for a notification catch-up history fetch.
     ///
     /// Called by ConversationManager when a `notification_intent` arrives for a
     /// conversation that already has an active ViewModel. Must be followed by a
     /// `requestReconnectHistory()` call on the ConversationRestorer.
     public func prepareForNotificationCatchUp() {
-        needsReconnectCatchUp = true
+        prepareForLatestHistoryReconciliation()
     }
 
     /// Prepare the view model for a channel conversation refresh.
@@ -1390,7 +1395,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// `needsReconnectCatchUp` so `populateFromHistory` does an atomic
     /// message replace instead of clearing the array first.
     public func prepareForChannelRefresh() {
-        needsReconnectCatchUp = true
+        prepareForLatestHistoryReconciliation()
         isHistoryLoaded = false
     }
 


### PR DESCRIPTION
## Summary
- Reconcile already-loaded macOS chat histories when conversation-list metadata shows a newer latest message.
- Route list-driven, notification-driven, and channel-refresh catch-ups through the same server-authoritative history merge path.
- Add regression coverage that dedupes reconciliation requests by `lastMessageAt` and retries when the timestamp advances.

## Root Cause
macOS refreshed the conversation list when the app became active, but an already-loaded `ChatViewModel` could keep stale history. `loadHistoryIfNeeded` skips loaded threads, and the normal non-catch-up reconstruction path only prepends older messages, so messages sent from web/mobile could remain invisible in desktop until a stronger reload path ran.

## Impact
When web or mobile appends messages to a conversation that desktop already has loaded, desktop now treats the changed conversation-list `lastMessageAt` as a hint to fetch the latest authoritative history. The manager defers while the assistant is busy and then reconciles through the catch-up merge path.

## Validation
- `git diff --check`
- `swift build --package-path clients --target VellumAssistantLib`
- pre-push hook: full Swift build for `vellum-assistant` product and design-token guard

Note: a focused Swift test runner invocation was attempted locally, but the runner crashed before assertions because `llm-provider-catalog.json` was not found in the SwiftPM test resource bundle.