### PR TITLE
feat(daemon): batched-response handling in QuestionPrompter and /v1/question-response

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11829,7 +11829,9 @@ paths:
     post:
       operationId: questionresponse_post
       summary: Resolve a pending ask-question prompt
-      description: Submit the user's response (option selection or free-text) for a pending question prompt by requestId.
+      description:
+        Submit the user's batched response (or close the card) for a pending question prompt by requestId. Legacy
+        single-question payloads remain accepted as syntactic sugar for a one-element batch.
       tags:
         - approvals
       responses:
@@ -11850,7 +11852,74 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              anyOf:
+                - type: object
+                  properties:
+                    requestId:
+                      type: string
+                    kind:
+                      type: string
+                      const: submit
+                    responses:
+                      minItems: 1
+                      type: array
+                      items:
+                        oneOf:
+                          - type: object
+                            properties:
+                              questionId:
+                                type: string
+                              kind:
+                                type: string
+                                const: option
+                              optionId:
+                                type: string
+                            required:
+                              - questionId
+                              - kind
+                              - optionId
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              questionId:
+                                type: string
+                              kind:
+                                type: string
+                                const: free_text
+                              text:
+                                type: string
+                            required:
+                              - questionId
+                              - kind
+                              - text
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              questionId:
+                                type: string
+                              kind:
+                                type: string
+                                const: skip
+                            required:
+                              - questionId
+                              - kind
+                            additionalProperties: false
+                  required:
+                    - requestId
+                    - kind
+                    - responses
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    requestId:
+                      type: string
+                    kind:
+                      type: string
+                      const: close
+                  required:
+                    - requestId
+                    - kind
+                  additionalProperties: false
                 - type: object
                   properties:
                     requestId:

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -50,7 +50,9 @@ mock.module("../runtime/pending-interactions.js", () => ({
   clear: () => _piStore.clear(),
 }));
 
-const { QuestionPrompter } = await import("./question-prompter.js");
+const { QuestionPrompter, QuestionBatchValidationError } = await import(
+  "./question-prompter.js"
+);
 
 function makePrompter() {
   const sent: ServerMessage[] = [];
@@ -60,12 +62,40 @@ function makePrompter() {
   return { prompter, sent };
 }
 
-const baseParams = {
+const fruitOptions = [
+  { id: "a", label: "Apple" },
+  { id: "b", label: "Banana" },
+];
+
+const singleQuestionParams = {
   conversationId: "conv-1",
-  question: "Pick one",
-  options: [
-    { id: "a", label: "Apple" },
-    { id: "b", label: "Banana" },
+  questions: [
+    {
+      question: "Pick one",
+      options: fruitOptions,
+    },
+  ],
+};
+
+const threeQuestionParams = {
+  conversationId: "conv-1",
+  questions: [
+    { question: "Q1?", options: fruitOptions },
+    {
+      question: "Q2?",
+      options: [
+        { id: "x", label: "X" },
+        { id: "y", label: "Y" },
+      ],
+    },
+    {
+      question: "Q3?",
+      options: [
+        { id: "p", label: "P" },
+        { id: "q", label: "Q" },
+      ],
+      freeTextPlaceholder: "or type",
+    },
   ],
 };
 
@@ -74,60 +104,191 @@ describe("QuestionPrompter", () => {
     _piStore.clear();
   });
 
-  test("happy path: option resolution", async () => {
+  test("happy path: option resolution via submitQuestionBatch", async () => {
     const { prompter, sent } = makePrompter();
 
-    const promise = prompter.prompt(baseParams);
+    const promise = prompter.prompt(singleQuestionParams);
 
     expect(sent).toHaveLength(1);
-    expect(sent[0]!.type).toBe("question_request");
+    const req = sent[0] as QuestionRequest;
+    expect(req.type).toBe("question_request");
+    expect(req.questions).toHaveLength(1);
+    expect(req.questions[0]?.id).toBe("q1");
 
-    const requestId = (sent[0] as QuestionRequest).requestId;
-    prompter.resolveQuestion(requestId, { kind: "option", optionId: "a" });
+    prompter.submitQuestionBatch(req.requestId, [
+      { questionId: "q1", kind: "option", optionId: "a" },
+    ]);
 
     const result = await promise;
-    expect(result).toEqual({ decision: "option", optionId: "a" });
-    expect(prompter.hasPendingRequest(requestId)).toBe(false);
+    expect(result).toEqual({
+      entries: [{ questionId: "q1", decision: "option", optionId: "a" }],
+      overall: "completed",
+    });
+    expect(prompter.hasPendingRequest(req.requestId)).toBe(false);
   });
 
   test("free-text resolution", async () => {
     const { prompter, sent } = makePrompter();
 
     const promise = prompter.prompt({
-      ...baseParams,
-      freeTextPlaceholder: "Type a fruit",
+      conversationId: "conv-1",
+      questions: [
+        {
+          question: "Pick one",
+          options: fruitOptions,
+          freeTextPlaceholder: "Type a fruit",
+        },
+      ],
     });
 
     const req = sent[0] as QuestionRequest;
     expect(req.freeTextPlaceholder).toBe("Type a fruit");
+    expect(req.questions[0]?.freeTextPlaceholder).toBe("Type a fruit");
 
-    prompter.resolveQuestion(req.requestId, {
-      kind: "free_text",
-      text: "Cherry",
-    });
+    prompter.submitQuestionBatch(req.requestId, [
+      { questionId: "q1", kind: "free_text", text: "Cherry" },
+    ]);
 
     const result = await promise;
-    expect(result).toEqual({ decision: "free_text", text: "Cherry" });
+    expect(result).toEqual({
+      entries: [{ questionId: "q1", decision: "free_text", text: "Cherry" }],
+      overall: "completed",
+    });
   });
 
-  test("timeout fires with decision: timed_out", async () => {
+  test("batched broadcast: assigns sequential q1..qN ids and mirrors questions[0] in flat fields", async () => {
+    const { prompter, sent } = makePrompter();
+
+    void prompter.prompt(threeQuestionParams);
+
+    expect(sent).toHaveLength(1);
+    const req = sent[0] as QuestionRequest;
+    expect(req.questions.map((q) => q.id)).toEqual(["q1", "q2", "q3"]);
+    // Flat fields mirror the first entry for backwards compat.
+    expect(req.question).toBe("Q1?");
+    expect(req.options).toEqual(fruitOptions);
+  });
+
+  test("three-question batch: two options + one free-text → ordered entries", async () => {
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt(threeQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    prompter.submitQuestionBatch(req.requestId, [
+      { questionId: "q2", kind: "option", optionId: "y" },
+      { questionId: "q1", kind: "option", optionId: "a" },
+      { questionId: "q3", kind: "free_text", text: "noon-ish" },
+    ]);
+
+    const result = await promise;
+    expect(result.overall).toBe("completed");
+    // Result entries are in the original questions[] order, regardless of
+    // the order submissions arrive in.
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "option", optionId: "a" },
+      { questionId: "q2", decision: "option", optionId: "y" },
+      { questionId: "q3", decision: "free_text", text: "noon-ish" },
+    ]);
+  });
+
+  test("three-question batch: all skipped via submitQuestionBatch", async () => {
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt(threeQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    prompter.submitQuestionBatch(req.requestId, [
+      { questionId: "q1", kind: "skip" },
+      { questionId: "q2", kind: "skip" },
+      { questionId: "q3", kind: "skip" },
+    ]);
+
+    const result = await promise;
+    expect(result.overall).toBe("completed");
+    expect(result.entries.every((e) => e.decision === "skipped")).toBe(true);
+  });
+
+  test("closeQuestion: all entries skipped with overall=closed", async () => {
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt(threeQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    prompter.closeQuestion(req.requestId);
+
+    const result = await promise;
+    expect(result.overall).toBe("closed");
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "skipped" },
+      { questionId: "q2", decision: "skipped" },
+      { questionId: "q3", decision: "skipped" },
+    ]);
+  });
+
+  test("submitQuestionBatch rejects unknown questionId", async () => {
+    const { prompter, sent } = makePrompter();
+    void prompter.prompt(singleQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    expect(() =>
+      prompter.submitQuestionBatch(req.requestId, [
+        { questionId: "qX", kind: "option", optionId: "a" },
+      ]),
+    ).toThrow(QuestionBatchValidationError);
+  });
+
+  test("submitQuestionBatch rejects missing entry", async () => {
+    const { prompter, sent } = makePrompter();
+    void prompter.prompt(threeQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    expect(() =>
+      prompter.submitQuestionBatch(req.requestId, [
+        { questionId: "q1", kind: "option", optionId: "a" },
+        { questionId: "q2", kind: "option", optionId: "x" },
+      ]),
+    ).toThrow(QuestionBatchValidationError);
+  });
+
+  test("submitQuestionBatch rejects unknown optionId", async () => {
+    const { prompter, sent } = makePrompter();
+    void prompter.prompt(singleQuestionParams);
+    const req = sent[0] as QuestionRequest;
+
+    expect(() =>
+      prompter.submitQuestionBatch(req.requestId, [
+        { questionId: "q1", kind: "option", optionId: "nope" },
+      ]),
+    ).toThrow(QuestionBatchValidationError);
+  });
+
+  test("timeout fires with overall: timed_out and timed_out entries", async () => {
     const { prompter } = makePrompter();
-    const result = await prompter.prompt(baseParams);
-    expect(result).toEqual({ decision: "timed_out" });
+    const result = await prompter.prompt(threeQuestionParams);
+    expect(result.overall).toBe("timed_out");
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "timed_out" },
+      { questionId: "q2", decision: "timed_out" },
+      { questionId: "q3", decision: "timed_out" },
+    ]);
   });
 
-  test("abort signal triggers decision: aborted", async () => {
+  test("abort signal triggers overall: aborted", async () => {
     const { prompter, sent } = makePrompter();
     const ac = new AbortController();
 
-    const promise = prompter.prompt({ ...baseParams, signal: ac.signal });
-    const requestId = (sent[0] as QuestionRequest).requestId;
-    expect(prompter.hasPendingRequest(requestId)).toBe(true);
+    const promise = prompter.prompt({
+      ...threeQuestionParams,
+      signal: ac.signal,
+    });
+    const req = sent[0] as QuestionRequest;
+    expect(prompter.hasPendingRequest(req.requestId)).toBe(true);
 
     ac.abort();
     const result = await promise;
-    expect(result).toEqual({ decision: "aborted" });
-    expect(prompter.hasPendingRequest(requestId)).toBe(false);
+    expect(result.overall).toBe("aborted");
+    expect(prompter.hasPendingRequest(req.requestId)).toBe(false);
   });
 
   test("pre-aborted signal short-circuits before broadcasting", async () => {
@@ -135,8 +296,11 @@ describe("QuestionPrompter", () => {
     const ac = new AbortController();
     ac.abort();
 
-    const result = await prompter.prompt({ ...baseParams, signal: ac.signal });
-    expect(result).toEqual({ decision: "aborted" });
+    const result = await prompter.prompt({
+      ...threeQuestionParams,
+      signal: ac.signal,
+    });
+    expect(result.overall).toBe("aborted");
     expect(sent).toHaveLength(0);
   });
 });

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -12,26 +12,133 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("question-prompter");
 
-export interface QuestionPromptResult {
-  decision: "option" | "free_text" | "timed_out" | "aborted";
+/**
+ * Thrown when a batched submission fails validation (unknown questionId,
+ * missing entries, unknown optionId, duplicate questionId). The route layer
+ * maps this to a 400.
+ */
+export class QuestionBatchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QuestionBatchValidationError";
+  }
+}
+
+/**
+ * One per-question entry in a batched question result.
+ *
+ * `decision` records how the user responded to that specific question:
+ *  - `"option"` / `"free_text"` — direct answer.
+ *  - `"skipped"` — the user explicitly skipped this question, or the card
+ *    was closed before any answer was submitted.
+ *  - `"timed_out"` — the prompt timer fired before the client submitted.
+ *
+ * `questionId` matches the daemon-assigned id (`q1`, `q2`...) that the
+ * prompter attached to the broadcast.
+ */
+export interface QuestionPromptEntryResult {
+  questionId: string;
+  decision: "option" | "free_text" | "skipped" | "timed_out";
   optionId?: string;
   text?: string;
 }
 
-export interface QuestionPromptParams {
-  conversationId: string;
+/**
+ * Aggregate result for a single `prompt()` call. `entries` is ordered to
+ * match the original `questions` array; `overall` summarizes how the
+ * card lifecycle ended.
+ */
+export interface QuestionPromptResult {
+  entries: QuestionPromptEntryResult[];
+  overall: "completed" | "closed" | "timed_out" | "aborted";
+}
+
+export interface QuestionPromptParamsEntry {
   question: string;
   description?: string;
   options: QuestionOption[];
-  allowFreeText?: boolean;
   freeTextPlaceholder?: string;
+}
+
+export interface QuestionPromptParams {
+  conversationId: string;
+  /** One or more clarifying questions to broadcast as a single card. */
+  questions: QuestionPromptParamsEntry[];
   toolUseId?: string;
   signal?: AbortSignal;
 }
 
-export type QuestionResponse =
-  | { kind: "option"; optionId: string }
-  | { kind: "free_text"; text: string };
+/** One per-question submission inside a batch from the client. */
+export type QuestionBatchSubmission =
+  | { questionId: string; kind: "option"; optionId: string }
+  | { questionId: string; kind: "free_text"; text: string }
+  | { questionId: string; kind: "skip" };
+
+/**
+ * Validate a batched submission against the original ordered ids and per-id
+ * option-id sets, and return the ordered per-entry result. The lookup helpers
+ * are passed in so callers can back the metadata with whatever container
+ * they prefer (Set/Map, plain Record, etc.).
+ *
+ * Throws {@link QuestionBatchValidationError} if validation fails.
+ */
+export function buildBatchEntries(
+  orderedIds: readonly string[],
+  isKnownOption: (questionId: string, optionId: string) => boolean,
+  knownQuestionIds: ReadonlySet<string>,
+  submissions: readonly QuestionBatchSubmission[],
+): QuestionPromptEntryResult[] {
+  const submittedIds = new Set<string>();
+  for (const s of submissions) {
+    if (!knownQuestionIds.has(s.questionId)) {
+      throw new QuestionBatchValidationError(
+        `Unknown questionId in batch: ${s.questionId}`,
+      );
+    }
+    if (submittedIds.has(s.questionId)) {
+      throw new QuestionBatchValidationError(
+        `Duplicate questionId in batch: ${s.questionId}`,
+      );
+    }
+    submittedIds.add(s.questionId);
+    if (s.kind === "option" && !isKnownOption(s.questionId, s.optionId)) {
+      throw new QuestionBatchValidationError(
+        `Unknown optionId "${s.optionId}" for question ${s.questionId}`,
+      );
+    }
+  }
+  for (const id of orderedIds) {
+    if (!submittedIds.has(id)) {
+      throw new QuestionBatchValidationError(
+        `Missing response for questionId ${id}`,
+      );
+    }
+  }
+
+  const byId = new Map<string, QuestionBatchSubmission>();
+  for (const s of submissions) byId.set(s.questionId, s);
+
+  return orderedIds.map((id) => {
+    const s = byId.get(id)!;
+    if (s.kind === "option") {
+      return { questionId: id, decision: "option", optionId: s.optionId };
+    }
+    if (s.kind === "free_text") {
+      return { questionId: id, decision: "free_text", text: s.text };
+    }
+    return { questionId: id, decision: "skipped" };
+  });
+}
+
+/**
+ * Shape of the per-batch bookkeeping stashed on `PendingInteraction.metadata`.
+ * The route reads this to validate batched submissions without needing a
+ * reference to the prompter that registered them.
+ */
+interface QuestionBatchMetadata {
+  orderedIds: string[];
+  optionsById: Record<string, string[]>;
+}
 
 /**
  * Broadcast an ask-question request to all connected clients and wait for the
@@ -39,6 +146,13 @@ export type QuestionResponse =
  * patterns: lifecycle state (rpcResolve, rpcReject, timer) lives in
  * pendingInteractions; this class only tracks ownership so dispose can scope
  * cleanup to a single conversation.
+ *
+ * Batching: a single `prompt()` call broadcasts one or more questions, and
+ * the prompter waits for exactly one resolution call carrying the full
+ * ordered response array. The web UI collects per-question answers
+ * locally, lets the user revise freely while the card is open, and POSTs
+ * the whole batch to `/v1/question-response` when the user is done — no
+ * per-question accumulator, no partial state machine.
  *
  * Timeout reuses `getConfig().timeouts.permissionTimeoutSec` (default 5 min) —
  * questions are user-prompts in the same UX family as permission prompts and
@@ -52,30 +166,60 @@ export class QuestionPrompter {
   ) {}
 
   async prompt(params: QuestionPromptParams): Promise<QuestionPromptResult> {
-    const {
-      conversationId,
-      question,
-      description,
-      options,
-      freeTextPlaceholder,
-      toolUseId,
-      signal,
-    } = params;
+    const { conversationId, questions, toolUseId, signal } = params;
 
-    if (signal?.aborted) return { decision: "aborted" };
+    if (questions.length === 0) {
+      throw new AssistantError(
+        "QuestionPrompter.prompt requires at least one question",
+        ErrorCode.INTERNAL_ERROR,
+      );
+    }
+
+    // Assign per-question ids (`q1`, `q2`, ...) — daemon-side only; the LLM
+    // never sees these. Build the on-wire entries in the same pass.
+    const entries = questions.map((q, i) => ({
+      id: `q${i + 1}`,
+      question: q.question,
+      description: q.description,
+      options: q.options,
+      freeTextPlaceholder: q.freeTextPlaceholder,
+    }));
+    const orderedIds = entries.map((e) => e.id);
+    const optionsById: Record<string, string[]> = {};
+    for (const e of entries) {
+      optionsById[e.id] = e.options.map((o) => o.id);
+    }
+
+    if (signal?.aborted) {
+      return {
+        entries: orderedIds.map((id) => ({
+          questionId: id,
+          decision: "skipped",
+        })),
+        overall: "aborted",
+      };
+    }
 
     const requestId = uuid();
 
-    return new Promise((resolve, reject) => {
+    return new Promise<QuestionPromptResult>((resolve, reject) => {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
 
       const timer = setTimeout(() => {
         pendingInteractions.resolve(requestId);
         this.ownedIds.delete(requestId);
         log.warn({ requestId, conversationId }, "Question prompt timed out");
-        resolve({ decision: "timed_out" });
+        resolve({
+          entries: orderedIds.map((id) => ({
+            questionId: id,
+            decision: "timed_out",
+          })),
+          overall: "timed_out",
+        });
       }, timeoutMs);
 
+      // Stash the per-question metadata on the interaction so the route can
+      // validate batched submissions without holding a prompter reference.
       pendingInteractions.register(requestId, {
         conversationId,
         kind: "question",
@@ -83,6 +227,7 @@ export class QuestionPrompter {
         rpcReject: reject,
         timer,
         toolUseId,
+        metadata: { orderedIds, optionsById } satisfies QuestionBatchMetadata,
       });
       this.ownedIds.add(requestId);
 
@@ -91,7 +236,13 @@ export class QuestionPrompter {
           if (this.ownedIds.has(requestId)) {
             pendingInteractions.resolve(requestId);
             this.ownedIds.delete(requestId);
-            resolve({ decision: "aborted" });
+            resolve({
+              entries: orderedIds.map((id) => ({
+                questionId: id,
+                decision: "skipped",
+              })),
+              overall: "aborted",
+            });
           }
         };
         signal.addEventListener("abort", onAbort, { once: true });
@@ -100,22 +251,15 @@ export class QuestionPrompter {
       // Populate both shapes on the wire: `questions[]` is the canonical
       // batched payload, and the flat fields mirror `questions[0]` for
       // backwards compat with clients that haven't adopted `questions[]`.
+      const head = entries[0]!;
       const msg: QuestionRequest = {
         type: "question_request",
         requestId,
-        questions: [
-          {
-            id: "q1",
-            question,
-            description,
-            options,
-            freeTextPlaceholder,
-          },
-        ],
-        question,
-        description,
-        options,
-        freeTextPlaceholder,
+        questions: entries,
+        question: head.question,
+        description: head.description,
+        options: head.options,
+        freeTextPlaceholder: head.freeTextPlaceholder,
         conversationId,
         toolUseId,
       };
@@ -128,20 +272,47 @@ export class QuestionPrompter {
     return this.ownedIds.has(requestId);
   }
 
-  resolveQuestion(requestId: string, response: QuestionResponse): void {
-    if (!this.ownedIds.has(requestId)) {
-      log.warn({ requestId }, "No pending prompt for question response");
-      return;
-    }
-    const interaction = pendingInteractions.resolve(requestId);
-    this.ownedIds.delete(requestId);
-    const result: QuestionPromptResult =
-      response.kind === "option"
-        ? { decision: "option", optionId: response.optionId }
-        : { decision: "free_text", text: response.text };
-    (interaction?.rpcResolve as
-      | ((v: QuestionPromptResult) => void)
-      | undefined)?.(result);
+  /**
+   * Resolve a pending request with a complete batched submission. Validates
+   * that every original questionId is covered exactly once, no unknown
+   * questionId appears, and each `"option"` entry's optionId is one of
+   * the question's options.
+   *
+   * Throws {@link QuestionBatchValidationError} on validation failure so the
+   * route can map it to a 400. Returns `false` if no request matches.
+   */
+  submitQuestionBatch(
+    requestId: string,
+    submissions: QuestionBatchSubmission[],
+  ): boolean {
+    const meta = this.getOwnedBatchMetadata(requestId);
+    if (!meta) return false;
+
+    const entries = buildBatchEntries(
+      meta.orderedIds,
+      (qid, oid) => (meta.optionsById[qid] ?? []).includes(oid),
+      new Set(Object.keys(meta.optionsById)),
+      submissions,
+    );
+    this.resolveOwned(requestId, { entries, overall: "completed" });
+    return true;
+  }
+
+  /**
+   * Resolve a pending request as "closed" — the user dismissed the card
+   * without answering. Every entry is reported as `skipped` and the overall
+   * status is `closed`. Returns `false` if no request matches.
+   */
+  closeQuestion(requestId: string): boolean {
+    const meta = this.getOwnedBatchMetadata(requestId);
+    if (!meta) return false;
+
+    const entries: QuestionPromptEntryResult[] = meta.orderedIds.map((id) => ({
+      questionId: id,
+      decision: "skipped",
+    }));
+    this.resolveOwned(requestId, { entries, overall: "closed" });
+    return true;
   }
 
   dispose(): void {
@@ -152,5 +323,29 @@ export class QuestionPrompter {
         new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),
       );
     }
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────
+
+  /** Read batch metadata for an owned requestId, or null/log-warn otherwise. */
+  private getOwnedBatchMetadata(
+    requestId: string,
+  ): QuestionBatchMetadata | null {
+    if (!this.ownedIds.has(requestId)) {
+      log.warn({ requestId }, "No pending prompt for this requestId");
+      return null;
+    }
+    const interaction = pendingInteractions.get(requestId);
+    const meta = interaction?.metadata as QuestionBatchMetadata | undefined;
+    return meta ?? null;
+  }
+
+  /** Resolve an owned request: deregister, drop ownership, fire rpcResolve. */
+  private resolveOwned(requestId: string, value: QuestionPromptResult): void {
+    const interaction = pendingInteractions.resolve(requestId);
+    this.ownedIds.delete(requestId);
+    (interaction?.rpcResolve as
+      | ((v: QuestionPromptResult) => void)
+      | undefined)?.(value);
   }
 }

--- a/assistant/src/prompts/templates/system/04-ask-question.md
+++ b/assistant/src/prompts/templates/system/04-ask-question.md
@@ -4,3 +4,5 @@ enabled: hasAskQuestion
 ## Clarifying questions
 
 If the user skips an `ask_question`, proceed with reasonable defaults rather than re-asking — a skip is a signal to stop interrupting.
+
+Batch related clarifications into one `ask_question` call (up to 5 questions).

--- a/assistant/src/runtime/routes/__tests__/question-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/question-routes.test.ts
@@ -2,19 +2,21 @@
  * Tests for the `/v1/question-response` route in `question-routes.ts`.
  *
  * Covers:
- *   - 200 OK + rpcResolve invoked with `{ decision: "option", optionId }`
- *     on valid option body with a registered "question" interaction.
- *   - 200 OK + rpcResolve invoked with `{ decision: "free_text", text }`
- *     on valid free-text body.
- *   - 404 when no pending interaction exists for the requestId.
- *   - 400 when the request body fails zod validation.
- *   - Cross-talk safety: a registered "confirmation" requestId returns 404
- *     rather than being mis-resolved.
+ *   - kind: "submit" — single-entry happy path (option + free_text).
+ *   - kind: "submit" — multi-entry batch resolves with the full result.
+ *   - kind: "close" — every entry reported as skipped, overall="closed".
+ *   - Validation: missing questionId from the batch → 400.
+ *   - Validation: unknown questionId → 400.
+ *   - Validation: option submission with unknown optionId → 400.
+ *   - Cross-talk safety: a registered "confirmation" requestId returns 404.
+ *   - Legacy single-question shim: works against a one-element batch,
+ *     400s against a multi-element batch.
  *   - The pending interaction is removed after a successful resolve.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { QuestionPromptResult } from "../../../permissions/question-prompter.js";
 import * as pendingInteractions from "../../pending-interactions.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
 import { ROUTES as QUESTION_ROUTES } from "../question-routes.js";
@@ -36,6 +38,29 @@ async function call(args: RouteHandlerArgs): Promise<unknown> {
   return await handler(args);
 }
 
+/**
+ * Register a pending "question" interaction with the metadata the route
+ * needs to validate batched submissions. Mirrors what
+ * QuestionPrompter.prompt() does internally.
+ */
+function registerQuestion(
+  requestId: string,
+  questions: Array<{ id: string; options: string[] }>,
+  rpcResolve: (value: unknown) => void = () => {},
+): void {
+  const optionsById: Record<string, string[]> = {};
+  for (const q of questions) optionsById[q.id] = q.options;
+  pendingInteractions.register(requestId, {
+    conversationId: "conv-1",
+    kind: "question",
+    rpcResolve,
+    metadata: {
+      orderedIds: questions.map((q) => q.id),
+      optionsById,
+    },
+  });
+}
+
 beforeEach(() => {
   pendingInteractions.clear();
 });
@@ -49,46 +74,132 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("POST /v1/question-response", () => {
-  test("resolves a pending question with an option selection", async () => {
-    const resolved: unknown[] = [];
-    pendingInteractions.register("req-1", {
-      conversationId: "conv-1",
-      kind: "question",
-      rpcResolve: (value) => resolved.push(value),
-    });
+  test("submit: resolves a one-question batch with an option entry", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-1",
+      [{ id: "q1", options: ["yes", "no"] }],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
 
     const result = await call({
-      body: { requestId: "req-1", kind: "option", optionId: "yes" },
+      body: {
+        requestId: "req-1",
+        kind: "submit",
+        responses: [{ questionId: "q1", kind: "option", optionId: "yes" }],
+      },
     });
 
     expect(result).toEqual({ success: true });
-    expect(resolved).toEqual([{ decision: "option", optionId: "yes" }]);
-    // Interaction deregistered after resolve.
+    expect(resolved).toEqual([
+      {
+        entries: [{ questionId: "q1", decision: "option", optionId: "yes" }],
+        overall: "completed",
+      },
+    ]);
     expect(pendingInteractions.get("req-1")).toBeUndefined();
   });
 
-  test("resolves a pending question with a free-text response", async () => {
-    const resolved: unknown[] = [];
-    pendingInteractions.register("req-2", {
-      conversationId: "conv-1",
-      kind: "question",
-      rpcResolve: (value) => resolved.push(value),
-    });
+  test("submit: three-question batch with two options + one free-text", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-3",
+      [
+        { id: "q1", options: ["alice_work", "alice_personal"] },
+        { id: "q2", options: ["yes", "no"] },
+        { id: "q3", options: ["noon", "1pm"] },
+      ],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
 
     const result = await call({
-      body: { requestId: "req-2", kind: "free_text", text: "maybe" },
+      body: {
+        requestId: "req-3",
+        kind: "submit",
+        responses: [
+          { questionId: "q1", kind: "option", optionId: "alice_work" },
+          { questionId: "q3", kind: "free_text", text: "noon-ish" },
+          { questionId: "q2", kind: "option", optionId: "yes" },
+        ],
+      },
     });
 
     expect(result).toEqual({ success: true });
-    expect(resolved).toEqual([{ decision: "free_text", text: "maybe" }]);
-    expect(pendingInteractions.get("req-2")).toBeUndefined();
+    expect(resolved[0]?.overall).toBe("completed");
+    // Entries are ordered to match the original questions array.
+    expect(resolved[0]?.entries).toEqual([
+      { questionId: "q1", decision: "option", optionId: "alice_work" },
+      { questionId: "q2", decision: "option", optionId: "yes" },
+      { questionId: "q3", decision: "free_text", text: "noon-ish" },
+    ]);
+  });
+
+  test("submit: all-skip resolves with completed + skipped entries", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-skip-all",
+      [
+        { id: "q1", options: ["a", "b"] },
+        { id: "q2", options: ["x", "y"] },
+      ],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    await call({
+      body: {
+        requestId: "req-skip-all",
+        kind: "submit",
+        responses: [
+          { questionId: "q1", kind: "skip" },
+          { questionId: "q2", kind: "skip" },
+        ],
+      },
+    });
+
+    expect(resolved[0]).toEqual({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "completed",
+    });
+  });
+
+  test("close: every entry reported as skipped with overall=closed", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-close",
+      [
+        { id: "q1", options: ["a", "b"] },
+        { id: "q2", options: ["x", "y"] },
+      ],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    const result = await call({
+      body: { requestId: "req-close", kind: "close" },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(resolved[0]).toEqual({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "closed",
+    });
+    expect(pendingInteractions.get("req-close")).toBeUndefined();
   });
 
   test("returns 404 when no pending interaction exists for the requestId", async () => {
     let thrown: unknown;
     try {
       await call({
-        body: { requestId: "missing", kind: "option", optionId: "a" },
+        body: {
+          requestId: "missing",
+          kind: "submit",
+          responses: [{ questionId: "q1", kind: "option", optionId: "a" }],
+        },
       });
     } catch (err) {
       thrown = err;
@@ -97,11 +208,12 @@ describe("POST /v1/question-response", () => {
     expect((thrown as NotFoundError).statusCode).toBe(404);
   });
 
-  test("returns 400 when the request body fails validation", async () => {
-    // Missing optionId for kind: "option".
+  test("returns 400 when the request body fails schema validation", async () => {
+    registerQuestion("req-bad", [{ id: "q1", options: ["a", "b"] }]);
     let thrown: unknown;
     try {
-      await call({ body: { requestId: "req-3", kind: "option" } });
+      // Missing `responses` for kind: "submit".
+      await call({ body: { requestId: "req-bad", kind: "submit" } });
     } catch (err) {
       thrown = err;
     }
@@ -109,12 +221,10 @@ describe("POST /v1/question-response", () => {
     expect((thrown as BadRequestError).statusCode).toBe(400);
   });
 
-  test("returns 400 when kind is an unknown discriminator value", async () => {
+  test("returns 400 when kind is unknown", async () => {
     let thrown: unknown;
     try {
-      await call({
-        body: { requestId: "req-4", kind: "bogus", optionId: "x" },
-      });
+      await call({ body: { requestId: "req-1", kind: "bogus" } });
     } catch (err) {
       thrown = err;
     }
@@ -131,7 +241,75 @@ describe("POST /v1/question-response", () => {
     expect(thrown).toBeInstanceOf(BadRequestError);
   });
 
-  test("cross-talk safe: confirmation requestId returns 404 instead of mis-resolving", async () => {
+  test("validation: batch missing a questionId from the original set → 400", async () => {
+    const resolved: unknown[] = [];
+    registerQuestion(
+      "req-miss",
+      [
+        { id: "q1", options: ["a", "b"] },
+        { id: "q2", options: ["x", "y"] },
+      ],
+      (v) => resolved.push(v),
+    );
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: {
+          requestId: "req-miss",
+          kind: "submit",
+          responses: [{ questionId: "q1", kind: "option", optionId: "a" }],
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+    // Pending interaction left in place so the user can retry.
+    expect(pendingInteractions.get("req-miss")).toBeDefined();
+    expect(resolved).toEqual([]);
+  });
+
+  test("validation: unknown questionId → 400", async () => {
+    registerQuestion("req-uq", [{ id: "q1", options: ["a", "b"] }]);
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: {
+          requestId: "req-uq",
+          kind: "submit",
+          responses: [
+            { questionId: "q1", kind: "option", optionId: "a" },
+            { questionId: "qX", kind: "skip" },
+          ],
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+  });
+
+  test("validation: unknown optionId → 400", async () => {
+    registerQuestion("req-uo", [{ id: "q1", options: ["a", "b"] }]);
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: {
+          requestId: "req-uo",
+          kind: "submit",
+          responses: [{ questionId: "q1", kind: "option", optionId: "nope" }],
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+  });
+
+  test("cross-talk safe: confirmation requestId returns 404", async () => {
     const resolved: unknown[] = [];
     pendingInteractions.register("req-confirm", {
       conversationId: "conv-1",
@@ -142,14 +320,76 @@ describe("POST /v1/question-response", () => {
     let thrown: unknown;
     try {
       await call({
-        body: { requestId: "req-confirm", kind: "option", optionId: "yes" },
+        body: {
+          requestId: "req-confirm",
+          kind: "submit",
+          responses: [{ questionId: "q1", kind: "option", optionId: "yes" }],
+        },
       });
     } catch (err) {
       thrown = err;
     }
     expect(thrown).toBeInstanceOf(NotFoundError);
-    // The confirmation interaction was not touched.
     expect(resolved).toEqual([]);
     expect(pendingInteractions.get("req-confirm")?.kind).toBe("confirmation");
+  });
+
+  test("legacy single-question shim: resolves against a one-element batch", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-legacy",
+      [{ id: "q1", options: ["yes", "no"] }],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    const result = await call({
+      body: { requestId: "req-legacy", kind: "option", optionId: "yes" },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(resolved[0]).toEqual({
+      entries: [{ questionId: "q1", decision: "option", optionId: "yes" }],
+      overall: "completed",
+    });
+  });
+
+  test("legacy single-question shim: free-text resolves against a one-element batch", async () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-legacy-ft",
+      [{ id: "q1", options: ["yes", "no"] }],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    await call({
+      body: { requestId: "req-legacy-ft", kind: "free_text", text: "maybe" },
+    });
+
+    expect(resolved[0]).toEqual({
+      entries: [{ questionId: "q1", decision: "free_text", text: "maybe" }],
+      overall: "completed",
+    });
+  });
+
+  test("legacy single-question shim: rejects against a multi-element batch", async () => {
+    registerQuestion("req-legacy-multi", [
+      { id: "q1", options: ["a", "b"] },
+      { id: "q2", options: ["x", "y"] },
+    ]);
+
+    let thrown: unknown;
+    try {
+      await call({
+        body: { requestId: "req-legacy-multi", kind: "option", optionId: "a" },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(BadRequestError);
+    expect((thrown as BadRequestError).message.toLowerCase()).toContain(
+      "multi-question",
+    );
+    // Pending interaction left in place.
+    expect(pendingInteractions.get("req-legacy-multi")).toBeDefined();
   });
 });

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -2,20 +2,31 @@
  * Route handler for resolving pending question prompts.
  *
  * POST /v1/question-response — a client (UI or remote channel) submits the
- * user's selection (one of the supplied options, or free-text) for a pending
- * ask-question interaction registered by {@link QuestionPrompter}.
+ * user's selection for a pending ask-question interaction registered by
+ * {@link QuestionPrompter}. Two top-level shapes are accepted:
  *
- * Mirrors `/v1/confirm` and `/v1/secret`: the request body is validated via
- * zod, the pending interaction is looked up from the shared
- * `pendingInteractions` map, and the caller's Promise is resolved with the
- * appropriate `QuestionPromptResult` shape.
+ *  - `kind: "submit"` carries a `responses` array — one entry per question in
+ *    the original batch. The web client builds this locally and POSTs it once
+ *    the user is done revising the card.
+ *  - `kind: "close"` records that the user dismissed the card without
+ *    answering; every entry is reported as `skipped`.
+ *
+ * For backwards-compat we also accept the prior single-question shape
+ * (`{ kind: "option" | "free_text", ... }`) as syntactic sugar for a
+ * one-element batch. That branch only succeeds against a single-question
+ * batch — multi-question batches reject it with a helpful error.
  *
  * Cross-talk safety: pending interactions of other kinds (`confirmation`,
  * `secret`, host_*, etc.) return 404 here rather than being mis-resolved.
  */
 import { z } from "zod";
 
-import type { QuestionPromptResult } from "../../permissions/question-prompter.js";
+import {
+  buildBatchEntries,
+  type QuestionBatchSubmission,
+  QuestionBatchValidationError,
+  type QuestionPromptResult,
+} from "../../permissions/question-prompter.js";
 import { getLogger } from "../../util/logger.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
@@ -23,19 +34,61 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("question-routes");
 
-const QuestionResponseBody = z.discriminatedUnion("kind", [
+// ── Batched (current) body shape ────────────────────────────────────
+
+const SubmitEntry = z.discriminatedUnion("kind", [
   z.object({
-    requestId: z.string(),
+    questionId: z.string(),
     kind: z.literal("option"),
     optionId: z.string(),
   }),
   z.object({
-    requestId: z.string(),
+    questionId: z.string(),
     kind: z.literal("free_text"),
     text: z.string(),
   }),
+  z.object({
+    questionId: z.string(),
+    kind: z.literal("skip"),
+  }),
 ]);
 
+const SubmitBody = z.object({
+  requestId: z.string(),
+  kind: z.literal("submit"),
+  responses: z.array(SubmitEntry).min(1),
+});
+
+const CloseBody = z.object({
+  requestId: z.string(),
+  kind: z.literal("close"),
+});
+
+// ── Legacy single-question body shape (sugar for one-element batch) ──
+
+const LegacyOptionBody = z.object({
+  requestId: z.string(),
+  kind: z.literal("option"),
+  optionId: z.string(),
+});
+
+const LegacyFreeTextBody = z.object({
+  requestId: z.string(),
+  kind: z.literal("free_text"),
+  text: z.string(),
+});
+
+const QuestionResponseBody = z.union([
+  SubmitBody,
+  CloseBody,
+  LegacyOptionBody,
+  LegacyFreeTextBody,
+]);
+
+type SubmitBody = z.infer<typeof SubmitBody>;
+type CloseBody = z.infer<typeof CloseBody>;
+type LegacyOptionBody = z.infer<typeof LegacyOptionBody>;
+type LegacyFreeTextBody = z.infer<typeof LegacyFreeTextBody>;
 type QuestionResponseBody = z.infer<typeof QuestionResponseBody>;
 
 /**
@@ -63,18 +116,39 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
     );
   }
 
-  // Deregister now that we know we'll resolve — clears the prompter timer.
-  pendingInteractions.resolve(requestId);
+  // Build + validate the result BEFORE touching `pendingInteractions`, so a
+  // bad payload leaves the pending interaction (and its timer) intact and the
+  // user gets another chance to submit a correct batch.
+  let result: QuestionPromptResult;
+  try {
+    if (response.kind === "close") {
+      const { orderedIds } = readBatchMetadata(interaction);
+      result = {
+        entries: orderedIds.map((id) => ({
+          questionId: id,
+          decision: "skipped" as const,
+        })),
+        overall: "closed",
+      };
+    } else {
+      const submissions = buildSubmissions(response, interaction);
+      result = buildCompletedResult(submissions, interaction);
+    }
+  } catch (err) {
+    if (err instanceof QuestionBatchValidationError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
 
-  const result: QuestionPromptResult =
-    response.kind === "option"
-      ? { decision: "option", optionId: response.optionId }
-      : { decision: "free_text", text: response.text };
+  // Validation passed — deregister now to clear the prompter timer, then
+  // hand the result to the prompter's caller via rpcResolve.
+  pendingInteractions.resolve(requestId);
 
   log.info(
     {
       requestId,
-      decision: result.decision,
+      overall: result.overall,
       conversationId: interaction.conversationId,
     },
     "Question resolved",
@@ -85,6 +159,79 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
     | undefined)?.(result);
 
   return { success: true };
+}
+
+/**
+ * Normalize the incoming body to a `QuestionBatchSubmission[]` for the
+ * submit/legacy paths. Returns `null` for the `close` path (no submissions).
+ */
+function buildSubmissions(
+  body: SubmitBody | LegacyOptionBody | LegacyFreeTextBody,
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): QuestionBatchSubmission[] {
+  if (body.kind === "submit") return body.responses;
+
+  // Legacy single-question shim: synthesize a one-element batch. The
+  // prompter stashed the ordered ids on the interaction metadata so we can
+  // pick the (single) target questionId here.
+  const { orderedIds } = readBatchMetadata(interaction);
+  if (orderedIds.length === 0) {
+    throw new QuestionBatchValidationError(
+      "Legacy single-question payload requires a registered batch with at least one question",
+    );
+  }
+  if (orderedIds.length > 1) {
+    throw new QuestionBatchValidationError(
+      'Legacy single-question payload cannot answer a multi-question batch; submit `{ kind: "submit", responses: [...] }` covering every question instead.',
+    );
+  }
+  const questionId = orderedIds[0]!;
+  if (body.kind === "option") {
+    return [{ questionId, kind: "option", optionId: body.optionId }];
+  }
+  return [{ questionId, kind: "free_text", text: body.text }];
+}
+
+/**
+ * Build a `completed` QuestionPromptResult from a batched submission and the
+ * per-question metadata the prompter stashed on the interaction. Delegates
+ * the validation + ordering loop to {@link buildBatchEntries} so the
+ * prompter and the route share a single implementation.
+ */
+function buildCompletedResult(
+  submissions: QuestionBatchSubmission[],
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): QuestionPromptResult {
+  const { orderedIds, optionsById } = readBatchMetadata(interaction);
+  if (orderedIds.length === 0) {
+    throw new QuestionBatchValidationError(
+      "No registered question ids for this batch",
+    );
+  }
+  const entries = buildBatchEntries(
+    orderedIds,
+    (qid, oid) => (optionsById[qid] ?? []).includes(oid),
+    new Set(Object.keys(optionsById)),
+    submissions,
+  );
+  return { entries, overall: "completed" };
+}
+
+/**
+ * Pull the prompter-stashed batch bookkeeping off a pending interaction.
+ * Returns empty defaults if the metadata is absent.
+ */
+function readBatchMetadata(
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): { orderedIds: string[]; optionsById: Record<string, string[]> } {
+  return {
+    orderedIds:
+      (interaction?.metadata?.orderedIds as string[] | undefined) ?? [],
+    optionsById:
+      (interaction?.metadata?.optionsById as
+        | Record<string, string[]>
+        | undefined) ?? {},
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -100,7 +247,7 @@ export const ROUTES: RouteDefinition[] = [
     requireGuardian: true,
     summary: "Resolve a pending ask-question prompt",
     description:
-      "Submit the user's response (option selection or free-text) for a pending question prompt by requestId.",
+      "Submit the user's batched response (or close the card) for a pending question prompt by requestId. Legacy single-question payloads remain accepted as syntactic sugar for a one-element batch.",
     tags: ["approvals"],
     requestBody: QuestionResponseBody,
     responseBody: z.object({

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -42,8 +42,15 @@ const validInput = {
   freeTextPlaceholder: "Type a fruit",
 };
 
+const singleQ = {
+  question: validInput.question,
+  description: validInput.description,
+  options: validInput.options,
+  freeTextPlaceholder: validInput.freeTextPlaceholder,
+};
+
 describe("AskQuestionTool definition", () => {
-  test("exposes the expected schema shape", () => {
+  test("exposes the expected schema shape and description language", () => {
     const def = new AskQuestionTool().getDefinition();
     expect(def.name).toBe("ask_question");
     expect(def.description).toContain("free-text fallback is always added");
@@ -51,10 +58,13 @@ describe("AskQuestionTool definition", () => {
     expect(def.description).toContain("'something else'");
     expect(def.description).toContain("plain-text clarification");
     expect(def.description).toContain("obvious from context");
-    // Prescriptive framing assertions — proactive ask, skip-all.
     expect(def.description).toContain("Use this tool whenever");
     expect(def.description).toContain("When in doubt");
     expect(def.description).toContain("skips the question");
+    // Batching language is back now that the prompter handles batches.
+    expect(def.description).toContain("Batch related clarifications");
+    expect(def.description).toContain("up to 5");
+    expect(def.description).toContain("Skip button");
 
     const schema = def.input_schema as {
       properties: Record<
@@ -63,88 +73,115 @@ describe("AskQuestionTool definition", () => {
       >;
       required?: string[];
     };
-    // PR 2 removed top-level `required` — caller may supply either
-    // `questions` or the legacy flat fields, enforced at runtime by Zod.
-    // Per-shape `required` arrays still live on the legacy `options` field
-    // and on the `questions[]` item schema.
     expect(schema.properties.options?.type).toBe("array");
     expect(schema.properties.options?.minItems).toBe(2);
     expect(schema.properties.options?.maxItems).toBe(4);
   });
 });
 
+// Build a single-question completed result for tests that just need to
+// exercise the formatter on a one-element batch.
+function singleCompleted(
+  entry:
+    | { decision: "option"; optionId: string }
+    | { decision: "free_text"; text: string }
+    | { decision: "skipped" },
+): QuestionPromptResult {
+  return {
+    entries: [{ questionId: "q1", ...entry }],
+    overall: "completed",
+  };
+}
+
 describe("AskQuestionTool.execute", () => {
-  test("forwards options unchanged to the prompter", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+  test("forwards questions array unchanged to the prompter", async () => {
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute(validInput, makeContext());
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.conversationId).toBe("conv-1");
-    expect(calls[0]?.question).toBe(validInput.question);
-    expect(calls[0]?.description).toBe(validInput.description);
-    expect(calls[0]?.options).toEqual(validInput.options);
-    expect(calls[0]?.freeTextPlaceholder).toBe(validInput.freeTextPlaceholder);
+    expect(calls[0]?.questions).toHaveLength(1);
+    expect(calls[0]?.questions[0]?.question).toBe(validInput.question);
+    expect(calls[0]?.questions[0]?.description).toBe(validInput.description);
+    expect(calls[0]?.questions[0]?.options).toEqual(validInput.options);
+    expect(calls[0]?.questions[0]?.freeTextPlaceholder).toBe(
+      validInput.freeTextPlaceholder,
+    );
     expect(calls[0]?.toolUseId).toBe("tu-1");
 
     expect(result.isError).toBe(false);
-    expect(result.content).toBe("Option: a\nLabel: Apple");
+    expect(result.content).toBe(
+      `Question "${validInput.question}" → Option: a (Apple)`,
+    );
   });
 
   test("formats option result with looked-up label", async () => {
-    const { tool } = makeToolWithStub({
-      decision: "option",
-      optionId: "b",
-    });
+    const { tool } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "b" }),
+    );
     const result = await tool.execute(validInput, makeContext());
-    expect(result.content).toBe("Option: b\nLabel: Banana");
+    expect(result.content).toBe(
+      `Question "${validInput.question}" → Option: b (Banana)`,
+    );
     expect(result.isError).toBe(false);
   });
 
   test("falls back to '(unknown)' label when optionId is not in options", async () => {
-    // Defensive: prompter never returns an out-of-band id, but the handler
-    // must not crash if it ever did. Verifies the lookup default branch.
-    const { tool } = makeToolWithStub({
-      decision: "option",
-      optionId: "ghost",
-    });
+    const { tool } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "ghost" }),
+    );
     const result = await tool.execute(validInput, makeContext());
-    expect(result.content).toBe("Option: ghost\nLabel: (unknown)");
+    expect(result.content).toBe(
+      `Question "${validInput.question}" → Option: ghost ((unknown))`,
+    );
     expect(result.isError).toBe(false);
   });
 
   test("formats free-text result", async () => {
-    const { tool } = makeToolWithStub({
-      decision: "free_text",
-      text: "Cherry",
-    });
+    const { tool } = makeToolWithStub(
+      singleCompleted({ decision: "free_text", text: "Cherry" }),
+    );
     const result = await tool.execute(validInput, makeContext());
-    expect(result.content).toBe("Free text: Cherry");
+    expect(result.content).toBe(
+      `Question "${validInput.question}" → Free text: Cherry`,
+    );
+    expect(result.isError).toBe(false);
+  });
+
+  test("formats skipped result", async () => {
+    const { tool } = makeToolWithStub(singleCompleted({ decision: "skipped" }));
+    const result = await tool.execute(validInput, makeContext());
+    expect(result.content).toBe(`Question "${validInput.question}" → Skipped`);
     expect(result.isError).toBe(false);
   });
 
   test("timeout produces tool error", async () => {
-    const { tool } = makeToolWithStub({ decision: "timed_out" });
+    const { tool } = makeToolWithStub({
+      entries: [{ questionId: "q1", decision: "timed_out" }],
+      overall: "timed_out",
+    });
     const result = await tool.execute(validInput, makeContext());
     expect(result.isError).toBe(true);
     expect(result.content).toBe("User did not respond within timeout");
   });
 
   test("aborted produces tool error", async () => {
-    const { tool } = makeToolWithStub({ decision: "aborted" });
+    const { tool } = makeToolWithStub({
+      entries: [{ questionId: "q1", decision: "skipped" }],
+      overall: "aborted",
+    });
     const result = await tool.execute(validInput, makeContext());
     expect(result.isError).toBe(true);
     expect(result.content).toBe("Question aborted");
   });
 
   test("rejects input with fewer than 2 options", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
     const result = await tool.execute(
       { ...validInput, options: [{ id: "a", label: "Apple" }] },
       makeContext(),
@@ -155,10 +192,9 @@ describe("AskQuestionTool.execute", () => {
   });
 
   test("rejects input with more than 4 options", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
     const result = await tool.execute(
       {
         ...validInput,
@@ -177,10 +213,9 @@ describe("AskQuestionTool.execute", () => {
   });
 
   test("rejects input with empty question", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
     const result = await tool.execute(
       { ...validInput, question: "" },
       makeContext(),
@@ -190,10 +225,9 @@ describe("AskQuestionTool.execute", () => {
   });
 
   test("propagates abort signal into the prompter", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
     const ac = new AbortController();
     await tool.execute(validInput, makeContext({ signal: ac.signal }));
     expect(calls[0]?.signal).toBe(ac.signal);
@@ -201,38 +235,26 @@ describe("AskQuestionTool.execute", () => {
 });
 
 // ── Batched input ───────────────────────────────────────────────────
-// These tests cover the input-shape contract only — the `questions[]`
-// shape, the 1..5 cap, and the legacy-flat normalization. Outbound
-// prompter behavior (id assignment, batched broadcasting) is covered
-// in `question-prompter.test.ts`.
-
-const singleQ = {
-  question: validInput.question,
-  description: validInput.description,
-  options: validInput.options,
-  freeTextPlaceholder: validInput.freeTextPlaceholder,
-};
 
 describe("AskQuestionTool batched input", () => {
-  test("normalizes legacy flat input into a one-element batch", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+  test("normalizes legacy flat input into a one-element batch forwarded to the prompter", async () => {
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute(validInput, makeContext());
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.question).toBe(validInput.question);
-    expect(calls[0]?.options).toEqual(validInput.options);
+    expect(calls[0]?.questions).toHaveLength(1);
+    expect(calls[0]?.questions[0]?.question).toBe(validInput.question);
+    expect(calls[0]?.questions[0]?.options).toEqual(validInput.options);
     expect(result.isError).toBe(false);
   });
 
   test("accepts a single-element `questions` batch", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute(
       { questions: [singleQ] },
@@ -240,53 +262,159 @@ describe("AskQuestionTool batched input", () => {
     );
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.question).toBe(singleQ.question);
-    expect(calls[0]?.options).toEqual(singleQ.options);
-    expect(calls[0]?.description).toBe(singleQ.description);
-    expect(calls[0]?.freeTextPlaceholder).toBe(singleQ.freeTextPlaceholder);
+    expect(calls[0]?.questions).toHaveLength(1);
+    expect(calls[0]?.questions[0]?.question).toBe(singleQ.question);
+    expect(calls[0]?.questions[0]?.options).toEqual(singleQ.options);
+    expect(calls[0]?.questions[0]?.description).toBe(singleQ.description);
+    expect(calls[0]?.questions[0]?.freeTextPlaceholder).toBe(
+      singleQ.freeTextPlaceholder,
+    );
     expect(result.isError).toBe(false);
   });
 
-  test("runtime guard rejects a 5-entry batch even though the schema cap allows it", async () => {
+  test("forwards the full questions array for a multi-question batch", async () => {
+    const q2 = {
+      question: "Preferred time?",
+      options: [
+        { id: "morning", label: "Morning" },
+        { id: "afternoon", label: "Afternoon" },
+      ],
+      freeTextPlaceholder: "or specify",
+    };
+    const q3 = {
+      question: "Send invite?",
+      options: [
+        { id: "yes", label: "Yes" },
+        { id: "no", label: "No" },
+      ],
+    };
+
     const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
+      entries: [
+        { questionId: "q1", decision: "option", optionId: "a" },
+        { questionId: "q2", decision: "free_text", text: "noon-ish" },
+        { questionId: "q3", decision: "option", optionId: "yes" },
+      ],
+      overall: "completed",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ, q2, q3] },
+      makeContext(),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.questions).toHaveLength(3);
+    expect(calls[0]?.questions.map((q) => q.question)).toEqual([
+      singleQ.question,
+      q2.question,
+      q3.question,
+    ]);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe(
+      [
+        `Question "${singleQ.question}" → Option: a (Apple)`,
+        `Question "${q2.question}" → Free text: noon-ish`,
+        `Question "${q3.question}" → Option: yes (Yes)`,
+      ].join("\n"),
+    );
+  });
+
+  test("formats all-skipped batch as a non-error transcript", async () => {
+    const q2 = {
+      question: "Preferred time?",
+      options: [
+        { id: "morning", label: "Morning" },
+        { id: "afternoon", label: "Afternoon" },
+      ],
+    };
+    const q3 = {
+      question: "Send invite?",
+      options: [
+        { id: "yes", label: "Yes" },
+        { id: "no", label: "No" },
+      ],
+    };
+    const { tool } = makeToolWithStub({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+        { questionId: "q3", decision: "skipped" },
+      ],
+      overall: "completed",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ, q2, q3] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe(
+      [
+        `Question "${singleQ.question}" → Skipped`,
+        `Question "${q2.question}" → Skipped`,
+        `Question "${q3.question}" → Skipped`,
+      ].join("\n"),
+    );
+  });
+
+  test("closed batch prepends a summary line and remains non-error", async () => {
+    const q2 = {
+      question: "Preferred time?",
+      options: [
+        { id: "morning", label: "Morning" },
+        { id: "afternoon", label: "Afternoon" },
+      ],
+    };
+    const { tool } = makeToolWithStub({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "closed",
+    });
+
+    const result = await tool.execute(
+      { questions: [singleQ, q2] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe(
+      [
+        "User closed the question card without answering. All questions skipped.",
+        `Question "${singleQ.question}" → Skipped`,
+        `Question "${q2.question}" → Skipped`,
+      ].join("\n"),
+    );
+  });
+
+  test("accepts a 5-entry batch (max allowed)", async () => {
+    const { tool, calls } = makeToolWithStub({
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+        { questionId: "q3", decision: "skipped" },
+        { questionId: "q4", decision: "skipped" },
+        { questionId: "q5", decision: "skipped" },
+      ],
+      overall: "completed",
     });
     const five = [singleQ, singleQ, singleQ, singleQ, singleQ];
 
     const result = await tool.execute({ questions: five }, makeContext());
 
-    // Schema validation passes (the 1..5 cap holds), but the runtime guard
-    // refuses to forward anything because the prompter can't broadcast a
-    // batch yet — see the TODO in `execute()`.
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("Batched questions");
-    expect(calls).toHaveLength(0);
-  });
-
-  test("rejects a 2-entry batch with the documented guard message", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
-
-    const result = await tool.execute(
-      { questions: [singleQ, singleQ] },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toBe(
-      "Batched questions (more than one entry in `questions`) are not yet supported by this assistant build. Call ask_question once per clarification for now.",
-    );
-    expect(calls).toHaveLength(0);
+    expect(result.isError).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.questions).toHaveLength(5);
   });
 
   test("rejects batches with 6+ questions", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
     const six = [singleQ, singleQ, singleQ, singleQ, singleQ, singleQ];
 
     const result = await tool.execute({ questions: six }, makeContext());
@@ -297,10 +425,9 @@ describe("AskQuestionTool batched input", () => {
   });
 
   test("rejects empty `questions` array", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute({ questions: [] }, makeContext());
 
@@ -310,10 +437,9 @@ describe("AskQuestionTool batched input", () => {
   });
 
   test("rejects input missing both `questions` and flat fields", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute({}, makeContext());
 
@@ -323,10 +449,9 @@ describe("AskQuestionTool batched input", () => {
   });
 
   test("rejects legacy `question` without `options`", async () => {
-    const { tool, calls } = makeToolWithStub({
-      decision: "option",
-      optionId: "a",
-    });
+    const { tool, calls } = makeToolWithStub(
+      singleCompleted({ decision: "option", optionId: "a" }),
+    );
 
     const result = await tool.execute(
       { question: "Hi?" },
@@ -336,21 +461,6 @@ describe("AskQuestionTool batched input", () => {
     expect(result.isError).toBe(true);
     expect(result.content.toLowerCase()).toContain("invalid input");
     expect(calls).toHaveLength(0);
-  });
-
-  test("formats free-text result for batched input", async () => {
-    const { tool } = makeToolWithStub({
-      decision: "free_text",
-      text: "Cherry",
-    });
-
-    const result = await tool.execute(
-      { questions: [singleQ] },
-      makeContext(),
-    );
-
-    expect(result.content).toBe("Free text: Cherry");
-    expect(result.isError).toBe(false);
   });
 });
 
@@ -374,14 +484,11 @@ describe("AskQuestionTool definition (batched schema)", () => {
       required?: string[];
     };
 
-    // Batched shape is present and capped at 5.
     const questions = schema.properties.questions;
     expect(questions?.type).toBe("array");
     expect(questions?.minItems).toBe(1);
     expect(questions?.maxItems).toBe(5);
 
-    // Per-question item schema requires `question` and `options` but
-    // explicitly does NOT include an `id` field — ids are daemon-assigned.
     const itemProps = questions?.items?.properties ?? {};
     expect(Object.keys(itemProps)).toEqual(
       expect.arrayContaining([
@@ -394,20 +501,12 @@ describe("AskQuestionTool definition (batched schema)", () => {
     expect(Object.keys(itemProps)).not.toContain("id");
     expect(questions?.items?.required).toEqual(["question", "options"]);
 
-    // Legacy flat fields are still present (optional, no top-level required).
     expect(schema.properties.question?.type).toBe("string");
     expect(schema.properties.options?.type).toBe("array");
     expect(schema.properties.options?.minItems).toBe(2);
     expect(schema.properties.options?.maxItems).toBe(4);
     expect(schema.properties.freeTextPlaceholder?.type).toBe("string");
 
-    // No top-level `required` array — the choice between batched and flat
-    // is enforced at runtime by Zod's `.refine`, which is the source of
-    // truth. The "accepts a single-element `questions` batch",
-    // "normalizes legacy flat input into a one-element batch",
-    // "rejects input missing both `questions` and flat fields", and
-    // "rejects legacy `question` without `options`" tests above exercise
-    // every branch of that refine.
     expect(schema.required).toBeUndefined();
   });
 });

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -72,10 +72,6 @@ export type SingleQuestion = z.infer<typeof SingleQuestionSchema>;
 export type AskQuestionInput = z.infer<typeof InputSchema>;
 
 // ── Tool description ────────────────────────────────────────────────
-// The input schema accepts a single `question` + `options` payload only.
-// Do not advertise a batched `questions` shape here — the executor will
-// reject it as invalid input. (Batching is planned but lives behind a
-// schema extension that has not landed yet.)
 
 const DESCRIPTION = [
   "Use this tool whenever the user's request is ambiguous and can be resolved",
@@ -89,6 +85,9 @@ const DESCRIPTION = [
   "are two plausible Alice contacts, ask which Alice with options like",
   '`{id: "alice_work", label: "Alice (work)"}` and',
   '`{id: "alice_personal", label: "Alice (personal)"}`.',
+  "",
+  "Batch related clarifications into one call by passing multiple entries in",
+  "`questions` (up to 5). Each question gets its own page with a Skip button.",
   "",
   "When NOT to use this tool:",
   "- The answer is obvious from context or recent conversation.",
@@ -237,19 +236,6 @@ export class AskQuestionTool implements Tool {
       };
     }
 
-    // TODO: remove this guard once PR 3 wires the prompter to handle batches.
-    // The schema accepts up to MAX_QUESTIONS_PER_BATCH entries so PR 3 doesn't
-    // have to re-extend it, but until the prompter can broadcast multi-question
-    // batches we must reject them explicitly — otherwise extra entries would
-    // be silently dropped and the caller would receive an incomplete answer.
-    if (parsed.data.questions && parsed.data.questions.length > 1) {
-      return {
-        content:
-          "Batched questions (more than one entry in `questions`) are not yet supported by this assistant build. Call ask_question once per clarification for now.",
-        isError: true,
-      };
-    }
-
     // Normalize legacy flat input into a one-element `questions` batch so
     // downstream code only has to deal with the batched shape. The refine
     // above guarantees `question` and `options` are present whenever
@@ -263,35 +249,44 @@ export class AskQuestionTool implements Tool {
       },
     ];
 
-    // The prompter currently handles one question at a time. Multi-question
-    // batches are rejected by the guard above, so `questions` is guaranteed
-    // to hold exactly one entry here.
-    const head = questions[0]!;
-    const { question, description, options, freeTextPlaceholder } = head;
-
     const prompter = this.prompterFactory();
     const result = await prompter.prompt({
       conversationId: context.conversationId,
-      question,
-      description,
-      options,
-      freeTextPlaceholder,
+      questions: questions.map((q) => ({
+        question: q.question,
+        description: q.description,
+        options: q.options,
+        freeTextPlaceholder: q.freeTextPlaceholder,
+      })),
       toolUseId: context.toolUseId,
       signal: context.signal,
     });
 
-    switch (result.decision) {
-      case "option": {
-        const chosen = options.find((o) => o.id === result.optionId);
+    // Format the aggregated transcript. Each line is keyed by the original
+    // question text (not the daemon-assigned id) — the LLM never sees those
+    // ids, and human-readable labels read better in the result content.
+    const lines = result.entries.map((entry, i) => {
+      const q = questions[i]!;
+      const prefix = `Question "${q.question}" →`;
+      if (entry.decision === "option") {
+        const chosen = q.options.find((o) => o.id === entry.optionId);
         const label = chosen?.label ?? "(unknown)";
-        return {
-          content: `Option: ${result.optionId}\nLabel: ${label}`,
-          isError: false,
-        };
+        return `${prefix} Option: ${entry.optionId} (${label})`;
       }
-      case "free_text": {
+      if (entry.decision === "free_text") {
+        return `${prefix} Free text: ${entry.text ?? ""}`;
+      }
+      return `${prefix} Skipped`;
+    });
+
+    switch (result.overall) {
+      case "completed":
+        return { content: lines.join("\n"), isError: false };
+      case "closed": {
+        const summary =
+          "User closed the question card without answering. All questions skipped.";
         return {
-          content: `Free text: ${result.text ?? ""}`,
+          content: [summary, ...lines].join("\n"),
           isError: false,
         };
       }


### PR DESCRIPTION
## Summary
- Assigns daemon-side per-question ids (`q1..qN`) in the prompter and wires the full `questions` array through to clients.
- New `QuestionPromptResult` shape carrying ordered per-entry decisions + an `overall` status.
- Adds `submitQuestionBatch` and `closeQuestion` to the prompter; updates `/v1/question-response` to accept the batched payload (with legacy single-question shim).
- Removes the temporary multi-question guard from `execute()` (added in PR 2) and re-adds batching language to the tool description and workspace section.

Part of plan: ask-question-proactive-and-batched.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->