### PR TITLE
Strengthen task_progress hint: fold into tool-use section, add to ui_show

### DIFF
--- a/assistant/src/prompts/__tests__/task-progress-hint-section.test.ts
+++ b/assistant/src/prompts/__tests__/task-progress-hint-section.test.ts
@@ -1,13 +1,11 @@
 /**
- * Tests for the task_progress_hint workspace system prompt section.
+ * Tests for the task_progress hint in the 01-parallel-tool-calls workspace
+ * system prompt section.
  *
- * Verifies that 02-task-progress-hint.md exists as a bundled template and
- * renders unconditionally into the system prompt output — no `enabled`
- * frontmatter gating, no options dependency.
+ * Verifies that the task_progress guidance renders unconditionally in the
+ * system prompt — no `enabled` frontmatter gating, no options dependency.
  */
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const noopLogger: Record<string, unknown> = new Proxy(
@@ -59,32 +57,20 @@ mock.module("../../config/loader.js", () => ({
 const { buildSystemPrompt, ensurePromptFiles, SYSTEM_PROMPT_CACHE_BOUNDARY } =
   await import("../system-prompt.js");
 
-const TEMPLATE_PATH = join(
-  import.meta.dirname ?? __dirname,
-  "..",
-  "templates",
-  "system",
-  "02-task-progress-hint.md",
-);
-
-describe("task_progress_hint workspace section", () => {
+describe("task_progress hint in parallel-tool-calls section", () => {
   beforeEach(() => {
-    // Seed template files into the test workspace — mirrors daemon startup.
     ensurePromptFiles();
   });
 
-  test("template file exists at the expected bundled path", () => {
-    expect(existsSync(TEMPLATE_PATH)).toBe(true);
-  });
-
-  test("buildSystemPrompt() includes task_progress content", () => {
+  test("buildSystemPrompt() includes task_progress guidance", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("task_progress");
+    expect(result).toContain("No exceptions");
   });
 
   test("renders unconditionally — no options required", () => {
     const result = buildSystemPrompt(undefined);
-    expect(result).toContain("task_progress_hint");
+    expect(result).toContain("task_progress");
   });
 
   test("renders regardless of options passed", () => {
@@ -98,16 +84,16 @@ describe("task_progress_hint workspace section", () => {
       excludeCustomPrefix: true,
     });
 
-    expect(withBackground).toContain("task_progress_hint");
-    expect(withoutBackground).toContain("task_progress_hint");
-    expect(withExcludePrefix).toContain("task_progress_hint");
+    expect(withBackground).toContain("task_progress");
+    expect(withoutBackground).toContain("task_progress");
+    expect(withExcludePrefix).toContain("task_progress");
   });
 
-  test("section lives in the static (cached) block before SYSTEM_PROMPT_CACHE_BOUNDARY", () => {
+  test("hint lives in the static (cached) block before SYSTEM_PROMPT_CACHE_BOUNDARY", () => {
     const result = buildSystemPrompt();
     const boundaryIdx = result.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
     expect(boundaryIdx).toBeGreaterThan(-1);
     const staticBlock = result.slice(0, boundaryIdx);
-    expect(staticBlock).toContain("task_progress_hint");
+    expect(staticBlock).toContain("task_progress");
   });
 });

--- a/assistant/src/prompts/templates/system/01-parallel-tool-calls.md
+++ b/assistant/src/prompts/templates/system/01-parallel-tool-calls.md
@@ -4,4 +4,6 @@ Batch independent tool calls into the same response. An extra LLM round trip cos
 Before emitting a single tool call, ask whether your next turn would be another tool call that doesn't consume this one's output — if so, they belong together. Serialized tool calls without a real data dependency are a bug.
 
 For non-trivial independent workstreams — research, coding, multi-step investigations — delegate to subagents (load the `subagent` skill) and spawn them early and in parallel; an unnecessary subagent is cheaper than serialized work.
+
+**Before your first tool call**, check: does this turn involve a web search, file operations, multi-step work, or anything that will take more than a few seconds? If yes, call ui_show with surface_type "card" and template "task_progress" first, then update steps via ui_update as work progresses. No exceptions.
 </use_parallel_tool_calls>

--- a/assistant/src/prompts/templates/system/02-task-progress-hint.md
+++ b/assistant/src/prompts/templates/system/02-task-progress-hint.md
@@ -1,3 +1,0 @@
-<task_progress_hint>
-If you expect this turn to take more than ~15 seconds, call ui_show with surface_type "card" and template "task_progress" before your first tool call, then update steps via ui_update as work progresses. When in doubt, show it.
-</task_progress_hint>

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -36,7 +36,8 @@ export const uiShowTool: Tool = {
     '- list: { items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }\n' +
     "- confirmation: { message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }\n" +
     "- dynamic_page: { html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }\n" +
-    "- file_upload: { prompt, acceptedTypes?, maxFiles? }",
+    "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n\n" +
+    "Proactively show a task_progress card before multi-step or long-running work (web searches, file operations, research). Show it before your first tool call, then update steps as work progresses.",
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionMode: "proxy",


### PR DESCRIPTION
## Summary
- Fold task_progress reminder into 01-parallel-tool-calls.md (removes standalone 02-task-progress-hint.md)
- Strengthen wording: absolute language ("No exceptions"), crisp trigger (web search, file ops, multi-step work)
- Add proactive task_progress reminder to ui_show tool description as last-mile nudge
- Update tests to match new location

Addresses Devin review feedback on system prompt minimalism (offset additions by folding into existing content).

Part of plan: task-progress-injection.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->