### PR TITLE
fix(migrations): gate memory_v2_reembed enqueue on v2 enabled

### DIFF
--- a/assistant/src/__tests__/workspace-migration-075-memory-v2-bm25-b-default-reembed.test.ts
+++ b/assistant/src/__tests__/workspace-migration-075-memory-v2-bm25-b-default-reembed.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for workspace migration `075-memory-v2-bm25-b-default-reembed`.
+ *
+ * The migration enqueues a one-shot `memory_v2_reembed` job so existing
+ * concept pages pick up the new `bm25_b` default. It must be gated on
+ * `memory.v2.enabled` so v1-only workspaces don't run an unnecessary pass.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { memoryV2Bm25BDefaultReembedMigration } from "../workspace/migrations/075-memory-v2-bm25-b-default-reembed.js";
+
+let workspaceDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-075-test-"));
+  const dbDir = join(workspaceDir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  dbPath = join(dbDir, "assistant.db");
+
+  const db = new Database(dbPath);
+  db.run(`
+    CREATE TABLE memory_jobs (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempts INTEGER NOT NULL,
+      deferrals INTEGER NOT NULL,
+      run_after INTEGER NOT NULL,
+      last_error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  db.close();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function countReembedJobs(): number {
+  const db = new Database(dbPath);
+  try {
+    const row = db
+      .query(
+        `SELECT COUNT(*) AS n FROM memory_jobs WHERE type='memory_v2_reembed'`,
+      )
+      .get() as { n: number };
+    return row.n;
+  } finally {
+    db.close();
+  }
+}
+
+describe("075-memory-v2-bm25-b-default-reembed migration", () => {
+  test("enqueues memory_v2_reembed when config.json is absent (v2 enabled by default)", () => {
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+  });
+
+  test("enqueues memory_v2_reembed when memory.v2.enabled is explicitly true", () => {
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({ memory: { v2: { enabled: true } } }),
+      "utf-8",
+    );
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+  });
+
+  test("skips enqueue when memory.v2.enabled is explicitly false", () => {
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({ memory: { v2: { enabled: false } } }),
+      "utf-8",
+    );
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("enqueues when config.json is malformed (falls back to default-enabled)", () => {
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      "{not valid json",
+      "utf-8",
+    );
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+  });
+});

--- a/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
+++ b/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
@@ -12,6 +12,10 @@ import type { WorkspaceMigration } from "./types.js";
  * vectors at write time, so without this nudge workspaces that never pinned
  * the field would silently mix old and new length normalization until a
  * manual reembed.
+ *
+ * Skipped when `memory.v2.enabled` is explicitly `false`. Those workspaces
+ * have no v2 concept pages to refresh, so the job would be a no-op (or
+ * worse, confusing) once the v2 worker is disabled.
  */
 export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
   id: "075-memory-v2-bm25-b-default-reembed",
@@ -19,6 +23,8 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
     "Enqueue memory_v2_reembed so existing concept pages pick up the new bm25_b=0.4 default",
 
   run(workspaceDir: string): void {
+    if (isMemoryV2Disabled(workspaceDir)) return;
+
     const dbPath = join(workspaceDir, "data", "db", "assistant.db");
     if (!existsSync(dbPath)) return; // Fresh install — pages will embed at the new default.
 
@@ -59,3 +65,20 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
     // Forward-only: the reembed is a one-shot data refresh.
   },
 };
+
+/**
+ * Returns true only when `memory.v2.enabled` is explicitly set to `false` in
+ * the workspace `config.json`. Missing/unparseable config falls through to
+ * the schema default (enabled), matching `MemoryV2ConfigSchema`.
+ */
+function isMemoryV2Disabled(workspaceDir: string): boolean {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const memory = (raw as { memory?: { v2?: { enabled?: unknown } } })?.memory;
+    return memory?.v2?.enabled === false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Addresses Codex review feedback on #30082. The migration unconditionally enqueued memory_v2_reembed for every workspace, including ones that opted out of memory v2. Now gates the enqueue on memory.v2.enabled so v1-only workspaces don't run a no-op or unnecessary reembed pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->