### PR TITLE
M3: Add client-side filter bar to homepage

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A single filter pill rendered inside `HomeFeedFilterBar`. Displays a
+/// capitalized category label in either a filled (selected) or ghost/outlined
+/// (unselected) style, following the capsule pill pattern established by
+/// `HomeSuggestionPill`.
+private struct HomeFeedFilterPill: View {
+    let label: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(label)
+                .font(VFont.bodySmallEmphasised)
+                .foregroundStyle(isSelected ? VColor.contentInset : VColor.contentSecondary)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.xs)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? VColor.primaryBase : Color.clear)
+                )
+                .overlay(
+                    Capsule()
+                        .stroke(isSelected ? Color.clear : VColor.borderElement, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+/// Horizontal pill/chip bar that filters the home feed by `FeedItemCategory`.
+///
+/// Renders an "All" pill (selected by default when `activeFilter` is nil)
+/// followed by one pill per `FeedItemCategory` case. The parent owns the
+/// filter state and passes it down; tapping a pill fires `onFilterChanged`
+/// with the new selection (nil for "All").
+struct HomeFeedFilterBar: View {
+    let activeFilter: FeedItemCategory?
+    let onFilterChanged: (FeedItemCategory?) -> Void
+
+    /// Display labels derived from `FeedItemCategory` raw values.
+    private static let categories: [(label: String, category: FeedItemCategory)] =
+        FeedItemCategory.allCases.map { category in
+            (label: category.rawValue.capitalized, category: category)
+        }
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            HomeFeedFilterPill(
+                label: "All",
+                isSelected: activeFilter == nil,
+                onTap: { onFilterChanged(nil) }
+            )
+
+            ForEach(Self.categories, id: \.category) { entry in
+                HomeFeedFilterPill(
+                    label: entry.label,
+                    isSelected: activeFilter == entry.category,
+                    onTap: { onFilterChanged(entry.category) }
+                )
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -65,6 +65,9 @@ struct HomePageView<DetailPanel: View>: View {
     /// refresh. Persistent per-account dismissal is a follow-up.
     @State private var suggestionsDismissed: Bool = false
 
+    /// Active category filter. `nil` means "All" — show every feed item.
+    @State private var activeFilter: FeedItemCategory? = nil
+
     /// Editorial column width. Bumped from 600pt to 960pt to match the
     /// Figma redesign — the new three-block layout reads as a wider page,
     /// not a narrow column.
@@ -125,6 +128,19 @@ struct HomePageView<DetailPanel: View>: View {
                             onDismissSuggestions()
                         }
                     )
+                }
+
+                HomeFeedFilterBar(
+                    activeFilter: activeFilter,
+                    onFilterChanged: { activeFilter = $0 }
+                )
+
+                if groupedFeed.isEmpty, activeFilter != nil {
+                    Text("No notifications")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, VSpacing.xxl)
                 }
 
                 ForEach(Array(groupedFeed.enumerated()), id: \.element.group) { _, bucket in
@@ -245,7 +261,16 @@ struct HomePageView<DetailPanel: View>: View {
             if a.priority != b.priority { return a.priority > b.priority }
             return a.createdAt > b.createdAt
         }
-        let filtered = sorted.filter { $0.status != .dismissed }
+        let filtered = sorted.filter { item in
+            guard item.status != .dismissed else { return false }
+            // When a category filter is active, include items that match the
+            // filter OR items with no category (backward compat — legacy items
+            // that predate the category field should always remain visible).
+            if let active = activeFilter {
+                return item.category == active || item.category == nil
+            }
+            return true
+        }
         let buckets = HomeFeedTimeGroup.bucket(filtered)
         return buckets.map { bucket in
             (group: bucket.group, rows: HomeFeedGrouping.group(bucket.items))

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -53,7 +53,7 @@ public enum FeedItemUrgency: String, Codable, Sendable, Hashable {
 }
 
 /// Broad category for grouping and filtering feed items.
-public enum FeedItemCategory: String, Codable, Sendable, Hashable {
+public enum FeedItemCategory: String, Codable, Sendable, Hashable, CaseIterable {
     case security
     case scheduling
     case background


### PR DESCRIPTION
Part of #30470.

## Summary
- Adds `HomeFeedFilterBar` — a horizontal pill/chip bar with "All" + one pill per `FeedItemCategory` case (Security, Scheduling, Background, Email, System)
- Selected pill uses filled style (`VColor.primaryBase`), unselected uses ghost/outlined style (`VColor.borderElement` stroke)
- Filters the home feed locally: when a category is selected, only items matching that category (plus items with no category for backward compat) are shown
- Shows "No notifications" empty state when the filtered feed has no items
- Adds `CaseIterable` conformance to `FeedItemCategory` for dynamic pill generation

## Files changed
- **New:** `clients/macos/vellum-assistant/Features/Home/HomeFeedFilterBar.swift` — filter bar component
- **Modified:** `clients/macos/vellum-assistant/Features/Home/HomePageView.swift` — integrates filter bar + filtering logic
- **Modified:** `clients/shared/Network/FeedItem.swift` — adds `CaseIterable` to `FeedItemCategory`

## Test plan
- [ ] Verify "All" pill is selected by default and all feed items are visible
- [ ] Tap each category pill — only items of that category (+ uncategorized items) should appear
- [ ] Tap "All" to reset — all items should reappear
- [ ] Verify empty state text when filtering yields no results
- [ ] Verify pill styling: selected = filled, unselected = outlined