### PR TITLE
fix(migrations): persist isNewWorkspace in checkpoint file

### DIFF
--- a/assistant/src/__tests__/workspace-migrations-runner.test.ts
+++ b/assistant/src/__tests__/workspace-migrations-runner.test.ts
@@ -137,9 +137,10 @@ describe("runWorkspaceMigrations", () => {
     expect(m1.run).toHaveBeenCalledTimes(1);
     expect(m2.run).toHaveBeenCalledTimes(1);
 
-    // Checkpoints saved: started m1, completed m1, started m2, failed m2 = 4 writes
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(4);
-    expect(renameSyncFn).toHaveBeenCalledTimes(4);
+    // Checkpoints saved: started m1, completed m1, started m2, failed m2,
+    // then the post-loop flip clearing isNewWorkspace = 5 writes.
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(5);
+    expect(renameSyncFn).toHaveBeenCalledTimes(5);
 
     // Verify the completed checkpoint contains m1
     // The second write is the "completed" marker for m1
@@ -276,6 +277,86 @@ describe("runWorkspaceMigrations", () => {
 
     // The migration itself did not run because the "started" checkpoint failed
     expect(m1.run).not.toHaveBeenCalled();
+  });
+
+  test("persists isNewWorkspace=true on first creation, then flips to false after sweep", async () => {
+    // No checkpoint file → fresh workspace.
+    const m1 = makeMigration("001");
+    let observed: boolean | undefined;
+    (m1.run as ReturnType<typeof mock>).mockImplementation(
+      (_dir: string, ctx?: { isNewWorkspace: boolean }) => {
+        observed = ctx?.isNewWorkspace;
+      },
+    );
+
+    await runWorkspaceMigrations(WORKSPACE_DIR, [m1]);
+
+    // The migration saw the new-workspace flag.
+    expect(observed).toBe(true);
+
+    // The first persisted checkpoint (m1's "started" save) carries the flag.
+    const firstSave = JSON.parse(
+      (writeFileSyncFn.mock.calls[0] as unknown[])[1] as string,
+    );
+    expect(firstSave.isNewWorkspace).toBe(true);
+
+    // The final persisted checkpoint clears the flag so subsequent boots
+    // treat this workspace as an upgrade.
+    const finalSave = JSON.parse(
+      (writeFileSyncFn.mock.calls.at(-1) as unknown[])[1] as string,
+    );
+    expect(finalSave.isNewWorkspace).toBe(false);
+  });
+
+  test("preserves isNewWorkspace=true across a crash before seeding migrations run", async () => {
+    // Simulate a crash mid-first-boot: an earlier migration recorded its
+    // "started" marker (writing the checkpoint file) and the daemon then
+    // died before reaching the seeding migration. The persisted flag must
+    // survive the reboot so the seeding migration still observes the
+    // brand-new workspace.
+    mockCheckpointContents = JSON.stringify({
+      isNewWorkspace: true,
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "started" },
+      },
+    });
+
+    const seedingMigration = makeMigration("seed");
+    let observed: boolean | undefined;
+    (seedingMigration.run as ReturnType<typeof mock>).mockImplementation(
+      (_dir: string, ctx?: { isNewWorkspace: boolean }) => {
+        observed = ctx?.isNewWorkspace;
+      },
+    );
+
+    const m1 = makeMigration("001");
+    await runWorkspaceMigrations(WORKSPACE_DIR, [m1, seedingMigration]);
+
+    expect(m1.run).toHaveBeenCalledTimes(1);
+    expect(seedingMigration.run).toHaveBeenCalledTimes(1);
+    expect(observed).toBe(true);
+  });
+
+  test("treats pre-existing checkpoint without isNewWorkspace field as upgrade", async () => {
+    // Workspaces created before this field was introduced have a checkpoint
+    // file with only `applied`. They must not be re-seeded.
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
+      },
+    });
+
+    const seedingMigration = makeMigration("seed");
+    let observed: boolean | undefined;
+    (seedingMigration.run as ReturnType<typeof mock>).mockImplementation(
+      (_dir: string, ctx?: { isNewWorkspace: boolean }) => {
+        observed = ctx?.isNewWorkspace;
+      },
+    );
+
+    await runWorkspaceMigrations(WORKSPACE_DIR, [seedingMigration]);
+
+    expect(observed).toBe(false);
   });
 
   test("warns on malformed checkpoint file", async () => {

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -22,6 +22,13 @@ export type CheckpointFile = {
     string,
     { appliedAt: string; status?: WorkspaceMigrationStatus }
   >;
+  /** Persisted "fresh workspace" flag. Set to `true` by the runner when the
+   *  checkpoint file is being created for the first time; cleared after the
+   *  initial migration sweep finishes. Survives crashes mid-first-boot so
+   *  seeding migrations that fall later in the sequence still observe the
+   *  brand-new state. Absent on workspaces that pre-date this field — those
+   *  are treated as not-new. */
+  isNewWorkspace?: boolean;
 };
 
 function getCheckpointPath(workspaceDir: string): string {
@@ -80,14 +87,20 @@ export async function runWorkspaceMigrations(
     seen.add(m.id);
   }
 
-  // Detect a brand-new workspace: no checkpoint file existed before this run.
-  // Captured before loadCheckpoints so seeding migrations can distinguish a
-  // first-ever boot from an upgrade where the user may have cleared seeded files.
-  const ctx: MigrationRunContext = {
-    isNewWorkspace: readTextFileSync(getCheckpointPath(workspaceDir)) == null,
-  };
-
+  // The checkpoint file is written *before* each migration's run() (to record
+  // the "started" status), so file-absence alone cannot be used to detect a
+  // brand-new workspace — a crash mid-first-boot would flip the next boot's
+  // verdict to "upgrade" before later seeding migrations have run. Persist
+  // the flag inside the file instead so it survives across reboots.
+  const checkpointExisted =
+    readTextFileSync(getCheckpointPath(workspaceDir)) != null;
   const checkpoints = loadCheckpoints(workspaceDir);
+  if (!checkpointExisted) {
+    checkpoints.isNewWorkspace = true;
+  }
+  const ctx: MigrationRunContext = {
+    isNewWorkspace: checkpoints.isNewWorkspace === true,
+  };
 
   for (const [id, entry] of Object.entries(checkpoints.applied)) {
     if (entry.status === "started" || entry.status === "rolling_back") {
@@ -134,6 +147,15 @@ export async function runWorkspaceMigrations(
       appliedAt: new Date().toISOString(),
       status: "completed",
     };
+    saveCheckpoints(workspaceDir, checkpoints);
+  }
+
+  // First-boot sweep finished cleanly — clear the flag so future runs (and
+  // future seeding migrations added later) treat the workspace as an upgrade.
+  // A crash above this point leaves the flag set, so the retry on the next
+  // boot still observes a fresh workspace.
+  if (checkpoints.isNewWorkspace === true) {
+    checkpoints.isNewWorkspace = false;
     saveCheckpoints(workspaceDir, checkpoints);
   }
 }


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30107. `isNewWorkspace` was derived from checkpoint-file-absence at boot, but `saveCheckpoints` writes the file during migration 001 — so a crash mid-first-boot permanently flipped `isNewWorkspace` to false on the next boot, skipping onboarding-thread seeding. Now persists `isNewWorkspace` inside `CheckpointFile` on first creation so the flag survives a crash before migration 069 lands, and clears it after the sweep finishes so future seeding migrations registered later still treat the workspace as an upgrade.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->