### PR TITLE
fix: send unnamed SSE events so UI onmessage receives them

### DIFF
--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -17,15 +17,17 @@ function parseSSE(text: string): SSEEvent[] {
   const blocks = text.split('\n\n').filter(Boolean);
   for (const block of blocks) {
     const lines = block.split('\n');
-    let type = '';
     let data = '';
     for (const line of lines) {
-      if (line.startsWith('event: ')) type = line.slice(7);
-      else if (line.startsWith('data: ')) data = line.slice(6);
+      if (line.startsWith('data: ')) data = line.slice(6);
     }
-    if (type && data) {
+    if (data) {
       try {
-        events.push({ type, data: JSON.parse(data) });
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        const { type, ...rest } = parsed;
+        if (typeof type === 'string') {
+          events.push({ type, data: rest });
+        }
       } catch {
         // skip malformed
       }

--- a/a2a-demo/src/events.ts
+++ b/a2a-demo/src/events.ts
@@ -32,7 +32,7 @@ export class EventBus {
    * Silently drops disconnected clients.
    */
   broadcast(eventType: string, data: object): void {
-    const payload = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+    const payload = `data: ${JSON.stringify({ type: eventType, ...data })}\n\n`;
 
     for (const client of this.clients) {
       try {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for a2a-tracer-bullet-demo.md.

**Gap:** SSE named events vs onmessage — UI completely broken
**What was expected:** UI receives all SSE events
**What was found:** Server sent named events, but EventSource.onmessage only receives unnamed events
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->