### PR TITLE
fix(compaction): preserve boundary tool_results and tighten /compact tests

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -129,10 +129,11 @@ describe("ContextWindowManager", () => {
     // `tool_result(tool-1)`. Once the projection-optimism clamp
     // decrements the keep boundary to that user turn,
     // `adjustForToolPairs` walks the boundary back through the
-    // tool_use/tool_result chain to index 0 — under the old code that
-    // routed `/compact` through the "already fits" skip path. With the
-    // rescue, summarization runs and orphan `tool_result` blocks are
-    // stripped from the kept region.
+    // tool_use/tool_result chain to index 0. The force-rescue must run
+    // summarization in this case; any boundary `tool_result` blocks
+    // whose matching `tool_use` lives in the compacted region must be
+    // captured by the summary and stripped from the kept region so the
+    // next LLM request does not fail.
     const history: Message[] = [
       {
         role: "assistant",
@@ -224,18 +225,17 @@ describe("ContextWindowManager", () => {
         targetBudgetRatio: 0.5,
       }),
     });
-    // Two user turns separated by a single assistant message — the
-    // smallest realistic conversation where a forced compaction has
-    // anything to summarize. After the projection clamp + rescue, the
-    // compactable region is at most one user turn (the first one),
-    // which can fall below `MIN_COMPACTABLE_PERSISTED_MESSAGES`. The
-    // bypass must let summarization run instead of returning
-    // "insufficient compactable persisted messages".
+    // Two user turns — after the projection clamp the compactable
+    // region is a single user message, below
+    // `MIN_COMPACTABLE_PERSISTED_MESSAGES`. The precomputed estimate
+    // sits above the compaction threshold (60%) but below the severe
+    // pressure ratio (95%), so only the forced-compaction bypass keeps
+    // summarization running.
     const history: Message[] = [message("user", "u1"), message("user", "u2")];
 
     const result = await manager.maybeCompact(history, undefined, {
       force: true,
-      precomputedEstimate: 50_000,
+      precomputedEstimate: 8_000,
     });
 
     expect(result.compacted).toBe(true);

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -729,12 +729,44 @@ export class ContextWindowManager {
     const retainedThreadRefs = collectRetainedThreadReferences(
       messages.slice(keepPlan.keepFromIndex),
     );
+    // Force-rescue path: the kept region may begin with a `tool_result`
+    // whose matching `tool_use` lives in the (now-compacted) prefix. We
+    // must remove those orphan blocks before sending to the LLM (which
+    // would reject them), but their content was never visible to the
+    // summarizer either — `compactableMessages` ends before the boundary.
+    // Split them out here so they can (a) be fed into the summarizer as
+    // part of the compacted transcript, and (b) be stripped from the
+    // kept region below. Without this routing the orphan tool_result
+    // content is silently lost.
+    const { messages: truncatedKeptMessages } =
+      truncateToolResultsAcrossHistory(
+        messages.slice(keepPlan.keepFromIndex),
+        COMPACTION_TOOL_RESULT_MAX_CHARS,
+      );
+    const { orphans: boundaryOrphanToolResults, stripped: keptMessages } =
+      forceRescueApplied
+        ? splitOrphanToolResults(truncatedKeptMessages)
+        : {
+            orphans: [] as ContentBlock[],
+            stripped: truncatedKeptMessages,
+          };
+    const summaryInputMessages =
+      boundaryOrphanToolResults.length > 0
+        ? [
+            ...compactableMessages,
+            {
+              role: "user" as const,
+              content: boundaryOrphanToolResults,
+            },
+          ]
+        : compactableMessages;
     // Strip runtime injections (memory, turn context, workspace hints, etc.)
     // from the messages fed to the summarizer. These blocks are system
     // metadata; leaving them in causes the summary to echo rotating memory
     // content instead of the actual conversation. The caller's live message
     // array is untouched so prefix caching stays intact.
-    const transcriptSource = stripCompactionOnlyInjections(compactableMessages);
+    const transcriptSource =
+      stripCompactionOnlyInjections(summaryInputMessages);
     const transcriptBlocks = this.capTranscriptBlocksToTokenBudget(
       serializeMessagesToContentBlocks(transcriptSource),
       existingSummary ?? "No previous summary.",
@@ -782,18 +814,6 @@ export class ContextWindowManager {
     // describe their visual content in the summary text.
     const summaryMessage = createContextSummaryMessage(summary);
 
-    const { messages: truncatedKeptMessages } =
-      truncateToolResultsAcrossHistory(
-        messages.slice(keepPlan.keepFromIndex),
-        COMPACTION_TOOL_RESULT_MAX_CHARS,
-      );
-    // The force-rescue boundary bypasses `adjustForToolPairs`, so the
-    // kept region may contain `tool_result` blocks whose matching
-    // `tool_use` is in the (now-compacted) prefix. Strip those orphans
-    // so the next agent turn does not fail with an LLM API error.
-    const keptMessages = forceRescueApplied
-      ? stripOrphanToolResults(truncatedKeptMessages)
-      : truncatedKeptMessages;
     const compactedMessages = [summaryMessage, ...keptMessages];
     const estimatedInputTokens = estimatePromptTokens(
       compactedMessages,
@@ -1330,16 +1350,22 @@ function adjustForToolPairs(
 }
 
 /**
- * Strip `tool_result` blocks whose matching `tool_use` is not present in
+ * Split `tool_result` blocks whose matching `tool_use` is not present in
  * the message array. Used by the force-rescue path in `_maybeCompact`
  * which bypasses `adjustForToolPairs` to honor user-explicit `/compact`
  * commands — the kept region's first user message can otherwise contain
  * an orphan `tool_result`, which the LLM API rejects.
  *
- * A user message that contains only orphan `tool_result` blocks is
- * dropped entirely; partial messages keep the surviving content blocks.
+ * Returns the orphan blocks alongside the stripped message array so the
+ * caller can route their content into the summarizer rather than
+ * dropping it silently. A user message that contains only orphan
+ * `tool_result` blocks is dropped entirely; partial messages keep the
+ * surviving content blocks.
  */
-function stripOrphanToolResults(messages: Message[]): Message[] {
+function splitOrphanToolResults(messages: Message[]): {
+  orphans: ContentBlock[];
+  stripped: Message[];
+} {
   const knownToolUseIds = new Set<string>();
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
@@ -1353,9 +1379,10 @@ function stripOrphanToolResults(messages: Message[]): Message[] {
     }
   }
 
-  return messages.flatMap((msg) => {
+  const orphans: ContentBlock[] = [];
+  const stripped = messages.flatMap((msg) => {
     if (msg.role !== "user") return [msg];
-    let stripped = false;
+    let changed = false;
     const filtered = msg.content.filter((block) => {
       if (
         (block.type === "tool_result" ||
@@ -1364,16 +1391,18 @@ function stripOrphanToolResults(messages: Message[]): Message[] {
       ) {
         const id = (block as { tool_use_id: string }).tool_use_id;
         if (!knownToolUseIds.has(id)) {
-          stripped = true;
+          orphans.push(block);
+          changed = true;
           return false;
         }
       }
       return true;
     });
-    if (!stripped) return [msg];
+    if (!changed) return [msg];
     if (filtered.length === 0) return [];
     return [{ ...msg, content: filtered }];
   });
+  return { orphans, stripped };
 }
 
 export function getSummaryFromContextMessage(


### PR DESCRIPTION
Addresses Codex / Devin review feedback on #30344. (1) Preserve boundary tool_results that fall just outside the keepFromIndex summarization range so stripOrphanToolResults doesn't silently drop them. (2) Rewrite the history-narrating comment in context-window-manager.test.ts:132-133 to describe current behavior. (3) Tighten the below-MIN test so it isolates the new !options?.force path instead of tripping severePressure via precomputedEstimate=50_000.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->