### PR TITLE
fix(macos): decrement turn count on per-message cancel and watchdog reset

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -775,6 +775,12 @@ final class ChatActionHandler {
         guard belongsToConversation(cancelled.conversationId) else { return }
         let wasCancelling = vm.isCancelling
         vm.isCancelling = false
+        // Per-message daemon cancel (e.g. queue eviction): the matching
+        // `message_complete` will never arrive. Decrement here, above the
+        // stale-event early-return below, which per-message cancels also hit.
+        if !wasCancelling && vm.messageManager.pendingUserTurnCount > 0 {
+            vm.messageManager.pendingUserTurnCount -= 1
+        }
         // Stale cancel event from a previous cancel cycle — the daemon
         // emits generation_cancelled for each queued entry during abort,
         // but the first event already reset state and dispatched any
@@ -805,16 +811,8 @@ final class ChatActionHandler {
                     vm.messages[i].status = .sent
                 }
             }
-        } else {
-            // Per-message cancel from the daemon (e.g. queue eviction). The
-            // matching `message_complete` will never arrive, so decrement the
-            // pending counter to keep the interactive-tick gate accurate.
-            if vm.messageManager.pendingUserTurnCount > 0 {
-                vm.messageManager.pendingUserTurnCount -= 1
-            }
-            if vm.pendingQueuedCount == 0 {
-                vm.isSending = false
-            }
+        } else if vm.pendingQueuedCount == 0 {
+            vm.isSending = false
         }
         vm.messageManager.batchUpdateMessages { msgs in
             if let existingId = vm.currentAssistantMessageId {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -247,6 +247,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
                     self.messageManager.isSending = false
+                    self.messageManager.pendingUserTurnCount = 0
                     self.sendingWatchdogTask?.cancel()
                     self.sendingWatchdogTask = nil
                     self.thinkingWatchdogTask = nil
@@ -383,6 +384,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.requestIdToMessageId.removeAll()
                     self.activeRequestIdToMessageId.removeAll()
                     self.pendingLocalDeletions.removeAll()
+                    self.messageManager.pendingUserTurnCount = 0
                     // Cancel stale cancel-timeout task
                     self.cancelTimeoutTask?.cancel()
                     self.cancelTimeoutTask = nil
@@ -1509,6 +1511,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 self?.isThinking = false
                 self?.isSending = false
                 self?.isCancelling = false
+                // Stream dropped mid-turn — `message_complete` won't arrive,
+                // so clear pending turns to avoid bumping
+                // `interactiveTurnCompletionTick` on the next turn.
+                self?.messageManager.pendingUserTurnCount = 0
                 if let existingId = self?.currentAssistantMessageId {
                     self?.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
                 }


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30096. (1) Hoist pendingUserTurnCount decrement above the !wasCancelling && isSending early-return so per-message daemon cancels (queue eviction) actually decrement. (2) Clear pendingUserTurnCount in turn-abort/watchdog reset paths (e.g. ChatViewModel.startMessageLoop stream-end recovery) so disconnect-recovery leaks don't bump interactiveTurnCompletionTick with stale entries on the next turn.