### PR TITLE
fix(agent-wake): move usage-log serialization under error boundary

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1545,4 +1545,46 @@ describe("wakeAgentForOpportunity", () => {
       messageId: undefined,
     });
   });
+
+  test("non-serializable usage payload does not abort the wake", async () => {
+    // Circular reference in rawRequest — JSON.stringify throws on this.
+    // Serialization must happen inside persistLog's try/catch so the
+    // failure is swallowed as a non-fatal log warning rather than
+    // escaping and aborting the wake.
+    const circular: Record<string, unknown> = { request: "produced wake" };
+    circular.self = circular;
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: circular,
+      rawResponse: { response: "real reply" },
+    };
+    const target = makeTarget({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // Wake still produced output even though logging failed.
+    expect(target.persistedTailCalls).toHaveLength(1);
+    // No log row was inserted because JSON.stringify threw.
+    expect(recordRequestLogCalls).toHaveLength(0);
+  });
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -542,21 +542,18 @@ export async function wakeAgentForOpportunity(
     // drops them — otherwise the next user-turn's `backfillMessageIdOnLogs`
     // sweep would misattach these NULL-messageId rows to an unrelated
     // future assistant message, contaminating inspector context.
-    const pendingLogs: Array<{
-      requestPayload: string;
-      responsePayload: string;
+    type PendingLog = {
+      rawRequest: unknown;
+      rawResponse: unknown;
       provider?: string;
-    }> = [];
-    const persistLog = (record: {
-      requestPayload: string;
-      responsePayload: string;
-      provider?: string;
-    }): void => {
+    };
+    const pendingLogs: PendingLog[] = [];
+    const persistLog = (record: PendingLog): void => {
       try {
         recordRequestLog(
           conversationId,
-          record.requestPayload,
-          record.responsePayload,
+          JSON.stringify(record.rawRequest),
+          JSON.stringify(record.rawResponse),
           undefined,
           record.provider,
         );
@@ -583,8 +580,8 @@ export async function wakeAgentForOpportunity(
       // Defer persistence while buffering — see `pendingLogs` above.
       if (event.type === "usage" && event.rawRequest && event.rawResponse) {
         const record = {
-          requestPayload: JSON.stringify(event.rawRequest),
-          responsePayload: JSON.stringify(event.rawResponse),
+          rawRequest: event.rawRequest,
+          rawResponse: event.rawResponse,
           provider: event.actualProvider,
         };
         if (mode === "buffering") {


### PR DESCRIPTION
Addresses Codex P1 review feedback on #30529.

The wake `onEvent` path built `requestPayload`/`responsePayload` with `JSON.stringify(...)` *before* entering `persistLog`'s `try/catch`. A provider that emitted `rawRequest`/`rawResponse` with a circular reference (or any non-serializable value) would throw out of `onEvent` and abort the wake — regressing the prior behavior where the full `recordRequestLog` flow was guarded.

Fix: store the raw values in `pendingLogs` and move `JSON.stringify` calls inside `persistLog`'s existing error boundary. Serialization failures now become non-fatal log warnings, matching the rest of the request-log persistence flow.

Regression test added covering a circular `rawRequest` — the wake still produces output and no log row is inserted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->