### PR TITLE
fix(filing): guard compaction retry from re-arming after service stop

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -413,6 +413,36 @@ describe("FilingService", () => {
       expect(hold.compactionCalls()).toBe(0);
     });
 
+    test("stop() prevents retry callback from re-arming a fresh timer", async () => {
+      // Race: the retry callback fires while filing is still in-flight and
+      // stop() has begun. The callback already cleared compactionRetryTimer,
+      // so clearCompactionRetry is a no-op. Without a stopped flag, the
+      // callback's runCompactionOnce() hits the activeRun branch and schedules
+      // a fresh retry, leaving a live timer after stop() resolves.
+      const hold = holdFilingRun();
+      const service = new FilingService({ compactionContendedRetryMs: 5 });
+      const filingPromise = service.runOnce();
+      await hold.waitForFilingStarted();
+      await service.runCompactionOnce();
+      expect(service.nextCompactionAt).not.toBeNull();
+
+      // Begin stop without awaiting — it would block on the held filing run.
+      // stop() flips `stopped` synchronously before the retry timer fires.
+      const stopPromise = service.stop();
+
+      // Wait past the retry delay. Without the guard, the callback would call
+      // runCompactionOnce(), observe activeRun, and re-arm a new retry.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(service.nextCompactionAt).toBeNull();
+
+      hold.release();
+      await filingPromise;
+      await stopPromise;
+
+      expect(service.nextCompactionAt).toBeNull();
+      expect(hold.compactionCalls()).toBe(0);
+    });
+
     test("respects active hours", async () => {
       mockConfig.filing.activeHoursStart = 9;
       mockConfig.filing.activeHoursEnd = 17;

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -88,6 +88,7 @@ export class FilingService {
   private compactionRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private activeRun: Promise<void> | null = null;
   private activeCompactionRun: Promise<void> | null = null;
+  private stopped = false;
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
   private _lastCompactionAt: number | null = null;
@@ -115,6 +116,7 @@ export class FilingService {
   }
 
   start(): void {
+    this.stopped = false;
     const fullConfig = getConfig();
     if (fullConfig.memory.v2.enabled) {
       log.info("Filing service disabled — memory v2 is active");
@@ -171,6 +173,7 @@ export class FilingService {
   }
 
   async stop(): Promise<void> {
+    this.stopped = true;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
@@ -316,8 +319,10 @@ export class FilingService {
 
   private scheduleCompactionRetry(delayMs: number): void {
     this.clearCompactionRetry();
+    if (this.stopped) return;
     this.compactionRetryTimer = setTimeout(() => {
       this.compactionRetryTimer = null;
+      if (this.stopped) return;
       this.runCompactionOnce().catch((err) => {
         log.error({ err }, "Compaction retry failed");
       });


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #30533.

If \`stop()\` is called while a compaction retry callback is already executing, \`clearCompactionRetry()\` cannot cancel it (the callback already set \`compactionRetryTimer = null\`). The callback would then call \`runCompactionOnce()\`, hit the \`activeRun\` branch (filing still in-flight, since \`stop()\` is awaiting it), and schedule a fresh retry — leaving a live timer after \`stop()\` resolves.

Fix: add a \`stopped\` flag set synchronously at the start of \`stop()\` (and cleared in \`start()\`). \`scheduleCompactionRetry()\` bails when stopped, and the retry callback re-checks the flag before invoking \`runCompactionOnce()\` to cover the case where the callback was already mid-execution when \`stop()\` was called.

## Test plan
- [x] New regression test \`stop() prevents retry callback from re-arming a fresh timer\` exercises the race by beginning \`stop()\` without awaiting, waiting past the retry delay, and asserting \`nextCompactionAt\` stays null and no compaction runs.
- [x] Existing filing-service tests pass (23/23).
- [x] \`bunx tsc --noEmit\` clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->