### PR TITLE
fix(daemon): hasAskQuestion gates on full final tool-set

### DIFF
--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -86,4 +86,38 @@ describe("subagent-only tool filtering", () => {
     expect(isToolActiveForContext("ask_question", ctx)).toBe(false);
     expect(isToolActiveForContext(TEST_TOOL_NAME, ctx)).toBe(false);
   });
+
+  test("returns false for every tool when toolsDisabledDepth > 0", () => {
+    // `createResolveToolsCallback` returns an empty tool list when tools are
+    // disabled; mirror it here so system-prompt gating doesn't advertise tools
+    // the LLM cannot invoke.
+    const ctx: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: {},
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 1,
+      hasNoClient: false,
+    };
+
+    expect(isToolActiveForContext("bash", ctx)).toBe(false);
+    expect(isToolActiveForContext("ask_question", ctx)).toBe(false);
+  });
+
+  test("under disk-pressure cleanup mode, only cleanup-safe tools are active", () => {
+    // `createResolveToolsCallback` restricts the turn to cleanup-safe tools
+    // (`file_remove`, `bash`, etc.); ensure the helper agrees so the system
+    // prompt doesn't advertise tools that have been filtered out.
+    const ctx: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: {},
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 0,
+      hasNoClient: false,
+      diskPressureCleanupModeActive: true,
+    };
+
+    // `bash` is in DISK_PRESSURE_CLEANUP_TOOL_NAMES; `ask_question` is not.
+    expect(isToolActiveForContext("bash", ctx)).toBe(true);
+    expect(isToolActiveForContext("ask_question", ctx)).toBe(false);
+  });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -407,11 +407,12 @@ export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
 ]);
 
 /**
- * Determine whether a tool should be included in the LLM tool definitions
- * for the current turn based on conversation context. Tools not active for the
- * current context are omitted from the definitions sent to the provider,
- * reducing noise and preventing the model from attempting calls that would
- * fail.
+ * Determine whether a tool is part of the final exposed tool set for the
+ * current turn. This helper mirrors the filtering applied by
+ * `createResolveToolsCallback` — including the subagent allowlist,
+ * `toolsDisabledDepth`, and disk-pressure cleanup restrictions — so callers
+ * using it for system-prompt gating (e.g. `hasAskQuestion`) see the same
+ * tool set the LLM ultimately receives.
  */
 export function isToolActiveForContext(
   name: string,
@@ -423,6 +424,19 @@ export function isToolActiveForContext(
   // callers using this helper for system-prompt gating (e.g. hasAskQuestion)
   // see the same final tool set as `createResolveToolsCallback`.
   if (ctx.subagentAllowedTools && !ctx.subagentAllowedTools.has(name)) {
+    return false;
+  }
+  // `createResolveToolsCallback` returns an empty tool list when tools are
+  // disabled (e.g. pointer-generation turns) and restricts to cleanup-safe
+  // tools under disk pressure. Mirror both here so system-prompt gating
+  // doesn't advertise tools the LLM cannot actually invoke.
+  if (ctx.toolsDisabledDepth > 0) {
+    return false;
+  }
+  if (
+    ctx.diskPressureCleanupModeActive === true &&
+    !isDiskPressureCleanupToolName(name)
+  ) {
     return false;
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -70,6 +70,11 @@ export async function runBtwSidechain(
   const tools = params.tools;
   const history = params.messages ?? params.conversation?.getMessages() ?? [];
   const messages = [...history, userMessage(trimmedContent)];
+  // Side-chains force `tool_choice: { type: "none" }` below, so the model
+  // cannot invoke `ask_question` (or any other tool) from this path. Leaving
+  // `hasAskQuestion` unset keeps the "## Clarifying questions" workspace
+  // section out of the side-chain system prompt — advertising the tool would
+  // be misleading.
   const systemPrompt =
     params.systemPrompt ??
     (params.conversation?.hasSystemPromptOverride


### PR DESCRIPTION
## Summary
Fixes plan-review gaps for ask-question-proactive-and-batched:
- `isToolActiveForContext` now short-circuits on `toolsDisabledDepth > 0` and `diskPressureCleanupModeActive` (matches `createResolveToolsCallback` post-filter).
- `btw-sidechain.ts` now documents why it doesn't set `hasAskQuestion` (side-chains force `tool_choice: { type: "none" }`, so advertising the tool would be misleading).
- JSDoc on `isToolActiveForContext` updated to reflect the helper now mirrors final exposed tool set.

Part of plan: ask-question-proactive-and-batched.md (review fix R1-1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->