### PR TITLE
fix(filing): retry compaction when filing run is in-flight

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -303,6 +303,116 @@ describe("FilingService", () => {
       expect(processMessageCalls).toHaveLength(1);
     });
 
+    // Helpers for the compaction-retry tests: hold the filing run open by
+    // making processMessage return a manually-resolved promise, so `activeRun`
+    // stays set and runCompactionOnce() sees the contention path.
+    function holdFilingRun(): {
+      release: () => void;
+      filingCalls: () => number;
+      compactionCalls: () => number;
+      waitForFilingStarted: () => Promise<void>;
+    } {
+      let release: (() => void) | undefined;
+      let started = false;
+      let filingCalls = 0;
+      let compactionCalls = 0;
+
+      setTestProcessMessage((...args: unknown[]) => {
+        const callSite = (args[3] as { callSite?: string } | undefined)
+          ?.callSite;
+        if (callSite === "filingAgent") {
+          filingCalls += 1;
+          started = true;
+          return new Promise((resolve) => {
+            release = () => resolve({ messageId: "filing-done" });
+          });
+        }
+        if (callSite === "compactionAgent") {
+          compactionCalls += 1;
+        }
+        return Promise.resolve({ messageId: "mock" });
+      });
+
+      return {
+        release: () => release?.(),
+        filingCalls: () => filingCalls,
+        compactionCalls: () => compactionCalls,
+        waitForFilingStarted: async () => {
+          while (!started) await Promise.resolve();
+        },
+      };
+    }
+
+    test("schedules a near-term retry when filing run is in-flight", async () => {
+      const hold = holdFilingRun();
+      // 5s retry override paired with a production-realistic 24h compaction
+      // interval — the assertion proves retry << interval.
+      const retryMs = 5_000;
+      mockConfig.filing.compactionIntervalMs = 24 * 60 * 60 * 1000;
+      const service = new FilingService({
+        compactionContendedRetryMs: retryMs,
+      });
+      const filingPromise = service.runOnce();
+      await hold.waitForFilingStarted();
+
+      const beforeRetry = Date.now();
+      const ran = await service.runCompactionOnce();
+
+      expect(ran).toBe(false);
+      expect(service.nextCompactionAt).not.toBeNull();
+      const nextAt = service.nextCompactionAt!;
+      expect(nextAt - beforeRetry).toBeLessThan(
+        mockConfig.filing.compactionIntervalMs,
+      );
+      expect(nextAt - beforeRetry).toBeLessThanOrEqual(retryMs + 100);
+
+      hold.release();
+      await filingPromise;
+      await service.stop();
+    });
+
+    test("retry fires after filing run completes", async () => {
+      const hold = holdFilingRun();
+      const service = new FilingService({ compactionContendedRetryMs: 1 });
+      const filingPromise = service.runOnce();
+      await hold.waitForFilingStarted();
+
+      const skipped = await service.runCompactionOnce();
+      expect(skipped).toBe(false);
+      expect(hold.compactionCalls()).toBe(0);
+
+      hold.release();
+      await filingPromise;
+
+      const start = Date.now();
+      while (hold.compactionCalls() === 0 && Date.now() - start < 1000) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      expect(hold.filingCalls()).toBe(1);
+      expect(hold.compactionCalls()).toBe(1);
+
+      await service.stop();
+    });
+
+    test("stop() clears a scheduled compaction retry", async () => {
+      const hold = holdFilingRun();
+      const service = new FilingService({ compactionContendedRetryMs: 50 });
+      const filingPromise = service.runOnce();
+      await hold.waitForFilingStarted();
+      await service.runCompactionOnce();
+      expect(service.nextCompactionAt).not.toBeNull();
+
+      hold.release();
+      await filingPromise;
+      await service.stop();
+
+      // After stop, the retry timer must be cleared and never fire.
+      expect(service.nextCompactionAt).toBeNull();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(hold.compactionCalls()).toBe(0);
+    });
+
     test("respects active hours", async () => {
       mockConfig.filing.activeHoursStart = 9;
       mockConfig.filing.activeHoursEnd = 17;

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -17,6 +17,11 @@ const log = getLogger("filing-service");
 
 const FILING_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
+// When compaction skips because a filing run holds the serialization lock,
+// retry on this near-term cadence so phase-aligned 24h timers don't starve
+// compaction across consecutive ticks.
+const COMPACTION_CONTENDED_RETRY_MS = 10 * 60 * 1000; // 10 minutes
+
 const FILING_PROMPT_TEMPLATE = `You are running a periodic knowledge base filing job. This is a background maintenance task focused on the buffer.
 
 Read \`pkb/buffer.md\`. For each item in the buffer:
@@ -66,6 +71,7 @@ This is your knowledge base — keep it sharp.`;
 
 export interface FilingDeps {
   getCurrentHour?: () => number;
+  compactionContendedRetryMs?: number;
 }
 
 export class FilingService {
@@ -79,6 +85,7 @@ export class FilingService {
   private readonly deps: FilingDeps;
   private timer: ReturnType<typeof setInterval> | null = null;
   private compactionTimer: ReturnType<typeof setInterval> | null = null;
+  private compactionRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private activeRun: Promise<void> | null = null;
   private activeCompactionRun: Promise<void> | null = null;
   private _lastRunAt: number | null = null;
@@ -157,6 +164,7 @@ export class FilingService {
       clearInterval(this.compactionTimer);
       this.compactionTimer = null;
     }
+    this.clearCompactionRetry();
     this._nextRunAt = null;
     this._nextCompactionAt = null;
     this.start();
@@ -171,6 +179,7 @@ export class FilingService {
       clearInterval(this.compactionTimer);
       this.compactionTimer = null;
     }
+    this.clearCompactionRetry();
     this._nextRunAt = null;
     this._nextCompactionAt = null;
     const inflight: Promise<void>[] = [];
@@ -269,9 +278,13 @@ export class FilingService {
       log.debug(
         "Filing run in progress, skipping compaction to avoid concurrent PKB writes",
       );
+      this.scheduleCompactionRetry(
+        this.deps.compactionContendedRetryMs ?? COMPACTION_CONTENDED_RETRY_MS,
+      );
       return false;
     }
 
+    this.clearCompactionRetry();
     const run = this.executeCompactionRun();
     this.activeCompactionRun = run;
     try {
@@ -299,6 +312,27 @@ export class FilingService {
 
   private scheduleNextCompactionRun(intervalMs: number): void {
     this._nextCompactionAt = Date.now() + intervalMs;
+  }
+
+  private scheduleCompactionRetry(delayMs: number): void {
+    this.clearCompactionRetry();
+    this.compactionRetryTimer = setTimeout(() => {
+      this.compactionRetryTimer = null;
+      this.runCompactionOnce().catch((err) => {
+        log.error({ err }, "Compaction retry failed");
+      });
+    }, delayMs);
+    // unref so the pending retry doesn't keep the daemon process alive on
+    // shutdown paths that don't call stop().
+    this.compactionRetryTimer.unref?.();
+    this._nextCompactionAt = Date.now() + delayMs;
+  }
+
+  private clearCompactionRetry(): void {
+    if (this.compactionRetryTimer) {
+      clearTimeout(this.compactionRetryTimer);
+      this.compactionRetryTimer = null;
+    }
   }
 
   private shouldSkipForDiskPressure(source: "filing" | "compaction"): boolean {


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30015. When compaction skips because a filing run holds the new serialization lock, schedule a near-term retry instead of waiting for the next 24h tick — otherwise phase-aligned filing/compaction timers can starve compaction across consecutive cycles.