### PR TITLE
fix: server agent card + cancelTask + hitl_stale_infer timing

### DIFF
--- a/a2a-demo/src/executor.ts
+++ b/a2a-demo/src/executor.ts
@@ -63,7 +63,15 @@ export class VellumSocialExecutor implements AgentExecutor {
     }
   }
 
-  async cancelTask(_taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    const canceledStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId,
+      contextId: taskId,
+      status: { state: 'canceled' },
+      final: true,
+    };
+    eventBus.publish(canceledStatus);
     eventBus.finished();
   }
 
@@ -191,7 +199,7 @@ export class VellumSocialExecutor implements AgentExecutor {
     };
     eventBus.publish(workingStatus2);
 
-    await Bun.sleep(this.config.humanDelayMs);
+    await Bun.sleep(1000);
 
     const artifactEvent: TaskArtifactUpdateEvent = {
       kind: 'artifact-update',

--- a/a2a-demo/src/server.ts
+++ b/a2a-demo/src/server.ts
@@ -39,21 +39,21 @@ export function createServer(options: ServerOptions = {}) {
     name: assistantName,
     url: `${publicBaseUrl}/a2a/jsonrpc`,
     description: `${assistantName} — A2A demo assistant with Vellum social extension`,
-    protocolVersion: '0.2.0',
+    protocolVersion: '0.3.0',
     version: '0.1.0',
     capabilities: {
       streaming: true,
     },
     skills: [
       {
-        id: 'coffee-order',
+        id: 'coffee_order',
         name: 'Coffee Order',
         description: 'Respond to coffee run requests',
         tags: ['coffee', 'social'],
       },
     ],
-    defaultInputModes: ['text/plain', 'application/json'],
-    defaultOutputModes: ['text/plain', 'application/json'],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
   };
 
   const peerConfig: PeerConfig = {


### PR DESCRIPTION
## Summary
Fixes 5 gaps from plan review.

**Gap 1:** protocolVersion 0.2.0 → 0.3.0
**Gap 2:** Remove extra application/json from input/output modes
**Gap 3:** Skill id coffee-order → coffee_order
**Gap 4:** cancelTask now publishes canceled status
**Gap 5:** hitl_stale_infer second sleep now 1000ms (not humanDelayMs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->