### PR TITLE
fix(migrations): carry forward conversationStarters in 072 replySuggestion seed

### DIFF
--- a/assistant/src/__tests__/workspace-migration-072-seed-reply-suggestion-callsite.test.ts
+++ b/assistant/src/__tests__/workspace-migration-072-seed-reply-suggestion-callsite.test.ts
@@ -106,6 +106,56 @@ describe("072-seed-reply-suggestion-callsite migration", () => {
     });
   });
 
+  test("carries forward customized conversationStarters override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        callSites: {
+          conversationStarters: {
+            model: "claude-opus-4-7",
+            effort: "high",
+            thinking: { enabled: true },
+          },
+        },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "claude-opus-4-7",
+      effort: "high",
+      thinking: { enabled: true },
+    });
+  });
+
+  test("carries forward conversationStarters even on non-Anthropic provider", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+        callSites: {
+          conversationStarters: {
+            model: "gpt-5.4-mini",
+            effort: "low",
+          },
+        },
+      },
+    });
+
+    seedReplySuggestionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.replySuggestion).toEqual({
+      model: "gpt-5.4-mini",
+      effort: "low",
+    });
+  });
+
   test("skips when replySuggestion already has an explicit override", () => {
     writeConfig({
       llm: {

--- a/assistant/src/workspace/migrations/072-seed-reply-suggestion-callsite.ts
+++ b/assistant/src/workspace/migrations/072-seed-reply-suggestion-callsite.ts
@@ -14,12 +14,20 @@ import type { WorkspaceMigration } from "./types.js";
  * high-effort / extended-thinking default, every turn would kick off an
  * expensive reasoning call and reject the assistant prefill.
  *
+ * Carry-forward: when `replySuggestion` is absent but the workspace has a
+ * customized `conversationStarters` entry (the call site this one was split
+ * out of), clone that entry into `replySuggestion` so users who previously
+ * tuned the combined call site keep their override. Only fall back to the
+ * fixed Haiku defaults when no `conversationStarters` override exists.
+ *
  * Mirrors `046-seed-conversation-starters-callsite`:
  *   - Skip entirely when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set
  *     (platform overlay owns call-site seeds).
- *   - Skip when the resolved provider is not Anthropic or OpenRouter (the
- *     seeded model IDs are Anthropic-shaped, so mixing with another
- *     provider would guarantee invalid-model errors).
+ *   - In the fallback default path, skip when the resolved provider is not
+ *     Anthropic or OpenRouter (the seeded model IDs are Anthropic-shaped, so
+ *     mixing with another provider would guarantee invalid-model errors).
+ *     The carry-forward path is provider-agnostic since the cloned config
+ *     already reflects the user's explicit choice.
  *   - No-op when `llm.callSites.replySuggestion` is already set.
  *
  * Idempotent, append-only — existing entries are untouched.
@@ -46,29 +54,34 @@ export const seedReplySuggestionCallsiteMigration: WorkspaceMigration = {
     }
 
     const llm = readObject(config.llm) ?? {};
-    const defaultBlock = readObject(llm.default);
-
-    const explicitProvider = readString(defaultBlock?.provider);
-    if (
-      explicitProvider !== undefined &&
-      explicitProvider !== "anthropic" &&
-      explicitProvider !== "openrouter"
-    ) {
-      return;
-    }
-    const provider = explicitProvider ?? "anthropic";
-    const fastModel = resolveLatencyModel(provider);
-    if (fastModel === undefined) return;
-
     const callSites = readObject(llm.callSites) ?? {};
     if (readObject(callSites.replySuggestion) !== null) return;
 
-    callSites.replySuggestion = {
-      model: fastModel,
-      effort: "low",
-      thinking: { enabled: false },
-    };
+    const conversationStarters = readObject(callSites.conversationStarters);
+    let seed: Record<string, unknown>;
+    if (conversationStarters !== null) {
+      seed = { ...conversationStarters };
+    } else {
+      const defaultBlock = readObject(llm.default);
+      const explicitProvider = readString(defaultBlock?.provider);
+      if (
+        explicitProvider !== undefined &&
+        explicitProvider !== "anthropic" &&
+        explicitProvider !== "openrouter"
+      ) {
+        return;
+      }
+      const provider = explicitProvider ?? "anthropic";
+      const fastModel = resolveLatencyModel(provider);
+      if (fastModel === undefined) return;
+      seed = {
+        model: fastModel,
+        effort: "low",
+        thinking: { enabled: false },
+      };
+    }
 
+    callSites.replySuggestion = seed;
     llm.callSites = callSites;
     config.llm = llm;
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");


### PR DESCRIPTION
Addresses Codex review feedback on #29959. Migration 072 now carries forward user-customized llm.callSites.conversationStarters config to llm.callSites.replySuggestion when replySuggestion is absent, instead of unconditionally seeding fixed Haiku defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->