### PR TITLE
feat(daemon): batched-question input shape for ask_question

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -241,9 +241,16 @@ export interface QuestionOption {
   description?: string;
 }
 
-export interface QuestionRequest {
-  type: "question_request";
-  requestId: string;
+/**
+ * One entry in a batched ask-question request.
+ *
+ * `id` is daemon-assigned (e.g. `q1`, `q2`...) — the LLM neither sees nor
+ * supplies it. It exists so the client has a stable handle to post the
+ * user's answer back against. See `QuestionRequest` for the batching
+ * contract.
+ */
+export interface QuestionEntry {
+  id: string;
   question: string;
   description?: string;
   /** LLM-supplied options, capped at 4. The client always renders a fixed
@@ -251,6 +258,38 @@ export interface QuestionRequest {
    *  array never represents the full choice set the user sees. */
   options: QuestionOption[];
   /** Optional placeholder shown in the free-text input. */
+  freeTextPlaceholder?: string;
+}
+
+/**
+ * A single broadcast that carries either one or a small batch (≤5) of
+ * clarifying questions. The whole batch is one card lifecycle on the client:
+ * one render, one state machine, one response submission.
+ *
+ * Wire-compat plan: both shapes are populated on every broadcast.
+ *  - `questions[]` is the canonical shape new clients should consume.
+ *  - The flat `question` / `description` / `options` / `freeTextPlaceholder`
+ *    fields mirror `questions[0]` for backwards compat with the existing
+ *    web client, which keys off the flat fields. Once that client adopts
+ *    `questions[]`, the flat fields can be dropped (separate cleanup).
+ *
+ * Daemon callers that don't supply a batch get a one-element `questions`
+ * array synthesized from the flat fields.
+ */
+export interface QuestionRequest {
+  type: "question_request";
+  requestId: string;
+  /** Batched-question payload. Always populated (single questions are sent
+   *  as a one-element array). Each entry's `id` is daemon-assigned. */
+  questions: QuestionEntry[];
+  /** Legacy: mirrors `questions[0].question`. Kept populated for clients
+   *  that haven't adopted the batched `questions[]` shape yet. */
+  question: string;
+  /** Legacy: mirrors `questions[0].description`. */
+  description?: string;
+  /** Legacy: mirrors `questions[0].options`. */
+  options: QuestionOption[];
+  /** Legacy: mirrors `questions[0].freeTextPlaceholder`. */
   freeTextPlaceholder?: string;
   conversationId?: string;
   toolUseId?: string;

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -97,9 +97,21 @@ export class QuestionPrompter {
         signal.addEventListener("abort", onAbort, { once: true });
       }
 
+      // Populate both shapes on the wire: `questions[]` is the canonical
+      // batched payload, and the flat fields mirror `questions[0]` for
+      // backwards compat with clients that haven't adopted `questions[]`.
       const msg: QuestionRequest = {
         type: "question_request",
         requestId,
+        questions: [
+          {
+            id: "q1",
+            question,
+            description,
+            options,
+            freeTextPlaceholder,
+          },
+        ],
         question,
         description,
         options,

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -243,7 +243,7 @@ describe("AskQuestionTool batched input", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("accepts a multi-question batch up to 5", async () => {
+  test("runtime guard rejects a 5-entry batch even though the schema cap allows it", async () => {
     const { tool, calls } = makeToolWithStub({
       decision: "option",
       optionId: "a",
@@ -252,9 +252,30 @@ describe("AskQuestionTool batched input", () => {
 
     const result = await tool.execute({ questions: five }, makeContext());
 
-    // Only the head is forwarded until the prompter learns to batch.
-    expect(calls).toHaveLength(1);
-    expect(result.isError).toBe(false);
+    // Schema validation passes (the 1..5 cap holds), but the runtime guard
+    // refuses to forward anything because the prompter can't broadcast a
+    // batch yet — see the TODO in `execute()`.
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Batched questions");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects a 2-entry batch with the documented guard message", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ, singleQ] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(
+      "Batched questions (more than one entry in `questions`) are not yet supported by this assistant build. Call ask_question once per clarification for now.",
+    );
+    expect(calls).toHaveLength(0);
   });
 
   test("rejects batches with 6+ questions", async () => {
@@ -377,7 +398,12 @@ describe("AskQuestionTool definition (batched schema)", () => {
     expect(schema.properties.freeTextPlaceholder?.type).toBe("string");
 
     // No top-level `required` array — the choice between batched and flat
-    // is enforced at runtime by Zod.
+    // is enforced at runtime by Zod's `.refine`, which is the source of
+    // truth. The "accepts a single-element `questions` batch",
+    // "normalizes legacy flat input into a one-element batch",
+    // "rejects input missing both `questions` and flat fields", and
+    // "rejects legacy `question` without `options`" tests above exercise
+    // every branch of that refine.
     expect(schema.required).toBeUndefined();
   });
 });

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -57,9 +57,12 @@ describe("AskQuestionTool definition", () => {
         string,
         { type?: string; minItems?: number; maxItems?: number }
       >;
-      required: string[];
+      required?: string[];
     };
-    expect(schema.required).toEqual(["question", "options"]);
+    // PR 2 removed top-level `required` — caller may supply either
+    // `questions` or the legacy flat fields, enforced at runtime by Zod.
+    // Per-shape `required` arrays still live on the legacy `options` field
+    // and on the `questions[]` item schema.
     expect(schema.properties.options?.type).toBe("array");
     expect(schema.properties.options?.minItems).toBe(2);
     expect(schema.properties.options?.maxItems).toBe(4);
@@ -190,5 +193,191 @@ describe("AskQuestionTool.execute", () => {
     const ac = new AbortController();
     await tool.execute(validInput, makeContext({ signal: ac.signal }));
     expect(calls[0]?.signal).toBe(ac.signal);
+  });
+});
+
+// ── Batched input ───────────────────────────────────────────────────
+// These tests cover the input-shape contract only — the `questions[]`
+// shape, the 1..5 cap, and the legacy-flat normalization. Outbound
+// prompter behavior (id assignment, batched broadcasting) is covered
+// in `question-prompter.test.ts`.
+
+const singleQ = {
+  question: validInput.question,
+  description: validInput.description,
+  options: validInput.options,
+  freeTextPlaceholder: validInput.freeTextPlaceholder,
+};
+
+describe("AskQuestionTool batched input", () => {
+  test("normalizes legacy flat input into a one-element batch", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute(validInput, makeContext());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.question).toBe(validInput.question);
+    expect(calls[0]?.options).toEqual(validInput.options);
+    expect(result.isError).toBe(false);
+  });
+
+  test("accepts a single-element `questions` batch", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ] },
+      makeContext(),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.question).toBe(singleQ.question);
+    expect(calls[0]?.options).toEqual(singleQ.options);
+    expect(calls[0]?.description).toBe(singleQ.description);
+    expect(calls[0]?.freeTextPlaceholder).toBe(singleQ.freeTextPlaceholder);
+    expect(result.isError).toBe(false);
+  });
+
+  test("accepts a multi-question batch up to 5", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const five = [singleQ, singleQ, singleQ, singleQ, singleQ];
+
+    const result = await tool.execute({ questions: five }, makeContext());
+
+    // Only the head is forwarded until the prompter learns to batch.
+    expect(calls).toHaveLength(1);
+    expect(result.isError).toBe(false);
+  });
+
+  test("rejects batches with 6+ questions", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+    const six = [singleQ, singleQ, singleQ, singleQ, singleQ, singleQ];
+
+    const result = await tool.execute({ questions: six }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("invalid input");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects empty `questions` array", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute({ questions: [] }, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("invalid input");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects input missing both `questions` and flat fields", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute({}, makeContext());
+
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("invalid input");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects legacy `question` without `options`", async () => {
+    const { tool, calls } = makeToolWithStub({
+      decision: "option",
+      optionId: "a",
+    });
+
+    const result = await tool.execute(
+      { question: "Hi?" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("invalid input");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("formats free-text result for batched input", async () => {
+    const { tool } = makeToolWithStub({
+      decision: "free_text",
+      text: "Cherry",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ] },
+      makeContext(),
+    );
+
+    expect(result.content).toBe("Free text: Cherry");
+    expect(result.isError).toBe(false);
+  });
+});
+
+describe("AskQuestionTool definition (batched schema)", () => {
+  test("exposes `questions[]` shape, keeps legacy fields, omits per-question id", () => {
+    const def = new AskQuestionTool().getDefinition();
+    const schema = def.input_schema as {
+      properties: Record<
+        string,
+        {
+          type?: string;
+          minItems?: number;
+          maxItems?: number;
+          items?: {
+            type?: string;
+            properties?: Record<string, unknown>;
+            required?: string[];
+          };
+        }
+      >;
+      required?: string[];
+    };
+
+    // Batched shape is present and capped at 5.
+    const questions = schema.properties.questions;
+    expect(questions?.type).toBe("array");
+    expect(questions?.minItems).toBe(1);
+    expect(questions?.maxItems).toBe(5);
+
+    // Per-question item schema requires `question` and `options` but
+    // explicitly does NOT include an `id` field — ids are daemon-assigned.
+    const itemProps = questions?.items?.properties ?? {};
+    expect(Object.keys(itemProps)).toEqual(
+      expect.arrayContaining([
+        "question",
+        "description",
+        "options",
+        "freeTextPlaceholder",
+      ]),
+    );
+    expect(Object.keys(itemProps)).not.toContain("id");
+    expect(questions?.items?.required).toEqual(["question", "options"]);
+
+    // Legacy flat fields are still present (optional, no top-level required).
+    expect(schema.properties.question?.type).toBe("string");
+    expect(schema.properties.options?.type).toBe("array");
+    expect(schema.properties.options?.minItems).toBe(2);
+    expect(schema.properties.options?.maxItems).toBe(4);
+    expect(schema.properties.freeTextPlaceholder?.type).toBe("string");
+
+    // No top-level `required` array — the choice between batched and flat
+    // is enforced at runtime by Zod.
+    expect(schema.required).toBeUndefined();
   });
 });

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -18,7 +18,12 @@ const OptionSchema = z.object({
   description: z.string().optional(),
 });
 
-const InputSchema = z.object({
+// One question in a (possibly single-element) batch. Intentionally has no
+// `id` field — per-question ids are daemon-assigned (`q1`, `q2`, ...) inside
+// the prompter, never supplied by the LLM. This keeps the LLM-facing schema
+// smaller and removes a validation surface (no duplicate-id check, no
+// length cap on ids).
+const SingleQuestionSchema = z.object({
   question: z.string().min(1),
   description: z.string().optional(),
   // 2–4 LLM-supplied options. The client renders a fixed 5th "Type
@@ -28,6 +33,42 @@ const InputSchema = z.object({
   freeTextPlaceholder: z.string().optional(),
 });
 
+// Cap at 5 questions per batch. Past that it starts to feel like a form,
+// not a clarification — the model should be implementing, not asking. Any
+// input with ≥6 entries is rejected with a clear Zod error.
+const MAX_QUESTIONS_PER_BATCH = 5;
+
+// Both the new batched shape (`questions[]`) and the legacy flat shape are
+// accepted. `execute()` normalizes legacy callers into a one-element
+// `questions` array before forwarding to the prompter.
+const InputSchema = z
+  .object({
+    questions: z
+      .array(SingleQuestionSchema)
+      .min(1)
+      .max(MAX_QUESTIONS_PER_BATCH, {
+        message: `At most ${MAX_QUESTIONS_PER_BATCH} questions per batch; split into multiple turns if you need more.`,
+      })
+      .optional(),
+    // Legacy flat fields. Optional so batched callers can omit them; when
+    // present and `questions` is absent, they are normalized into a
+    // one-element batch in `execute()`.
+    question: z.string().min(1).optional(),
+    description: z.string().optional(),
+    options: z.array(OptionSchema).min(2).max(4).optional(),
+    freeTextPlaceholder: z.string().optional(),
+  })
+  .refine(
+    (v) =>
+      v.questions !== undefined ||
+      (v.question !== undefined && v.options !== undefined),
+    {
+      message:
+        "Provide `questions` (preferred) or the legacy flat fields (`question` + `options`).",
+    },
+  );
+
+export type SingleQuestion = z.infer<typeof SingleQuestionSchema>;
 export type AskQuestionInput = z.infer<typeof InputSchema>;
 
 // ── Tool description ────────────────────────────────────────────────
@@ -76,55 +117,98 @@ export class AskQuestionTool implements Tool {
   }
 
   getDefinition(): ToolDefinition {
+    // Shared option-schema fragment used by both the batched `questions[]`
+    // shape and the legacy flat `options` field.
+    const optionItemsSchema = {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description:
+            "Stable identifier for this option (returned verbatim in the response).",
+        },
+        label: {
+          type: "string",
+          description: "Short human-readable label.",
+        },
+        description: {
+          type: "string",
+          description: "Optional one-line context shown beneath the label.",
+        },
+      },
+      required: ["id", "label"],
+    } as const;
+
     return {
       name: this.name,
       description: this.description,
       input_schema: {
         type: "object",
         properties: {
+          // ── Recommended shape ─────────────────────────────────────
+          questions: {
+            type: "array",
+            minItems: 1,
+            maxItems: MAX_QUESTIONS_PER_BATCH,
+            description: `Recommended shape. 1–${MAX_QUESTIONS_PER_BATCH} clarifying questions to ask in a single turn. Use a batch when several independent ambiguities block progress; ask one at a time when they're sequentially dependent. Past ${MAX_QUESTIONS_PER_BATCH} questions you should be implementing, not asking.`,
+            items: {
+              type: "object",
+              properties: {
+                question: {
+                  type: "string",
+                  description: "The clarifying question shown to the user.",
+                },
+                description: {
+                  type: "string",
+                  description:
+                    "Optional one-line context shown beneath the question.",
+                },
+                options: {
+                  type: "array",
+                  minItems: 2,
+                  maxItems: 4,
+                  description:
+                    "2–4 structured options. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
+                  items: optionItemsSchema,
+                },
+                freeTextPlaceholder: {
+                  type: "string",
+                  description:
+                    "Optional placeholder text shown inside the free-text fallback input.",
+                },
+              },
+              required: ["question", "options"],
+            },
+          },
+          // ── Legacy single-question fields ─────────────────────────
+          // Kept optional so existing prompt caches and any single-question
+          // callers continue to work. New callers should use `questions`.
           question: {
             type: "string",
-            description: "The clarifying question shown to the user.",
+            description:
+              "Legacy: the single clarifying question. Prefer `questions[]` for new code.",
           },
           description: {
             type: "string",
             description:
-              "Optional one-line context shown beneath the question.",
+              "Legacy: optional one-line context shown beneath the question. Prefer `questions[].description`.",
           },
           options: {
             type: "array",
             minItems: 2,
             maxItems: 4,
             description:
-              "2–4 structured options. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
-            items: {
-              type: "object",
-              properties: {
-                id: {
-                  type: "string",
-                  description:
-                    "Stable identifier for this option (returned verbatim in the response).",
-                },
-                label: {
-                  type: "string",
-                  description: "Short human-readable label.",
-                },
-                description: {
-                  type: "string",
-                  description:
-                    "Optional one-line context shown beneath the label.",
-                },
-              },
-              required: ["id", "label"],
-            },
+              "Legacy: 2–4 structured options. Prefer `questions[].options`. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
+            items: optionItemsSchema,
           },
           freeTextPlaceholder: {
             type: "string",
             description:
-              "Optional placeholder text shown inside the free-text fallback input.",
+              "Legacy: optional placeholder text for the free-text fallback input. Prefer `questions[].freeTextPlaceholder`.",
           },
         },
-        required: ["question", "options"],
+        // No top-level `required` — caller must supply either `questions`
+        // or the legacy flat trio (`question` + `options`). Enforced in Zod.
       },
     };
   }
@@ -141,7 +225,24 @@ export class AskQuestionTool implements Tool {
       };
     }
 
-    const { question, description, options, freeTextPlaceholder } = parsed.data;
+    // Normalize legacy flat input into a one-element `questions` batch so
+    // downstream code only has to deal with the batched shape. The refine
+    // above guarantees `question` and `options` are present whenever
+    // `questions` is absent.
+    const questions: SingleQuestion[] = parsed.data.questions ?? [
+      {
+        question: parsed.data.question!,
+        description: parsed.data.description,
+        options: parsed.data.options!,
+        freeTextPlaceholder: parsed.data.freeTextPlaceholder,
+      },
+    ];
+
+    // The prompter currently handles one question at a time; multi-question
+    // batches are accepted at the schema layer but only the head is sent
+    // until the prompter learns to broadcast batches.
+    const head = questions[0]!;
+    const { question, description, options, freeTextPlaceholder } = head;
 
     const prompter = this.prompterFactory();
     const result = await prompter.prompt({

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -225,6 +225,19 @@ export class AskQuestionTool implements Tool {
       };
     }
 
+    // TODO: remove this guard once PR 3 wires the prompter to handle batches.
+    // The schema accepts up to MAX_QUESTIONS_PER_BATCH entries so PR 3 doesn't
+    // have to re-extend it, but until the prompter can broadcast multi-question
+    // batches we must reject them explicitly — otherwise extra entries would
+    // be silently dropped and the caller would receive an incomplete answer.
+    if (parsed.data.questions && parsed.data.questions.length > 1) {
+      return {
+        content:
+          "Batched questions (more than one entry in `questions`) are not yet supported by this assistant build. Call ask_question once per clarification for now.",
+        isError: true,
+      };
+    }
+
     // Normalize legacy flat input into a one-element `questions` batch so
     // downstream code only has to deal with the batched shape. The refine
     // above guarantees `question` and `options` are present whenever
@@ -238,9 +251,9 @@ export class AskQuestionTool implements Tool {
       },
     ];
 
-    // The prompter currently handles one question at a time; multi-question
-    // batches are accepted at the schema layer but only the head is sent
-    // until the prompter learns to broadcast batches.
+    // The prompter currently handles one question at a time. Multi-question
+    // batches are rejected by the guard above, so `questions` is guaranteed
+    // to hold exactly one entry here.
     const head = questions[0]!;
     const { question, description, options, freeTextPlaceholder } = head;
 


### PR DESCRIPTION
## Summary
- Adds `questions: z.array(SingleQuestionSchema).min(1).max(5)` to the `ask_question` tool input schema.
- Normalizes legacy flat-input shape (single-question fields) into a one-element `questions` array at the top of `execute()`.
- Extends `QuestionRequest` message type with `questions: QuestionEntry[]` (where each entry has a daemon-assigned `id`); keeps legacy flat fields populated for backwards compat with existing clients.

Part of plan: ask-question-proactive-and-batched.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->