### PR TITLE
fix(profiles): preserve custom profile order on order-patch failure

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3589,13 +3589,20 @@ public final class SettingsStore: ObservableObject {
             ])
             guard orderSuccess else {
                 log.error("Failed to patch llm.profileOrder after replacing llm.profiles.\(name, privacy: .public)")
-                // Server-side replace already succeeded and `profiles`
-                // includes the new entry, but the follow-up order patch
-                // failed. Without rebuilding `profileOrder`, a caller
-                // retry hits a stuck "already exists" collision and
-                // `reorderPublishedProfiles` silently drops the unlisted
-                // name on the next refresh.
-                let rebuiltOrder = profiles.map(\.name).sorted()
+                // Server-side replace already succeeded, so `profiles`
+                // has the new entry but `profileOrder` lacks it. Without
+                // reconciliation a caller retry hits a stuck "already
+                // exists" collision and `reorderPublishedProfiles`
+                // silently drops the unlisted name. Reconcile against
+                // the existing order (not an alphabetic resort) so a
+                // user-defined custom order survives — a retry's
+                // `nextProfileOrderAfterSaving` reads local state and
+                // would otherwise persist alphabetical order back to
+                // the daemon.
+                let rebuiltOrder = Self.normalizedProfileOrder(
+                    profileNames: profiles.map(\.name),
+                    storedOrder: profileOrder
+                )
                 profileOrder = rebuiltOrder
                 reorderPublishedProfiles(to: rebuiltOrder)
                 return false

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -416,6 +416,40 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertEqual(store.profiles.map(\.name).sorted(), store.profileOrder)
     }
 
+    /// Regression: when the follow-up `profileOrder` PATCH fails, the
+    /// rebuilt local order must preserve any user-defined ordering of
+    /// existing profiles instead of collapsing to alphabetical. A retry
+    /// of `replaceProfile` computes `nextProfileOrderAfterSaving` from
+    /// local state and would otherwise persist the alphabetic order back
+    /// to the daemon, silently overwriting the user's prior ordering.
+    func testReplaceProfileFailedOrderPatchPreservesCustomOrder() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "profileOrder": ["zeta", "alpha", "mike"],
+                "profiles": [
+                    "alpha": ["model": "claude-sonnet-4-6"],
+                    "mike": ["model": "claude-sonnet-4-6"],
+                    "zeta": ["model": "claude-sonnet-4-6"],
+                ],
+            ]
+        ])
+        mockSettingsClient.patchConfigResponse = false
+
+        let newProfile = InferenceProfile(
+            name: "bravo",
+            provider: "anthropic",
+            model: "claude-opus-4-7"
+        )
+        let success = await store.replaceProfile(name: "bravo", fragment: newProfile)
+        XCTAssertFalse(success)
+
+        // Custom order of existing profiles must survive; only the new
+        // name is appended (alphabetically after preserved entries).
+        XCTAssertEqual(store.profileOrder, ["zeta", "alpha", "mike", "bravo"])
+        XCTAssertEqual(Set(store.profileOrder), Set(store.profiles.map(\.name)))
+        XCTAssertEqual(store.profiles.map(\.name), store.profileOrder)
+    }
+
     // MARK: - deleteProfile blocked-by-active
 
     func testDeleteProfileBlockedByActive() async {


### PR DESCRIPTION
Addresses Codex P1 on #30547. The recovery path for a failed `llm.profileOrder` PATCH was rebuilding the local order with `profiles.map(\.name).sorted()`, which discards any user-defined ordering. A caller retry of `replaceProfile` would then compute `nextProfileOrderAfterSaving` from the alphabetized cache and persist that back to the daemon, silently clobbering the user's prior custom order.

Switch the recovery path to `normalizedProfileOrder`, which preserves the existing `profileOrder` positions for known names and appends only the newcomer. This keeps the existing test green (the case had only one preserved entry) and adds a regression test that exercises a non-alphabetic custom order across multiple existing profiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->