### PR TITLE
fix(memory-v2): resolve router_prompt_path against runRouter workspaceDir

### DIFF
--- a/assistant/src/memory/v2/__tests__/prompts-router.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-router.test.ts
@@ -229,7 +229,7 @@ describe("resolveRouterPrompt — override path", () => {
   };
 
   test("null overridePath returns the bundled prompt verbatim", () => {
-    expect(resolveRouterPrompt(null, STD_OPTS)).toEqual(
+    expect(resolveRouterPrompt(null, tmpDir, STD_OPTS)).toEqual(
       renderRouterPrompt(STD_OPTS),
     );
   });
@@ -242,16 +242,35 @@ describe("resolveRouterPrompt — override path", () => {
       "utf-8",
     );
 
-    const out = resolveRouterPrompt(overridePath, STD_OPTS);
+    const out = resolveRouterPrompt(overridePath, tmpDir, STD_OPTS);
     expect(out).toContain("Hi Aria, you are routing for Alice.");
     expect(out).toContain(SAMPLE_INDEX);
     expect(out).not.toContain("{{ASSISTANT_NAME}}");
     expect(out).not.toContain("{{PAGE_INDEX}}");
   });
 
+  test("relative override path is resolved under the passed workspaceDir, not the default workspace", () => {
+    // Write the override into the per-test temp dir, which acts as a
+    // non-default workspace. The configured path is purely relative so the
+    // loader must resolve it against the supplied workspaceDir — if it
+    // resolved against the process-wide default workspace instead, the file
+    // wouldn't be found and the bundled prompt would be returned.
+    const relativeName = "router-override.md";
+    writeFileSync(
+      join(tmpDir, relativeName),
+      "Routed via {{ASSISTANT_NAME}} for {{USER_NAME}} :: {{PAGE_INDEX}}",
+      "utf-8",
+    );
+
+    const out = resolveRouterPrompt(relativeName, tmpDir, STD_OPTS);
+    expect(out).toContain("Routed via Aria for Alice");
+    expect(out).toContain(SAMPLE_INDEX);
+    expect(out).not.toEqual(renderRouterPrompt(STD_OPTS));
+  });
+
   test("missing override file falls back to bundled prompt", () => {
     const overridePath = join(tmpDir, "does-not-exist.md");
-    expect(resolveRouterPrompt(overridePath, STD_OPTS)).toEqual(
+    expect(resolveRouterPrompt(overridePath, tmpDir, STD_OPTS)).toEqual(
       renderRouterPrompt(STD_OPTS),
     );
   });
@@ -259,7 +278,7 @@ describe("resolveRouterPrompt — override path", () => {
   test("empty override file falls back to bundled prompt", () => {
     const overridePath = join(tmpDir, "empty.md");
     writeFileSync(overridePath, "   \n\t\n", "utf-8");
-    expect(resolveRouterPrompt(overridePath, STD_OPTS)).toEqual(
+    expect(resolveRouterPrompt(overridePath, tmpDir, STD_OPTS)).toEqual(
       renderRouterPrompt(STD_OPTS),
     );
   });
@@ -267,7 +286,7 @@ describe("resolveRouterPrompt — override path", () => {
   test("override that is a directory falls back to bundled prompt", () => {
     // Pass the temp directory itself as the override path — lstat sees a
     // directory, not a regular file, so the loader bails to bundled.
-    expect(resolveRouterPrompt(tmpDir, STD_OPTS)).toEqual(
+    expect(resolveRouterPrompt(tmpDir, tmpDir, STD_OPTS)).toEqual(
       renderRouterPrompt(STD_OPTS),
     );
   });
@@ -280,7 +299,7 @@ describe("resolveRouterPrompt — override path", () => {
       "utf-8",
     );
 
-    const out = resolveRouterPrompt(overridePath, {
+    const out = resolveRouterPrompt(overridePath, tmpDir, {
       assistantName: null,
       userName: null,
       pageIndexBlock: "",

--- a/assistant/src/memory/v2/prompts/router.ts
+++ b/assistant/src/memory/v2/prompts/router.ts
@@ -27,7 +27,6 @@ import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
 import { getLogger } from "../../../util/logger.js";
-import { getWorkspaceDir } from "../../../util/platform.js";
 
 const log = getLogger("memory-v2-router-prompt");
 
@@ -102,7 +101,7 @@ export function renderRouterPrompt(opts: RenderRouterPromptOpts): string {
  * referenced by `memory.v2.router.router_prompt_path`, then substitute the
  * standard placeholders. Path-resolution rules mirror the consolidation
  * prompt override: absolute paths used as-is, leading `~/` expanded to home,
- * relative paths resolved under the workspace root.
+ * relative paths resolved under `workspaceDir`.
  *
  * Failure handling is intentionally permissive — missing file, read error,
  * oversized file, or empty/whitespace-only body all log a warning and fall
@@ -111,11 +110,12 @@ export function renderRouterPrompt(opts: RenderRouterPromptOpts): string {
  */
 export function resolveRouterPrompt(
   overridePath: string | null,
+  workspaceDir: string,
   opts: RenderRouterPromptOpts,
 ): string {
   if (overridePath === null) return renderRouterPrompt(opts);
 
-  const resolvedPath = resolveOverridePath(overridePath);
+  const resolvedPath = resolveOverridePath(overridePath, workspaceDir);
   let contents: string;
   try {
     const stat = lstatSync(resolvedPath);
@@ -183,10 +183,13 @@ function substitutePlaceholders(
     .replaceAll(PAGE_INDEX_PLACEHOLDER, () => opts.pageIndexBlock);
 }
 
-function resolveOverridePath(overridePath: string): string {
+function resolveOverridePath(
+  overridePath: string,
+  workspaceDir: string,
+): string {
   if (overridePath.startsWith("~/")) {
     return join(homedir(), overridePath.slice(2));
   }
   if (isAbsolute(overridePath)) return overridePath;
-  return join(getWorkspaceDir(), overridePath);
+  return join(workspaceDir, overridePath);
 }

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -181,6 +181,7 @@ export async function runRouter(
 
   const systemPrompt = resolveRouterPrompt(
     config.memory?.v2?.router?.router_prompt_path ?? null,
+    workspaceDir,
     {
       assistantName: getAssistantName(),
       userName: resolveUserName(workspaceDir),


### PR DESCRIPTION
Addresses Codex review feedback on #30234. Relative router_prompt_path values were resolved against getWorkspaceDir() (the default workspace) instead of the workspaceDir parameter that runRouter already accepts, so non-default workspaces silently fell back to the bundled prompt. Now uses the threaded workspaceDir.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->