### PR TITLE
fix(migrations): gate memory_v2_reembed enqueue on concept-page existence

### DIFF
--- a/assistant/src/__tests__/workspace-migration-075-memory-v2-bm25-b-default-reembed.test.ts
+++ b/assistant/src/__tests__/workspace-migration-075-memory-v2-bm25-b-default-reembed.test.ts
@@ -2,8 +2,10 @@
  * Tests for workspace migration `075-memory-v2-bm25-b-default-reembed`.
  *
  * The migration enqueues a one-shot `memory_v2_reembed` job so existing
- * concept pages pick up the new `bm25_b` default. It must be gated on
- * `memory.v2.enabled` so v1-only workspaces don't run an unnecessary pass.
+ * concept pages pick up the new `bm25_b` default. It is gated on whether
+ * the workspace already has concept pages on disk so a workspace that
+ * disabled v2 (but kept its pages) still gets the queued reembed when v2
+ * is re-enabled later.
  */
 
 import {
@@ -14,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
@@ -53,6 +55,12 @@ afterEach(() => {
   }
 });
 
+function seedConceptPage(relativePath: string): void {
+  const fullPath = join(workspaceDir, "memory", "concepts", relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, "---\nedges: []\n---\nbody\n", "utf-8");
+}
+
 function countReembedJobs(): number {
   const db = new Database(dbPath);
   try {
@@ -68,37 +76,49 @@ function countReembedJobs(): number {
 }
 
 describe("075-memory-v2-bm25-b-default-reembed migration", () => {
-  test("enqueues memory_v2_reembed when config.json is absent (v2 enabled by default)", () => {
+  test("skips enqueue when memory/concepts/ does not exist", () => {
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("skips enqueue when memory/concepts/ is empty", () => {
+    mkdirSync(join(workspaceDir, "memory", "concepts"), { recursive: true });
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("enqueues when a top-level concept page exists", () => {
+    seedConceptPage("alice.md");
     memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 
-  test("enqueues memory_v2_reembed when memory.v2.enabled is explicitly true", () => {
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      JSON.stringify({ memory: { v2: { enabled: true } } }),
-      "utf-8",
-    );
+  test("enqueues when only a nested concept page exists", () => {
+    seedConceptPage("people/alice.md");
     memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 
-  test("skips enqueue when memory.v2.enabled is explicitly false", () => {
+  test("enqueues even when memory.v2.enabled is explicitly false (pages may be reembedded once v2 is re-enabled)", () => {
+    seedConceptPage("alice.md");
     writeFileSync(
       join(workspaceDir, "config.json"),
       JSON.stringify({ memory: { v2: { enabled: false } } }),
       "utf-8",
     );
     memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
-    expect(countReembedJobs()).toBe(0);
+    expect(countReembedJobs()).toBe(1);
   });
 
-  test("enqueues when config.json is malformed (falls back to default-enabled)", () => {
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      "{not valid json",
-      "utf-8",
+  test("does not duplicate when a pending reembed job already exists", () => {
+    seedConceptPage("alice.md");
+    const db = new Database(dbPath);
+    db.run(
+      `INSERT INTO memory_jobs
+         (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+       VALUES ('pre-existing', 'memory_v2_reembed', '{}', 'pending', 0, 0, 0, NULL, 0, 0)`,
     );
+    db.close();
     memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });

--- a/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
+++ b/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
@@ -13,9 +13,11 @@ import type { WorkspaceMigration } from "./types.js";
  * the field would silently mix old and new length normalization until a
  * manual reembed.
  *
- * Skipped when `memory.v2.enabled` is explicitly `false`. Those workspaces
- * have no v2 concept pages to refresh, so the job would be a no-op (or
- * worse, confusing) once the v2 worker is disabled.
+ * Gated on whether the workspace already has concept pages on disk, not on
+ * `memory.v2.enabled`. A workspace that has v2 disabled today may still
+ * carry pages from a prior session; if v2 is re-enabled later, the queued
+ * job is what brings those pages onto the new default. Workspaces that
+ * have never written a v2 page have nothing to reembed.
  */
 export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
   id: "075-memory-v2-bm25-b-default-reembed",
@@ -23,7 +25,7 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
     "Enqueue memory_v2_reembed so existing concept pages pick up the new bm25_b=0.4 default",
 
   run(workspaceDir: string): void {
-    if (isMemoryV2Disabled(workspaceDir)) return;
+    if (!hasConceptPages(workspaceDir)) return;
 
     const dbPath = join(workspaceDir, "data", "db", "assistant.db");
     if (!existsSync(dbPath)) return; // Fresh install — pages will embed at the new default.
@@ -67,18 +69,27 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
 };
 
 /**
- * Returns true only when `memory.v2.enabled` is explicitly set to `false` in
- * the workspace `config.json`. Missing/unparseable config falls through to
- * the schema default (enabled), matching `MemoryV2ConfigSchema`.
+ * Returns true when `memory/concepts/` contains any `.md` file. Walks the
+ * tree iteratively so we bail on the first hit — pages can be nested in
+ * subdirectories (e.g. `memory/concepts/people/alice.md`).
  */
-function isMemoryV2Disabled(workspaceDir: string): boolean {
-  const configPath = join(workspaceDir, "config.json");
-  if (!existsSync(configPath)) return false;
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    const memory = (raw as { memory?: { v2?: { enabled?: unknown } } })?.memory;
-    return memory?.v2?.enabled === false;
-  } catch {
-    return false;
+function hasConceptPages(workspaceDir: string): boolean {
+  const stack = [join(workspaceDir, "memory", "concepts")];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        stack.push(join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        return true;
+      }
+    }
   }
+  return false;
 }


### PR DESCRIPTION
Addresses Codex P2 feedback on #30565.

Migration 075 previously skipped when memory.v2.enabled was explicitly false. But a workspace that disabled v2 can still have v2 concept pages from a prior session — and migrations don't rerun, so re-enabling v2 later left those pages stuck on the pre-0.4 sparse vectors with no second chance.

Now gates on whether memory/concepts/ contains any .md page. If pages exist, enqueue the job (regardless of the current flag); if v2 happens to be disabled the job sits pending until the worker comes back. Workspaces that have never written a v2 page still skip — there's nothing to reembed.

Walk is iterative with early-exit so the gate bails on the first match instead of materializing the full tree.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->