### PR TITLE
chore(ci): add GitHub-to-Slack mappings for new team members

### DIFF
--- a/.github/config/github_slack_mapping.yaml
+++ b/.github/config/github_slack_mapping.yaml
@@ -7,7 +7,9 @@ github_to_slack_all_notifications:
   emmiekehoe: U08Q1QHGKTM
   alex-nork: U095KUZ3L20
   Jasonnnz: U09DVL1JN3V
+  marinatrajk: U0A6VKE2RAA
   vex-assistant-bot[bot]: U0ALUGLCUFJ
+  agarg5: U0B40DTTR08
 
 github_to_slack_failure_notifications: # neutral good
   asharma53: U04BTP01B2S
@@ -20,3 +22,7 @@ github_to_slack_failure_notifications: # neutral good
 github_to_slack_success_notifications: # chaotic evil
 
 github_to_slack_cancelled_notifications: # chaotic neutral
+  dvargas92495: U05D5EGNNMS
+  clopen-set: U08QQU27M0W
+  m-abboud: U06CMAEKH4L
+  Shaarson: U08EREL8F18


### PR DESCRIPTION
## Summary
- Add `marinatrajk` and `agarg5` to all-notifications mapping
- Add `dvargas92495`, `clopen-set`, `m-abboud`, and `Shaarson` to cancelled-notifications mapping

## Original prompt
Ship the pending edits to `.github/config/github_slack_mapping.yaml` that add Slack user IDs for additional GitHub accounts so workflow notifications route to the right people.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->