### PR TITLE
Guard OAuth request hosts

### DIFF
--- a/assistant/src/__tests__/oauth-commands-routes.test.ts
+++ b/assistant/src/__tests__/oauth-commands-routes.test.ts
@@ -22,6 +22,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 interface MockProviderRow {
   provider: string;
   managedServiceConfigKey: string | null;
+  baseUrl: string | null;
+  injectionTemplates: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
   pingHeaders: string | null;
@@ -31,6 +33,8 @@ interface MockProviderRow {
 const baseProvider: MockProviderRow = {
   provider: "google",
   managedServiceConfigKey: "google-oauth",
+  baseUrl: "https://api.google.com",
+  injectionTemplates: null,
   pingUrl: null,
   pingMethod: null,
   pingHeaders: null,
@@ -45,7 +49,10 @@ let mockApps: Record<string, unknown> = {};
 let mockTokenValue = "tok-fake";
 let platformAvailable = true;
 let platformAssistantId: string | null = "assistant-1";
-let mockFetchImpl: (path: string, init?: RequestInit) => Promise<{
+let mockFetchImpl: (
+  path: string,
+  init?: RequestInit,
+) => Promise<{
   ok: boolean;
   status: number;
   json: () => Promise<unknown>;
@@ -61,6 +68,7 @@ let mockResolveResponse: {
   headers: Record<string, string>;
   body: unknown;
 } = { status: 200, headers: {}, body: { ok: true } };
+let mockResolveRequests: unknown[] = [];
 
 const mockDisconnectOAuthProvider = mock(() => Promise.resolve());
 const mockSaveRawConfig = mock(() => undefined);
@@ -102,7 +110,10 @@ mock.module("../oauth/oauth-store.js", () => ({
 
 mock.module("../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: async (_provider: string) => ({
-    request: async () => mockResolveResponse,
+    request: async (req: unknown) => {
+      mockResolveRequests.push(req);
+      return mockResolveResponse;
+    },
   }),
 }));
 
@@ -119,17 +130,19 @@ mock.module("../platform/client.js", () => ({
 }));
 
 mock.module("../security/token-manager.js", () => ({
-  withValidToken: async <T,>(
-    _provider: string,
-    fn: (t: string) => Promise<T>,
-  ) => fn(mockTokenValue),
+  withValidToken: async <T>(_provider: string, fn: (t: string) => Promise<T>) =>
+    fn(mockTokenValue),
 }));
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({ services: {} }),
   loadRawConfig: () => ({ services: {} }),
   saveRawConfig: mockSaveRawConfig,
-  setNestedValue: (obj: Record<string, unknown>, path: string, value: unknown) => {
+  setNestedValue: (
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ) => {
     const parts = path.split(".");
     let cur: Record<string, unknown> = obj;
     for (let i = 0; i < parts.length - 1; i++) {
@@ -152,7 +165,11 @@ mock.module("../config/schemas/services.js", () => ({
   },
 }));
 
-import { BadRequestError, InternalError, NotFoundError } from "../runtime/routes/errors.js";
+import {
+  BadRequestError,
+  InternalError,
+  NotFoundError,
+} from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/oauth-commands-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 
@@ -194,6 +211,7 @@ beforeEach(() => {
     text: async () => "",
   });
   mockResolveResponse = { status: 200, headers: {}, body: { ok: true } };
+  mockResolveRequests = [];
   mockDisconnectOAuthProvider.mockClear();
   mockSaveRawConfig.mockClear();
 });
@@ -430,7 +448,10 @@ describe("GET oauth/status", () => {
     ];
     const result = (await getRoute("GET", "oauth/status").handler(
       makeArgs({ queryParams: { provider: "google" } }),
-    )) as { mode: string; connections: Array<{ id: string; grantedScopes: string[] }> };
+    )) as {
+      mode: string;
+      connections: Array<{ id: string; grantedScopes: string[] }>;
+    };
     expect(result.mode).toBe("byo");
     expect(result.connections).toHaveLength(1);
     expect(result.connections[0]!.id).toBe("conn-1");
@@ -507,7 +528,11 @@ describe("POST oauth/ping", () => {
       ...baseProvider,
       pingUrl: "https://api.google.com/v1/me",
     };
-    mockResolveResponse = { status: 401, headers: {}, body: { error: "unauthorized" } };
+    mockResolveResponse = {
+      status: 401,
+      headers: {},
+      body: { error: "unauthorized" },
+    };
     const result = (await getRoute("POST", "oauth/ping").handler(
       makeArgs({ body: { provider: "google" } }),
     )) as { ok: boolean; status: number; hint?: string };
@@ -543,7 +568,9 @@ describe("POST oauth/token", () => {
     // No active connections registered for google
     await expect(
       getRoute("POST", "oauth/token").handler(
-        makeArgs({ body: { provider: "google", account: "missing@example.com" } }),
+        makeArgs({
+          body: { provider: "google", account: "missing@example.com" },
+        }),
       ),
     ).rejects.toBeInstanceOf(NotFoundError);
   });
@@ -576,6 +603,130 @@ describe("POST oauth/request", () => {
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
     expect(result.body).toEqual({ hello: "world" });
+  });
+
+  test("rejects absolute URL host outside provider base host when no injection templates exist", async () => {
+    await expect(
+      getRoute("POST", "oauth/request").handler(
+        makeArgs({
+          body: { provider: "google", url: "https://attacker.example/v1/me" },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockResolveRequests).toHaveLength(0);
+  });
+
+  test("rejects protocol downgrade for absolute OAuth request URLs", async () => {
+    await expect(
+      getRoute("POST", "oauth/request").handler(
+        makeArgs({
+          body: { provider: "google", url: "http://api.google.com/v1/me" },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockResolveRequests).toHaveLength(0);
+  });
+
+  test("rejects absolute URL host outside provider injection templates", async () => {
+    mockProviders.slack_channel = {
+      ...baseProvider,
+      provider: "slack_channel",
+      managedServiceConfigKey: null,
+      baseUrl: "https://slack.com/api",
+      injectionTemplates: JSON.stringify([
+        {
+          hostPattern: "slack.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ]),
+    };
+
+    await expect(
+      getRoute("POST", "oauth/request").handler(
+        makeArgs({
+          body: {
+            provider: "slack_channel",
+            url: "https://attacker.example/api/auth.test",
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(mockResolveRequests).toHaveLength(0);
+  });
+
+  test("allows absolute URL host matching provider injection templates", async () => {
+    mockProviders.slack_channel = {
+      ...baseProvider,
+      provider: "slack_channel",
+      managedServiceConfigKey: null,
+      baseUrl: "https://slack.com/api",
+      injectionTemplates: JSON.stringify([
+        {
+          hostPattern: "slack.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ]),
+    };
+
+    await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: {
+          provider: "slack_channel",
+          url: "https://slack.com/api/auth.test?team=T123",
+        },
+      }),
+    );
+
+    expect(mockResolveRequests).toEqual([
+      {
+        method: "GET",
+        path: "/api/auth.test",
+        query: { team: "T123" },
+        baseUrl: "https://slack.com",
+      },
+    ]);
+  });
+
+  test("allows cross-host absolute URLs declared by provider injection templates", async () => {
+    mockProviders.google = {
+      ...baseProvider,
+      baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+      injectionTemplates: JSON.stringify([
+        {
+          hostPattern: "gmail.googleapis.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+        {
+          hostPattern: "www.googleapis.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ]),
+    };
+
+    await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: {
+          provider: "google",
+          url: "https://www.googleapis.com/calendar/v3/calendars",
+        },
+      }),
+    );
+
+    expect(mockResolveRequests).toEqual([
+      {
+        method: "GET",
+        path: "/calendar/v3/calendars",
+        baseUrl: "https://www.googleapis.com",
+      },
+    ]);
   });
 
   test("attaches reconnect hint on 401 response", async () => {
@@ -681,10 +832,7 @@ describe("GET oauth/managed-connect/poll", () => {
       ],
       text: async () => "",
     });
-    const result = (await getRoute(
-      "GET",
-      "oauth/managed-connect/poll",
-    ).handler(
+    const result = (await getRoute("GET", "oauth/managed-connect/poll").handler(
       makeArgs({ queryParams: { provider: "google" } }),
     )) as {
       ok: boolean;
@@ -696,7 +844,11 @@ describe("GET oauth/managed-connect/poll", () => {
     };
     expect(result.ok).toBe(true);
     expect(result.connections).toEqual([
-      { id: "conn-1", account_label: "alice@example.com", scopes_granted: ["email"] },
+      {
+        id: "conn-1",
+        account_label: "alice@example.com",
+        scopes_granted: ["email"],
+      },
     ]);
   });
 

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -722,6 +722,14 @@ export const PROVIDER_SEED_DATA: Record<
     requiresClientSecret: false,
     logoUrl: "https://cdn.simpleicons.org/slack",
     defaultScopes: [],
+    injectionTemplates: [
+      {
+        hostPattern: "slack.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
   },
 
   telegram: {

--- a/assistant/src/runtime/routes/oauth-commands-routes.ts
+++ b/assistant/src/runtime/routes/oauth-commands-routes.ts
@@ -7,7 +7,12 @@
 
 import { readFileSync } from "node:fs";
 
-import { getConfig, loadRawConfig, saveRawConfig, setNestedValue } from "../../config/loader.js";
+import {
+  getConfig,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
 import {
   getServiceMode,
   type Services,
@@ -26,9 +31,11 @@ import {
   getProvider,
   listActiveConnectionsByProvider,
   listConnections,
+  type OAuthProviderRow,
 } from "../../oauth/oauth-store.js";
 import { VellumPlatformClient } from "../../platform/client.js";
 import { withValidToken } from "../../security/token-manager.js";
+import { matchHostPattern } from "../../tools/credentials/host-pattern-match.js";
 import { getLogger } from "../../util/logger.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -121,6 +128,82 @@ async function countManagedConnections(provider: string): Promise<number> {
   }
 }
 
+function parseUrl(value: string | null | undefined): URL | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getAllowedRequestHostPatterns(
+  providerRow: OAuthProviderRow,
+): string[] {
+  const patterns: string[] = [];
+
+  if (providerRow.injectionTemplates) {
+    try {
+      const parsed = JSON.parse(providerRow.injectionTemplates) as unknown;
+      if (Array.isArray(parsed)) {
+        for (const entry of parsed) {
+          if (
+            entry &&
+            typeof entry === "object" &&
+            typeof (entry as { hostPattern?: unknown }).hostPattern === "string"
+          ) {
+            const hostPattern = (
+              entry as { hostPattern: string }
+            ).hostPattern.trim();
+            if (hostPattern) patterns.push(hostPattern);
+          }
+        }
+      }
+    } catch {
+      // Fall back to the provider's base URL host below.
+    }
+  }
+
+  if (patterns.length === 0) {
+    const baseUrl = parseUrl(providerRow.baseUrl);
+    if (baseUrl) patterns.push(baseUrl.hostname);
+  }
+
+  return [...new Set(patterns)];
+}
+
+function assertOAuthRequestUrlAllowed(
+  providerRow: OAuthProviderRow,
+  parsedUrl: URL,
+): void {
+  const providerBaseUrl = parseUrl(providerRow.baseUrl);
+  const allowedProtocol = providerBaseUrl?.protocol ?? "https:";
+  if (parsedUrl.protocol !== allowedProtocol) {
+    throw new BadRequestError(
+      `OAuth request URL for "${providerRow.provider}" must use ${allowedProtocol.replace(/:$/, "")}.`,
+    );
+  }
+
+  const allowedHostPatterns = getAllowedRequestHostPatterns(providerRow);
+  if (allowedHostPatterns.length === 0) {
+    throw new BadRequestError(
+      `OAuth provider "${providerRow.provider}" does not define an allowed request host.`,
+    );
+  }
+
+  const allowed = allowedHostPatterns.some(
+    (pattern) =>
+      matchHostPattern(parsedUrl.hostname, pattern, {
+        includeApexForWildcard: true,
+      }) !== "none",
+  );
+  if (!allowed) {
+    throw new BadRequestError(
+      `OAuth request URL host "${parsedUrl.hostname}" is not allowed for "${providerRow.provider}". Allowed hosts: ${allowedHostPatterns.join(", ")}.`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Disconnect handler
 // ---------------------------------------------------------------------------
@@ -176,7 +259,9 @@ async function handleDisconnect({ body = {} }: RouteHandlerArgs) {
       accountLabel = match.account_label;
     } else {
       if (entries.length === 0) {
-        throw new NotFoundError(`No active connections found for "${b.provider}".`);
+        throw new NotFoundError(
+          `No active connections found for "${b.provider}".`,
+        );
       }
       if (entries.length > 1) {
         throw new BadRequestError(
@@ -235,7 +320,9 @@ async function handleDisconnect({ body = {} }: RouteHandlerArgs) {
   } else {
     const active = listActiveConnectionsByProvider(b.provider);
     if (active.length === 0) {
-      throw new NotFoundError(`No active connections found for "${b.provider}".`);
+      throw new NotFoundError(
+        `No active connections found for "${b.provider}".`,
+      );
     }
     if (active.length > 1) {
       throw new BadRequestError(
@@ -582,11 +669,7 @@ async function handleToken({ body = {} }: RouteHandlerArgs) {
     tokenOpts = { connectionId: conn.id };
   }
 
-  const token = await withValidToken(
-    b.provider,
-    async (t) => t,
-    tokenOpts,
-  );
+  const token = await withValidToken(b.provider, async (t) => t, tokenOpts);
 
   return { ok: true, token };
 }
@@ -666,6 +749,7 @@ async function handleRequest({ body = {} }: RouteHandlerArgs) {
 
   if (b.url.startsWith("http://") || b.url.startsWith("https://")) {
     const parsed = new URL(b.url);
+    assertOAuthRequestUrlAllowed(providerRow, parsed);
     baseUrl = `${parsed.protocol}//${parsed.host}`;
     requestPath = parsed.pathname;
     for (const [key, value] of parsed.searchParams.entries()) {
@@ -717,7 +801,12 @@ async function handleRequest({ body = {} }: RouteHandlerArgs) {
   const query: Record<string, string | string[]> = { ...queryFromUrl };
 
   // Use pre-parsed data from CLI, or fall back to raw data string for direct API callers
-  const resolvedData = b.parsed_data !== undefined ? b.parsed_data : b.data !== undefined ? readBodyData(b.data) : undefined;
+  const resolvedData =
+    b.parsed_data !== undefined
+      ? b.parsed_data
+      : b.data !== undefined
+        ? readBodyData(b.data)
+        : undefined;
 
   if (resolvedData !== undefined) {
     const rawBody = resolvedData;
@@ -855,7 +944,9 @@ async function handleManagedConnect({ body = {} }: RouteHandlerArgs) {
   return { ok: true, connect_url: result.connect_url };
 }
 
-async function handleManagedConnectPoll({ queryParams = {} }: RouteHandlerArgs) {
+async function handleManagedConnectPoll({
+  queryParams = {},
+}: RouteHandlerArgs) {
   const provider = queryParams.provider;
   if (!provider) throw new BadRequestError("provider query param is required");
 
@@ -894,7 +985,8 @@ export const ROUTES: RouteDefinition[] = [
     endpoint: "oauth/mode",
     method: "GET",
     summary: "Get OAuth mode",
-    description: "Get the current OAuth mode (managed or your-own) for a provider.",
+    description:
+      "Get the current OAuth mode (managed or your-own) for a provider.",
     tags: ["oauth"],
     requirePolicyEnforcement: true,
     queryParams: [
@@ -913,8 +1005,7 @@ export const ROUTES: RouteDefinition[] = [
     method: "POST",
     policyKey: "oauth/mode.set",
     summary: "Set OAuth mode",
-    description:
-      "Set the OAuth mode (managed or your-own) for a provider.",
+    description: "Set the OAuth mode (managed or your-own) for a provider.",
     tags: ["oauth"],
     requirePolicyEnforcement: true,
     handler: handleModeSet,
@@ -955,8 +1046,7 @@ export const ROUTES: RouteDefinition[] = [
     method: "POST",
     policyKey: "oauth/token",
     summary: "Get OAuth token",
-    description:
-      "Retrieve a valid OAuth access token for a BYO-mode provider.",
+    description: "Retrieve a valid OAuth access token for a BYO-mode provider.",
     tags: ["oauth"],
     requirePolicyEnforcement: true,
     handler: handleToken,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -584,7 +584,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T20:12:14-04:00"
+      "updatedAt": "2026-05-13T08:59:50-04:00"
     },
     {
       "id": "slack-app-setup",

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Slack"
 ---
 
-You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via `assistant oauth request --provider slack_channel` -- there are no dedicated Slack tools.
+You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via `assistant oauth request --provider slack_channel` -- there are no dedicated Slack tools. Use relative Slack API method paths such as `/chat.postMessage`; the provider supplies the Slack host.
 
 ## Resolution Scripts
 
@@ -29,7 +29,7 @@ The cache is stored locally under `~/.vellum/workspace/data/slack-skill/`. On fi
 
 ## Making Slack API Calls
 
-Use `assistant oauth request --provider slack_channel` to call any Slack Web API method. Auth is handled transparently -- the provider injects the bot token automatically.
+Use `assistant oauth request --provider slack_channel` to call any Slack Web API method. Auth is handled transparently -- the provider injects the bot token automatically. Pass relative method paths; do not include a host.
 
 General pattern:
 
@@ -37,7 +37,7 @@ General pattern:
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C123","text":"Hello world"}' \
-  https://slack.com/api/chat.postMessage --json
+  /chat.postMessage --json
 ```
 
 The model knows the full Slack API from training data. Refer to https://api.slack.com/methods for the complete list of available endpoints.
@@ -48,7 +48,7 @@ The model knows the full Slack API from training data. Refer to https://api.slac
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C0123456789","text":"Hello from the assistant!"}' \
-  https://slack.com/api/chat.postMessage --json
+  /chat.postMessage --json
 ```
 
 ### Read channel history
@@ -57,7 +57,7 @@ assistant oauth request --provider slack_channel \
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C0123456789","limit":20}' \
-  https://slack.com/api/conversations.history --json
+  /conversations.history --json
 ```
 
 ### Read thread replies
@@ -66,7 +66,7 @@ assistant oauth request --provider slack_channel \
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C0123456789","ts":"1716000000.000001"}' \
-  https://slack.com/api/conversations.replies --json
+  /conversations.replies --json
 ```
 
 ### Add a reaction
@@ -75,7 +75,7 @@ assistant oauth request --provider slack_channel \
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C0123456789","timestamp":"1716000000.000001","name":"thumbsup"}' \
-  https://slack.com/api/reactions.add --json
+  /reactions.add --json
 ```
 
 ### Send with blocks (rich formatting)
@@ -91,7 +91,7 @@ assistant oauth request --provider slack_channel \
       {"type":"section","text":{"type":"mrkdwn","text":"*Project Alpha*: on track\n*Project Beta*: needs review"}}
     ]
   }' \
-  https://slack.com/api/chat.postMessage --json
+  /chat.postMessage --json
 ```
 
 ### Upload a file
@@ -103,21 +103,21 @@ File uploads use a multi-step flow: get an upload URL, upload the file, then com
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"filename":"notes.txt","length":42}' \
-  https://slack.com/api/files.getUploadURLExternal --json
+  /files.getUploadURLExternal --json
 
 # Step 2: Upload file content to the returned upload_url (use curl directly)
 # Step 3: Complete the upload
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"files":[{"id":"FILE_ID","title":"Meeting Notes"}],"channel_id":"C0123456789"}' \
-  https://slack.com/api/files.completeUploadExternal --json
+  /files.completeUploadExternal --json
 ```
 
 ### Search messages
 
 ```bash
 assistant oauth request --provider slack_channel \
-  "https://slack.com/api/search.messages?query=project+launch+in%3A%23general" --json
+  "/search.messages?query=project+launch+in%3A%23general" --json
 ```
 
 ### Open a DM
@@ -126,7 +126,7 @@ assistant oauth request --provider slack_channel \
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"users":"U0123456789"}' \
-  https://slack.com/api/conversations.open --json
+  /conversations.open --json
 ```
 
 ## Typical Workflow
@@ -163,7 +163,7 @@ When responding to messages from Slack channels, replies should be threaded. Pas
 assistant oauth request --provider slack_channel \
   -X POST \
   -d '{"channel":"C0123456789","text":"Replying in thread","thread_ts":"1716000000.000001"}' \
-  https://slack.com/api/chat.postMessage --json
+  /chat.postMessage --json
 ```
 
 ## Connection

--- a/skills/slack/scripts/lib/slack-client.ts
+++ b/skills/slack/scripts/lib/slack-client.ts
@@ -91,7 +91,7 @@ export async function slackRequest<T = unknown>(
       args.push("--account", opts.account);
     }
 
-    let path = `https://slack.com/api${opts.path}`;
+    let path = opts.path.startsWith("/") ? opts.path : `/${opts.path}`;
     if (opts.query && Object.keys(opts.query).length > 0) {
       const qs = new URLSearchParams(opts.query).toString();
       path += "?" + qs;


### PR DESCRIPTION
## Summary
- Restrict absolute OAuth request URL overrides to provider injection host patterns, falling back to the provider base URL host.
- Reject protocol downgrades before resolving or using OAuth credentials.
- Seed slack_channel with the Slack host policy and update Slack skill/script calls to use relative API method paths.

Closes ATL-558

## Tests
- PATH="/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.local/bin:/Users/alex/.codex/tmp/arg0/codex-arg0Pn5fEy:/Users/alex/bin:/Users/alex/.bun/bin:/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.antigravity/antigravity/bin:/Users/alex/.nvm/versions/node/v22.13.1/bin:/Users/alex/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/alex/.local/bin:/Applications/Codex.app/Contents/Resources" bun test src/__tests__/oauth-commands-routes.test.ts
- PATH="/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.local/bin:/Users/alex/.codex/tmp/arg0/codex-arg0Pn5fEy:/Users/alex/bin:/Users/alex/.bun/bin:/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.antigravity/antigravity/bin:/Users/alex/.nvm/versions/node/v22.13.1/bin:/Users/alex/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/alex/.local/bin:/Applications/Codex.app/Contents/Resources" bun test src/__tests__/oauth-provider-profiles.test.ts
- PATH="/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.local/bin:/Users/alex/.codex/tmp/arg0/codex-arg0Pn5fEy:/Users/alex/bin:/Users/alex/.bun/bin:/Users/alex/.bun/bin:/Users/alex/.local/bin:/Users/alex/.antigravity/antigravity/bin:/Users/alex/.nvm/versions/node/v22.13.1/bin:/Users/alex/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/alex/.local/bin:/Applications/Codex.app/Contents/Resources" bunx tsc --noEmit
- pre-commit/pre-push lint and typecheck
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->