### PR TITLE
fix(acp): pad acp_session_history limit by filtered in-memory count

### DIFF
--- a/assistant/src/runtime/routes/acp-routes-list.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-list.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the GET /v1/acp/sessions list handler — specifically the SQL
+ * pad amount applied to acp_session_history when in-memory sessions are
+ * also present. We mock the DB layer so the limit value passed to the
+ * query builder can be asserted directly.
+ *
+ * Regression for codex P2 feedback on PR #29993: padding by the global
+ * inMemory.length over-fetched when many unrelated sessions were live
+ * but only one conversation was being queried.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+import type { AcpSessionState } from "../../acp/index.js";
+
+const inMemoryStates = new Map<string, AcpSessionState>();
+
+mock.module("../../acp/index.js", () => ({
+  getAcpSessionManager: () => ({
+    getStatus: (id?: string) => {
+      if (id === undefined) return Array.from(inMemoryStates.values());
+      const state = inMemoryStates.get(id);
+      if (!state) throw new Error(`ACP session "${id}" not found`);
+      return state;
+    },
+  }),
+}));
+
+// Spy on the drizzle limit() call to assert the exact value the handler
+// passes to SQL. The stub mirrors only the chained methods used by
+// listMergedSessions; calls fall through to a final `.all()` returning [].
+const capturedLimits: number[] = [];
+
+mock.module("../../memory/db-connection.js", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const builder: any = {};
+  builder.select = () => builder;
+  builder.from = () => builder;
+  builder.where = () => builder;
+  builder.orderBy = () => builder;
+  builder.limit = (n: number) => {
+    capturedLimits.push(n);
+    return builder;
+  };
+  builder.all = () => [];
+  return {
+    getDb: () => builder,
+  };
+});
+
+const { ROUTES } = await import("./acp-routes.js");
+
+function getListHandler() {
+  const route = ROUTES.find(
+    (r: { endpoint: string; method: string }) =>
+      r.endpoint === "acp/sessions" && r.method === "GET",
+  );
+  if (!route) throw new Error("GET acp/sessions route not registered");
+  return route.handler;
+}
+
+function makeInMemoryState(
+  id: string,
+  parentConversationId: string,
+): AcpSessionState {
+  return {
+    id,
+    agentId: "claude",
+    acpSessionId: `proto-${id}`,
+    parentConversationId,
+    status: "running",
+    startedAt: 1_700_000_000_000,
+  };
+}
+
+afterAll(() => {
+  inMemoryStates.clear();
+  capturedLimits.length = 0;
+});
+
+describe("GET /v1/acp/sessions — SQL pad amount", () => {
+  test("pads SQL limit by the conversation-filtered in-memory count, not the global one", async () => {
+    inMemoryStates.clear();
+    capturedLimits.length = 0;
+
+    // Many in-memory sessions for an unrelated conversation, plus one
+    // that matches the target conversation.
+    for (let i = 0; i < 25; i++) {
+      inMemoryStates.set(
+        `other-${i}`,
+        makeInMemoryState(`other-${i}`, "conv-other"),
+      );
+    }
+    inMemoryStates.set(
+      "target-mem",
+      makeInMemoryState("target-mem", "conv-target"),
+    );
+
+    const handler = getListHandler();
+    await handler({
+      queryParams: { conversationId: "conv-target", limit: "10" },
+    });
+
+    expect(capturedLimits).toHaveLength(1);
+    // pad = filtered in-memory count (1), not global (26).
+    expect(capturedLimits[0]).toBe(11);
+  });
+
+  test("pads by zero when no in-memory sessions match the target conversation", async () => {
+    inMemoryStates.clear();
+    capturedLimits.length = 0;
+
+    for (let i = 0; i < 10; i++) {
+      inMemoryStates.set(
+        `other-${i}`,
+        makeInMemoryState(`other-${i}`, "conv-other"),
+      );
+    }
+
+    const handler = getListHandler();
+    await handler({
+      queryParams: { conversationId: "conv-target", limit: "5" },
+    });
+
+    expect(capturedLimits).toEqual([5]);
+  });
+
+  test("pads by the full in-memory count when no conversation filter is supplied", async () => {
+    inMemoryStates.clear();
+    capturedLimits.length = 0;
+
+    for (let i = 0; i < 4; i++) {
+      inMemoryStates.set(
+        `sess-${i}`,
+        makeInMemoryState(`sess-${i}`, `conv-${i}`),
+      );
+    }
+
+    const handler = getListHandler();
+    await handler({ queryParams: { limit: "20" } });
+
+    expect(capturedLimits).toEqual([24]);
+  });
+});

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -373,11 +373,13 @@ function listMergedSessions(opts: {
     : baseQuery;
   // Fetch only enough rows to fill the requested page after merging with
   // in-memory sessions. In-memory entries take precedence on id collision,
-  // so we pad by inMemory.length to guarantee we still surface `limit`
-  // distinct rows even when every in-memory session shadows a DB row.
+  // so we pad by the count that survived the conversation filter to
+  // guarantee we still surface `limit` distinct rows even when every
+  // in-memory session shadows a DB row — without over-fetching when many
+  // unrelated sessions are in memory.
   const historyRows = filtered
     .orderBy(desc(acpSessionHistory.startedAt))
-    .limit(opts.limit + inMemory.length)
+    .limit(opts.limit + merged.size)
     .all();
 
   for (const row of historyRows) {


### PR DESCRIPTION
Addresses Codex P2 review feedback on #29993. Pad SQL limit by the conversation-filtered in-memory count (or post-dedupe merged.size) rather than the global inMemory.length so single-conversation queries don't over-fetch when many unrelated sessions are in memory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->