### PR TITLE
fix(memory-v2): include assistantLast in PKB query vector text

### DIFF
--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -107,18 +107,20 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
+const embedWithBackendMock = mock(async (_config, texts: string[]) => ({
+  provider: "local",
+  model: "test-model",
+  vectors: texts.map(() => [0.1, 0.2, 0.3]) as number[][],
+}));
+const generateSparseEmbeddingMock = mock((_text: string) => ({
+  indices: [1, 2, 3],
+  values: [0.5, 0.5, 0.5] as number[],
+}));
 const realEmbeddingBackend = await import("../../embedding-backend.js");
 mock.module("../../embedding-backend.js", () => ({
   ...realEmbeddingBackend,
-  embedWithBackend: async () => ({
-    provider: "local",
-    model: "test-model",
-    vectors: [[0.1, 0.2, 0.3]] as number[][],
-  }),
-  generateSparseEmbedding: () => ({
-    indices: [1, 2, 3],
-    values: [0.5, 0.5, 0.5] as number[],
-  }),
+  embedWithBackend: embedWithBackendMock,
+  generateSparseEmbedding: generateSparseEmbeddingMock,
 }));
 
 const realQdrantClient = await import("../../qdrant-client.js");
@@ -293,6 +295,8 @@ beforeEach(() => {
   qdrantState.queryResponses.sparse.length = 0;
   loadContextMemoryMock.mockClear();
   retrieveForTurnMock.mockClear();
+  embedWithBackendMock.mockClear();
+  generateSparseEmbeddingMock.mockClear();
   _resetMemoryV2QdrantForTests();
 });
 
@@ -388,6 +392,59 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)",
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
     expect(firstBlock.text.match(/<\/memory>/g)?.length).toBe(1);
     expect(firstBlock.text).toContain("# memory/concepts/alice-vscode.md");
+  });
+
+  test("per-turn dense embedding is computed from combined assistant+user text", async () => {
+    // Short referential follow-ups ("do that one") carry no semantic signal
+    // on their own — the dense PKB query embedding must mirror v1's
+    // `retrieveForTurn` and combine the prior assistant turn so hint search
+    // still resolves what "that one" refers to. The sparse vector matches
+    // v1 by using the user message alone so lexical signal isn't diluted.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const assistantText =
+      "Alice prefers VS Code as her editor — she finds the extension ecosystem unmatched.";
+    const userText = "do that one";
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text" as const, text: "what editors did we cover?" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text" as const, text: assistantText }],
+      },
+      { role: "user", content: [{ type: "text" as const, text: userText }] },
+    ];
+
+    await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    // v1's `retrieveForTurn` joins assistantLast + userLast with "\n\n" and
+    // embeds the combined string as the dense query vector. Assert the v2
+    // path makes the exact same embed call somewhere during this turn.
+    const expectedCombined = `${assistantText}\n\n${userText}`;
+    const matchingCall = embedWithBackendMock.mock.calls.find((call) => {
+      const texts = call[1] as string[];
+      return texts.length === 1 && texts[0] === expectedCombined;
+    });
+    expect(matchingCall).toBeDefined();
+
+    // Sparse embedding for the per-turn query uses userLast only.
+    expect(generateSparseEmbeddingMock.mock.calls).toContainEqual([userText]);
+    expect(
+      generateSparseEmbeddingMock.mock.calls.some((call) =>
+        (call[0] as string).includes(assistantText),
+      ),
+    ).toBe(false);
   });
 
   test("config on with empty Qdrant hits → no v2 block, v1 fallback skipped", async () => {

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -438,8 +438,10 @@ export class ConversationGraphMemory {
       // turns. v1's `loadContextMemory` produced these as a side effect of
       // hybrid retrieval; the v2 path skips that retrieval, so embed
       // explicitly here.
+      const userQueryText = rawUserText ?? userQuery ?? "";
       const userQueryEmbed = await this.computeQueryVectors(
-        rawUserText ?? userQuery ?? "",
+        userQueryText,
+        userQueryText,
         config,
         signal,
       );
@@ -598,8 +600,16 @@ export class ConversationGraphMemory {
     if (v2.routed) {
       // Surface a per-turn query embedding so PKB hint search still runs
       // on v2 turns. v1's `retrieveForTurn` produced these as a side effect;
-      // the v2 path skips that retrieval, so embed explicitly here.
+      // the v2 path skips that retrieval, so embed explicitly here. Match
+      // v1's split: dense embeds the combined assistant+user text (short
+      // referential follow-ups like "do that one" need the assistant turn
+      // for semantic grounding), while sparse uses the user message alone
+      // to keep lexical signal focused on what the user actually said.
+      const denseQueryText = [assistantLast, userLast]
+        .filter((m) => m.length > 0)
+        .join("\n\n");
       const perTurnEmbed = await this.computeQueryVectors(
+        denseQueryText,
         userLast,
         config,
         signal,
@@ -697,24 +707,30 @@ export class ConversationGraphMemory {
    * static fallback rather than blocking the turn.
    */
   private async computeQueryVectors(
-    text: string,
+    denseText: string,
+    sparseText: string,
     config: AssistantConfig,
     signal: AbortSignal,
   ): Promise<{ dense?: number[]; sparse?: QdrantSparseVector }> {
-    const trimmed = text.trim();
-    if (trimmed.length === 0) return {};
+    const trimmedDense = denseText.trim();
+    const trimmedSparse = sparseText.trim();
     let dense: number[] | undefined;
-    try {
-      const result = await embedWithRetry(config, [trimmed], { signal });
-      dense = result.vectors[0];
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Failed to embed query for PKB hints on v2 path",
-      );
+    if (trimmedDense.length > 0) {
+      try {
+        const result = await embedWithRetry(config, [trimmedDense], { signal });
+        dense = result.vectors[0];
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Failed to embed query for PKB hints on v2 path",
+        );
+      }
     }
-    const sparseRaw = generateSparseEmbedding(trimmed);
-    const sparse = sparseRaw.indices.length > 0 ? sparseRaw : undefined;
+    let sparse: QdrantSparseVector | undefined;
+    if (trimmedSparse.length > 0) {
+      const sparseRaw = generateSparseEmbedding(trimmedSparse);
+      sparse = sparseRaw.indices.length > 0 ? sparseRaw : undefined;
+    }
     return { dense, sparse };
   }
 


### PR DESCRIPTION
Addresses Codex review feedback on #30104. v2 was computing the per-turn PKB query vector from userLast alone, while v1's retrieveForTurn uses combined assistantLast + userLast. Short referential follow-ups ('do that one') lose hint relevance without the assistant-turn context, so PKB retrieval misses on v2 turns where v1 would have hit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->