### PR TITLE
fix(memory-v2): auto-reseed skills after BM25 corpus stats build

### DIFF
--- a/assistant/src/__tests__/context-search-memory-v2-source.test.ts
+++ b/assistant/src/__tests__/context-search-memory-v2-source.test.ts
@@ -41,7 +41,6 @@ mock.module("../memory/embedding-backend.js", () => ({
     model: "test-model",
     vectors: [denseEmbedReturn],
   }),
-  generateSparseEmbedding: () => ({ indices: [1], values: [1] }),
 }));
 
 interface QdrantHit {

--- a/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
+++ b/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
@@ -34,6 +34,9 @@ interface TestState {
   listPagesResult: string[];
   enqueueCalls: Array<{ type: string; payload: Record<string, unknown> }>;
   clearSentinelCallCount: number;
+  // BM25 corpus-stats rebuild + reseed mocks.
+  corpusStatsBuildCount: number;
+  corpusStatsThrows: Error | null;
 }
 
 const state: TestState = {
@@ -48,6 +51,8 @@ const state: TestState = {
   listPagesResult: [],
   enqueueCalls: [],
   clearSentinelCallCount: 0,
+  corpusStatsBuildCount: 0,
+  corpusStatsThrows: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -79,6 +84,13 @@ mock.module("../memory/v2/qdrant.js", () => ({
 mock.module("../memory/v2/page-store.js", () => ({
   hasConceptPages: async (): Promise<boolean> =>
     state.listPagesResult.length > 0,
+}));
+
+mock.module("../memory/v2/sparse-bm25.js", () => ({
+  rebuildConceptPageCorpusStats: async (): Promise<void> => {
+    state.corpusStatsBuildCount += 1;
+    if (state.corpusStatsThrows) throw state.corpusStatsThrows;
+  },
 }));
 
 mock.module("../memory/jobs-store.js", () => ({
@@ -113,8 +125,11 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
-const { maybeSeedMemoryV2Skills, maybeRebuildMemoryV2Concepts } =
-  await import("../daemon/memory-v2-startup.js");
+const {
+  maybeSeedMemoryV2Skills,
+  maybeRebuildMemoryV2Concepts,
+  rebuildBm25CorpusStatsAndReseedSkills,
+} = await import("../daemon/memory-v2-startup.js");
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -159,6 +174,8 @@ function resetState(): void {
   state.listPagesResult = [];
   state.enqueueCalls = [];
   state.clearSentinelCallCount = 0;
+  state.corpusStatsBuildCount = 0;
+  state.corpusStatsThrows = null;
 }
 
 describe("maybeSeedMemoryV2Skills (daemon startup gate)", () => {
@@ -272,5 +289,68 @@ describe("maybeRebuildMemoryV2Concepts (daemon startup gate)", () => {
     expect((lastWarn.obj as { err: Error }).err.message).toBe(
       "Qdrant unreachable",
     );
+  });
+});
+
+describe("rebuildBm25CorpusStatsAndReseedSkills", () => {
+  beforeEach(resetState);
+
+  test("builds corpus stats then re-seeds skills when v2 is enabled", async () => {
+    await rebuildBm25CorpusStatsAndReseedSkills(makeConfig(true));
+
+    expect(state.corpusStatsBuildCount).toBe(1);
+    expect(state.seedCallCount).toBe(1);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("builds corpus stats but skips skill reseed when v2 is disabled", async () => {
+    await rebuildBm25CorpusStatsAndReseedSkills(makeConfig(false));
+
+    expect(state.corpusStatsBuildCount).toBe(1);
+    expect(state.seedCallCount).toBe(0);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("skips the reseed and logs a warning when the corpus-stats build throws", async () => {
+    state.corpusStatsThrows = new Error("listPages failed");
+
+    // Must not throw — fire-and-forget startup must not block.
+    let thrown: unknown = null;
+    try {
+      await rebuildBm25CorpusStatsAndReseedSkills(makeConfig(true));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeNull();
+
+    expect(state.corpusStatsBuildCount).toBe(1);
+    expect(state.seedCallCount).toBe(0);
+    const corpusWarn = state.warnCalls.find(
+      (w) =>
+        typeof w.msg === "string" &&
+        w.msg.includes("BM25 corpus-stats rebuild failed"),
+    );
+    expect(corpusWarn).toBeTruthy();
+  });
+
+  test("swallows skill-reseed rejections after a successful corpus-stats build", async () => {
+    state.seedShouldReject = new Error("reseed failed");
+
+    let thrown: unknown = null;
+    try {
+      await rebuildBm25CorpusStatsAndReseedSkills(makeConfig(true));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeNull();
+
+    expect(state.corpusStatsBuildCount).toBe(1);
+    expect(state.seedCallCount).toBe(1);
+    const reseedWarn = state.warnCalls.find(
+      (w) =>
+        typeof w.msg === "string" &&
+        w.msg.includes("Failed to re-seed v2 skill entries"),
+    );
+    expect(reseedWarn).toBeTruthy();
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -116,6 +116,7 @@ import { installAssistantSymlink } from "./install-symlink.js";
 import {
   maybeRebuildMemoryV2Concepts,
   maybeSeedMemoryV2Skills,
+  rebuildBm25CorpusStatsAndReseedSkills,
 } from "./memory-v2-startup.js";
 import { processMessage } from "./process-message.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
@@ -837,25 +838,13 @@ export async function runDaemon(): Promise<void> {
         }
 
         // Build the BM25 corpus stats (per-token document frequencies and
-        // average document length) used by the v2 sparse channel. Without
-        // this, document-side sparse embeddings fall back to legacy TF-only
-        // weighting via the chicken-and-egg guard in
-        // `embed-concept-page.ts`. Fire-and-forget for the same reason as
-        // PKB reconcile — the stats are an optional optimization, never a
-        // boot-blocking dependency.
-        void (async () => {
-          try {
-            const { rebuildConceptPageCorpusStats } =
-              await import("../memory/v2/sparse-bm25.js");
-            await rebuildConceptPageCorpusStats(getWorkspaceDir());
-            log.info("Memory v2 BM25 corpus stats built");
-          } catch (err) {
-            log.warn(
-              { err },
-              "BM25 corpus-stats rebuild failed — sparse channel will fall back to TF-only until next rebuild",
-            );
-          }
-        })();
+        // average document length) used by the v2 sparse channel, then
+        // re-seed v2 skill entries so any skill vectors written during the
+        // cold-start window with the legacy TF encoder get rewritten with
+        // stemmed BM25 vectors. Fire-and-forget for the same reason as PKB
+        // reconcile — the stats and skill reseed are optional optimizations,
+        // never boot-blocking dependencies.
+        void rebuildBm25CorpusStatsAndReseedSkills(config);
 
         // Validate every concept page's frontmatter against the strict
         // schema and emit a `warn` per offender. Surfaces schema drift

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -36,6 +36,53 @@ export function maybeSeedMemoryV2Skills(config: AssistantConfig): void {
 }
 
 /**
+ * Build the v2 BM25 corpus stats (per-token document frequencies + avg doc
+ * length), then re-seed the v2 skill entries so any skills written during
+ * cold start with the legacy TF encoder get rewritten with stemmed BM25
+ * vectors. The cold-start window exists because the very first
+ * `maybeSeedMemoryV2Skills` call can race ahead of the corpus-stats build —
+ * `skill-store.runSeedOnce` falls back to `generateSparseEmbedding` while
+ * `getConceptPageCorpusStats()` is still `null`, leaving stored skill
+ * sparse vectors in a different hash space than the BM25 query vectors
+ * callers issue (see `simBatch`, `activation.selectCandidates`). Reseeding
+ * here closes that gap without operator intervention.
+ *
+ * Fire-and-forget by design — startup must not block on either step. Errors
+ * are logged and swallowed independently for each step so a corpus-stats
+ * failure does not mask a reseed failure (and vice versa).
+ */
+export async function rebuildBm25CorpusStatsAndReseedSkills(
+  config: AssistantConfig,
+): Promise<void> {
+  try {
+    const { rebuildConceptPageCorpusStats } =
+      await import("../memory/v2/sparse-bm25.js");
+    await rebuildConceptPageCorpusStats(getWorkspaceDir());
+    log.info("Memory v2 BM25 corpus stats built");
+  } catch (err) {
+    log.warn(
+      { err },
+      "BM25 corpus-stats rebuild failed — sparse channel will fall back to TF-only until next rebuild",
+    );
+    return;
+  }
+
+  if (!config.memory.v2.enabled) return;
+  try {
+    const { seedV2SkillEntries } = await import("../memory/v2/skill-store.js");
+    await seedV2SkillEntries();
+    log.info(
+      "Memory v2 skill embeddings re-seeded with BM25 vectors after corpus-stats build",
+    );
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to re-seed v2 skill entries after BM25 corpus-stats build — skills seeded during cold start may keep TF-only sparse vectors until next reseed",
+    );
+  }
+}
+
+/**
  * Reconcile the v2 concept-page Qdrant collection with the expected schema
  * and enqueue `memory_v2_reembed` when the collection is missing data.
  * Triggers reembed in two cases:

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -52,9 +52,7 @@ mock.module("../../qdrant-client.js", () => ({
 
 const state = {
   embedCalls: [] as Array<{ inputs: unknown[] }>,
-  sparseCalls: [] as string[],
   embedReturn: [[0.1, 0.2, 0.3]] as number[][],
-  sparseReturn: { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] },
   /**
    * Programmable Qdrant query response queues — one per channel. Each test
    * stages whatever ordered hits it needs and lets `simBatch` /
@@ -86,10 +84,6 @@ mock.module("../../embedding-backend.js", () => ({
       model: "test-model",
       vectors: state.embedReturn,
     };
-  },
-  generateSparseEmbedding: (text: string) => {
-    state.sparseCalls.push(text);
-    return state.sparseReturn;
   },
 }));
 
@@ -176,9 +170,7 @@ const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
 
 function resetState(): void {
   state.embedCalls.length = 0;
-  state.sparseCalls.length = 0;
   state.embedReturn = [[0.1, 0.2, 0.3]];
-  state.sparseReturn = { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] };
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   state.queryCalls.length = 0;


### PR DESCRIPTION
Addresses Devin review feedback on #30084. (1) When BM25 corpus-stats build completes, automatically enqueue a skill reseed so cold-start skills (seeded with the legacy TF encoder) get rewritten with stemmed BM25 vectors. (2) Removes dead generateSparseEmbedding mocks from activation.test.ts and context-search-memory-v2-source.test.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->