### PR TITLE
fix(memory-v2): swallow router-fallback save errors

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1679,6 +1679,56 @@ describe("injectMemoryV2Block", () => {
       expect(row.concepts).toEqual([]);
     });
 
+    test("flag-on: router-failure path swallows a save() error and returns block:null instead of throwing", async () => {
+      // PR 30176 refactored router-failure handling to delegate to
+      // `finalizeInjection`. That regressed the prior inline log-and-continue
+      // semantics on the router-failure path: a transient SQLite write
+      // throwing during the stub-state save now aborted the whole turn
+      // because `finalizeInjection`'s try/catch re-threw caughtErr at the end.
+      //
+      // This test stages exactly that scenario — router returns
+      // `failureReason: api_error` AND `save()` throws — and asserts the
+      // turn completes with `{ block: null, toInject: [] }` rather than
+      // propagating the SQLite error to `prepareMemory`.
+      routerState.nextResult = {
+        selectedSlugs: [],
+        failureReason: "api_error",
+      };
+      activationStoreState.saveShouldThrow = true;
+
+      let threw: unknown = undefined;
+      let result: Awaited<ReturnType<typeof injectMemoryV2Block>> | undefined;
+      try {
+        result = await injectMemoryV2Block({
+          database: db,
+          conversationId: "conv-router-fail-save-throws",
+          currentTurn: 5,
+          userMessage: "anything",
+          assistantMessage: "ok",
+          nowText: "Now",
+          messageId: "msg-fail-save",
+          config: makeConfig({ router: { enabled: true } }),
+        });
+      } catch (err) {
+        threw = err;
+      }
+
+      expect(threw).toBeUndefined();
+      expect(result).toBeDefined();
+      expect(result!.block).toBeNull();
+      expect(result!.toInject).toEqual([]);
+
+      // Telemetry still flushes with `mode: "errored"` so the failure stays
+      // observable — the same row the inline pre-refactor path emitted.
+      expect(telemetryState.recordCalls.length).toBe(1);
+      const row = telemetryState.recordCalls[0] as {
+        mode: string;
+        concepts: unknown[];
+      };
+      expect(row.mode).toBe("errored");
+      expect(row.concepts).toEqual([]);
+    });
+
     test("flag-on: router abstention (empty selectedSlugs, no failure) writes mode:`router` row with no injected pages", async () => {
       routerState.nextResult = {
         selectedSlugs: [],

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -310,6 +310,14 @@ async function finalizeInjection(args: {
   telemetryRows: MemoryV2ConceptRowRecord[];
   config: AssistantConfig;
   nextStateMap: Record<string, number>;
+  /**
+   * When true, errors thrown inside the helper (save / render / status
+   * finalization) are logged and swallowed instead of re-thrown. Used by
+   * the router-failure path, which is already a best-effort cleanup: a
+   * transient SQLite write here must not abort the turn on top of the
+   * router failure that already happened. Defaults to throwing.
+   */
+  bestEffort?: boolean;
 }): Promise<InjectMemoryV2BlockResult> {
   const {
     workspaceDir,
@@ -449,9 +457,16 @@ async function finalizeInjection(args: {
   } catch (err) {
     // Stash the error and let `finally` flush a best-effort telemetry row
     // before we re-throw to the caller. `mode = "errored"` flags the row
-    // for observability dashboards / inspector queries.
+    // for observability dashboards / inspector queries. On the best-effort
+    // path the error is logged and swallowed so the trailing return stands.
     caughtErr = err;
     mode = "errored";
+    if (args.bestEffort) {
+      log.warn(
+        { err, conversationId, turn: currentTurn },
+        "Memory v2 finalizeInjection error on best-effort path — swallowing",
+      );
+    }
   } finally {
     try {
       recordMemoryV2ActivationLog({
@@ -469,7 +484,7 @@ async function finalizeInjection(args: {
     }
   }
 
-  if (caughtErr !== undefined) throw caughtErr;
+  if (caughtErr !== undefined && !args.bestEffort) throw caughtErr;
   return { block, toInject: newlyInjected };
 }
 
@@ -537,7 +552,10 @@ async function injectViaRouter(args: {
     // (preserving `priorEverInjected` so future turns still subtract
     // previously-attached slugs) and writes the telemetry row through the
     // same code path as the success branch — no inline duplication of
-    // `save` + `recordMemoryV2ActivationLog`.
+    // `save` + `recordMemoryV2ActivationLog`. `bestEffort: true` matches
+    // the pre-refactor inline behavior of logging and continuing if the
+    // stub-state `save()` throws — we don't want a transient SQLite write
+    // to abort the turn on top of the router failure that already happened.
     return finalizeInjection({
       workspaceDir,
       database,
@@ -550,6 +568,7 @@ async function injectViaRouter(args: {
       telemetryRows: [],
       config,
       nextStateMap: {},
+      bestEffort: true,
     });
   }
 


### PR DESCRIPTION
Addresses Codex/Devin review feedback on #30176. Refactoring router-failure handling to share finalizeInjection introduced a save-error rethrow that the prior inline router-failure path explicitly swallowed. A transient SQLite write during router fallback now aborts the turn instead of returning block: null cleanly. Restores the log-and-continue semantics for the router-fallback path.