### PR TITLE
fix(memory): defensive-copy listSkillEntries returns

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -521,4 +521,35 @@ describe("listSkillEntries", () => {
     expect(second).toHaveLength(1);
     expect(second[0].id).toBe("example-skill-a");
   });
+
+  test("mutating a returned entry does not corrupt the cache", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    const first = listSkillEntries();
+    expect(first).toHaveLength(1);
+    const originalContent = first[0].content;
+
+    // Frozen entries throw in strict mode (ESM tests are strict) when
+    // mutated; suppress so we can prove cache invariance even if a future
+    // refactor swaps freeze for a plain clone.
+    try {
+      (first[0] as { id: string }).id = "tampered";
+      (first[0] as { content: string }).content = "tampered";
+    } catch {
+      // expected under Object.freeze
+    }
+
+    const second = listSkillEntries();
+    expect(second[0].id).toBe("example-skill-a");
+    expect(second[0].content).toBe(originalContent);
+
+    // Lookup-by-id path also unaffected.
+    const viaLookup = getSkillCapability("example-skill-a");
+    expect(viaLookup?.content).toBe(originalContent);
+  });
 });

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -280,8 +280,9 @@ export function isSkillSlug(slug: string): boolean {
 
 /**
  * Snapshot of the in-process skill cache, sorted by skill id (ASCII order)
- * for determinism. Returns a freshly allocated array on each call so callers
- * cannot mutate the underlying cache.
+ * for determinism. Returns a freshly allocated array of frozen entry copies
+ * on each call, so callers cannot mutate the underlying cache — neither by
+ * reassigning the array nor by writing through entry fields.
  *
  * The cache is replaced atomically by `seedV2SkillEntries`, so a snapshot
  * may be stale once a subsequent seed run completes. Callers that need
@@ -289,9 +290,9 @@ export function isSkillSlug(slug: string): boolean {
  */
 export function listSkillEntries(): SkillEntry[] {
   if (!entries) return [];
-  return [...entries.values()].sort((a, b) =>
-    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
-  );
+  return [...entries.values()]
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((entry) => Object.freeze({ ...entry }));
 }
 
 /** @internal Test-only: clear the module-level cache. */


### PR DESCRIPTION
Addresses Codex review feedback on #30169. listSkillEntries previously exposed the module-level skill cache directly, so callers that mutated entry fields could corrupt rendered skill content and getSkillCapability lookups. Now returns defensive copies (or a deeply readonly type) to prevent mutation aliasing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->