### PR TITLE
fix(githooks): rename LINENO to avoid shadowing bash built-in

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -867,14 +867,16 @@ while IFS= read -r -d '' FILE; do
             if [ -z "$line" ]; then
                 continue
             fi
-            LINENO="${line%%:*}"
+            MATCH_LINENO="${line%%:*}"
             CONTENT="${line#*:}"
             # Context-aware patterns need the line that follows the match
             # in the staged blob (e.g. to confirm a bare `clientSecret:` key
             # sits in an OpenAPI schema). Compute lazily — only when needed.
+            # Note: do not use the name `LINENO` here — it shadows bash's
+            # built-in, which always reports the current script line.
             NEXT_LINE=""
-            if [[ "$LINENO" =~ ^[0-9]+$ ]] && [[ "$FILE" =~ \.(yaml|yml)$ ]]; then
-                NEXT_LINE=$(git show ":$FILE" 2>/dev/null | sed -n "$((LINENO + 1))p")
+            if [[ "$MATCH_LINENO" =~ ^[0-9]+$ ]] && [[ "$FILE" =~ \.(yaml|yml)$ ]]; then
+                NEXT_LINE=$(git show ":$FILE" 2>/dev/null | sed -n "$((MATCH_LINENO + 1))p")
             fi
             if matches_safe_line_pattern "$CONTENT" "$FILE" "$NEXT_LINE"; then
                 # Strip safe-line portions and re-check: a real secret


### PR DESCRIPTION
## Summary

Follow-up to #30549. The variable `LINENO` in pre-commit hook shadows bash's built-in `LINENO`, which always evaluates to the current **script** line number regardless of assignment. So `LINENO="${line%%:*}"` had no lasting effect — when later referenced, bash returned the script's physical line (~877), not the grep match line.

Result: `sed -n "$((LINENO + 1))p"` fetched approximately line 878 of the staged file regardless of match position. For YAML files shorter than ~878 lines, NEXT_LINE was always empty, so the context guard always failed and bare `clientSecret:` was never whitelisted even in legitimate OpenAPI schemas.

Renamed to `MATCH_LINENO` and added an inline comment documenting why.

## Test plan
- [x] `.githooks/pre-commit --self-test` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->