### PR TITLE
fix(schedule): preserve skip semantics when mapping empty conversation IDs

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -549,13 +549,15 @@ export async function runScheduleOnce(
           });
         },
       });
-      // Bootstrap-failure path returns `conversationId: ""`. Substitute a
-      // sentinel so the schedule-run DB row carries a recognizable marker
-      // instead of an empty string.
+      // Bootstrap-failure path returns `{ ok: false, conversationId: "" }`.
+      // Substitute a sentinel only for failures so the schedule-run DB row
+      // carries a recognizable marker. Successful skips (e.g.
+      // `pre_first_user_message`) also return `conversationId: ""` but with
+      // `ok: true` — keep the empty ID to preserve their skip contract.
       conversationId =
-        result.conversationId !== ""
-          ? result.conversationId
-          : `bootstrap-error:${job.id}`;
+        !result.ok && result.conversationId === ""
+          ? `bootstrap-error:${job.id}`
+          : result.conversationId;
       ok = result.ok;
       errorMsg = result.error?.message;
     }


### PR DESCRIPTION
## Summary
- Restrict the `bootstrap-error:<job.id>` sentinel substitution to actual failures (`!result.ok`).
- Skips (`ok: true`, empty `conversationId`, `skipReason: "pre_first_user_message"`) now keep the documented empty-ID contract instead of being recorded with a synthetic failure-looking ID.

Addresses Codex P2 + Devin review feedback on #30532.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/__tests__/task-scheduler.test.ts src/__tests__/scheduler-reuse-conversation.test.ts src/__tests__/scheduler-recurrence.test.ts src/__tests__/schedule-retry.test.ts` — 47 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->