### PR TITLE
fix(memory-v2): normalize page-index summary newlines and dedupe slugs

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-index.test.ts
@@ -245,6 +245,89 @@ describe("getPageIndex", () => {
     const idx = await getPageIndex(workspaceDir);
     expect(idx.bySlug.get("alice")?.summary.length).toBe(200);
   });
+
+  test("collapses embedded newlines in frontmatter.summary to single spaces", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", { summary: "First line.\nSecond line.\nThird line." }),
+    );
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.summary).toBe(
+      "First line. Second line. Third line.",
+    );
+  });
+
+  test("collapses embedded newlines and runs of whitespace in body fallback", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", {
+        body: "  Body  with\n\nmultiple\tlines\n  and   spaces.  ",
+      }),
+    );
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("alice")?.summary).toBe(
+      "Body with multiple lines and spaces.",
+    );
+  });
+
+  test("normalizes skill-entry content with embedded newlines", async () => {
+    skillState.entries = [
+      { id: "browser", content: "Drive a browser.\nSupports multiple tabs." },
+    ];
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.bySlug.get("skills/browser")?.summary).toBe(
+      "Drive a browser. Supports multiple tabs.",
+    );
+  });
+
+  test("renders a single line per entry even when summaries contain newlines", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("alice", { summary: "line one\nline two" }),
+    );
+    const idx = await getPageIndex(workspaceDir);
+    // Exactly one trailing newline — the entry itself must not split.
+    expect(idx.rendered.split("\n").filter(Boolean).length).toBe(1);
+  });
+
+  test("drops a user concept page whose slug collides with a seeded skill entry", async () => {
+    await writePage(
+      workspaceDir,
+      makePage("skills/browser", {
+        summary: "User-authored page that shadows the skill.",
+      }),
+    );
+    skillState.entries = [{ id: "browser", content: "Seeded skill content." }];
+
+    const idx = await getPageIndex(workspaceDir);
+    // Only the skill entry survives under skills/browser.
+    expect(idx.entries.filter((e) => e.slug === "skills/browser").length).toBe(
+      1,
+    );
+    expect(idx.bySlug.get("skills/browser")?.summary).toBe(
+      "Seeded skill content.",
+    );
+  });
+
+  test("collision dedupe leaves non-colliding pages and skills intact", async () => {
+    await writePage(workspaceDir, makePage("alice", { summary: "Alice" }));
+    await writePage(
+      workspaceDir,
+      makePage("skills/browser", { summary: "Shadow page." }),
+    );
+    skillState.entries = [
+      { id: "browser", content: "Seeded browser." },
+      { id: "calendar", content: "Seeded calendar." },
+    ];
+
+    const idx = await getPageIndex(workspaceDir);
+    expect(idx.entries.map((e) => e.slug)).toEqual([
+      "alice",
+      "skills/browser",
+      "skills/calendar",
+    ]);
+    expect(idx.bySlug.get("skills/browser")?.summary).toBe("Seeded browser.");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -31,6 +31,16 @@ const log = getLogger("memory-v2-page-index");
 const SUMMARY_MAX_LENGTH = 200;
 
 /**
+ * Collapse every run of whitespace (including embedded newlines and tabs) to a
+ * single space and trim. The router prompt renders one entry per line, so an
+ * embedded newline anywhere in `summary` would split that entry across lines
+ * and corrupt the format the router parses.
+ */
+function normalizeSummary(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, SUMMARY_MAX_LENGTH);
+}
+
+/**
  * One row in the rendered page index. `id` is a 1-based dense integer that is
  * stable within a single index version (i.e. a single build). It changes when
  * the index is rebuilt because IDs are derived from the slug-sorted position;
@@ -97,6 +107,21 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     outgoingSlugs: string[];
   }
 
+  const { listSkillEntries, SKILL_SLUG_PREFIX } =
+    await import("./skill-store.js");
+
+  // Build the skill-slug set first so we can drop colliding concept pages.
+  // Collision policy: **skill entries win**. Skill rows are seeded from the
+  // curated catalog and the router needs them to be reachable under their
+  // canonical slugs; a hand-authored page sitting under `skills/<id>` is
+  // either a stale leftover from a prior write or a user mistake. `bySlug`
+  // is last-writer-wins, so without explicit dedupe one side would silently
+  // shadow the other depending on iteration order.
+  const skillEntries = listSkillEntries();
+  const skillSlugs = new Set(
+    skillEntries.map((entry) => `${SKILL_SLUG_PREFIX}${entry.id}`),
+  );
+
   const drafts: DraftEntry[] = [];
   for (let i = 0; i < settled.length; i++) {
     const result = settled[i];
@@ -110,20 +135,25 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     }
     const page = result.value;
     if (!page) continue;
+    if (skillSlugs.has(slug)) {
+      log.warn(
+        { slug },
+        "Dropping concept page from index — slug collides with a seeded skill entry; skill wins",
+      );
+      continue;
+    }
     const summarySource = page.frontmatter.summary?.trim() || page.body.trim();
     drafts.push({
       slug,
-      summary: summarySource.slice(0, SUMMARY_MAX_LENGTH),
+      summary: normalizeSummary(summarySource),
       outgoingSlugs: page.frontmatter.edges,
     });
   }
 
-  const { listSkillEntries, SKILL_SLUG_PREFIX } =
-    await import("./skill-store.js");
-  for (const entry of listSkillEntries()) {
+  for (const entry of skillEntries) {
     drafts.push({
       slug: `${SKILL_SLUG_PREFIX}${entry.id}`,
-      summary: entry.content.trim().slice(0, SUMMARY_MAX_LENGTH),
+      summary: normalizeSummary(entry.content),
       outgoingSlugs: [],
     });
   }


### PR DESCRIPTION
Addresses Codex review feedback on #30172. (1) Normalize newlines in page-index summary text before rendering so embedded newlines in frontmatter.summary or body fallback don't split entries across multiple lines and break the one-line-per-entry router prompt format. (2) Resolve slug collisions between user concept pages (slug=skills/<id>) and seeded skill entries with an explicit collision policy: skill entries win, since they are curated catalog rows and must remain reachable under their canonical slugs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->