### PR TITLE
fix(app-control): identity-key session rollback to handle out-of-order start responses

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -678,6 +678,62 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
+    test("late-failing start does not clobber a newer successful start (out-of-order rollback)", async () => {
+      // Overlapping starts from the same conversation where the older one
+      // fails AFTER the newer succeeds. Identity-keyed rollback must make
+      // the stale failure a no-op rather than restoring the pre-A session.
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // Establish prior session A.
+      const pA = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.a" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdA = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(reqIdA, payload({ pngBase64: PNG_A }));
+      await pA;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.a");
+
+      // Start B is dispatched but its host response is delayed.
+      sentMessages.length = 0;
+      const pB = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.b" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdB = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+
+      // Start C overtakes B and succeeds first.
+      sentMessages.length = 0;
+      const pC = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.c" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdC = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(reqIdC, payload({ pngBase64: PNG_A }));
+      await pC;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // Now B finally fails — rollback must NOT restore A or clobber C.
+      proxy.resolve(reqIdB, payload({ state: "missing" }));
+      await pB;
+
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.c");
+
+      proxy.dispose();
+    });
+
     test("first-start failure releases the lock (no prior session to restore)", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -240,6 +240,7 @@ export class HostAppControlProxy extends HostProxyBase<
     // gate, prompt-injected calls would bypass the start-time approval and
     // send raw input to arbitrary apps.
     let priorSession: ActiveAppControlSession | undefined;
+    let attemptedSession: ActiveAppControlSession | undefined;
     if (input.tool === "start") {
       if (
         activeAppControlSession != null &&
@@ -263,11 +264,14 @@ export class HostAppControlProxy extends HostProxyBase<
       // concurrent starts from different conversations would otherwise both
       // see `activeAppControlSession == null` and both pass the guard. The
       // lock is rolled back below if dispatch fails or the host returns a
-      // non-running state.
-      activeAppControlSession = {
+      // non-running state — keyed on object identity so that a later
+      // overlapping start that has already replaced our write is not
+      // clobbered by a stale rollback.
+      attemptedSession = {
         conversationId: this.conversationId,
         app: input.app,
       };
+      activeAppControlSession = attemptedSession;
     } else {
       const sessionError = checkNonStartAuthorization(
         input,
@@ -288,12 +292,12 @@ export class HostAppControlProxy extends HostProxyBase<
         targetClientId,
       );
       if (input.tool === "start" && payload.state !== "running") {
-        this.restoreSessionIfHeld(priorSession);
+        this.rollbackStartIfCurrent(attemptedSession, priorSession);
       }
       return this.handleSuccess(payload);
     } catch (err) {
       if (input.tool === "start") {
-        this.restoreSessionIfHeld(priorSession);
+        this.rollbackStartIfCurrent(attemptedSession, priorSession);
       }
       if (err instanceof HostProxyRequestError) {
         if (err.reason === "timeout") {
@@ -314,16 +318,32 @@ export class HostAppControlProxy extends HostProxyBase<
   }
 
   /**
-   * Restore the module-level session to `prior` only if this proxy is the
-   * current holder. Used to roll back the optimistic overwrite performed
-   * by a `start` when the dispatch fails or the host returns non-running.
-   * Passing `undefined` releases the lock outright (used by `dispose()`).
+   * Roll back the optimistic overwrite performed by a `start` when the
+   * dispatch fails or the host returns non-running. Keyed on the
+   * `attempted` reference, not just `conversationId`, so that an
+   * out-of-order failure does not clobber a newer overlapping start that
+   * already replaced our write — e.g. start A → start B (pending) →
+   * start C (success); when B later fails, the live session is C and the
+   * identity check makes our rollback a no-op rather than restoring A.
    */
-  private restoreSessionIfHeld(
+  private rollbackStartIfCurrent(
+    attempted: ActiveAppControlSession | undefined,
     prior: ActiveAppControlSession | undefined,
   ): void {
-    if (activeAppControlSession?.conversationId === this.conversationId) {
+    if (attempted != null && activeAppControlSession === attempted) {
       activeAppControlSession = prior;
+    }
+  }
+
+  /**
+   * Release the module-level session lock if this proxy is the current
+   * holder. Used by `dispose()` — distinct from `rollbackStartIfCurrent`
+   * because dispose is keyed on ownership (conversationId) rather than on
+   * a specific in-flight start.
+   */
+  private releaseSessionIfHeld(): void {
+    if (activeAppControlSession?.conversationId === this.conversationId) {
+      activeAppControlSession = undefined;
     }
   }
 
@@ -420,6 +440,6 @@ export class HostAppControlProxy extends HostProxyBase<
    */
   override dispose(): void {
     super.dispose();
-    this.restoreSessionIfHeld(undefined);
+    this.releaseSessionIfHeld();
   }
 }


### PR DESCRIPTION
Addresses Codex P2 on #30531: when two `app_control_start` calls from the same conversation overlap, an older request that fails after a newer one succeeds used to clobber the live session because rollback only checked `conversationId` and then unconditionally assigned `prior`.

Gate rollback on object identity of the optimistic write instead of conversation ownership. The optimistically-written session object is captured before dispatch, and rollback only fires when `activeAppControlSession` is still that same reference — if a newer start has already replaced it, the stale rollback becomes a no-op.

Split the prior helper accordingly:
- `rollbackStartIfCurrent(attempted, prior)` — identity-keyed, used for start failure/non-running responses.
- `releaseSessionIfHeld()` — conversationId-keyed, used by `dispose()` (ownership semantics, not in-flight semantics).

Regression test covers the A→B(pending)→C(success)→B(fails) sequence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->