### PR TITLE
fix(memory): three correctness bugs in memory-retrospective pass

### DIFF
--- a/assistant/src/__tests__/messages-after-tiebreaker.test.ts
+++ b/assistant/src/__tests__/messages-after-tiebreaker.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import {
+  countMessagesAfter,
+  getMessagesAfter,
+} from "../memory/conversation-crud.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { conversations, messages } from "../memory/schema.js";
+
+initializeDb();
+
+const CONV_ID = "conv-tiebreaker";
+
+function clearDb(): void {
+  const db = getDb();
+  db.delete(messages).run();
+  db.delete(conversations).run();
+}
+
+function seedConversation(): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({
+      id: CONV_ID,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      source: "test",
+      conversationType: "default",
+      memoryScopeId: "default",
+    })
+    .run();
+}
+
+function insertMessage(id: string, createdAt: number): void {
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId: CONV_ID,
+      role: "user",
+      content: "",
+      createdAt,
+      metadata: null,
+    })
+    .run();
+}
+
+describe("countMessagesAfter / getMessagesAfter — millisecond-collision tie-breaker", () => {
+  beforeEach(() => {
+    clearDb();
+    seedConversation();
+  });
+
+  test("messages sharing a millisecond timestamp with the reference are NOT permanently skipped (countMessagesAfter)", () => {
+    const ts = 1_700_000_000_000;
+    // Both messages share the exact same createdAt — id "b" sorts after
+    // id "a" lexicographically. Without a tie-breaker the second message
+    // would never be counted.
+    insertMessage("a", ts);
+    insertMessage("b", ts);
+
+    expect(countMessagesAfter(CONV_ID, "a")).toBe(1);
+  });
+
+  test("messages sharing a millisecond timestamp with the reference are NOT permanently skipped (getMessagesAfter)", () => {
+    const ts = 1_700_000_000_000;
+    insertMessage("a", ts);
+    insertMessage("b", ts);
+
+    const result = getMessagesAfter(CONV_ID, "a");
+    expect(result.map((m) => m.id)).toEqual(["b"]);
+  });
+
+  test("strict-after semantics: a message with id sorting BEFORE the reference but identical timestamp is NOT included", () => {
+    const ts = 1_700_000_000_000;
+    // "a" sorts before "b". Reference is "b", so "a" should be excluded
+    // (strictly-after semantics, not "all rows at the same timestamp").
+    insertMessage("a", ts);
+    insertMessage("b", ts);
+
+    expect(countMessagesAfter(CONV_ID, "b")).toBe(0);
+    expect(getMessagesAfter(CONV_ID, "b")).toEqual([]);
+  });
+
+  test("mixed collision + later timestamps: counts both same-ts tie-breaker rows and strictly-later rows", () => {
+    const ts = 1_700_000_000_000;
+    insertMessage("a", ts);
+    insertMessage("b", ts);
+    insertMessage("c", ts);
+    insertMessage("d", ts + 1);
+
+    expect(countMessagesAfter(CONV_ID, "a")).toBe(3);
+    const result = getMessagesAfter(CONV_ID, "a");
+    expect(result.map((m) => m.id)).toEqual(["b", "c", "d"]);
+  });
+
+  test("missing reference returns 0/[] (conservative semantics preserved)", () => {
+    insertMessage("a", 1_700_000_000_000);
+    expect(countMessagesAfter(CONV_ID, "nonexistent")).toBe(0);
+    expect(getMessagesAfter(CONV_ID, "nonexistent")).toEqual([]);
+  });
+
+  test("null/empty reference still returns all messages", () => {
+    const ts = 1_700_000_000_000;
+    insertMessage("a", ts);
+    insertMessage("b", ts);
+
+    expect(countMessagesAfter(CONV_ID, null)).toBe(2);
+    expect(countMessagesAfter(CONV_ID, "")).toBe(2);
+    expect(getMessagesAfter(CONV_ID, null)).toHaveLength(2);
+    expect(getMessagesAfter(CONV_ID, "")).toHaveLength(2);
+  });
+});

--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -424,4 +424,24 @@ describe("disposeConversation — memory-retrospective lifecycle safety net", ()
     expect(memoryRetroCalls).toHaveLength(0);
     expect(autoAnalyzeCalls).toHaveLength(0);
   });
+
+  // Regression test: the retrospective lifecycle enqueue was previously
+  // outside the `!isAutoAnalysis` guard, so it fired even for auto-analysis
+  // conversations. Mirrors the indexer-time gate in `indexer.ts` and
+  // matches the existing graph_extract recursion-guard semantics.
+  test("auto-analysis conversation — does NOT enqueue memory-retrospective even with flag on", () => {
+    memoryRetroEnabled = true;
+    autoAnalysisConversations.add("conv-auto-retro");
+    const ctx = makeDisposeContext({
+      conversationId: "conv-auto-retro",
+      trustClass: "guardian",
+    });
+
+    disposeConversation(ctx);
+
+    expect(memoryRetroCalls).toHaveLength(0);
+    // graph_extract is also recursion-guarded by the same `!isAutoAnalysis`
+    // block, so it should be skipped here too.
+    expect(memoryJobCalls).toHaveLength(0);
+  });
 });

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -423,6 +423,23 @@ export function disposeConversation(ctx: DisposeContext): void {
           // Best-effort — don't block conversation disposal
         }
       }
+
+      try {
+        // Memory-retrospective lifecycle safety-net. The periodic triggers
+        // (interval / message_count / pre-compaction) handle the common
+        // path; lifecycle catches the gap between the last interval fire
+        // and conversation eviction. The job's `no_new_messages` early
+        // return makes this a cheap no-op when the periodic path already
+        // covered things. Lives inside the `!isAutoAnalysis` guard so
+        // auto-analysis conversations don't trigger retrospective enqueues
+        // on disposal — mirrors the indexer-time gate in `indexer.ts`.
+        enqueueMemoryRetrospectiveIfEnabled({
+          conversationId: ctx.conversationId,
+          trigger: "lifecycle",
+        });
+      } catch {
+        // Best-effort — don't block conversation disposal
+      }
     }
 
     try {
@@ -430,22 +447,6 @@ export function disposeConversation(ctx: DisposeContext): void {
       // (it checks `isAutoAnalysisConversation()`), so it's safe to call
       // unconditionally here.
       enqueueAutoAnalysisIfEnabled({
-        conversationId: ctx.conversationId,
-        trigger: "lifecycle",
-      });
-    } catch {
-      // Best-effort — don't block conversation disposal
-    }
-
-    try {
-      // Memory-retrospective lifecycle safety-net. The periodic triggers
-      // (interval / message_count / pre-compaction) handle the common
-      // path; lifecycle catches the gap between the last interval fire
-      // and conversation eviction. The job's `no_new_messages` early
-      // return makes this a cheap no-op when the periodic path already
-      // covered things. `enqueueMemoryRetrospectiveIfEnabled` has its
-      // own internal recursion guard.
-      enqueueMemoryRetrospectiveIfEnabled({
         conversationId: ctx.conversationId,
         trigger: "lifecycle",
       });

--- a/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -15,6 +15,7 @@ type ConvRow = {
   id: string;
   source: string | null;
   last_message_at: number | null;
+  fork_parent_conversation_id: string | null;
 };
 type JobRow = {
   type: string;
@@ -58,11 +59,10 @@ mock.module("../db-connection.js", () => ({
                   return { conversationId: convId };
                 });
             }
-            // Otherwise, this is the conversation query.
-            // The test harness applies its OWN filter logic below since the
-            // production code uses drizzle's combinator. We expose all rows
-            // tagged with the right source/last_message_at, and the test
-            // post-filters them to mirror the production query.
+            // Otherwise, this is the conversation query. The production
+            // predicate now compares `forkParentConversationId` (the source
+            // ID encoded on the background conversation row) against the
+            // set of source IDs extracted from active jobs.
             return mockConversations
               .filter((c) => c.source === "memory-retrospective")
               .filter(
@@ -70,7 +70,11 @@ mock.module("../db-connection.js", () => ({
                   c.last_message_at !== null &&
                   c.last_message_at < injectedNowMinusOrphanAgeMs,
               )
-              .filter((c) => !activeJobConvIds.has(c.id))
+              .filter(
+                (c) =>
+                  c.fork_parent_conversation_id === null ||
+                  !activeJobSourceConvIds.has(c.fork_parent_conversation_id),
+              )
               .map((c) => ({ id: c.id }));
           },
         }),
@@ -79,7 +83,7 @@ mock.module("../db-connection.js", () => ({
   }),
 }));
 
-let activeJobConvIds = new Set<string>();
+let activeJobSourceConvIds = new Set<string>();
 let injectedNowMinusOrphanAgeMs = 0;
 
 mock.module("../conversation-crud.js", () => ({
@@ -94,7 +98,7 @@ import { sweepOrphanMemoryRetrospectiveConversations } from "../memory-retrospec
 const ORPHAN_AGE_MS = 60 * 60 * 1000;
 
 function rebuildActiveJobSet(): void {
-  activeJobConvIds = new Set();
+  activeJobSourceConvIds = new Set();
   for (const j of mockJobs) {
     if (
       j.type !== "memory_retrospective" ||
@@ -105,7 +109,7 @@ function rebuildActiveJobSet(): void {
     try {
       const parsed = JSON.parse(j.payload) as { conversationId?: unknown };
       if (typeof parsed.conversationId === "string") {
-        activeJobConvIds.add(parsed.conversationId);
+        activeJobSourceConvIds.add(parsed.conversationId);
       }
     } catch {
       // ignore
@@ -118,7 +122,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     mockConversations = [];
     mockJobs = [];
     deletedIds = [];
-    activeJobConvIds = new Set();
+    activeJobSourceConvIds = new Set();
     injectedNowMinusOrphanAgeMs = 0;
   });
 
@@ -135,6 +139,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         id: "old-orphan",
         source: "memory-retrospective",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
       },
     ];
     rebuildActiveJobSet();
@@ -153,6 +158,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         id: "fresh-bg",
         source: "memory-retrospective",
         last_message_at: now - 60_000,
+        fork_parent_conversation_id: "source-A",
       },
     ];
     rebuildActiveJobSet();
@@ -171,6 +177,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         id: "auto-analysis-old",
         source: "auto-analysis",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
       },
     ];
     rebuildActiveJobSet();
@@ -180,21 +187,29 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     expect(result.swept).toBe(0);
   });
 
-  test("does NOT sweep an orphan whose source conversation has an active job", () => {
+  // Regression test for the previously-broken active-job guard. Before the
+  // fix, the predicate compared `conversations.id` (the BACKGROUND-conv id)
+  // to source-conv ids extracted from job payloads — two different identifier
+  // spaces — so the guard never matched and in-flight retros were swept.
+  test("does NOT sweep a background conversation whose SOURCE has an active job (different identifier spaces)", () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    // The background conv has its own id, distinct from the source it forks
+    // from. The active job's payload references the SOURCE, not the
+    // background.
     mockConversations = [
       {
-        id: "orphan-but-protected",
+        id: "background-conv-id",
         source: "memory-retrospective",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-conv-id",
       },
     ];
     mockJobs = [
       {
         type: "memory_retrospective",
         status: "pending",
-        payload: JSON.stringify({ conversationId: "orphan-but-protected" }),
+        payload: JSON.stringify({ conversationId: "source-conv-id" }),
       },
     ];
     rebuildActiveJobSet();
@@ -203,6 +218,34 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
+  });
+
+  test("sweeps a background conversation whose source has NO active job, even when another unrelated job is pending", () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    mockConversations = [
+      {
+        id: "background-A",
+        source: "memory-retrospective",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+      },
+    ];
+    // Active job references a DIFFERENT source — the orphan above is not
+    // protected because its forkParent doesn't match.
+    mockJobs = [
+      {
+        type: "memory_retrospective",
+        status: "pending",
+        payload: JSON.stringify({ conversationId: "source-B" }),
+      },
+    ];
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
+    expect(result.swept).toBe(1);
+    expect(deletedIds).toEqual(["background-A"]);
   });
 
   test("running across an empty workspace returns swept=0 without errors", () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -14,6 +14,7 @@ import {
   like,
   lt,
   lte,
+  or,
   sql,
 } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
@@ -1115,13 +1116,23 @@ export function countMessagesAfter(
     .where(eq(messages.id, afterMessageId))
     .get();
   if (!ref) return 0;
+  // Tie-breaker on `messages.id` so rows that share a millisecond timestamp
+  // with the reference are not permanently skipped. Mirrors the
+  // `(createdAt, id)` cursor pattern used by the backfill job-handler and
+  // turn-events-store.
   const row = db
     .select({ c: count() })
     .from(messages)
     .where(
       and(
         eq(messages.conversationId, conversationId),
-        gt(messages.createdAt, ref.createdAt),
+        or(
+          gt(messages.createdAt, ref.createdAt),
+          and(
+            eq(messages.createdAt, ref.createdAt),
+            gt(messages.id, afterMessageId),
+          ),
+        ),
       ),
     )
     .get();
@@ -1155,16 +1166,24 @@ export function getMessagesAfter(
     .where(eq(messages.id, afterMessageId))
     .get();
   if (!ref) return [];
+  // Same `(createdAt, id)` cursor as `countMessagesAfter` — rows sharing
+  // the reference's millisecond timestamp would otherwise be skipped.
   return db
     .select()
     .from(messages)
     .where(
       and(
         eq(messages.conversationId, conversationId),
-        gt(messages.createdAt, ref.createdAt),
+        or(
+          gt(messages.createdAt, ref.createdAt),
+          and(
+            eq(messages.createdAt, ref.createdAt),
+            gt(messages.id, afterMessageId),
+          ),
+        ),
       ),
     )
-    .orderBy(asc(messages.createdAt))
+    .orderBy(asc(messages.createdAt), asc(messages.id))
     .all()
     .map(parseMessage);
 }

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -53,7 +53,14 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   const cutoff = now - ORPHAN_AGE_MS;
   const db = getDb();
 
-  const activeJobConversationIds = db
+  // Job payloads encode the SOURCE conversation id (the conversation being
+  // analyzed), not the background-conversation id of the retrospective itself.
+  // The background conversation links back to its source via
+  // `forkParentConversationId` (set when bootstrapped — see
+  // memory-retrospective-job.ts). To protect in-flight jobs we therefore
+  // compare source-id to source-id by filtering on
+  // `conversations.forkParentConversationId`, not `conversations.id`.
+  const activeJobSourceConversationIds = db
     .select({
       conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
     })
@@ -79,8 +86,11 @@ export function sweepOrphanMemoryRetrospectiveConversations(
         // last_message_at value are too fresh to assess.
         isNotNull(conversations.lastMessageAt),
         lt(conversations.lastMessageAt, cutoff),
-        activeJobConversationIds.length > 0
-          ? notInArray(conversations.id, activeJobConversationIds)
+        activeJobSourceConversationIds.length > 0
+          ? notInArray(
+              conversations.forkParentConversationId,
+              activeJobSourceConversationIds,
+            )
           : sql`1=1`,
       ),
     )


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30310. (1) countMessagesAfter / getMessagesAfter now use a rowid/id tie-breaker so messages sharing a millisecond timestamp aren't permanently skipped. (2) sweepOrphanMemoryRetrospectiveConversations active-job guard now compares the correct identifier space (source IDs to source IDs) so in-flight jobs are actually protected. (3) enqueueMemoryRetrospectiveIfEnabled in conversation-lifecycle moved inside the !isAutoAnalysis guard so auto-analysis conversations don't trigger lifecycle-time retrospective enqueues.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->