### PR TITLE
fix(acp): preserve empty PATH override in resolver preflight

### DIFF
--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -73,7 +73,7 @@ function installHintFor(command: string): string {
  */
 function findAgentBinary(agent: AcpAgentConfig): string | null {
   const PATH = agent.env?.PATH ?? process.env.PATH;
-  return Bun.which(agent.command, PATH ? { PATH } : undefined);
+  return Bun.which(agent.command, PATH != null ? { PATH } : undefined);
 }
 
 /**


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #29971. Change `PATH ? { PATH }` to `PATH != null ? { PATH }` so an intentionally empty PATH override (env: { PATH: '' }) is preserved into Bun.which, matching what AcpAgentProcess.spawn actually uses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->