### PR TITLE
fix(bookmarks): reference-count BookmarkStore.isLoading for overlapping reloads

### DIFF
--- a/clients/macos/vellum-assistant/Services/BookmarkStore.swift
+++ b/clients/macos/vellum-assistant/Services/BookmarkStore.swift
@@ -30,7 +30,14 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Bookm
 public final class BookmarkStore {
     public private(set) var bookmarks: [BookmarkSummary] = []
     public private(set) var bookmarkedMessageIds: Set<String> = []
-    public private(set) var isLoading = true
+    /// True until the first ``reload()`` completes, and true whenever at least
+    /// one ``reload()`` is in flight. Reference-counted via ``loadingCount`` so
+    /// overlapping reloads (e.g. the view's `.task` and an SSE-driven reload)
+    /// don't briefly flip the flag to `false` when the earlier call returns.
+    public var isLoading: Bool { !hasLoaded || loadingCount > 0 }
+
+    private var loadingCount = 0
+    private var hasLoaded = false
 
     @ObservationIgnored private let client: BookmarkClient
     @ObservationIgnored private var sseChangeCancellable: AnyCancellable?
@@ -51,8 +58,11 @@ public final class BookmarkStore {
     /// local state. Call once the gateway connection is established, and
     /// whenever a `bookmark.*` SSE event arrives from another window.
     public func reload() async {
-        isLoading = true
-        defer { isLoading = false }
+        loadingCount += 1
+        defer {
+            loadingCount -= 1
+            hasLoaded = true
+        }
         do {
             let fetched = try await client.listBookmarks()
             bookmarks = fetched


### PR DESCRIPTION
Addresses Codex P2 + Devin BUG feedback on #30563.

## Problem
`reload()` unconditionally sets `isLoading = true` on entry and `false` via `defer` on exit. When two reloads overlap (e.g. `SettingsBookmarksTab`'s `.task` and an SSE-driven reload via `bookmarkDidChange`, or the AppDelegate reload racing the view), the first to complete sets `isLoading = false` while the second is still fetching. If the first reload returned an empty array, `SettingsBookmarksTab` briefly renders the 'No bookmarks' empty state instead of the spinner.

## Fix
Replace the stored `isLoading` boolean with a computed property backed by a reference counter:

- `loadingCount` — incremented on `reload()` entry, decremented in `defer`
- `hasLoaded` — flipped to `true` after the first reload completes, so the initial `isLoading = true` semantics are preserved before any reload runs
- `isLoading: Bool { !hasLoaded || loadingCount > 0 }`

Now `isLoading` only becomes `false` when every in-flight reload has settled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->