### PR TITLE
fix(macos): use post-await lookup for SettingsStore.setProfile reorder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3365,8 +3365,11 @@ public final class SettingsStore: ObservableObject {
             // config push (via `applyDaemonConfig` → `loadInferenceProfiles`)
             // can replace `profiles` during the suspension, invalidating
             // `existingIndex` and risking an out-of-bounds subscript or
-            // a write to the wrong row.
-            if let index = profiles.firstIndex(where: { $0.name == name }) {
+            // a write to the wrong row. The same post-await result must
+            // gate the reorder branch below so the merge/append and
+            // reorder decisions stay consistent.
+            let postAwaitIndex = profiles.firstIndex(where: { $0.name == name })
+            if let index = postAwaitIndex {
                 // Daemon deep-merges the patch (toJSON omits nil fields).
                 // Mirror that locally so fields the fragment leaves nil
                 // retain whatever the daemon already had.
@@ -3383,7 +3386,7 @@ public final class SettingsStore: ObservableObject {
                     profileOrder = profiles.map(\.name)
                 }
             }
-            if let nextOrder, existingIndex != nil {
+            if let nextOrder, postAwaitIndex != nil {
                 profileOrder = nextOrder
                 reorderPublishedProfiles(to: nextOrder)
             }


### PR DESCRIPTION
Addresses Devin review feedback on #29994. SettingsStore.setProfile now uses the post-await lookup result for the reorder decision (matching the subscript-write fix from #29994) so the merge/append and reorder branches stay consistent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->