### PR TITLE
fix(recall): match camelCase secret filenames in SECRET_TOKEN_PATTERN

### DIFF
--- a/assistant/src/__tests__/context-search-workspace-source.test.ts
+++ b/assistant/src/__tests__/context-search-workspace-source.test.ts
@@ -126,10 +126,15 @@ describe("searchWorkspaceSource", () => {
     writeWorkspaceFile(root, "api-key.md", "needle key");
     writeWorkspaceFile(root, "secret-plan.md", "needle secret");
     writeWorkspaceFile(root, "token-cache.md", "needle token");
+    writeWorkspaceFile(root, "apiKey.json", "needle camel key");
+    writeWorkspaceFile(root, "userToken.txt", "needle camel token");
+    writeWorkspaceFile(root, "MySecret.md", "needle camel secret");
     writeWorkspaceFile(root, "credentials.json", "needle credentials");
     writeWorkspaceFile(root, "protected/readme.md", "needle protected");
     writeWorkspaceFile(root, "gateway-security/readme.md", "needle gateway");
     writeWorkspaceFile(root, "ces-security/readme.md", "needle ces");
+    writeWorkspaceFile(root, "keyboard.ts", "needle keyboard");
+    writeWorkspaceFile(root, "tokenizer.py", "needle tokenizer");
     writeWorkspaceFile(root, "src/readme.md", "needle safe");
 
     const result = await searchWorkspaceSource("needle", makeContext(root), 10);
@@ -138,7 +143,9 @@ describe("searchWorkspaceSource", () => {
       ".hidden.md:1",
       ".notes/.format-rec.md:1",
       ".notes/cake.md:1",
+      "keyboard.ts:1",
       "src/readme.md:1",
+      "tokenizer.py:1",
     ]);
   });
 

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -68,6 +68,9 @@ const SECRET_SEGMENT_NAMES = new Set([
 const SECRET_TOKEN_PATTERN =
   /(?:^|[-_.])(?:keys?|secrets?|tokens?)(?:[-_.]|$)/i;
 
+const SECRET_TOKEN_CAMEL_CASE_PATTERN =
+  /(?<=[a-z0-9])(?:Keys?|Secrets?|Tokens?)(?=[A-Z]|[-_.]|$)/;
+
 const QUERY_STOP_WORDS = new Set([
   "a",
   "about",
@@ -1185,6 +1188,7 @@ function shouldSkipSegmentName(name: string): boolean {
     GENERATED_OR_DEPENDENCY_DIR_NAMES.has(lowerName) ||
     lowerName.startsWith(".env") ||
     SECRET_TOKEN_PATTERN.test(lowerName) ||
+    SECRET_TOKEN_CAMEL_CASE_PATTERN.test(name) ||
     lowerName.startsWith("credentials") ||
     SECRET_SEGMENT_NAMES.has(lowerName)
   );


### PR DESCRIPTION
Addresses Codex P1 review feedback on #29978. Extend SECRET_TOKEN_PATTERN to detect lowercase→uppercase boundaries so camelCase secret-bearing filenames like apiKey.json and userToken.txt are caught, without re-introducing the over-broad substring match that previously flagged keyboard.ts / tokenizer.py.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->