### PR TITLE
test(assistant): backfill missing scratchpadInjection in conversation test mocks

### DIFF
--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -55,7 +55,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -84,6 +84,7 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
+    memory: { retrieval: { scratchpadInjection: { enabled: true } } },
     ui: {},
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -87,6 +87,7 @@ mock.module("../config/loader.js", () => ({
     llm: mockLlmConfig,
     rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
+    memory: { retrieval: { scratchpadInjection: { enabled: true } } },
     ui: {},
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -61,6 +61,7 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
+    memory: { retrieval: { scratchpadInjection: { enabled: true } } },
     ui: mockUiConfig,
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -97,7 +97,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -57,7 +57,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     services: {
       inference: {
         mode: "your-own",

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -77,7 +77,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     conversations: { skipAutoRetitling: false },
     timeouts: { permissionTimeoutSec: 1 },
     skills: { entries: {}, allowBundled: true },

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -60,7 +60,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     conversations: { skipAutoRetitling: false },
     daemon: {
       startupSocketWaitMs: 5000,

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -60,7 +60,10 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { v2: { enabled: false } },
+    memory: {
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -63,7 +63,11 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { enabled: false, v2: { enabled: false } },
+    memory: {
+      enabled: false,
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -61,7 +61,11 @@ mock.module("../config/loader.js", () => ({
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
-    memory: { enabled: false, v2: { enabled: false } },
+    memory: {
+      enabled: false,
+      v2: { enabled: false },
+      retrieval: { scratchpadInjection: { enabled: true } },
+    },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,


### PR DESCRIPTION
## Summary
- Adds `memory.retrieval.scratchpadInjection.enabled: true` to the mocked `getConfig()` return value in 11 conversation tests.
- Unblocks the Test job on main, which broke after #30441 began reading the new config field without updating these mocks.

## Original prompt
Fix the specific CI issue in the failing Test job (run 25765318469) on commit 4129735dc9 (NOW.md injection configurable, #30441). The PR added a strict read of `getConfig().memory.retrieval.scratchpadInjection.enabled` in `conversation-agent-loop.ts`, but eleven conversation test files mock `getConfig()` with a partial config that omits `memory.retrieval`, so the new property access throws `TypeError: undefined is not an object` before the agent loop ever runs. Restore CI without touching the production behavior added by #30441.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->