### PR TITLE
fix: align hitlState, protocol_event fields, and task_error shape

### DIFF
--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -230,10 +230,7 @@ describe('e2e coffee run', () => {
       // maria should also have awaiting_human_input_stale
       const mariaHitlStates = hitlEvents
         .filter((e) => e.data.peer === 'peer-maria')
-        .map((e) => {
-          const hitlState = e.data.hitlState as Record<string, unknown> | null;
-          return hitlState?.hitl_state;
-        });
+        .map((e) => e.data.hitlState as string | null);
       expect(mariaHitlStates).toContain('awaiting_human_input');
       expect(mariaHitlStates).toContain('awaiting_human_input_stale');
 
@@ -246,7 +243,7 @@ describe('e2e coffee run', () => {
       expect(protocolWithTaskId.length).toBeGreaterThan(0);
 
       // Extension payloads should be present (events carry full prettified event data)
-      const protocolWithEvent = protocolEvents.filter((e) => e.data.event != null);
+      const protocolWithEvent = protocolEvents.filter((e) => e.data.sdkEvent != null);
       expect(protocolWithEvent.length).toBeGreaterThan(0);
 
       // --- Assert task_sent events include method: 'message/stream' ---

--- a/a2a-demo/src/coffee-run.ts
+++ b/a2a-demo/src/coffee-run.ts
@@ -47,6 +47,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         const message = err instanceof Error ? err.message : String(err);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: `Failed to discover agent card: ${message}`,
         });
         return;
@@ -58,6 +59,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         console.warn(`Peer ${conn.peer_assistant_id} does not support x-vellum-social-v1, skipping`);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: 'peer does not support x-vellum-social-v1',
         });
         return;
@@ -100,9 +102,9 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
             if (taskId) {
               eventBus.broadcast('protocol_event', {
                 peer: conn.peer_assistant_id,
-                type: 'task_assigned',
+                eventType: 'task_assigned',
                 taskId,
-                event: prettifyEvent(event),
+                sdkEvent: prettifyEvent(event),
               });
             }
           }
@@ -111,9 +113,9 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
           const eventRecord = event as unknown as Record<string, unknown>;
           eventBus.broadcast('protocol_event', {
             peer: conn.peer_assistant_id,
-            type: event.kind,
+            eventType: event.kind,
             taskId: eventRecord.taskId ?? null,
-            event: prettifyEvent(event),
+            sdkEvent: prettifyEvent(event),
           });
 
           // Handle TaskArtifactUpdateEvent — cache the artifact
@@ -132,7 +134,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
               eventBus.broadcast('hitl_update', {
                 peer: conn.peer_assistant_id,
                 taskId: statusEvent.taskId,
-                hitlState: socialData,
+                hitlState: socialData && 'hitl_state' in socialData ? socialData.hitl_state : null,
                 sdkEvent: prettifyEvent(event),
               });
             }
@@ -171,6 +173,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         const message = err instanceof Error ? err.message : String(err);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: message,
         });
       }

--- a/a2a-demo/ui/src/types.ts
+++ b/a2a-demo/ui/src/types.ts
@@ -44,7 +44,7 @@ export type SSEEvent =
   | {
       type: 'task_error';
       peer: string;
-      taskId: string;
+      taskId: string | null;
       error: string;
     }
   | {


### PR DESCRIPTION
## Summary
Fixes 3 field mismatches between coffee-run.ts broadcasts and UI expectations.

**Gap A:** hitlState was full object, UI expects string
**Gap B:** protocol_event used type/event, UI expects eventType/sdkEvent
**Gap C:** task_error missing taskId field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->