### PR TITLE
fix(bookmarks): derive conversationId from message in createBookmark

### DIFF
--- a/assistant/src/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-crud.test.ts
@@ -93,14 +93,8 @@ describe("bookmark-crud", () => {
       messageId: "msg-1",
     });
 
-    const first = createBookmark(db, {
-      messageId: "msg-1",
-      conversationId: "conv-1",
-    });
-    const second = createBookmark(db, {
-      messageId: "msg-1",
-      conversationId: "conv-1",
-    });
+    const first = createBookmark(db, { messageId: "msg-1" });
+    const second = createBookmark(db, { messageId: "msg-1" });
 
     expect(second.id).toBe(first.id);
     expect(second.createdAt).toBe(first.createdAt);
@@ -119,10 +113,7 @@ describe("bookmark-crud", () => {
       messageRole: "assistant",
     });
 
-    const summary = createBookmark(db, {
-      messageId: "msg-summary",
-      conversationId: "conv-summary",
-    });
+    const summary = createBookmark(db, { messageId: "msg-summary" });
 
     expect(summary.conversationTitle).toBe("Title goes here");
     expect(summary.messagePreview).toBe("summary body");
@@ -179,14 +170,8 @@ describe("bookmark-crud", () => {
       conversationId: "conv-drop",
       messageId: "msg-drop",
     });
-    createBookmark(db, {
-      messageId: "msg-keep",
-      conversationId: "conv-keep",
-    });
-    createBookmark(db, {
-      messageId: "msg-drop",
-      conversationId: "conv-drop",
-    });
+    createBookmark(db, { messageId: "msg-keep" });
+    createBookmark(db, { messageId: "msg-drop" });
     expect(listBookmarks(db).length).toBe(2);
 
     // Deleting the parent conversation cascades through messages → bookmarks.
@@ -203,7 +188,7 @@ describe("bookmark-crud", () => {
       conversationId: "conv-d",
       messageId: "msg-d",
     });
-    createBookmark(db, { messageId: "msg-d", conversationId: "conv-d" });
+    createBookmark(db, { messageId: "msg-d" });
     expect(listBookmarks(db).length).toBe(1);
 
     expect(deleteBookmarkByMessageId(db, "msg-d")).toBe(true);
@@ -223,10 +208,7 @@ describe("bookmark-crud", () => {
       messageRole: "user",
     });
 
-    const summary = createBookmark(db, {
-      messageId: "msg-blocks",
-      conversationId: "conv-blocks",
-    });
+    const summary = createBookmark(db, { messageId: "msg-blocks" });
 
     // Without the decode step, this would render as the raw JSON literal
     // (`[{"type":"text","text":"…"}]`) rather than the spoken text.
@@ -248,11 +230,27 @@ describe("bookmark-crud", () => {
       messageRole: "assistant",
     });
 
-    const summary = createBookmark(db, {
-      messageId: "msg-multi",
-      conversationId: "conv-multi",
-    });
+    const summary = createBookmark(db, { messageId: "msg-multi" });
 
     expect(summary.messagePreview).toBe("first paragraph\nsecond paragraph");
+  });
+
+  test("createBookmark derives conversationId from the message row", () => {
+    const { db, raw } = setupDb();
+    seedConversationAndMessage(raw, {
+      conversationId: "conv-real",
+      messageId: "msg-x",
+    });
+
+    const summary = createBookmark(db, { messageId: "msg-x" });
+    expect(summary.conversationId).toBe("conv-real");
+    expect(listBookmarks(db)[0]?.conversationId).toBe("conv-real");
+  });
+
+  test("createBookmark throws when the message id does not exist", () => {
+    const { db } = setupDb();
+    expect(() => createBookmark(db, { messageId: "ghost" })).toThrow(
+      /Message ghost not found/,
+    );
   });
 });

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -110,12 +110,26 @@ export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
  * {@link BookmarkSummary}. Idempotent on the unique `message_id` index —
  * if a bookmark already exists for `messageId`, the existing summary is
  * returned and no new row is inserted.
+ *
+ * `conversationId` is derived from the message row rather than trusted from
+ * the caller, so a buggy or malicious caller cannot persist a bookmark
+ * whose `conversationId` disagrees with the message's actual conversation.
  */
 export function createBookmark(
   db: DrizzleDb,
-  params: { messageId: string; conversationId: string },
+  params: { messageId: string },
 ): BookmarkSummary {
-  const { messageId, conversationId } = params;
+  const { messageId } = params;
+  const message = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (!message) {
+    throw new Error(`Message ${messageId} not found`);
+  }
+  const conversationId = message.conversationId;
+
   const existing = db
     .select({ id: messageBookmarks.id })
     .from(messageBookmarks)

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -79,7 +79,7 @@ function handleCreateBookmark({
     );
   }
 
-  const summary = createBookmark(getDb(), { messageId, conversationId });
+  const summary = createBookmark(getDb(), { messageId });
   publishBookmarkCreated(summary);
   return summary;
 }


### PR DESCRIPTION
Addresses Codex review feedback on #30117. createBookmark now derives conversationId from the message row instead of trusting caller input, so the CRUD helper cannot persist a bookmark row whose conversationId disagrees with the message's actual conversation (defense in depth).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->