### PR TITLE
M5: Build out stub detail panel views with structured metadata

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeAuthDetailCard.swift
@@ -1,13 +1,118 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for payment-authorization detail panels.
-/// Will be replaced with a rich approval UI when the daemon surfaces
-/// structured payment-auth fields on `FeedItem`.
+/// Body component for payment-authorization detail panels.
+///
+/// Reads structured fields from `FeedItem.metadata`:
+///   - `amount` (String) — the payment amount (e.g. "$42.99")
+///   - `merchant` (String) — merchant name
+///   - `cardLast4` (String?) — last four digits of the card
+///   - `status` (String?) — authorization status label
+///
+/// Falls back to `item.title` when metadata is absent or missing
+/// the required keys.
 struct HomeAuthDetailCard: View {
     let item: FeedItem
 
+    // MARK: - Metadata accessors
+
+    private var merchant: String? {
+        item.metadata?["merchant"]?.value as? String
+    }
+
+    private var amount: String? {
+        item.metadata?["amount"]?.value as? String
+    }
+
+    private var cardLast4: String? {
+        item.metadata?["cardLast4"]?.value as? String
+    }
+
+    private var status: String? {
+        item.metadata?["status"]?.value as? String
+    }
+
+    /// Whether the metadata contains enough data to render the rich layout.
+    private var hasStructuredData: Bool {
+        merchant != nil && amount != nil
+    }
+
+    // MARK: - Body
+
     var body: some View {
+        if hasStructuredData {
+            structuredContent
+        } else {
+            fallbackContent
+        }
+    }
+
+    // MARK: - Structured layout
+
+    private var structuredContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Merchant name
+            Text(merchant ?? "")
+                .font(VFont.titleMedium)
+                .foregroundStyle(VColor.contentDefault)
+
+            // Amount — prominent display
+            Text(amount ?? "")
+                .font(VFont.titleLarge)
+                .foregroundStyle(VColor.contentEmphasized)
+
+            // Card info (secondary)
+            if let last4 = cardLast4 {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Card ending in")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Text(last4)
+                        .font(VFont.bodyMediumEmphasised)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+            }
+
+            // Status badge
+            if let statusText = status {
+                statusBadge(statusText)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Status badge
+
+    private func statusBadge(_ text: String) -> some View {
+        let (foreground, background) = statusColors(for: text)
+        return Text(text.capitalized)
+            .font(VFont.bodySmallEmphasised)
+            .foregroundStyle(foreground)
+            .padding(EdgeInsets(top: VSpacing.xxs, leading: VSpacing.sm, bottom: VSpacing.xxs, trailing: VSpacing.sm))
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm, style: .continuous)
+                    .fill(background)
+            )
+    }
+
+    /// Maps a status string to foreground + background color pairs.
+    private func statusColors(for status: String) -> (Color, Color) {
+        switch status.lowercased() {
+        case "approved", "completed":
+            return (VColor.systemPositiveStrong, VColor.systemPositiveWeak)
+        case "declined", "failed":
+            return (VColor.systemNegativeStrong, VColor.systemNegativeWeak)
+        case "pending":
+            return (VColor.systemMidStrong, VColor.systemMidWeak)
+        default:
+            return (VColor.contentSecondary, VColor.surfaceActive)
+        }
+    }
+
+    // MARK: - Fallback
+
+    private var fallbackContent: some View {
         Text(item.title)
             .font(VFont.bodyMediumDefault)
             .foregroundStyle(VColor.contentSecondary)

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -1,13 +1,152 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for tool-permission detail panels.
-/// Will be replaced with a rich permission approval UI when the daemon
-/// surfaces structured permission fields on `FeedItem`.
+/// Body component for credential/permission detail panels.
+///
+/// Reads structured fields from `FeedItem.metadata`:
+///   - `provider` (String) — service provider name
+///   - `accountInfo` (String?) — account identifier or email
+///   - `status` (String?) — permission status (e.g. "active", "revoked", "expired", "degraded")
+///   - `details` (String?) — additional context
+///   - `missingScopes` ([String]?) — list of missing permission scopes
+///
+/// Falls back to `item.title` when metadata is absent.
 struct HomePermissionDetailCard: View {
     let item: FeedItem
 
+    // MARK: - Metadata accessors
+
+    private var provider: String? {
+        item.metadata?["provider"]?.value as? String
+    }
+
+    private var accountInfo: String? {
+        item.metadata?["accountInfo"]?.value as? String
+    }
+
+    private var status: String? {
+        item.metadata?["status"]?.value as? String
+    }
+
+    private var details: String? {
+        item.metadata?["details"]?.value as? String
+    }
+
+    private var missingScopes: [String]? {
+        item.metadata?["missingScopes"]?.value as? [String]
+    }
+
+    /// Whether the metadata contains enough data to render the rich layout.
+    private var hasStructuredData: Bool {
+        provider != nil
+    }
+
+    // MARK: - Body
+
     var body: some View {
+        if hasStructuredData {
+            structuredContent
+        } else {
+            fallbackContent
+        }
+    }
+
+    // MARK: - Structured layout
+
+    private var structuredContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            // Provider name
+            Text(provider ?? "")
+                .font(VFont.titleMedium)
+                .foregroundStyle(VColor.contentDefault)
+
+            // Account info
+            if let account = accountInfo {
+                Text(account)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+
+            // Status indicator
+            if let statusText = status {
+                statusRow(statusText)
+            }
+
+            // Details text
+            if let detailsText = details {
+                Text(detailsText)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Missing scopes list
+            if let scopes = missingScopes, !scopes.isEmpty {
+                missingScopesList(scopes)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Status row
+
+    private func statusRow(_ text: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Circle()
+                .fill(statusColor(for: text))
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+
+            Text(text.capitalized)
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(statusColor(for: text))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("Status: \(text)"))
+    }
+
+    /// Maps a status string to the appropriate color.
+    ///
+    /// "revoked" / "expired" → negative (red), "degraded" → warning (amber),
+    /// everything else → secondary (muted).
+    private func statusColor(for status: String) -> Color {
+        switch status.lowercased() {
+        case "revoked", "expired":
+            return VColor.systemNegativeStrong
+        case "degraded":
+            return VColor.systemMidStrong
+        default:
+            return VColor.contentSecondary
+        }
+    }
+
+    // MARK: - Missing scopes
+
+    private func missingScopesList(_ scopes: [String]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Missing Scopes")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .accessibilityAddTraits(.isHeader)
+
+            ForEach(scopes, id: \.self) { scope in
+                HStack(spacing: VSpacing.xs) {
+                    Text("\u{2022}")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                        .accessibilityHidden(true)
+                    Text(scope)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                }
+            }
+        }
+    }
+
+    // MARK: - Fallback
+
+    private var fallbackContent: some View {
         Text(item.title)
             .font(VFont.bodyMediumDefault)
             .foregroundStyle(VColor.contentSecondary)

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeUpdatesListDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeUpdatesListDetailCard.swift
@@ -1,13 +1,104 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Stub body component for updates-list detail panels.
-/// Will be replaced with a rich list UI when the daemon surfaces
-/// structured update items on `FeedItem`.
+/// Body component for updates-list detail panels.
+///
+/// Reads structured fields from `FeedItem.metadata`:
+///   - `updates` ([[String: Any]]?) — array of update entries, each with:
+///       - `title` (String) — update title
+///       - `description` (String?) — update description
+///       - `timestamp` (String?) — human-readable timestamp
+///
+/// Falls back to `item.summary` when no `updates` array is present,
+/// or to `item.title` when metadata is entirely absent.
 struct HomeUpdatesListDetailCard: View {
     let item: FeedItem
 
+    // MARK: - Metadata accessors
+
+    private var updates: [[String: Any]]? {
+        item.metadata?["updates"]?.value as? [[String: Any]]
+    }
+
+    // MARK: - Body
+
     var body: some View {
+        if let entries = updates, !entries.isEmpty {
+            updatesList(entries)
+        } else if item.metadata != nil {
+            summaryFallback
+        } else {
+            fallbackContent
+        }
+    }
+
+    // MARK: - Updates list
+
+    private func updatesList(_ entries: [[String: Any]]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
+                if index > 0 {
+                    VColor.borderBase
+                        .frame(height: 1)
+                        .padding(.horizontal, VSpacing.lg)
+                        .accessibilityHidden(true)
+                }
+
+                updateRow(entry)
+            }
+        }
+    }
+
+    private func updateRow(_ entry: [String: Any]) -> some View {
+        let title = entry["title"] as? String ?? ""
+        let description = entry["description"] as? String
+        let timestamp = entry["timestamp"] as? String
+
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Spacer(minLength: VSpacing.sm)
+
+                if let ts = timestamp {
+                    Text(ts)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+
+            if let desc = description, !desc.isEmpty {
+                Text(desc)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(EdgeInsets(
+            top: VSpacing.md,
+            leading: VSpacing.lg,
+            bottom: VSpacing.md,
+            trailing: VSpacing.lg
+        ))
+    }
+
+    // MARK: - Summary fallback
+
+    /// When metadata exists but `updates` is absent, show the item summary
+    /// as a single block of text.
+    private var summaryFallback: some View {
+        Text(item.summary)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(VSpacing.lg)
+    }
+
+    // MARK: - Fallback
+
+    private var fallbackContent: some View {
         Text(item.title)
             .font(VFont.bodyMediumDefault)
             .foregroundStyle(VColor.contentSecondary)


### PR DESCRIPTION
Part of #30470. Replaces stub Text() rendering in HomeAuthDetailCard, HomePermissionDetailCard, and HomeUpdatesListDetailCard with structured layouts that read from FeedItem.metadata. Graceful fallback when metadata is absent.

## Summary
- **HomeAuthDetailCard**: Renders merchant name, payment amount (prominent), card last-4 digits, and a color-coded status badge (approved/declined/pending). Falls back to `item.title` when metadata is nil or missing required keys (`merchant`, `amount`).
- **HomePermissionDetailCard**: Renders provider name, account info, a color-coded status indicator dot (revoked/expired = negative red, degraded = warning amber), details text, and a bulleted missing-scopes list. Falls back to `item.title` when metadata is nil.
- **HomeUpdatesListDetailCard**: Renders a VStack of update rows, each with title + trailing timestamp + description. Rows separated by hairline dividers. Falls back to `item.summary` when metadata exists but `updates` key is absent, or to `item.title` when metadata is nil entirely.

All views use `VColor`, `VFont`, `VSpacing`, and `VRadius` design tokens exclusively. Metadata is accessed via the `item.metadata?["key"]?.value as? T` AnyCodable pattern.

## Test plan
- [ ] Verify HomeAuthDetailCard renders structured data with merchant, amount, card info, and status badge
- [ ] Verify HomeAuthDetailCard falls back to title text when metadata is nil
- [ ] Verify HomePermissionDetailCard renders provider, account, status dot, details, and missing scopes
- [ ] Verify HomePermissionDetailCard status colors: revoked/expired = red, degraded = amber, other = secondary
- [ ] Verify HomeUpdatesListDetailCard renders update rows with dividers
- [ ] Verify HomeUpdatesListDetailCard falls back to summary when metadata present but updates key absent
- [ ] Verify all three views fall back to item.title when metadata is nil
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->