### PR TITLE
fix(macos): sync activeProfile on late PATCH success

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3320,7 +3320,11 @@ public final class SettingsStore: ObservableObject {
     /// to a sibling optimistic value that itself never landed on the
     /// daemon. The current-value guard ensures a newer call that has
     /// already overwritten the published state is not stomped by a
-    /// stale revert.
+    /// stale revert. On success, also resyncs `self.activeProfile` to
+    /// the confirmed name so a late-arriving success (after a competing
+    /// later pick failed and reverted) lands the UI on the
+    /// daemon-persisted value rather than leaving it stuck on the prior
+    /// confirmed profile.
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
         self.activeProfile = name
@@ -3329,6 +3333,7 @@ public final class SettingsStore: ObservableObject {
         ])
         if success {
             lastConfirmedActiveProfile = name
+            self.activeProfile = name
         } else {
             if self.activeProfile == name {
                 self.activeProfile = lastConfirmedActiveProfile


### PR DESCRIPTION
Addresses Codex P1 review feedback on #29979. When setActiveProfile's PATCH succeeds out-of-order (after a later pick failed and rolled back to lastConfirmedActiveProfile), the UI stayed stuck on the prior confirmed profile. Now also resets self.activeProfile = name on the late-success path so the UI matches the daemon-persisted value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->