### PR TITLE
feat(a2a-demo): wire up main assistant server with coffee run orchestrator

### DIFF
--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
+    "dev": "bun run build:ui && bun run src/server.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/a2a-demo/src/coffee-run.ts
+++ b/a2a-demo/src/coffee-run.ts
@@ -1,0 +1,205 @@
+import type { Artifact, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import { VellumSocialInterceptor } from './interceptor.js';
+import { extractVellumSocial } from './extension.js';
+import type { Connection, ConnectionsConfig, VellumSocialResponseData } from './types.js';
+import type { EventBus } from './events.js';
+
+import connectionsJson from './connections.json' with { type: 'json' };
+
+interface CoffeeRunOptions {
+  deadlineSeconds?: number;
+  eventBus: EventBus;
+  connections?: Connection[];
+}
+
+/**
+ * Orchestrate a coffee run: fan out A2A requests to all connected peers in parallel,
+ * collect responses via streaming, and broadcast SSE events for the demo UI.
+ */
+export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void> {
+  const { eventBus, deadlineSeconds = 15 } = options;
+  const correlationId = crypto.randomUUID();
+  const deadline = new Date(Date.now() + deadlineSeconds * 1000).toISOString();
+
+  const connections = options.connections ?? (connectionsJson as ConnectionsConfig).connections;
+
+  // Fan out to all peers in parallel
+  const results = await Promise.allSettled(
+    connections.map(async (conn) => {
+      // Create a ClientFactory with the interceptor configured upfront
+      const interceptor = new VellumSocialInterceptor(() => ({
+        connection_id: conn.id,
+        sender_relationship: conn.declared_relationship,
+        correlation_id: correlationId,
+        deadline,
+      }));
+      const factory = new ClientFactory(
+        ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+          clientConfig: { interceptors: [interceptor] },
+        }),
+      );
+
+      let client;
+      try {
+        client = await factory.createFromUrl(conn.peer_base_url);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: `Failed to discover agent card: ${message}`,
+        });
+        return;
+      }
+
+      // Check for x-vellum-social-v1 support on the resolved agent card
+      const agentCard = await client.getAgentCard() as unknown as Record<string, unknown>;
+      if (!agentCard['x-vellum-social-v1']) {
+        console.warn(`Peer ${conn.peer_assistant_id} does not support x-vellum-social-v1, skipping`);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: 'peer does not support x-vellum-social-v1',
+        });
+        return;
+      }
+
+      // Cache the latest artifact per peer — needed because `completed` status
+      // does NOT carry the artifact
+      const artifactCache = new Map<string, Artifact>();
+
+      const messageId = crypto.randomUUID();
+
+      // Broadcast task_sent immediately — taskId is null because the SDK
+      // assigns it server-side; we don't know it until the first stream event
+      eventBus.broadcast('task_sent', {
+        peer: conn.peer_assistant_id,
+        messageId,
+        correlationId,
+        taskId: null,
+        method: 'message/stream',
+      });
+
+      try {
+        const stream = client.sendMessageStream({
+          message: {
+            kind: 'message',
+            messageId,
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Coffee run! What would you like?' }],
+          },
+        });
+
+        let firstEvent = true;
+
+        for await (const event of stream) {
+          // On the first stream event, extract the taskId
+          if (firstEvent) {
+            firstEvent = false;
+            const e = event as unknown as Record<string, unknown>;
+            const taskId = e.taskId ?? e.id ?? null;
+            if (taskId) {
+              eventBus.broadcast('protocol_event', {
+                peer: conn.peer_assistant_id,
+                type: 'task_assigned',
+                taskId,
+                event: prettifyEvent(event),
+              });
+            }
+          }
+
+          // Always broadcast protocol_event with the raw prettified SDK event
+          const eventRecord = event as unknown as Record<string, unknown>;
+          eventBus.broadcast('protocol_event', {
+            peer: conn.peer_assistant_id,
+            type: event.kind,
+            taskId: eventRecord.taskId ?? null,
+            event: prettifyEvent(event),
+          });
+
+          // Handle TaskArtifactUpdateEvent — cache the artifact
+          if (event.kind === 'artifact-update') {
+            const artifactEvent = event as TaskArtifactUpdateEvent;
+            artifactCache.set(artifactEvent.artifact.artifactId, artifactEvent.artifact);
+          }
+
+          // Handle TaskStatusUpdateEvent
+          if (event.kind === 'status-update') {
+            const statusEvent = event as TaskStatusUpdateEvent;
+
+            if (statusEvent.status.state === 'working' && statusEvent.status.message) {
+              // Extract HITL DataPart from working status message
+              const socialData = extractVellumSocial(statusEvent.status.message.parts);
+              eventBus.broadcast('hitl_update', {
+                peer: conn.peer_assistant_id,
+                taskId: statusEvent.taskId,
+                hitlState: socialData,
+                sdkEvent: prettifyEvent(event),
+              });
+            }
+
+            if (statusEvent.status.state === 'completed') {
+              // Read artifact from cache (not from the status event)
+              const cachedArtifact = [...artifactCache.values()].pop();
+              let responseText: string | null = null;
+              let responseBasis: string | null = null;
+
+              if (cachedArtifact) {
+                // Extract responseText from TextPart
+                const textPart = cachedArtifact.parts.find((p) => p.kind === 'text');
+                if (textPart && textPart.kind === 'text') {
+                  responseText = (textPart as { kind: 'text'; text: string }).text;
+                }
+
+                // Extract responseBasis from response DataPart
+                const socialData = extractVellumSocial(cachedArtifact.parts);
+                if (socialData && 'response_basis' in socialData) {
+                  responseBasis = (socialData as VellumSocialResponseData).response_basis;
+                }
+              }
+
+              eventBus.broadcast('task_completed', {
+                peer: conn.peer_assistant_id,
+                taskId: statusEvent.taskId,
+                responseText,
+                responseBasis,
+                sdkEvent: prettifyEvent(event),
+              });
+            }
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: message,
+        });
+      }
+    }),
+  );
+
+  // Log any unhandled rejections (shouldn't happen with allSettled, but be safe)
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('Unexpected rejection in coffee run:', result.reason);
+    }
+  }
+
+  eventBus.broadcast('run_complete', { correlationId });
+}
+
+/**
+ * Create a prettified representation of an SDK event for protocol logging.
+ */
+function prettifyEvent(event: unknown): Record<string, unknown> {
+  const e = event as Record<string, unknown>;
+  return {
+    kind: e.kind,
+    ...(e.taskId != null ? { taskId: e.taskId } : {}),
+    ...(e.contextId != null ? { contextId: e.contextId } : {}),
+    ...(e.status != null ? { status: e.status } : {}),
+    ...(e.artifact != null ? { artifact: e.artifact } : {}),
+    ...(e.role != null ? { role: e.role } : {}),
+    ...(e.parts != null ? { parts: e.parts } : {}),
+    ...(e.final != null ? { final: e.final } : {}),
+  };
+}

--- a/a2a-demo/src/events.ts
+++ b/a2a-demo/src/events.ts
@@ -1,0 +1,51 @@
+import type { Response } from 'express';
+
+/**
+ * SSE event bus for the demo UI.
+ * Maintains a set of connected SSE clients and broadcasts events to all of them.
+ */
+export class EventBus {
+  private readonly clients = new Set<Response>();
+
+  /**
+   * Register an SSE client. Sets required headers, flushes an initial `:ok` comment,
+   * and removes the client on disconnect.
+   */
+  addClient(res: Response): void {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    // Send initial comment to flush the connection
+    res.write(':ok\n\n');
+
+    this.clients.add(res);
+
+    res.on('close', () => {
+      this.clients.delete(res);
+    });
+  }
+
+  /**
+   * Broadcast an SSE event to all connected clients.
+   * Silently drops disconnected clients.
+   */
+  broadcast(eventType: string, data: object): void {
+    const payload = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+
+    for (const client of this.clients) {
+      try {
+        client.write(payload);
+      } catch {
+        // Client disconnected — remove silently
+        this.clients.delete(client);
+      }
+    }
+  }
+
+  /** Number of currently connected clients (useful for testing). */
+  get size(): number {
+    return this.clients.size;
+  }
+}

--- a/a2a-demo/src/server.ts
+++ b/a2a-demo/src/server.ts
@@ -1,0 +1,131 @@
+import type { AgentCard } from '@a2a-js/sdk';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import express from 'express';
+import path from 'path';
+
+import { EventBus } from './events.js';
+import { VellumSocialExecutor, type PeerConfig } from './executor.js';
+import { runCoffeeScenario } from './coffee-run.js';
+import type { Connection, ConnectionsConfig, VellumAgentCard } from './types.js';
+
+import connectionsJson from './connections.json' with { type: 'json' };
+
+interface ServerOptions {
+  port?: number;
+  publicBaseUrl?: string;
+  assistantName?: string;
+  assistantId?: string;
+  coffeeResponse?: string;
+  responseStrategy?: PeerConfig['strategy'];
+  connections?: Connection[];
+}
+
+/**
+ * Create and start the main A2A demo server.
+ * Accepts DI options for testing and configuration.
+ */
+export function createServer(options: ServerOptions = {}) {
+  const port = options.port ?? (Number(process.env.PORT) || 3000);
+  const publicBaseUrl = options.publicBaseUrl ?? process.env.PUBLIC_BASE_URL ?? `http://localhost:${port}`;
+  const assistantName = options.assistantName ?? process.env.ASSISTANT_NAME ?? 'Demo Assistant';
+  const assistantId = options.assistantId ?? process.env.ASSISTANT_ID ?? 'demo-assistant-1';
+  const coffeeResponse = options.coffeeResponse ?? process.env.COFFEE_RESPONSE ?? 'I appreciate the offer!';
+  const responseStrategy = (options.responseStrategy ?? process.env.RESPONSE_STRATEGY ?? 'standing_preference') as PeerConfig['strategy'];
+  const connections = options.connections ?? (connectionsJson as ConnectionsConfig).connections;
+
+  const agentCard: VellumAgentCard = {
+    'x-vellum-social-v1': true,
+    name: assistantName,
+    url: `${publicBaseUrl}/a2a/jsonrpc`,
+    description: `${assistantName} — A2A demo assistant with Vellum social extension`,
+    protocolVersion: '0.2.0',
+    version: '0.1.0',
+    capabilities: {
+      streaming: true,
+    },
+    skills: [
+      {
+        id: 'coffee-order',
+        name: 'Coffee Order',
+        description: 'Respond to coffee run requests',
+        tags: ['coffee', 'social'],
+      },
+    ],
+    defaultInputModes: ['text/plain', 'application/json'],
+    defaultOutputModes: ['text/plain', 'application/json'],
+  };
+
+  const peerConfig: PeerConfig = {
+    name: assistantName,
+    responseText: coffeeResponse,
+    strategy: responseStrategy,
+    humanDelayMs: 2000,
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const executor = new VellumSocialExecutor(peerConfig);
+  const requestHandler = new DefaultRequestHandler(agentCard as AgentCard, taskStore, executor);
+
+  const app = express();
+
+  const eventBus = new EventBus();
+
+  // Agent card endpoint
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => agentCard as AgentCard }),
+  );
+
+  // JSON-RPC endpoint
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  // SSE endpoint
+  app.get('/events', (_req, res) => {
+    eventBus.addClient(res);
+  });
+
+  // Connections endpoint
+  app.get('/connections', (_req, res) => {
+    res.json({
+      owner: { id: assistantId, name: assistantName },
+      connections,
+    });
+  });
+
+  // Coffee run trigger
+  app.post('/run/coffee', express.json(), (req, res) => {
+    const deadlineSeconds = (req.body as Record<string, unknown>)?.deadlineSeconds as number | undefined;
+
+    // Fire and forget — respond 202 immediately
+    runCoffeeScenario({
+      deadlineSeconds: deadlineSeconds ?? 15,
+      eventBus,
+      connections,
+    }).catch((err) => {
+      console.error('Coffee run failed:', err);
+    });
+
+    res.status(202).json({ status: 'started' });
+  });
+
+  // Static file serving — serves the built UI
+  app.use(express.static(path.resolve(import.meta.dir, '..', 'ui', 'dist')));
+
+  const server = app.listen(port, () => {
+    console.log(`${assistantName} running on http://localhost:${port}`);
+  });
+
+  return { app, server, eventBus };
+}
+
+// When run directly, start the server
+if (import.meta.main) {
+  createServer();
+}


### PR DESCRIPTION
## Summary
- Add EventBus for SSE broadcasting to connected UI clients
- Implement coffee run orchestrator with parallel peer fan-out via ClientFactory
- Wire up main Express server with agent card, JSON-RPC, SSE, and static file serving

Part of plan: a2a-tracer-bullet-demo.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->