### PR TITLE
test(daemon): preserve transitive exports in conversation-lifecycle-auto-analyze mocks

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -62,8 +62,11 @@ const autoAnalysisConversations = new Set<string>();
 // flip this to true.
 let v2Enabled = false;
 
+const realLoader = await import("../../config/loader.js");
 mock.module("../../config/loader.js", () => ({
+  ...realLoader,
   getConfig: () => ({ memory: { v2: { enabled: v2Enabled } } }),
+  loadConfig: () => ({ memory: { v2: { enabled: v2Enabled } } }),
 }));
 
 mock.module("../../memory/auto-analysis-guard.js", () => ({
@@ -81,7 +84,10 @@ mock.module("../../memory/jobs-store.js", () => ({
   },
 }));
 
+const realAutoAnalysisEnqueue =
+  await import("../../memory/auto-analysis-enqueue.js");
 mock.module("../../memory/auto-analysis-enqueue.js", () => ({
+  ...realAutoAnalysisEnqueue,
   enqueueAutoAnalysisIfEnabled: (args: {
     conversationId: string;
     trigger: "batch" | "idle" | "lifecycle";
@@ -114,15 +120,23 @@ mock.module("../../memory/memory-retrospective-enqueue.js", () => ({
 
 // Stub all side-effecting cleanup helpers that disposeConversation chains
 // into after the enqueue block. We assert on enqueue behavior only.
+const realBrowserScreencast =
+  await import("../../tools/browser/browser-screencast.js");
 mock.module("../../tools/browser/browser-screencast.js", () => ({
+  ...realBrowserScreencast,
   unregisterConversationSender: () => {},
 }));
 
+const realConversationNotifiers = await import("../conversation-notifiers.js");
 mock.module("../conversation-notifiers.js", () => ({
+  ...realConversationNotifiers,
   unregisterCallNotifiers: () => {},
 }));
 
+const realConversationSkillTools =
+  await import("../conversation-skill-tools.js");
 mock.module("../conversation-skill-tools.js", () => ({
+  ...realConversationSkillTools,
   resetSkillToolProjection: () => {},
 }));
 


### PR DESCRIPTION
## Summary

- The mocks in \`conversation-lifecycle-auto-analyze.test.ts\` replaced all exports of each mocked module rather than overlaying overrides. After PR #30575 added transitive imports of \`loadConfig\` (via \`memory/v2/static-context.ts\`) and \`resolveTrustClass\` (via \`daemon/conversation-tool-setup.ts\`), the narrow mocks broke imports for \`loadConfig\`, \`stopAllScreencasts\`, \`enqueueAutoAnalysisOnCompaction\`, and \`registerConversationNotifiers\`, causing the Test job to fail with \`SyntaxError: Export named ... not found in module\`.
- Spread the real module into each mock (same pattern already used for \`jobs-store.js\`) so transitive consumers keep working while the test still overrides only the specific functions it controls.

## Original prompt

Fix the failing Test job in CI run https://github.com/vellum-ai/vellum-assistant/actions/runs/25816908018. The job failed on \`conversation-lifecycle-auto-analyze.test.ts\` with \`SyntaxError: Export named 'loadConfig' not found in module '.../config/loader.ts'\`, because a recent commit added a transitive import chain through the test's mocked modules and the mocks didn't preserve the original exports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->