### PR TITLE
fix(memory-v2): gate router dispatch on per-turn mode

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1904,5 +1904,44 @@ describe("injectMemoryV2Block", () => {
       const row = telemetryState.recordCalls[0] as { mode: string };
       expect(row.mode).toBe("per-turn");
     });
+
+    test("flag-on + mode='context-load': activation pipeline runs (not the router) so post-compaction bootstrap can re-emit pages already in everInjected", async () => {
+      // Context-load is the full top-K bootstrap fired after compaction or
+      // a fresh conversation reload. The router's `everInjected` dedupe is
+      // correct for per-turn deltas but wrong here — pages the user just
+      // lost from compaction live in `everInjected` and would be filtered
+      // out, so context-load must always bypass the router and re-run the
+      // activation pipeline against the full top-K.
+      stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+      routerState.nextResult = {
+        selectedSlugs: ["should-not-be-used"],
+        failureReason: null,
+      };
+
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-context-load-router-on",
+        currentTurn: 1,
+        userMessage: "Tell me about Alice",
+        assistantMessage: "",
+        nowText: "Now",
+        messageId: "msg-1",
+        mode: "context-load",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      // Router must not be called — context-load bypasses the gate even
+      // when the flag is on.
+      expect(routerState.callCount).toBe(0);
+
+      // Activation pipeline produced the normal context-load result.
+      expect(result.toInject).toEqual(["alice-vscode"]);
+      expect(result.block).toContain("# memory/concepts/alice-vscode.md");
+
+      // Telemetry row reflects the activation mode, not router.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as { mode: string };
+      expect(row.mode).toBe("context-load");
+    });
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -144,6 +144,7 @@ export async function injectMemoryV2Block(
   } = params;
 
   const workspaceDir = getWorkspaceDir();
+  const mode: InjectMemoryV2Mode = params.mode ?? "per-turn";
 
   // (1) Hydrate. Missing rows are normal at conversation start — proceed
   // with an effective empty prior state so the first turn can still inject.
@@ -155,7 +156,14 @@ export async function injectMemoryV2Block(
   // for persistence, render, and telemetry. The activation pipeline below
   // remains the default (flag-off) behavior — every code path past this
   // branch only runs when the router is disabled.
-  if (config.memory.v2.router.enabled) {
+  //
+  // Restricted to `mode === "per-turn"`: `context-load` (the full top-K
+  // bootstrap after compaction/reload) must always re-emit pages the user
+  // just lost. The router's abstention + `everInjected` dedupe is correct
+  // for per-turn delta injection but breaks context-restoration — pages
+  // already in `everInjected` from before compaction would be filtered out
+  // and never re-attached.
+  if (config.memory.v2.router.enabled && mode === "per-turn") {
     return injectViaRouter({
       workspaceDir,
       database,
@@ -214,7 +222,6 @@ export async function injectMemoryV2Block(
   // prior cached attachments don't exist or have been thrown away. The user
   // message gets a complete top-K dump alongside the static
   // essentials/threads/recent block, then per-turn turns just add deltas.
-  const mode: InjectMemoryV2Mode = params.mode ?? "per-turn";
   const priorEverInjected: readonly EverInjectedEntry[] =
     priorState?.everInjected ?? [];
   const { topNow, toInject } = selectInjections({


### PR DESCRIPTION
Addresses Codex review feedback on #30175. The router-dispatch branch fired for all injection modes including context-load. The router's everInjected dedupe correctly suppresses already-shown pages for per-turn injection, but breaks context-restoration after compaction: pages the user just lost can't be re-injected. Gate the router dispatch on mode === 'per-turn'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->