### PR TITLE
fix(live-voice): guard against concurrent interrupt during close

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -435,8 +435,10 @@ final class LiveVoiceChannelManager {
             guard generation == self.sessionGeneration else { return }
 
             self.sessionGeneration &+= 1
+            let closingGeneration = self.sessionGeneration
             self.state = .ending
             await completedClient?.close()
+            guard closingGeneration == self.sessionGeneration else { return }
             self.resetIgnoredSessionState()
             self.sessionId = nil
             self.state = .idle


### PR DESCRIPTION
Addresses Codex P1 / Devin review feedback on #30010. After await completedClient?.close(), check sessionGeneration — if a concurrent interruptSpeakingAndStartListening started a new session during the close suspension, skip the trailing resetIgnoredSessionState / sessionId = nil / state = .idle assignments that would clobber the new session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->