### PR TITLE
test(live-voice): cover transcriber handle retention on stop() throw

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -229,6 +229,63 @@ describe("LiveVoiceSession STT", () => {
     ]);
   });
 
+  test("retains transcriber handle when stop() throws so close() can clean up", async () => {
+    class ThrowingStopTranscriber extends MockStreamingTranscriber {
+      stopCalls = 0;
+      override stop(): void {
+        this.stopCalls += 1;
+        if (this.stopCalls === 1) {
+          throw new Error("stop failed");
+        }
+      }
+    }
+
+    const transcriber = new ThrowingStopTranscriber();
+    const { frames, session } = createSessionWithTranscriber(transcriber);
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    expect(transcriber.stopCalls).toBe(1);
+    expect(
+      frames.some(
+        (frame) =>
+          frame.type === "error" &&
+          frame.message.includes(
+            "Live voice transcription could not be stopped",
+          ),
+      ),
+    ).toBe(true);
+
+    await session.close("websocket_close");
+
+    expect(transcriber.stopCalls).toBe(2);
+  });
+
+  test("retains transcriber handle when stop() throws so interrupt() can clean up", async () => {
+    class ThrowingStopTranscriber extends MockStreamingTranscriber {
+      stopCalls = 0;
+      override stop(): void {
+        this.stopCalls += 1;
+        if (this.stopCalls === 1) {
+          throw new Error("stop failed");
+        }
+      }
+    }
+
+    const transcriber = new ThrowingStopTranscriber();
+    const { session } = createSessionWithTranscriber(transcriber);
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    expect(transcriber.stopCalls).toBe(1);
+
+    await session.handleClientFrame({ type: "interrupt" });
+
+    expect(transcriber.stopCalls).toBe(2);
+  });
+
   test("uses the production streaming transcriber resolver by default", () => {
     const source = readFileSync(
       new URL("../live-voice-session.ts", import.meta.url),


### PR DESCRIPTION
Addresses Devin review feedback on #30053. Adds a regression test for the stop()-throws path verifying subsequent close()/interrupt() calls still clean up the retained transcriber handle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->