### PR TITLE
feat(settings): remove colored top borders from community feature cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCommunityTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCommunityTab.swift
@@ -86,23 +86,13 @@ private struct BenefitRow: View {
 // MARK: - Feature Card
 
 private struct FeatureCardContainer<Content: View>: View {
-    let accentColor: Color
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            accentColor
-                .frame(height: 3)
-                .clipShape(UnevenRoundedRectangle(
-                    topLeadingRadius: VRadius.lg,
-                    topTrailingRadius: VRadius.lg
-                ))
-
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                content()
-            }
-            .padding(VSpacing.xl)
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            content()
         }
+        .padding(VSpacing.xl)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard()
     }
@@ -139,7 +129,7 @@ private struct OpenSourceFeatureCard: View {
     @Environment(\.openURL) private var openURL
 
     var body: some View {
-        FeatureCardContainer(accentColor: VColor.contentEmphasized) {
+        FeatureCardContainer {
             FeatureCardHeader(
                 icon: .github,
                 iconBg: VColor.contentEmphasized,
@@ -191,7 +181,7 @@ private struct DiscordFeatureCard: View {
     private static let discordBlue = Color(red: 88 / 255, green: 101 / 255, blue: 242 / 255)
 
     var body: some View {
-        FeatureCardContainer(accentColor: Self.discordBlue) {
+        FeatureCardContainer {
             FeatureCardHeader(
                 icon: .discord,
                 iconBg: Self.discordBlue,


### PR DESCRIPTION
## Prompt / plan
Remove the colored top accent borders from the Open Source (black) and Discord (blue) feature cards on the Community settings tab.

## Test plan
- CI checks pass
- Verify in Xcode that the Open Source and Discord cards no longer have colored top borders
- Verify icon backgrounds still show the correct accent colors

### Notes
The `accentColor` property was removed from `FeatureCardContainer` since it was only used for the top border. The icon background color is passed separately via `FeatureCardHeader.iconBg`.

Link to Devin session: https://app.devin.ai/sessions/c307d5e633654fcead4b2b3e2dad98e7
Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->