### PR TITLE
fix(runtime): guard bg-job conversationId on result.ok at callers

### DIFF
--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -31,6 +31,7 @@ const runBackgroundJobOptions: Array<{
   onConversationCreated?: (id: string) => void;
 }> = [];
 let runBackgroundJobShouldFail = false;
+let runBackgroundJobBootstrapFails = false;
 mock.module("../runtime/background-job-runner.js", () => ({
   runBackgroundJob: async (opts: {
     prompt: string;
@@ -40,6 +41,25 @@ mock.module("../runtime/background-job-runner.js", () => ({
     suppressFailureNotifications?: boolean;
     onConversationCreated?: (id: string) => void;
   }) => {
+    runBackgroundJobOptions.push({
+      conversationType: opts.conversationType,
+      scheduleJobId: opts.scheduleJobId,
+      groupId: opts.groupId,
+      suppressFailureNotifications: opts.suppressFailureNotifications,
+      onConversationCreated: opts.onConversationCreated,
+    });
+    // Bootstrap-failure path: the real runner returns conversationId: ""
+    // when `bootstrapConversation` throws before assignment. Skip the
+    // callback (it was never reached) and surface the empty id to the
+    // scheduler so it can exercise the sentinel guard.
+    if (runBackgroundJobBootstrapFails) {
+      return {
+        conversationId: "",
+        ok: false,
+        error: new Error("Bootstrap failure"),
+        errorKind: "exception" as const,
+      };
+    }
     const { createConversation } =
       await import("../memory/conversation-crud.js");
     const conv = createConversation({
@@ -48,13 +68,6 @@ mock.module("../runtime/background-job-runner.js", () => ({
       source: "schedule",
       ...(opts.groupId ? { groupId: opts.groupId } : {}),
       ...(opts.scheduleJobId ? { scheduleJobId: opts.scheduleJobId } : {}),
-    });
-    runBackgroundJobOptions.push({
-      conversationType: opts.conversationType,
-      scheduleJobId: opts.scheduleJobId,
-      groupId: opts.groupId,
-      suppressFailureNotifications: opts.suppressFailureNotifications,
-      onConversationCreated: opts.onConversationCreated,
     });
     // Mirror the real runner's contract: fire the SSE callback synchronously
     // BEFORE the job's processMessage finishes, with the bootstrap-returned
@@ -137,6 +150,7 @@ describe("scheduler conversation reuse", () => {
     processedMessages.length = 0;
     runBackgroundJobOptions.length = 0;
     runBackgroundJobShouldFail = false;
+    runBackgroundJobBootstrapFails = false;
   });
 
   test("recurring schedule with reuseConversation=true reuses conversation across runs", async () => {
@@ -393,6 +407,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     processedMessages.length = 0;
     runBackgroundJobOptions.length = 0;
     runBackgroundJobShouldFail = false;
+    runBackgroundJobBootstrapFails = false;
   });
 
   test("talk-mode propagates conversationType=scheduled, scheduleJobId, and quiet=>suppressFailureNotifications", async () => {
@@ -441,6 +456,38 @@ describe("scheduler talk-mode runner option propagation", () => {
     expect(runBackgroundJobOptions[0]!.suppressFailureNotifications).toBe(
       false,
     );
+  });
+
+  test("talk-mode bootstrap failure writes sentinel conversationId, not empty string", async () => {
+    /**
+     * Regression: `runBackgroundJob` returns `{ conversationId: "", ok: false }`
+     * when bootstrap throws before the conversation row is assigned. The
+     * scheduler previously stored that empty string in the cron_runs DB row.
+     * Guard ensures we substitute a recognizable sentinel.
+     */
+    const rruleExpr = buildEveryMinuteRrule();
+    const schedule = createSchedule({
+      name: "Bootstrap Failure",
+      cronExpression: rruleExpr,
+      message: "x",
+      syntax: "rrule",
+      expression: rruleExpr,
+    });
+    forceScheduleDue(schedule.id);
+    runBackgroundJobBootstrapFails = true;
+
+    const processMessage = async () => {};
+    const scheduler = startScheduler(processMessage, () => {});
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs.length).toBe(1);
+    expect(runs[0].status).toBe("error");
+    // Critical: must NOT be empty — the DB column should carry a marker that
+    // identifies this run as a bootstrap-failure case.
+    expect(runs[0].conversationId).not.toBe("");
+    expect(runs[0].conversationId).toBe(`bootstrap-error:${schedule.id}`);
   });
 
   test("talk-mode fires onScheduleConversationCreated synchronously via runner callback (BEFORE the runner returns)", async () => {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -549,7 +549,13 @@ export async function runScheduleOnce(
           });
         },
       });
-      conversationId = result.conversationId;
+      // Bootstrap-failure path returns `conversationId: ""`. Substitute a
+      // sentinel so the schedule-run DB row carries a recognizable marker
+      // instead of an empty string.
+      conversationId =
+        result.conversationId !== ""
+          ? result.conversationId
+          : `bootstrap-error:${job.id}`;
       ok = result.ok;
       errorMsg = result.error?.message;
     }

--- a/assistant/src/watcher/__tests__/engine.test.ts
+++ b/assistant/src/watcher/__tests__/engine.test.ts
@@ -250,6 +250,28 @@ describe("runWatchersOnce — Phase 2 runBackgroundJob integration", () => {
     expect(dispositionCalls[0].reason).toBe("model exploded");
   });
 
+  test("on bootstrap failure (conversationId: ''): does not overwrite prior conversation id", async () => {
+    fakeWatchers = [makeWatcher()];
+    fakePending = [makeEvent()];
+    // bootstrap failure shape from runBackgroundJob — empty conversationId
+    // signals that conversation creation failed before assignment.
+    runJobImpl = async () => ({
+      conversationId: "",
+      ok: false,
+      error: new Error("bootstrap exploded"),
+      errorKind: "exception",
+    });
+
+    await runWatchersOnce(() => {});
+
+    // Critical: we must NOT have called setWatcherConversationId with "",
+    // which would clobber a valid prior conversation id in the DB.
+    expect(setConvCalls).toEqual([]);
+    // Failure path still updates event dispositions.
+    expect(dispositionCalls).toHaveLength(1);
+    expect(dispositionCalls[0].disposition).toBe("error");
+  });
+
   test("skips runBackgroundJob entirely when no pending events", async () => {
     fakeWatchers = [makeWatcher()];
     fakePending = [];

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -263,8 +263,12 @@ export async function runWatchersOnce(
     });
 
     // Persist the per-tick conversation id so downstream surfaces (UI,
-    // store reads) can link back to the most recent watcher run.
-    setWatcherConversationId(watcher.id, result.conversationId);
+    // store reads) can link back to the most recent watcher run. Skip
+    // persistence when the runner failed before bootstrap (conversationId
+    // is empty) — otherwise we'd overwrite a valid prior id with "".
+    if (result.conversationId !== "") {
+      setWatcherConversationId(watcher.id, result.conversationId);
+    }
 
     if (result.ok) {
       // Mark events as silent by default. The LLM is expected to use


### PR DESCRIPTION
Addresses Devin P1 / Codex P1 review feedback on #30042. Both watcher/engine.ts and schedule/scheduler.ts consumed runBackgroundJob's new failure return shape unconditionally, overwriting a valid prior conversationId with '' or storing '' in the DB. Guard both call sites on result.ok before using conversationId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->