### PR TITLE
fix(bookmarks): fall back to raw text + drop unused type

### DIFF
--- a/assistant/src/memory/__tests__/message-content.test.ts
+++ b/assistant/src/memory/__tests__/message-content.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { stringifyMessageContent } from "../message-content.js";
+
+describe("stringifyMessageContent", () => {
+  test("returns trimmed raw text for legacy plain-string rows", () => {
+    expect(stringifyMessageContent("  hello world  ")).toBe("hello world");
+  });
+
+  test("returns trimmed inner string when JSON parses to a string", () => {
+    expect(stringifyMessageContent(JSON.stringify("  inner  "))).toBe("inner");
+  });
+
+  test("concatenates text blocks from a ContentBlock[] payload", () => {
+    const raw = JSON.stringify([
+      { type: "text", text: "alpha" },
+      { type: "tool_use", id: "x", name: "noop", input: {} },
+      { type: "text", text: "beta" },
+    ]);
+    expect(stringifyMessageContent(raw)).toBe("alpha\nbeta");
+  });
+
+  test("falls back to raw trimmed text when JSON parses to a non-array object", () => {
+    const raw = '  {"type":"text","text":"hi"}  ';
+    expect(stringifyMessageContent(raw)).toBe('{"type":"text","text":"hi"}');
+  });
+
+  test("falls back to raw trimmed text when JSON parses to a number", () => {
+    expect(stringifyMessageContent("  42  ")).toBe("42");
+  });
+
+  test("returns trimmed raw text when JSON parsing fails", () => {
+    expect(stringifyMessageContent("  not json  ")).toBe("not json");
+  });
+});

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -152,7 +152,7 @@ export function stringifyMessageContent(stored: string): string {
     return stored.trim();
   }
   if (typeof parsed === "string") return parsed.trim();
-  if (!Array.isArray(parsed)) return "";
+  if (!Array.isArray(parsed)) return stored.trim();
   const parts: string[] = [];
   for (const block of parsed) {
     if (

--- a/assistant/src/memory/schema/bookmarks.ts
+++ b/assistant/src/memory/schema/bookmarks.ts
@@ -34,5 +34,3 @@ export const messageBookmarks = sqliteTable(
     index("message_bookmarks_created_at_idx").on(table.createdAt),
   ],
 );
-
-export type MessageBookmarkRow = typeof messageBookmarks.$inferSelect;


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30127. (1) stringifyMessageContent now falls back to raw trimmed text when JSON parses to a non-array. (2) Removes the unused MessageBookmarkRow type at assistant/src/memory/schema/bookmarks.ts:38.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->