### PR TITLE
fix(ci): fall back to GitHub username when should_tag=false in cancelled alerts

### DIFF
--- a/.github/actions/send-build-alert/action.yml
+++ b/.github/actions/send-build-alert/action.yml
@@ -57,7 +57,7 @@ runs:
         if [ "$SHOULD_TAG" = "true" ]; then
           ACTOR="<@$SLACK_USER_ID>"
         else
-          ACTOR="$SLACK_USER_ID"
+          ACTOR="$GITHUB_ACTOR"
         fi
 
         REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"


### PR DESCRIPTION
Addresses Codex P2 / Devin review feedback on #30443. send-build-alert/action.yml was printing the raw Slack user ID verbatim for cancelled builds (since should_tag is hardcoded false for STATUS=cancelled), defeating the purpose of the github_to_slack_cancelled_notifications mappings. Now falls back to GITHUB_ACTOR for readability while leaving the mappings in place.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->