### PR TITLE
M1: Add category and metadata fields to FeedItem schema

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -82,6 +82,40 @@ describe("feedItemSchema — valid minimal items", () => {
     expect(parsed.expiresAt).toBe("2026-04-15T00:00:00.000Z");
     expect(parsed.detailPanel?.kind).toBe("emailDraft");
   });
+
+  test("category field passes through when present", () => {
+    for (const cat of [
+      "security",
+      "scheduling",
+      "background",
+      "email",
+      "system",
+    ] as const) {
+      const parsed = feedItemSchema.parse({
+        ...minimalNotification(),
+        category: cat,
+      });
+      expect(parsed.category).toBe(cat);
+    }
+  });
+
+  test("metadata field passes through when present", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNotification(),
+      metadata: { subject: "Hello", count: 3, nested: { ok: true } },
+    });
+    expect(parsed.metadata).toEqual({
+      subject: "Hello",
+      count: 3,
+      nested: { ok: true },
+    });
+  });
+
+  test("items without category or metadata still parse (backward compat)", () => {
+    const parsed = feedItemSchema.parse(minimalNotification());
+    expect(parsed.category).toBeUndefined();
+    expect(parsed.metadata).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -140,6 +174,12 @@ describe("feedItemSchema — enum validation", () => {
         feedItemSchema.parse({ ...minimalNotification(), type: legacy }),
       ).toThrow();
     }
+  });
+
+  test("rejects unknown `category`", () => {
+    expect(() =>
+      feedItemSchema.parse({ ...minimalNotification(), category: "weather" }),
+    ).toThrow();
   });
 
   test("rejects unknown `status`", () => {

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -38,6 +38,14 @@ export type FeedItemStatus = "new" | "seen" | "acted_on" | "dismissed";
 /** Visual urgency treatment — controls badge color independently of sort priority. */
 export type FeedItemUrgency = "low" | "medium" | "high" | "critical";
 
+/** Broad category for grouping and filtering feed items. */
+export type FeedItemCategory =
+  | "security"
+  | "scheduling"
+  | "background"
+  | "email"
+  | "system";
+
 /**
  * A single action button attached to a feed item.
  *
@@ -96,6 +104,10 @@ export interface FeedItem {
   conversationId?: string;
   /** Server-driven detail panel descriptor; when present, the client opens this panel kind. */
   detailPanel?: FeedItemDetailPanel;
+  /** Broad category for grouping and filtering feed items. */
+  category?: FeedItemCategory;
+  /** Arbitrary structured data the detail panel or other consumers can use. */
+  metadata?: Record<string, unknown>;
   /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
   createdAt: string;
 }
@@ -164,6 +176,14 @@ const feedItemDetailPanelSchema = z.object({
   kind: feedItemDetailPanelKindSchema,
 });
 
+const feedItemCategorySchema = z.enum([
+  "security",
+  "scheduling",
+  "background",
+  "email",
+  "system",
+]);
+
 /**
  * Schema for a single `FeedItem`.
  *
@@ -187,6 +207,8 @@ export const feedItemSchema = z.object({
   urgency: feedItemUrgencySchema.optional(),
   conversationId: z.string().optional(),
   detailPanel: feedItemDetailPanelSchema.optional(),
+  category: feedItemCategorySchema.optional(),
+  metadata: z.record(z.unknown()).optional(),
   createdAt: z.string(),
 });
 

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -208,7 +208,7 @@ export const feedItemSchema = z.object({
   conversationId: z.string().optional(),
   detailPanel: feedItemDetailPanelSchema.optional(),
   category: feedItemCategorySchema.optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string(),
 });
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -267,6 +267,8 @@ public final class HomeFeedStore {
             urgency: item.urgency,
             conversationId: item.conversationId,
             detailPanel: item.detailPanel,
+            category: item.category,
+            metadata: item.metadata,
             createdAt: item.createdAt
         )
     }

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -52,6 +52,15 @@ public enum FeedItemUrgency: String, Codable, Sendable, Hashable {
     case critical
 }
 
+/// Broad category for grouping and filtering feed items.
+public enum FeedItemCategory: String, Codable, Sendable, Hashable {
+    case security
+    case scheduling
+    case background
+    case email
+    case system
+}
+
 // MARK: - FeedAction
 
 /// A single action button attached to a feed item.
@@ -101,7 +110,7 @@ public struct FeedItemDetailPanel: Codable, Sendable, Hashable {
 /// In v2 every feed item is a `.notification` — the legacy
 /// `source` / `author` / `minTimeAway` discriminators were removed when
 /// the type collapsed. See the module comment above for rationale.
-public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
+public struct FeedItem: Codable, Sendable, Identifiable {
     public let id: String
     public let type: FeedItemType
     /// Integer in [0, 100]; higher values sort earlier.
@@ -120,6 +129,10 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
     public let conversationId: String?
     /// Server-driven detail panel descriptor; when present, the client opens this panel kind.
     public let detailPanel: FeedItemDetailPanel?
+    /// Broad category for grouping and filtering feed items.
+    public let category: FeedItemCategory?
+    /// Arbitrary structured data the detail panel or other consumers can use.
+    public let metadata: [String: AnyCodable]?
     /// Internal: writer-record time, used for ordering + TTL.
     public let createdAt: Date
 
@@ -136,6 +149,8 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
         urgency: FeedItemUrgency? = nil,
         conversationId: String? = nil,
         detailPanel: FeedItemDetailPanel? = nil,
+        category: FeedItemCategory? = nil,
+        metadata: [String: AnyCodable]? = nil,
         createdAt: Date
     ) {
         self.id = id
@@ -150,7 +165,34 @@ public struct FeedItem: Codable, Sendable, Identifiable, Hashable {
         self.urgency = urgency
         self.conversationId = conversationId
         self.detailPanel = detailPanel
+        self.category = category
+        self.metadata = metadata
         self.createdAt = createdAt
+    }
+}
+
+extension FeedItem: Equatable {
+    public static func == (lhs: FeedItem, rhs: FeedItem) -> Bool {
+        lhs.id == rhs.id
+            && lhs.type == rhs.type
+            && lhs.priority == rhs.priority
+            && lhs.title == rhs.title
+            && lhs.summary == rhs.summary
+            && lhs.timestamp == rhs.timestamp
+            && lhs.status == rhs.status
+            && lhs.expiresAt == rhs.expiresAt
+            && lhs.actions == rhs.actions
+            && lhs.urgency == rhs.urgency
+            && lhs.conversationId == rhs.conversationId
+            && lhs.detailPanel == rhs.detailPanel
+            && lhs.category == rhs.category
+            && lhs.createdAt == rhs.createdAt
+    }
+}
+
+extension FeedItem: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 


### PR DESCRIPTION
Part of #30470. Adds `FeedItemCategory` type and `metadata` field to the shared FeedItem contract (daemon TypeScript + client Swift) so notifications can be categorized and carry structured data for detail panels.

## Changes
- **assistant/src/home/feed-types.ts**: Added `FeedItemCategory` type (`security | scheduling | background | email | system`), `category` and `metadata` Zod schemas + interface fields
- **clients/shared/Network/FeedItem.swift**: Added `FeedItemCategory` enum, `category: FeedItemCategory?` and `metadata: [String: AnyCodable]?` fields, custom `Equatable`/`Hashable` conformance (metadata uses `AnyCodable` which is not `Hashable`)
- **clients/macos/.../HomeFeedStore.swift**: Updated `replacingStatus` to preserve `category` and `metadata`
- **assistant/src/home/__tests__/feed-types.test.ts**: Added tests for category/metadata parsing and backward compat

## Test plan
- [ ] Items with category and metadata decode correctly on both daemon and client
- [ ] Items without category/metadata still decode (backward compat)
- [ ] Zod schema validates category enum values
- [ ] Swift Codable round-trips correctly