### PR TITLE
fix(migrations): resolve full call-site provider context in migration 057

### DIFF
--- a/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
+++ b/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
@@ -275,6 +275,99 @@ describe("057-repair-stale-gemini-model-ids migration", () => {
     expect(config.llm.profiles.balanced.model).toBe("gemini-3-flash-preview");
   });
 
+  test("rewrites call-site model when site.profile resolves to Gemini despite non-Gemini default", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama-3.1" },
+        profiles: {
+          geminiProfile: {
+            provider: "gemini",
+            model: "gemini-3-flash-preview",
+          },
+        },
+        callSites: {
+          memoryRetrieval: {
+            profile: "geminiProfile",
+            model: "gemini-3-flash",
+          },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { memoryRetrieval: { model: string } } };
+    };
+    expect(config.llm.callSites.memoryRetrieval.model).toBe(
+      "gemini-3.1-flash-lite-preview",
+    );
+  });
+
+  test("rewrites call-site model when activeProfile resolves to Gemini despite non-Gemini default", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama-3.1" },
+        activeProfile: "geminiActive",
+        profiles: {
+          geminiActive: { provider: "gemini", model: "gemini-3-flash-preview" },
+        },
+        callSites: {
+          recall: { model: "gemini-3-flash" },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { recall: { model: string } } };
+    };
+    expect(config.llm.callSites.recall.model).toBe("gemini-3-flash-preview");
+  });
+
+  test("does not rewrite call-site model when local provider override beats Gemini activeProfile", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-3-flash-preview" },
+        activeProfile: "geminiActive",
+        profiles: {
+          geminiActive: { provider: "gemini", model: "gemini-3-flash-preview" },
+        },
+        callSites: {
+          recall: { provider: "ollama", model: "gemini-3-flash" },
+        },
+      },
+    });
+    const before = readFileSync(configPath(), "utf-8");
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("mainAgent: rewrites when activeProfile is Gemini even if callSites.mainAgent.provider is non-Gemini", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama-3.1" },
+        activeProfile: "geminiActive",
+        profiles: {
+          geminiActive: { provider: "gemini", model: "gemini-3-flash-preview" },
+        },
+        callSites: {
+          mainAgent: { provider: "ollama", model: "gemini-3-flash" },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { mainAgent: { model: string } } };
+    };
+    expect(config.llm.callSites.mainAgent.model).toBe("gemini-3-flash-preview");
+  });
+
   test("no-ops when config.json is missing or invalid", () => {
     repairStaleGeminiModelIdsMigration.run(workspaceDir);
     expect(existsSync(configPath())).toBe(false);

--- a/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
+++ b/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
@@ -35,8 +35,15 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
 
     const defaultBlock = readObject(llm.default);
     const defaultProvider = readProvider(defaultBlock);
+    const profiles = readObject(llm.profiles);
+    const activeProfileName =
+      typeof llm.activeProfile === "string" ? llm.activeProfile : undefined;
+    const activeProfileProvider =
+      profiles !== null && activeProfileName !== undefined
+        ? readProvider(readObject(profiles[activeProfileName]))
+        : undefined;
 
-    if (defaultBlock !== null && isGeminiBlock(defaultBlock, defaultProvider)) {
+    if (defaultBlock !== null && isGeminiProvider(defaultProvider)) {
       changed = repairModel(defaultBlock, DEFAULT_REPLACEMENT_MODEL) || changed;
     }
 
@@ -45,7 +52,14 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       for (const [site, rawConfig] of Object.entries(callSites)) {
         const callSiteConfig = readObject(rawConfig);
         if (callSiteConfig === null) continue;
-        if (!isGeminiBlock(callSiteConfig, defaultProvider)) continue;
+        const effective = resolveCallSiteEffectiveProvider({
+          callSite: site,
+          callSiteConfig,
+          profiles,
+          activeProfileProvider,
+          defaultProvider,
+        });
+        if (!isGeminiProvider(effective)) continue;
         const replacement = LATENCY_CALL_SITES.has(site)
           ? LATENCY_REPLACEMENT_MODEL
           : DEFAULT_REPLACEMENT_MODEL;
@@ -53,12 +67,12 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       }
     }
 
-    const profiles = readObject(llm.profiles);
     if (profiles !== null) {
       for (const rawProfile of Object.values(profiles)) {
         const profile = readObject(rawProfile);
         if (profile === null) continue;
-        if (!isGeminiBlock(profile, defaultProvider)) continue;
+        const effective = readProvider(profile) ?? defaultProvider;
+        if (!isGeminiProvider(effective)) continue;
         changed = repairModel(profile, DEFAULT_REPLACEMENT_MODEL) || changed;
       }
     }
@@ -109,14 +123,51 @@ function readProvider(
   return typeof block.provider === "string" ? block.provider : undefined;
 }
 
-// A block targets Gemini if it explicitly sets provider="gemini", or if it has
-// no provider field and the default block resolves to Gemini. An explicit
-// non-Gemini provider blocks the rewrite.
-function isGeminiBlock(
-  block: Record<string, unknown>,
-  defaultProvider: string | undefined,
-): boolean {
-  const local = readProvider(block);
-  const effective = local ?? defaultProvider;
-  return effective === undefined || effective === "gemini";
+function isGeminiProvider(provider: string | undefined): boolean {
+  return provider === undefined || provider === "gemini";
+}
+
+// Walks the call-site provider resolution chain the same way
+// `resolveCallSiteConfig` does: for `mainAgent`, `activeProfile` overrides the
+// static `callSites.mainAgent` block, while for every other call site the
+// call-site block (and its referenced profile) wins over `activeProfile`.
+// Returns the highest-precedence explicit provider, falling back to `default`.
+function resolveCallSiteEffectiveProvider(args: {
+  callSite: string;
+  callSiteConfig: Record<string, unknown>;
+  profiles: Record<string, unknown> | null;
+  activeProfileProvider: string | undefined;
+  defaultProvider: string | undefined;
+}): string | undefined {
+  const {
+    callSite,
+    callSiteConfig,
+    profiles,
+    activeProfileProvider,
+    defaultProvider,
+  } = args;
+  const siteProvider = readProvider(callSiteConfig);
+  const siteProfileName =
+    typeof callSiteConfig.profile === "string"
+      ? callSiteConfig.profile
+      : undefined;
+  const siteProfileProvider =
+    profiles !== null && siteProfileName !== undefined
+      ? readProvider(readObject(profiles[siteProfileName]))
+      : undefined;
+
+  if (callSite === "mainAgent") {
+    return (
+      activeProfileProvider ??
+      siteProvider ??
+      siteProfileProvider ??
+      defaultProvider
+    );
+  }
+  return (
+    siteProvider ??
+    siteProfileProvider ??
+    activeProfileProvider ??
+    defaultProvider
+  );
 }


### PR DESCRIPTION
Addresses Codex P2 review feedback on #29998. Migration 057's stale-Gemini repair now resolves the full call-site provider context (callSites override → site.profile → activeProfile → default) before deciding whether to repair, so call-sites whose effective provider is Gemini via profile reference are no longer skipped when llm.default.provider is non-Gemini.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->