### PR TITLE
fix(macos): handle providerInvalidKey in ChatErrorToastView switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -162,7 +162,7 @@ struct ChatConversationErrorToast: View {
             return .refreshCw
         case .authenticationRequired:
             return .lock
-        case .providerNotConfigured, .managedKeyInvalid:
+        case .providerNotConfigured, .providerInvalidKey, .managedKeyInvalid:
             return .keyRound
         case .unknown:
             return .circleAlert


### PR DESCRIPTION
## Summary
- Adds missing `.providerInvalidKey` case to the exhaustive `iconForCategory` switch in `ChatErrorToastView.swift`, mapping it to `.keyRound` (consistent with `InlineChatErrorAlert.swift`)
- Fixes macOS build and test failures introduced when `providerInvalidKey` was added to `ConversationErrorCategory` in #30437

## Test plan
- [x] `swift build --product vellum-assistant` passes locally
- [x] 482 macOS tests pass locally
- [ ] CI macOS Build + Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)