### PR TITLE
M2: Enrich daemon signal producers with category and metadata

### DIFF
--- a/assistant/src/home/post-connect-feed.ts
+++ b/assistant/src/home/post-connect-feed.ts
@@ -44,6 +44,7 @@ export async function emitPostConnectNudge(service: string): Promise<void> {
       "I can triage your inbox, summarize new emails, or draft replies to important threads.",
     timestamp: now.toISOString(),
     status: "new",
+    category: "email",
     expiresAt,
     createdAt: now.toISOString(),
     actions: [

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -12,6 +12,8 @@
  */
 import {
   type FeedItem,
+  type FeedItemCategory,
+  type FeedItemDetailPanelKind,
   feedItemSchema,
   type FeedItemUrgency,
 } from "../home/feed-types.js";
@@ -61,6 +63,15 @@ export async function writeHomeFeedItemForSignal(
     : undefined;
   const now = new Date().toISOString();
 
+  const category = deriveCategory(signal);
+  const panelKind = deriveDetailPanelKind(signal);
+  const metadata =
+    signal.contextPayload &&
+    typeof signal.contextPayload === "object" &&
+    !Array.isArray(signal.contextPayload)
+      ? (signal.contextPayload as Record<string, unknown>)
+      : undefined;
+
   const item: FeedItem = {
     id: `notif:${signal.signalId}`,
     type: "notification",
@@ -70,8 +81,11 @@ export async function writeHomeFeedItemForSignal(
     timestamp: now,
     createdAt: now,
     status: "new",
+    category,
     ...(urgency ? { urgency } : {}),
     ...(conversationId ? { conversationId } : {}),
+    ...(panelKind ? { detailPanel: { kind: panelKind } } : {}),
+    ...(metadata ? { metadata } : {}),
   };
 
   try {
@@ -86,6 +100,47 @@ export async function writeHomeFeedItemForSignal(
 
   await appendFeedItem(item);
   return item;
+}
+
+// ── Category & detail-panel derivation ────────────────────────────────
+
+const EVENT_CATEGORY_MAP: Record<string, FeedItemCategory> = {
+  "credential.health_alert": "security",
+  "activity.failed": "background",
+  "activity.complete": "background",
+  "heartbeat.alert": "system",
+  "watcher.notification": "system",
+  "schedule.notify": "scheduling",
+  "guardian.question": "security",
+  "guardian.channel_activation": "security",
+  "ingress.access_request": "security",
+  "ingress.escalation": "security",
+};
+
+function deriveCategory(signal: NotificationSignal): FeedItemCategory {
+  return EVENT_CATEGORY_MAP[signal.sourceEventName] ?? "system";
+}
+
+function deriveDetailPanelKind(
+  signal: NotificationSignal,
+): FeedItemDetailPanelKind | undefined {
+  if (signal.sourceEventName === "credential.health_alert") {
+    return "toolPermission";
+  }
+
+  if (signal.sourceEventName === "guardian.question") {
+    const payload = signal.contextPayload;
+    if (
+      payload &&
+      typeof payload === "object" &&
+      "requestKind" in payload &&
+      (payload as Record<string, unknown>).requestKind === "tool_approval"
+    ) {
+      return "permissionChat";
+    }
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Part of #30470. Maps sourceEventName to FeedItemCategory, passes contextPayload as metadata, and sets detailPanel.kind for credential and permission signals.

## Changes

### `assistant/src/notifications/home-feed-side-effect.ts`
- Added `deriveCategory()` — maps `sourceEventName` to `FeedItemCategory` (security, background, scheduling, system)
- Added `deriveDetailPanelKind()` — returns `"toolPermission"` for credential health alerts, `"permissionChat"` for guardian tool_approval questions
- Updated `writeHomeFeedItemForSignal()` to set `category`, `metadata`, and `detailPanel` on constructed FeedItems

### `assistant/src/home/post-connect-feed.ts`
- Set `category: "email"` on the Gmail connect nudge item
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->