### PR TITLE
fix(memory-v2): correct static-block rehydration trust gate and order

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -450,6 +450,119 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(messages[2].content).toEqual([{ type: "text", text: "Tail" }]);
   });
 
+  test("internal-channel trusted_contact view still rehydrates memoryV2StaticBlock", async () => {
+    // Regression: the prior `!isUntrustedTrustClass(trustClass)` gate
+    // blocked any non-guardian view from rehydrating personal memory,
+    // including legitimate internal flows (e.g. trusted_contact actors
+    // arriving over the internal `"vellum"` channel). Injection time
+    // uses `shouldExposePersonalMemory`, which keys on `sourceChannel`
+    // rather than `trustClass` and exposes personal memory for
+    // `sourceChannel === "vellum"` regardless of actor trust class. The
+    // rehydrate gate must match so a daemon-restart reload of the same
+    // conversation produces an identical prefix.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First" }]),
+        metadata: JSON.stringify({
+          // Rows must carry `trusted_contact` / `unknown` provenance to
+          // survive the row-level filter for non-guardian views.
+          provenanceTrustClass: "trusted_contact",
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "vellum",
+    });
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+      },
+      { type: "text", text: "First" },
+    ]);
+  });
+
+  test("rehydration order matches injection-time order for the full personal-memory set", async () => {
+    // Injection-time layout (per `applyRuntimeInjections` after-memory-
+    // prefix splicing in ascending injector order: pkb-context 30,
+    // pkb-reminder 35, memory-v2-static 38, now-md 40):
+    //   [<memory __injected>, <memory>v2static</memory>, <NOW.md>,
+    //    <system_reminder>, <knowledge_base>, ...original]
+    // Rehydration must reproduce this exactly so Anthropic's prefix cache
+    // matches msg[0] across daemon restarts.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          memoryInjectedBlock: "mem payload",
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+          nowScratchpadBlock: "<NOW.md>\nnow body\n</NOW.md>",
+          pkbSystemReminderBlock:
+            "<system_reminder>\npkb reminder body\n</system_reminder>",
+          pkbContextBlock: "<knowledge_base>\nkb body\n</knowledge_base>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toEqual([
+      { type: "text", text: "<memory>\nmem payload\n</memory>" },
+      {
+        type: "text",
+        text: "<memory>\n## Essentials\n\nAlice prefers VS Code.\n</memory>",
+      },
+      { type: "text", text: "<NOW.md>\nnow body\n</NOW.md>" },
+      {
+        type: "text",
+        text: "<system_reminder>\npkb reminder body\n</system_reminder>",
+      },
+      { type: "text", text: "<knowledge_base>\nkb body\n</knowledge_base>" },
+      { type: "text", text: "First turn" },
+    ]);
+  });
+
   test("untrusted-actor view does not rehydrate memoryV2StaticBlock", async () => {
     mockConversation = defaultConv();
     // Rows with `trusted_contact` / `unknown` provenance survive the

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "../memory/memory-retrospective-enqueue.js";
+import { shouldExposePersonalMemory } from "../memory/v2/static-context.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -31,12 +32,14 @@ import { getLogger } from "../util/logger.js";
 import { unregisterCallNotifiers } from "./conversation-notifiers.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import { resetSkillToolProjection } from "./conversation-skill-tools.js";
+import { resolveTrustClass } from "./conversation-tool-setup.js";
 import { repairHistory } from "./history-repair.js";
 import type {
   SurfaceData,
   SurfaceType,
   UsageStats,
 } from "./message-protocol.js";
+import type { TrustContext } from "./trust-context.js";
 
 const log = getLogger("conversation-lifecycle");
 
@@ -113,7 +116,7 @@ export interface LoadFromDbContext {
   usageStats: UsageStats;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
-  trustContext?: { trustClass: TrustClass };
+  trustContext?: TrustContext;
   loadedHistoryTrustClass?: TrustClass;
 }
 
@@ -184,7 +187,16 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
     ctx.contextCompactedAt = conv?.contextCompactedAt ?? null;
   }
 
-  const personalMemoryAllowed = !isUntrustedTrustClass(trustClass);
+  // Mirror the injection-time gate (`shouldExposePersonalMemory` in
+  // `conversation-agent-loop.ts`) so background/local conversations
+  // (sourceChannel `undefined` or `"vellum"`) can rehydrate the persisted
+  // v2 static memory block. Use `resolveTrustClass` for parity with the
+  // agent loop — it folds in the HTTP-auth-disabled dev bypass so
+  // rehydration and injection agree on the effective trust class.
+  const personalMemoryAllowed = shouldExposePersonalMemory({
+    sourceChannel: ctx.trustContext?.sourceChannel,
+    isTrustedActor: resolveTrustClass(ctx.trustContext) === "guardian",
+  });
   const parsedMessages: Message[] = dbMessages
     .slice(ctx.contextCompactedMessageCount)
     .map((m, index, arr) => {
@@ -212,21 +224,19 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           const meta = JSON.parse(m.metadata);
           const isTail = index === arr.length - 1;
 
-          // All rehydration steps are prepends — the ordering below
-          // (innermost block first, outermost last) builds the documented
-          // shape right-to-left, since each prepend shifts previously-
-          // prepended blocks one slot right:
-          //   [<workspace>, <turn_context>, <NOW.md>, <memory __injected>,
-          //    <memory>\n…</memory>, <system_reminder>, <knowledge_base>,
-          //    ...original]
-          //
-          // Persisted non-tail rows rehydrate the full set so Anthropic's
-          // prefix cache keeps matching msg[0] across daemon restarts and
-          // conversation eviction. The tail row gets fresh blocks via
-          // applyRuntimeInjections on the next turn, so rehydration for the
-          // tail is limited to blocks that the next turn's injection pipeline
-          // cannot reconstruct (currently just `memoryInjectedBlock`, which
-          // is not always re-injected on the next turn).
+          // Rehydrate in reverse injection order (innermost block first)
+          // so the resulting layout matches `applyRuntimeInjections`'s
+          // after-memory-prefix splices in ascending injector order
+          // (pkb-context 30, pkb-reminder 35, memory-v2-static 38,
+          // now-md 40 — the v2 static block lands inside the memory
+          // prefix, so now-md splices *after* it):
+          //   [<workspace>, <turn_context>, <memory __injected>,
+          //    <memory>\n…</memory>, <NOW.md>, <system_reminder>,
+          //    <knowledge_base>, ...original]
+          // Required so Anthropic's prefix cache keeps matching msg[0]
+          // across daemon restart and conversation eviction. The tail
+          // row only rehydrates `memoryInjectedBlock` — the next turn
+          // re-injects the rest fresh.
           if (!isTail && typeof meta.pkbContextBlock === "string") {
             content = [
               { type: "text" as const, text: meta.pkbContextBlock },
@@ -237,6 +247,13 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           if (!isTail && typeof meta.pkbSystemReminderBlock === "string") {
             content = [
               { type: "text" as const, text: meta.pkbSystemReminderBlock },
+              ...content,
+            ];
+          }
+
+          if (!isTail && typeof meta.nowScratchpadBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.nowScratchpadBlock },
               ...content,
             ];
           }
@@ -277,13 +294,6 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
                 type: "text" as const,
                 text: `<memory>\n${inner}\n</memory>`,
               },
-              ...content,
-            ];
-          }
-
-          if (!isTail && typeof meta.nowScratchpadBlock === "string") {
-            content = [
-              { type: "text" as const, text: meta.nowScratchpadBlock },
               ...content,
             ];
           }


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30137. (1) Replace the rehydration trust gate `!isUntrustedTrustClass(trustClass)` with `shouldExposePersonalMemory` semantics (thread `sourceChannel` through `LoadFromDbContext`) so background/local conversations with undefined trust class can rehydrate `memoryV2StaticBlock`. (2) Reorder the rehydration prepends to match injection-time order `[memoryInjected, memoryV2Static, nowMd, pkbReminder, pkbContext, ...]` so the Anthropic prefix cache stays valid across daemon restarts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->