### PR TITLE
docs(meet-host): remove stale manifest-hash claim from ensureRunning JSDoc

### DIFF
--- a/assistant/src/daemon/meet-host-supervisor.ts
+++ b/assistant/src/daemon/meet-host-supervisor.ts
@@ -254,10 +254,11 @@ export class MeetHostSupervisor {
   }
 
   /**
-   * Ensure the meet-host child is spawned, the IPC handshake has been
-   * received, and the manifest hash validated. Idempotent: a second
-   * call while the child is already running is a no-op; a second call
-   * during an in-flight spawn awaits the same promise.
+   * Ensure the meet-host child is spawned and the IPC handshake has
+   * been received. Idempotent: a second call while the child is
+   * already running is a no-op; a second call during an in-flight
+   * spawn awaits the same promise. Manifest hash validation is
+   * currently dormant (see {@link notifyHandshake}).
    */
   ensureRunning(): Promise<void> {
     if (this.shuttingDown) {


### PR DESCRIPTION
Addresses Devin review feedback on #29969. The ensureRunning() JSDoc still claimed 'manifest hash validated' which contradicts the rest of this file's updated comments noting that hash validation is dormant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->