### PR TITLE
fix(macos): preserve scroll watermark on showThoughts toggle when not at bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -354,17 +354,23 @@ struct ACPSessionDetailView: View {
                     }
                 }
                 .onChange(of: showThoughts) {
-                    // Toggling thought visibility shrinks/grows the timeline,
-                    // which moves the bottom offset. Reset the watermark for
-                    // the same reason as the ring-buffer trim above. Only
-                    // re-engage auto-scroll if the user was already parked at
-                    // the bottom — otherwise we'd snap users who deliberately
-                    // scrolled up to read history back down on the next event.
+                    // Toggling thoughts shifts content like a head trim. If
+                    // the user was parked at the bottom, re-anchor by zeroing
+                    // the watermark and re-engaging auto-scroll. Otherwise
+                    // defer to the head-trim sentinel so the next offset
+                    // reading absorbs the shift — zeroing here would discard
+                    // the "true bottom" anchor `returnedToBottom` compares
+                    // against, blocking auto-scroll resume on later scroll-down.
                     let wasAtBottom = abs(lastScrollOffset - lastMaxScrollOffset) < Self.scrollAtBottomTolerance
-                    lastMaxScrollOffset = 0
-                    lastScrollOffset = 0
                     if wasAtBottom {
+                        lastMaxScrollOffset = 0
+                        lastScrollOffset = 0
                         autoScrollEnabled = true
+                    } else {
+                        pendingHeadTrim = true
+                        DispatchQueue.main.async {
+                            pendingHeadTrim = false
+                        }
                     }
                 }
                 .onAppear {


### PR DESCRIPTION
Addresses Codex P2 review feedback on #30559.

Previously, toggling `showThoughts` always zeroed `lastMaxScrollOffset` and `lastScrollOffset`. When the user was not parked at the bottom, this discarded the "true bottom" anchor that `handleScrollOffsetChange` compares against in its `returnedToBottom` check. After the toggle, the watermark was rebuilt from the user's current motion — so scrolling back to the real bottom did not re-engage auto-scroll until extra jitter pushed the watermark back to the true bottom.

Fix: only zero the watermark when the user was at the bottom (and re-engage auto-scroll). Otherwise, fall through to the head-trim sentinel path (`pendingHeadTrim`) so the next offset reading lowers the watermark by the observed content shift, preserving the bottom anchor.

## Test plan
- [ ] Open an ACP session with many events, scroll up to read history, toggle thoughts on/off, scroll back to bottom — auto-scroll re-engages.
- [ ] Stay parked at bottom, toggle thoughts — view re-anchors to new bottom, next event pins.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->