### PR TITLE
feat(assistant): make NOW.md injection configurable

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -361,6 +361,27 @@ describe("AssistantConfigSchema", () => {
     });
   });
 
+  test("scratchpad injection defaults to enabled", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.memory.retrieval.scratchpadInjection).toEqual({
+      enabled: true,
+    });
+  });
+
+  test("scratchpad injection accepts disabled override", () => {
+    const result = AssistantConfigSchema.parse({
+      memory: { retrieval: { scratchpadInjection: { enabled: false } } },
+    });
+    expect(result.memory.retrieval.scratchpadInjection.enabled).toBe(false);
+  });
+
+  test("scratchpad injection rejects non-boolean enabled", () => {
+    const result = AssistantConfigSchema.safeParse({
+      memory: { retrieval: { scratchpadInjection: { enabled: "yes" } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
   test("applies memory.cleanup defaults", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.cleanup).toEqual({

--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -284,6 +284,21 @@ const MemoryInjectionConfigSchema = z
     "Controls how many memory items are injected at conversation start and per turn",
   );
 
+const ScratchpadInjectionConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({
+        error: "memory.retrieval.scratchpadInjection.enabled must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Whether NOW.md scratchpad content is injected into the conversation prompt. Injection occurs on the first turn and post-compaction; flipping this off takes effect on the next conversation or compaction.",
+      ),
+  })
+  .describe(
+    "Controls whether the user-maintained NOW.md scratchpad is injected into prompts",
+  );
+
 export const MemoryRetrievalConfigSchema = z
   .object({
     maxInjectTokens: z
@@ -311,6 +326,9 @@ export const MemoryRetrievalConfigSchema = z
     ),
     injection: MemoryInjectionConfigSchema.default(
       MemoryInjectionConfigSchema.parse({}),
+    ),
+    scratchpadInjection: ScratchpadInjectionConfigSchema.default(
+      ScratchpadInjectionConfigSchema.parse({}),
     ),
   })
   .describe(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1440,9 +1440,13 @@ export async function runAgentLoopImpl(
     // are never stripped on normal turns — this preserves the cached prefix.
     // PKB/NOW content is sourced from the `memoryRetrieval` pipeline above
     // so plugins can override either source without touching the agent loop.
-    const currentNowContent = personalMemoryAllowed
-      ? memoryResult.nowContent
-      : null;
+    // NOW.md injection can be disabled via `memory.retrieval.scratchpadInjection.enabled`.
+    const scratchpadInjectionEnabled =
+      getConfig().memory.retrieval.scratchpadInjection.enabled;
+    const currentNowContent =
+      personalMemoryAllowed && scratchpadInjectionEnabled
+        ? memoryResult.nowContent
+        : null;
     const shouldInjectNowAndPkb = isFirstMessage || compactedThisTurn;
     const nowScratchpad = shouldInjectNowAndPkb ? currentNowContent : null;
 

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { z } from "zod";
 
+import { getConfig } from "../../config/loader.js";
 import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { buildToolDefinitions } from "../../daemon/conversation-tool-setup.js";
@@ -92,7 +93,10 @@ async function handleBtw({
 
   // ----- Greeting context enrichment -----
   let effectiveContent = trimmedContent;
-  if (conversationKey === GREETING_KEY) {
+  if (
+    conversationKey === GREETING_KEY &&
+    getConfig().memory.retrieval.scratchpadInjection.enabled
+  ) {
     const now = readNowScratchpad();
     if (now) {
       effectiveContent = `${trimmedContent}\n\n<context>\n${now}\n</context>`;


### PR DESCRIPTION
## Summary
- Add `memory.retrieval.scratchpadInjection.enabled` config flag (default `true`) — flipping it to `false` stops NOW.md from being injected into prompts.
- Gate both known injection sites: the main agent-loop (`conversation-agent-loop.ts`, first-turn / post-compaction) and the BTW greeting sidechain (`btw-routes.ts`).
- Reads remain unconditional; only the injection is skipped, so `memoryResult.nowContent` stays available for future inspection / UX paths.

## Original prompt
User asked whether NOW.md injection could be made configurable. Today injection happens unconditionally on first turn / post-compaction and in the BTW greeting fast-path. Plan: add a single boolean under `memory.retrieval.scratchpadInjection`, default `true` for zero behavior change, gate the two known injection sites, leave the `nowMdInjector` untouched since it already short-circuits on null content. Flipping the flag mid-conversation takes effect on the next conversation or the next compaction — acceptable given how the cadence works.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->