### PR TITLE
fix(daemon): retry Anthropic stream aborted by transport (LUM-1537)

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -834,6 +834,36 @@ describe("RetryProvider — streaming response handling", () => {
     expect(callCount).toBe(1);
   });
 
+  test("does NOT retry OpenAI/Gemini-shaped 'Request was aborted' (no inner-timeout rewrite at those catch-sites)", async () => {
+    // The OpenAI chat-completions, OpenAI responses, and Gemini catch-sites
+    // format their errors as `"<Provider> API error (undefined): Request
+    // was aborted."` (note the `(undefined)` parenthetical that the
+    // Anthropic catch-site intentionally omits) and — unlike the Anthropic
+    // catch-site — they do NOT rewrite their inner-streamTimeoutMs
+    // deadline failures. A provider-agnostic transport-abort predicate
+    // would burn three retries on what is by construction a deterministic
+    // 30-minute deadline failure that will fire again on every attempt.
+    // Scoping the predicate to the Anthropic message prefix avoids that
+    // wasted retry budget for non-Anthropic providers until their
+    // catch-sites grow the same `innerTimeoutFired` distinction.
+    const openaiAbortError = new ProviderError(
+      "OpenAI API error (undefined): Request was aborted.",
+      "openai",
+      undefined,
+    );
+    let callCount = 0;
+    const inner: Provider = {
+      name: "openai-aborted-stream",
+      async sendMessage() {
+        callCount++;
+        throw openaiAbortError;
+      },
+    };
+    const provider = new RetryProvider(inner);
+    await expect(provider.sendMessage(MESSAGES)).rejects.toBe(openaiAbortError);
+    expect(callCount).toBe(1);
+  });
+
   test("events accumulate across retries (each attempt delivers events independently)", async () => {
     let callCount = 0;
     const inner: Provider = {

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -753,6 +753,87 @@ describe("RetryProvider — streaming response handling", () => {
     expect(callCount).toBe(2);
   });
 
+  test("retries transport-aborted stream (Anthropic 'Request was aborted' with no abortReason)", async () => {
+    let callCount = 0;
+    const inner: Provider = {
+      name: "retry-transport-abort",
+      async sendMessage() {
+        callCount++;
+        if (callCount <= 1) {
+          // Mirrors the ProviderError shape produced by the catch-site in
+          // providers/anthropic/client.ts when the SDK reports
+          // ``Anthropic.APIError(status === undefined, message: "Request
+          // was aborted.")`` and the daemon's AbortController was NOT the
+          // cause (i.e. abortReason is undefined). Empirically the #1
+          // daemon error by a factor of 5x — 1,344 events in 4d on the
+          // SSE chat path, all of which used to surface as a 45s blank
+          // screen on the web client via LUM-1431.
+          throw new ProviderError(
+            "Anthropic API error: Request was aborted.",
+            "anthropic",
+            undefined,
+          );
+        }
+        return successResponse();
+      },
+    };
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(MESSAGES);
+    expect(callCount).toBe(2);
+  });
+
+  test("does NOT retry caller-aborted stream (abortReason set short-circuits retry)", async () => {
+    let callCount = 0;
+    const abortError = new ProviderError(
+      "Anthropic API error: Request was aborted.",
+      "anthropic",
+      undefined,
+      // Tagging abortReason exactly matches what the catch-site does when
+      // signal.aborted was true at the moment of failure — i.e. the
+      // daemon (or the user) cancelled the request, not the transport.
+      // The retry layer must respect this and surface the error
+      // immediately without consuming retry budget.
+      { abortReason: "user-cancelled" },
+    );
+    const inner: Provider = {
+      name: "caller-abort",
+      async sendMessage() {
+        callCount++;
+        throw abortError;
+      },
+    };
+    const provider = new RetryProvider(inner);
+    await expect(provider.sendMessage(MESSAGES)).rejects.toBe(abortError);
+    expect(callCount).toBe(1);
+  });
+
+  test("does NOT retry inner-timeout stream (deterministic 30min deadline failure)", async () => {
+    let callCount = 0;
+    // When the inner streamTimeoutMs fires, the catch-site rewrites the
+    // message to "Anthropic stream timed out after Xs (inner
+    // streamTimeoutMs)" instead of "Request was aborted." That rewrite is
+    // what allows this branch to bypass the transport-abort retry —
+    // retrying a 30min-deadline failure would almost certainly hit the
+    // same deadline on the next attempt and waste retry budget.
+    const innerTimeoutError = new ProviderError(
+      "Anthropic API error: Anthropic stream timed out after 1800s (inner streamTimeoutMs)",
+      "anthropic",
+      undefined,
+    );
+    const inner: Provider = {
+      name: "inner-timeout",
+      async sendMessage() {
+        callCount++;
+        throw innerTimeoutError;
+      },
+    };
+    const provider = new RetryProvider(inner);
+    await expect(provider.sendMessage(MESSAGES)).rejects.toBe(
+      innerTimeoutError,
+    );
+    expect(callCount).toBe(1);
+  });
+
   test("events accumulate across retries (each attempt delivers events independently)", async () => {
     let callCount = 0;
     const inner: Provider = {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -72,6 +72,26 @@ const RETRYABLE_STREAM_PATTERNS = [
  */
 const RETRYABLE_PROVIDER_MESSAGE_PATTERNS = [/overloaded/i];
 
+/**
+ * Patterns that indicate the provider SDK reported a transport-level abort
+ * (TCP close mid-stream, edge LB idle cutoff, Bun fetch deadline) rather than
+ * a caller-initiated cancellation. Anthropic in particular surfaces both
+ * cases as ``Request was aborted`` from the SDK with ``error.status ===
+ * undefined``; the catch-site in ``providers/anthropic/client.ts`` tags
+ * caller cancellations with ``abortReason`` so they short-circuit *above*
+ * this check in {@link isRetryableError}. By the time a ProviderError with
+ * an aborted-request message reaches this predicate, ``abortReason`` is
+ * undefined — meaning the abort came from the transport, not the daemon —
+ * and a retry should issue a fresh request rather than letting the user
+ * stare at a blank screen until the client-side SSE watchdog fires.
+ *
+ * This is the daemon-side counterpart to the vembda graceful-close behavior
+ * for upstream disconnects (LUM-1536) — together they collapse the 45 s
+ * silent-stall window the web client used to observe whenever Anthropic's
+ * stream was cut mid-token.
+ */
+const RETRYABLE_TRANSPORT_ABORT_PATTERNS = [/request was aborted/i];
+
 function isRetryableStreamError(error: unknown): boolean {
   if (!(error instanceof ProviderError)) return false;
   if (error.statusCode !== undefined) return false; // has a real HTTP status — not a stream error
@@ -82,6 +102,15 @@ function isRetryableProviderMessage(error: unknown): boolean {
   if (!(error instanceof ProviderError)) return false;
   if (error.statusCode !== undefined) return false; // has a real HTTP status — handled by status check
   return RETRYABLE_PROVIDER_MESSAGE_PATTERNS.some((p) => p.test(error.message));
+}
+
+function isRetryableTransportAbort(error: unknown): boolean {
+  if (!(error instanceof ProviderError)) return false;
+  // Transport aborts surface with ``status === undefined`` (the SDK never
+  // saw an HTTP response). A real HTTP status here means a server error,
+  // which is handled by the status check.
+  if (error.statusCode !== undefined) return false;
+  return RETRYABLE_TRANSPORT_ABORT_PATTERNS.some((p) => p.test(error.message));
 }
 
 function isRetryableError(error: unknown): boolean {
@@ -103,6 +132,7 @@ function isRetryableError(error: unknown): boolean {
   }
   if (isRetryableProviderMessage(error)) return true;
   if (isRetryableStreamError(error)) return true;
+  if (isRetryableTransportAbort(error)) return true;
   return isRetryableNetworkError(error);
 }
 
@@ -482,7 +512,9 @@ export class RetryProvider implements Provider {
                   ? "provider_overloaded"
                   : isRetryableStreamError(error)
                     ? "stream_corruption"
-                    : "network_error";
+                    : isRetryableTransportAbort(error)
+                      ? "transport_abort"
+                      : "network_error";
           log.warn(
             {
               attempt: attempt + 1,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -73,24 +73,38 @@ const RETRYABLE_STREAM_PATTERNS = [
 const RETRYABLE_PROVIDER_MESSAGE_PATTERNS = [/overloaded/i];
 
 /**
- * Patterns that indicate the provider SDK reported a transport-level abort
- * (TCP close mid-stream, edge LB idle cutoff, Bun fetch deadline) rather than
- * a caller-initiated cancellation. Anthropic in particular surfaces both
- * cases as ``Request was aborted`` from the SDK with ``error.status ===
- * undefined``; the catch-site in ``providers/anthropic/client.ts`` tags
- * caller cancellations with ``abortReason`` so they short-circuit *above*
- * this check in {@link isRetryableError}. By the time a ProviderError with
- * an aborted-request message reaches this predicate, ``abortReason`` is
- * undefined — meaning the abort came from the transport, not the daemon —
- * and a retry should issue a fresh request rather than letting the user
- * stare at a blank screen until the client-side SSE watchdog fires.
+ * Patterns that indicate the Anthropic provider SDK reported a transport-level
+ * abort (TCP close mid-stream, edge LB idle cutoff, Bun fetch deadline) rather
+ * than a caller-initiated cancellation or inner-timeout deadline. The SDK
+ * surfaces all three cases as ``Request was aborted`` with ``error.status ===
+ * undefined``; the catch-site in ``providers/anthropic/client.ts`` separates
+ * them by:
+ *   - tagging caller cancellations with ``abortReason`` (short-circuits in
+ *     {@link isRetryableError} before reaching this predicate)
+ *   - rewriting the inner-timeout message to ``"Anthropic stream timed out
+ *     after Xs (inner streamTimeoutMs)"`` (doesn't start with ``Anthropic API
+ *     error:`` so it falls through to network-error classification)
+ *   - leaving the transport-abort message verbatim as
+ *     ``"Anthropic API error: Request was aborted."``
+ *
+ * Pattern is intentionally anchored to the Anthropic-specific message prefix.
+ * The OpenAI / Gemini / OpenRouter catch-sites format their errors as
+ * ``"<Provider> API error (undefined): Request was aborted."`` (note the
+ * ``(undefined)`` parenthetical) and — crucially — do **not** rewrite
+ * inner-timeout failures, so a provider-agnostic ``/request was aborted/i``
+ * predicate would erroneously retry their 30-minute deadline failures three
+ * additional times. Once those catch-sites grow the same
+ * ``innerTimeoutFired`` distinction the Anthropic one has, the pattern set
+ * here can be expanded to cover them too.
  *
  * This is the daemon-side counterpart to the vembda graceful-close behavior
  * for upstream disconnects (LUM-1536) — together they collapse the 45 s
  * silent-stall window the web client used to observe whenever Anthropic's
  * stream was cut mid-token.
  */
-const RETRYABLE_TRANSPORT_ABORT_PATTERNS = [/request was aborted/i];
+const RETRYABLE_TRANSPORT_ABORT_PATTERNS = [
+  /^anthropic api error:\s*request was aborted/i,
+];
 
 function isRetryableStreamError(error: unknown): boolean {
   if (!(error instanceof ProviderError)) return false;


### PR DESCRIPTION
## Prompt / plan

Sentry telemetry over the last 4d showed `[anthropic-client] Anthropic stream aborted by transport — likely bun fetch deadline, edge LB, or network idle cutoff` firing 1,344 times — the daemon's #1 error by 5×, on the `/v1/agent/loop` SSE chat path. Cross-correlating with the platform Sentry projects on the same time window:

- vembda `RemoteProtocolError: peer closed connection... (incomplete chunked read)` on `/assistants/{assistant_id}/query`: **234** + 34 related = 268
- web `sse_watchdog_fired`: **313**

That order-of-magnitude match (1,344 daemon aborts → 268 vembda upstream-disconnects → 313 web watchdog fires) traced the failure chain end-to-end:

1. Anthropic stream cuts off mid-token (Anthropic blip / Bun fetch deadline / LB idle cutoff). SDK throws `Anthropic.APIError(status: undefined, message: "Request was aborted.")`.
2. The daemon's Anthropic provider catch-site at `assistant/src/providers/anthropic/client.ts:1447` correctly classifies this as a transport abort (vs. caller-cancel by `abortReason`, vs. inner-timeout by message rewrite) and re-throws as `ProviderError(statusCode: undefined, message: "Anthropic API error: Request was aborted.")`.
3. **`RetryProvider` then drops the error onto the floor.** `isRetryableError()` short-circuits `abortReason !== undefined` (✓ correct), skips the 429/5xx branch (`statusCode === undefined`), `isRetryableProviderMessage` matches only `/overloaded/i`, `isRetryableStreamError` matches only the four SDK stream-corruption patterns, and `isRetryableNetworkError` checks ECONNRESET-style errno codes that the SDK never sets on this path. So the error rethrows up the agent loop, the turn fails, the daemon→vembda TCP closes mid-frame, and the web client observes 45 s of silence before its watchdog fires.

The comment at `retry.ts:97` even calls out this gap: *"transport-level aborts (retryable) and caller-cancels both surface as 'Request was aborted' from the SDK."* — the daemon-cancel side was wired up; the transport-retryable side wasn't.

This PR adds the missing positive predicate.

Companion PRs that address the same chain at the other two layers:
- `vellum-ai/vellum-assistant-platform#6708` — vembda emits a graceful-close SSE comment frame on `httpx.RemoteProtocolError` (boundary-gated per WHATWG §10.5) so the client gets an SSE-level signal instead of a half-open chunked response.
- `vellum-ai/vellum-assistant-platform#6711` — web SSE observability (`wasTurnSending` tag, `lastByteAgeMs`, heartbeat-vs-data counters, `attachStacktrace`) to split user-harming stalls from benign idle stalls in Sentry.

Together these collapse the 45 s silent-stall window described in [LUM-1431](https://linear.app/vellum/issue/LUM-1431) and the deeper investigation at [LUM-1459](https://linear.app/vellum/issue/LUM-1459). This PR is the daemon-side primary fix — the other two are observability + symptom mitigation.

## What this changes

`assistant/src/providers/retry.ts`:

1. New `RETRYABLE_TRANSPORT_ABORT_PATTERNS = [/request was aborted/i]` constant, separate from the existing `RETRYABLE_PROVIDER_MESSAGE_PATTERNS` (overloaded) and `RETRYABLE_STREAM_PATTERNS` (SDK corruption) so log/metric tagging stays distinguishable.
2. New `isRetryableTransportAbort(error)` predicate — gated on `ProviderError` with `statusCode === undefined`, message matches the pattern.
3. `isRetryableError()` calls it after `isRetryableStreamError` and before `isRetryableNetworkError`, so:
   - Daemon-initiated cancellations stay non-retryable (`abortReason !== undefined` short-circuits first, unchanged).
   - HTTP-status errors (429/5xx) take the existing fast path (unchanged).
   - Inner-timeout failures stay non-retryable — the catch-site rewrites the message to `"Anthropic stream timed out after Xs (inner streamTimeoutMs)"`, which doesn't contain `"request was aborted"`.
   - Only true transport aborts retry, with the same exponential-backoff budget (`DEFAULT_MAX_RETRIES = 3`, `DEFAULT_BASE_DELAY_MS = 1000` with equal jitter) as overloaded_error.
4. New `errorType: "transport_abort"` in the retry log warning so Logfire/Sentry filters can distinguish it from generic `network_error`.

Retry semantics on `sendMessage()` are stream-aware: each attempt delivers events independently via `onEvent`, the existing `RetryProvider — streaming response handling > events accumulate across retries` test covers the partial-token replay case. No new idempotency surface is introduced — `sendMessage()` always issues a fresh HTTP request, so retries are at-most-once at the SDK layer.

## Test plan

Three new regression tests in `src/__tests__/provider-error-scenarios.test.ts`:

- `retries transport-aborted stream (Anthropic 'Request was aborted' with no abortReason)` — mirrors the exact `ProviderError` shape from the catch-site, confirms 1 fail + 1 success → 2 calls (one retry).
- `does NOT retry caller-aborted stream (abortReason set short-circuits retry)` — same message, `abortReason: "user-cancelled"` set, confirms `callCount === 1` (zero retries, error surfaces as-is).
- `does NOT retry inner-timeout stream (deterministic 30min deadline failure)` — uses the catch-site's rewritten message, confirms `callCount === 1`.

Existing coverage (also re-verified):

- `retries overloaded_error with undefined statusCode (mid-stream SSE)` — overloaded path unchanged.
- `retries on 429 and succeeds after transient rate limit` — HTTP-status path unchanged.
- All four `RETRYABLE_STREAM_PATTERNS` tests — SDK-corruption path unchanged.
- `events accumulate across retries` — onEvent-replay semantics unchanged.

Local verification:

```
$ bun test src/__tests__/provider-error-scenarios.test.ts src/__tests__/retry-backoff.test.ts src/__tests__/retry-after-extraction.test.ts src/providers/__tests__/retry-callsite.test.ts src/__tests__/openai-provider.test.ts
158 pass, 0 fail
```

Pre-push hook ran all 521 affected tests in `assistant/` — all pass. `bunx tsc --noEmit` clean, `bun run lint` clean (one pre-existing warning in an unrelated file).

## CLI verb checklist

No new IPC routes — pure retry-policy change in the provider adapter layer.

## References

- WHATWG SSE §10.5 (HTTP/1.1 chunked-transfer requirements for SSE termination): https://html.spec.whatwg.org/multipage/server-sent-events.html
- Anthropic Node SDK error classes (`APIError`, `APIConnectionError`, `APIUserAbortError`): https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/error.ts
- Bun fetch deadline behavior on long-running streams: https://bun.sh/docs/api/fetch#timeout-and-cancellation
- Exponential backoff with equal jitter (the algorithm `computeRetryDelay` already implements): https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

## Alternatives considered

- **Add `/request was aborted/i` to `RETRYABLE_NETWORK_MESSAGE_PATTERNS` in `util/retry.ts`.** Rejected — that predicate is shared with `notifications/adapters/platform.ts` and `memory/embed.ts`, neither of which has the `abortReason` short-circuit that distinguishes caller-cancel from transport-abort. Adding the pattern there would risk retrying user-cancelled requests in those code paths. Keeping the pattern provider-retry-local preserves the abort-reason invariant.
- **Move the classification into the Anthropic catch-site (set a `retryable: true` flag on the `ProviderError`).** Rejected — the retry layer is intentionally generic across providers (OpenAI, Gemini, OpenRouter, Fireworks). Future providers that surface the same SDK message shape (e.g. `@anthropic-ai/sdk` is used internally by OpenRouter's Anthropic-compat path) get this fix for free without changing each catch-site.
- **Cap retries at 1 for transport aborts** (vs. the `DEFAULT_MAX_RETRIES = 3` budget used for 429/5xx). Rejected — empirically the abort rate is bursty (Anthropic edge LB rolling restarts, Bun fetch deadline spikes correlated with cold cache). A single retry leaves users stalled when 2 successive aborts hit; the equal-jitter backoff (500-1000ms, 1000-2000ms, 2000-4000ms) keeps total retry budget bounded at ≤7s. Cheaper than the 45s the user currently waits.

## Root cause analysis

1. **How did the code get into this state?** The `isRetryableError()` chain was built in tranches — `isRetryableNetworkError` handled errno-coded transport failures, `isRetryableStreamError` handled SDK stream-corruption patterns, `isRetryableProviderMessage` handled `overloaded`. The Anthropic transport-abort case wasn't a runtime observation when the chain was written; it became prominent only as call volume scaled.
2. **What mistakes or decisions led to it?** The catch-site in `anthropic/client.ts` correctly logged the transport-abort case with a clear `WARN`-level message ("Anthropic stream aborted by transport — likely bun fetch deadline, edge LB, or network idle cutoff"), but no observability surface paged the team when the rate of those warnings climbed. So the gap between "the warning is logged" and "the warning is acted on by the retry layer" went unnoticed for 1,344 events in 4d.
3. **Were there warning signs we missed?** Yes — three of them. (a) The retry.ts comment at line 97 explicitly named the gap: *"transport-level aborts (retryable) and caller-cancels both surface as 'Request was aborted' from the SDK"* — the comment acknowledges retryability but the predicate didn't follow. (b) Web Sentry showed 313 `sse_watchdog_fired` events with 100% `messagesAddedBucket=0`, which is the symptom side of this bug. (c) Vembda Sentry showed 268 `RemoteProtocolError` peer-closed events, which are the proxy-layer symptom. None of these were cross-correlated until this investigation.
4. **What can we do to prevent this pattern from recurring?** The new `errorType: "transport_abort"` tag on the retry log warning is the first step — once it's deployed, Logfire/Sentry can alert on it specifically rather than collapsing it into `network_error`. Beyond that, the broader pattern (a logged WARN with no SLO attached) is the systemic issue. Worth following up with: an Logfire/Sentry alert on `module=retry AND errorType=transport_abort AND count > X/hour` so retry exhaustion (i.e. transport aborts that persist through 3 retries) pages the on-call.
5. **AGENTS.md guidance?** No new rule. The catch-site / retry-layer separation of concerns is already correct; the bug was a missed predicate, not a missed convention. Adding a rule like "every catch-site that re-throws a logged warning must verify the retry layer handles it" would be too prescriptive — most logged warnings genuinely shouldn't retry. The right durable artifact is the test coverage in this PR (the three new tests pin the desired retry behavior for the three abort sub-cases) plus the in-code docstring on `RETRYABLE_TRANSPORT_ABORT_PATTERNS` that links transport-abort to the LUM-1536 / LUM-1538 companion PRs so future readers see the full chain.

Refs LUM-1537, LUM-1431, LUM-1459, LUM-1536, LUM-1538.

Link to Devin session: https://app.devin.ai/sessions/c23057eacba947afb722cea232ba157d
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->