### PR TITLE
fix(memory-v2): invalidate history cache on sourceChannel change

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -605,4 +605,64 @@ describe("loadFromDb metadata injection rehydration", () => {
     // suppresses the personal-memory block.
     expect(messages[0].content).toEqual([{ type: "text", text: "First" }]);
   });
+
+  test("ensureActorScopedHistory reloads when sourceChannel changes within the same trust class", async () => {
+    // Regression: cache invalidation previously keyed only on trust class.
+    // `loadFromDb` gates `memoryV2StaticBlock` rehydration on `sourceChannel`
+    // via `shouldExposePersonalMemory`, so a same-trust-class reuse from a
+    // different channel (e.g. internal `vellum` → remote channel) must
+    // re-run `loadFromDb` or stale personal-memory exposure persists.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First" }]),
+        metadata: JSON.stringify({
+          provenanceTrustClass: "trusted_contact",
+          memoryV2StaticBlock:
+            "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    // First load: internal channel, trusted_contact actor → personal memory
+    // exposed via `shouldExposePersonalMemory({sourceChannel: "vellum", ...})`.
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "vellum",
+    });
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()[0].content).toEqual([
+      {
+        type: "text",
+        text: "<memory>\n## Essentials\n\nprivate memory\n</memory>",
+      },
+      { type: "text", text: "First" },
+    ]);
+
+    // Reuse with the same trust class but a remote channel. The cache must
+    // invalidate and trigger a reload that strips the personal-memory block.
+    conversation.setTrustContext({
+      trustClass: "trusted_contact",
+      sourceChannel: "telegram",
+    });
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()[0].content).toEqual([
+      { type: "text", text: "First" },
+    ]);
+  });
 });

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -118,6 +118,7 @@ export interface LoadFromDbContext {
   contextCompactedAt: number | null;
   trustContext?: TrustContext;
   loadedHistoryTrustClass?: TrustClass;
+  loadedHistoryPersonalMemoryAllowed?: boolean;
 }
 
 export interface AbortContext {
@@ -346,6 +347,7 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
   }
 
   ctx.loadedHistoryTrustClass = trustClass;
+  ctx.loadedHistoryPersonalMemoryAllowed = personalMemoryAllowed;
 
   log.info(
     { conversationId: ctx.conversationId, count: ctx.messages.length },

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -56,6 +56,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { isBackgroundConversationType } from "../memory/conversation-types.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
+import { shouldExposePersonalMemory } from "../memory/v2/static-context.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { UserDecision } from "../permissions/types.js";
@@ -118,6 +119,7 @@ import {
   buildToolDefinitions,
   createResolveToolsCallback,
   createToolExecutor,
+  resolveTrustClass,
 } from "./conversation-tool-setup.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
 import { canonicalizeTimeZone } from "./date-context.js";
@@ -225,6 +227,7 @@ export class Conversation {
   /** @internal */ currentTurnOverrideProfile?: string;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
+  /** @internal */ loadedHistoryPersonalMemoryAllowed?: boolean;
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ transportHints?: string[];
   /** @internal */ slackRuntimeContextNotice?: string;
@@ -647,7 +650,21 @@ export class Conversation {
 
   async ensureActorScopedHistory(): Promise<void> {
     const currentTrustClass = this.trustContext?.trustClass;
-    if (this.loadedHistoryTrustClass === currentTrustClass) return;
+    // `loadFromDb` gates personal-memory rehydration on `sourceChannel` too
+    // (via `shouldExposePersonalMemory`), so a same-trust-class reuse from a
+    // different channel (e.g. internal `vellum` → remote channel) must also
+    // trigger a reload. Otherwise stale personal-memory blocks can leak to
+    // an untrusted remote turn, or be hidden when they should be present.
+    const currentPersonalMemoryAllowed = shouldExposePersonalMemory({
+      sourceChannel: this.trustContext?.sourceChannel,
+      isTrustedActor: resolveTrustClass(this.trustContext) === "guardian",
+    });
+    if (
+      this.loadedHistoryTrustClass === currentTrustClass &&
+      this.loadedHistoryPersonalMemoryAllowed === currentPersonalMemoryAllowed
+    ) {
+      return;
+    }
     await this.loadFromDb();
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #30575. Reviewer (Codex P1) flagged that `loadFromDb` now gates `memoryV2StaticBlock` rehydration on `sourceChannel` via `shouldExposePersonalMemory`, but `ensureActorScopedHistory` still compares only `loadedHistoryTrustClass` to the current trust class. A conversation reused with the same trust class but a different channel (internal `vellum` vs remote) would not reload, so the previously loaded personal-memory visibility persists and can either leak personal-memory blocks to a remote untrusted turn or hide blocks that should be present.

Extends cache invalidation to also track the effective personal-memory exposure:

- Add `loadedHistoryPersonalMemoryAllowed` to `LoadFromDbContext` and the `Conversation` class.
- `loadFromDb` writes both `loadedHistoryTrustClass` and the new flag at the end of the load.
- `ensureActorScopedHistory` computes the current `shouldExposePersonalMemory` and triggers a reload when either the trust class or the personal-memory flag differs from the cached value.

## Test plan

- [x] `bun test src/__tests__/conversation-lifecycle.test.ts` — 12/12 pass, includes new regression: trusted_contact actor on `vellum` then `telegram` reloads and strips personal memory on the second `ensureActorScopedHistory`.
- [x] `bun test src/runtime/services/__tests__/analyze-conversation.test.ts` — 14/14 pass.
- [x] `bunx tsc --noEmit` clean.