### PR TITLE
fix(memory): stabilize getMessagesAfter null cursor; sweep null fork parents

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1152,11 +1152,14 @@ export function getMessagesAfter(
 ): MessageRow[] {
   const db = getDb();
   if (afterMessageId === null || afterMessageId === "") {
+    // Secondary `asc(messages.id)` matches the non-null path's cursor
+    // ordering, so callers tracking `cutoffMessageId` across runs see a
+    // consistent ordering when multiple rows share a millisecond timestamp.
     return db
       .select()
       .from(messages)
       .where(eq(messages.conversationId, conversationId))
-      .orderBy(asc(messages.createdAt))
+      .orderBy(asc(messages.createdAt), asc(messages.id))
       .all()
       .map(parseMessage);
   }

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -30,7 +30,17 @@
 //     `<already_remembered>` dedup block; sweeping it would force the
 //     next run to re-save facts the prior pass already captured.
 
-import { and, eq, inArray, isNotNull, lt, notInArray, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { getLogger } from "../util/logger.js";
 import { deleteConversation } from "./conversation-crud.js";
@@ -126,9 +136,16 @@ export function sweepOrphanMemoryRetrospectiveConversations(
         isNotNull(conversations.lastMessageAt),
         lt(conversations.lastMessageAt, cutoff),
         activeJobSourceConversationIds.length > 0
-          ? notInArray(
-              conversations.forkParentConversationId,
-              activeJobSourceConversationIds,
+          ? // `forkParentConversationId` is nullable, and SQLite's
+            // `NULL NOT IN (...)` evaluates to unknown (falsy), so legacy
+            // rows with a null parent would never match. Include them
+            // explicitly so the sweep covers them.
+            or(
+              isNull(conversations.forkParentConversationId),
+              notInArray(
+                conversations.forkParentConversationId,
+                activeJobSourceConversationIds,
+              ),
             )
           : sql`1=1`,
       ),


### PR DESCRIPTION
Follow-up review feedback on #30568.

## Changes

- `assistant/src/memory/conversation-crud.ts` — add secondary `asc(messages.id)` to the null/empty `afterMessageId` branch of `getMessagesAfter` so it matches the non-null branch's cursor ordering. Stops same-millisecond rows from being returned in arbitrary order, which previously let `cutoffMessageId` lag behind the lexicographically greatest id at that timestamp and caused re-inclusion on the next retrospective pass.
- `assistant/src/memory/memory-retrospective-startup-cleanup.ts` — `forkParentConversationId` is nullable, and SQLite's `NULL NOT IN (...)` is unknown/falsy. Wrap the active-job guard in `or(isNull(...), notInArray(...))` so legacy retro rows with a null parent are eligible for sweep.

## Test plan
- [x] `bun test src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts`
- [x] `bun test src/memory/__tests__/memory-retrospective-job.test.ts`
- [x] `bunx tsc --noEmit`