### PR TITLE
fix(provider): preserve web_search titles/URLs in orphan downgrade

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -766,6 +766,79 @@ describe("repairHistory", () => {
         (b as { text: string }).text.includes("srvtoolu_orphan"),
     );
     expect(downgraded).toBeDefined();
+    // Titles/URLs from the original results must survive the downgrade so
+    // the model can still reason about what was searched.
+    const text = (downgraded as { text: string }).text;
+    expect(text).toContain("Example");
+    expect(text).toContain("https://example.com");
+  });
+
+  test("preserves all titles/URLs when downgrading multi-result orphan", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "search" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_multi",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://alpha.test",
+                title: "Alpha",
+                encrypted_content: "enc_a",
+              },
+              {
+                type: "web_search_result",
+                url: "https://beta.test",
+                title: "Beta",
+                encrypted_content: "enc_b",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { messages: repaired } = repairHistory(messages);
+    const downgraded = repaired[1].content.find((b) => b.type === "text") as
+      | { text: string }
+      | undefined;
+    expect(downgraded).toBeDefined();
+    expect(downgraded!.text).toContain("Alpha");
+    expect(downgraded!.text).toContain("https://alpha.test");
+    expect(downgraded!.text).toContain("Beta");
+    expect(downgraded!.text).toContain("https://beta.test");
+    // Must NOT emit the legacy fixed placeholder.
+    expect(downgraded!.text).not.toContain("[web search result]");
+  });
+
+  test("downgrades error-envelope web_search orphan to a stable marker", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "search" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_err",
+            content: {
+              type: "web_search_tool_result_error",
+              error_code: "unavailable",
+            },
+          },
+        ],
+      },
+    ];
+
+    const { messages: repaired } = repairHistory(messages);
+    const downgraded = repaired[1].content.find((b) => b.type === "text") as
+      | { text: string }
+      | undefined;
+    expect(downgraded).toBeDefined();
+    expect(downgraded!.text).toContain("srvtoolu_err");
+    expect(downgraded!.text).toContain("results unavailable");
   });
 
   test("repairs both orphan directions within the same assistant message", () => {

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -318,9 +318,36 @@ function downgradeResult(tr: {
   content?: unknown;
 }): ContentBlock {
   const content =
-    tr.type === "tool_result" ? tr.content : "[web search result]"; // guard:allow-tool-result-only — distinguishes content format between the two types
+    tr.type === "tool_result" ? tr.content : formatWebSearchContent(tr.content); // guard:allow-tool-result-only — distinguishes content format between the two types
   return {
     type: "text",
     text: `[orphaned ${tr.type} for ${tr.tool_use_id}]: ${content}`,
   };
+}
+
+function formatWebSearchContent(content: unknown): string {
+  if (Array.isArray(content)) {
+    const entries: string[] = [];
+    for (const r of content) {
+      if (
+        typeof r !== "object" ||
+        r == null ||
+        (r as { type?: string }).type !== "web_search_result"
+      ) {
+        continue;
+      }
+      const title =
+        typeof (r as { title?: unknown }).title === "string"
+          ? (r as { title: string }).title
+          : "(untitled)";
+      const url =
+        typeof (r as { url?: unknown }).url === "string"
+          ? (r as { url: string }).url
+          : "";
+      const idx = entries.length + 1;
+      entries.push(url ? `${idx}. ${title}\n   ${url}` : `${idx}. ${title}`);
+    }
+    if (entries.length > 0) return entries.join("\n");
+  }
+  return "results unavailable";
 }


### PR DESCRIPTION
Addresses Codex review feedback on #30307. downgradeResult was emitting a fixed '[web search result]' placeholder when downgrading orphan web_search_tool_result blocks, dropping the original titles and URLs (the only searchable evidence the model could reason about) — contradicting the PR description's stated 'preserving titles/URLs for the model'. Now preserves the original block.content text.