### PR TITLE
fix(app-control): restore prior session on failed re-start

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -27,10 +27,8 @@ interface RegisteredInteraction {
 const registeredInteractions: RegisteredInteraction[] = [];
 
 mock.module("../runtime/pending-interactions.js", () => ({
-  register: (
-    _requestId: string,
-    entry: RegisteredInteraction,
-  ) => registeredInteractions.push(entry),
+  register: (_requestId: string, entry: RegisteredInteraction) =>
+    registeredInteractions.push(entry),
   resolve: (requestId: string) => {
     resolvedInteractionIds.push(requestId);
     return undefined;
@@ -595,6 +593,116 @@ describe("HostAppControlProxy", () => {
   });
 
   // -------------------------------------------------------------------------
+  // (c.1) Failed re-start restores the prior session
+  // -------------------------------------------------------------------------
+
+  describe("failed re-start restores prior session", () => {
+    test("non-running re-start in the same conversation restores the prior session", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // Establish an active session targeting the editor.
+      const p1 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await p1;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.editor");
+
+      // Re-start against a different app — host returns "missing".
+      sentMessages.length = 0;
+      const p2 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.other" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ state: "missing" }),
+      );
+      await p2;
+
+      // Prior session restored (editor) — not stranded as undefined and not
+      // overwritten with the failed re-start target.
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.editor");
+
+      proxy.dispose();
+    });
+
+    test("dispatch failure on re-start in the same conversation restores the prior session", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      const p1 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await p1;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.editor");
+
+      // Re-start against a different app, then abort before the host
+      // responds. The catch path in `request()` should restore the prior
+      // session rather than stranding the lock.
+      sentMessages.length = 0;
+      const reCtrl = new AbortController();
+      const p2 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.other" },
+        "conv-1",
+        reCtrl.signal,
+      );
+      reCtrl.abort();
+      const r = await p2;
+      expect(r.isError).toBe(true);
+      expect(r.content).toContain("Aborted");
+
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.editor");
+
+      proxy.dispose();
+    });
+
+    test("first-start failure releases the lock (no prior session to restore)", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // No prior session; re-start the first time and get a non-running.
+      const p1 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ state: "missing" }),
+      );
+      await p1;
+
+      // Lock released so another conversation can acquire.
+      expect(_getActiveAppControlSession()).toBeUndefined();
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // (d) dispose releases the lock
   // -------------------------------------------------------------------------
 
@@ -805,8 +913,8 @@ describe("HostAppControlProxy", () => {
         { tool: "observe", app: "com.example.app" },
         "conv-1",
         ctrl.signal,
-        "actor-principal-1",    // sourceActorPrincipalId
-        "client-A",             // targetClientId
+        "actor-principal-1", // sourceActorPrincipalId
+        "client-A", // targetClientId
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -840,8 +948,8 @@ describe("HostAppControlProxy", () => {
         { tool: "observe", app: "com.example.app" },
         "conv-1",
         ctrl.signal,
-        "user-1",    // sourceActorPrincipalId
-        "client-A",  // targetClientId → hub resolves actorPrincipalId = "user-1"
+        "user-1", // sourceActorPrincipalId
+        "client-A", // targetClientId → hub resolves actorPrincipalId = "user-1"
       );
 
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -863,8 +971,8 @@ describe("HostAppControlProxy", () => {
         { tool: "start", app: "com.example.app" },
         "conv-1",
         ctrl.signal,
-        "user-1",    // sourceActorPrincipalId
-        undefined,   // no targetClientId
+        "user-1", // sourceActorPrincipalId
+        undefined, // no targetClientId
       );
 
       const sent = sentMessages[0] as Record<string, unknown>;

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -17,9 +17,12 @@
  * targets the user's actual desktop application, which is a host-wide
  * resource. It is acquired optimistically when `app_control_start` is
  * dispatched (storing `(conversationId, app)`) so that the synchronous
- * guard and the asynchronous host round-trip cannot race; it is released
- * when the host returns a non-running state, the dispatch fails, or the
- * owning proxy's `dispose()` fires.
+ * guard and the asynchronous host round-trip cannot race; the prior
+ * session value is snapshotted before the overwrite and restored if the
+ * dispatch fails or the host returns a non-running state, so a failed
+ * re-start within the same conversation does not strand the original
+ * session. The lock is released outright when the owning proxy's
+ * `dispose()` fires.
  *
  * `app_control_start` is the only tool that can acquire the lock — the
  * user's medium-risk approval at start time is the consent boundary. All
@@ -236,6 +239,7 @@ export class HostAppControlProxy extends HostProxyBase<
     // belong to the active session and target the same `app`. Without this
     // gate, prompt-injected calls would bypass the start-time approval and
     // send raw input to arbitrary apps.
+    let priorSession: ActiveAppControlSession | undefined;
     if (input.tool === "start") {
       if (
         activeAppControlSession != null &&
@@ -249,11 +253,16 @@ export class HostAppControlProxy extends HostProxyBase<
           isError: true,
         };
       }
+      // Snapshot the prior session before the optimistic overwrite so a
+      // failed re-start within the same conversation can restore it rather
+      // than stranding the original session. For a first start from a
+      // clean state this is `undefined` (restore == release).
+      priorSession = activeAppControlSession;
       // Acquire optimistically to close the TOCTOU window between this
       // synchronous guard and the asynchronous `dispatchRequest` below. Two
       // concurrent starts from different conversations would otherwise both
       // see `activeAppControlSession == null` and both pass the guard. The
-      // lock is released below if dispatch fails or the host returns a
+      // lock is rolled back below if dispatch fails or the host returns a
       // non-running state.
       activeAppControlSession = {
         conversationId: this.conversationId,
@@ -278,10 +287,13 @@ export class HostAppControlProxy extends HostProxyBase<
         undefined,
         targetClientId,
       );
-      return this.handleSuccess(input, payload);
+      if (input.tool === "start" && payload.state !== "running") {
+        this.restoreSessionIfHeld(priorSession);
+      }
+      return this.handleSuccess(payload);
     } catch (err) {
       if (input.tool === "start") {
-        this.releaseSessionIfHeld();
+        this.restoreSessionIfHeld(priorSession);
       }
       if (err instanceof HostProxyRequestError) {
         if (err.reason === "timeout") {
@@ -301,9 +313,17 @@ export class HostAppControlProxy extends HostProxyBase<
     }
   }
 
-  private releaseSessionIfHeld(): void {
+  /**
+   * Restore the module-level session to `prior` only if this proxy is the
+   * current holder. Used to roll back the optimistic overwrite performed
+   * by a `start` when the dispatch fails or the host returns non-running.
+   * Passing `undefined` releases the lock outright (used by `dispose()`).
+   */
+  private restoreSessionIfHeld(
+    prior: ActiveAppControlSession | undefined,
+  ): void {
     if (activeAppControlSession?.conversationId === this.conversationId) {
-      activeAppControlSession = undefined;
+      activeAppControlSession = prior;
     }
   }
 
@@ -312,7 +332,6 @@ export class HostAppControlProxy extends HostProxyBase<
   // ---------------------------------------------------------------------------
 
   private handleSuccess(
-    input: HostAppControlInput,
     payload: HostAppControlResultPayload,
   ): ToolExecutionResult {
     // Update PNG-hash loop tracking only for the "running" state — other
@@ -330,14 +349,6 @@ export class HostAppControlProxy extends HostProxyBase<
       if (this.observationHashRepeatCount >= STUCK_REPEAT_THRESHOLD) {
         stuck = true;
       }
-    }
-
-    // The optimistic lock acquired in `request()` for `start` stays held
-    // only when the host confirms the session is running. Non-running
-    // outcomes (missing/minimized) release it so a retry or another
-    // conversation can acquire.
-    if (input.tool === "start" && payload.state !== "running") {
-      this.releaseSessionIfHeld();
     }
 
     return this.formatResult(payload, stuck);
@@ -409,6 +420,6 @@ export class HostAppControlProxy extends HostProxyBase<
    */
   override dispose(): void {
     super.dispose();
-    this.releaseSessionIfHeld();
+    this.restoreSessionIfHeld(undefined);
   }
 }


### PR DESCRIPTION
Addresses Codex / Devin review feedback on #30083. Capture activeAppControlSession before optimistic overwrite and restore it (rather than calling releaseSessionIfHeld) when dispatch fails or the host returns non-running, so a failed re-start within the same conversation doesn't strand the original session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->