### PR TITLE
M3: Redesign objective section as bordered card

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -91,14 +91,18 @@ struct SubagentDetailPanel: View {
 
             // Objective
             if let objective, !objective.isEmpty {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("OBJECTIVE")
-                        .font(VFont.labelSmall)
-                        .foregroundStyle(VColor.contentTertiary)
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Objective")
+                        .font(VFont.bodyMediumEmphasised)
+                        .foregroundStyle(VColor.contentEmphasized)
                     Text(objective)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentSecondary)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentDefault)
+                        .lineSpacing(18 - 14)
                 }
+                .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.md, bottom: VSpacing.lg, trailing: VSpacing.md))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .vCard(background: VColor.surfaceOverlay)
             }
 
             // Usage metrics row


### PR DESCRIPTION
Wrap the objective section in a bordered card with overlay background using the existing .vCard() modifier. Part of #30452.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->