### PR TITLE
M4: Wire PanelCoordinator to real panel views and per-category icons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -289,26 +289,44 @@ struct HomePageView<DetailPanel: View>: View {
 
     // MARK: - Recap row styling
 
-    /// Icon glyph for a feed item. The v2 schema collapsed all items to
-    /// the single `notification` type, so every row uses the same glyph
-    /// — a per-item visual language driven by `urgency` or
-    /// `detailPanel.kind` is a future iteration. The `FeedItem` parameter
-    /// is retained (internal name dropped to flag intentionally unused) so
-    /// a future per-urgency / per-detail-panel-kind dispatch can re-thread
-    /// it without touching every call site.
-    private func icon(for _: FeedItem) -> VIcon {
-        .bell
+    /// Icon glyph for a feed item, dispatched per `FeedItemCategory`.
+    /// Falls back to `.bell` for items without a category.
+    private func icon(for item: FeedItem) -> VIcon {
+        switch item.category {
+        case .security:    return .shieldCheck
+        case .email:       return .mail
+        case .scheduling:  return .clock
+        case .background:  return .settings
+        case .system:      return .bell
+        case nil:          return .bell
+        }
     }
 
-    /// Foreground (glyph) color for the recap icon. See the `feed*`
-    /// tokens in `ColorTokens.swift`.
-    private func iconForeground(for _: FeedItem) -> Color {
-        VColor.feedDigestStrong
+    /// Foreground (glyph) color for the recap icon, dispatched per
+    /// `FeedItemCategory`. Uses feed-specific semantic tokens from
+    /// `ColorTokens.swift`.
+    private func iconForeground(for item: FeedItem) -> Color {
+        switch item.category {
+        case .security:    return VColor.feedNudgeStrong
+        case .email:       return VColor.feedDigestStrong
+        case .scheduling:  return VColor.feedThreadStrong
+        case .background:  return VColor.systemInfoStrong
+        case .system:      return VColor.feedDigestStrong
+        case nil:          return VColor.feedDigestStrong
+        }
     }
 
-    /// Background (circle fill) color for the recap icon.
-    private func iconBackground(for _: FeedItem) -> Color {
-        VColor.feedDigestWeak
+    /// Background (circle fill) color for the recap icon, dispatched per
+    /// `FeedItemCategory`.
+    private func iconBackground(for item: FeedItem) -> Color {
+        switch item.category {
+        case .security:    return VColor.feedNudgeWeak
+        case .email:       return VColor.feedDigestWeak
+        case .scheduling:  return VColor.feedThreadWeak
+        case .background:  return VColor.systemInfoWeak
+        case .system:      return VColor.feedDigestWeak
+        case nil:          return VColor.feedDigestWeak
+        }
     }
 
     // MARK: - Actions

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -266,6 +266,11 @@ extension MainWindowView {
             detailPanel: {
                 switch activeHomeDetailPanel {
                 case .emailDraft(let item):
+                    // TODO: Wire HomeEmailEditor once FeedItem metadata
+                    // provides editable draft fields (to, subject, body)
+                    // and action callbacks (send, discard, connect).
+                    // HomeEmailEditor requires @Binding state and callbacks
+                    // that cannot be constructed from metadata alone.
                     HomeDetailPanel(
                         icon: nil,
                         title: item.title,
@@ -277,6 +282,11 @@ extension MainWindowView {
                             .padding(VSpacing.lg)
                     }
                 case .documentPreview(let item):
+                    // TODO: Wire HomeDocumentPreview once FeedItem
+                    // metadata provides an image (NSImage) or document
+                    // URL that can be loaded into the preview. Currently
+                    // the preview requires an NSImage which cannot be
+                    // constructed from string metadata.
                     HomeDetailPanel(
                         icon: nil,
                         title: item.title,
@@ -288,6 +298,12 @@ extension MainWindowView {
                             .padding(VSpacing.lg)
                     }
                 case .permissionChat(let item):
+                    // TODO: Wire HomePermissionChatPreview once FeedItem
+                    // metadata provides structured confirmation data
+                    // (ToolConfirmationData) and action callbacks
+                    // (allow, deny, alwaysAllow). The preview requires
+                    // complex types that cannot be constructed from
+                    // string metadata alone.
                     HomeDetailPanel(
                         icon: nil,
                         title: item.title,
@@ -903,23 +919,43 @@ extension MainWindowView {
 
 // MARK: - Feed Item Icon Helpers
 
-/// With the v2 schema collapsed to a single `.notification` type these
-/// helpers no longer per-type-dispatch — every feed item uses the same
-/// generic glyph. A per-item visual language driven by `urgency` or
-/// `detailPanel.kind` is a future iteration. The `FeedItem` parameter is
-/// retained (named `_` internally to flag intentionally unused) so a
-/// future per-urgency / per-detail-panel-kind dispatch can re-thread it
-/// without touching every call site.
-private func iconForFeedItem(_: FeedItem) -> VIcon {
-    .bell
+/// Icon glyph for a feed item in the detail panel, dispatched per
+/// `FeedItemCategory`. Falls back to `.bell` for items without a category.
+private func iconForFeedItem(_ item: FeedItem) -> VIcon {
+    switch item.category {
+    case .security:    return .shieldCheck
+    case .email:       return .mail
+    case .scheduling:  return .clock
+    case .background:  return .settings
+    case .system:      return .bell
+    case nil:          return .bell
+    }
 }
 
-private func iconForegroundForFeedItem(_: FeedItem) -> Color {
-    VColor.feedDigestStrong
+/// Foreground (glyph) color for the detail-panel recap icon, dispatched
+/// per `FeedItemCategory`.
+private func iconForegroundForFeedItem(_ item: FeedItem) -> Color {
+    switch item.category {
+    case .security:    return VColor.feedNudgeStrong
+    case .email:       return VColor.feedDigestStrong
+    case .scheduling:  return VColor.feedThreadStrong
+    case .background:  return VColor.systemInfoStrong
+    case .system:      return VColor.feedDigestStrong
+    case nil:          return VColor.feedDigestStrong
+    }
 }
 
-private func iconBackgroundForFeedItem(_: FeedItem) -> Color {
-    VColor.feedDigestWeak
+/// Background (circle fill) color for the detail-panel recap icon,
+/// dispatched per `FeedItemCategory`.
+private func iconBackgroundForFeedItem(_ item: FeedItem) -> Color {
+    switch item.category {
+    case .security:    return VColor.feedNudgeWeak
+    case .email:       return VColor.feedDigestWeak
+    case .scheduling:  return VColor.feedThreadWeak
+    case .background:  return VColor.systemInfoWeak
+    case .system:      return VColor.feedDigestWeak
+    case nil:          return VColor.feedDigestWeak
+    }
 }
 
 // MARK: - Wrapper Views


### PR DESCRIPTION
Part of #30470. Per-category icon dispatch in HomePageView and PanelCoordinator, plus TODO annotations on panel stubs that need complex types (email editor, document preview, permission chat).

## Changes
- **HomePageView.swift**: `icon(for:)`, `iconForeground(for:)`, `iconBackground(for:)` now dispatch per `FeedItemCategory` — security gets shield, email gets mail, scheduling gets clock, etc.
- **PanelCoordinator.swift**: Same per-category icon dispatch for the detail panel icon helpers. Added TODO comments on `.emailDraft`, `.documentPreview`, `.permissionChat` stubs explaining why they can't be wired yet (need @Binding, NSImage, ToolConfirmationData).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->