### PR TITLE
fix(memory-v2): defensive-copy getSkillCapability returns

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -578,6 +578,38 @@ describe("getSkillCapability", () => {
 
     expect(getSkillCapability("does-not-exist")).toBeNull();
   });
+
+  test("mutating the returned entry does not corrupt the cache", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    const first = getSkillCapability("example-skill-a");
+    expect(first).not.toBeNull();
+    const originalContent = first!.content;
+
+    // Frozen entries throw in strict mode when mutated; suppress so we can
+    // prove cache invariance even if a future refactor swaps freeze for a
+    // plain clone.
+    try {
+      (first as unknown as { id: string }).id = "tampered";
+      (first as unknown as { content: string }).content = "tampered";
+    } catch {
+      // expected under Object.freeze
+    }
+
+    const second = getSkillCapability("example-skill-a");
+    expect(second?.id).toBe("example-skill-a");
+    expect(second?.content).toBe(originalContent);
+
+    // listSkillEntries path also unaffected.
+    const viaList = listSkillEntries();
+    expect(viaList[0].id).toBe("example-skill-a");
+    expect(viaList[0].content).toBe(originalContent);
+  });
 });
 
 describe("listSkillEntries", () => {

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -291,12 +291,16 @@ async function runSeedOnce(): Promise<void> {
  * Accepts either a bare skill id (`example-skill`) or its unified-collection
  * slug (`skills/example-skill`) so render-side callers can pass through what
  * they have without a manual prefix strip.
+ *
+ * Returns a frozen copy so callers cannot mutate the underlying cache entry
+ * — matches the defensive-copy contract of `listSkillEntries`.
  */
 export function getSkillCapability(idOrSlug: string): SkillEntry | null {
   const id = idOrSlug.startsWith(SKILL_SLUG_PREFIX)
     ? idOrSlug.slice(SKILL_SLUG_PREFIX.length)
     : idOrSlug;
-  return entries?.get(id) ?? null;
+  const entry = entries?.get(id);
+  return entry ? Object.freeze({ ...entry }) : null;
 }
 
 /** True iff the slug refers to a skill entry in the unified collection. */


### PR DESCRIPTION
## Summary
Addresses Devin review feedback on #30550. `listSkillEntries()` was updated there to return frozen copies, but `getSkillCapability()` still returned a direct reference to the cache entry — a caller mutating the result would silently corrupt the in-process cache. Apply the same \`Object.freeze({ ...entry })\` pattern for contract parity. Adds a regression test that mutates the \`getSkillCapability\` return value directly.

## Test plan
- [x] \`bun test assistant/src/memory/v2/__tests__/skill-store.test.ts\` — 23 pass
- [x] \`bunx tsc --noEmit\` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->