### PR TITLE
fix(macos): preserve user scroll position on showThoughts toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -346,12 +346,16 @@ struct ACPSessionDetailView: View {
                 .onChange(of: showThoughts) {
                     // Toggling thought visibility shrinks/grows the timeline,
                     // which moves the bottom offset. Reset the watermark for
-                    // the same reason as the ring-buffer trim above and
-                    // re-engage auto-scroll so users who flip the toggle while
-                    // parked at the bottom keep getting new events pinned.
+                    // the same reason as the ring-buffer trim above. Only
+                    // re-engage auto-scroll if the user was already parked at
+                    // the bottom — otherwise we'd snap users who deliberately
+                    // scrolled up to read history back down on the next event.
+                    let wasAtBottom = abs(lastScrollOffset - lastMaxScrollOffset) < Self.scrollAtBottomTolerance
                     lastMaxScrollOffset = 0
                     lastScrollOffset = 0
-                    autoScrollEnabled = true
+                    if wasAtBottom {
+                        autoScrollEnabled = true
+                    }
                 }
                 .onAppear {
                     // First-paint: park at the bottom so the user lands on


### PR DESCRIPTION
Addresses Codex P2 review feedback on #30014. Only re-enable autoScrollEnabled on showThoughts toggle when the user was already at/near bottom — unconditionally forcing autoScrollEnabled = true overrode users who deliberately scrolled up to read history and snapped them to the bottom on the next event.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->