### PR TITLE
fix(macos): remove dead deleteTokenFile helper

### DIFF
--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -188,24 +188,6 @@ public enum GuardianTokenFileReader {
             : .importValid(creds)
     }
 
-    /// Deletes any CLI-persisted guardian token on disk for the given
-    /// assistant. Used by forced re-bootstrap paths to avoid re-importing a
-    /// stale/revoked token that shares the same file. A missing file is
-    /// treated as success.
-    @discardableResult
-    public static func deleteTokenFile(assistantId: String) -> Bool {
-        let path = guardianTokenPath(for: assistantId, paths: VellumPaths.current)
-        guard FileManager.default.fileExists(atPath: path) else { return true }
-        do {
-            try FileManager.default.removeItem(atPath: path)
-            log.info("Deleted guardian token file at \(path, privacy: .public)")
-            return true
-        } catch {
-            log.warning("Failed to delete guardian token file at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return false
-        }
-    }
-
     /// Deletes the guardian-token file for the given assistant across every
     /// `VellumEnvironment`'s config dir.
     ///


### PR DESCRIPTION
Addresses Devin review feedback on #30182. The importIfAvailable signature break was already fixed by #30183; this PR removes the now-unused single-env deleteTokenFile helper (replaced by deleteTokenFileAcrossAllEnvs in the multi-env Re-pair work).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->