### PR TITLE
fix(voice): guard forcePromptSideEffects against failed turn setup

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1183,6 +1183,63 @@ describe("voice-session-bridge", () => {
     expect(handleSecretCalls[0].delivery).toBe("store");
   });
 
+  test("forcePromptSideEffects does not leak when persistUserMessage fails", async () => {
+    const conversation = createConversation(
+      "voice bridge forcePromptSideEffects leak test",
+    );
+
+    const session = {
+      isProcessing: () => false,
+      forcePromptSideEffects: false,
+      callSessionId: undefined as string | undefined,
+      persistUserMessage: async () => {
+        throw new Error("simulated persistence failure");
+      },
+      memoryPolicy: {
+        scopeId: "default",
+        includeDefaultFallback: false,
+      },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setTrustContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      setVoiceCallControlPrompt: () => {},
+      updateClient: () => {},
+      ensureActorScopedHistory: async () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+      abort: () => {},
+    } as unknown as Conversation & { forcePromptSideEffects: boolean };
+
+    injectDeps(() => session);
+
+    // Non-guardian voice would normally set forcePromptSideEffects = true.
+    // The setup must fail before that assignment happens so the flag stays
+    // false and cannot leak into subsequent non-voice turns.
+    let caught: Error | null = null;
+    try {
+      await startVoiceTurn({
+        conversationId: conversation.id,
+        content: "Hello",
+        isInbound: true,
+        trustContext: {
+          sourceChannel: "phone",
+          trustClass: "trusted_contact",
+        },
+        onTextDelta: () => {},
+        onComplete: () => {},
+        onError: () => {},
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught?.message).toBe("simulated persistence failure");
+    expect(session.forcePromptSideEffects).toBe(false);
+  });
+
   test("pre-aborted signal triggers immediate abort", async () => {
     const conversation = createConversation("voice bridge pre-abort test");
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -318,8 +318,9 @@ export async function startVoiceTurn(
 
   // Phone voice has no interactive permission/secret UI, so apply explicit
   // per-role policies by default. Local live voice opts into the normal
-  // client approval path instead. Side-effect double-defense is wired
-  // below at the conversation-configure point.
+  // client approval path instead. Side-effect double-defense
+  // (forcePromptSideEffects) is wired inside the agent-loop IIFE so it
+  // is always paired with cleanup() in the IIFE's finally.
   const trustClass = opts.trustContext?.trustClass;
   const isGuardian = trustClass === "guardian";
   const approvalMode = opts.approvalMode ?? "phone-call";
@@ -391,13 +392,6 @@ export async function startVoiceTurn(
     }
   }
 
-  // Non-guardian phone voice forces side-effect tools to prompt so the
-  // auto-deny handler below reliably sees a confirmation_request. Without
-  // this, a broad allow trust rule (e.g. wildcard bash) would let
-  // side-effect tools execute without ever emitting an event for the
-  // auto-deny / scoped-grant handler to intercept.
-  conversation.forcePromptSideEffects =
-    !isGuardian && !usesLocalInteractiveApprovals;
   conversation.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
   conversation.callSessionId = voiceSessionId;
   conversation.setTrustContext(opts.trustContext ?? null);
@@ -575,6 +569,15 @@ export async function startVoiceTurn(
 
   void (async () => {
     try {
+      // Non-guardian phone voice forces side-effect tools to prompt so the
+      // auto-deny handler above reliably sees a confirmation_request. Without
+      // this, a broad allow trust rule (e.g. wildcard bash) would let
+      // side-effect tools execute without ever emitting an event for the
+      // auto-deny / scoped-grant handler to intercept. Set inside the
+      // try/finally so a failed setup before this point cannot leak the
+      // flag into subsequent non-voice turns on the same conversation.
+      conversation.forcePromptSideEffects =
+        !isGuardian && !usesLocalInteractiveApprovals;
       await conversation.runAgentLoop(
         persistedContent,
         messageId,


### PR DESCRIPTION
Addresses Codex P2 review feedback on #29988. Move the `conversation.forcePromptSideEffects = !isGuardian && !usesLocalInteractiveApprovals` assignment inside the agent-loop IIFE's try block, so the existing `cleanup()` in its `finally` always clears the flag. Previously, if `persistUserMessage` (or any synchronous setup between the assignment and the IIFE) threw, the flag would remain set on the conversation and leak forced-prompt state into subsequent non-voice turns on the same conversation.

Adds a regression test that throws from `persistUserMessage` and asserts the flag stays false.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->