### PR TITLE
fix(memory-v2): route embed_concept_page through Qdrant breaker

### DIFF
--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -151,6 +151,8 @@ type MemoryJob = ReturnType<MemoryJobMod["claimMemoryJobs"]>[number];
 const { embedConceptPageJob, enqueueEmbedConceptPageJob } =
   await import("../embed-concept-page.js");
 const { writePage } = await import("../../v2/page-store.js");
+const { _resetQdrantBreaker, isQdrantBreakerOpen, withQdrantBreaker } =
+  await import("../../qdrant-circuit-breaker.js");
 
 // Use a tiny vectorSize so the cache-dim check matches our stub vector.
 const TEST_CONFIG = {
@@ -186,6 +188,7 @@ beforeEach(() => {
   embedWithBackendCalls.length = 0;
   upsertCalls.length = 0;
   deleteCalls.length = 0;
+  _resetQdrantBreaker();
 });
 
 afterEach(() => {
@@ -433,6 +436,76 @@ describe("embedConceptPageJob — defensive", () => {
     await embedConceptPageJob(makeJob({ slug: "" }), TEST_CONFIG);
     expect(upsertCalls).toEqual([]);
     expect(deleteCalls).toEqual([]);
+  });
+});
+
+describe("embedConceptPageJob — Qdrant breaker integration", () => {
+  test("half-open probe success closes the breaker so embed catch-up unthrottles", async () => {
+    // Trip the breaker by recording 5 consecutive Qdrant failures. Without
+    // this fix, `embed_concept_page` bypassed the breaker entirely — winning
+    // the half-open probe slot did not transition state back to closed and
+    // the embed lane stayed throttled at one job per tick indefinitely.
+    for (let i = 0; i < 5; i++) {
+      try {
+        await withQdrantBreaker(async () => {
+          throw new Error("simulated qdrant failure");
+        });
+      } catch {
+        // expected
+      }
+    }
+    expect(isQdrantBreakerOpen()).toBe(true);
+
+    // Advance time past the 30s cooldown so the next breaker call transitions
+    // open → half-open and allows the probe through.
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 60_000;
+    try {
+      await writePage(tmpWorkspace, {
+        slug: "probe-success",
+        frontmatter: { edges: [], ref_files: [], ref_urls: [] },
+        body: "Probe body.\n",
+      });
+
+      await embedConceptPageJob(
+        makeJob({ slug: "probe-success" }),
+        TEST_CONFIG,
+      );
+    } finally {
+      Date.now = originalNow;
+    }
+
+    expect(upsertCalls).toHaveLength(1);
+    // Probe succeeded → breaker should now be closed (not open, not
+    // half-open), restoring full embed-lane concurrency.
+    expect(isQdrantBreakerOpen()).toBe(false);
+  });
+
+  test("half-open probe success on the delete path also closes the breaker", async () => {
+    // Same flow as above but exercising the missing-page branch — both v2
+    // Qdrant calls (`upsert` and `delete`) must close the breaker on success.
+    for (let i = 0; i < 5; i++) {
+      try {
+        await withQdrantBreaker(async () => {
+          throw new Error("simulated qdrant failure");
+        });
+      } catch {
+        // expected
+      }
+    }
+    expect(isQdrantBreakerOpen()).toBe(true);
+
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 60_000;
+    try {
+      // No `writePage` — the handler takes the delete branch.
+      await embedConceptPageJob(makeJob({ slug: "missing-slug" }), TEST_CONFIG);
+    } finally {
+      Date.now = originalNow;
+    }
+
+    expect(deleteCalls).toEqual(["missing-slug"]);
+    expect(isQdrantBreakerOpen()).toBe(false);
   });
 });
 

--- a/assistant/src/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/memory/jobs/embed-concept-page.ts
@@ -34,6 +34,7 @@ import {
 import { embeddingInputContentHash } from "../embedding-types.js";
 import { asString, blobToVector, vectorToBlob } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { memoryEmbeddings } from "../schema.js";
 import { readPage } from "../v2/page-store.js";
 import {
@@ -81,7 +82,10 @@ export async function embedConceptPageJob(
   if (!page) {
     // Page was deleted out from under us — clean up the prior embedding so
     // retrieval no longer surfaces a slug whose disk-side prose is gone.
-    await deleteConceptPageEmbedding(slug);
+    // Route through the Qdrant breaker so success on the half-open probe
+    // slot transitions the breaker back to closed and unthrottles embed
+    // catch-up.
+    await withQdrantBreaker(() => deleteConceptPageEmbedding(slug));
     return;
   }
 
@@ -280,16 +284,21 @@ export async function embedConceptPageJob(
     ? await applyCorrectionIfCalibrated(summaryDense, writeProvider, writeModel)
     : undefined;
 
-  await upsertConceptPageEmbedding({
-    slug,
-    dense: correctedDense,
-    sparse,
-    summary:
-      correctedSummaryDense && summarySparse
-        ? { dense: correctedSummaryDense, sparse: summarySparse }
-        : undefined,
-    updatedAt: now,
-  });
+  // Route through the Qdrant breaker so a probe-slot success transitions the
+  // breaker back to closed; without this wrapper the embed lane stays
+  // throttled at one job per tick indefinitely after a half-open success.
+  await withQdrantBreaker(() =>
+    upsertConceptPageEmbedding({
+      slug,
+      dense: correctedDense,
+      sparse,
+      summary:
+        correctedSummaryDense && summarySparse
+          ? { dense: correctedSummaryDense, sparse: summarySparse }
+          : undefined,
+      updatedAt: now,
+    }),
+  );
 }
 
 /** SQLite cache row shape returned by `readEmbeddingCache`. */


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30032. embed_concept_page was using v2 QdrantRestClient directly so probe-slot successes never closed the breaker, leaving embed catch-up throttled at one job per tick indefinitely. Wraps the v2 path through withQdrantBreaker so success transitions half-open → closed correctly.

Also evaluated: `memory_v2_activation_recompute` queries Qdrant but is in the fast lane (pre-existing classification, not changed by #30032). Worth a separate look but not clearly wrong: a probe-slot success there would also help the breaker recover, but the trade-off is putting Qdrant-dependent work in the fast lane where it could starve under degraded Qdrant. Flagging only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->