### PR TITLE
fix(macos): emit steer-failure as non-coalescing chunk

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -621,6 +621,8 @@ struct ACPSessionDetailView: View {
         // We piggy-back on `userMessageChunk` rather than introducing a new
         // wire-side update type so `buildRows` keeps a closed switch and the
         // entry coalesces naturally with any prior user-message run.
+        // The failure follow-up uses a distinct `.steerFailure` updateType
+        // so it renders as its own row instead of coalescing with this one.
         session.appendEvent(ACPSessionUpdateMessage(
             acpSessionId: session.state.acpSessionId,
             updateType: .userMessageChunk,
@@ -641,7 +643,7 @@ struct ACPSessionDetailView: View {
             if case .failure = result {
                 session.appendEvent(ACPSessionUpdateMessage(
                     acpSessionId: acpSessionId,
-                    updateType: .userMessageChunk,
+                    updateType: .steerFailure,
                     content: "→ steer failed — the session may have ended."
                 ))
             }
@@ -819,6 +821,15 @@ extension ACPSessionDetailView {
                 lastChunk = nil
                 let items = parsePlanItems(event.content ?? "")
                 rows.append(.plan(id: event.id.uuidString, items: items))
+            case .steerFailure:
+                // Reset `lastChunk` so the row neither coalesces with the
+                // preceding optimistic "→ steered: …" user-message chunk
+                // nor with any subsequent user chunk.
+                lastChunk = nil
+                rows.append(.userMessage(
+                    id: event.id.uuidString,
+                    content: event.content ?? ""
+                ))
             case .unknown:
                 // Tolerated by design — ACP allows unknown updateType
                 // values; rather than crashing or showing a placeholder we

--- a/clients/shared/Network/ACPMessages.swift
+++ b/clients/shared/Network/ACPMessages.swift
@@ -143,6 +143,11 @@ public struct ACPSessionUpdateMessage: Codable, Equatable, Identifiable, Sendabl
         case toolCall = "tool_call"
         case toolCallUpdate = "tool_call_update"
         case plan
+        // Local-only synthetic event emitted by the macOS client when a
+        // steer call fails. Distinct from `.userMessageChunk` so `buildRows`
+        // renders it as its own non-coalescing row instead of merging into
+        // the preceding optimistic "→ steered: …" chunk.
+        case steerFailure = "steer_failure"
         case unknown
 
         /// Fall back to `.unknown` for unrecognized update types.


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30040. The steer-failure event used updateType: .userMessageChunk which buildRows coalesced with the preceding optimistic '→ steered: …' chunk, producing one garbled bubble. Switch to a distinct updateType so the failure renders as its own row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->