### PR TITLE
docs(githooks): clarify scissors-line cleanup-mode behavior

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -62,7 +62,7 @@ Runs the same generic-examples patterns as `pre-commit`, but against the commit 
 **Behavior:**
 
 - Comment lines (lines starting with `#`) are stripped before scanning when `commit.cleanup` is `default`, `strip`, or `scissors` (the modes that drop them from the recorded commit). Under `verbatim` or `whitespace`, comment lines are scanned because git keeps them.
-- Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is ignored, since git also drops it.
+- Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is ignored when `commit.cleanup` is `default`, `strip`, or `scissors` (the modes that drop it from the recorded commit). Under `verbatim` or `whitespace`, content below the scissors line is scanned because git keeps it.
 <!-- generic-examples:ignore-next-line — illustrative example of what the rule flags -->
 - Patterns are quote-anchored — they catch quoted/back-ticked emails and phone numbers (e.g., `Updated "alice@gmail.com" to be hashed`), not bare prose. Angle-bracketed trailers like `Co-Authored-By: Claude <noreply@anthropic.com>` are not flagged.
 - Suppression: `generic-examples:ignore-line` on the flagged line itself works (note that the marker survives into the recorded message). `generic-examples:ignore-next-line` is intentionally not supported here, since the marker line would also survive into the recorded message — use the same-line form instead.

--- a/scripts/check-generic-examples.ts
+++ b/scripts/check-generic-examples.ts
@@ -200,12 +200,12 @@ function parseUnifiedDiff(diff: string): AddedLine[] {
 // everything below it is dropped before the commit is recorded.
 const COMMIT_MSG_SCISSORS = "# ------------------------ >8 ------------------------";
 
-// `verbatim` and `whitespace` cleanup modes keep `#` lines in the recorded
-// commit message, so we cannot blindly skip them — quoted real data on a
-// `#` line would slip through the scan. `default`/`strip`/`scissors` strip
-// `#` lines, so skipping them avoids false positives on git editor template
-// text (`# Please enter the commit message...`).
-const STRIPS_HASH_LINES: ReadonlySet<string> = new Set([
+// `verbatim` and `whitespace` cleanup modes keep `#` lines (and content below
+// the scissors line) in the recorded commit message, so we cannot blindly skip
+// either — quoted real data in those regions would slip through the scan.
+// `default`/`strip`/`scissors` drop both, so skipping them avoids false
+// positives on git editor template text and on the `-v` diff body.
+const DROPS_HASH_LINES_AND_SCISSORS: ReadonlySet<string> = new Set([
   "default",
   "strip",
   "scissors",
@@ -230,15 +230,17 @@ function parseCommitMessage(
 ): AddedLine[] {
   const result: AddedLine[] = [];
   const lines = text.split("\n");
-  const stripsHashLines = STRIPS_HASH_LINES.has(cleanupMode);
+  const dropsBelowScissors = DROPS_HASH_LINES_AND_SCISSORS.has(cleanupMode);
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
-    // Always honor the scissors marker: under `scissors` cleanup (and the
-    // implicit mode used by `git commit -v`) everything below it is dropped
-    // before the commit is recorded, and that region typically contains the
-    // diff which can include quoted strings unrelated to the message.
-    if (raw === COMMIT_MSG_SCISSORS) break;
-    if (stripsHashLines && raw.startsWith("#")) continue;
+    // Under `default`/`strip`/`scissors` cleanup (the modes used implicitly by
+    // `git commit -v`), everything from the scissors line down and all `#`
+    // comment lines are dropped before the commit is recorded. Under
+    // `verbatim`/`whitespace`, git keeps both, so we must scan them.
+    if (dropsBelowScissors) {
+      if (raw === COMMIT_MSG_SCISSORS) break;
+      if (raw.startsWith("#")) continue;
+    }
     // No previousContent tracking: prior-line suppression markers in commit
     // messages would survive into the recorded message (odd UX). Same-line
     // `generic-examples:ignore-line` still works via isSuppressed().
@@ -466,6 +468,26 @@ const COMMIT_MSG_TEST_CASES: CommitMsgTestCase[] = [
       'diff --git a/file.ts b/file.ts\n' +
       '+const e = "alice@gmail.com";\n',
     expectPatterns: [],
+  },
+  {
+    name: "content below scissors line is scanned under verbatim cleanup",
+    text:
+      'fix: bug\n\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      'diff --git a/file.ts b/file.ts\n' +
+      '+const e = "alice@gmail.com";\n',
+    cleanupMode: "verbatim",
+    expectPatterns: ["non-example-email"],
+  },
+  {
+    name: "content below scissors line is scanned under whitespace cleanup",
+    text:
+      'fix: bug\n\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      'diff --git a/file.ts b/file.ts\n' +
+      '+const e = "alice@gmail.com";\n',
+    cleanupMode: "whitespace",
+    expectPatterns: ["non-example-email"],
   },
   {
     name: "Co-Authored-By trailer with angle-bracketed email is OK",


### PR DESCRIPTION
Addresses Devin review feedback on #30097. `.githooks/README.md` line 65 implied scissors-line truncation matches git's commit-message behavior unconditionally, but it only does under `default`/`strip`/`scissors` cleanup — under `verbatim`/`whitespace` git keeps content below the scissors line. Mirrors the adjacent line 64 cleanup-mode note.

Also makes `scripts/check-generic-examples.ts` scissors handling cleanup-mode-aware so the hook actually matches git's recording behavior (previously it always truncated below the scissors line). Adds self-tests covering `verbatim` and `whitespace` cleanup modes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->