### PR TITLE
fix(memory-retrospective): preserve most-recent retro from startup-cleanup sweep

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -16,6 +16,7 @@ type ConvRow = {
   source: string | null;
   last_message_at: number | null;
   fork_parent_conversation_id: string | null;
+  created_at: number;
 };
 type JobRow = {
   type: string;
@@ -59,10 +60,26 @@ mock.module("../db-connection.js", () => ({
                   return { conversationId: convId };
                 });
             }
-            // Otherwise, this is the conversation query. The production
-            // predicate now compares `forkParentConversationId` (the source
-            // ID encoded on the background conversation row) against the
-            // set of source IDs extracted from active jobs.
+            // The "all retros" query (used to compute most-recent-per-source
+            // preservation) requests id + forkParentConversationId + createdAt
+            // with only the source + isNotNull(forkParent) predicate.
+            if (
+              colKeys.includes("forkParentConversationId") &&
+              colKeys.includes("createdAt")
+            ) {
+              return mockConversations
+                .filter((c) => c.source === "memory-retrospective")
+                .filter((c) => c.fork_parent_conversation_id !== null)
+                .map((c) => ({
+                  id: c.id,
+                  forkParentConversationId: c.fork_parent_conversation_id,
+                  createdAt: c.created_at,
+                }));
+            }
+            // Otherwise, this is the orphan-candidate query. The production
+            // predicate compares `forkParentConversationId` (the source ID
+            // encoded on the background conversation row) against the set
+            // of source IDs extracted from active jobs.
             return mockConversations
               .filter((c) => c.source === "memory-retrospective")
               .filter(
@@ -131,7 +148,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     mockJobs = [];
   });
 
-  test("sweeps an old memory-retrospective conversation with no active job", () => {
+  test("sweeps an old memory-retrospective orphan that has been superseded by a newer retro for the same source", () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -140,6 +157,15 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         source: "memory-retrospective",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
         fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      // Newer successful retro for the same source — this one is preserved.
+      {
+        id: "newer-retro",
+        source: "memory-retrospective",
+        last_message_at: now - 90 * 60 * 1000,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
     rebuildActiveJobSet();
@@ -159,6 +185,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         source: "memory-retrospective",
         last_message_at: now - 60_000,
         fork_parent_conversation_id: "source-A",
+        created_at: now - 60_000,
       },
     ];
     rebuildActiveJobSet();
@@ -178,6 +205,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         source: "auto-analysis",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
         fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
     rebuildActiveJobSet();
@@ -203,6 +231,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         source: "memory-retrospective",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
         fork_parent_conversation_id: "source-conv-id",
+        created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
     mockJobs = [
@@ -220,7 +249,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     expect(deletedIds).toEqual([]);
   });
 
-  test("sweeps a background conversation whose source has NO active job, even when another unrelated job is pending", () => {
+  test("sweeps a superseded background conversation whose source has NO active job, even when another unrelated job is pending", () => {
     const now = Date.now();
     injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
     mockConversations = [
@@ -229,10 +258,18 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
         source: "memory-retrospective",
         last_message_at: now - 2 * ORPHAN_AGE_MS,
         fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      {
+        id: "newer-A",
+        source: "memory-retrospective",
+        last_message_at: now - 90 * 60 * 1000,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
       },
     ];
-    // Active job references a DIFFERENT source — the orphan above is not
-    // protected because its forkParent doesn't match.
+    // Active job references a DIFFERENT source — neither retro above is
+    // protected by the active-job guard.
     mockJobs = [
       {
         type: "memory_retrospective",
@@ -246,6 +283,31 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
 
     expect(result.swept).toBe(1);
     expect(deletedIds).toEqual(["background-A"]);
+  });
+
+  // Regression test for Devin's concern on PR #30331: the sweep used to
+  // delete every memory-retrospective conversation older than 1h, including
+  // the most-recent successful one per source. That broke
+  // `findMostRecentRetrospectiveFor` on the next run — the next retro had
+  // no dedup context and could re-save facts the prior pass already captured.
+  test("PRESERVES the most-recent retro per source even when older than the orphan cutoff", () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    mockConversations = [
+      {
+        id: "successful-retro",
+        source: "memory-retrospective",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
+    expect(result.swept).toBe(0);
+    expect(deletedIds).toEqual([]);
   });
 
   test("running across an empty workspace returns swept=0 without errors", () => {

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -24,6 +24,11 @@
 //     conversation might be the active one. We're conservative and only
 //     sweep when no job exists at all, since the worst-case false-positive
 //     is leaving a few extra orphans for the next sweep to catch.)
+//   - AND the row is NOT the most-recent retrospective for its source
+//     conversation. The next retrospective run reads the most-recent prior
+//     retro via `findMostRecentRetrospectiveFor` to seed its
+//     `<already_remembered>` dedup block; sweeping it would force the
+//     next run to re-save facts the prior pass already captured.
 
 import { and, eq, inArray, isNotNull, lt, notInArray, sql } from "drizzle-orm";
 
@@ -75,6 +80,40 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     .map((row) => row.conversationId)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
 
+  // Compute the most-recent retro per source so we can preserve it.
+  // `findMostRecentRetrospectiveFor` (called by the next retrospective run)
+  // pulls dedup context from this row; sweeping it would re-introduce the
+  // unbounded-growth bug PR #30331 was created to fix.
+  const allRetros = db
+    .select({
+      id: conversations.id,
+      forkParentConversationId: conversations.forkParentConversationId,
+      createdAt: conversations.createdAt,
+    })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.source, MEMORY_RETROSPECTIVE_SOURCE),
+        isNotNull(conversations.forkParentConversationId),
+      ),
+    )
+    .all();
+  const mostRecentPerSource = new Map<
+    string,
+    { id: string; createdAt: number }
+  >();
+  for (const row of allRetros) {
+    const parent = row.forkParentConversationId;
+    if (parent === null) continue;
+    const cur = mostRecentPerSource.get(parent);
+    if (!cur || row.createdAt > cur.createdAt) {
+      mostRecentPerSource.set(parent, { id: row.id, createdAt: row.createdAt });
+    }
+  }
+  const preservedIds = new Set(
+    Array.from(mostRecentPerSource.values(), (v) => v.id),
+  );
+
   const orphans = db
     .select({ id: conversations.id })
     .from(conversations)
@@ -94,7 +133,8 @@ export function sweepOrphanMemoryRetrospectiveConversations(
           : sql`1=1`,
       ),
     )
-    .all();
+    .all()
+    .filter((row) => !preservedIds.has(row.id));
 
   let swept = 0;
   for (const row of orphans) {


### PR DESCRIPTION
Addresses Devin's startup-cleanup concern on #30331.

The startup orphan sweep deleted every `source = memory-retrospective` conversation older than 1h, including the most-recent successful retro per source. That broke `findMostRecentRetrospectiveFor` on the next run — the next retrospective had no dedup context and could re-save facts the prior pass had already captured.

This PR computes the most-recent retro per fork-parent (source) at sweep time and excludes those IDs from deletion. Orphans from crashed runs that have been superseded by a newer retro for the same source are still swept; the still-needed dedup row is preserved.

Devin's other concern (hardcoded `'memory-retrospective'` string in `conversation-crud.ts`) was already addressed in the follow-up #30568, which now uses the `MEMORY_RETROSPECTIVE_SOURCE` constant.

Codex's P1 suggestion to revert to cumulative dedup across all prior retrospectives is intentionally skipped — that would re-introduce the unbounded growth this PR was originally created to bound. The intent of #30331 is exactly to scope the `<already_remembered>` block to a single prior retrospective.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->