### PR TITLE
fix(macos): re-insert bookmark id post-create to survive reload race

### DIFF
--- a/clients/macos/vellum-assistant/Services/BookmarkStore.swift
+++ b/clients/macos/vellum-assistant/Services/BookmarkStore.swift
@@ -86,6 +86,10 @@ public final class BookmarkStore {
                     messageId: messageId,
                     conversationId: conversationId
                 )
+                // Re-insert into the id set in case a concurrent reload()
+                // overwrote the optimistic insert before createBookmark
+                // returned — keeps bookmarkedMessageIds and bookmarks in sync.
+                bookmarkedMessageIds.insert(created.messageId)
                 // Guard against a duplicate row if an SSE-driven reload
                 // landed the same record first.
                 if !bookmarks.contains(where: { $0.messageId == created.messageId }) {


### PR DESCRIPTION
Addresses Devin review feedback on #30128. In BookmarkStore.toggle() create branch, the local bookmarkedMessageIds cache desynced from the bookmarks array when a concurrent reload() landed mid-await. Re-insert messageId into bookmarkedMessageIds after createBookmark returns to keep them in sync.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->