### PR TITLE
fix(chat): include canBookmarkMessage in supportsOverflowHover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -254,8 +254,12 @@ struct ChatBubble: View, Equatable {
         showInspectButton && !isUser && message.daemonMessageId != nil
     }
 
+    var canBookmarkMessage: Bool {
+        onToggleBookmark != nil && bookmarkStore != nil && message.daemonMessageId != nil && bookmarkConversationId != nil && !message.isStreaming && MacOSClientFeatureFlagManager.shared.isEnabled("bookmarks")
+    }
+
     var supportsOverflowHover: Bool {
-        !message.isStreaming && (hasCopyableText || canInspectMessage || canForkFromMessage)
+        !message.isStreaming && (hasCopyableText || canInspectMessage || canForkFromMessage || canBookmarkMessage)
     }
 
     /// Composite identity for the `.task` modifier so it re-runs when either


### PR DESCRIPTION
Addresses Devin review feedback on #30120. ChatBubble.supportsOverflowHover didn't include canBookmarkMessage, so messages whose only available overflow action was bookmark (e.g., empty-text assistant messages) reserved the overflow row but never set hoverState.isHovered=true, leaving the bookmark button unreachable on hover.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->