### PR TITLE
fix(macos): drop stale head-trim sentinel when trim removes non-rendered rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -342,6 +342,16 @@ struct ACPSessionDetailView: View {
                     // the next offset reading, which lowers the watermark by the
                     // observed content shift instead.
                     pendingHeadTrim = true
+                    // If the trim removed non-rendered content (e.g. a `.thought`
+                    // row while `showThoughts` is off), the visible offset won't
+                    // change and no preference callback fires to consume the
+                    // sentinel. Drop it on the next runloop tick so the user's
+                    // next real scroll isn't misread as a layout artifact. The
+                    // SwiftUI preference callback for this update runs during
+                    // the current runloop pass, before this async block.
+                    DispatchQueue.main.async {
+                        pendingHeadTrim = false
+                    }
                 }
                 .onChange(of: showThoughts) {
                     // Toggling thought visibility shrinks/grows the timeline,


### PR DESCRIPTION
Addresses Codex P2 feedback on #30544.

The `pendingHeadTrim` sentinel always consumes the next offset event. If the ring buffer trims an event that is not currently rendered (e.g. a `.thought` row while `showThoughts` is off), the visible content offset does not change, no preference callback fires, and the sentinel sticks until the user's next real scroll. That scroll is then mis-categorized as a layout artifact, so `movedUp`/`returnedToBottom` evaluation is skipped and `autoScrollEnabled` can stay `true` — the next append yanks the user back to the bottom.

Schedule a `DispatchQueue.main.async` clear when setting the sentinel. The SwiftUI preference callback for the trim fires during the current runloop pass and consumes the sentinel first when there is a visible offset shift. When there isn't, the async block runs on the next tick and drops the stale flag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->