### PR TITLE
Add OpenRouter attribution headers

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13702,6 +13702,44 @@ paths:
               required:
                 - sourceText
               additionalProperties: false
+  /v1/skills/import:
+    post:
+      operationId: skills_import_post
+      summary: Import skill from file
+      description: Import a custom skill by uploading a ZIP or tar.gz archive containing a SKILL.md file.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  skillId:
+                    type: string
+                required:
+                  - ok
+                  - skillId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileName:
+                  type: string
+                fileContent:
+                  type: string
+              required:
+                - fileName
+                - fileContent
+              additionalProperties: false
   /v1/skills/install:
     post:
       operationId: skills_install_post

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -2346,6 +2346,35 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
     expect(lastStreamParams!.reasoning).toBeUndefined();
   });
 
+  test("sends OpenRouter app-attribution headers on Anthropic-compatible requests", async () => {
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: {
+        usageAttributionHeaders: {
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    });
+
+    expect(_lastStreamOptions?.headers).toEqual(
+      expect.objectContaining({
+        "HTTP-Referer": "https://www.vellum.ai",
+        "X-OpenRouter-Title": "Vellum Assistant",
+        "X-OpenRouter-Categories": "personal-agent,cli-agent",
+        "Vellum-Organization-Id": "org-123",
+      }),
+    );
+    expect(lastStreamParams).not.toHaveProperty("HTTP-Referer");
+    expect(lastStreamParams).not.toHaveProperty("X-OpenRouter-Title");
+    expect(lastStreamParams).not.toHaveProperty("X-OpenRouter-Categories");
+    expect(lastStreamParams).not.toHaveProperty("usageAttributionHeaders");
+  });
+
   test("per-request model override routes based on the overridden model", async () => {
     const { OpenRouterProvider } =
       await import("../providers/openrouter/client.js");

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1344,6 +1344,30 @@ describe("OpenRouterProvider reasoning", () => {
     expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
   });
 
+  test("sends OpenRouter app-attribution headers on OpenAI-compatible requests", async () => {
+    const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: {
+        usageAttributionHeaders: {
+          "Vellum-Organization-Id": "org-123",
+        },
+      },
+    });
+
+    expect(lastCreateOptions?.headers).toEqual(
+      expect.objectContaining({
+        "HTTP-Referer": "https://www.vellum.ai",
+        "X-OpenRouter-Title": "Vellum Assistant",
+        "X-OpenRouter-Categories": "personal-agent,cli-agent",
+        "Vellum-Organization-Id": "org-123",
+      }),
+    );
+    expect(lastCreateParams).not.toHaveProperty("HTTP-Referer");
+    expect(lastCreateParams).not.toHaveProperty("X-OpenRouter-Title");
+    expect(lastCreateParams).not.toHaveProperty("X-OpenRouter-Categories");
+    expect(lastCreateParams).not.toHaveProperty("usageAttributionHeaders");
+  });
+
   test("RetryProvider + OpenRouterProvider enables thinking end-to-end", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     const retry = new RetryProvider(provider);

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -715,6 +715,7 @@ export class AnthropicProvider implements Provider {
   private model: string;
   private useNativeWebSearch: boolean;
   private streamTimeoutMs: number;
+  private requestHeaders: Record<string, string>;
 
   constructor(
     apiKey: string,
@@ -730,9 +731,12 @@ export class AnthropicProvider implements Provider {
        * positional `apiKey` argument is ignored on the wire.
        */
       authToken?: string;
+      /** Provider-level request headers merged into every API request. */
+      requestHeaders?: Record<string, string>;
     } = {},
   ) {
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
+    this.requestHeaders = options.requestHeaders ?? {};
     // Pass the same deadline to the SDK so its per-request timeout can't
     // fire before `createStreamTimeout` does. The SDK's default is 10 min,
     // which truncates any request we intend to run longer than that. We add
@@ -1201,6 +1205,16 @@ export class AnthropicProvider implements Provider {
 
       let response: Anthropic.Message;
       try {
+        const requestHeaders = {
+          ...this.requestHeaders,
+          ...(usageAttributionHeaders ?? {}),
+        };
+        const requestOptions = {
+          signal: timeoutSignal,
+          ...(Object.keys(requestHeaders).length > 0
+            ? { headers: requestHeaders }
+            : {}),
+        };
         const stream: UnifiedStream = useFastMode
           ? (this.client.beta.messages.stream(
               {
@@ -1209,12 +1223,7 @@ export class AnthropicProvider implements Provider {
                 betas,
               } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                 Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-              {
-                signal: timeoutSignal,
-                ...(usageAttributionHeaders
-                  ? { headers: usageAttributionHeaders }
-                  : {}),
-              },
+              requestOptions,
             ) as unknown as UnifiedStream)
           : betas.length > 0
             ? (this.client.beta.messages.stream(
@@ -1223,19 +1232,12 @@ export class AnthropicProvider implements Provider {
                   betas,
                 } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                   Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-                {
-                  signal: timeoutSignal,
-                  ...(usageAttributionHeaders
-                    ? { headers: usageAttributionHeaders }
-                    : {}),
-                },
+                requestOptions,
               ) as unknown as UnifiedStream)
-            : (this.client.messages.stream(params, {
-                signal: timeoutSignal,
-                ...(usageAttributionHeaders
-                  ? { headers: usageAttributionHeaders }
-                  : {}),
-              }) as unknown as UnifiedStream);
+            : (this.client.messages.stream(
+                params,
+                requestOptions,
+              ) as unknown as UnifiedStream);
 
         // Buffer streaming text until it's clear the accumulated text isn't
         // going to form a placeholder sentinel. Sentinels are injected into

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -60,6 +60,8 @@ export interface OpenAIChatCompletionsProviderOptions {
   providerName?: string;
   providerLabel?: string;
   streamTimeoutMs?: number;
+  /** Provider-level request headers merged into every API request. */
+  requestHeaders?: Record<string, string>;
   /** Extra params spread into every chat.completions.create call (e.g. reasoning). */
   extraCreateParams?: Record<string, unknown>;
   /** Upper bound for `reasoning_effort` sent on the wire. Defaults to "xhigh"
@@ -110,6 +112,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private streamTimeoutMs: number;
   private extraCreateParams: Record<string, unknown>;
   private maxReasoningEffort: "high" | "xhigh";
+  private requestHeaders: Record<string, string>;
 
   constructor(
     apiKey: string,
@@ -126,6 +129,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     this.extraCreateParams = options.extraCreateParams ?? {};
     this.maxReasoningEffort = options.maxReasoningEffort ?? "xhigh";
+    this.requestHeaders = options.requestHeaders ?? {};
   }
 
   async sendMessage(
@@ -197,10 +201,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
       let cachedPromptTokens = 0;
 
       try {
+        const requestHeaders = {
+          ...this.requestHeaders,
+          ...(usageAttributionHeaders ?? {}),
+        };
         const stream = await this.client.chat.completions.create(params, {
           signal: timeoutSignal,
-          ...(usageAttributionHeaders
-            ? { headers: usageAttributionHeaders }
+          ...(Object.keys(requestHeaders).length > 0
+            ? { headers: requestHeaders }
             : {}),
         });
 

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -18,6 +18,11 @@ export interface OpenRouterProviderOptions {
 }
 
 const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const OPENROUTER_APP_ATTRIBUTION_HEADERS = {
+  "HTTP-Referer": "https://www.vellum.ai",
+  "X-OpenRouter-Title": "Vellum Assistant",
+  "X-OpenRouter-Categories": "personal-agent,cli-agent",
+};
 
 // Models on OpenRouter prefixed `anthropic/` are routed through OpenRouter's
 // Anthropic-compatible Messages API at `<root>/v1/messages` (where `<root>` is
@@ -93,6 +98,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       providerName: "openrouter",
       providerLabel: "OpenRouter",
       streamTimeoutMs: options.streamTimeoutMs,
+      requestHeaders: OPENROUTER_APP_ATTRIBUTION_HEADERS,
     });
     this.openRouterApiKey = apiKey;
     this.defaultModel = model;
@@ -192,6 +198,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
           streamTimeoutMs: this.providerStreamTimeoutMs,
           authToken: this.openRouterApiKey,
           useNativeWebSearch: this.useNativeWebSearch,
+          requestHeaders: OPENROUTER_APP_ATTRIBUTION_HEADERS,
         },
       );
     }


### PR DESCRIPTION
## Summary
- add OpenRouter app-attribution headers to assistant OpenRouter requests
- pass provider-level request headers through OpenAI-compatible and Anthropic-compatible transports
- cover both dispatch paths with provider tests

Part of #30453
Closes #30455
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->