### PR TITLE
fix(settings): show ProgressView during BookmarksTab initial load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBookmarksTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBookmarksTab.swift
@@ -24,7 +24,10 @@ struct SettingsBookmarksTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            if bookmarkStore.bookmarks.isEmpty {
+            if bookmarkStore.isLoading && bookmarkStore.bookmarks.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 120)
+            } else if bookmarkStore.bookmarks.isEmpty {
                 GeometryReader { geo in
                     VEmptyState(
                         title: "No bookmarks",

--- a/clients/macos/vellum-assistant/Services/BookmarkStore.swift
+++ b/clients/macos/vellum-assistant/Services/BookmarkStore.swift
@@ -30,6 +30,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Bookm
 public final class BookmarkStore {
     public private(set) var bookmarks: [BookmarkSummary] = []
     public private(set) var bookmarkedMessageIds: Set<String> = []
+    public private(set) var isLoading = true
 
     @ObservationIgnored private let client: BookmarkClient
     @ObservationIgnored private var sseChangeCancellable: AnyCancellable?
@@ -50,6 +51,8 @@ public final class BookmarkStore {
     /// local state. Call once the gateway connection is established, and
     /// whenever a `bookmark.*` SSE event arrives from another window.
     public func reload() async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             let fetched = try await client.listBookmarks()
             bookmarks = fetched


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30121. SettingsBookmarksTab showed the No-bookmarks empty state during initial .task reload because bookmarkStore.isLoading was never checked. Now mirrors SettingsSchedulesTab: render ProgressView when isLoading && bookmarks.isEmpty before falling back to empty state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->