### PR TITLE
fix(settings): react to bookmarks flag toggle without restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -302,6 +302,8 @@ struct SettingsPanel: View {
                     isEmbeddingProviderEnabled = enabled
                 } else if key == Self.soundsFeatureFlagKey {
                     isSoundsEnabled = enabled
+                } else if key == Self.bookmarksFeatureFlagKey {
+                    isBookmarksEnabled = enabled
                 }
             }
         }


### PR DESCRIPTION
Addresses Devin review feedback on #30122. SettingsPanel's .onReceive(.assistantFeatureFlagDidChange) handler didn't branch on bookmarksFeatureFlagKey, so toggling the flag in Developer settings didn't reactively update isBookmarksEnabled. Adds the branch so the tab appears/disappears immediately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->