### PR TITLE
M2: Redesign stats row as three bordered cards with icon pills

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -300,30 +300,38 @@ struct SubagentDetailPanel: View {
 
     @ViewBuilder
     private func usageMetrics(_ usage: SubagentUsageStats) -> some View {
-        HStack(spacing: 0) {
-            metricItem(icon: "arrow.down.circle", label: "Input", value: "\(formatNumber(usage.inputTokens)) tokens")
-            Spacer()
-            metricItem(icon: "arrow.up.circle", label: "Output", value: "\(formatNumber(usage.outputTokens)) tokens")
-            Spacer()
-            metricItem(icon: "dollarsign.circle", label: "Cost", value: formatCost(usage.estimatedCost))
+        HStack(spacing: VSpacing.sm) {
+            metricCard(icon: .arrowDown, label: "Input", value: formatNumber(usage.inputTokens))
+            metricCard(icon: .arrowUp, label: "Output", value: formatNumber(usage.outputTokens))
+            metricCard(icon: .circleDollarSign, label: "Cost", value: formatCost(usage.estimatedCost))
         }
-        .padding(.vertical, VSpacing.xs)
     }
 
     @ViewBuilder
-    private func metricItem(icon: String, label: String, value: String) -> some View {
-        HStack(spacing: VSpacing.xxs) {
-            VIconView(SFSymbolMapping.icon(forSFSymbol: icon, fallback: .puzzle), size: 10)
+    private func metricCard(icon: VIcon, label: String, value: String) -> some View {
+        HStack(spacing: VSpacing.lg) {
+            VIconView(icon, size: 16)
                 .foregroundStyle(VColor.contentTertiary)
+                .padding(VSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .fill(VColor.primaryDisabled)
+                )
             VStack(alignment: .leading, spacing: 0) {
-                Text(label)
-                    .font(VFont.labelSmall)
-                    .foregroundStyle(VColor.contentTertiary)
                 Text(value)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentSecondary)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Text(label)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
             }
         }
+        .padding(VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
+        )
     }
 
     // MARK: - Formatting


### PR DESCRIPTION
## Summary
- Redesign the usage metrics row in SubagentDetailPanel to three equal-width bordered cards with icon pills matching the Figma mock
- Each card: bordered container (1px border, 12px corners, 12px padding), icon pill with background on left, value/label stacked on right
- Uses existing design tokens: VColor.borderHover, VColor.primaryDisabled, VRadius.lg, VFont.titleSmall, VIcon.arrowDown/arrowUp/circleDollarSign

## Test plan
- [ ] Open a subagent detail panel with usage stats visible
- [ ] Verify three equal-width bordered cards render horizontally with 8px gap
- [ ] Verify each card has an icon pill (rounded square with light background) on the left
- [ ] Verify value text is 16px medium and label is 12px below it
- [ ] Verify cards resize proportionally when panel width changes

Part of #30452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->