### PR TITLE
feat(a2a-demo): A2A social extension tracer bullet demo

### DIFF
--- a/a2a-demo/README.md
+++ b/a2a-demo/README.md
@@ -1,0 +1,92 @@
+# A2A Social Extension Demo -- Coffee Run
+
+Proves the Vellum social extension wire format on top of the official A2A SDK. Exercises all four `response_basis` values (`standing_preference`, `confirmed`, `inferred`, `unreachable`) across four mock peers with different HITL strategies. The full demo runs in ~15 seconds.
+
+## Quick start (solo)
+
+```bash
+cd a2a-demo && bun install
+
+# Terminal 1: Start mock peers
+bun run peers:start
+
+# Terminal 2: Build UI and start your assistant
+bun run dev
+
+# Open http://localhost:3000 and click "Start coffee run"
+```
+
+Or use the single-command supervisor which starts everything in one process:
+
+```bash
+cd a2a-demo && bun install
+bun run demo
+# Open http://localhost:3000 and click "Start coffee run"
+```
+
+## Run with a friend
+
+Both people check out the branch and `bun install` in `a2a-demo/`.
+
+**Friend** starts their assistant with identity config:
+
+```bash
+ASSISTANT_NAME="Friend's Assistant" \
+ASSISTANT_ID="friend-assistant-1" \
+COFFEE_RESPONSE="Large cold brew please!" \
+PUBLIC_BASE_URL=http://<their-ip>:3000 \
+bun run dev
+```
+
+**You** edit `connections.json`: change one peer entry's `peer_base_url` and `peer_agent_card_url` to `http://<friend-ip>:3000`.
+
+Then start peers and your assistant:
+
+```bash
+bun run peers:start  # terminal 1
+bun run dev          # terminal 2
+```
+
+Click "Start coffee run" -- that peer's card now shows whatever their assistant returns.
+
+**Important**: `PUBLIC_BASE_URL` must be set to a reachable address (not `localhost`) on the friend's machine.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `PORT` | `3000` | Server port |
+| `PUBLIC_BASE_URL` | `http://localhost:$PORT` | Externally-reachable URL for agent card |
+| `ASSISTANT_NAME` | `Demo Assistant` | Name in agent card |
+| `ASSISTANT_ID` | `demo-assistant-1` | Assistant identifier |
+| `COFFEE_RESPONSE` | `I appreciate the offer!` | What this assistant replies when asked |
+| `RESPONSE_STRATEGY` | `standing_preference` | How this assistant responds |
+
+## What each mock peer exercises
+
+| Peer | Port | Strategy | `response_basis` | HITL states |
+|------|------|----------|-------------------|-------------|
+| Sarah | 3010 | Standing preference | `standing_preference` | none |
+| Jake | 3011 | HITL -> confirm | `confirmed` | `awaiting_human_input` |
+| Maria | 3012 | HITL -> stale -> infer | `inferred` | `awaiting_human_input`, `awaiting_human_input_stale` |
+| Priya | 3013 | HITL -> unreachable | `unreachable` | `awaiting_human_input` |
+
+## Architecture
+
+The demo is built on the [A2A JS SDK](https://github.com/nicholasgriffintn/a2a-js) and layers Vellum's social extension on top.
+
+**SDK usage:**
+- `ClientFactory` and `ClientFactoryOptions` create A2A clients from a base URL by discovering the agent card at `/.well-known/agent-card.json`
+- `DefaultRequestHandler` + `InMemoryTaskStore` handle incoming A2A JSON-RPC requests
+- `UserBuilder.noAuthentication` disables auth for the demo
+- `VellumSocialExecutor` implements `AgentExecutor` to produce task status updates, artifacts, and HITL working states
+
+**Vellum extension layers:**
+- `DataPart` on message and artifact parts carries `x-vellum-social-v1` payloads (request, response, and working/HITL data)
+- `VellumSocialInterceptor` (a `CallInterceptor` wired via `ClientFactory`) injects extension data into outgoing `sendMessage`/`sendMessageStream` calls
+- `VellumAgentCard` type extends `AgentCard` with `x-vellum-social-v1: true`
+- Agent-card discovery checks for `x-vellum-social-v1` support before sending requests
+
+## Demo time vs real time
+
+Deadlines default to 15 seconds, and peer delays range from 0-8 seconds. In production the deadline would be minutes and HITL waits would be longer. The `deadlineSeconds` parameter on `POST /run/coffee` can be changed to adjust the demo pace.

--- a/a2a-demo/bun.lock
+++ b/a2a-demo/bun.lock
@@ -1,0 +1,181 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/a2a-demo",
+      "dependencies": {
+        "@a2a-js/sdk": "0.3.13",
+        "express": "5.2.1",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "@types/express": "5.0.6",
+        "typescript": "6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
+
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+  }
+}

--- a/a2a-demo/bun.lock
+++ b/a2a-demo/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@a2a-js/sdk": "0.3.13",
         "express": "5.2.1",
+        "preact": "10.29.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -133,6 +134,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
+    "peers:start": "bun run src/peers/start-all.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
+    "dev": "bun run build:ui && bun run src/server.ts",
     "peers:start": "bun run src/peers/start-all.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vellumai/a2a-demo",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "@a2a-js/sdk": "0.3.13",
+    "express": "5.2.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "@types/express": "5.0.6",
+    "typescript": "6.0.3"
+  }
+}

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -6,6 +6,7 @@
     "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
     "dev": "bun run build:ui && bun run src/server.ts",
     "peers:start": "bun run src/peers/start-all.ts",
+    "demo": "bun run src/demo.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/a2a-demo/package.json
+++ b/a2a-demo/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "build:ui": "bun build ui/src/main.tsx --outdir ui/dist --bundle --minify && cp ui/index.html ui/src/styles.css ui/dist/",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },
   "dependencies": {
     "@a2a-js/sdk": "0.3.13",
-    "express": "5.2.1"
+    "express": "5.2.1",
+    "preact": "10.29.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -17,15 +17,17 @@ function parseSSE(text: string): SSEEvent[] {
   const blocks = text.split('\n\n').filter(Boolean);
   for (const block of blocks) {
     const lines = block.split('\n');
-    let type = '';
     let data = '';
     for (const line of lines) {
-      if (line.startsWith('event: ')) type = line.slice(7);
-      else if (line.startsWith('data: ')) data = line.slice(6);
+      if (line.startsWith('data: ')) data = line.slice(6);
     }
-    if (type && data) {
+    if (data) {
       try {
-        events.push({ type, data: JSON.parse(data) });
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        const { type, ...rest } = parsed;
+        if (typeof type === 'string') {
+          events.push({ type, data: rest });
+        }
       } catch {
         // skip malformed
       }

--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -232,10 +232,7 @@ describe('e2e coffee run', () => {
       // maria should also have awaiting_human_input_stale
       const mariaHitlStates = hitlEvents
         .filter((e) => e.data.peer === 'peer-maria')
-        .map((e) => {
-          const hitlState = e.data.hitlState as Record<string, unknown> | null;
-          return hitlState?.hitl_state;
-        });
+        .map((e) => e.data.hitlState as string | null);
       expect(mariaHitlStates).toContain('awaiting_human_input');
       expect(mariaHitlStates).toContain('awaiting_human_input_stale');
 
@@ -248,7 +245,7 @@ describe('e2e coffee run', () => {
       expect(protocolWithTaskId.length).toBeGreaterThan(0);
 
       // Extension payloads should be present (events carry full prettified event data)
-      const protocolWithEvent = protocolEvents.filter((e) => e.data.event != null);
+      const protocolWithEvent = protocolEvents.filter((e) => e.data.sdkEvent != null);
       expect(protocolWithEvent.length).toBeGreaterThan(0);
 
       // --- Assert task_sent events include method: 'message/stream' ---

--- a/a2a-demo/src/__tests__/e2e.test.ts
+++ b/a2a-demo/src/__tests__/e2e.test.ts
@@ -1,0 +1,270 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import type { Server } from 'node:http';
+import { createPeerServer, type PeerServer } from '../peers/create-peer-server.js';
+import { createServer } from '../server.js';
+import type { Connection } from '../types.js';
+
+const BASE_PORT = 3100;
+const PEER_PORTS = { sarah: 3110, jake: 3111, maria: 3112, priya: 3113 };
+
+interface SSEEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+function parseSSE(text: string): SSEEvent[] {
+  const events: SSEEvent[] = [];
+  const blocks = text.split('\n\n').filter(Boolean);
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    let type = '';
+    let data = '';
+    for (const line of lines) {
+      if (line.startsWith('event: ')) type = line.slice(7);
+      else if (line.startsWith('data: ')) data = line.slice(6);
+    }
+    if (type && data) {
+      try {
+        events.push({ type, data: JSON.parse(data) });
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return events;
+}
+
+const testConnections: Connection[] = [
+  {
+    id: 'test_conn_sarah',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-sarah',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.sarah}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.sarah}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_jake',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-jake',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.jake}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.jake}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_maria',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-maria',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.maria}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.maria}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'test_conn_priya',
+    owner_assistant_id: 'test-assistant',
+    peer_assistant_id: 'peer-priya',
+    peer_agent_card_url: `http://localhost:${PEER_PORTS.priya}/.well-known/agent-card.json`,
+    peer_base_url: `http://localhost:${PEER_PORTS.priya}`,
+    declared_relationship: 'colleague',
+    scopes: ['coffee_order'],
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+// --- Server setup ---
+
+const peerServers: PeerServer[] = [];
+let mainServer: Server;
+
+const sarahServer = createPeerServer({
+  name: 'Sarah',
+  port: PEER_PORTS.sarah,
+  assistantId: 'sarah-assistant',
+  config: { name: 'Sarah', responseText: 'Cortado, oat milk', strategy: 'standing_preference', humanDelayMs: 50 },
+});
+peerServers.push(sarahServer);
+
+const jakeServer = createPeerServer({
+  name: 'Jake',
+  port: PEER_PORTS.jake,
+  assistantId: 'jake-assistant',
+  config: { name: 'Jake', responseText: 'Black drip, large', strategy: 'hitl_confirm', humanDelayMs: 200 },
+});
+peerServers.push(jakeServer);
+
+const mariaServer = createPeerServer({
+  name: 'Maria',
+  port: PEER_PORTS.maria,
+  assistantId: 'maria-assistant',
+  config: { name: 'Maria', responseText: 'Usually an Americano, unconfirmed', strategy: 'hitl_stale_infer', humanDelayMs: 500 },
+});
+peerServers.push(mariaServer);
+
+const priyaServer = createPeerServer({
+  name: 'Priya',
+  port: PEER_PORTS.priya,
+  assistantId: 'priya-assistant',
+  config: { name: 'Priya', responseText: "Priya's in a meeting, no response", strategy: 'hitl_unreachable', humanDelayMs: 700 },
+});
+peerServers.push(priyaServer);
+
+const { server } = createServer({
+  port: BASE_PORT,
+  connections: testConnections,
+  assistantName: 'Test Assistant',
+  assistantId: 'test-assistant',
+});
+mainServer = server;
+
+afterAll(() => {
+  mainServer.close();
+  for (const ps of peerServers) ps.server.close();
+});
+
+// Helper to wait for a server to be ready
+async function waitReady(port: number, retries = 30): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(`http://localhost:${port}/.well-known/agent-card.json`);
+      if (res.ok) return;
+    } catch {
+      // not ready
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Server on port ${port} did not become ready`);
+}
+
+describe('e2e coffee run', () => {
+  test(
+    'full scenario exercises all 4 response strategies and HITL states',
+    async () => {
+      // Wait for all servers to be ready
+      await Promise.all([
+        waitReady(BASE_PORT),
+        waitReady(PEER_PORTS.sarah),
+        waitReady(PEER_PORTS.jake),
+        waitReady(PEER_PORTS.maria),
+        waitReady(PEER_PORTS.priya),
+      ]);
+
+      // Subscribe to SSE BEFORE triggering the coffee run
+      const sseResponse = await fetch(`http://localhost:${BASE_PORT}/events`);
+      expect(sseResponse.ok).toBe(true);
+      expect(sseResponse.headers.get('content-type')).toBe('text/event-stream');
+
+      const reader = sseResponse.body!.getReader();
+      const decoder = new TextDecoder();
+      let sseBuffer = '';
+      const allEvents: SSEEvent[] = [];
+
+      // Read the initial :ok comment
+      {
+        const { value } = await reader.read();
+        if (value) sseBuffer += decoder.decode(value, { stream: true });
+      }
+
+      // Trigger coffee run
+      const runRes = await fetch(`http://localhost:${BASE_PORT}/run/coffee`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deadlineSeconds: 15 }),
+      });
+      expect(runRes.status).toBe(202);
+
+      // Collect SSE events until run_complete
+      const deadline = Date.now() + 25_000;
+      let gotRunComplete = false;
+
+      while (!gotRunComplete && Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) {
+          sseBuffer += decoder.decode(value, { stream: true });
+        }
+        const newEvents = parseSSE(sseBuffer);
+        // Only add events we haven't seen yet
+        if (newEvents.length > allEvents.length) {
+          for (let i = allEvents.length; i < newEvents.length; i++) {
+            allEvents.push(newEvents[i]);
+            if (newEvents[i].type === 'run_complete') {
+              gotRunComplete = true;
+            }
+          }
+        }
+      }
+
+      // Cancel the reader to close the connection
+      await reader.cancel();
+
+      expect(gotRunComplete).toBe(true);
+
+      // --- Assert all 4 peers reach task_completed ---
+      const completedEvents = allEvents.filter((e) => e.type === 'task_completed');
+      const completedPeers = completedEvents.map((e) => e.data.peer as string).sort();
+      expect(completedPeers).toEqual(['peer-jake', 'peer-maria', 'peer-priya', 'peer-sarah']);
+
+      // --- Assert response_basis values ---
+      const basisByPeer = Object.fromEntries(
+        completedEvents.map((e) => [e.data.peer, e.data.responseBasis]),
+      );
+      expect(basisByPeer['peer-sarah']).toBe('standing_preference');
+      expect(basisByPeer['peer-jake']).toBe('confirmed');
+      expect(basisByPeer['peer-maria']).toBe('inferred');
+      expect(basisByPeer['peer-priya']).toBe('unreachable');
+
+      // --- Assert HITL states ---
+      const hitlEvents = allEvents.filter((e) => e.type === 'hitl_update');
+      const hitlPeers = new Set(hitlEvents.map((e) => e.data.peer as string));
+      // jake, maria, priya should have awaiting_human_input
+      expect(hitlPeers.has('peer-jake')).toBe(true);
+      expect(hitlPeers.has('peer-maria')).toBe(true);
+      expect(hitlPeers.has('peer-priya')).toBe(true);
+
+      // maria should also have awaiting_human_input_stale
+      const mariaHitlStates = hitlEvents
+        .filter((e) => e.data.peer === 'peer-maria')
+        .map((e) => {
+          const hitlState = e.data.hitlState as Record<string, unknown> | null;
+          return hitlState?.hitl_state;
+        });
+      expect(mariaHitlStates).toContain('awaiting_human_input');
+      expect(mariaHitlStates).toContain('awaiting_human_input_stale');
+
+      // --- Assert protocol_event events include raw SDK data ---
+      const protocolEvents = allEvents.filter((e) => e.type === 'protocol_event');
+      expect(protocolEvents.length).toBeGreaterThan(0);
+
+      // Task IDs should be present in protocol events
+      const protocolWithTaskId = protocolEvents.filter((e) => e.data.taskId != null);
+      expect(protocolWithTaskId.length).toBeGreaterThan(0);
+
+      // Extension payloads should be present (events carry full prettified event data)
+      const protocolWithEvent = protocolEvents.filter((e) => e.data.event != null);
+      expect(protocolWithEvent.length).toBeGreaterThan(0);
+
+      // --- Assert task_sent events include method: 'message/stream' ---
+      const taskSentEvents = allEvents.filter((e) => e.type === 'task_sent');
+      expect(taskSentEvents.length).toBe(4);
+      for (const ev of taskSentEvents) {
+        expect(ev.data.method).toBe('message/stream');
+      }
+
+      // --- Assert agent-card discovery happened ---
+      // Each peer's x-vellum-social-v1 was checked — verified by the fact that
+      // no task_error events with "does not support x-vellum-social-v1" appeared
+      // and all 4 peers completed successfully
+      const errorEvents = allEvents.filter(
+        (e) => e.type === 'task_error' && String(e.data.error).includes('x-vellum-social-v1'),
+      );
+      expect(errorEvents.length).toBe(0);
+    },
+    30_000,
+  );
+});

--- a/a2a-demo/src/__tests__/executor.test.ts
+++ b/a2a-demo/src/__tests__/executor.test.ts
@@ -1,0 +1,318 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import type { Server } from 'http';
+import type {
+  AgentCard,
+  Message,
+  Task,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  DataPart,
+} from '@a2a-js/sdk';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import express from 'express';
+import { VellumSocialExecutor, type PeerConfig } from '../executor.js';
+import { makeRequestPart } from '../extension.js';
+import type { VellumSocialResponseData, VellumSocialWorkingData } from '../types.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type StreamEvent = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
+
+function createTestServer(config: PeerConfig): { server: Server; port: number } {
+  const port = 30_000 + Math.floor(Math.random() * 10_000);
+
+  const agentCard: AgentCard = {
+    name: config.name,
+    url: `http://localhost:${port}/a2a/jsonrpc`,
+    description: `Test peer: ${config.name}`,
+    protocolVersion: '0.2.0',
+    version: '0.1.0',
+    capabilities: { streaming: true },
+    skills: [{ id: 'social', name: 'Social', description: 'Social response', tags: ['social'] }],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+  };
+
+  const executor = new VellumSocialExecutor(config);
+  const taskStore = new InMemoryTaskStore();
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, executor);
+
+  const app = express();
+  app.use('/.well-known/agent-card.json', agentCardHandler({ agentCardProvider: async () => agentCard }));
+  app.use('/a2a/jsonrpc', jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+
+  const server = app.listen(port);
+  return { server, port };
+}
+
+async function waitForListening(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onListening = () => { server.removeListener('error', onError); resolve(); };
+    const onError = (err: Error) => { server.removeListener('listening', onListening); reject(err); };
+    server.once('listening', onListening);
+    server.once('error', onError);
+    if (server.listening) { server.removeListener('error', onError); resolve(); }
+  });
+}
+
+async function sendAndCollect(port: number, parts: Message['parts']): Promise<StreamEvent[]> {
+  const factory = new ClientFactory(ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {}));
+  const client = await factory.createFromUrl(`http://localhost:${port}`);
+
+  const message: Message = {
+    kind: 'message',
+    messageId: crypto.randomUUID(),
+    role: 'user',
+    parts,
+  };
+
+  const events: StreamEvent[] = [];
+  for await (const event of client.sendMessageStream({ message })) {
+    events.push(event);
+  }
+  return events;
+}
+
+function buildRequestParts(correlationId: string) {
+  return [
+    { kind: 'text' as const, text: 'Can you attend the meeting?' },
+    makeRequestPart({
+      connection_id: 'conn_test_123',
+      sender_relationship: 'colleague',
+      correlation_id: correlationId,
+    }),
+  ];
+}
+
+function findStatusEvents(events: StreamEvent[], state?: string): TaskStatusUpdateEvent[] {
+  return events.filter(
+    (e): e is TaskStatusUpdateEvent =>
+      e.kind === 'status-update' && (state === undefined || (e as TaskStatusUpdateEvent).status.state === state),
+  );
+}
+
+function findArtifactEvents(events: StreamEvent[]): TaskArtifactUpdateEvent[] {
+  return events.filter((e): e is TaskArtifactUpdateEvent => e.kind === 'artifact-update');
+}
+
+function extractResponseData(artifact: TaskArtifactUpdateEvent): VellumSocialResponseData | undefined {
+  const dataPart = artifact.artifact.parts.find((p) => p.kind === 'data') as DataPart | undefined;
+  if (!dataPart) return undefined;
+  return dataPart.data as unknown as VellumSocialResponseData;
+}
+
+function extractWorkingData(status: TaskStatusUpdateEvent): VellumSocialWorkingData | undefined {
+  const message = status.status.message;
+  if (!message) return undefined;
+  const dataPart = message.parts.find((p) => p.kind === 'data') as DataPart | undefined;
+  if (!dataPart) return undefined;
+  return dataPart.data as unknown as VellumSocialWorkingData;
+}
+
+const servers: Server[] = [];
+afterAll(() => {
+  for (const s of servers) s.close();
+});
+
+describe('VellumSocialExecutor', () => {
+  test('standing_preference: artifact then completed', async () => {
+    const config: PeerConfig = {
+      name: 'Standing Pref Peer',
+      responseText: 'I always attend Friday standups.',
+      strategy: 'standing_preference',
+      humanDelayMs: 0,
+    };
+    const { server, port } = createTestServer(config);
+    servers.push(server);
+    await waitForListening(server);
+
+    const events = await sendAndCollect(port, buildRequestParts('corr_sp_001'));
+
+    const artifacts = findArtifactEvents(events);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts.some((p) => p.kind === 'text' && (p as { text: string }).text === config.responseText)).toBe(true);
+
+    const responseData = extractResponseData(artifacts[0]);
+    expect(responseData).toBeDefined();
+    expect(responseData!.response_basis).toBe('standing_preference');
+    expect(responseData!.correlation_id).toBe('corr_sp_001');
+
+    const completedStatuses = findStatusEvents(events, 'completed');
+    expect(completedStatuses).toHaveLength(1);
+    expect(completedStatuses[0].final).toBe(true);
+
+    // Artifact must come before completed status
+    const artifactIdx = events.indexOf(artifacts[0]);
+    const completedIdx = events.indexOf(completedStatuses[0]);
+    expect(artifactIdx).toBeLessThan(completedIdx);
+  }, 10_000);
+
+  test('hitl_confirm: working then artifact then completed', async () => {
+    const config: PeerConfig = {
+      name: 'HITL Confirm Peer',
+      responseText: 'Yes, confirmed by human.',
+      strategy: 'hitl_confirm',
+      humanDelayMs: 50,
+    };
+    const { server, port } = createTestServer(config);
+    servers.push(server);
+    await waitForListening(server);
+
+    const events = await sendAndCollect(port, buildRequestParts('corr_hc_001'));
+
+    // Working status with awaiting_human_input
+    const workingStatuses = findStatusEvents(events, 'working');
+    expect(workingStatuses.length).toBeGreaterThanOrEqual(1);
+    const workingData = extractWorkingData(workingStatuses[0]);
+    expect(workingData).toBeDefined();
+    expect(workingData!.hitl_state).toBe('awaiting_human_input');
+    expect(workingData!.correlation_id).toBe('corr_hc_001');
+
+    // Artifact with confirmed response
+    const artifacts = findArtifactEvents(events);
+    expect(artifacts).toHaveLength(1);
+    const responseData = extractResponseData(artifacts[0]);
+    expect(responseData).toBeDefined();
+    expect(responseData!.response_basis).toBe('confirmed');
+
+    // Completed status
+    const completedStatuses = findStatusEvents(events, 'completed');
+    expect(completedStatuses).toHaveLength(1);
+    expect(completedStatuses[0].final).toBe(true);
+
+    // Order: working < artifact < completed
+    const workingIdx = events.indexOf(workingStatuses[0]);
+    const artifactIdx = events.indexOf(artifacts[0]);
+    const completedIdx = events.indexOf(completedStatuses[0]);
+    expect(workingIdx).toBeLessThan(artifactIdx);
+    expect(artifactIdx).toBeLessThan(completedIdx);
+  }, 10_000);
+
+  test('hitl_stale_infer: two working statuses then artifact then completed', async () => {
+    const config: PeerConfig = {
+      name: 'HITL Stale Infer Peer',
+      responseText: 'Inferred: probably yes.',
+      strategy: 'hitl_stale_infer',
+      humanDelayMs: 50,
+    };
+    const { server, port } = createTestServer(config);
+    servers.push(server);
+    await waitForListening(server);
+
+    const events = await sendAndCollect(port, buildRequestParts('corr_si_001'));
+
+    // Two working statuses
+    const workingStatuses = findStatusEvents(events, 'working');
+    expect(workingStatuses.length).toBeGreaterThanOrEqual(2);
+
+    const working1Data = extractWorkingData(workingStatuses[0]);
+    expect(working1Data).toBeDefined();
+    expect(working1Data!.hitl_state).toBe('awaiting_human_input');
+
+    const working2Data = extractWorkingData(workingStatuses[1]);
+    expect(working2Data).toBeDefined();
+    expect(working2Data!.hitl_state).toBe('awaiting_human_input_stale');
+
+    // Artifact with inferred response
+    const artifacts = findArtifactEvents(events);
+    expect(artifacts).toHaveLength(1);
+    const responseData = extractResponseData(artifacts[0]);
+    expect(responseData).toBeDefined();
+    expect(responseData!.response_basis).toBe('inferred');
+
+    // Completed status
+    const completedStatuses = findStatusEvents(events, 'completed');
+    expect(completedStatuses).toHaveLength(1);
+    expect(completedStatuses[0].final).toBe(true);
+
+    // Order: working1 < working2 < artifact < completed
+    const w1Idx = events.indexOf(workingStatuses[0]);
+    const w2Idx = events.indexOf(workingStatuses[1]);
+    const artifactIdx = events.indexOf(artifacts[0]);
+    const completedIdx = events.indexOf(completedStatuses[0]);
+    expect(w1Idx).toBeLessThan(w2Idx);
+    expect(w2Idx).toBeLessThan(artifactIdx);
+    expect(artifactIdx).toBeLessThan(completedIdx);
+  }, 10_000);
+
+  test('hitl_unreachable: working then artifact then completed', async () => {
+    const config: PeerConfig = {
+      name: 'HITL Unreachable Peer',
+      responseText: 'No response received',
+      strategy: 'hitl_unreachable',
+      humanDelayMs: 50,
+    };
+    const { server, port } = createTestServer(config);
+    servers.push(server);
+    await waitForListening(server);
+
+    const events = await sendAndCollect(port, buildRequestParts('corr_ur_001'));
+
+    // Working status with awaiting_human_input
+    const workingStatuses = findStatusEvents(events, 'working');
+    expect(workingStatuses.length).toBeGreaterThanOrEqual(1);
+    const workingData = extractWorkingData(workingStatuses[0]);
+    expect(workingData).toBeDefined();
+    expect(workingData!.hitl_state).toBe('awaiting_human_input');
+
+    // Artifact with unreachable response and "No response received" text
+    const artifacts = findArtifactEvents(events);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.parts.some((p) => p.kind === 'text' && (p as { text: string }).text === 'No response received')).toBe(true);
+    const responseData = extractResponseData(artifacts[0]);
+    expect(responseData).toBeDefined();
+    expect(responseData!.response_basis).toBe('unreachable');
+
+    // Completed status
+    const completedStatuses = findStatusEvents(events, 'completed');
+    expect(completedStatuses).toHaveLength(1);
+    expect(completedStatuses[0].final).toBe(true);
+
+    // Order: working < artifact < completed
+    const workingIdx = events.indexOf(workingStatuses[0]);
+    const artifactIdx = events.indexOf(artifacts[0]);
+    const completedIdx = events.indexOf(completedStatuses[0]);
+    expect(workingIdx).toBeLessThan(artifactIdx);
+    expect(artifactIdx).toBeLessThan(completedIdx);
+  }, 10_000);
+
+  test('missing extension data results in failed status', async () => {
+    const config: PeerConfig = {
+      name: 'Missing Ext Peer',
+      responseText: 'Should not appear',
+      strategy: 'standing_preference',
+      humanDelayMs: 0,
+    };
+    const { server, port } = createTestServer(config);
+    servers.push(server);
+    await waitForListening(server);
+
+    // Send message without any Vellum social extension data
+    const events = await sendAndCollect(port, [{ kind: 'text', text: 'No extension here' }]);
+
+    const failedStatuses = findStatusEvents(events, 'failed');
+    expect(failedStatuses).toHaveLength(1);
+    expect(failedStatuses[0].final).toBe(true);
+
+    const failMessage = failedStatuses[0].status.message;
+    expect(failMessage).toBeDefined();
+    expect(failMessage!.kind).toBe('message');
+    expect(failMessage!.messageId).toBeTruthy();
+    expect(failMessage!.role).toBe('agent');
+    expect(failMessage!.parts.some((p) => p.kind === 'text' && (p as { text: string }).text === 'Missing x-vellum-social-v1 extension data')).toBe(true);
+
+    // No artifacts should be published
+    const artifacts = findArtifactEvents(events);
+    expect(artifacts).toHaveLength(0);
+  }, 10_000);
+
+  test('scope stub: TODO comment is present in executor source', () => {
+    const executorSource = fs.readFileSync(
+      path.join(import.meta.dir, '..', 'executor.ts'),
+      'utf-8',
+    );
+    expect(executorSource).toContain('// TODO: enforce scope');
+  });
+});

--- a/a2a-demo/src/__tests__/extension.test.ts
+++ b/a2a-demo/src/__tests__/extension.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test';
+import type { Part } from '@a2a-js/sdk';
+import { extractVellumSocial, makeRequestPart, makeResponsePart, makeWorkingPart } from '../extension.js';
+
+describe('extractVellumSocial', () => {
+  test('returns null for empty parts array', () => {
+    expect(extractVellumSocial([])).toBeNull();
+  });
+
+  test('returns null when no DataPart matches', () => {
+    const parts: Part[] = [
+      { kind: 'text', text: 'hello' },
+      { kind: 'data', data: { extension: 'some-other-extension', value: 42 } },
+    ];
+    expect(extractVellumSocial(parts)).toBeNull();
+  });
+
+  test('correctly extracts request data from parts', () => {
+    const parts: Part[] = [
+      { kind: 'text', text: 'requesting coffee order' },
+      {
+        kind: 'data',
+        data: {
+          extension: 'x-vellum-social-v1',
+          connection_id: 'conn_123',
+          sender_relationship: 'colleague',
+          correlation_id: 'corr_abc',
+        },
+      },
+    ];
+    const result = extractVellumSocial(parts);
+    expect(result).not.toBeNull();
+    expect(result!.extension).toBe('x-vellum-social-v1');
+    expect((result as { connection_id: string }).connection_id).toBe('conn_123');
+    expect((result as { sender_relationship: string }).sender_relationship).toBe('colleague');
+    expect((result as { correlation_id: string }).correlation_id).toBe('corr_abc');
+  });
+
+  test('correctly extracts response data from parts', () => {
+    const parts: Part[] = [
+      {
+        kind: 'data',
+        data: {
+          extension: 'x-vellum-social-v1',
+          response_basis: 'confirmed',
+          correlation_id: 'corr_xyz',
+        },
+      },
+    ];
+    const result = extractVellumSocial(parts);
+    expect(result).not.toBeNull();
+    expect(result!.extension).toBe('x-vellum-social-v1');
+    expect((result as { response_basis: string }).response_basis).toBe('confirmed');
+    expect((result as { correlation_id: string }).correlation_id).toBe('corr_xyz');
+  });
+});
+
+describe('makeRequestPart', () => {
+  test('produces correct DataPart structure with extension field set', () => {
+    const part = makeRequestPart({
+      connection_id: 'conn_demo_peer1',
+      sender_relationship: 'colleague',
+      correlation_id: 'corr_001',
+      deadline: '2026-01-01T12:00:00Z',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      connection_id: 'conn_demo_peer1',
+      sender_relationship: 'colleague',
+      correlation_id: 'corr_001',
+      deadline: '2026-01-01T12:00:00Z',
+    });
+  });
+});
+
+describe('makeResponsePart', () => {
+  test('produces correct DataPart structure', () => {
+    const part = makeResponsePart({
+      response_basis: 'standing_preference',
+      correlation_id: 'corr_002',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      response_basis: 'standing_preference',
+      correlation_id: 'corr_002',
+    });
+  });
+});
+
+describe('makeWorkingPart', () => {
+  test('produces correct DataPart structure', () => {
+    const part = makeWorkingPart({
+      hitl_state: 'awaiting_human_input',
+      correlation_id: 'corr_003',
+    });
+    expect(part.kind).toBe('data');
+    expect(part.data).toEqual({
+      extension: 'x-vellum-social-v1',
+      hitl_state: 'awaiting_human_input',
+      correlation_id: 'corr_003',
+    });
+  });
+});

--- a/a2a-demo/src/__tests__/interceptor.test.ts
+++ b/a2a-demo/src/__tests__/interceptor.test.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect } from 'bun:test';
+import type { BeforeArgs, AfterArgs } from '@a2a-js/sdk/client';
+import type { AgentCard, Part } from '@a2a-js/sdk';
+import { VellumSocialInterceptor } from '../interceptor.js';
+
+const stubAgentCard: AgentCard = {
+  name: 'Test Agent',
+  url: 'http://localhost:9999/a2a/jsonrpc',
+  description: 'Test agent for interceptor tests',
+  protocolVersion: '0.2.0',
+  version: '0.1.0',
+  capabilities: {},
+  skills: [],
+  defaultInputModes: ['text/plain'],
+  defaultOutputModes: ['text/plain'],
+};
+
+function makeSendMessageStreamArgs(parts: Part[]): BeforeArgs {
+  return {
+    input: {
+      method: 'sendMessageStream',
+      value: {
+        message: {
+          kind: 'message',
+          messageId: 'test-msg-id',
+          role: 'user',
+          parts,
+        },
+      },
+    },
+    agentCard: stubAgentCard,
+  } as unknown as BeforeArgs;
+}
+
+function makeSendMessageArgs(parts: Part[]): BeforeArgs {
+  return {
+    input: {
+      method: 'sendMessage',
+      value: {
+        message: {
+          kind: 'message',
+          messageId: 'test-msg-id',
+          role: 'user',
+          parts,
+        },
+      },
+    },
+    agentCard: stubAgentCard,
+  } as unknown as BeforeArgs;
+}
+
+describe('VellumSocialInterceptor', () => {
+  const extensionData = {
+    connection_id: 'conn_demo_peer1',
+    sender_relationship: 'colleague' as const,
+    correlation_id: 'corr_001',
+    deadline: '2026-01-01T12:00:00Z',
+  };
+
+  const interceptor = new VellumSocialInterceptor(() => extensionData);
+
+  describe('before — sendMessageStream', () => {
+    test('prepends DataPart with extension data to message parts', async () => {
+      const originalParts: Part[] = [{ kind: 'text', text: 'coffee?' }];
+      const args = makeSendMessageStreamArgs([...originalParts]);
+
+      await interceptor.before(args);
+
+      const parts = (args.input as { value: { message: { parts: Part[] } } }).value.message.parts;
+      expect(parts).toHaveLength(2);
+
+      // First part should be the DataPart with extension data
+      expect(parts[0].kind).toBe('data');
+      expect((parts[0] as { data: Record<string, unknown> }).data).toEqual({
+        extension: 'x-vellum-social-v1',
+        connection_id: 'conn_demo_peer1',
+        sender_relationship: 'colleague',
+        correlation_id: 'corr_001',
+        deadline: '2026-01-01T12:00:00Z',
+      });
+
+      // Second part should be the original TextPart (preserved, not overwritten)
+      expect(parts[1].kind).toBe('text');
+      expect((parts[1] as { text: string }).text).toBe('coffee?');
+    });
+
+    test('DataPart contains all required fields from callback', async () => {
+      const customData = {
+        connection_id: 'conn_custom',
+        sender_relationship: 'friend' as const,
+        correlation_id: 'corr_custom',
+      };
+      const customInterceptor = new VellumSocialInterceptor(() => customData);
+      const args = makeSendMessageStreamArgs([{ kind: 'text', text: 'hi' }]);
+
+      await customInterceptor.before(args);
+
+      const parts = (args.input as { value: { message: { parts: Part[] } } }).value.message.parts;
+      const dataPart = (parts[0] as { data: Record<string, unknown> }).data;
+      expect(dataPart.connection_id).toBe('conn_custom');
+      expect(dataPart.sender_relationship).toBe('friend');
+      expect(dataPart.correlation_id).toBe('corr_custom');
+      expect(dataPart.extension).toBe('x-vellum-social-v1');
+    });
+  });
+
+  describe('before — sendMessage', () => {
+    test('prepends DataPart for non-streaming sendMessage calls', async () => {
+      const args = makeSendMessageArgs([{ kind: 'text', text: 'order?' }]);
+
+      await interceptor.before(args);
+
+      const parts = (args.input as { value: { message: { parts: Part[] } } }).value.message.parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].kind).toBe('data');
+      expect((parts[0] as { data: Record<string, unknown> }).data).toEqual({
+        extension: 'x-vellum-social-v1',
+        connection_id: 'conn_demo_peer1',
+        sender_relationship: 'colleague',
+        correlation_id: 'corr_001',
+        deadline: '2026-01-01T12:00:00Z',
+      });
+    });
+  });
+
+  describe('before — method guard', () => {
+    test('does not modify args for getTask method', async () => {
+      const args = {
+        input: {
+          method: 'getTask',
+          value: { taskId: 'task-123' },
+        },
+        agentCard: stubAgentCard,
+      } as unknown as BeforeArgs;
+
+      const originalValue = JSON.parse(JSON.stringify(args.input));
+      await interceptor.before(args);
+
+      // Args should be completely unmodified
+      expect(JSON.parse(JSON.stringify(args.input))).toEqual(originalValue);
+    });
+
+    test('does not modify args for cancelTask method', async () => {
+      const args = {
+        input: {
+          method: 'cancelTask',
+          value: { taskId: 'task-456' },
+        },
+        agentCard: stubAgentCard,
+      } as unknown as BeforeArgs;
+
+      const originalValue = JSON.parse(JSON.stringify(args.input));
+      await interceptor.before(args);
+
+      expect(JSON.parse(JSON.stringify(args.input))).toEqual(originalValue);
+    });
+  });
+
+  describe('after', () => {
+    test('does not throw or modify the result', async () => {
+      const args = {
+        result: {
+          method: 'sendMessageStream',
+          value: { kind: 'status-update', taskId: 'task-1', contextId: 'ctx-1', status: { state: 'completed' }, final: true },
+        },
+        agentCard: stubAgentCard,
+      } as unknown as AfterArgs;
+
+      const originalResult = JSON.parse(JSON.stringify(args.result));
+      await interceptor.after(args);
+
+      expect(JSON.parse(JSON.stringify(args.result))).toEqual(originalResult);
+    });
+  });
+});

--- a/a2a-demo/src/__tests__/spike.test.ts
+++ b/a2a-demo/src/__tests__/spike.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import type { Server } from 'http';
+import type { Message, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import { createSpikeServer } from '../spike.js';
+
+// Use a random high port to avoid collisions
+const PORT = 30_000 + Math.floor(Math.random() * 10_000);
+
+let server: Server;
+
+afterAll(() => {
+  server?.close();
+});
+
+describe('SDK spike roundtrip', () => {
+  test('server/client lifecycle completes with echo artifact', async () => {
+    server = createSpikeServer(PORT);
+
+    await new Promise<void>((resolve, reject) => {
+      const onListening = () => { server.removeListener('error', onError); resolve(); };
+      const onError = (err: Error) => { server.removeListener('listening', onListening); reject(err); };
+      server.once('listening', onListening);
+      server.once('error', onError);
+      if (server.listening) { server.removeListener('error', onError); resolve(); }
+    });
+
+    // Create client via ClientFactory
+    const factory = new ClientFactory(
+      ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {}),
+    );
+    const client = await factory.createFromUrl(`http://localhost:${PORT}`);
+
+    // Build message
+    const message: Message = {
+      kind: 'message',
+      messageId: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ kind: 'text', text: 'hello from spike test' }],
+    };
+
+    // Collect stream events
+    const events: Array<Message | import('@a2a-js/sdk').Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent> = [];
+    for await (const event of client.sendMessageStream({ message })) {
+      events.push(event);
+    }
+
+    // Verify we received events
+    expect(events.length).toBeGreaterThan(0);
+
+    // Find the artifact-update event
+    const artifactEvent = events.find((e) => e.kind === 'artifact-update') as TaskArtifactUpdateEvent | undefined;
+    expect(artifactEvent).toBeDefined();
+    expect(artifactEvent!.artifact.parts).toHaveLength(1);
+    expect(artifactEvent!.artifact.parts[0].kind).toBe('text');
+    expect((artifactEvent!.artifact.parts[0] as { kind: 'text'; text: string }).text).toBe(
+      'echo: hello from spike test',
+    );
+
+    // Find the completed status event
+    const statusEvent = events.find(
+      (e) => e.kind === 'status-update' && (e as TaskStatusUpdateEvent).status.state === 'completed',
+    ) as TaskStatusUpdateEvent | undefined;
+    expect(statusEvent).toBeDefined();
+    expect(statusEvent!.final).toBe(true);
+  });
+});

--- a/a2a-demo/src/coffee-run.ts
+++ b/a2a-demo/src/coffee-run.ts
@@ -47,6 +47,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         const message = err instanceof Error ? err.message : String(err);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: `Failed to discover agent card: ${message}`,
         });
         return;
@@ -58,6 +59,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         console.warn(`Peer ${conn.peer_assistant_id} does not support x-vellum-social-v1, skipping`);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: 'peer does not support x-vellum-social-v1',
         });
         return;
@@ -100,9 +102,9 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
             if (taskId) {
               eventBus.broadcast('protocol_event', {
                 peer: conn.peer_assistant_id,
-                type: 'task_assigned',
+                eventType: 'task_assigned',
                 taskId,
-                event: prettifyEvent(event),
+                sdkEvent: prettifyEvent(event),
               });
             }
           }
@@ -111,9 +113,9 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
           const eventRecord = event as unknown as Record<string, unknown>;
           eventBus.broadcast('protocol_event', {
             peer: conn.peer_assistant_id,
-            type: event.kind,
+            eventType: event.kind,
             taskId: eventRecord.taskId ?? null,
-            event: prettifyEvent(event),
+            sdkEvent: prettifyEvent(event),
           });
 
           // Handle TaskArtifactUpdateEvent — cache the artifact
@@ -132,7 +134,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
               eventBus.broadcast('hitl_update', {
                 peer: conn.peer_assistant_id,
                 taskId: statusEvent.taskId,
-                hitlState: socialData,
+                hitlState: socialData && 'hitl_state' in socialData ? socialData.hitl_state : null,
                 sdkEvent: prettifyEvent(event),
               });
             }
@@ -171,6 +173,7 @@ export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void
         const message = err instanceof Error ? err.message : String(err);
         eventBus.broadcast('task_error', {
           peer: conn.peer_assistant_id,
+          taskId: null,
           error: message,
         });
       }

--- a/a2a-demo/src/coffee-run.ts
+++ b/a2a-demo/src/coffee-run.ts
@@ -1,0 +1,205 @@
+import type { Artifact, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import { VellumSocialInterceptor } from './interceptor.js';
+import { extractVellumSocial } from './extension.js';
+import type { Connection, ConnectionsConfig, VellumSocialResponseData } from './types.js';
+import type { EventBus } from './events.js';
+
+import connectionsJson from './connections.json' with { type: 'json' };
+
+interface CoffeeRunOptions {
+  deadlineSeconds?: number;
+  eventBus: EventBus;
+  connections?: Connection[];
+}
+
+/**
+ * Orchestrate a coffee run: fan out A2A requests to all connected peers in parallel,
+ * collect responses via streaming, and broadcast SSE events for the demo UI.
+ */
+export async function runCoffeeScenario(options: CoffeeRunOptions): Promise<void> {
+  const { eventBus, deadlineSeconds = 15 } = options;
+  const correlationId = crypto.randomUUID();
+  const deadline = new Date(Date.now() + deadlineSeconds * 1000).toISOString();
+
+  const connections = options.connections ?? (connectionsJson as ConnectionsConfig).connections;
+
+  // Fan out to all peers in parallel
+  const results = await Promise.allSettled(
+    connections.map(async (conn) => {
+      // Create a ClientFactory with the interceptor configured upfront
+      const interceptor = new VellumSocialInterceptor(() => ({
+        connection_id: conn.id,
+        sender_relationship: conn.declared_relationship,
+        correlation_id: correlationId,
+        deadline,
+      }));
+      const factory = new ClientFactory(
+        ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+          clientConfig: { interceptors: [interceptor] },
+        }),
+      );
+
+      let client;
+      try {
+        client = await factory.createFromUrl(conn.peer_base_url);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: `Failed to discover agent card: ${message}`,
+        });
+        return;
+      }
+
+      // Check for x-vellum-social-v1 support on the resolved agent card
+      const agentCard = await client.getAgentCard() as unknown as Record<string, unknown>;
+      if (!agentCard['x-vellum-social-v1']) {
+        console.warn(`Peer ${conn.peer_assistant_id} does not support x-vellum-social-v1, skipping`);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: 'peer does not support x-vellum-social-v1',
+        });
+        return;
+      }
+
+      // Cache the latest artifact per peer — needed because `completed` status
+      // does NOT carry the artifact
+      const artifactCache = new Map<string, Artifact>();
+
+      const messageId = crypto.randomUUID();
+
+      // Broadcast task_sent immediately — taskId is null because the SDK
+      // assigns it server-side; we don't know it until the first stream event
+      eventBus.broadcast('task_sent', {
+        peer: conn.peer_assistant_id,
+        messageId,
+        correlationId,
+        taskId: null,
+        method: 'message/stream',
+      });
+
+      try {
+        const stream = client.sendMessageStream({
+          message: {
+            kind: 'message',
+            messageId,
+            role: 'user',
+            parts: [{ kind: 'text', text: 'Coffee run! What would you like?' }],
+          },
+        });
+
+        let firstEvent = true;
+
+        for await (const event of stream) {
+          // On the first stream event, extract the taskId
+          if (firstEvent) {
+            firstEvent = false;
+            const e = event as unknown as Record<string, unknown>;
+            const taskId = e.taskId ?? e.id ?? null;
+            if (taskId) {
+              eventBus.broadcast('protocol_event', {
+                peer: conn.peer_assistant_id,
+                type: 'task_assigned',
+                taskId,
+                event: prettifyEvent(event),
+              });
+            }
+          }
+
+          // Always broadcast protocol_event with the raw prettified SDK event
+          const eventRecord = event as unknown as Record<string, unknown>;
+          eventBus.broadcast('protocol_event', {
+            peer: conn.peer_assistant_id,
+            type: event.kind,
+            taskId: eventRecord.taskId ?? null,
+            event: prettifyEvent(event),
+          });
+
+          // Handle TaskArtifactUpdateEvent — cache the artifact
+          if (event.kind === 'artifact-update') {
+            const artifactEvent = event as TaskArtifactUpdateEvent;
+            artifactCache.set(artifactEvent.artifact.artifactId, artifactEvent.artifact);
+          }
+
+          // Handle TaskStatusUpdateEvent
+          if (event.kind === 'status-update') {
+            const statusEvent = event as TaskStatusUpdateEvent;
+
+            if (statusEvent.status.state === 'working' && statusEvent.status.message) {
+              // Extract HITL DataPart from working status message
+              const socialData = extractVellumSocial(statusEvent.status.message.parts);
+              eventBus.broadcast('hitl_update', {
+                peer: conn.peer_assistant_id,
+                taskId: statusEvent.taskId,
+                hitlState: socialData,
+                sdkEvent: prettifyEvent(event),
+              });
+            }
+
+            if (statusEvent.status.state === 'completed') {
+              // Read artifact from cache (not from the status event)
+              const cachedArtifact = [...artifactCache.values()].pop();
+              let responseText: string | null = null;
+              let responseBasis: string | null = null;
+
+              if (cachedArtifact) {
+                // Extract responseText from TextPart
+                const textPart = cachedArtifact.parts.find((p) => p.kind === 'text');
+                if (textPart && textPart.kind === 'text') {
+                  responseText = (textPart as { kind: 'text'; text: string }).text;
+                }
+
+                // Extract responseBasis from response DataPart
+                const socialData = extractVellumSocial(cachedArtifact.parts);
+                if (socialData && 'response_basis' in socialData) {
+                  responseBasis = (socialData as VellumSocialResponseData).response_basis;
+                }
+              }
+
+              eventBus.broadcast('task_completed', {
+                peer: conn.peer_assistant_id,
+                taskId: statusEvent.taskId,
+                responseText,
+                responseBasis,
+                sdkEvent: prettifyEvent(event),
+              });
+            }
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        eventBus.broadcast('task_error', {
+          peer: conn.peer_assistant_id,
+          error: message,
+        });
+      }
+    }),
+  );
+
+  // Log any unhandled rejections (shouldn't happen with allSettled, but be safe)
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('Unexpected rejection in coffee run:', result.reason);
+    }
+  }
+
+  eventBus.broadcast('run_complete', { correlationId });
+}
+
+/**
+ * Create a prettified representation of an SDK event for protocol logging.
+ */
+function prettifyEvent(event: unknown): Record<string, unknown> {
+  const e = event as Record<string, unknown>;
+  return {
+    kind: e.kind,
+    ...(e.taskId != null ? { taskId: e.taskId } : {}),
+    ...(e.contextId != null ? { contextId: e.contextId } : {}),
+    ...(e.status != null ? { status: e.status } : {}),
+    ...(e.artifact != null ? { artifact: e.artifact } : {}),
+    ...(e.role != null ? { role: e.role } : {}),
+    ...(e.parts != null ? { parts: e.parts } : {}),
+    ...(e.final != null ? { final: e.final } : {}),
+  };
+}

--- a/a2a-demo/src/connections.json
+++ b/a2a-demo/src/connections.json
@@ -1,0 +1,45 @@
+{
+  "owner": { "id": "demo-assistant-1", "name": "Demo Assistant", "port": 3000 },
+  "connections": [
+    {
+      "id": "conn_demo_peer1",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-sarah",
+      "peer_agent_card_url": "http://localhost:3010/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3010",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer2",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-jake",
+      "peer_agent_card_url": "http://localhost:3011/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3011",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer3",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-maria",
+      "peer_agent_card_url": "http://localhost:3012/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3012",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    },
+    {
+      "id": "conn_demo_peer4",
+      "owner_assistant_id": "demo-assistant-1",
+      "peer_assistant_id": "peer-priya",
+      "peer_agent_card_url": "http://localhost:3013/.well-known/agent-card.json",
+      "peer_base_url": "http://localhost:3013",
+      "declared_relationship": "colleague",
+      "scopes": ["coffee_order"],
+      "created_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/a2a-demo/src/demo.ts
+++ b/a2a-demo/src/demo.ts
@@ -1,0 +1,116 @@
+import type { Server } from 'node:http';
+import { createPeerServer, type PeerServer } from './peers/create-peer-server.js';
+import { createServer } from './server.js';
+
+const PEERS = [
+  {
+    name: 'Sarah',
+    port: 3010,
+    assistantId: 'sarah-assistant',
+    config: {
+      name: 'Sarah',
+      responseText: 'Cortado, oat milk',
+      strategy: 'standing_preference' as const,
+      humanDelayMs: 0,
+    },
+  },
+  {
+    name: 'Jake',
+    port: 3011,
+    assistantId: 'jake-assistant',
+    config: {
+      name: 'Jake',
+      responseText: 'Black drip, large',
+      strategy: 'hitl_confirm' as const,
+      humanDelayMs: 3000,
+    },
+  },
+  {
+    name: 'Maria',
+    port: 3012,
+    assistantId: 'maria-assistant',
+    config: {
+      name: 'Maria',
+      responseText: 'Usually an Americano, unconfirmed',
+      strategy: 'hitl_stale_infer' as const,
+      humanDelayMs: 6000,
+    },
+  },
+  {
+    name: 'Priya',
+    port: 3013,
+    assistantId: 'priya-assistant',
+    config: {
+      name: 'Priya',
+      responseText: "Priya's in a meeting, no response",
+      strategy: 'hitl_unreachable' as const,
+      humanDelayMs: 8000,
+    },
+  },
+];
+
+async function waitForServer(url: string, retries = 20, delayMs = 200): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // Not ready yet
+    }
+    await Bun.sleep(delayMs);
+  }
+  throw new Error(`Server at ${url} did not become ready`);
+}
+
+async function main() {
+  const peerServers: PeerServer[] = [];
+  let mainServer: Server | undefined;
+
+  function shutdown() {
+    console.log('\nShutting down...');
+    if (mainServer) mainServer.close();
+    for (const ps of peerServers) ps.server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // Build UI
+  console.log('Building UI...');
+  const result = Bun.spawnSync(['bun', 'run', 'build:ui'], {
+    cwd: import.meta.dir + '/..',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  if (result.exitCode !== 0) {
+    console.error('UI build failed');
+    process.exit(1);
+  }
+  console.log('UI built successfully');
+
+  // Start all peer servers in-process
+  console.log('Starting peer servers...');
+  for (const peer of PEERS) {
+    const ps = createPeerServer(peer);
+    peerServers.push(ps);
+  }
+
+  // Wait for all peers to be ready
+  await Promise.all(
+    PEERS.map((peer) => waitForServer(`http://localhost:${peer.port}/.well-known/agent-card.json`)),
+  );
+  console.log('All peers ready on ports 3010-3013');
+
+  // Start main server
+  const { server } = createServer();
+  mainServer = server;
+
+  await waitForServer(`http://localhost:${Number(process.env.PORT) || 3000}/.well-known/agent-card.json`);
+  console.log(`\nDemo ready at http://localhost:${Number(process.env.PORT) || 3000}`);
+}
+
+main().catch((err) => {
+  console.error('Demo failed to start:', err);
+  process.exit(1);
+});

--- a/a2a-demo/src/events.ts
+++ b/a2a-demo/src/events.ts
@@ -1,0 +1,51 @@
+import type { Response } from 'express';
+
+/**
+ * SSE event bus for the demo UI.
+ * Maintains a set of connected SSE clients and broadcasts events to all of them.
+ */
+export class EventBus {
+  private readonly clients = new Set<Response>();
+
+  /**
+   * Register an SSE client. Sets required headers, flushes an initial `:ok` comment,
+   * and removes the client on disconnect.
+   */
+  addClient(res: Response): void {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    // Send initial comment to flush the connection
+    res.write(':ok\n\n');
+
+    this.clients.add(res);
+
+    res.on('close', () => {
+      this.clients.delete(res);
+    });
+  }
+
+  /**
+   * Broadcast an SSE event to all connected clients.
+   * Silently drops disconnected clients.
+   */
+  broadcast(eventType: string, data: object): void {
+    const payload = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+
+    for (const client of this.clients) {
+      try {
+        client.write(payload);
+      } catch {
+        // Client disconnected — remove silently
+        this.clients.delete(client);
+      }
+    }
+  }
+
+  /** Number of currently connected clients (useful for testing). */
+  get size(): number {
+    return this.clients.size;
+  }
+}

--- a/a2a-demo/src/events.ts
+++ b/a2a-demo/src/events.ts
@@ -32,7 +32,7 @@ export class EventBus {
    * Silently drops disconnected clients.
    */
   broadcast(eventType: string, data: object): void {
-    const payload = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+    const payload = `data: ${JSON.stringify({ type: eventType, ...data })}\n\n`;
 
     for (const client of this.clients) {
       try {

--- a/a2a-demo/src/executor.ts
+++ b/a2a-demo/src/executor.ts
@@ -1,0 +1,271 @@
+import type {
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '@a2a-js/sdk';
+import type { AgentExecutor, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
+import { extractVellumSocial, makeResponsePart, makeWorkingPart } from './extension.js';
+import type { VellumSocialRequestData } from './types.js';
+
+export interface PeerConfig {
+  name: string;
+  responseText: string;
+  strategy: 'standing_preference' | 'hitl_confirm' | 'hitl_stale_infer' | 'hitl_unreachable';
+  humanDelayMs: number;
+}
+
+export class VellumSocialExecutor implements AgentExecutor {
+  constructor(private readonly config: PeerConfig) {}
+
+  async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    // Extract Vellum extension data from user message parts
+    const socialData = extractVellumSocial(context.userMessage.parts);
+
+    if (!socialData) {
+      const failedStatus: TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: context.taskId,
+        contextId: context.contextId,
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            messageId: crypto.randomUUID(),
+            role: 'agent',
+            parts: [{ kind: 'text', text: 'Missing x-vellum-social-v1 extension data' }],
+          },
+        },
+        final: true,
+      };
+      eventBus.publish(failedStatus);
+      eventBus.finished();
+      return;
+    }
+
+    // TODO: enforce scope
+    console.log('scope check: pass');
+
+    const requestData = socialData as VellumSocialRequestData;
+    const correlationId = requestData.correlation_id;
+
+    switch (this.config.strategy) {
+      case 'standing_preference':
+        await this.executeStandingPreference(context, eventBus, correlationId);
+        break;
+      case 'hitl_confirm':
+        await this.executeHitlConfirm(context, eventBus, correlationId);
+        break;
+      case 'hitl_stale_infer':
+        await this.executeHitlStaleInfer(context, eventBus, correlationId);
+        break;
+      case 'hitl_unreachable':
+        await this.executeHitlUnreachable(context, eventBus, correlationId);
+        break;
+    }
+  }
+
+  async cancelTask(_taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    eventBus.finished();
+  }
+
+  private async executeStandingPreference(
+    context: RequestContext,
+    eventBus: ExecutionEventBus,
+    correlationId: string,
+  ): Promise<void> {
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      artifact: {
+        artifactId: crypto.randomUUID(),
+        parts: [
+          { kind: 'text', text: this.config.responseText },
+          makeResponsePart({ response_basis: 'standing_preference', correlation_id: correlationId }),
+        ],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    const completedStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(completedStatus);
+
+    eventBus.finished();
+  }
+
+  private async executeHitlConfirm(
+    context: RequestContext,
+    eventBus: ExecutionEventBus,
+    correlationId: string,
+  ): Promise<void> {
+    const workingStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [makeWorkingPart({ hitl_state: 'awaiting_human_input', correlation_id: correlationId })],
+        },
+      },
+      final: false,
+    };
+    eventBus.publish(workingStatus);
+
+    await Bun.sleep(this.config.humanDelayMs);
+
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      artifact: {
+        artifactId: crypto.randomUUID(),
+        parts: [
+          { kind: 'text', text: this.config.responseText },
+          makeResponsePart({ response_basis: 'confirmed', correlation_id: correlationId }),
+        ],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    const completedStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(completedStatus);
+
+    eventBus.finished();
+  }
+
+  private async executeHitlStaleInfer(
+    context: RequestContext,
+    eventBus: ExecutionEventBus,
+    correlationId: string,
+  ): Promise<void> {
+    // First working status: awaiting_human_input
+    const workingStatus1: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [makeWorkingPart({ hitl_state: 'awaiting_human_input', correlation_id: correlationId })],
+        },
+      },
+      final: false,
+    };
+    eventBus.publish(workingStatus1);
+
+    await Bun.sleep(this.config.humanDelayMs);
+
+    // Second working status: awaiting_human_input_stale
+    const workingStatus2: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [makeWorkingPart({ hitl_state: 'awaiting_human_input_stale', correlation_id: correlationId })],
+        },
+      },
+      final: false,
+    };
+    eventBus.publish(workingStatus2);
+
+    await Bun.sleep(this.config.humanDelayMs);
+
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      artifact: {
+        artifactId: crypto.randomUUID(),
+        parts: [
+          { kind: 'text', text: this.config.responseText },
+          makeResponsePart({ response_basis: 'inferred', correlation_id: correlationId }),
+        ],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    const completedStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(completedStatus);
+
+    eventBus.finished();
+  }
+
+  private async executeHitlUnreachable(
+    context: RequestContext,
+    eventBus: ExecutionEventBus,
+    correlationId: string,
+  ): Promise<void> {
+    const workingStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: {
+        state: 'working',
+        message: {
+          kind: 'message',
+          messageId: crypto.randomUUID(),
+          role: 'agent',
+          parts: [makeWorkingPart({ hitl_state: 'awaiting_human_input', correlation_id: correlationId })],
+        },
+      },
+      final: false,
+    };
+    eventBus.publish(workingStatus);
+
+    await Bun.sleep(this.config.humanDelayMs);
+
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      artifact: {
+        artifactId: crypto.randomUUID(),
+        parts: [
+          { kind: 'text', text: this.config.responseText },
+          makeResponsePart({ response_basis: 'unreachable', correlation_id: correlationId }),
+        ],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    const completedStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(completedStatus);
+
+    eventBus.finished();
+  }
+}

--- a/a2a-demo/src/executor.ts
+++ b/a2a-demo/src/executor.ts
@@ -63,7 +63,15 @@ export class VellumSocialExecutor implements AgentExecutor {
     }
   }
 
-  async cancelTask(_taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    const canceledStatus: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId,
+      contextId: taskId,
+      status: { state: 'canceled' },
+      final: true,
+    };
+    eventBus.publish(canceledStatus);
     eventBus.finished();
   }
 
@@ -191,7 +199,7 @@ export class VellumSocialExecutor implements AgentExecutor {
     };
     eventBus.publish(workingStatus2);
 
-    await Bun.sleep(this.config.humanDelayMs);
+    await Bun.sleep(1000);
 
     const artifactEvent: TaskArtifactUpdateEvent = {
       kind: 'artifact-update',

--- a/a2a-demo/src/extension.ts
+++ b/a2a-demo/src/extension.ts
@@ -1,0 +1,50 @@
+import type { Part, DataPart } from '@a2a-js/sdk';
+import type {
+  VellumSocialData,
+  VellumSocialRequestData,
+  VellumSocialResponseData,
+  VellumSocialWorkingData,
+} from './types.js';
+
+/**
+ * Scans an array of Parts for a DataPart carrying the Vellum social extension.
+ * Returns the typed data if found, null otherwise.
+ */
+export function extractVellumSocial(parts: Part[]): VellumSocialData | null {
+  for (const part of parts) {
+    if (part.kind === 'data' && (part.data as Record<string, unknown>).extension === 'x-vellum-social-v1') {
+      return part.data as unknown as VellumSocialData;
+    }
+  }
+  return null;
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social request payload.
+ */
+export function makeRequestPart(data: Omit<VellumSocialRequestData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social response payload.
+ */
+export function makeResponsePart(data: Omit<VellumSocialResponseData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}
+
+/**
+ * Creates a DataPart carrying a Vellum social working/HITL payload.
+ */
+export function makeWorkingPart(data: Omit<VellumSocialWorkingData, 'extension'>): DataPart {
+  return {
+    kind: 'data',
+    data: { extension: 'x-vellum-social-v1', ...data },
+  };
+}

--- a/a2a-demo/src/interceptor.ts
+++ b/a2a-demo/src/interceptor.ts
@@ -1,0 +1,49 @@
+import type { CallInterceptor, BeforeArgs, AfterArgs } from '@a2a-js/sdk/client';
+import type { MessageSendParams } from '@a2a-js/sdk';
+import { makeRequestPart } from './extension.js';
+import type { VellumSocialRequestData } from './types.js';
+
+/**
+ * Client-side interceptor that injects Vellum social extension data
+ * into outgoing A2A messages (sendMessage / sendMessageStream).
+ *
+ * Usage:
+ * ```ts
+ * const interceptor = new VellumSocialInterceptor(getExtensionData);
+ * const factory = new ClientFactory(
+ *   ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+ *     clientConfig: { interceptors: [interceptor] },
+ *   })
+ * );
+ * const client = await factory.createFromUrl(peerBaseUrl);
+ * ```
+ */
+export class VellumSocialInterceptor implements CallInterceptor {
+  private readonly getExtensionData: (args: BeforeArgs) => Omit<VellumSocialRequestData, 'extension'>;
+
+  constructor(getExtensionData: (args: BeforeArgs) => Omit<VellumSocialRequestData, 'extension'>) {
+    this.getExtensionData = getExtensionData;
+  }
+
+  async before(args: BeforeArgs): Promise<void> {
+    const method = args.input?.method;
+
+    // Only apply to message-sending methods
+    if (method !== 'sendMessage' && method !== 'sendMessageStream') {
+      return;
+    }
+
+    const extensionData = this.getExtensionData(args);
+    const dataPart = makeRequestPart(extensionData);
+
+    // After the method guard, we know input.value is MessageSendParams
+    const params = args.input!.value as MessageSendParams;
+
+    // Prepend the extension DataPart to the message parts
+    params.message.parts.unshift(dataPart);
+  }
+
+  async after(_args: AfterArgs): Promise<void> {
+    // No-op
+  }
+}

--- a/a2a-demo/src/peers/create-peer-server.ts
+++ b/a2a-demo/src/peers/create-peer-server.ts
@@ -1,0 +1,66 @@
+import type { Server } from 'node:http';
+import type { Express } from 'express';
+import express from 'express';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { VellumSocialExecutor, type PeerConfig } from '../executor.js';
+import type { VellumAgentCard } from '../types.js';
+
+export interface CreatePeerServerOptions {
+  name: string;
+  port: number;
+  assistantId: string;
+  config: PeerConfig;
+}
+
+export interface PeerServer {
+  app: Express;
+  server: Server;
+}
+
+export function createPeerServer(options: CreatePeerServerOptions): PeerServer {
+  const { name, port, assistantId, config } = options;
+
+  const card: VellumAgentCard = {
+    name: `${name}'s Assistant`,
+    url: `http://localhost:${port}/a2a/jsonrpc`,
+    description: `Mock peer [${assistantId}] for A2A demo — exercises ${config.strategy}`,
+    protocolVersion: '0.3.0',
+    version: '0.1.0',
+    capabilities: { streaming: true },
+    skills: [
+      {
+        id: 'coffee_order',
+        name: 'Coffee Order',
+        description: 'Responds to coffee order requests',
+        tags: ['coffee', 'social'],
+      },
+    ],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    'x-vellum-social-v1': true,
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const executor = new VellumSocialExecutor(config);
+  const requestHandler = new DefaultRequestHandler(card, taskStore, executor);
+
+  const app = express();
+
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => card }),
+  );
+
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  const server = app.listen(port);
+
+  return { app, server };
+}

--- a/a2a-demo/src/peers/jake.ts
+++ b/a2a-demo/src/peers/jake.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Jake',
+  port: 3011,
+  assistantId: 'jake-assistant',
+  config: {
+    name: 'Jake',
+    responseText: 'Black drip, large',
+    strategy: 'hitl_confirm',
+    humanDelayMs: 3000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Jake] listening on port 3011');
+});

--- a/a2a-demo/src/peers/maria.ts
+++ b/a2a-demo/src/peers/maria.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Maria',
+  port: 3012,
+  assistantId: 'maria-assistant',
+  config: {
+    name: 'Maria',
+    responseText: 'Usually an Americano, unconfirmed',
+    strategy: 'hitl_stale_infer',
+    humanDelayMs: 6000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Maria] listening on port 3012');
+});

--- a/a2a-demo/src/peers/priya.ts
+++ b/a2a-demo/src/peers/priya.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Priya',
+  port: 3013,
+  assistantId: 'priya-assistant',
+  config: {
+    name: 'Priya',
+    responseText: "Priya's in a meeting, no response",
+    strategy: 'hitl_unreachable',
+    humanDelayMs: 8000,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Priya] listening on port 3013');
+});

--- a/a2a-demo/src/peers/sarah.ts
+++ b/a2a-demo/src/peers/sarah.ts
@@ -1,0 +1,17 @@
+import { createPeerServer } from './create-peer-server.js';
+
+const { server } = createPeerServer({
+  name: 'Sarah',
+  port: 3010,
+  assistantId: 'sarah-assistant',
+  config: {
+    name: 'Sarah',
+    responseText: 'Cortado, oat milk',
+    strategy: 'standing_preference',
+    humanDelayMs: 0,
+  },
+});
+
+server.on('listening', () => {
+  console.log('[Sarah] listening on port 3010');
+});

--- a/a2a-demo/src/peers/start-all.ts
+++ b/a2a-demo/src/peers/start-all.ts
@@ -1,0 +1,99 @@
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface PeerDef {
+  label: string;
+  script: string;
+  port: number;
+}
+
+const peers: PeerDef[] = [
+  { label: 'Sarah', script: 'sarah.ts', port: 3010 },
+  { label: 'Jake', script: 'jake.ts', port: 3011 },
+  { label: 'Maria', script: 'maria.ts', port: 3012 },
+  { label: 'Priya', script: 'priya.ts', port: 3013 },
+];
+
+const children: Array<ReturnType<typeof Bun.spawn>> = [];
+
+for (const peer of peers) {
+  const scriptPath = resolve(__dirname, peer.script);
+
+  const child = Bun.spawn(['bun', 'run', scriptPath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  children.push(child);
+
+  // Pipe stdout with prefix
+  (async () => {
+    if (!child.stdout) return;
+    const reader = child.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        console.log(`[${peer.label}] ${line}`);
+      }
+    }
+    if (buffer) {
+      console.log(`[${peer.label}] ${buffer}`);
+    }
+  })();
+
+  // Pipe stderr with prefix
+  (async () => {
+    if (!child.stderr) return;
+    const reader = child.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        console.error(`[${peer.label}] ${line}`);
+      }
+    }
+    if (buffer) {
+      console.error(`[${peer.label}] ${buffer}`);
+    }
+  })();
+}
+
+console.log('All peers started on ports 3010-3013');
+
+function shutdown() {
+  console.log('\nShutting down peers...');
+  for (const child of children) {
+    child.kill();
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+// Keep the process alive — fail fast if any peer exits non-zero
+await Promise.all(
+  children.map(async (child, i) => {
+    const code = await child.exited;
+    if (code !== 0) {
+      console.error(`[${peers[i].label}] exited with code ${code} — shutting down remaining peers`);
+      for (const c of children) {
+        c.kill();
+      }
+      process.exit(code ?? 1);
+    }
+  }),
+);

--- a/a2a-demo/src/server.ts
+++ b/a2a-demo/src/server.ts
@@ -1,0 +1,131 @@
+import type { AgentCard } from '@a2a-js/sdk';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import express from 'express';
+import path from 'path';
+
+import { EventBus } from './events.js';
+import { VellumSocialExecutor, type PeerConfig } from './executor.js';
+import { runCoffeeScenario } from './coffee-run.js';
+import type { Connection, ConnectionsConfig, VellumAgentCard } from './types.js';
+
+import connectionsJson from './connections.json' with { type: 'json' };
+
+interface ServerOptions {
+  port?: number;
+  publicBaseUrl?: string;
+  assistantName?: string;
+  assistantId?: string;
+  coffeeResponse?: string;
+  responseStrategy?: PeerConfig['strategy'];
+  connections?: Connection[];
+}
+
+/**
+ * Create and start the main A2A demo server.
+ * Accepts DI options for testing and configuration.
+ */
+export function createServer(options: ServerOptions = {}) {
+  const port = options.port ?? (Number(process.env.PORT) || 3000);
+  const publicBaseUrl = options.publicBaseUrl ?? process.env.PUBLIC_BASE_URL ?? `http://localhost:${port}`;
+  const assistantName = options.assistantName ?? process.env.ASSISTANT_NAME ?? 'Demo Assistant';
+  const assistantId = options.assistantId ?? process.env.ASSISTANT_ID ?? 'demo-assistant-1';
+  const coffeeResponse = options.coffeeResponse ?? process.env.COFFEE_RESPONSE ?? 'I appreciate the offer!';
+  const responseStrategy = (options.responseStrategy ?? process.env.RESPONSE_STRATEGY ?? 'standing_preference') as PeerConfig['strategy'];
+  const connections = options.connections ?? (connectionsJson as ConnectionsConfig).connections;
+
+  const agentCard: VellumAgentCard = {
+    'x-vellum-social-v1': true,
+    name: assistantName,
+    url: `${publicBaseUrl}/a2a/jsonrpc`,
+    description: `${assistantName} — A2A demo assistant with Vellum social extension`,
+    protocolVersion: '0.2.0',
+    version: '0.1.0',
+    capabilities: {
+      streaming: true,
+    },
+    skills: [
+      {
+        id: 'coffee-order',
+        name: 'Coffee Order',
+        description: 'Respond to coffee run requests',
+        tags: ['coffee', 'social'],
+      },
+    ],
+    defaultInputModes: ['text/plain', 'application/json'],
+    defaultOutputModes: ['text/plain', 'application/json'],
+  };
+
+  const peerConfig: PeerConfig = {
+    name: assistantName,
+    responseText: coffeeResponse,
+    strategy: responseStrategy,
+    humanDelayMs: 2000,
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const executor = new VellumSocialExecutor(peerConfig);
+  const requestHandler = new DefaultRequestHandler(agentCard as AgentCard, taskStore, executor);
+
+  const app = express();
+
+  const eventBus = new EventBus();
+
+  // Agent card endpoint
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => agentCard as AgentCard }),
+  );
+
+  // JSON-RPC endpoint
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  // SSE endpoint
+  app.get('/events', (_req, res) => {
+    eventBus.addClient(res);
+  });
+
+  // Connections endpoint
+  app.get('/connections', (_req, res) => {
+    res.json({
+      owner: { id: assistantId, name: assistantName },
+      connections,
+    });
+  });
+
+  // Coffee run trigger
+  app.post('/run/coffee', express.json(), (req, res) => {
+    const deadlineSeconds = (req.body as Record<string, unknown>)?.deadlineSeconds as number | undefined;
+
+    // Fire and forget — respond 202 immediately
+    runCoffeeScenario({
+      deadlineSeconds: deadlineSeconds ?? 15,
+      eventBus,
+      connections,
+    }).catch((err) => {
+      console.error('Coffee run failed:', err);
+    });
+
+    res.status(202).json({ status: 'started' });
+  });
+
+  // Static file serving — serves the built UI
+  app.use(express.static(path.resolve(import.meta.dir, '..', 'ui', 'dist')));
+
+  const server = app.listen(port, () => {
+    console.log(`${assistantName} running on http://localhost:${port}`);
+  });
+
+  return { app, server, eventBus };
+}
+
+// When run directly, start the server
+if (import.meta.main) {
+  createServer();
+}

--- a/a2a-demo/src/server.ts
+++ b/a2a-demo/src/server.ts
@@ -39,21 +39,21 @@ export function createServer(options: ServerOptions = {}) {
     name: assistantName,
     url: `${publicBaseUrl}/a2a/jsonrpc`,
     description: `${assistantName} — A2A demo assistant with Vellum social extension`,
-    protocolVersion: '0.2.0',
+    protocolVersion: '0.3.0',
     version: '0.1.0',
     capabilities: {
       streaming: true,
     },
     skills: [
       {
-        id: 'coffee-order',
+        id: 'coffee_order',
         name: 'Coffee Order',
         description: 'Respond to coffee run requests',
         tags: ['coffee', 'social'],
       },
     ],
-    defaultInputModes: ['text/plain', 'application/json'],
-    defaultOutputModes: ['text/plain', 'application/json'],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
   };
 
   const peerConfig: PeerConfig = {

--- a/a2a-demo/src/spike.ts
+++ b/a2a-demo/src/spike.ts
@@ -1,0 +1,204 @@
+/**
+ * SDK Spike — Minimal A2A server + client roundtrip to verify exact SDK import paths and API shapes.
+ *
+ * ===== VERIFIED SDK FINDINGS =====
+ *
+ * Import paths (all compile from @a2a-js/sdk v0.3.13):
+ *   - Types (Part, DataPart, Message, AgentCard, etc.): `@a2a-js/sdk`
+ *   - Server (AgentExecutor, RequestContext, ExecutionEventBus, DefaultRequestHandler,
+ *     InMemoryTaskStore, DefaultExecutionEventBusManager): `@a2a-js/sdk/server`
+ *   - Express handlers (agentCardHandler, jsonRpcHandler, UserBuilder): `@a2a-js/sdk/server/express`
+ *   - Client (ClientFactory, ClientFactoryOptions): `@a2a-js/sdk/client`
+ *   - Client interceptors (CallInterceptor, BeforeArgs): `@a2a-js/sdk/client`
+ *
+ * RequestContext:
+ *   - Field is `.userMessage` (not `.message`)
+ *   - Constructor: (userMessage, taskId, contextId, task?, referenceTasks?, context?)
+ *   - `.task` is optional — undefined for first message of a new task
+ *
+ * ExecutionEventBus:
+ *   - `.publish(event)` — publishes AgentExecutionEvent (Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent)
+ *   - `.finished()` — REQUIRED. Signals end of execution. Without it the stream never closes.
+ *
+ * Message:
+ *   - Requires `kind: 'message'` (discriminator field)
+ *   - Requires `messageId: string` (UUID)
+ *   - Requires `role: 'user' | 'agent'`
+ *   - Requires `parts: Part[]`
+ *
+ * TaskStatusUpdateEvent:
+ *   - `final: boolean` is REQUIRED (not optional). Must be `true` on the last status event.
+ *   - Requires `kind: 'status-update'`, `taskId`, `contextId`, `status: { state }`
+ *
+ * TaskArtifactUpdateEvent:
+ *   - Requires `kind: 'artifact-update'`, `taskId`, `contextId`, `artifact: { artifactId, parts }`
+ *
+ * BeforeArgs (interceptor):
+ *   - `args.input.value` contains the MessageSendParams
+ *   - For sendMessageStream: `args.input.value.message.parts` to access outgoing message parts
+ *   - `args.input.method` is 'sendMessage' | 'sendMessageStream' | etc.
+ *
+ * ClientFactory:
+ *   - Constructor takes optional ClientFactoryOptions
+ *   - `ClientFactoryOptions.createFrom(ClientFactoryOptions.default, { clientConfig: { interceptors: [...] } })`
+ *   - Interceptors go in `clientConfig.interceptors`, NOT registered post-construction
+ *   - `.createFromUrl(baseUrl)` fetches agent card and creates client
+ *
+ * UserBuilder.noAuthentication:
+ *   - Required for jsonRpcHandler options
+ *   - `jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication })` — options object API
+ *
+ * agentCardHandler:
+ *   - Takes `{ agentCardProvider }` — can be a requestHandler or an async lambda `() => Promise<AgentCard>`
+ *
+ * DefaultRequestHandler constructor:
+ *   - (agentCard, taskStore, agentExecutor, eventBusManager?, ...)
+ *   - eventBusManager is optional — if not provided, uses its own internal default
+ *
+ * ===== END FINDINGS =====
+ */
+
+import type {
+  AgentCard,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+  Message,
+} from '@a2a-js/sdk';
+import type { AgentExecutor, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { agentCardHandler, jsonRpcHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { ClientFactory, ClientFactoryOptions } from '@a2a-js/sdk/client';
+import express from 'express';
+
+/**
+ * Trivial executor that echoes incoming text back as an artifact, then completes.
+ */
+const echoExecutor: AgentExecutor = {
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    // Extract text from the user message
+    const userText = requestContext.userMessage.parts
+      .filter((p): p is { kind: 'text'; text: string; metadata?: Record<string, unknown> } => p.kind === 'text')
+      .map((p) => p.text)
+      .join(' ');
+
+    // Publish an artifact with the echoed text
+    const artifactEvent: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId: requestContext.taskId,
+      contextId: requestContext.contextId,
+      artifact: {
+        artifactId: 'echo-artifact-1',
+        name: 'echo',
+        parts: [{ kind: 'text', text: `echo: ${userText}` }],
+      },
+    };
+    eventBus.publish(artifactEvent);
+
+    // Publish completed status with final: true
+    const statusEvent: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId: requestContext.taskId,
+      contextId: requestContext.contextId,
+      status: { state: 'completed' },
+      final: true,
+    };
+    eventBus.publish(statusEvent);
+
+    // Signal the event bus that execution is done — REQUIRED or the stream never closes
+    eventBus.finished();
+  },
+
+  async cancelTask(_taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    eventBus.finished();
+  },
+};
+
+/**
+ * Creates and starts a minimal A2A server on the given port.
+ * Returns the HTTP server instance for cleanup.
+ */
+export function createSpikeServer(port: number) {
+  const agentCard: AgentCard = {
+    name: 'Spike Echo Agent',
+    url: `http://localhost:${port}/a2a/jsonrpc`,
+    description: 'A trivial echo agent for SDK spike testing',
+    protocolVersion: '0.2.0',
+    version: '0.1.0',
+    capabilities: {
+      streaming: true,
+    },
+    skills: [
+      {
+        id: 'echo',
+        name: 'Echo',
+        description: 'Echoes back the input',
+        tags: ['echo', 'test'],
+      },
+    ],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+  };
+
+  const taskStore = new InMemoryTaskStore();
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, echoExecutor);
+
+  const app = express();
+
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({ agentCardProvider: async () => agentCard }),
+  );
+
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+    }),
+  );
+
+  const server = app.listen(port);
+  return server;
+}
+
+/**
+ * Runs the full spike: starts server, sends a message via ClientFactory, iterates the stream.
+ * Returns the collected stream events for assertions.
+ */
+export async function runSpike(port: number) {
+  const server = createSpikeServer(port);
+
+  await new Promise<void>((resolve, reject) => {
+    const onListening = () => { server.removeListener('error', onError); resolve(); };
+    const onError = (err: Error) => { server.removeListener('listening', onListening); reject(err); };
+    server.once('listening', onListening);
+    server.once('error', onError);
+    if (server.listening) { server.removeListener('error', onError); resolve(); }
+  });
+
+  try {
+    // Create client via ClientFactory (NOT deprecated A2AClient)
+    const factory = new ClientFactory(
+      ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {}),
+    );
+    const client = await factory.createFromUrl(`http://localhost:${port}`);
+
+    // Build a properly-formed Message
+    const message: Message = {
+      kind: 'message',
+      messageId: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ kind: 'text', text: 'hello' }],
+    };
+
+    // Send via streaming — collect raw A2AStreamEventData events
+    const events: Array<Message | import('@a2a-js/sdk').Task | import('@a2a-js/sdk').TaskStatusUpdateEvent | import('@a2a-js/sdk').TaskArtifactUpdateEvent> = [];
+    for await (const event of client.sendMessageStream({ message })) {
+      events.push(event);
+    }
+
+    return events;
+  } finally {
+    server.close();
+  }
+}

--- a/a2a-demo/src/types.ts
+++ b/a2a-demo/src/types.ts
@@ -1,0 +1,46 @@
+import type { AgentCard } from '@a2a-js/sdk';
+
+export type RelationshipType = 'colleague' | 'work_contact' | 'friend' | 'family' | 'other';
+export type ResponseBasis = 'confirmed' | 'standing_preference' | 'inferred' | 'unreachable';
+export type HitlState = 'awaiting_human_input' | 'awaiting_human_input_stale';
+
+// TypeScript typed wrapper — AgentCard may reject extra literal fields
+export type VellumAgentCard = AgentCard & { 'x-vellum-social-v1': true };
+
+export interface Connection {
+  id: string;
+  owner_assistant_id: string;
+  peer_assistant_id: string;
+  peer_agent_card_url: string;
+  peer_base_url: string;
+  declared_relationship: RelationshipType;
+  scopes: string[];
+  created_at: string;
+}
+
+export interface ConnectionsConfig {
+  owner: { id: string; name: string; port: number };
+  connections: Connection[];
+}
+
+export interface VellumSocialRequestData {
+  extension: 'x-vellum-social-v1';
+  connection_id: string;
+  sender_relationship: RelationshipType;
+  correlation_id: string;
+  deadline?: string;
+}
+
+export interface VellumSocialResponseData {
+  extension: 'x-vellum-social-v1';
+  response_basis: ResponseBasis;
+  correlation_id: string;
+}
+
+export interface VellumSocialWorkingData {
+  extension: 'x-vellum-social-v1';
+  hitl_state: HitlState;
+  correlation_id: string;
+}
+
+export type VellumSocialData = VellumSocialRequestData | VellumSocialResponseData | VellumSocialWorkingData;

--- a/a2a-demo/tsconfig.json
+++ b/a2a-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "types": ["bun-types"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "ui/src/**/*"],
+  "exclude": ["node_modules", "dist", "ui/dist"]
+}

--- a/a2a-demo/ui/index.html
+++ b/a2a-demo/ui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A2A Coffee Run Demo</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/a2a-demo/ui/src/PeerCard.tsx
+++ b/a2a-demo/ui/src/PeerCard.tsx
@@ -1,0 +1,85 @@
+import type { PeerState } from './types.js';
+
+function statusLabel(status: PeerState['status']): string {
+  switch (status) {
+    case 'idle':
+      return 'Ready';
+    case 'sent':
+      return 'Sent...';
+    case 'awaiting_human':
+      return 'Waiting for human';
+    case 'stale':
+      return 'Stale - deadline approaching';
+    case 'done':
+      return 'Done';
+  }
+}
+
+function statusClass(status: PeerState['status']): string {
+  switch (status) {
+    case 'idle':
+      return 'status-idle';
+    case 'sent':
+      return 'status-sent';
+    case 'awaiting_human':
+      return 'status-awaiting';
+    case 'stale':
+      return 'status-stale';
+    case 'done':
+      return 'status-done';
+  }
+}
+
+function basisBadgeClass(basis: string): string {
+  switch (basis) {
+    case 'standing_preference':
+      return 'badge-standing';
+    case 'confirmed':
+      return 'badge-confirmed';
+    case 'inferred':
+      return 'badge-inferred';
+    case 'unreachable':
+      return 'badge-unreachable';
+    default:
+      return '';
+  }
+}
+
+function basisLabel(basis: string): string {
+  switch (basis) {
+    case 'standing_preference':
+      return 'Standing';
+    case 'confirmed':
+      return 'Confirmed';
+    case 'inferred':
+      return 'Inferred';
+    case 'unreachable':
+      return 'Unreachable';
+    default:
+      return basis;
+  }
+}
+
+export function PeerCard({ id, name, relationship, status, responseText, responseBasis }: PeerState) {
+  return (
+    <div class={`peer-card ${statusClass(status)}`} data-peer-id={id}>
+      <div class="peer-header">
+        <h3 class="peer-name">{name}</h3>
+        <span class="peer-relationship">{relationship}</span>
+      </div>
+      <div class={`peer-status ${statusClass(status)}`}>
+        {statusLabel(status)}
+      </div>
+      {status === 'done' && responseText && (
+        <div class="peer-response">
+          <p class="response-text">{responseText}</p>
+          {responseBasis && (
+            <span class={`badge ${basisBadgeClass(responseBasis)}`}>
+              {basisLabel(responseBasis)}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/a2a-demo/ui/src/ProtocolLog.tsx
+++ b/a2a-demo/ui/src/ProtocolLog.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'preact/hooks';
+import type { LogEntry } from './types.js';
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toTimeString().slice(0, 8);
+}
+
+export function ProtocolLog({ entries }: { entries: LogEntry[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [entries.length]);
+
+  return (
+    <div class="protocol-log" ref={containerRef}>
+      {entries.length === 0 && (
+        <div class="log-empty">No events yet. Start the coffee run to see protocol traffic.</div>
+      )}
+      {entries.map((entry, i) => {
+        const arrow = entry.direction === 'out' ? '-->' : '<--';
+        return (
+          <div class="log-entry" key={i}>
+            <span class="log-line">
+              [{formatTimestamp(entry.timestamp)}] {arrow} {entry.peer}: {entry.message}
+            </span>
+            {entry.raw && (
+              <details class="log-raw">
+                <summary>Raw event</summary>
+                <pre>{JSON.stringify(entry.raw, null, 2)}</pre>
+              </details>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/a2a-demo/ui/src/main.tsx
+++ b/a2a-demo/ui/src/main.tsx
@@ -1,0 +1,237 @@
+import { render } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+import { PeerCard } from './PeerCard.js';
+import { ProtocolLog } from './ProtocolLog.js';
+import type { PeerState, LogEntry, SSEEvent } from './types.js';
+
+interface ConnectionsResponse {
+  owner: { id: string; name: string };
+  connections: Array<{
+    peer_assistant_id: string;
+    declared_relationship: string;
+  }>;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function peerDisplayName(peerId: string): string {
+  // "peer-sarah" -> "Sarah"
+  const parts = peerId.split('-');
+  const name = parts.length > 1 ? parts[parts.length - 1] : peerId;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function App() {
+  const [peers, setPeers] = useState<PeerState[]>([]);
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [running, setRunning] = useState(false);
+  const [ownerName, setOwnerName] = useState('');
+  const [connectionCount, setConnectionCount] = useState(0);
+
+  useEffect(() => {
+    // Fetch connections to populate peer list
+    fetch('/connections')
+      .then((res) => res.json() as Promise<ConnectionsResponse>)
+      .then((data) => {
+        setOwnerName(data.owner.name);
+        setConnectionCount(data.connections.length);
+        setPeers(
+          data.connections.map((c) => ({
+            id: c.peer_assistant_id,
+            name: peerDisplayName(c.peer_assistant_id),
+            relationship: c.declared_relationship,
+            status: 'idle' as const,
+          }))
+        );
+      })
+      .catch((err) => {
+        console.error('Failed to load connections:', err);
+      });
+
+    // Connect EventSource on page load (before any POST)
+    const es = new EventSource('/events');
+
+    es.onmessage = (e) => {
+      let event: SSEEvent;
+      try {
+        event = JSON.parse(e.data) as SSEEvent;
+      } catch {
+        return;
+      }
+
+      switch (event.type) {
+        case 'task_sent': {
+          const name = peerDisplayName(event.peer);
+          setPeers((prev) =>
+            prev.map((p) => (p.id === event.peer ? { ...p, status: 'sent' as const } : p))
+          );
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'out',
+              peer: name,
+              message: `${event.method} (correlation: ${event.correlationId})`,
+            },
+          ]);
+          break;
+        }
+
+        case 'hitl_update': {
+          const name = peerDisplayName(event.peer);
+          const newStatus =
+            event.hitlState === 'awaiting_human_input_stale'
+              ? ('stale' as const)
+              : ('awaiting_human' as const);
+          setPeers((prev) =>
+            prev.map((p) => (p.id === event.peer ? { ...p, status: newStatus } : p))
+          );
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'in',
+              peer: name,
+              message: `HITL: ${event.hitlState}`,
+              raw: event.sdkEvent,
+            },
+          ]);
+          break;
+        }
+
+        case 'task_completed': {
+          const name = peerDisplayName(event.peer);
+          setPeers((prev) =>
+            prev.map((p) =>
+              p.id === event.peer
+                ? {
+                    ...p,
+                    status: 'done' as const,
+                    responseText: event.responseText,
+                    responseBasis: event.responseBasis,
+                  }
+                : p
+            )
+          );
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'in',
+              peer: name,
+              message: `Completed: ${event.responseText} (${event.responseBasis})`,
+              raw: event.sdkEvent,
+            },
+          ]);
+          break;
+        }
+
+        case 'task_error': {
+          const name = peerDisplayName(event.peer);
+          setPeers((prev) =>
+            prev.map((p) =>
+              p.id === event.peer
+                ? {
+                    ...p,
+                    status: 'done' as const,
+                    responseText: `Error: ${event.error}`,
+                    responseBasis: 'unreachable',
+                  }
+                : p
+            )
+          );
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'in',
+              peer: name,
+              message: `Error: ${event.error}`,
+            },
+          ]);
+          break;
+        }
+
+        case 'protocol_event': {
+          const name = peerDisplayName(event.peer);
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'in',
+              peer: name,
+              message: `${event.eventType}`,
+              raw: event.sdkEvent,
+            },
+          ]);
+          break;
+        }
+
+        case 'run_complete': {
+          setRunning(false);
+          setLog((prev) => [
+            ...prev,
+            {
+              timestamp: now(),
+              direction: 'in',
+              peer: 'system',
+              message: 'Run complete',
+            },
+          ]);
+          break;
+        }
+      }
+    };
+
+    return () => {
+      es.close();
+    };
+  }, []);
+
+  function startCoffeeRun() {
+    setRunning(true);
+    // Reset peers to sent/idle
+    setPeers((prev) => prev.map((p) => ({ ...p, status: 'idle' as const, responseText: undefined, responseBasis: undefined })));
+    setLog([]);
+    fetch('/run/coffee', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deadlineSeconds: 15 }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          console.error(`Coffee run request failed: ${res.status} ${res.statusText}`);
+          setRunning(false);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to start coffee run:', err);
+        setRunning(false);
+      });
+  }
+
+  return (
+    <div class="app">
+      <header class="app-header">
+        <h1>{ownerName || 'A2A Demo'}</h1>
+        <span class="connection-count">{connectionCount} connections</span>
+        <button class="start-button" onClick={startCoffeeRun} disabled={running}>
+          {running ? 'Running...' : 'Start coffee run'}
+        </button>
+      </header>
+      <section class="peer-grid">
+        {peers.map((peer) => (
+          <PeerCard key={peer.id} {...peer} />
+        ))}
+      </section>
+      <section class="log-section">
+        <h2>Protocol Log</h2>
+        <ProtocolLog entries={log} />
+      </section>
+    </div>
+  );
+}
+
+render(<App />, document.getElementById('app')!);

--- a/a2a-demo/ui/src/styles.css
+++ b/a2a-demo/ui/src/styles.css
@@ -1,0 +1,324 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* Header */
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.app-header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.connection-count {
+  font-size: 0.875rem;
+  color: #888;
+  margin-right: auto;
+}
+
+.start-button {
+  padding: 10px 24px;
+  border: none;
+  border-radius: 8px;
+  background: #4361ee;
+  color: #fff;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.start-button:hover:not(:disabled) {
+  background: #3a56d4;
+}
+
+.start-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Peer Cards Grid */
+
+.peer-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+@media (max-width: 900px) {
+  .peer-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 500px) {
+  .peer-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Peer Card */
+
+.peer-card {
+  background: #16213e;
+  border-radius: 12px;
+  padding: 20px;
+  border: 2px solid transparent;
+  transition: border-color 0.2s;
+}
+
+.peer-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.peer-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.peer-relationship {
+  font-size: 0.75rem;
+  color: #888;
+  text-transform: capitalize;
+}
+
+.peer-status {
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 6px;
+  display: inline-block;
+  margin-bottom: 8px;
+}
+
+/* Status Colors */
+
+.status-idle {
+  color: #888;
+  border-color: #333;
+}
+
+.peer-status.status-idle {
+  background: rgba(136, 136, 136, 0.1);
+}
+
+.status-sent {
+  color: #60a5fa;
+  border-color: #3b82f6;
+}
+
+.peer-status.status-sent {
+  background: rgba(59, 130, 246, 0.15);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.status-awaiting {
+  color: #fb923c;
+  border-color: #f97316;
+}
+
+.peer-status.status-awaiting {
+  background: rgba(249, 115, 22, 0.15);
+}
+
+.status-stale {
+  color: #facc15;
+  border-color: #eab308;
+}
+
+.peer-status.status-stale {
+  background: rgba(234, 179, 8, 0.15);
+  animation: flash 0.8s ease-in-out infinite;
+}
+
+.status-done {
+  color: #a3e635;
+  border-color: #84cc16;
+}
+
+.peer-status.status-done {
+  background: rgba(132, 204, 22, 0.1);
+}
+
+/* Peer card border matches status */
+.peer-card.status-idle {
+  border-color: #333;
+}
+
+.peer-card.status-sent {
+  border-color: #3b82f6;
+}
+
+.peer-card.status-awaiting {
+  border-color: #f97316;
+}
+
+.peer-card.status-stale {
+  border-color: #eab308;
+}
+
+.peer-card.status-done {
+  border-color: #84cc16;
+}
+
+/* Animations */
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes flash {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* Response */
+
+.peer-response {
+  margin-top: 8px;
+}
+
+.response-text {
+  font-size: 0.875rem;
+  color: #ccc;
+  margin-bottom: 8px;
+}
+
+/* Badges */
+
+.badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.badge-standing {
+  background: rgba(34, 197, 94, 0.2);
+  color: #4ade80;
+}
+
+.badge-confirmed {
+  background: rgba(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
+.badge-inferred {
+  background: rgba(234, 179, 8, 0.2);
+  color: #facc15;
+}
+
+.badge-unreachable {
+  background: rgba(136, 136, 136, 0.2);
+  color: #888;
+}
+
+/* Protocol Log Section */
+
+.log-section h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 12px;
+}
+
+.protocol-log {
+  background: #0f0f23;
+  border: 1px solid #2a2a4a;
+  border-radius: 8px;
+  padding: 16px;
+  max-height: 400px;
+  overflow-y: auto;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+}
+
+.log-empty {
+  color: #555;
+  font-style: italic;
+}
+
+.log-entry {
+  margin-bottom: 4px;
+}
+
+.log-line {
+  color: #b0b0c0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Collapsible raw JSON */
+
+.log-raw {
+  margin-top: 4px;
+  margin-left: 16px;
+}
+
+.log-raw summary {
+  color: #666;
+  cursor: pointer;
+  font-size: 0.75rem;
+  user-select: none;
+}
+
+.log-raw summary:hover {
+  color: #999;
+}
+
+.log-raw pre {
+  background: #0a0a1a;
+  border: 1px solid #2a2a4a;
+  border-radius: 4px;
+  padding: 8px;
+  margin-top: 4px;
+  color: #8888aa;
+  font-size: 0.75rem;
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/a2a-demo/ui/src/types.ts
+++ b/a2a-demo/ui/src/types.ts
@@ -44,7 +44,7 @@ export type SSEEvent =
   | {
       type: 'task_error';
       peer: string;
-      taskId: string;
+      taskId: string | null;
       error: string;
     }
   | {

--- a/a2a-demo/ui/src/types.ts
+++ b/a2a-demo/ui/src/types.ts
@@ -1,0 +1,59 @@
+export type PeerStatus = 'idle' | 'sent' | 'awaiting_human' | 'stale' | 'done';
+
+export interface PeerState {
+  id: string;
+  name: string;
+  relationship: string;
+  status: PeerStatus;
+  responseText?: string;
+  responseBasis?: string;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  direction: 'out' | 'in';
+  peer: string;
+  message: string;
+  raw?: object;
+}
+
+export type SSEEvent =
+  | {
+      type: 'task_sent';
+      peer: string;
+      messageId: string;
+      correlationId: string;
+      taskId: null;
+      method: string;
+    }
+  | {
+      type: 'hitl_update';
+      peer: string;
+      taskId: string;
+      hitlState: string;
+      sdkEvent: object;
+    }
+  | {
+      type: 'task_completed';
+      peer: string;
+      taskId: string;
+      responseText: string;
+      responseBasis: string;
+      sdkEvent: object;
+    }
+  | {
+      type: 'task_error';
+      peer: string;
+      taskId: string;
+      error: string;
+    }
+  | {
+      type: 'protocol_event';
+      peer: string;
+      taskId: string;
+      eventType: string;
+      sdkEvent: object;
+    }
+  | {
+      type: 'run_complete';
+    };


### PR DESCRIPTION
## Summary
Self-contained demo package (`a2a-demo/`) proving the Vellum social extension wire format works on top of `@a2a-js/sdk`. Runs a coffee scenario end-to-end with four mock peers exercising all four `response_basis` values (standing_preference, confirmed, inferred, unreachable), with a live Preact UI showing protocol activity in real time.

## Self-review result
GAPS FOUND — 9 gaps fixed across 3 fix PRs (#30505, #30506, #30507). Re-review passed clean.

## PRs merged into feature branch
- #30487: feat(a2a-demo): add package scaffolding, types, extension helpers, and SDK spike
- #30492: feat(a2a-demo): implement VellumSocialExecutor with all response strategies
- #30491: feat(a2a-demo): implement VellumSocialInterceptor (CallInterceptor)
- #30490: feat(a2a-demo): add Preact demo UI with PeerCard and ProtocolLog
- #30495: feat(a2a-demo): add four mock peer A2A servers
- #30497: feat(a2a-demo): wire up main assistant server with coffee run orchestrator
- #30501: feat(a2a-demo): add README, startup scripts, and e2e smoke test

### Fix PRs
- #30505: fix: send unnamed SSE events so UI onmessage receives them
- #30506: fix: server agent card + cancelTask + hitl_stale_infer timing
- #30507: fix: align hitlState, protocol_event fields, and task_error shape

Part of plan: a2a-tracer-bullet-demo.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->