### PR TITLE
fix(memory): drop graph_trigger_embed from V1_QDRANT_JOB_TYPES

### DIFF
--- a/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression: `graph_trigger_embed` must NOT be short-circuited when
+ * `memory.v2.enabled` is true. The handler `embedGraphTriggerJob` writes
+ * `conditionEmbedding` to SQLite and never touches the v1 Qdrant client, so
+ * including it in `V1_QDRANT_JOB_TYPES` would leave semantic triggers
+ * permanently unembedded under v2 and break `evaluateSemanticTriggers`
+ * recall.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import type { AssistantConfig } from "../../config/types.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+const TEST_CONFIG: AssistantConfig = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    enabled: true,
+    v2: { ...DEFAULT_CONFIG.memory.v2, enabled: true },
+  },
+};
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => TEST_CONFIG,
+  loadConfig: () => TEST_CONFIG,
+  invalidateConfigCache: () => {},
+}));
+
+let triggerHandlerCalls = 0;
+
+mock.module("../graph/graph-search.js", () => ({
+  searchGraphNodes: async () => [],
+  embedGraphNodeDirect: async () => {},
+  embedGraphNodeJob: async (): Promise<void> => {},
+  enqueueGraphNodeEmbed: () => {},
+  embedGraphTriggerJob: async (): Promise<void> => {
+    triggerHandlerCalls += 1;
+  },
+  enqueueGraphTriggerEmbed: () => {},
+}));
+
+mock.module("../db-maintenance.js", () => ({
+  maybeRunDbMaintenance: () => {},
+}));
+
+const tmpWorkspace = mkdtempSync(
+  join(tmpdir(), "jobs-worker-v2-graph-trigger-embed-"),
+);
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { enqueueMemoryJob } from "../jobs-store.js";
+import { runMemoryJobsOnce } from "../jobs-worker.js";
+import { _resetQdrantBreaker } from "../qdrant-circuit-breaker.js";
+import { memoryJobs } from "../schema.js";
+
+describe("graph_trigger_embed under memory v2", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getDb().run("DELETE FROM memory_jobs");
+    triggerHandlerCalls = 0;
+    _resetQdrantBreaker();
+  });
+
+  test("handler runs (is not short-circuited) when v2 is enabled", async () => {
+    const jobId = enqueueMemoryJob("graph_trigger_embed", {
+      triggerId: "trigger-123",
+    });
+
+    await runMemoryJobsOnce();
+
+    expect(triggerHandlerCalls).toBe(1);
+
+    const rows = getDb()
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, jobId))
+      .all();
+    expect(rows[0]?.status).toBe("completed");
+  });
+});

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -95,7 +95,6 @@ const V1_QDRANT_JOB_TYPES = new Set<MemoryJobType>([
   "embed_attachment",
   "embed_graph_node",
   "embed_pkb_file",
-  "graph_trigger_embed",
   "rebuild_index",
   "delete_qdrant_vectors",
 ]);


### PR DESCRIPTION
Addresses Codex review feedback on #30105. embedGraphTriggerJob writes conditionEmbedding to SQLite and never calls getQdrantClient(), so including graph_trigger_embed in V1_QDRANT_JOB_TYPES left semantic triggers permanently unembedded under v2 — evaluateSemanticTriggers then never fires.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->