### PR TITLE
fix(memory-v2): backfill kind on legacy skill Qdrant points

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -48,6 +48,11 @@ interface PruneCall {
   options?: { kind?: string };
 }
 
+interface BackfillCall {
+  prefix: string;
+  kind: string;
+}
+
 interface TestState {
   catalog: SkillSummary[];
   resolved: ResolvedSkill[];
@@ -60,6 +65,10 @@ interface TestState {
   upsertCalls: UpsertCall[];
   pruneCalls: PruneCall[];
   upsertThrows: Error | null;
+  backfillCalls: BackfillCall[];
+  backfillReturn: number;
+  backfillThrows: Error | null;
+  callSequence: Array<"upsert" | "prune" | "backfill">;
 }
 
 const state: TestState = {
@@ -74,6 +83,10 @@ const state: TestState = {
   upsertCalls: [],
   pruneCalls: [],
   upsertThrows: null,
+  backfillCalls: [],
+  backfillReturn: 0,
+  backfillThrows: null,
+  callSequence: [],
 };
 
 // Stub config so resolveSkillStates / mcp augmentation have something to read.
@@ -115,6 +128,7 @@ mock.module("../../embedding-backend.js", () => ({
 mock.module("../qdrant.js", () => ({
   upsertConceptPageEmbedding: async (params: UpsertCall) => {
     if (state.upsertThrows) throw state.upsertThrows;
+    state.callSequence.push("upsert");
     state.upsertCalls.push(params);
   },
   pruneSlugsWithPrefixExcept: async (
@@ -122,7 +136,14 @@ mock.module("../qdrant.js", () => ({
     activeSuffixes: readonly string[],
     options?: { kind?: string },
   ) => {
+    state.callSequence.push("prune");
     state.pruneCalls.push({ prefix, activeSuffixes, options });
+  },
+  backfillKindOnPointsWithPrefix: async (prefix: string, kind: string) => {
+    if (state.backfillThrows) throw state.backfillThrows;
+    state.callSequence.push("backfill");
+    state.backfillCalls.push({ prefix, kind });
+    return state.backfillReturn;
   },
 }));
 
@@ -170,6 +191,10 @@ function resetState(): void {
   state.upsertCalls.length = 0;
   state.pruneCalls.length = 0;
   state.upsertThrows = null;
+  state.backfillCalls.length = 0;
+  state.backfillReturn = 0;
+  state.backfillThrows = null;
+  state.callSequence.length = 0;
   _resetSkillStoreForTests();
 }
 
@@ -442,6 +467,86 @@ describe("seedV2SkillEntries", () => {
     expect(state.pruneCalls).toHaveLength(1);
     expect(state.pruneCalls[0].prefix).toBe("skills/");
     expect([...state.pruneCalls[0].activeSuffixes]).toEqual(["remote-only"]);
+  });
+
+  test("passes kind: 'skill' to upsert and prune so legacy skill rows stay scoped to the skill kind", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].kind).toBe("skill");
+    expect(state.pruneCalls).toHaveLength(1);
+    expect(state.pruneCalls[0].options).toEqual({ kind: "skill" });
+  });
+
+  test("runs the legacy kind backfill before pruning so kindless skill points become prunable", async () => {
+    // Simulates an install carrying legacy skill points written before the
+    // kind discriminator existed: the backfill must run before prune so the
+    // kind-scoped prune can see and delete the orphans.
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+    state.backfillReturn = 3;
+
+    await seedV2SkillEntries();
+
+    expect(state.backfillCalls).toEqual([{ prefix: "skills/", kind: "skill" }]);
+    expect(state.pruneCalls).toHaveLength(1);
+    expect(state.pruneCalls[0].options).toEqual({ kind: "skill" });
+    expect(state.callSequence.filter((s) => s !== "upsert")).toEqual([
+      "backfill",
+      "prune",
+    ]);
+  });
+
+  test("backfill only runs once per process across repeated seed runs", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+    expect(state.backfillCalls).toHaveLength(1);
+
+    // A second seed should not re-scan: new upserts already carry kind, so
+    // there's nothing for the backfill to do.
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+    await seedV2SkillEntries();
+    expect(state.backfillCalls).toHaveLength(1);
+    expect(state.pruneCalls).toHaveLength(2);
+  });
+
+  test("backfill failure is non-fatal — prune still runs and lastSeedError stays clean", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+    state.backfillThrows = new Error("qdrant scroll exploded");
+
+    await expect(
+      seedV2SkillEntries({ throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    // Prune still ran despite the backfill failure — we don't want to block
+    // the steady-state prune when the legacy scan trips.
+    expect(state.pruneCalls).toHaveLength(1);
   });
 
   test("skips pruning when catalog fetch returns empty (network failure guard)", async () => {

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -492,6 +492,72 @@ export async function pruneSlugsWithPrefixExcept(
 }
 
 /**
+ * Set `payload.kind` on every point whose slug starts with `prefix` and is
+ * currently missing the `kind` discriminator. Used to tag legacy rows that
+ * predate the kind field so the kind-scoped
+ * {@link pruneSlugsWithPrefixExcept} no longer leaves them as orphans.
+ *
+ * The "missing kind" predicate is pushed to Qdrant via `is_empty`, so once
+ * every legacy row has been tagged the scroll returns the bounded set of
+ * other kindless concept pages without ever touching the already-tagged
+ * rows. Idempotent across retries: a row tagged by an earlier partial run
+ * no longer matches the filter and is silently skipped.
+ */
+export async function backfillKindOnPointsWithPrefix(
+  prefix: string,
+  kind: string,
+): Promise<number> {
+  await ensureConceptPageCollection();
+
+  const client = getClient();
+
+  const doBackfill = async (): Promise<number> => {
+    const pointIds: Array<string | number> = [];
+    let offset: string | number | undefined = undefined;
+    const maxIterations = 10_000;
+    const batchSize = 256;
+    for (let i = 0; i < maxIterations; i++) {
+      const result = await client.scroll(MEMORY_V2_COLLECTION, {
+        limit: batchSize,
+        with_payload: true,
+        with_vector: false,
+        filter: { must: [{ is_empty: { key: "kind" } }] },
+        ...(offset !== undefined ? { offset } : {}),
+      });
+      for (const point of result.points) {
+        const slug = (point.payload as { slug?: unknown } | null)?.slug;
+        if (typeof slug !== "string") continue;
+        if (!slug.startsWith(prefix)) continue;
+        pointIds.push(point.id);
+      }
+      const next = result.next_page_offset;
+      if (next == null) break;
+      offset = typeof next === "string" ? next : (next as number);
+    }
+
+    if (pointIds.length === 0) return 0;
+
+    await client.setPayload(MEMORY_V2_COLLECTION, {
+      payload: { kind },
+      points: pointIds,
+      wait: true,
+    });
+    return pointIds.length;
+  };
+
+  try {
+    return await doBackfill();
+  } catch (err) {
+    if (isCollectionMissing(err)) {
+      _collectionReady = false;
+      await ensureConceptPageCollection();
+      return await doBackfill();
+    }
+    throw err;
+  }
+}
+
+/**
  * Approximate count of points in the v2 concept-page collection. Used by the
  * daemon-startup rebuild hook to detect "collection exists but empty" — the
  * crash-mid-rebuild recovery case where a prior boot dropped + recreated the

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -36,6 +36,7 @@ import {
 } from "../embedding-backend.js";
 import { invalidatePageIndex } from "./page-index.js";
 import {
+  backfillKindOnPointsWithPrefix,
   pruneSlugsWithPrefixExcept,
   upsertConceptPageEmbedding,
 } from "./qdrant.js";
@@ -94,6 +95,13 @@ let entries: Map<string, SkillEntry> | null = null;
 let seedTail: Promise<void> = Promise.resolve();
 let seedPending: Promise<void> | null = null;
 let lastSeedError: unknown = null;
+
+/**
+ * In-process latch for the legacy `kind` backfill (see
+ * {@link backfillKindOnPointsWithPrefix}). New upserts always write `kind`,
+ * so once the latch is set there is no follow-up work to do this process.
+ */
+let legacyKindBackfillDone = false;
 
 export async function seedV2SkillEntries(
   opts: { throwOnError?: boolean } = {},
@@ -233,6 +241,24 @@ async function runSeedOnce(): Promise<void> {
     // uninstalled catalog skills should exist, so skip pruning entirely to
     // avoid aggressively removing previously-seeded catalog skill embeddings.
     if (catalogAvailable) {
+      // Tag legacy skill points missing `payload.kind` before pruning so the
+      // kind-scoped prune can see them. Once-per-process; the backfill is
+      // idempotent (server-side `is_empty` filter), so a partial failure
+      // converges on retry.
+      if (!legacyKindBackfillDone) {
+        try {
+          await backfillKindOnPointsWithPrefix(
+            SKILL_SLUG_PREFIX,
+            SKILL_PAYLOAD_KIND,
+          );
+          legacyKindBackfillDone = true;
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to backfill kind on legacy skill points — pruning may leave orphans this run",
+          );
+        }
+      }
       await pruneSlugsWithPrefixExcept(
         SKILL_SLUG_PREFIX,
         seeds.map((s) => s.id),
@@ -301,4 +327,5 @@ export function _resetSkillStoreForTests(): void {
   seedTail = Promise.resolve();
   seedPending = null;
   lastSeedError = null;
+  legacyKindBackfillDone = false;
 }


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30106. Pre-existing skill Qdrant points lack the new payload.kind field, so the kind-scoped prune leaves legacy rows for uninstalled/removed skills as permanent orphans. Adds a one-time backfill (server-side `is_empty` filter) that sets `kind: 'skill'` on those rows so they can be pruned. Also adds an assertion that `kind: 'skill'` is passed to upsert/prune calls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->