### PR TITLE
feat(a2a-demo): add README, startup scripts, and e2e smoke test

### DIFF
--- a/a2a-demo/README.md
+++ b/a2a-demo/README.md
@@ -1,0 +1,92 @@
+# A2A Social Extension Demo -- Coffee Run
+
+Proves the Vellum social extension wire format on top of the official A2A SDK. Exercises all four `response_basis` values (`standing_preference`, `confirmed`, `inferred`, `unreachable`) across four mock peers with different HITL strategies. The full demo runs in ~15 seconds.
+
+## Quick start (solo)
+
+```bash
+cd a2a-demo && bun install
+
+# Terminal 1: Start mock peers
+bun run peers:start
+
+# Terminal 2: Build UI and start your assistant
+bun run dev
+
+# Open http://localhost:3000 and click "Start coffee run"
+```
+
+Or use the single-command supervisor which starts everything in one process:
+
+```bash
+cd a2a-demo && bun install
+bun run demo
+# Open http://localhost:3000 and click "Start coffee run"
+```
+
+## Run with a friend
+
+Both people check out the branch and `bun install` in `a2a-demo/`.
+
+**Friend** starts their assistant with identity config:
+
+```bash
+ASSISTANT_NAME="Friend's Assistant" \
+ASSISTANT_ID="friend-assistant-1" \
+COFFEE_RESPONSE="Large cold brew please!" \
+PUBLIC_BASE_URL=http://<their-ip>:3000 \
+bun run dev
+```
+
+**You** edit `connections.json`: change one peer entry's `peer_base_url` and `peer_agent_card_url` to `http://<friend-ip>:3000`.
+
+Then start peers and your assistant:
+
+```bash
+bun run peers:start  # terminal 1
+bun run dev          # terminal 2
+```
+
+Click "Start coffee run" -- that peer's card now shows whatever their assistant returns.
+
+**Important**: `PUBLIC_BASE_URL` must be set to a reachable address (not `localhost`) on the friend's machine.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `PORT` | `3000` | Server port |
+| `PUBLIC_BASE_URL` | `http://localhost:$PORT` | Externally-reachable URL for agent card |
+| `ASSISTANT_NAME` | `Demo Assistant` | Name in agent card |
+| `ASSISTANT_ID` | `demo-assistant-1` | Assistant identifier |
+| `COFFEE_RESPONSE` | `I appreciate the offer!` | What this assistant replies when asked |
+| `RESPONSE_STRATEGY` | `standing_preference` | How this assistant responds |
+
+## What each mock peer exercises
+
+| Peer | Port | Strategy | `response_basis` | HITL states |
+|------|------|----------|-------------------|-------------|
+| Sarah | 3010 | Standing preference | `standing_preference` | none |
+| Jake | 3011 | HITL -> confirm | `confirmed` | `awaiting_human_input` |
+| Maria | 3012 | HITL -> stale -> infer | `inferred` | `awaiting_human_input`, `awaiting_human_input_stale` |
+| Priya | 3013 | HITL -> unreachable | `unreachable` | `awaiting_human_input` |
+
+## Architecture
+
+The demo is built on the [A2A JS SDK](https://github.com/nicholasgriffintn/a2a-js) and layers Vellum's social extension on top.
+
+**SDK usage:**
+- `ClientFactory` and `ClientFactoryOptions` create A2A clients from a base URL by discovering the agent card at `/.well-known/agent-card.json`
+- `DefaultRequestHandler` + `InMemoryTaskStore` handle incoming A2A JSON-RPC requests
+- `UserBuilder.noAuthentication` disables auth for the demo
+- `VellumSocialExecutor` implements `AgentExecutor` to produce task status updates, artifacts, and HITL working states
+
+**Vellum extension layers:**
+- `DataPart` on message and artifact parts carries `x-vellum-social-v1` payloads (request, response, and working/HITL data)
+- `VellumSocialInterceptor` (a `CallInterceptor` wired via `ClientFactory`) injects extension data into outgoing `sendMessage`/`sendMessageStream` calls
+- `VellumAgentCard` type extends `AgentCard` with `x-vellum-social-v1: true`
+- Agent-card discovery checks for `x-vellum-social-v1` support before sending requests
+
+## Demo time vs real time
+
+Deadlines default to 15 seconds, and peer delays range from 0-8 seconds. In production the deadline would be minutes and HITL waits would be longer. The `deadlineSeconds` parameter on `POST /run/coffee` can be changed to adjust the demo pace.

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -6,6 +6,7 @@
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
     "dev": "bun run build:ui && bun run src/server.ts",
     "peers:start": "bun run src/peers/start-all.ts",
+    "demo": "bun run src/demo.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -1,0 +1,270 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import type { Server } from 'node:http';
+import { createPeerServer, type PeerServer } from '../peers/create-peer-server.js';
+import { createServer } from '../server.js';
+import type { Connection } from '../types.js';
+
+const BASE_PORT = 3100;
+const PEER_PORTS = { sarah: 3110, jake: 3111, maria: 3112, priya: 3113 };
+
+interface SSEEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+function parseSSE(text: string): SSEEvent[] {
+  const events: SSEEvent[] = [];
+  const blocks = text.split('\n\n').filter(Boolean);
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    let type = '';
+    let data = '';
+    for (const line of lines) {
+      if (line.startsWith('event: ')) type = line.slice(7);
+      else if (line.startsWith('data: ')) data = line.slice(6);
+    }
+    if (type && data) {
+      try {
+        events.push({ type, data: JSON.parse(data) });
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return events;
+}
+
+const testConnections: Connection[] = [
+  {
+    id: 'test_conn_sarah',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-sarah',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.sarah}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.sarah}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_jake',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-jake',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.jake}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.jake}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_maria',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-maria',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.maria}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.maria}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_priya',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-priya',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.priya}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.priya}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+// --- Server setup ---
+
+const peerServers: PeerServer[] = [];
+let mainServer: Server;
+
+const sarahServer = createPeerServer({
+  name: 'Sarah',
+  port: PEER_PORTS.sarah,
+  assistantId: 'sarah-assistant',
+  config: { name: 'Sarah', responseText: 'Cortado, oat milk', strategy: 'standing_preference', humanDelayMs: 50 },
+});
+peerServers.push(sarahServer);
+
+const jakeServer = createPeerServer({
+  name: 'Jake',
+  port: PEER_PORTS.jake,
+  assistantId: 'jake-assistant',
+  config: { name: 'Jake', responseText: 'Black drip, large', strategy: 'hitl_confirm', humanDelayMs: 200 },
+});
+peerServers.push(jakeServer);
+
+const mariaServer = createPeerServer({
+  name: 'Maria',
+  port: PEER_PORTS.maria,
+  assistantId: 'maria-assistant',
+  config: { name: 'Maria', responseText: 'Usually an Americano, unconfirmed', strategy: 'hitl_stale_infer', humanDelayMs: 500 },
+});
+peerServers.push(mariaServer);
+
+const priyaServer = createPeerServer({
+  name: 'Priya',
+  port: PEER_PORTS.priya,
+  assistantId: 'priya-assistant',
+  config: { name: 'Priya', responseText: "Priya's in a meeting, no response", strategy: 'hitl_unreachable', humanDelayMs: 700 },
+});
+peerServers.push(priyaServer);
+
+const { server } = createServer({
+  port: BASE_PORT,
+  connections: testConnections,
+  assistantName: 'Test Assistant',
+  assistantId: 'test-assistant',
+});
+mainServer = server;
+
+afterAll(() => {
+  mainServer.close();
+  for (const ps of peerServers) ps.server.close();
+});
+
+// Helper to wait for a server to be ready
+async function waitReady(port: number, retries = 30): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(`http://localhost:${port}/.well-known/agent-card.json`);
+      if (res.ok) return;
+    } catch {
+      // not ready
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Server on port ${port} did not become ready`);
+}
+
+describe('e2e coffee run', () => {
+  test(
+    'full scenario exercises all 4 response strategies and HITL states',
+    async () => {
+      // Wait for all servers to be ready
+      await Promise.all([
+        waitReady(BASE_PORT),
+        waitReady(PEER_PORTS.sarah),
+        waitReady(PEER_PORTS.jake),
+        waitReady(PEER_PORTS.maria),
+        waitReady(PEER_PORTS.priya),
+      ]);
+
+      // Subscribe to SSE BEFORE triggering the coffee run
+      const sseResponse = await fetch(`http://localhost:${BASE_PORT}/events`);
+      expect(sseResponse.ok).toBe(true);
+      expect(sseResponse.headers.get('content-type')).toBe('text/event-stream');
+
+      const reader = sseResponse.body!.getReader();
+      const decoder = new TextDecoder();
+      let sseBuffer = '';
+      const allEvents: SSEEvent[] = [];
+
+      // Read the initial :ok comment
+      {
+        const { value } = await reader.read();
+        if (value) sseBuffer += decoder.decode(value, { stream: true });
+      }
+
+      // Trigger coffee run
+      const runRes = await fetch(`http://localhost:${BASE_PORT}/run/coffee`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deadlineSeconds: 15 }),
+      });
+      expect(runRes.status).toBe(202);
+
+      // Collect SSE events until run_complete
+      const deadline = Date.now() + 25_000;
+      let gotRunComplete = false;
+
+      while (!gotRunComplete && Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) {
+          sseBuffer += decoder.decode(value, { stream: true });
+        }
+        const newEvents = parseSSE(sseBuffer);
+        // Only add events we haven't seen yet
+        if (newEvents.length > allEvents.length) {
+          for (let i = allEvents.length; i < newEvents.length; i++) {
+            allEvents.push(newEvents[i]);
+            if (newEvents[i].type === 'run_complete') {
+              gotRunComplete = true;
+            }
+          }
+        }
+      }
+
+      // Cancel the reader to close the connection
+      await reader.cancel();
+
+      expect(gotRunComplete).toBe(true);
+
+      // --- Assert all 4 peers reach task_completed ---
+      const completedEvents = allEvents.filter((e) => e.type === 'task_completed');
+      const completedPeers = completedEvents.map((e) => e.data.peer as string).sort();
+      expect(completedPeers).toEqual(['peer-jake', 'peer-maria', 'peer-priya', 'peer-sarah']);
+
+      // --- Assert response_basis values ---
+      const basisByPeer = Object.fromEntries(
+        completedEvents.map((e) => [e.data.peer, e.data.responseBasis]),
+      );
+      expect(basisByPeer['peer-sarah']).toBe('standing_preference');
+      expect(basisByPeer['peer-jake']).toBe('confirmed');
+      expect(basisByPeer['peer-maria']).toBe('inferred');
+      expect(basisByPeer['peer-priya']).toBe('unreachable');
+
+      // --- Assert HITL states ---
+      const hitlEvents = allEvents.filter((e) => e.type === 'hitl_update');
+      const hitlPeers = new Set(hitlEvents.map((e) => e.data.peer as string));
+      // jake, maria, priya should have awaiting_human_input
+      expect(hitlPeers.has('peer-jake')).toBe(true);
+      expect(hitlPeers.has('peer-maria')).toBe(true);
+      expect(hitlPeers.has('peer-priya')).toBe(true);
+
+      // maria should also have awaiting_human_input_stale
+      const mariaHitlStates = hitlEvents
+        .filter((e) => e.data.peer === 'peer-maria')
+        .map((e) => {
+          const hitlState = e.data.hitlState as Record<string, unknown> | null;
+          return hitlState?.hitl_state;
+        });
+      expect(mariaHitlStates).toContain('awaiting_human_input');
+      expect(mariaHitlStates).toContain('awaiting_human_input_stale');
+
+      // --- Assert protocol_event events include raw SDK data ---
+      const protocolEvents = allEvents.filter((e) => e.type === 'protocol_event');
+      expect(protocolEvents.length).toBeGreaterThan(0);
+
+      // Task IDs should be present in protocol events
+      const protocolWithTaskId = protocolEvents.filter((e) => e.data.taskId != null);
+      expect(protocolWithTaskId.length).toBeGreaterThan(0);
+
+      // Extension payloads should be present (events carry full prettified event data)
+      const protocolWithEvent = protocolEvents.filter((e) => e.data.event != null);
+      expect(protocolWithEvent.length).toBeGreaterThan(0);
+
+      // --- Assert task_sent events include method: 'message/stream' ---
+      const taskSentEvents = allEvents.filter((e) => e.type === 'task_sent');
+      expect(taskSentEvents.length).toBe(4);
+      for (const ev of taskSentEvents) {
+        expect(ev.data.method).toBe('message/stream');
+      }
+
+      // --- Assert agent-card discovery happened ---
+      // Each peer's x-vellum-social-v1 was checked — verified by the fact that
+      // no task_error events with "does not support x-vellum-social-v1" appeared
+      // and all 4 peers completed successfully
+      const errorEvents = allEvents.filter(
+        (e) => e.type === 'task_error' && String(e.data.error).includes('x-vellum-social-v1'),
+      );
+      expect(errorEvents.length).toBe(0);
+    },
+    30_000,
+  );
+});

--- a/a2a-demo/src/demo.ts
+++ b/a2a-demo/src/demo.ts
@@ -1,0 +1,116 @@
+import type { Server } from 'node:http';
+import { createPeerServer, type PeerServer } from './peers/create-peer-server.js';
+import { createServer } from './server.js';
+
+const PEERS = [
+  {
+    name: 'Sarah',
+    port: 3010,
+    assistantId: 'sarah-assistant',
+    config: {
+      name: 'Sarah',
+      responseText: 'Cortado, oat milk',
+      strategy: 'standing_preference' as const,
+      humanDelayMs: 0,
+    },
+  },
+  {
+    name: 'Jake',
+    port: 3011,
+    assistantId: 'jake-assistant',
+    config: {
+      name: 'Jake',
+      responseText: 'Black drip, large',
+      strategy: 'hitl_confirm' as const,
+      humanDelayMs: 3000,
+    },
+  },
+  {
+    name: 'Maria',
+    port: 3012,
+    assistantId: 'maria-assistant',
+    config: {
+      name: 'Maria',
+      responseText: 'Usually an Americano, unconfirmed',
+      strategy: 'hitl_stale_infer' as const,
+      humanDelayMs: 6000,
+    },
+  },
+  {
+    name: 'Priya',
+    port: 3013,
+    assistantId: 'priya-assistant',
+    config: {
+      name: 'Priya',
+      responseText: "Priya's in a meeting, no response",
+      strategy: 'hitl_unreachable' as const,
+      humanDelayMs: 8000,
+    },
+  },
+];
+
+async function waitForServer(url: string, retries = 20, delayMs = 200): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // Not ready yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(`Server at ${url} did not become ready`);
+}
+
+async function main() {
+  const peerServers: PeerServer[] = [];
+  let mainServer: Server | undefined;
+
+  function shutdown() {
+    console.log('\nShutting down...');
+    if (mainServer) mainServer.close();
+    for (const ps of peerServers) ps.server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // Build UI
+  console.log('Building UI...');
+  const result = Bun.spawnSync(['bun', 'run', 'build:ui'], {
+    cwd: import.meta.dir + '/..',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  if (result.exitCode !== 0) {
+    console.error('UI build failed');
+    process.exit(1);
+  }
+  console.log('UI built successfully');
+
+  // Start all peer servers in-process
+  console.log('Starting peer servers...');
+  for (const peer of PEERS) {
+    const ps = createPeerServer(peer);
+    peerServers.push(ps);
+  }
+
+  // Wait for all peers to be ready
+  await Promise.all(
+    PEERS.map((peer) => waitForServer(`http://localhost:${peer.port}/.well-known/agent-card.json`)),
+  );
+  console.log('All peers ready on ports 3010-3013');
+
+  // Start main server
+  const { server } = createServer();
+  mainServer = server;
+
+  await waitForServer(`http://localhost:${Number(process.env.PORT) || 3000}/.well-known/agent-card.json`);
+  console.log(`\nDemo ready at http://localhost:${Number(process.env.PORT) || 3000}`);
+}
+
+main().catch((err) => {
+  console.error('Demo failed to start:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add demo.ts supervisor for single-command startup of all peers and main server
- Create comprehensive README with solo and friend mode documentation
- Add e2e smoke test validating full coffee run scenario with all 4 response strategies

Part of plan: a2a-tracer-bullet-demo.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->