### PR TITLE
fix(memory-v2): dedupe router page IDs before applying max cap

### DIFF
--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -460,6 +460,21 @@ describe("runRouter — failure modes", () => {
     expect(warnSeen).toBe(true);
   });
 
+  test("duplicate-heavy IDs are deduped before the cap is applied", async () => {
+    // [1, 1, 2] with max=2 must yield two distinct slugs, not collapse to one
+    // after a pre-dedupe slice trims away the only other unique ID.
+    providerStub = makeProvider(toolUseResponse([1, 1, 2]));
+
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ maxPageIds: 2 }),
+    });
+
+    expect(result.failureReason).toBeNull();
+    expect(result.selectedSlugs).toEqual(["alpha", "bravo"]);
+  });
+
   test("more than max_page_ids → truncated with warn", async () => {
     providerStub = makeProvider(toolUseResponse([1, 2, 3]));
 

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -275,22 +275,22 @@ export async function runRouter(
     );
   }
 
-  const truncated = inRangeIds.length > maxPageIds;
-  const finalIds = truncated ? inRangeIds.slice(0, maxPageIds) : inRangeIds;
+  // De-duplicate BEFORE applying the cap — otherwise a duplicate-heavy
+  // model output like `[1, 1, 2]` with `max=2` slices to `[1, 1]` and
+  // dedupes to `[1]`, under-filling the cap.
+  const dedupedIds = Array.from(new Set(inRangeIds));
+
+  const truncated = dedupedIds.length > maxPageIds;
+  const finalIds = truncated ? dedupedIds.slice(0, maxPageIds) : dedupedIds;
   if (truncated) {
     log.warn(
-      { returned: inRangeIds.length, max: maxPageIds },
+      { returned: dedupedIds.length, max: maxPageIds },
       "Router returned more page IDs than max_page_ids; truncating",
     );
   }
 
-  // De-duplicate while preserving order — the index lookup alone wouldn't
-  // catch repeats from the model.
-  const seen = new Set<number>();
   const selectedSlugs: string[] = [];
   for (const id of finalIds) {
-    if (seen.has(id)) continue;
-    seen.add(id);
     const entry = pageIndex.byId.get(id);
     if (!entry) continue;
     selectedSlugs.push(entry.slug);


### PR DESCRIPTION
Addresses Codex review feedback on #30174. runRouter applied inRangeIds.slice(0, max_page_ids) before dedup, so duplicate-heavy LLM outputs like [1, 1, 2] with max=2 under-filled to [1] instead of returning two distinct pages. Now dedupes first, then caps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->