### PR TITLE
Clarify sync_changed event docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,10 +352,11 @@ The IPC protocol is newline-delimited JSON over the Unix domain socket:
 - Request:  `{ "id": string, "method": string, "params"?: object }`
 - Response: `{ "id": string, "result"?: unknown, "error"?: string }`
 
-When you need to publish events to connected clients (e.g. `open_url`,
-`avatar_updated`) from code running inside the daemon process, import and
-call the `assistantEventHub` singleton directly rather than adding a new
-HTTP endpoint.
+When you need to publish domain/live events to connected clients (e.g.
+`open_url`) from code running inside the daemon process, import and call the
+`assistantEventHub` singleton directly rather than adding a new HTTP endpoint.
+For persisted multi-client state invalidation, use `sync_changed` via
+`publishSyncInvalidation()` instead.
 
 ## See Also
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -454,6 +454,7 @@ The `message` field is the `ServerMessage` payload. All delta semantics are pres
 | `confirmation_request` | User approval needed before an action executes |
 | `generation_handoff` | Model handed off to a sub-agent |
 | `generation_cancelled` | Run was cancelled |
+| `sync_changed` | Persisted resource invalidation; clients inspect `tags` and refetch existing endpoints |
 
 #### Connection Management
 


### PR DESCRIPTION
## Summary
- list `sync_changed` in the assistant SSE internal reference event table
- clarify that direct assistant event hub publishing is for domain/live events, while persisted multi-client state invalidation should use `publishSyncInvalidation()`

## Original prompt
After the multi-client sync documentation PRs, we checked whether any other docs still described the old event model. This follow-up updates the remaining assistant docs references so the SSE reference and contribution guidance agree with the new generic sync tag contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->