### PR TITLE
fix(profiles): rebuild profileOrder on failed patch followup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3584,6 +3584,15 @@ public final class SettingsStore: ObservableObject {
             ])
             guard orderSuccess else {
                 log.error("Failed to patch llm.profileOrder after replacing llm.profiles.\(name, privacy: .public)")
+                // Server-side replace already succeeded and `profiles`
+                // includes the new entry, but the follow-up order patch
+                // failed. Without rebuilding `profileOrder`, a caller
+                // retry hits a stuck "already exists" collision and
+                // `reorderPublishedProfiles` silently drops the unlisted
+                // name on the next refresh.
+                let rebuiltOrder = profiles.map(\.name).sorted()
+                profileOrder = rebuiltOrder
+                reorderPublishedProfiles(to: rebuiltOrder)
                 return false
             }
         }

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -375,6 +375,47 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertEqual(stored?.contextWindowMaxInputTokens, 175000)
     }
 
+    /// Regression: when `replaceInferenceProfile` succeeds but the
+    /// follow-up `profileOrder` PATCH fails, the local cache must not be
+    /// left in a state where `profiles` contains a new entry that is
+    /// missing from `profileOrder`. Otherwise a caller retry sees the
+    /// "already exists" collision in `profiles` and
+    /// `reorderPublishedProfiles` silently drops the unlisted entry on the
+    /// next reorder pass.
+    func testReplaceProfileFailedOrderPatchRebuildsLocalOrder() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "profileOrder": ["balanced"],
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                ],
+            ]
+        ])
+        // The first PATCH after `replaceInferenceProfile` is the
+        // `profileOrder` patch — fail it to exercise the recovery path.
+        mockSettingsClient.patchConfigResponse = false
+
+        let newProfile = InferenceProfile(
+            name: "experimental",
+            provider: "anthropic",
+            model: "claude-opus-4-7"
+        )
+        let success = await store.replaceProfile(name: "experimental", fragment: newProfile)
+        XCTAssertFalse(success)
+
+        // The server-side replace already succeeded, so the new profile
+        // must be present in the local cache to mirror persisted state.
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "experimental" }))
+        // profileOrder must be rebuilt as a stable sort over `profiles`
+        // so it includes the new name. A retry must not see a stuck
+        // "already exists" collision against an out-of-order cache.
+        XCTAssertEqual(store.profileOrder, ["balanced", "experimental"])
+        XCTAssertEqual(Set(store.profileOrder), Set(store.profiles.map(\.name)))
+        // `reorderPublishedProfiles` must not silently drop the new
+        // profile — published `profiles` and `profileOrder` must agree.
+        XCTAssertEqual(store.profiles.map(\.name).sorted(), store.profileOrder)
+    }
+
     // MARK: - deleteProfile blocked-by-active
 
     func testDeleteProfileBlockedByActive() async {


### PR DESCRIPTION
Addresses review feedback on #30011. When the follow-up profileOrder patch fails after a successful replaceInferenceProfile, sort profiles by name and rebuild profileOrder before returning false so caller retries don't see a stuck 'already exists' collision and reorderPublishedProfiles can't silently drop the new profile.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->