### PR TITLE
fix(memory-v2): escape replacement specials in router prompt template

### DIFF
--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -123,6 +123,39 @@ describe("renderRouterPrompt — page index handling", () => {
   });
 });
 
+describe("renderRouterPrompt — replacement-pattern specials", () => {
+  // String.prototype.replaceAll interprets `$&`, `$'`, `` $` ``, `$$`, and
+  // `$n` in the replacement string as backreferences. LLM-generated page
+  // index content can contain literal `$` runs, so the substituter must
+  // pass values through unchanged.
+  const SPECIALS = "$& and $' and $` and $$ and $1";
+
+  test.each([
+    [
+      "pageIndexBlock",
+      { assistantName: "Aria", userName: "Alice", pageIndexBlock: SPECIALS },
+    ],
+    [
+      "assistantName",
+      {
+        assistantName: SPECIALS,
+        userName: "Alice",
+        pageIndexBlock: SAMPLE_INDEX,
+      },
+    ],
+    [
+      "userName",
+      {
+        assistantName: "Aria",
+        userName: SPECIALS,
+        pageIndexBlock: SAMPLE_INDEX,
+      },
+    ],
+  ])("renders %s with $ specials verbatim", (_, opts) => {
+    expect(renderRouterPrompt(opts)).toContain(SPECIALS);
+  });
+});
+
 describe("renderRouterPrompt — determinism & snapshot stability", () => {
   test("returns the same string for the same inputs", () => {
     const opts = {

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -178,9 +178,9 @@ function substitutePlaceholders(
   const assistant = opts.assistantName?.trim() || "the assistant";
   const user = opts.userName?.trim() || "the user";
   return template
-    .replaceAll(ASSISTANT_NAME_PLACEHOLDER, assistant)
-    .replaceAll(USER_NAME_PLACEHOLDER, user)
-    .replaceAll(PAGE_INDEX_PLACEHOLDER, opts.pageIndexBlock);
+    .replaceAll(ASSISTANT_NAME_PLACEHOLDER, () => assistant)
+    .replaceAll(USER_NAME_PLACEHOLDER, () => user)
+    .replaceAll(PAGE_INDEX_PLACEHOLDER, () => opts.pageIndexBlock);
 }
 
 function resolveOverridePath(overridePath: string): string {

--- a/assistant/src/memory/v2/prompts/sweep.ts
+++ b/assistant/src/memory/v2/prompts/sweep.ts
@@ -51,6 +51,6 @@ export function renderSweepPrompt(opts: {
   const user = opts.userName?.trim() || "the user";
   return SWEEP_PROMPT.replaceAll(
     ASSISTANT_NAME_PLACEHOLDER,
-    assistant,
-  ).replaceAll(USER_NAME_PLACEHOLDER, user);
+    () => assistant,
+  ).replaceAll(USER_NAME_PLACEHOLDER, () => user);
 }


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30166. renderRouterPrompt's replaceAll(placeholder, value) was interpreting JS replacement-pattern specials ($&, $', $`, $$) inside LLM-generated pageIndexBlock content as backreferences, corrupting the rendered prompt. Switches to the function form replaceAll(placeholder, () => value) so values are treated literally. Applies the same fix to the sibling sweep prompt template for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->