### PR TITLE
fix(memory-v2): propagate seed errors and correct reseed-flow JSDoc

### DIFF
--- a/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
+++ b/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
@@ -23,6 +23,7 @@ import type { AssistantConfig } from "../config/schema.js";
 
 interface TestState {
   seedCallCount: number;
+  seedCallOpts: Array<{ throwOnError?: boolean } | undefined>;
   seedShouldReject: Error | null;
   warnCalls: Array<{ obj: unknown; msg: unknown }>;
   infoCalls: Array<{ obj: unknown; msg: unknown }>;
@@ -41,6 +42,7 @@ interface TestState {
 
 const state: TestState = {
   seedCallCount: 0,
+  seedCallOpts: [],
   seedShouldReject: null,
   warnCalls: [],
   infoCalls: [],
@@ -60,8 +62,11 @@ const state: TestState = {
 // ---------------------------------------------------------------------------
 
 mock.module("../memory/v2/skill-store.js", () => ({
-  seedV2SkillEntries: async (): Promise<void> => {
+  seedV2SkillEntries: async (opts?: {
+    throwOnError?: boolean;
+  }): Promise<void> => {
     state.seedCallCount += 1;
+    state.seedCallOpts.push(opts);
     if (state.seedShouldReject) throw state.seedShouldReject;
   },
 }));
@@ -164,6 +169,7 @@ async function flushMicrotasks(): Promise<void> {
 
 function resetState(): void {
   state.seedCallCount = 0;
+  state.seedCallOpts = [];
   state.seedShouldReject = null;
   state.warnCalls = [];
   state.infoCalls = [];
@@ -300,6 +306,9 @@ describe("rebuildBm25CorpusStatsAndReseedSkills", () => {
 
     expect(state.corpusStatsBuildCount).toBe(1);
     expect(state.seedCallCount).toBe(1);
+    // Must pass throwOnError: true so a swallowed internal seed failure
+    // cannot trip the unconditional success log in the caller.
+    expect(state.seedCallOpts[0]).toEqual({ throwOnError: true });
     expect(state.warnCalls).toHaveLength(0);
   });
 

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -47,9 +47,11 @@ export function maybeSeedMemoryV2Skills(config: AssistantConfig): void {
  * callers issue (see `simBatch`, `activation.selectCandidates`). Reseeding
  * here closes that gap without operator intervention.
  *
- * Fire-and-forget by design — startup must not block on either step. Errors
- * are logged and swallowed independently for each step so a corpus-stats
- * failure does not mask a reseed failure (and vice versa).
+ * Fire-and-forget by design — startup must not block on either step. The
+ * reseed depends on the corpus-stats build, so a corpus-stats failure
+ * short-circuits and skips the reseed (the BM25 vectors it would produce
+ * would be wrong without fresh stats). Both steps log and swallow their own
+ * errors so neither blocks startup.
  */
 export async function rebuildBm25CorpusStatsAndReseedSkills(
   config: AssistantConfig,
@@ -70,7 +72,7 @@ export async function rebuildBm25CorpusStatsAndReseedSkills(
   if (!config.memory.v2.enabled) return;
   try {
     const { seedV2SkillEntries } = await import("../memory/v2/skill-store.js");
-    await seedV2SkillEntries();
+    await seedV2SkillEntries({ throwOnError: true });
     log.info(
       "Memory v2 skill embeddings re-seeded with BM25 vectors after corpus-stats build",
     );


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #30552.

- **Codex P2**: `rebuildBm25CorpusStatsAndReseedSkills` logged `Memory v2 skill embeddings re-seeded with BM25 vectors after corpus-stats build` unconditionally, even when `seedV2SkillEntries()` resolved after swallowing an internal error. Now passes `{ throwOnError: true }` so the wrapping try/catch surfaces inner failures and the success log only fires on real success.
- **Devin BUG**: JSDoc claimed corpus-stats and reseed errors were handled independently; the implementation returns early on corpus-stats failure, skipping the reseed. JSDoc now correctly describes the sequential dependency and short-circuit behavior.

Also extends the existing unit test to assert `throwOnError: true` is forwarded.

## Test plan
- [x] `bun test src/__tests__/lifecycle-memory-v2-seed.test.ts` — 13 pass
- [x] `bunx tsc --noEmit` clean