### PR TITLE
fix(inspector): drop wake LLM logs without persisted message

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -68,6 +68,33 @@ mock.module("../../daemon/disk-pressure-guard.js", () => ({
   getDiskPressureStatus: () => mockDiskPressureStatus,
 }));
 
+const recordRequestLogCalls: Array<{
+  conversationId: string;
+  requestPayload: string;
+  responsePayload: string;
+  messageId?: string;
+  provider?: string;
+}> = [];
+mock.module("../../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: (
+    conversationId: string,
+    requestPayload: string,
+    responsePayload: string,
+    messageId?: string,
+    provider?: string,
+  ) => {
+    recordRequestLogCalls.push({
+      conversationId,
+      requestPayload,
+      responsePayload,
+      messageId,
+      provider,
+    });
+    return "log-id-test";
+  },
+  backfillMessageIdOnLogs: () => {},
+}));
+
 import type { AgentEvent } from "../../agent/loop.js";
 import type { Message } from "../../providers/types.js";
 import {
@@ -220,6 +247,7 @@ function makeTarget(options: {
 
 beforeEach(() => {
   __resetWakeChainForTests();
+  recordRequestLogCalls.length = 0;
   mockDiskPressureStatus = {
     enabled: false,
     state: "disabled",
@@ -1435,4 +1463,86 @@ describe("wakeAgentForOpportunity", () => {
       expect(uiBlock!.surfaceId).toBe(wakeProducedOutputCalls[0]);
     },
   );
+
+  test(
+    "silent no-op wake drops LLM request logs so a future backfillMessageIdOnLogs " +
+      "sweep cannot misattach them to an unrelated assistant reply",
+    async () => {
+      const usageEvent: AgentEvent = {
+        type: "usage",
+        inputTokens: 100,
+        outputTokens: 5,
+        model: "test-model",
+        actualProvider: "test-provider",
+        providerDurationMs: 10,
+        rawRequest: { request: "no-op wake" },
+        rawResponse: { response: "no output" },
+      };
+      const target = makeTarget({
+        baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        scriptedEvents: [usageEvent],
+        // Empty assistant text → silent no-op.
+        scriptedAssistant: {
+          role: "assistant",
+          content: [{ type: "text", text: "" }],
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: target.conversationId,
+          hint: "consider doing nothing",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => target },
+      );
+
+      expect(result).toEqual({ invoked: true, producedToolCalls: false });
+      // Nothing emitted, nothing persisted to the conversation.
+      expect(target.emittedEvents).toHaveLength(0);
+      expect(target.persistedTailCalls).toHaveLength(0);
+      // Critical: the LLM request log must NOT be inserted with messageId=NULL,
+      // otherwise the next user turn's backfillMessageIdOnLogs sweep would
+      // misattach this row to an unrelated future assistant reply.
+      expect(recordRequestLogCalls).toHaveLength(0);
+    },
+  );
+
+  test("wake that produces output persists buffered LLM request logs", async () => {
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: { request: "produced wake" },
+      rawResponse: { response: "real reply" },
+    };
+    const target = makeTarget({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(recordRequestLogCalls).toHaveLength(1);
+    expect(recordRequestLogCalls[0]).toMatchObject({
+      conversationId: target.conversationId,
+      provider: "test-provider",
+      messageId: undefined,
+    });
+  });
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -537,6 +537,36 @@ export async function wakeAgentForOpportunity(
     // only after `agentLoop.run()` returns.
     let mode: "buffering" | "live" = "buffering";
     const buffered: AgentEvent[] = [];
+    // LLM request logs accumulated while buffering. Persisted only if the
+    // wake transitions to live (i.e. produced output). A silent no-op wake
+    // drops them — otherwise the next user-turn's `backfillMessageIdOnLogs`
+    // sweep would misattach these NULL-messageId rows to an unrelated
+    // future assistant message, contaminating inspector context.
+    const pendingLogs: Array<{
+      requestPayload: string;
+      responsePayload: string;
+      provider?: string;
+    }> = [];
+    const persistLog = (record: {
+      requestPayload: string;
+      responsePayload: string;
+      provider?: string;
+    }): void => {
+      try {
+        recordRequestLog(
+          conversationId,
+          record.requestPayload,
+          record.responsePayload,
+          undefined,
+          record.provider,
+        );
+      } catch (err) {
+        log.warn(
+          { err, conversationId, source },
+          "agent-wake: failed to persist LLM request log (non-fatal)",
+        );
+      }
+    };
     const safeEmit = (event: AgentEvent): void => {
       try {
         target.emitAgentEvent(event);
@@ -550,20 +580,17 @@ export async function wakeAgentForOpportunity(
     const onEvent = (event: AgentEvent): void => {
       // Replicates the recordRequestLog side-effect in `handleUsage` because
       // wakes own their own onEvent and never reach `dispatchAgentEvent`.
+      // Defer persistence while buffering — see `pendingLogs` above.
       if (event.type === "usage" && event.rawRequest && event.rawResponse) {
-        try {
-          recordRequestLog(
-            conversationId,
-            JSON.stringify(event.rawRequest),
-            JSON.stringify(event.rawResponse),
-            undefined,
-            event.actualProvider,
-          );
-        } catch (err) {
-          log.warn(
-            { err, conversationId, source },
-            "agent-wake: failed to persist LLM request log (non-fatal)",
-          );
+        const record = {
+          requestPayload: JSON.stringify(event.rawRequest),
+          responsePayload: JSON.stringify(event.rawResponse),
+          provider: event.actualProvider,
+        };
+        if (mode === "buffering") {
+          pendingLogs.push(record);
+        } else {
+          persistLog(record);
         }
       }
       if (mode === "buffering") {
@@ -620,6 +647,10 @@ export async function wakeAgentForOpportunity(
         safeEmit(event);
       }
       buffered.length = 0;
+      for (const record of pendingLogs) {
+        persistLog(record);
+      }
+      pendingLogs.length = 0;
       mode = "live";
     };
 


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30051. Wake `onEvent` previously recorded LLM usage with `messageId=NULL` even when the wake produced no assistant message. A subsequent user-turn's `backfillMessageIdOnLogs` sweep then misattached those NULL-rows to an unrelated future assistant reply, contaminating inspector context.

Chose Option A: buffer LLM-log payloads alongside the existing event buffer during the wake's `buffering` mode and only persist them when the wake transitions to `live` (i.e. it actually produced output). Silent no-op wakes drop the pending logs entirely, so nothing with `messageId=NULL` ever lands in the table for the later sweep to grab. No schema change required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->