### PR TITLE
fix(daemon): question prompter/route plumbing cleanup

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11852,7 +11852,7 @@ paths:
         content:
           application/json:
             schema:
-              anyOf:
+              oneOf:
                 - type: object
                   properties:
                     requestId:

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -4,6 +4,10 @@ import type {
   QuestionRequest,
   ServerMessage,
 } from "../daemon/message-protocol.js";
+import type {
+  QuestionBatchSubmission,
+  QuestionPromptResult,
+} from "./question-prompter.js";
 
 // Use a tiny timeout so the setTimeout branch fires quickly in tests
 const mockConfig = {
@@ -33,9 +37,18 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Use a real Map so QuestionPrompter can store and retrieve callbacks.
-const _piStore = new Map<string, { timer?: ReturnType<typeof setTimeout> }>();
+interface MockInteraction {
+  rpcResolve?: (v: unknown) => void;
+  rpcReject?: (e: unknown) => void;
+  timer?: ReturnType<typeof setTimeout>;
+  metadata?: {
+    orderedIds: string[];
+    optionsById: Record<string, string[]>;
+  };
+}
+const _piStore = new Map<string, MockInteraction>();
 mock.module("../runtime/pending-interactions.js", () => ({
-  register: (id: string, entry: object) => _piStore.set(id, entry),
+  register: (id: string, entry: MockInteraction) => _piStore.set(id, entry),
   resolve: (id: string) => {
     const e = _piStore.get(id);
     if (e?.timer != null) clearTimeout(e.timer);
@@ -50,9 +63,11 @@ mock.module("../runtime/pending-interactions.js", () => ({
   clear: () => _piStore.clear(),
 }));
 
-const { QuestionPrompter, QuestionBatchValidationError } = await import(
-  "./question-prompter.js"
-);
+const {
+  QuestionPrompter,
+  QuestionBatchValidationError,
+  buildBatchEntries,
+} = await import("./question-prompter.js");
 
 function makePrompter() {
   const sent: ServerMessage[] = [];
@@ -60,6 +75,57 @@ function makePrompter() {
     broadcastMessage: (msg) => sent.push(msg),
   });
   return { prompter, sent };
+}
+
+/**
+ * Drive a pending question interaction the same way the
+ * `/v1/question-response` route does: look up the metadata, run
+ * `buildBatchEntries`, deregister, then fire `rpcResolve`. Centralizing the
+ * sequence in one helper keeps the tests focused on observable behavior and
+ * mirrors the production resolution path.
+ */
+function resolveBatch(
+  requestId: string,
+  submissions: QuestionBatchSubmission[],
+): QuestionPromptResult {
+  const interaction = _piStore.get(requestId);
+  if (!interaction?.metadata) {
+    throw new Error(`No pending question interaction for ${requestId}`);
+  }
+  const { orderedIds, optionsById } = interaction.metadata;
+  const entries = buildBatchEntries(
+    orderedIds,
+    (qid, oid) => (optionsById[qid] ?? []).includes(oid),
+    new Set(Object.keys(optionsById)),
+    submissions,
+  );
+  const result: QuestionPromptResult = { entries, overall: "completed" };
+  if (interaction.timer != null) clearTimeout(interaction.timer);
+  _piStore.delete(requestId);
+  interaction.rpcResolve?.(result);
+  return result;
+}
+
+/**
+ * Close a pending question card: every entry reported as `skipped`, overall
+ * status `closed`. Mirrors the route's `kind: "close"` branch.
+ */
+function closeBatch(requestId: string): QuestionPromptResult {
+  const interaction = _piStore.get(requestId);
+  if (!interaction?.metadata) {
+    throw new Error(`No pending question interaction for ${requestId}`);
+  }
+  const result: QuestionPromptResult = {
+    entries: interaction.metadata.orderedIds.map((id) => ({
+      questionId: id,
+      decision: "skipped" as const,
+    })),
+    overall: "closed",
+  };
+  if (interaction.timer != null) clearTimeout(interaction.timer);
+  _piStore.delete(requestId);
+  interaction.rpcResolve?.(result);
+  return result;
 }
 
 const fruitOptions = [
@@ -104,7 +170,7 @@ describe("QuestionPrompter", () => {
     _piStore.clear();
   });
 
-  test("happy path: option resolution via submitQuestionBatch", async () => {
+  test("happy path: option resolution via the shared batch helpers", async () => {
     const { prompter, sent } = makePrompter();
 
     const promise = prompter.prompt(singleQuestionParams);
@@ -115,7 +181,7 @@ describe("QuestionPrompter", () => {
     expect(req.questions).toHaveLength(1);
     expect(req.questions[0]?.id).toBe("q1");
 
-    prompter.submitQuestionBatch(req.requestId, [
+    resolveBatch(req.requestId, [
       { questionId: "q1", kind: "option", optionId: "a" },
     ]);
 
@@ -124,7 +190,7 @@ describe("QuestionPrompter", () => {
       entries: [{ questionId: "q1", decision: "option", optionId: "a" }],
       overall: "completed",
     });
-    expect(prompter.hasPendingRequest(req.requestId)).toBe(false);
+    expect(_piStore.has(req.requestId)).toBe(false);
   });
 
   test("free-text resolution", async () => {
@@ -145,7 +211,7 @@ describe("QuestionPrompter", () => {
     expect(req.freeTextPlaceholder).toBe("Type a fruit");
     expect(req.questions[0]?.freeTextPlaceholder).toBe("Type a fruit");
 
-    prompter.submitQuestionBatch(req.requestId, [
+    resolveBatch(req.requestId, [
       { questionId: "q1", kind: "free_text", text: "Cherry" },
     ]);
 
@@ -175,7 +241,7 @@ describe("QuestionPrompter", () => {
     const promise = prompter.prompt(threeQuestionParams);
     const req = sent[0] as QuestionRequest;
 
-    prompter.submitQuestionBatch(req.requestId, [
+    resolveBatch(req.requestId, [
       { questionId: "q2", kind: "option", optionId: "y" },
       { questionId: "q1", kind: "option", optionId: "a" },
       { questionId: "q3", kind: "free_text", text: "noon-ish" },
@@ -192,13 +258,13 @@ describe("QuestionPrompter", () => {
     ]);
   });
 
-  test("three-question batch: all skipped via submitQuestionBatch", async () => {
+  test("three-question batch: all skipped via submitted entries", async () => {
     const { prompter, sent } = makePrompter();
 
     const promise = prompter.prompt(threeQuestionParams);
     const req = sent[0] as QuestionRequest;
 
-    prompter.submitQuestionBatch(req.requestId, [
+    resolveBatch(req.requestId, [
       { questionId: "q1", kind: "skip" },
       { questionId: "q2", kind: "skip" },
       { questionId: "q3", kind: "skip" },
@@ -209,13 +275,13 @@ describe("QuestionPrompter", () => {
     expect(result.entries.every((e) => e.decision === "skipped")).toBe(true);
   });
 
-  test("closeQuestion: all entries skipped with overall=closed", async () => {
+  test("close path: all entries skipped with overall=closed", async () => {
     const { prompter, sent } = makePrompter();
 
     const promise = prompter.prompt(threeQuestionParams);
     const req = sent[0] as QuestionRequest;
 
-    prompter.closeQuestion(req.requestId);
+    closeBatch(req.requestId);
 
     const result = await promise;
     expect(result.overall).toBe("closed");
@@ -226,40 +292,39 @@ describe("QuestionPrompter", () => {
     ]);
   });
 
-  test("submitQuestionBatch rejects unknown questionId", async () => {
-    const { prompter, sent } = makePrompter();
-    void prompter.prompt(singleQuestionParams);
-    const req = sent[0] as QuestionRequest;
-
+  test("buildBatchEntries rejects unknown questionId", () => {
     expect(() =>
-      prompter.submitQuestionBatch(req.requestId, [
-        { questionId: "qX", kind: "option", optionId: "a" },
-      ]),
+      buildBatchEntries(
+        ["q1"],
+        () => true,
+        new Set(["q1"]),
+        [{ questionId: "qX", kind: "option", optionId: "a" }],
+      ),
     ).toThrow(QuestionBatchValidationError);
   });
 
-  test("submitQuestionBatch rejects missing entry", async () => {
-    const { prompter, sent } = makePrompter();
-    void prompter.prompt(threeQuestionParams);
-    const req = sent[0] as QuestionRequest;
-
+  test("buildBatchEntries rejects missing entry", () => {
     expect(() =>
-      prompter.submitQuestionBatch(req.requestId, [
-        { questionId: "q1", kind: "option", optionId: "a" },
-        { questionId: "q2", kind: "option", optionId: "x" },
-      ]),
+      buildBatchEntries(
+        ["q1", "q2", "q3"],
+        () => true,
+        new Set(["q1", "q2", "q3"]),
+        [
+          { questionId: "q1", kind: "option", optionId: "a" },
+          { questionId: "q2", kind: "option", optionId: "x" },
+        ],
+      ),
     ).toThrow(QuestionBatchValidationError);
   });
 
-  test("submitQuestionBatch rejects unknown optionId", async () => {
-    const { prompter, sent } = makePrompter();
-    void prompter.prompt(singleQuestionParams);
-    const req = sent[0] as QuestionRequest;
-
+  test("buildBatchEntries rejects unknown optionId", () => {
     expect(() =>
-      prompter.submitQuestionBatch(req.requestId, [
-        { questionId: "q1", kind: "option", optionId: "nope" },
-      ]),
+      buildBatchEntries(
+        ["q1"],
+        (qid, oid) => qid === "q1" && (oid === "a" || oid === "b"),
+        new Set(["q1"]),
+        [{ questionId: "q1", kind: "option", optionId: "nope" }],
+      ),
     ).toThrow(QuestionBatchValidationError);
   });
 
@@ -274,7 +339,7 @@ describe("QuestionPrompter", () => {
     ]);
   });
 
-  test("abort signal triggers overall: aborted", async () => {
+  test("abort signal triggers overall: aborted with per-entry aborted decisions", async () => {
     const { prompter, sent } = makePrompter();
     const ac = new AbortController();
 
@@ -283,15 +348,20 @@ describe("QuestionPrompter", () => {
       signal: ac.signal,
     });
     const req = sent[0] as QuestionRequest;
-    expect(prompter.hasPendingRequest(req.requestId)).toBe(true);
+    expect(_piStore.has(req.requestId)).toBe(true);
 
     ac.abort();
     const result = await promise;
     expect(result.overall).toBe("aborted");
-    expect(prompter.hasPendingRequest(req.requestId)).toBe(false);
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "aborted" },
+      { questionId: "q2", decision: "aborted" },
+      { questionId: "q3", decision: "aborted" },
+    ]);
+    expect(_piStore.has(req.requestId)).toBe(false);
   });
 
-  test("pre-aborted signal short-circuits before broadcasting", async () => {
+  test("pre-aborted signal short-circuits before broadcasting with aborted entries", async () => {
     const { prompter, sent } = makePrompter();
     const ac = new AbortController();
     ac.abort();
@@ -301,6 +371,11 @@ describe("QuestionPrompter", () => {
       signal: ac.signal,
     });
     expect(result.overall).toBe("aborted");
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "aborted" },
+      { questionId: "q2", decision: "aborted" },
+      { questionId: "q3", decision: "aborted" },
+    ]);
     expect(sent).toHaveLength(0);
   });
 });

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -32,13 +32,15 @@ export class QuestionBatchValidationError extends Error {
  *  - `"skipped"` — the user explicitly skipped this question, or the card
  *    was closed before any answer was submitted.
  *  - `"timed_out"` — the prompt timer fired before the client submitted.
+ *  - `"aborted"` — the prompter's abort signal fired before any answer
+ *    was submitted.
  *
  * `questionId` matches the daemon-assigned id (`q1`, `q2`...) that the
  * prompter attached to the broadcast.
  */
 export interface QuestionPromptEntryResult {
   questionId: string;
-  decision: "option" | "free_text" | "skipped" | "timed_out";
+  decision: "option" | "free_text" | "skipped" | "timed_out" | "aborted";
   optionId?: string;
   text?: string;
 }
@@ -135,17 +137,17 @@ export function buildBatchEntries(
  * The route reads this to validate batched submissions without needing a
  * reference to the prompter that registered them.
  */
-interface QuestionBatchMetadata {
+export interface QuestionBatchMetadata {
   orderedIds: string[];
   optionsById: Record<string, string[]>;
 }
 
 /**
  * Broadcast an ask-question request to all connected clients and wait for the
- * user's reply. Mirrors the {@link SecretPrompter} and {@link PermissionPrompter}
- * patterns: lifecycle state (rpcResolve, rpcReject, timer) lives in
- * pendingInteractions; this class only tracks ownership so dispose can scope
- * cleanup to a single conversation.
+ * user's reply. All lifecycle state (rpcResolve, rpcReject, timer, batch
+ * metadata) lives on the `pendingInteractions` entry — `/v1/question-response`
+ * resolves the entry directly without holding a reference back to the prompter
+ * that registered it.
  *
  * Batching: a single `prompt()` call broadcasts one or more questions, and
  * the prompter waits for exactly one resolution call carrying the full
@@ -159,8 +161,6 @@ interface QuestionBatchMetadata {
  * secret prompts, so they share the same idle-timeout knob.
  */
 export class QuestionPrompter {
-  private ownedIds = new Set<string>();
-
   constructor(
     private deps: { broadcastMessage(msg: ServerMessage): void },
   ) {}
@@ -194,7 +194,7 @@ export class QuestionPrompter {
       return {
         entries: orderedIds.map((id) => ({
           questionId: id,
-          decision: "skipped",
+          decision: "aborted",
         })),
         overall: "aborted",
       };
@@ -207,7 +207,6 @@ export class QuestionPrompter {
 
       const timer = setTimeout(() => {
         pendingInteractions.resolve(requestId);
-        this.ownedIds.delete(requestId);
         log.warn({ requestId, conversationId }, "Question prompt timed out");
         resolve({
           entries: orderedIds.map((id) => ({
@@ -229,21 +228,21 @@ export class QuestionPrompter {
         toolUseId,
         metadata: { orderedIds, optionsById } satisfies QuestionBatchMetadata,
       });
-      this.ownedIds.add(requestId);
 
       if (signal) {
         const onAbort = () => {
-          if (this.ownedIds.has(requestId)) {
-            pendingInteractions.resolve(requestId);
-            this.ownedIds.delete(requestId);
-            resolve({
-              entries: orderedIds.map((id) => ({
-                questionId: id,
-                decision: "skipped",
-              })),
-              overall: "aborted",
-            });
-          }
+          // `pendingInteractions.resolve(requestId)` returns the deregistered
+          // entry on first call and undefined thereafter — use that as the
+          // idempotency guard so a late abort after route/timeout resolution
+          // is a no-op.
+          if (pendingInteractions.resolve(requestId) === undefined) return;
+          resolve({
+            entries: orderedIds.map((id) => ({
+              questionId: id,
+              decision: "aborted",
+            })),
+            overall: "aborted",
+          });
         };
         signal.addEventListener("abort", onAbort, { once: true });
       }
@@ -266,86 +265,5 @@ export class QuestionPrompter {
 
       this.deps.broadcastMessage(msg);
     });
-  }
-
-  hasPendingRequest(requestId: string): boolean {
-    return this.ownedIds.has(requestId);
-  }
-
-  /**
-   * Resolve a pending request with a complete batched submission. Validates
-   * that every original questionId is covered exactly once, no unknown
-   * questionId appears, and each `"option"` entry's optionId is one of
-   * the question's options.
-   *
-   * Throws {@link QuestionBatchValidationError} on validation failure so the
-   * route can map it to a 400. Returns `false` if no request matches.
-   */
-  submitQuestionBatch(
-    requestId: string,
-    submissions: QuestionBatchSubmission[],
-  ): boolean {
-    const meta = this.getOwnedBatchMetadata(requestId);
-    if (!meta) return false;
-
-    const entries = buildBatchEntries(
-      meta.orderedIds,
-      (qid, oid) => (meta.optionsById[qid] ?? []).includes(oid),
-      new Set(Object.keys(meta.optionsById)),
-      submissions,
-    );
-    this.resolveOwned(requestId, { entries, overall: "completed" });
-    return true;
-  }
-
-  /**
-   * Resolve a pending request as "closed" — the user dismissed the card
-   * without answering. Every entry is reported as `skipped` and the overall
-   * status is `closed`. Returns `false` if no request matches.
-   */
-  closeQuestion(requestId: string): boolean {
-    const meta = this.getOwnedBatchMetadata(requestId);
-    if (!meta) return false;
-
-    const entries: QuestionPromptEntryResult[] = meta.orderedIds.map((id) => ({
-      questionId: id,
-      decision: "skipped",
-    }));
-    this.resolveOwned(requestId, { entries, overall: "closed" });
-    return true;
-  }
-
-  dispose(): void {
-    for (const requestId of [...this.ownedIds]) {
-      const interaction = pendingInteractions.resolve(requestId);
-      this.ownedIds.delete(requestId);
-      interaction?.rpcReject?.(
-        new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),
-      );
-    }
-  }
-
-  // ── Internals ──────────────────────────────────────────────────────
-
-  /** Read batch metadata for an owned requestId, or null/log-warn otherwise. */
-  private getOwnedBatchMetadata(
-    requestId: string,
-  ): QuestionBatchMetadata | null {
-    if (!this.ownedIds.has(requestId)) {
-      log.warn({ requestId }, "No pending prompt for this requestId");
-      return null;
-    }
-    const interaction = pendingInteractions.get(requestId);
-    const meta = interaction?.metadata as QuestionBatchMetadata | undefined;
-    return meta ?? null;
-  }
-
-  /** Resolve an owned request: deregister, drop ownership, fire rpcResolve. */
-  private resolveOwned(requestId: string, value: QuestionPromptResult): void {
-    const interaction = pendingInteractions.resolve(requestId);
-    this.ownedIds.delete(requestId);
-    (interaction?.rpcResolve as
-      | ((v: QuestionPromptResult) => void)
-      | undefined)?.(value);
   }
 }

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import {
   buildBatchEntries,
+  type QuestionBatchMetadata,
   type QuestionBatchSubmission,
   QuestionBatchValidationError,
   type QuestionPromptResult,
@@ -78,7 +79,11 @@ const LegacyFreeTextBody = z.object({
   text: z.string(),
 });
 
-const QuestionResponseBody = z.union([
+// All four variants are mutually exclusive by their `kind` literal, so use
+// `discriminatedUnion` rather than plain `union`. The generated OpenAPI then
+// emits `oneOf` for the body (matching the pre-batched-shape spec) instead
+// of the looser `anyOf` that `z.union` produces.
+const QuestionResponseBody = z.discriminatedUnion("kind", [
   SubmitBody,
   CloseBody,
   LegacyOptionBody,
@@ -223,14 +228,11 @@ function buildCompletedResult(
  */
 function readBatchMetadata(
   interaction: ReturnType<typeof pendingInteractions.get>,
-): { orderedIds: string[]; optionsById: Record<string, string[]> } {
+): QuestionBatchMetadata {
+  const meta = interaction?.metadata as Partial<QuestionBatchMetadata> | undefined;
   return {
-    orderedIds:
-      (interaction?.metadata?.orderedIds as string[] | undefined) ?? [],
-    optionsById:
-      (interaction?.metadata?.optionsById as
-        | Record<string, string[]>
-        | undefined) ?? {},
+    orderedIds: meta?.orderedIds ?? [],
+    optionsById: meta?.optionsById ?? {},
   };
 }
 

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -252,12 +252,7 @@ export class AskQuestionTool implements Tool {
     const prompter = this.prompterFactory();
     const result = await prompter.prompt({
       conversationId: context.conversationId,
-      questions: questions.map((q) => ({
-        question: q.question,
-        description: q.description,
-        options: q.options,
-        freeTextPlaceholder: q.freeTextPlaceholder,
-      })),
+      questions,
       toolUseId: context.toolUseId,
       signal: context.signal,
     });


### PR DESCRIPTION
## Summary
Plan-review fixes for ask-question-proactive-and-batched:
- Removes dead `QuestionPrompter` public methods (`submitQuestionBatch`/`closeQuestion`) and consolidates shared validation as a module export consumed by the route.
- Switches route body to `z.discriminatedUnion` so OpenAPI keeps `oneOf` (was downgraded to `anyOf`).
- Adds `"aborted"` to per-entry decision union; the prompter abort path now uses it (was reusing `"skipped"`).
- Removes identity-mapping noise in `ask-question-tool.ts`.

Part of plan: ask-question-proactive-and-batched.md (review fix R1-2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->