### PR TITLE
feat(a2a-demo): add package scaffolding, types, extension helpers, and SDK spike

### DIFF
--- a/a2a-demo/bun.lock
+++ b/a2a-demo/bun.lock
@@ -1,0 +1,181 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/a2a-demo",
+      "dependencies": {
+        "@a2a-js/sdk": "0.3.13",
+        "express": "5.2.1",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "@types/express": "5.0.6",
+        "typescript": "6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
+
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+  }
+}

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -3,11 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "bun run build:ui && bun run src/server.ts",
-    "peers:start": "bun run src/peers/start-all.ts",
     "typecheck": "bunx tsc --noEmit",
-    "test": "bun test src/",
-    "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/"
+    "test": "bun test src/"
   },
   "dependencies": {
     "@a2a-js/sdk": "0.3.13",

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@vellumai/a2a-demo",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run build:ui && bun run src/server.ts",
+    "peers:start": "bun run src/peers/start-all.ts",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/",
+    "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/"
+  },
+  "dependencies": {
+    "@a2a-js/sdk": "0.3.13",
+    "express": "5.2.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "@types/express": "5.0.6",
+    "typescript": "6.0.3"
+  }
+}

--- a/a2a-demo/src/__tests__/extension.test.ts
+++ b/a2a-demo/src/__tests__/extension.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test';
+import type { Part } from '@a2a-js/sdk';
+import { extractVellumSocial, makeRequestPart, makeResponsePart, makeWorkingPart } from '../extension.js';
+
+describe('extractVellumSocial', () => {
+  test('returns null for empty parts array', () => {
+    expect(extractVellumSocial([])).toBeNull();
+  });
+
+  test('returns null when no DataPart matches', () => {
+    const parts: Part[] = [
+      { kind: 'text', text: 'hello' },
+      { kind: 'data', data: { extension: 'some-other-extension', value: 42 } },
+    ];
+    expect(extractVellumSocial(parts)).toBeNull();
+  });
+
+  test('correctly extracts request data from parts', () => {
+    const parts: Part[] = [
+      { kind: 'text', text: 'requesting coffee order' },
+      {
+        kind: 'data',
+        data: {
+          extension: 'x-vellum-social-v1',
+          connection_id: 'conn_123',
+          sender_relationship: 'colleague',
+          correlation_id: 'corr_abc',
+        },
+      },
+    ];
+    const result = extractVellumSocial(parts);
+    expect(result).not.toBeNull();
+    expect(result!.extension).toBe('x-vellum-social-v1');
+    expect((result as { connection_id: string }).connection_id).toBe('conn_123');
+    expect((result as { sender_relationship: string }).sender_relationship).toBe('colleague');
+    expect((result as { correlation_id: string }).correlation_id).toBe('corr_abc');
+  });
+
+  test('correctly extracts response data from parts', () => {
+    const parts: Part[] = [
+      {
+        kind: 'data',
+        data: {
+          extension: 'x-vellum-social-v1',
+          response_basis: 'confirmed',
+          correlation_id: 'corr_xyz',
+        },
+      },
+    ];
+    const result = extractVellumSocial(parts);
+    expect(result).not.toBeNull();
+    expect(result!.extension).toBe('x-vellum-social-v1');
+    expect((result as { response_basis: string }).response_basis).toBe('confirmed');
+    expect((result as { correlation_id: string }).correlation_id).toBe('corr_xyz');
+  });
+});
+
+describe('makeRequestPart', () => {
+  test('produces correct DataPart structure with extension field set', () => {
+    const part = makeRequestPart({
+      connection_id: 'conn_demo_peer1',
+      sender_relationship: 'colleague',
+      correlation_id: 'corr_001',
+      deadline: '2026-01-01T12:00:00Z',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      connection_id: 'conn_demo_peer1',
+      sender_relationship: 'colleague',
+      correlation_id: 'corr_001',
+      deadline: '2026-01-01T12:00:00Z',
+    });
+  });
+});
+
+describe('makeResponsePart', () => {
+  test('produces correct DataPart structure', () => {
+    const part = makeResponsePart({
+      response_basis: 'standing_preference',
+      correlation_id: 'corr_002',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      response_basis: 'standing_preference',
+      correlation_id: 'corr_002',
+    });
+  });
+});
+
+describe('makeWorkingPart', () => {
+  test('produces correct DataPart structure', () => {
+    const part = makeWorkingPart({
+      hitl_state: 'awaiting_human_input',
+      correlation_id: 'corr_003',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      hitl_state: 'awaiting_human_input',
+      correlation_id: 'corr_003',
+    });
+  });
+});

--- a/a2a-demo/src/__tests__/spike.test.ts
+++ b/a2a-demo/src/__tests__/spike.test.ts
@@ -18,9 +18,11 @@ describe('SDK spike roundtrip', () => {
     server = createSpikeServer(PORT);
 
     await new Promise<void>((resolve, reject) => {
-      server.once('listening', resolve);
-      server.once('error', reject);
-      if (server.listening) resolve();
+      const onListening = () => { server.removeListener('error', onError); resolve(); };
+      const onError = (err: Error) => { server.removeListener('listening', onListening); reject(err); };
+      server.once('listening', onListening);
+      server.once('error', onError);
+      if (server.listening) { server.removeListener('error', onError); resolve(); }
     });
 
     // Create client via ClientFactory

--- a/a2a-demo/src/__tests__/spike.test.ts
+++ b/a2a-demo/src/__tests__/spike.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import type { Server } from 'http';
+import type { Message, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import { createSpikeServer } from '../spike.js';
+
+// Use a random high port to avoid collisions
+const PORT = 30_000 + Math.floor(Math.random() * 10_000);
+
+let server: Server;
+
+afterAll(() => {
+  server?.close();
+});
+
+describe('SDK spike roundtrip', () => {
+  test('server/client lifecycle completes with echo artifact', async () => {
+    server = createSpikeServer(PORT);
+
+    // Wait briefly for the server to be listening
+    await new Promise<void>((resolve) => {
+      server.once('listening', resolve);
+      // If already listening, resolve immediately
+      if (server.listening) resolve();
+    });
+
+    // Create client via ClientFactory
+    const factory = new ClientFactory(
+      ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {}),
+    );
+    const client = await factory.createFromUrl(`http://localhost:${PORT}`);
+
+    // Build message
+    const message: Message = {
+      kind: 'message',
+      messageId: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ kind: 'text', text: 'hello from spike test' }],
+    };
+
+    // Collect stream events
+    const events: Array<Message | import('@a2a-js/sdk').Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent> = [];
+    for await (const event of client.sendMessageStream({ message })) {
+      events.push(event);
+    }
+
+    // Verify we received events
+    expect(events.length).toBeGreaterThan(0);
+
+    // Find the artifact-update event
+    const artifactEvent = events.find((e) => e.kind === 'artifact-update') as TaskArtifactUpdateEvent | undefined;
+    expect(artifactEvent).toBeDefined();
+    expect(artifactEvent!.artifact.parts).toHaveLength(1);
+    expect(artifactEvent!.artifact.parts[0].kind).toBe('text');
+    expect((artifactEvent!.artifact.parts[0] as { kind: 'text'; text: string }).text).toBe(
+      'echo: hello from spike test',
+    );
+
+    // Find the completed status event
+    const statusEvent = events.find(
+      (e) => e.kind === 'status-update' && (e as TaskStatusUpdateEvent).status.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+    expect(statusEvent).toBeDefined();
+    expect(statusEvent!.final).toBe(true);
+  });
+});

--- a/a2a-demo/src/__tests__/spike.test.ts
+++ b/a2a-demo/src/__tests__/spike.test.ts
@@ -17,10 +17,9 @@ describe('SDK spike roundtrip', () => {
   test('server/client lifecycle completes with echo artifact', async () => {
     server = createSpikeServer(PORT);
 
-    // Wait briefly for the server to be listening
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       server.once('listening', resolve);
-      // If already listening, resolve immediately
+      server.once('error', reject);
       if (server.listening) resolve();
     });
 

--- a/a2a-demo/src/connections.json
+++ b/a2a-demo/src/connections.json
@@ -1,0 +1,45 @@
+{
+  "owner": { "id": "demo-assistant-1", "name": "Demo Assistant", "port": 3000 },
+  "connections": [
+    {
+      "id": "conn_demo_peer1",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-sarah",
+      "peer_agent_card_url": "http://localhost:3010/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3010",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer2",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-jake",
+      "peer_agent_card_url": "http://localhost:3011/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3011",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer3",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-maria",
+      "peer_agent_card_url": "http://localhost:3012/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3012",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer4",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-priya",
+      "peer_agent_card_url": "http://localhost:3013/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3013",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/a2a-demo/src/extension.ts
+++ b/a2a-demo/src/extension.ts
@@ -1,0 +1,50 @@
+import type { Part, DataPart } from '@a2a-js/sdk';
+import type {
+  VellumSocialData,
+  VellumSocialRequestData,
+  VellumSocialResponseData,
+  VellumSocialWorkingData,
+} from './types.js';
+
+/**
+ * Scans an array of Parts for a DataPart carrying the Vellum social extension.
+ * Returns the typed data if found, null otherwise.
+ */
+export function extractVellumSocial(parts: Part[]): VellumSocialData | null {
+  for (const part of parts) {
+    if (part.kind === 'data' && (part.data as Record<string, unknown>).extension === 'x-vellum-social-v1') {
+      return part.data as unknown as VellumSocialData;
+    }
+  }
+  return null;
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social request payload.
+ */
+export function makeRequestPart(data: Omit<VellumSocialRequestData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social response payload.
+ */
+export function makeResponsePart(data: Omit<VellumSocialResponseData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social working/HITL payload.
+ */
+export function makeWorkingPart(data: Omit<VellumSocialWorkingData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}

--- a/a2a-demo/src/spike.ts
+++ b/a2a-demo/src/spike.ts
@@ -1,0 +1,196 @@
+/**
+ * SDK Spike — Minimal A2A server + client roundtrip to verify exact SDK import paths and API shapes.
+ *
+ * ===== VERIFIED SDK FINDINGS =====
+ *
+ * Import paths (all compile from @a2a-js/sdk v0.3.13):
+ *   - Types (Part, DataPart, Message, AgentCard, etc.): `@a2a-js/sdk`
+ *   - Server (AgentExecutor, RequestContext, ExecutionEventBus, DefaultRequestHandler,
+ *     InMemoryTaskStore, DefaultExecutionEventBusManager): `@a2a-js/sdk/server`
+ *   - Express handlers (agentCardHandler, jsonRpcHandler, UserBuilder): `@a2a-js/sdk/server/express`
+ *   - Client (ClientFactory, ClientFactoryOptions): `@a2a-js/sdk/client`
+ *   - Client interceptors (CallInterceptor, BeforeArgs): `@a2a-js/sdk/client`
+ *
+ * RequestContext:
+ *   - Field is `.userMessage` (not `.message`)
+ *   - Constructor: (userMessage, taskId, contextId, task?, referenceTasks?, context?)
+ *   - `.task` is optional — undefined for first message of a new task
+ *
+ * ExecutionEventBus:
+ *   - `.publish(event)` — publishes AgentExecutionEvent (Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent)
+ *   - `.finished()` — REQUIRED. Signals end of execution. Without it the stream never closes.
+ *
+ * Message:
+ *   - Requires `kind: 'message'` (discriminator field)
+ *   - Requires `messageId: string` (UUID)
+ *   - Requires `role: 'user' | 'agent'`
+ *   - Requires `parts: Part[]`
+ *
+ * TaskStatusUpdateEvent:
+ *   - `final: boolean` is REQUIRED (not optional). Must be `true` on the last status event.
+ *   - Requires `kind: 'status-update'`, `taskId`, `contextId`, `status: { state }`
+ *
+ * TaskArtifactUpdateEvent:
+ *   - Requires `kind: 'artifact-update'`, `taskId`, `contextId`, `artifact: { artifactId, parts }`
+ *
+ * BeforeArgs (interceptor):
+ *   - `args.input.value` contains the MessageSendParams
+ *   - For sendMessageStream: `args.input.value.message.parts` to access outgoing message parts
+ *   - `args.input.method` is 'sendMessage' | 'sendMessageStream' | etc.
+ *
+ * ClientFactory:
+ *   - Constructor takes optional ClientFactoryOptions
+ *   - `ClientFactoryOptions.createFrom(ClientFactoryOptions.default, { clientConfig: { interceptors: [...] } })`
+ *   - Interceptors go in `clientConfig.interceptors`, NOT registered post-construction
+ *   - `.createFromUrl(baseUrl)` fetches agent card and creates client
+ *
+ * UserBuilder.noAuthentication:
+ *   - Required for jsonRpcHandler options
+ *   - `jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication })` — options object API
+ *
+ * agentCardHandler:
+ *   - Takes `{ agentCardProvider }` — can be a requestHandler or an async lambda `() => Promise<AgentCard>`
+ *
+ * DefaultRequestHandler constructor:
+ *   - (agentCard, taskStore, agentExecutor, eventBusManager?, ...)
+ *   - eventBusManager is optional — if not provided, uses its own internal default
+ *
+ * ===== END FINDINGS =====
+ */
+
+import type {
+  AgentCard,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  Message,
+} from '@a2a-js/sdk';
+import type { AgentExecutor, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import express from 'express';
+
+/**
+ * Trivial executor that echoes incoming text back as an artifact, then completes.
+ */
+const echoExecutor: AgentExecutor = {
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    // Extract text from the user message
+    const userText = requestContext.userMessage.parts
+      .filter((p): p is { kind: 'text'; text: string; metadata?: Record<string, unknown> } => p.kind === 'text')
+      .map((p) => p.text)
+      .join(' ');
+
+    // Publish an artifact with the echoed text
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: requestContext.taskId,
+      contextId: requestContext.contextId,
+      artifact: {
+        artifactId: 'echo-artifact-1',
+        name: 'echo',
+        parts: [{ kind: 'text', text: `echo: ${userText}` }],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    // Publish completed status with final: true
+    const statusEvent: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: requestContext.taskId,
+      contextId: requestContext.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(statusEvent);
+
+    // Signal the event bus that execution is done — REQUIRED or the stream never closes
+    eventBus.finished();
+  },
+
+  async cancelTask(_taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    eventBus.finished();
+  },
+};
+
+/**
+ * Creates and starts a minimal A2A server on the given port.
+ * Returns the HTTP server instance for cleanup.
+ */
+export function createSpikeServer(port: number) {
+  const agentCard: AgentCard = {
+    name: 'Spike Echo Agent',
+    url: `http://localhost:${port}/a2a/jsonrpc`,
+    description: 'A trivial echo agent for SDK spike testing',
+    protocolVersion: '0.2.0',
+    version: '0.1.0',
+    capabilities: {
+      streaming: true,
+    },
+    skills: [
+      {
+        id: 'echo',
+        name: 'Echo',
+        description: 'Echoes back the input',
+        tags: ['echo', 'test'],
+      },
+    ],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, echoExecutor);
+
+  const app = express();
+
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => agentCard }),
+  );
+
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  const server = app.listen(port);
+  return server;
+}
+
+/**
+ * Runs the full spike: starts server, sends a message via ClientFactory, iterates the stream.
+ * Returns the collected stream events for assertions.
+ */
+export async function runSpike(port: number) {
+  const server = createSpikeServer(port);
+
+  try {
+    // Create client via ClientFactory (NOT deprecated A2AClient)
+    const factory = new ClientFactory(
+      ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {}),
+    );
+    const client = await factory.createFromUrl(`http://localhost:${port}`);
+
+    // Build a properly-formed Message
+    const message: Message = {
+      kind: 'message',
+      messageId: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ kind: 'text', text: 'hello' }],
+    };
+
+    // Send via streaming — collect raw A2AStreamEventData events
+    const events: Array<Message | import('@a2a-js/sdk').Task | import('@a2a-js/sdk').TaskStatusUpdateEvent | import('@a2a-js/sdk').TaskArtifactUpdateEvent> = [];
+    for await (const event of client.sendMessageStream({ message })) {
+      events.push(event);
+    }
+
+    return events;
+  } finally {
+    server.close();
+  }
+}

--- a/a2a-demo/src/spike.ts
+++ b/a2a-demo/src/spike.ts
@@ -169,9 +169,11 @@ export async function runSpike(port: number) {
   const server = createSpikeServer(port);
 
   await new Promise<void>((resolve, reject) => {
-    server.once('listening', resolve);
-    server.once('error', reject);
-    if (server.listening) resolve();
+    const onListening = () => { server.removeListener('error', onError); resolve(); };
+    const onError = (err: Error) => { server.removeListener('listening', onListening); reject(err); };
+    server.once('listening', onListening);
+    server.once('error', onError);
+    if (server.listening) { server.removeListener('error', onError); resolve(); }
   });
 
   try {

--- a/a2a-demo/src/spike.ts
+++ b/a2a-demo/src/spike.ts
@@ -168,6 +168,12 @@ export function createSpikeServer(port: number) {
 export async function runSpike(port: number) {
   const server = createSpikeServer(port);
 
+  // Wait for the server to be listening before connecting the client
+  await new Promise<void>((resolve) => {
+    server.once('listening', resolve);
+    if (server.listening) resolve();
+  });
+
   try {
     // Create client via ClientFactory (NOT deprecated A2AClient)
     const factory = new ClientFactory(

--- a/a2a-demo/src/spike.ts
+++ b/a2a-demo/src/spike.ts
@@ -168,9 +168,9 @@ export function createSpikeServer(port: number) {
 export async function runSpike(port: number) {
   const server = createSpikeServer(port);
 
-  // Wait for the server to be listening before connecting the client
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
     server.once('listening', resolve);
+    server.once('error', reject);
     if (server.listening) resolve();
   });
 

--- a/a2a-demo/src/types.ts
+++ b/a2a-demo/src/types.ts
@@ -1,0 +1,46 @@
+import type { AgentCard } from '@a2a-js/sdk';
+
+export type RelationshipType = 'colleague' | 'work_contact' | 'friend' | 'family' | 'other';
+export type ResponseBasis = 'confirmed' | 'standing_preference' | 'inferred' | 'unreachable';
+export type HitlState = 'awaiting_human_input' | 'awaiting_human_input_stale';
+
+// TypeScript typed wrapper — AgentCard may reject extra literal fields
+export type VellumAgentCard = AgentCard & { 'x-vellum-social-v1': true };
+
+export interface Connection {
+  id: string;
+  owner_assistant_id: string;
+  peer_assistant_id: string;
+  peer_agent_card_url: string;
+  peer_base_url: string;
+  declared_relationship: RelationshipType;
+  scopes: string[];
+  created_at: string;
+}
+
+export interface ConnectionsConfig {
+  owner: { id: string; name: string; port: number };
+  connections: Connection[];
+}
+
+export interface VellumSocialRequestData {
+  extension: 'x-vellum-social-v1';
+  connection_id: string;
+  sender_relationship: RelationshipType;
+  correlation_id: string;
+  deadline?: string;
+}
+
+export interface VellumSocialResponseData {
+  extension: 'x-vellum-social-v1';
+  response_basis: ResponseBasis;
+  correlation_id: string;
+}
+
+export interface VellumSocialWorkingData {
+  extension: 'x-vellum-social-v1';
+  hitl_state: HitlState;
+  correlation_id: string;
+}
+
+export type VellumSocialData = VellumSocialRequestData | VellumSocialResponseData | VellumSocialWorkingData;

--- a/a2a-demo/tsconfig.json
+++ b/a2a-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "types": ["bun-types"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "ui/src/**/*"],
+  "exclude": ["node_modules", "dist", "ui/dist"]
+}


### PR DESCRIPTION
## Summary
- Add a2a-demo package with types, extension helpers, connections config, and SDK spike
- Verify @a2a-js/sdk import paths, API shapes, ClientFactory, and server/client roundtrip
- Include comprehensive tests for extension helpers and SDK spike

Part of plan: a2a-tracer-bullet-demo.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->