### PR TITLE
fix(memory): gate fork-memory copy to full-history forks

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -609,6 +609,88 @@ describe("forkConversation", () => {
     expect(await hydrateActivationState(db, fork.id)).toBeNull();
     expect(loadGraphMemoryState(fork.id)).toBeNull();
   });
+
+  test("does not copy memory state when the fork is truncated mid-history", async () => {
+    const source = createConversation("Truncated thread");
+    const firstMessage = await addMessage(
+      source.id,
+      "user",
+      "first turn",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "assistant", "first reply", undefined, {
+      skipIndexing: true,
+    });
+    const lastMessage = await addMessage(
+      source.id,
+      "user",
+      "second turn",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const db = getDb();
+    db.insert(activationState)
+      .values({
+        conversationId: source.id,
+        messageId: lastMessage.id,
+        stateJson: JSON.stringify({ "concepts/foo": 0.5 }),
+        everInjectedJson: JSON.stringify([{ slug: "concepts/foo", turn: 2 }]),
+        currentTurn: 2,
+        updatedAt: 1_700_000_000_000,
+      })
+      .run();
+    saveGraphMemoryState(
+      source.id,
+      JSON.stringify({
+        initialized: true,
+        needsReload: false,
+        inContext: ["node-foo"],
+        log: [{ nodeId: "node-foo", turn: 2 }],
+        currentTurn: 2,
+      }),
+    );
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: firstMessage.id,
+    });
+
+    expect(await hydrateActivationState(db, fork.id)).toBeNull();
+    expect(loadGraphMemoryState(fork.id)).toBeNull();
+  });
+
+  test("copies memory state when throughMessageId points at the last message", async () => {
+    const source = createConversation("Through-last thread");
+    const lastMessage = await addMessage(
+      source.id,
+      "user",
+      "only turn",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const db = getDb();
+    db.insert(activationState)
+      .values({
+        conversationId: source.id,
+        messageId: lastMessage.id,
+        stateJson: JSON.stringify({ "concepts/foo": 0.9 }),
+        everInjectedJson: JSON.stringify([{ slug: "concepts/foo", turn: 1 }]),
+        currentTurn: 1,
+        updatedAt: 1_700_000_000_000,
+      })
+      .run();
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: lastMessage.id,
+    });
+
+    const childState = await hydrateActivationState(db, fork.id);
+    expect(childState?.currentTurn).toBe(1);
+  });
 });
 
 describe("forkConversation + memory_retrospective_state", () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -727,9 +727,14 @@ export function forkConversation(params: {
 
     // Carry the parent's per-conversation memory state into the child so the
     // forked thread resumes with the same activation/injection log and
-    // in-context tracker the parent had at fork time.
-    forkActivationState(db, sourceConversation.id, fc.id);
-    forkGraphMemoryState(sourceConversation.id, fc.id);
+    // in-context tracker the parent had at fork time. Only valid for
+    // full-history forks: a truncated fork would inherit activation/tracker
+    // entries for turns the child does not actually contain.
+    const isFullHistoryFork = copyBoundaryIndex === sourceMessages.length - 1;
+    if (isFullHistoryFork) {
+      forkActivationState(db, sourceConversation.id, fc.id);
+      forkGraphMemoryState(sourceConversation.id, fc.id);
+    }
     forkRetrospectiveState({
       database: db,
       sourceConversationId: sourceConversation.id,


### PR DESCRIPTION
Addresses Codex review feedback on #30135. forkActivationState and forkGraphMemoryState now only copy parent state into the child when the fork is full-history; truncated forks (throughMessageId set) start with fresh state (or recompute up to the branch point) so the child doesn't carry activation/InContextTracker entries for turns it doesn't have.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->