### PR TITLE
fix(voice): clear partially-applied turn state when persistUserMessage throws

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1240,6 +1240,77 @@ describe("voice-session-bridge", () => {
     expect(session.forcePromptSideEffects).toBe(false);
   });
 
+  test("turn state does not leak when persistUserMessage fails", async () => {
+    const conversation = createConversation(
+      "voice bridge turn state leak test",
+    );
+
+    const lastSetterValue: Record<string, unknown> = {};
+    const recordLast =
+      (name: string) =>
+      (value: unknown): void => {
+        lastSetterValue[name] = value;
+      };
+    const session = {
+      isProcessing: () => false,
+      forcePromptSideEffects: false,
+      callSessionId: undefined as string | undefined,
+      persistUserMessage: async () => {
+        throw new Error("simulated persistence failure");
+      },
+      memoryPolicy: {
+        scopeId: "default",
+        includeDefaultFallback: false,
+      },
+      setChannelCapabilities: recordLast("setChannelCapabilities"),
+      setAssistantId: recordLast("setAssistantId"),
+      setTrustContext: recordLast("setTrustContext"),
+      setCommandIntent: recordLast("setCommandIntent"),
+      setTurnChannelContext: recordLast("setTurnChannelContext"),
+      setTurnInterfaceContext: recordLast("setTurnInterfaceContext"),
+      setVoiceCallControlPrompt: recordLast("setVoiceCallControlPrompt"),
+      updateClient: () => {},
+      ensureActorScopedHistory: async () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+      abort: () => {},
+    } as unknown as Conversation & {
+      forcePromptSideEffects: boolean;
+      callSessionId?: string;
+    };
+    session.callSessionId = "session-leak-test-precondition";
+
+    injectDeps(() => session);
+
+    let caught: Error | null = null;
+    try {
+      await startVoiceTurn({
+        conversationId: conversation.id,
+        voiceSessionId: "session-leak-test",
+        content: "Hello",
+        isInbound: true,
+        trustContext: {
+          sourceChannel: "phone",
+          trustClass: "trusted_contact",
+        },
+        onTextDelta: () => {},
+        onComplete: () => {},
+        onError: () => {},
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught?.message).toBe("simulated persistence failure");
+    expect(lastSetterValue.setChannelCapabilities).toBeNull();
+    expect(lastSetterValue.setTrustContext).toBeNull();
+    expect(lastSetterValue.setCommandIntent).toBeNull();
+    expect(lastSetterValue.setAssistantId).toBe("self");
+    expect(lastSetterValue.setVoiceCallControlPrompt).toBeNull();
+    expect(session.callSessionId).toBeUndefined();
+    expect(session.forcePromptSideEffects).toBe(false);
+  });
+
   test("pre-aborted signal triggers immediate abort", async () => {
     const conversation = createConversation("voice bridge pre-abort test");
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -392,27 +392,52 @@ export async function startVoiceTurn(
     }
   }
 
-  conversation.setAssistantId(opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID);
-  conversation.callSessionId = voiceSessionId;
-  conversation.setTrustContext(opts.trustContext ?? null);
-  conversation.setCommandIntent(null);
-  conversation.setTurnChannelContext(turnChannelContext);
-  conversation.setTurnInterfaceContext?.(turnInterfaceContext);
-  conversation.setChannelCapabilities(
-    resolveChannelCapabilities(
-      turnChannelContext.userMessageChannel,
-      turnInterfaceContext.userMessageInterface,
-    ),
-  );
-  conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
+  // Hoisted so the catch below can clear partially-applied turn state
+  // when a setter or `persistUserMessage` throws — otherwise `trustContext`,
+  // `callSessionId`, etc. leak into subsequent non-voice turns on the same
+  // conversation.
+  const cleanup = () => {
+    conversation.setChannelCapabilities(null);
+    conversation.setTrustContext(null);
+    conversation.setCommandIntent(null);
+    conversation.setAssistantId("self");
+    conversation.setVoiceCallControlPrompt(null);
+    conversation.callSessionId = undefined;
+    conversation.forcePromptSideEffects = false;
+    // Reset the client callback to a no-op so the stale closure doesn't
+    // intercept events from future turns on the same conversation.
+    conversation.updateClient(() => {}, true);
+  };
 
   const requestId = crypto.randomUUID();
   const turnId = crypto.randomUUID();
-  const messageId = await conversation.persistUserMessage(
-    persistedContent,
-    [],
-    requestId,
-  );
+  let messageId: string;
+  try {
+    conversation.setAssistantId(
+      opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+    );
+    conversation.callSessionId = voiceSessionId;
+    conversation.setTrustContext(opts.trustContext ?? null);
+    conversation.setCommandIntent(null);
+    conversation.setTurnChannelContext(turnChannelContext);
+    conversation.setTurnInterfaceContext?.(turnInterfaceContext);
+    conversation.setChannelCapabilities(
+      resolveChannelCapabilities(
+        turnChannelContext.userMessageChannel,
+        turnInterfaceContext.userMessageInterface,
+      ),
+    );
+    conversation.setVoiceCallControlPrompt(voiceCallControlPrompt);
+
+    messageId = await conversation.persistUserMessage(
+      persistedContent,
+      [],
+      requestId,
+    );
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
   try {
     opts.callbacks?.persisted_user_message_id?.(messageId);
   } catch (err) {
@@ -552,21 +577,6 @@ export async function startVoiceTurn(
   });
 
   // Fire-and-forget the agent loop
-  const cleanup = () => {
-    // Reset channel capabilities so a subsequent desktop session on the
-    // same conversation is not incorrectly treated as a voice client.
-    conversation.setChannelCapabilities(null);
-    conversation.setTrustContext(null);
-    conversation.setCommandIntent(null);
-    conversation.setAssistantId("self");
-    conversation.setVoiceCallControlPrompt(null);
-    conversation.callSessionId = undefined;
-    conversation.forcePromptSideEffects = false;
-    // Reset the conversation's client callback to a no-op so the stale
-    // closure doesn't intercept events from future turns on the same conversation.
-    conversation.updateClient(() => {}, true);
-  };
-
   void (async () => {
     try {
       // Non-guardian phone voice forces side-effect tools to prompt so the


### PR DESCRIPTION
Follow-up to #30537. Devin flagged that the same leak pattern fixed for `forcePromptSideEffects` exists for the other per-turn state set before `persistUserMessage` at `voice-session-bridge.ts:395-407` — `setAssistantId`, `callSessionId`, `setTrustContext`, `setCommandIntent`, `setTurnChannelContext`, `setTurnInterfaceContext`, `setChannelCapabilities`, and `setVoiceCallControlPrompt`. If `persistUserMessage` (or any setter) throws, the IIFE never starts, its `finally { cleanup() }` never runs, and that state leaks into subsequent non-voice turns on the same conversation.

Constraint: `persistUserMessage` reads `trustContext` and the turn channel/interface contexts off the conversation, so these setters must run **before** `persistUserMessage`, not inside the IIFE.

Fix: hoist the `cleanup()` definition above the per-turn state writes, wrap the setters + `persistUserMessage` in a try/catch that calls `cleanup()` and rethrows. The IIFE's existing finally still owns cleanup on the happy path; on the early-failure path it runs once via the new catch.

Adds a regression test that throws from `persistUserMessage` and asserts every setter was reset (`setChannelCapabilities(null)`, `setAssistantId(\"self\")`, `callSessionId = undefined`, etc.).