### PR TITLE
feat(a2a-demo): add four mock peer A2A servers

### DIFF
--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
+    "peers:start": "bun run src/peers/start-all.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/a2a-demo/src/peers/create-peer-server.ts
+++ b/a2a-demo/src/peers/create-peer-server.ts
@@ -1,0 +1,66 @@
+import type { Server } from 'node:http';
+import type { Express } from 'express';
+import express from 'express';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { VellumSocialExecutor, type PeerConfig } from '../executor.js';
+import type { VellumAgentCard } from '../types.js';
+
+export interface CreatePeerServerOptions {
+  name: string;
+  port: number;
+  assistantId: string;
+  config: PeerConfig;
+}
+
+export interface PeerServer {
+  app: Express;
+  server: Server;
+}
+
+export function createPeerServer(options: CreatePeerServerOptions): PeerServer {
+  const { name, port, config } = options;
+
+  const card: VellumAgentCard = {
+    name: `${name}'s Assistant`,
+    url: `http://localhost:${port}/a2a/jsonrpc`,
+    description: `Mock peer for A2A demo — exercises ${config.strategy}`,
+    protocolVersion: '0.3.0',
+    version: '0.1.0',
+    capabilities: { streaming: true },
+    skills: [
+      {
+        id: 'coffee_order',
+        name: 'Coffee Order',
+        description: 'Responds to coffee order requests',
+        tags: ['coffee', 'social'],
+      },
+    ],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    'x-vellum-social-v1': true,
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const executor = new VellumSocialExecutor(config);
+  const requestHandler = new DefaultRequestHandler(card, taskStore, executor);
+
+  const app = express();
+
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => card }),
+  );
+
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  const server = app.listen(port);
+
+  return { app, server };
+}

--- a/a2a-demo/src/peers/create-peer-server.ts
+++ b/a2a-demo/src/peers/create-peer-server.ts
@@ -19,12 +19,12 @@ export interface PeerServer {
 }
 
 export function createPeerServer(options: CreatePeerServerOptions): PeerServer {
-  const { name, port, config } = options;
+  const { name, port, assistantId, config } = options;
 
   const card: VellumAgentCard = {
     name: `${name}'s Assistant`,
     url: `http://localhost:${port}/a2a/jsonrpc`,
-    description: `Mock peer for A2A demo — exercises ${config.strategy}`,
+    description: `Mock peer [${assistantId}] for A2A demo — exercises ${config.strategy}`,
     protocolVersion: '0.3.0',
     version: '0.1.0',
     capabilities: { streaming: true },

--- a/a2a-demo/src/peers/jake.ts
+++ b/a2a-demo/src/peers/jake.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Jake',
+  port: 3011,
+  assistantId: 'jake-assistant',
+  config: {
+    name: 'Jake',
+    responseText: 'Black drip, large',
+    strategy: 'hitl_confirm',
+    humanDelayMs: 3000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Jake] listening on port 3011');
+});

--- a/a2a-demo/src/peers/maria.ts
+++ b/a2a-demo/src/peers/maria.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Maria',
+  port: 3012,
+  assistantId: 'maria-assistant',
+  config: {
+    name: 'Maria',
+    responseText: 'Usually an Americano, unconfirmed',
+    strategy: 'hitl_stale_infer',
+    humanDelayMs: 6000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Maria] listening on port 3012');
+});

--- a/a2a-demo/src/peers/priya.ts
+++ b/a2a-demo/src/peers/priya.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Priya',
+  port: 3013,
+  assistantId: 'priya-assistant',
+  config: {
+    name: 'Priya',
+    responseText: "Priya's in a meeting, no response",
+    strategy: 'hitl_unreachable',
+    humanDelayMs: 8000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Priya] listening on port 3013');
+});

--- a/a2a-demo/src/peers/sarah.ts
+++ b/a2a-demo/src/peers/sarah.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Sarah',
+  port: 3010,
+  assistantId: 'sarah-assistant',
+  config: {
+    name: 'Sarah',
+    responseText: 'Cortado, oat milk',
+    strategy: 'standing_preference',
+    humanDelayMs: 0,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Sarah] listening on port 3010');
+});

--- a/a2a-demo/src/peers/start-all.ts
+++ b/a2a-demo/src/peers/start-all.ts
@@ -1,0 +1,88 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface PeerDef {
+  label: string;
+  script: string;
+  port: number;
+}
+
+const peers: PeerDef[] = [
+  { label: 'Sarah', script: 'sarah.ts', port: 3010 },
+  { label: 'Jake', script: 'jake.ts', port: 3011 },
+  { label: 'Maria', script: 'maria.ts', port: 3012 },
+  { label: 'Priya', script: 'priya.ts', port: 3013 },
+];
+
+const children: Array<ReturnType<typeof Bun.spawn>> = [];
+
+for (const peer of peers) {
+  const scriptPath = resolve(__dirname, peer.script);
+
+  const child = Bun.spawn(['bun', 'run', scriptPath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  children.push(child);
+
+  // Pipe stdout with prefix
+  (async () => {
+    if (!child.stdout) return;
+    const reader = child.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        console.log(`[${peer.label}] ${line}`);
+      }
+    }
+    if (buffer) {
+      console.log(`[${peer.label}] ${buffer}`);
+    }
+  })();
+
+  // Pipe stderr with prefix
+  (async () => {
+    if (!child.stderr) return;
+    const reader = child.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        console.error(`[${peer.label}] ${line}`);
+      }
+    }
+    if (buffer) {
+      console.error(`[${peer.label}] ${buffer}`);
+    }
+  })();
+}
+
+console.log('All peers started on ports 3010-3013');
+
+function shutdown() {
+  console.log('\nShutting down peers...');
+  for (const child of children) {
+    child.kill();
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+// Keep the process alive by awaiting all children
+await Promise.all(children.map((child) => child.exited));

--- a/a2a-demo/src/peers/start-all.ts
+++ b/a2a-demo/src/peers/start-all.ts
@@ -84,5 +84,16 @@ function shutdown() {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
-// Keep the process alive by awaiting all children
-await Promise.all(children.map((child) => child.exited));
+// Keep the process alive — fail fast if any peer exits non-zero
+await Promise.all(
+  children.map(async (child, i) => {
+    const code = await child.exited;
+    if (code !== 0) {
+      console.error(`[${peers[i].label}] exited with code ${code} — shutting down remaining peers`);
+      for (const c of children) {
+        c.kill();
+      }
+      process.exit(code ?? 1);
+    }
+  }),
+);


### PR DESCRIPTION
## Summary
- Add create-peer-server factory with SDK agent card, JSON-RPC handler, and VellumSocialExecutor
- Create four mock peers (Sarah, Jake, Maria, Priya) on ports 3010-3013
- Add start-all.ts supervisor script for launching all peers

Part of plan: a2a-tracer-bullet-demo.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->