### PR TITLE
fix(bookmarks): gate bookmark.created SSE on actual insert

### DIFF
--- a/assistant/src/memory/__tests__/bookmark-crud.test.ts
+++ b/assistant/src/memory/__tests__/bookmark-crud.test.ts
@@ -102,8 +102,10 @@ describe("bookmark-crud", () => {
       conversationId: "conv-1",
     });
 
-    expect(second.id).toBe(first.id);
-    expect(second.createdAt).toBe(first.createdAt);
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(false);
+    expect(second.bookmark.id).toBe(first.bookmark.id);
+    expect(second.bookmark.createdAt).toBe(first.bookmark.createdAt);
 
     const all = listBookmarks(db);
     expect(all.length).toBe(1);
@@ -119,11 +121,13 @@ describe("bookmark-crud", () => {
       messageRole: "assistant",
     });
 
-    const summary = createBookmark(db, {
+    const result = createBookmark(db, {
       messageId: "msg-summary",
       conversationId: "conv-summary",
     });
 
+    expect(result.inserted).toBe(true);
+    const summary = result.bookmark;
     expect(summary.conversationTitle).toBe("Title goes here");
     expect(summary.messagePreview).toBe("summary body");
     expect(summary.messageRole).toBe("assistant");
@@ -223,7 +227,7 @@ describe("bookmark-crud", () => {
       messageRole: "user",
     });
 
-    const summary = createBookmark(db, {
+    const { bookmark: summary } = createBookmark(db, {
       messageId: "msg-blocks",
       conversationId: "conv-blocks",
     });
@@ -248,7 +252,7 @@ describe("bookmark-crud", () => {
       messageRole: "assistant",
     });
 
-    const summary = createBookmark(db, {
+    const { bookmark: summary } = createBookmark(db, {
       messageId: "msg-multi",
       conversationId: "conv-multi",
     });

--- a/assistant/src/memory/bookmark-crud.ts
+++ b/assistant/src/memory/bookmark-crud.ts
@@ -106,22 +106,37 @@ export function listBookmarks(db: DrizzleDb): BookmarkSummary[] {
 }
 
 /**
- * Create a bookmark for the given message and return its JOIN-shaped
- * {@link BookmarkSummary}. Idempotent on the unique `message_id` index —
- * if a bookmark already exists for `messageId`, the existing summary is
- * returned and no new row is inserted.
+ * Discriminated result returned by {@link createBookmark}. `inserted`
+ * distinguishes a brand-new row from an idempotent return of an existing
+ * one, so callers can suppress side effects (e.g. `bookmark.created` SSE
+ * publishes) on duplicate POSTs.
+ */
+export type CreateBookmarkResult =
+  | { inserted: true; bookmark: BookmarkSummary }
+  | { inserted: false; bookmark: BookmarkSummary };
+
+/**
+ * Create a bookmark for the given message and return a discriminated
+ * result indicating whether a new row was actually inserted. Idempotent
+ * on the unique `message_id` index — if a bookmark already exists for
+ * `messageId`, the existing summary is returned with `inserted: false`.
  */
 export function createBookmark(
   db: DrizzleDb,
   params: { messageId: string; conversationId: string },
-): BookmarkSummary {
+): CreateBookmarkResult {
   const { messageId, conversationId } = params;
   const existing = db
     .select({ id: messageBookmarks.id })
     .from(messageBookmarks)
     .where(eq(messageBookmarks.messageId, messageId))
     .get();
-  if (existing) return readBookmarkSummaryOrThrow(db, existing.id);
+  if (existing) {
+    return {
+      inserted: false,
+      bookmark: readBookmarkSummaryOrThrow(db, existing.id),
+    };
+  }
 
   const id = uuid();
   try {
@@ -137,9 +152,12 @@ export function createBookmark(
       .where(eq(messageBookmarks.messageId, messageId))
       .get();
     if (!winner) throw err;
-    return readBookmarkSummaryOrThrow(db, winner.id);
+    return {
+      inserted: false,
+      bookmark: readBookmarkSummaryOrThrow(db, winner.id),
+    };
   }
-  return readBookmarkSummaryOrThrow(db, id);
+  return { inserted: true, bookmark: readBookmarkSummaryOrThrow(db, id) };
 }
 
 function readBookmarkSummaryOrThrow(

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -241,6 +241,23 @@ describe("bookmark routes", () => {
     ).toBe("msg-6");
   });
 
+  test("duplicate POSTs only broadcast one bookmark.created event", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-dup",
+      messageId: "msg-dup",
+    });
+
+    await call(createHandler, {
+      body: { messageId: "msg-dup", conversationId: "conv-dup" },
+    });
+    await call(createHandler, {
+      body: { messageId: "msg-dup", conversationId: "conv-dup" },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(publishedTypes()).toEqual(["bookmark.created"]);
+  });
+
   test("DELETE on a non-existent messageId does not publish", async () => {
     await call(deleteByMessageHandler, {
       pathParams: { messageId: "does-not-exist" },

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -79,9 +79,11 @@ function handleCreateBookmark({
     );
   }
 
-  const summary = createBookmark(getDb(), { messageId, conversationId });
-  publishBookmarkCreated(summary);
-  return summary;
+  const result = createBookmark(getDb(), { messageId, conversationId });
+  if (result.inserted) {
+    publishBookmarkCreated(result.bookmark);
+  }
+  return result.bookmark;
 }
 
 function handleDeleteBookmarkByMessage({ pathParams = {} }: RouteHandlerArgs): {


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30118. createBookmark now returns a discriminated result so the route layer can suppress bookmark.created SSE publishes when the helper returned an existing row (idempotent re-POST) rather than inserting a new one.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->