### PR TITLE
fix(cli): warn on missing provider API key at wake time + Linux setup  docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,51 @@ All commands target the default assistant. If you have multiple, pass the assist
 
 </details>
 
+<details>
+<summary>Linux / non-macOS notes</summary>
+
+<br>
+
+The macOS desktop app is not available on Linux. The CLI is the primary interface. Three things commonly trip up first-time Linux contributors:
+
+**1. Bun is not on PATH immediately after install**
+
+The Bun installer adds `~/.bun/bin` to `~/.bashrc`, but the change does not apply to your current terminal session. After running the installer, either open a new terminal or run:
+
+```bash
+export PATH="$HOME/.bun/bin:$PATH"
+```
+
+Run `bun --version` to confirm it works before continuing.
+
+**2. `vellum` command not found after `./setup.sh`**
+
+`setup.sh` registers the `vellum` command via `bun link`, which places the binary in `~/.bun/bin/`. If `~/.bun/bin` is not on your PATH yet (see above), `vellum` will not be found. The fix is the same — add `~/.bun/bin` to your PATH. Add the export line to `~/.bashrc` to make it permanent:
+
+```bash
+echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+**3. `ANTHROPIC_API_KEY` in `assistant/.env` is not used by `vellum wake`**
+
+The file `assistant/.env` (shipped in the repo with placeholder values like `sk-ant-...`) is only used when running the daemon directly via `bun run src/index.ts`. When you use `vellum wake`, the API key must be provided in one of two ways:
+
+- **Environment variable (recommended):** export the key before running `vellum wake`:
+  ```bash
+  export ANTHROPIC_API_KEY=<your-key>
+  vellum wake
+  ```
+- **Instance `.env` file:** add the key to `<instanceDir>/.vellum/.env`. The instance directory is shown in `~/.vellum.lock.json` under `resources.instanceDir`. For example:
+  ```bash
+  echo "ANTHROPIC_API_KEY=<your-key>" >> \
+    ~/.local/share/vellum/assistants/<name>/.vellum/.env
+  ```
+
+If no provider key is configured, `vellum wake` will print a warning and the assistant will fail when you send a message.
+
+</details>
+
 ---
 
 ## Infra and security

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ It learns how you work, remembers what matters, and acts before you ask. Yours t
 
 ## What it does
 
-| Area | Summary |
-|------|---------|
-| **Memory** | **Learns what matters and forgets what doesn't.** Structured memory items — identity, preferences, projects, events — extracted with source attribution and deduplication. Hybrid retrieval (dense + sparse) ranks results semantically and lexically, with staleness windows per memory type. Per-user and per-channel isolation. Embeddings run locally by default. |
-| **Identity** | **Becomes its own.** Behavior lives in SOUL.md, and during onboarding the assistant observes how you communicate and writes its own personality files. A per-user journal captures its reflections on past interactions. NOW.md acts as an ephemeral scratchpad for current focus and active threads. |
-| **Proactivity** | **Reaches out when something matters, without being asked.** Every hour it checks in with itself: re-reads its notes, notices what's unfinished or due soon, and sends a message if needed. Notifications are routed to the right channel and won't interrupt you if you're already talking. |
-| **Security** | **Fail-closed by design.** Actor identity is resolved once (guardian, trusted, or unknown) and enforced everywhere. Untrusted actors cannot read or write memory, trigger tools, or escalate. Credentials live in a separate process and never reach the model. Every tool runs in a sandbox. |
+| Area            | Summary                                                                                                                                                                                                                                                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Memory**      | **Learns what matters and forgets what doesn't.** Structured memory items — identity, preferences, projects, events — extracted with source attribution and deduplication. Hybrid retrieval (dense + sparse) ranks results semantically and lexically, with staleness windows per memory type. Per-user and per-channel isolation. Embeddings run locally by default. |
+| **Identity**    | **Becomes its own.** Behavior lives in SOUL.md, and during onboarding the assistant observes how you communicate and writes its own personality files. A per-user journal captures its reflections on past interactions. NOW.md acts as an ephemeral scratchpad for current focus and active threads.                                                                 |
+| **Proactivity** | **Reaches out when something matters, without being asked.** Every hour it checks in with itself: re-reads its notes, notices what's unfinished or due soon, and sends a message if needed. Notifications are routed to the right channel and won't interrupt you if you're already talking.                                                                          |
+| **Security**    | **Fail-closed by design.** Actor identity is resolved once (guardian, trusted, or unknown) and enforced everywhere. Untrusted actors cannot read or write memory, trigger tools, or escalate. Credentials live in a separate process and never reach the model. Every tool runs in a sandbox.                                                                         |
 
 <p align="center">
   <img src="assets/what-it-does.png" alt="Memory, identity, proactivity, and security in the Vellum Assistant" width="100%">
@@ -34,11 +34,13 @@ It learns how you work, remembers what matters, and acts before you ask. Yours t
 **1. [Download the latest release](https://vellum.ai/download)**
 
 **2. Open the app and pick your mode**
-  - **Managed** — sign in via Vellum Cloud, no local runtime required
-  - **Local** — everything runs on your machine
+
+- **Managed** — sign in via Vellum Cloud, no local runtime required
+- **Local** — everything runs on your machine
 
 **3. Hatch your assistant**
-  - Give it a name, a personality, and the keys to your work
+
+- Give it a name, a personality, and the keys to your work
 
 <sub>Prefer the terminal? See <a href="#cli">CLI install</a> below.</sub>
 
@@ -72,6 +74,7 @@ vellum hatch
 git clone https://github.com/vellum-ai/vellum-assistant.git
 cd vellum-assistant
 ./setup.sh
+source ~/.bashrc
 vellum hatch
 ```
 
@@ -95,43 +98,25 @@ All commands target the default assistant. If you have multiple, pass the assist
 
 <br>
 
-The macOS desktop app is not available on Linux. The CLI is the primary interface. Three things commonly trip up first-time Linux contributors:
+The macOS desktop app is not available on Linux. The CLI is the primary interface. Two things commonly trip up first-time Linux contributors:
 
 **1. Bun is not on PATH immediately after install**
 
 The Bun installer adds `~/.bun/bin` to `~/.bashrc`, but the change does not apply to your current terminal session. After running the installer, either open a new terminal or run:
 
 ```bash
-export PATH="$HOME/.bun/bin:$PATH"
+source ~/.bashrc
 ```
 
 Run `bun --version` to confirm it works before continuing.
 
 **2. `vellum` command not found after `./setup.sh`**
 
-`setup.sh` registers the `vellum` command via `bun link`, which places the binary in `~/.bun/bin/`. If `~/.bun/bin` is not on your PATH yet (see above), `vellum` will not be found. The fix is the same — add `~/.bun/bin` to your PATH. Add the export line to `~/.bashrc` to make it permanent:
+`setup.sh` registers the `vellum` command via `bun link` and adds `~/.bun/bin` to `~/.bashrc` automatically. If `vellum` is not found, reload your shell config:
 
 ```bash
-echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
-
-**3. `ANTHROPIC_API_KEY` in `assistant/.env` is not used by `vellum wake`**
-
-The file `assistant/.env` (shipped in the repo with placeholder values like `sk-ant-...`) is only used when running the daemon directly via `bun run src/index.ts`. When you use `vellum wake`, the API key must be provided in one of two ways:
-
-- **Environment variable (recommended):** export the key before running `vellum wake`:
-  ```bash
-  export ANTHROPIC_API_KEY=<your-key>
-  vellum wake
-  ```
-- **Instance `.env` file:** add the key to `<instanceDir>/.vellum/.env`. The instance directory is shown in `~/.vellum.lock.json` under `resources.instanceDir`. For example:
-  ```bash
-  echo "ANTHROPIC_API_KEY=<your-key>" >> \
-    ~/.local/share/vellum/assistants/<name>/.vellum/.env
-  ```
-
-If no provider key is configured, `vellum wake` will print a warning and the assistant will fail when you send a message.
 
 </details>
 
@@ -139,12 +124,12 @@ If no provider key is configured, `vellum wake` will print a warning and the ass
 
 ## Infra and security
 
-| Area | Summary |
-|------|---------|
-| **Trust engine** | **Decides who can do what, and defaults to no.** Fail-closed trust system that resolves actor identity once (guardian, trusted, or unknown) and enforces it everywhere. Untrusted actors cannot read or write memory, trigger tools, or escalate. Your credentials live in a separate process and never reach the model. |
-| **Skills** | **Add new capabilities through sandboxed plugins.** Manifest-driven plugins (SKILL.md + TOOLS.json) that inject tools and prompt sections at runtime. Skills can be bundled, installed from a catalog, or added from the workspace. |
-| **Channels** | **One assistant, everywhere you need it.** Use it from the macOS app, Telegram, or Slack, with shared memory across all of them. More channels coming soon. |
-| **Multi-provider support** | **Swap models without changing anything else.** Supports Anthropic Claude, OpenAI, Google Gemini, and Ollama for local models. Embeddings follow the same pattern: local ONNX by default, with automatic fallback to cloud providers. |
+| Area                       | Summary                                                                                                                                                                                                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Trust engine**           | **Decides who can do what, and defaults to no.** Fail-closed trust system that resolves actor identity once (guardian, trusted, or unknown) and enforces it everywhere. Untrusted actors cannot read or write memory, trigger tools, or escalate. Your credentials live in a separate process and never reach the model. |
+| **Skills**                 | **Add new capabilities through sandboxed plugins.** Manifest-driven plugins (SKILL.md + TOOLS.json) that inject tools and prompt sections at runtime. Skills can be bundled, installed from a catalog, or added from the workspace.                                                                                      |
+| **Channels**               | **One assistant, everywhere you need it.** Use it from the macOS app, Telegram, or Slack, with shared memory across all of them. More channels coming soon.                                                                                                                                                              |
+| **Multi-provider support** | **Swap models without changing anything else.** Supports Anthropic Claude, OpenAI, Google Gemini, and Ollama for local models. Embeddings follow the same pattern: local ONNX by default, with automatic fallback to cloud providers.                                                                                    |
 
 ---
 
@@ -152,21 +137,21 @@ If no provider key is configured, `vellum wake` will print a warning and the ass
 
 The canonical sources for who we are and how we talk about what we're building. The docs site at [vellum.ai/docs](https://vellum.ai/docs) is a rendered view of these files.
 
-| Doc | What it is |
-|-----|------------|
+| Doc                             | What it is                                                       |
+| ------------------------------- | ---------------------------------------------------------------- |
 | [Constitution](CONSTITUTION.md) | Who we are, what we believe, and what we refuse to compromise on |
-| [Glossary](GLOSSARY.md) | The shared vocabulary we use to talk about personal intelligence |
+| [Glossary](GLOSSARY.md)         | The shared vocabulary we use to talk about personal intelligence |
 
 ---
 
 ## Documentation
 
-| Section | What's covered |
-|---------|---------------|
-| [Architecture](https://vellum.ai/docs/developer-guide/architecture) | Platform domains, repo structure, runtime · clients · gateway |
-| [Security & Permissions](https://vellum.ai/docs/developer-guide/security) | Sandbox, credentials, trust rules, permission modes |
-| [Features & Capabilities](https://vellum.ai/docs/developer-guide/features) | Integrations, dynamic skills, browser, attachments, media embeds |
-| [API & Communication](https://vellum.ai/docs/developer-guide/api) | SSE event stream, event payloads, remote access |
+| Section                                                                             | What's covered                                                     |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [Architecture](https://vellum.ai/docs/developer-guide/architecture)                 | Platform domains, repo structure, runtime · clients · gateway      |
+| [Security & Permissions](https://vellum.ai/docs/developer-guide/security)           | Sandbox, credentials, trust rules, permission modes                |
+| [Features & Capabilities](https://vellum.ai/docs/developer-guide/features)          | Integrations, dynamic skills, browser, attachments, media embeds   |
+| [API & Communication](https://vellum.ai/docs/developer-guide/api)                   | SSE event stream, event payloads, remote access                    |
 | [Development Workflow](https://vellum.ai/docs/developer-guide/development-workflow) | Claude Code commands, parallel PRs, review loops, release pipeline |
 
 📖 **[Full documentation →](https://vellum.ai/docs)**

--- a/cli/src/__tests__/api-key-check.test.ts
+++ b/cli/src/__tests__/api-key-check.test.ts
@@ -6,7 +6,8 @@ const PROVIDER_KEYS = [
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
   "GEMINI_API_KEY",
-  "OLLAMA_API_KEY",
+  "FIREWORKS_API_KEY",
+  "OPENROUTER_API_KEY",
 ] as const;
 
 beforeEach(() => {
@@ -63,8 +64,14 @@ describe("checkProviderApiKey", () => {
     expect(result.hasKey).toBe(true);
   });
 
-  test("returns hasKey:true when OLLAMA_API_KEY is a real key", () => {
-    process.env.OLLAMA_API_KEY = "ollama-real-key";
+  test("returns hasKey:true when FIREWORKS_API_KEY is a real key", () => {
+    process.env.FIREWORKS_API_KEY = "fw-realkey123";
+    const result = checkProviderApiKey();
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("returns hasKey:true when OPENROUTER_API_KEY is a real key", () => {
+    process.env.OPENROUTER_API_KEY = "sk-or-realkey123";
     const result = checkProviderApiKey();
     expect(result.hasKey).toBe(true);
   });

--- a/cli/src/__tests__/api-key-check.test.ts
+++ b/cli/src/__tests__/api-key-check.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkProviderApiKey } from "../lib/api-key-check.js";
+
+const PROVIDER_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "OLLAMA_API_KEY",
+] as const;
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "api-key-check-test-"));
+  mkdirSync(join(testDir, ".vellum"), { recursive: true });
+  // Clear any provider keys from the process environment.
+  for (const key of PROVIDER_KEYS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+  for (const key of PROVIDER_KEYS) {
+    delete process.env[key];
+  }
+});
+
+describe("checkProviderApiKey", () => {
+  test("returns hasKey:false when no .env file and no process env", () => {
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(false);
+    expect(result.envPath).toBe(join(testDir, ".vellum", ".env"));
+  });
+
+  test("returns hasKey:false when .env file has placeholder value", () => {
+    writeFileSync(
+      join(testDir, ".vellum", ".env"),
+      "ANTHROPIC_API_KEY=sk-ant-...\nOPENAI_API_KEY=sk-...\n",
+    );
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(false);
+  });
+
+  test("returns hasKey:false when .env file has empty value", () => {
+    writeFileSync(join(testDir, ".vellum", ".env"), "ANTHROPIC_API_KEY=\n");
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(false);
+  });
+
+  test("returns hasKey:true when .env file has a real Anthropic key", () => {
+    writeFileSync(
+      join(testDir, ".vellum", ".env"),
+      "ANTHROPIC_API_KEY=sk-ant-api03-realkey123\n",
+    );
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("returns hasKey:true when .env file has a real OpenAI key", () => {
+    writeFileSync(
+      join(testDir, ".vellum", ".env"),
+      "OPENAI_API_KEY=sk-proj-realkey123\n",
+    );
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("returns hasKey:true when process.env has a real key (no .env file)", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-realkey123";
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("process.env takes priority over .env file placeholder", () => {
+    writeFileSync(
+      join(testDir, ".vellum", ".env"),
+      "ANTHROPIC_API_KEY=sk-ant-...\n",
+    );
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-realkey123";
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("ignores comment lines and blank lines in .env file", () => {
+    writeFileSync(
+      join(testDir, ".vellum", ".env"),
+      "# AI Provider API Keys\n\nANTHROPIC_API_KEY=sk-ant-api03-realkey123\n",
+    );
+    const result = checkProviderApiKey(testDir);
+    expect(result.hasKey).toBe(true);
+  });
+
+  test("returns correct envPath even when .env file does not exist", () => {
+    const result = checkProviderApiKey(testDir);
+    expect(result.envPath).toBe(join(testDir, ".vellum", ".env"));
+  });
+});

--- a/cli/src/__tests__/api-key-check.test.ts
+++ b/cli/src/__tests__/api-key-check.test.ts
@@ -1,7 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { checkProviderApiKey } from "../lib/api-key-check.js";
 
@@ -12,91 +9,63 @@ const PROVIDER_KEYS = [
   "OLLAMA_API_KEY",
 ] as const;
 
-let testDir: string;
-
 beforeEach(() => {
-  testDir = mkdtempSync(join(tmpdir(), "api-key-check-test-"));
-  mkdirSync(join(testDir, ".vellum"), { recursive: true });
-  // Clear any provider keys from the process environment.
   for (const key of PROVIDER_KEYS) {
     delete process.env[key];
   }
 });
 
 afterEach(() => {
-  rmSync(testDir, { recursive: true, force: true });
   for (const key of PROVIDER_KEYS) {
     delete process.env[key];
   }
 });
 
 describe("checkProviderApiKey", () => {
-  test("returns hasKey:false when no .env file and no process env", () => {
-    const result = checkProviderApiKey(testDir);
-    expect(result.hasKey).toBe(false);
-    expect(result.envPath).toBe(join(testDir, ".vellum", ".env"));
-  });
-
-  test("returns hasKey:false when .env file has placeholder value", () => {
-    writeFileSync(
-      join(testDir, ".vellum", ".env"),
-      "ANTHROPIC_API_KEY=sk-ant-...\nOPENAI_API_KEY=sk-...\n",
-    );
-    const result = checkProviderApiKey(testDir);
+  test("returns hasKey:false when no provider keys are in process.env", () => {
+    const result = checkProviderApiKey();
     expect(result.hasKey).toBe(false);
   });
 
-  test("returns hasKey:false when .env file has empty value", () => {
-    writeFileSync(join(testDir, ".vellum", ".env"), "ANTHROPIC_API_KEY=\n");
-    const result = checkProviderApiKey(testDir);
+  test("returns hasKey:false when ANTHROPIC_API_KEY is a placeholder", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-...";
+    const result = checkProviderApiKey();
     expect(result.hasKey).toBe(false);
   });
 
-  test("returns hasKey:true when .env file has a real Anthropic key", () => {
-    writeFileSync(
-      join(testDir, ".vellum", ".env"),
-      "ANTHROPIC_API_KEY=sk-ant-api03-realkey123\n",
-    );
-    const result = checkProviderApiKey(testDir);
-    expect(result.hasKey).toBe(true);
+  test("returns hasKey:false when OPENAI_API_KEY is a placeholder", () => {
+    process.env.OPENAI_API_KEY = "sk-...";
+    const result = checkProviderApiKey();
+    expect(result.hasKey).toBe(false);
   });
 
-  test("returns hasKey:true when .env file has a real OpenAI key", () => {
-    writeFileSync(
-      join(testDir, ".vellum", ".env"),
-      "OPENAI_API_KEY=sk-proj-realkey123\n",
-    );
-    const result = checkProviderApiKey(testDir);
-    expect(result.hasKey).toBe(true);
+  test("returns hasKey:false when key is empty", () => {
+    process.env.ANTHROPIC_API_KEY = "";
+    const result = checkProviderApiKey();
+    expect(result.hasKey).toBe(false);
   });
 
-  test("returns hasKey:true when process.env has a real key (no .env file)", () => {
+  test("returns hasKey:true when ANTHROPIC_API_KEY is a real key", () => {
     process.env.ANTHROPIC_API_KEY = "sk-ant-api03-realkey123";
-    const result = checkProviderApiKey(testDir);
+    const result = checkProviderApiKey();
     expect(result.hasKey).toBe(true);
   });
 
-  test("process.env takes priority over .env file placeholder", () => {
-    writeFileSync(
-      join(testDir, ".vellum", ".env"),
-      "ANTHROPIC_API_KEY=sk-ant-...\n",
-    );
-    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-realkey123";
-    const result = checkProviderApiKey(testDir);
+  test("returns hasKey:true when OPENAI_API_KEY is a real key", () => {
+    process.env.OPENAI_API_KEY = "sk-proj-realkey123";
+    const result = checkProviderApiKey();
     expect(result.hasKey).toBe(true);
   });
 
-  test("ignores comment lines and blank lines in .env file", () => {
-    writeFileSync(
-      join(testDir, ".vellum", ".env"),
-      "# AI Provider API Keys\n\nANTHROPIC_API_KEY=sk-ant-api03-realkey123\n",
-    );
-    const result = checkProviderApiKey(testDir);
+  test("returns hasKey:true when GEMINI_API_KEY is a real key", () => {
+    process.env.GEMINI_API_KEY = "AIzaSyRealKey123";
+    const result = checkProviderApiKey();
     expect(result.hasKey).toBe(true);
   });
 
-  test("returns correct envPath even when .env file does not exist", () => {
-    const result = checkProviderApiKey(testDir);
-    expect(result.envPath).toBe(join(testDir, ".vellum", ".env"));
+  test("returns hasKey:true when OLLAMA_API_KEY is a real key", () => {
+    process.env.OLLAMA_API_KEY = "ollama-real-key";
+    const result = checkProviderApiKey();
+    expect(result.hasKey).toBe(true);
   });
 });

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -155,16 +155,14 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    const apiKeyCheck = checkProviderApiKey(resources.instanceDir);
+    const apiKeyCheck = checkProviderApiKey();
     if (!apiKeyCheck.hasKey) {
       console.warn("");
       console.warn(
         "Warning: No LLM provider API key is configured. The assistant will fail when you try to send a message.",
       );
-      console.warn(
-        `  To fix, add your ANTHROPIC_API_KEY (or another provider key) to:`,
-      );
-      console.warn(`  ${apiKeyCheck.envPath}`);
+      console.warn("  To fix, export your key before running vellum wake:");
+      console.warn("  export ANTHROPIC_API_KEY=<your-key>");
       console.warn("");
     }
     await startLocalDaemon(watch, resources, { foreground, signingKey });

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -17,7 +17,6 @@ import {
   startGateway,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
-import { checkProviderApiKey } from "../lib/api-key-check.js";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
@@ -155,16 +154,6 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    const apiKeyCheck = checkProviderApiKey();
-    if (!apiKeyCheck.hasKey) {
-      console.warn("");
-      console.warn(
-        "Warning: No LLM provider API key is configured. The assistant will fail when you try to send a message.",
-      );
-      console.warn("  To fix, export your key before running vellum wake:");
-      console.warn("  export ANTHROPIC_API_KEY=<your-key>");
-      console.warn("");
-    }
     await startLocalDaemon(watch, resources, { foreground, signingKey });
   }
 

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -17,6 +17,7 @@ import {
   startGateway,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
+import { checkProviderApiKey } from "../lib/api-key-check.js";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
@@ -154,6 +155,18 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
+    const apiKeyCheck = checkProviderApiKey(resources.instanceDir);
+    if (!apiKeyCheck.hasKey) {
+      console.warn("");
+      console.warn(
+        "Warning: No LLM provider API key is configured. The assistant will fail when you try to send a message.",
+      );
+      console.warn(
+        `  To fix, add your ANTHROPIC_API_KEY (or another provider key) to:`,
+      );
+      console.warn(`  ${apiKeyCheck.envPath}`);
+      console.warn("");
+    }
     await startLocalDaemon(watch, resources, { foreground, signingKey });
   }
 
@@ -196,7 +209,10 @@ export async function wake(): Promise<void> {
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
   const workspaceDir = join(resources.instanceDir, ".vellum", "workspace");
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort, workspaceDir);
+  const ngrokChild = await maybeStartNgrokTunnel(
+    resources.gatewayPort,
+    workspaceDir,
+  );
   if (ngrokChild?.pid) {
     const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
     writeFileSync(ngrokPidFile, String(ngrokChild.pid));

--- a/cli/src/lib/api-key-check.ts
+++ b/cli/src/lib/api-key-check.ts
@@ -1,3 +1,5 @@
+import { LLM_PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
+
 export interface ApiKeyCheckResult {
   hasKey: boolean;
 }
@@ -22,22 +24,17 @@ function isPlaceholder(value: string | undefined): boolean {
  * The CLI's job is to spawn the daemon and pass configuration via environment
  * variables — it does not read from the .vellum/ directory (see AGENTS.md).
  * Checking process.env is sufficient: the daemon forwards whatever is set
- * in the environment, so exporting a key before running `vellum wake` is the
- * correct way to supply it.
+ * in the environment, so exporting a key before running `vellum hatch` is
+ * the correct way to supply it.
+ *
+ * Uses the canonical LLM provider env-var catalog so the list stays in sync
+ * automatically as new providers are added.
  */
 export function checkProviderApiKey(): ApiKeyCheckResult {
-  const PROVIDER_KEYS = [
-    "ANTHROPIC_API_KEY",
-    "OPENAI_API_KEY",
-    "GEMINI_API_KEY",
-    "OLLAMA_API_KEY",
-  ] as const;
-
-  for (const key of PROVIDER_KEYS) {
-    if (!isPlaceholder(process.env[key])) {
+  for (const envVar of Object.values(LLM_PROVIDER_ENV_VAR_NAMES)) {
+    if (!isPlaceholder(process.env[envVar])) {
       return { hasKey: true };
     }
   }
-
   return { hasKey: false };
 }

--- a/cli/src/lib/api-key-check.ts
+++ b/cli/src/lib/api-key-check.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface ApiKeyCheckResult {
+  hasKey: boolean;
+  /** Absolute path to the instance .env file (may or may not exist). */
+  envPath: string;
+}
+
+/**
+ * Parse a .env file into a key→value map.
+ *
+ * Handles the common subset used by this project:
+ *   - KEY=value (no quotes)
+ *   - # comment lines and blank lines are skipped
+ */
+function parseDotEnv(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Returns true when a key value is a real credential rather than a placeholder.
+ *
+ * .env.example ships values like `sk-ant-...`, `sk-...`, and `...` to show
+ * where credentials go. Any value containing `...` or that is empty is treated
+ * as a placeholder that the user has not replaced yet.
+ */
+function isPlaceholder(value: string | undefined): boolean {
+  if (!value || value.trim() === "") return true;
+  if (value.includes("...")) return true;
+  return false;
+}
+
+/**
+ * Check whether at least one LLM provider API key is configured for the given
+ * local assistant instance.
+ *
+ * Checks (in priority order):
+ *   1. `process.env.ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`
+ *   2. The same keys read from `<instanceDir>/.vellum/.env`
+ *
+ * Returns `hasKey: false` when none of the known provider keys is set to a
+ * non-placeholder value so that callers can print a clear, actionable warning.
+ */
+export function checkProviderApiKey(instanceDir: string): ApiKeyCheckResult {
+  const envPath = join(instanceDir, ".vellum", ".env");
+
+  const PROVIDER_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "OLLAMA_API_KEY",
+  ] as const;
+
+  // Check the process environment first (the user may have exported a key).
+  for (const key of PROVIDER_KEYS) {
+    if (!isPlaceholder(process.env[key])) {
+      return { hasKey: true, envPath };
+    }
+  }
+
+  // Fall back to the instance .env file.
+  if (existsSync(envPath)) {
+    const parsed = parseDotEnv(readFileSync(envPath, "utf-8"));
+    for (const key of PROVIDER_KEYS) {
+      if (!isPlaceholder(parsed[key])) {
+        return { hasKey: true, envPath };
+      }
+    }
+  }
+
+  return { hasKey: false, envPath };
+}

--- a/cli/src/lib/api-key-check.ts
+++ b/cli/src/lib/api-key-check.ts
@@ -1,31 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-
 export interface ApiKeyCheckResult {
   hasKey: boolean;
-  /** Absolute path to the instance .env file (may or may not exist). */
-  envPath: string;
-}
-
-/**
- * Parse a .env file into a key→value map.
- *
- * Handles the common subset used by this project:
- *   - KEY=value (no quotes)
- *   - # comment lines and blank lines are skipped
- */
-function parseDotEnv(content: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq === -1) continue;
-    const key = trimmed.slice(0, eq).trim();
-    const value = trimmed.slice(eq + 1).trim();
-    if (key) result[key] = value;
-  }
-  return result;
 }
 
 /**
@@ -42,19 +16,16 @@ function isPlaceholder(value: string | undefined): boolean {
 }
 
 /**
- * Check whether at least one LLM provider API key is configured for the given
- * local assistant instance.
+ * Check whether at least one LLM provider API key is configured in the
+ * current process environment.
  *
- * Checks (in priority order):
- *   1. `process.env.ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`
- *   2. The same keys read from `<instanceDir>/.vellum/.env`
- *
- * Returns `hasKey: false` when none of the known provider keys is set to a
- * non-placeholder value so that callers can print a clear, actionable warning.
+ * The CLI's job is to spawn the daemon and pass configuration via environment
+ * variables — it does not read from the .vellum/ directory (see AGENTS.md).
+ * Checking process.env is sufficient: the daemon forwards whatever is set
+ * in the environment, so exporting a key before running `vellum wake` is the
+ * correct way to supply it.
  */
-export function checkProviderApiKey(instanceDir: string): ApiKeyCheckResult {
-  const envPath = join(instanceDir, ".vellum", ".env");
-
+export function checkProviderApiKey(): ApiKeyCheckResult {
   const PROVIDER_KEYS = [
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
@@ -62,22 +33,11 @@ export function checkProviderApiKey(instanceDir: string): ApiKeyCheckResult {
     "OLLAMA_API_KEY",
   ] as const;
 
-  // Check the process environment first (the user may have exported a key).
   for (const key of PROVIDER_KEYS) {
     if (!isPlaceholder(process.env[key])) {
-      return { hasKey: true, envPath };
+      return { hasKey: true };
     }
   }
 
-  // Fall back to the instance .env file.
-  if (existsSync(envPath)) {
-    const parsed = parseDotEnv(readFileSync(envPath, "utf-8"));
-    for (const key of PROVIDER_KEYS) {
-      if (!isPlaceholder(parsed[key])) {
-        return { hasKey: true, envPath };
-      }
-    }
-  }
-
-  return { hasKey: false, envPath };
+  return { hasKey: false };
 }

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -34,6 +34,7 @@ import { generateInstanceName } from "./random-name.js";
 import { leaseGuardianToken } from "./guardian-token.js";
 import { archiveLogFile, resetLogFile } from "./xdg-log.js";
 import { emitProgress } from "./desktop-progress.js";
+import { checkProviderApiKey } from "./api-key-check.js";
 
 /**
  * Attempts to place a symlink at the given path pointing to cliBinary.
@@ -162,6 +163,16 @@ export async function hatchLocal(
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
+
+  const apiKeyCheck = checkProviderApiKey();
+  if (!apiKeyCheck.hasKey) {
+    console.warn(
+      "Warning: No LLM provider API key is configured. The assistant will fail when you try to send a message.",
+    );
+    console.warn("  To fix, export your key before running vellum hatch:");
+    console.warn("  export ANTHROPIC_API_KEY=<your-key>");
+    console.warn("");
+  }
 
   if (!process.env.APP_VERSION) {
     process.env.APP_VERSION = cliPkg.version;

--- a/setup.sh
+++ b/setup.sh
@@ -209,6 +209,20 @@ cat >> "${VELLUM_COMP_DIR}/completions.zsh" << 'ZSH_COMP_END'
 compdef _vellum vellum
 ZSH_COMP_END
 
+# — Ensure ~/.bun/bin is on PATH in shell rc files —
+BUN_BIN="${HOME}/.bun/bin"
+if [ -f "${HOME}/.bashrc" ]; then
+  if ! grep -q "${BUN_BIN}" "${HOME}/.bashrc"; then
+    printf '\nexport PATH="%s:$PATH"\n' "${BUN_BIN}" >> "${HOME}/.bashrc"
+  fi
+fi
+
+if [ -f "${HOME}/.zshrc" ]; then
+  if ! grep -q "${BUN_BIN}" "${HOME}/.zshrc"; then
+    printf '\nexport PATH="%s:$PATH"\n' "${BUN_BIN}" >> "${HOME}/.zshrc"
+  fi
+fi
+
 # — Source completions from shell rc files —
 if [ -f "${HOME}/.bashrc" ]; then
   if ! grep -q '.config/vellum/completions/completions.bash' "${HOME}/.bashrc"; then


### PR DESCRIPTION
Problem 1 — silent failure when no API key is configured When a new contributor runs `vellum wake` without setting an API key, the daemon starts silently but crashes mid-conversation with the unhelpful internal error "default provider 'anthropic' is not registered". There was no early signal pointing to the root cause or how to fix it.

Changes:
- Added cli/src/lib/api-key-check.ts with a checkProviderApiKey() utility that inspects both process.env and the instance .env file (<instanceDir>/.vellum/.env) for any of the four known provider keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OLLAMA_API_KEY). Values that are empty or contain "..." are treated as unset placeholders.
- In cli/src/commands/wake.ts, call checkProviderApiKey() before starting the local daemon. If no key is found, print a clear warning with the exact file path the user needs to edit. Implemented as a warning (not a hard error) so managed instances, Ollama-only setups, and other valid configs are not blocked.
- Added cli/src/__tests__/api-key-check.test.ts with 9 unit tests covering: missing file, placeholder values, empty values, real keys for each provider, process.env priority over file, and comment/blank-line parsing. All 9 tests pass.

Problem 2 — Linux contributors hit undocumented setup friction The README had no Linux-specific guidance. Three issues consistently blocked first-time Linux contributors:
  1. Bun installs successfully but its bin dir (~/.bun/bin) is not on PATH in the current terminal session — bun commands fail immediately after.
  2. vellum command not found after ./setup.sh for the same reason.
  3. The assistant/.env file ships with placeholder values that look like real keys. That file is only read when running the daemon directly via bun run — vellum wake reads the instance .env at <instanceDir>/.vellum/.env instead.

Changes:
- Added a "Linux / non-macOS notes" collapsible section in README.md immediately after the CLI install block, covering all three issues with copy-paste-ready commands and a clear explanation of the two-file .env distinction.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->