### PR TITLE
fix(db): scope migration 229 orphan-attachment sweep

### DIFF
--- a/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.test.ts
@@ -1133,7 +1133,7 @@ describe("migrateDeletePrivateConversations", () => {
         1,
         'text',
         'eA==',
-        ${now}
+        ${now - 60_000}
       );
     `);
 
@@ -1149,6 +1149,43 @@ describe("migrateDeletePrivateConversations", () => {
     expect(
       countWhere(raw, "attachments", `id = 'orphan-private-attachment'`),
     ).toBe(0);
+    expect(
+      countWhere(raw, "attachments", `id = 'conv-standard-attachment'`),
+    ).toBe(1);
+  });
+
+  test("preserves pre-staged uploads (unlinked attachments) created after migration starts", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapTables(raw);
+    seedConversation(raw, "conv-standard", "standard");
+    // created_at in the future ensures it lands after the migration's start
+    // snapshot regardless of clock resolution / test-runner scheduling.
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (
+        id,
+        original_filename,
+        mime_type,
+        size_bytes,
+        kind,
+        data_base64,
+        created_at
+      ) VALUES (
+        'pre-staged-upload',
+        'pending.txt',
+        'text/plain',
+        1,
+        'text',
+        'eA==',
+        ${now + 60_000}
+      );
+    `);
+
+    migrateDeletePrivateConversations(db);
+
+    expect(countWhere(raw, "attachments", `id = 'pre-staged-upload'`)).toBe(1);
     expect(
       countWhere(raw, "attachments", `id = 'conv-standard-attachment'`),
     ).toBe(1);

--- a/assistant/src/memory/migrations/229-delete-private-conversations.ts
+++ b/assistant/src/memory/migrations/229-delete-private-conversations.ts
@@ -12,6 +12,12 @@ const PRIVATE_GRAPH_NODE_IDS = /*sql*/ `
 `;
 
 export function migrateDeletePrivateConversations(database: DrizzleDb): void {
+  // Snapshot the migration's start time. The trailing orphan-attachment sweep
+  // uses this as an upper bound so it cleans up leaks from prior runs of this
+  // migration (those rows were created before this run started) without
+  // touching pre-staged uploads created during or after the migration.
+  const migrationStartTs = Date.now();
+
   database.run(/*sql*/ `
     DELETE FROM tool_invocations
     WHERE conversation_id IN (${PRIVATE_CONVERSATION_IDS})
@@ -204,6 +210,7 @@ export function migrateDeletePrivateConversations(database: DrizzleDb): void {
       FROM message_attachments ma
       WHERE ma.attachment_id = attachments.id
     )
+      AND created_at <= ${migrationStartTs}
   `);
   database.run(/*sql*/ `
     DELETE FROM memory_summaries


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30023. The unscoped DELETE FROM attachments WHERE NOT EXISTS message_attachments also deleted legitimate pre-staged uploads. Scopes the sweep to attachments that existed before migration 229 first ran (snapshot Date.now() at function start) so pre-staged uploads created during/after the migration are preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->