### PR TITLE
fix(macos): make voice bootstrap correlation observable

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -827,7 +827,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     @ObservationIgnored var secretBlockedCurrentPage: String?
     /// Nonce sent with `conversation_create` and echoed back in `conversation_info`.
     /// Used to ensure this ChatViewModel only claims its own conversation.
-    @ObservationIgnored var bootstrapCorrelationId: String?
+    /// Observed (not `@ObservationIgnored`) so that the computed `isBootstrapping`
+    /// propagates changes to `observationStream` consumers — e.g. the voice-mode
+    /// bootstrap wait in `ConversationManager.prepareActiveConversationForVoiceMode`.
+    var bootstrapCorrelationId: String?
     /// Conversation type sent with `conversation_create` (e.g. "background" or "scheduled").
     /// Set by `createConversationIfNeeded(conversationType:)` and included in the
     /// message so the daemon can persist the correct conversation kind.


### PR DESCRIPTION
Addresses Devin review feedback on #30022. The new observationStream couldn't detect isBootstrapping changes because bootstrapCorrelationId was @ObservationIgnored, regressing failure-path latency from ~50ms (polling) to ~10s (timeout). Removes the @ObservationIgnored annotation so the stream wakes on bootstrap completion/failure via the computed isBootstrapping property.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->