### PR TITLE
fix(githooks): always truncate commit-msg scan at scissors line

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -62,7 +62,7 @@ Runs the same generic-examples patterns as `pre-commit`, but against the commit 
 **Behavior:**
 
 - Comment lines (lines starting with `#`) are stripped before scanning when `commit.cleanup` is `default`, `strip`, or `scissors` (the modes that drop them from the recorded commit). Under `verbatim` or `whitespace`, comment lines are scanned because git keeps them.
-- Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is ignored when `commit.cleanup` is `default`, `strip`, or `scissors` (the modes that drop it from the recorded commit). Under `verbatim` or `whitespace`, content below the scissors line is scanned because git keeps it.
+- Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is always ignored. Git strips that region — which holds the verbose diff — from the recorded commit message regardless of cleanup mode, so scanning it would produce false positives on staged code rather than commit text.
 <!-- generic-examples:ignore-next-line — illustrative example of what the rule flags -->
 - Patterns are quote-anchored — they catch quoted/back-ticked emails and phone numbers (e.g., `Updated "alice@gmail.com" to be hashed`), not bare prose. Angle-bracketed trailers like `Co-Authored-By: Claude <noreply@anthropic.com>` are not flagged.
 - Suppression: `generic-examples:ignore-line` on the flagged line itself works (note that the marker survives into the recorded message). `generic-examples:ignore-next-line` is intentionally not supported here, since the marker line would also survive into the recorded message — use the same-line form instead.

--- a/scripts/check-generic-examples.ts
+++ b/scripts/check-generic-examples.ts
@@ -200,12 +200,11 @@ function parseUnifiedDiff(diff: string): AddedLine[] {
 // everything below it is dropped before the commit is recorded.
 const COMMIT_MSG_SCISSORS = "# ------------------------ >8 ------------------------";
 
-// `verbatim` and `whitespace` cleanup modes keep `#` lines (and content below
-// the scissors line) in the recorded commit message, so we cannot blindly skip
-// either — quoted real data in those regions would slip through the scan.
-// `default`/`strip`/`scissors` drop both, so skipping them avoids false
-// positives on git editor template text and on the `-v` diff body.
-const DROPS_HASH_LINES_AND_SCISSORS: ReadonlySet<string> = new Set([
+// `verbatim` and `whitespace` cleanup modes keep `#` lines in the recorded
+// commit message, so we cannot blindly skip them — quoted real data in `#`
+// comments would slip through the scan. `default`/`strip`/`scissors` drop
+// them, so skipping avoids false positives on git editor template text.
+const DROPS_HASH_LINES: ReadonlySet<string> = new Set([
   "default",
   "strip",
   "scissors",
@@ -230,17 +229,18 @@ function parseCommitMessage(
 ): AddedLine[] {
   const result: AddedLine[] = [];
   const lines = text.split("\n");
-  const dropsBelowScissors = DROPS_HASH_LINES_AND_SCISSORS.has(cleanupMode);
+  const dropsHashLines = DROPS_HASH_LINES.has(cleanupMode);
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
-    // Under `default`/`strip`/`scissors` cleanup (the modes used implicitly by
-    // `git commit -v`), everything from the scissors line down and all `#`
-    // comment lines are dropped before the commit is recorded. Under
-    // `verbatim`/`whitespace`, git keeps both, so we must scan them.
-    if (dropsBelowScissors) {
-      if (raw === COMMIT_MSG_SCISSORS) break;
-      if (raw.startsWith("#")) continue;
-    }
+    // The scissors line and everything below it are added by `git commit -v`
+    // and dropped before the commit is recorded regardless of cleanup mode —
+    // that region holds the verbose diff (passed to `commit-msg` but never
+    // part of the recorded message), so scanning it would produce false
+    // positives on staged code rather than commit text.
+    if (raw === COMMIT_MSG_SCISSORS) break;
+    // `#` comment lines are dropped under `default`/`strip`/`scissors` but
+    // kept verbatim under `verbatim`/`whitespace`, so gate skipping on mode.
+    if (dropsHashLines && raw.startsWith("#")) continue;
     // No previousContent tracking: prior-line suppression markers in commit
     // messages would survive into the recorded message (odd UX). Same-line
     // `generic-examples:ignore-line` still works via isSuppressed().
@@ -470,24 +470,24 @@ const COMMIT_MSG_TEST_CASES: CommitMsgTestCase[] = [
     expectPatterns: [],
   },
   {
-    name: "content below scissors line is scanned under verbatim cleanup",
+    name: "content below scissors line is ignored under verbatim cleanup (verbose diff is never recorded)",
     text:
       'fix: bug\n\n' +
       '# ------------------------ >8 ------------------------\n' +
       'diff --git a/file.ts b/file.ts\n' +
       '+const e = "alice@gmail.com";\n',
     cleanupMode: "verbatim",
-    expectPatterns: ["non-example-email"],
+    expectPatterns: [],
   },
   {
-    name: "content below scissors line is scanned under whitespace cleanup",
+    name: "content below scissors line is ignored under whitespace cleanup (verbose diff is never recorded)",
     text:
       'fix: bug\n\n' +
       '# ------------------------ >8 ------------------------\n' +
       'diff --git a/file.ts b/file.ts\n' +
       '+const e = "alice@gmail.com";\n',
     cleanupMode: "whitespace",
-    expectPatterns: ["non-example-email"],
+    expectPatterns: [],
   },
   {
     name: "Co-Authored-By trailer with angle-bracketed email is OK",


### PR DESCRIPTION
Addresses Codex P2 feedback on #30526.

The previous change gated scissors-line truncation on cleanup mode along with `#` comment stripping. That was overcorrected — `git commit -v` appends the diff below the scissors marker for the editor only, and git strips that region before recording the commit regardless of `commit.cleanup`. Under `verbatim`/`whitespace`, the hook was scanning the staged diff body as if it were commit-message text and could reject commits based on quoted strings in unrelated code.

This PR restores the unconditional scissors truncation while keeping the cleanup-mode gating for `#` comment lines (where `verbatim`/`whitespace` really do preserve content into the recorded message). Updates self-tests and `.githooks/README.md` to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->