### PR TITLE
fix(migrations): infer Gemini provider from stale model at fragment layer

### DIFF
--- a/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
+++ b/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
@@ -229,9 +229,6 @@ describe("057-repair-stale-gemini-model-ids migration", () => {
             provider: "openrouter",
             model: "gemini-3-flash",
           },
-          recall: {
-            model: "gemini-3-flash",
-          },
         },
         profiles: {
           custom: {
@@ -246,6 +243,28 @@ describe("057-repair-stale-gemini-model-ids migration", () => {
     repairStaleGeminiModelIdsMigration.run(workspaceDir);
 
     expect(readFileSync(configPath(), "utf-8")).toBe(before);
+  });
+
+  test("rewrites call-site model when site fragment implies Gemini via stale model even when activeProfile is Ollama", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-3-flash-preview" },
+        activeProfile: "ollamaActive",
+        profiles: {
+          ollamaActive: { provider: "ollama", model: "llama-3.1" },
+        },
+        callSites: {
+          recall: { model: "gemini-3-flash" },
+        },
+      },
+    });
+
+    repairStaleGeminiModelIdsMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { recall: { model: string } } };
+    };
+    expect(config.llm.callSites.recall.model).toBe("gemini-3-flash-preview");
   });
 
   test("rewrites call-site/profile blocks without local provider when default is Gemini", () => {

--- a/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
+++ b/assistant/src/workspace/migrations/057-repair-stale-gemini-model-ids.ts
@@ -40,7 +40,7 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       typeof llm.activeProfile === "string" ? llm.activeProfile : undefined;
     const activeProfileProvider =
       profiles !== null && activeProfileName !== undefined
-        ? readProvider(readObject(profiles[activeProfileName]))
+        ? inferProvider(readObject(profiles[activeProfileName]))
         : undefined;
 
     if (defaultBlock !== null && isGeminiProvider(defaultProvider)) {
@@ -71,7 +71,7 @@ export const repairStaleGeminiModelIdsMigration: WorkspaceMigration = {
       for (const rawProfile of Object.values(profiles)) {
         const profile = readObject(rawProfile);
         if (profile === null) continue;
-        const effective = readProvider(profile) ?? defaultProvider;
+        const effective = inferProvider(profile) ?? defaultProvider;
         if (!isGeminiProvider(effective)) continue;
         changed = repairModel(profile, DEFAULT_REPLACEMENT_MODEL) || changed;
       }
@@ -123,6 +123,20 @@ function readProvider(
   return typeof block.provider === "string" ? block.provider : undefined;
 }
 
+// Mirrors `resolveCallSiteConfig`'s catalog-based inference: a fragment with
+// no explicit `provider` but a Gemini-catalog `model` resolves to "gemini" at
+// that layer. The stale model is the only catalog entry the migration cares
+// about, so the check stays self-contained.
+function inferProvider(
+  block: Record<string, unknown> | null,
+): string | undefined {
+  if (block === null) return undefined;
+  const explicit = readProvider(block);
+  if (explicit !== undefined) return explicit;
+  if (block.model === STALE_MODEL) return "gemini";
+  return undefined;
+}
+
 function isGeminiProvider(provider: string | undefined): boolean {
   return provider === undefined || provider === "gemini";
 }
@@ -131,7 +145,7 @@ function isGeminiProvider(provider: string | undefined): boolean {
 // `resolveCallSiteConfig` does: for `mainAgent`, `activeProfile` overrides the
 // static `callSites.mainAgent` block, while for every other call site the
 // call-site block (and its referenced profile) wins over `activeProfile`.
-// Returns the highest-precedence explicit provider, falling back to `default`.
+// Returns the highest-precedence inferred provider, falling back to `default`.
 function resolveCallSiteEffectiveProvider(args: {
   callSite: string;
   callSiteConfig: Record<string, unknown>;
@@ -146,14 +160,14 @@ function resolveCallSiteEffectiveProvider(args: {
     activeProfileProvider,
     defaultProvider,
   } = args;
-  const siteProvider = readProvider(callSiteConfig);
+  const siteProvider = inferProvider(callSiteConfig);
   const siteProfileName =
     typeof callSiteConfig.profile === "string"
       ? callSiteConfig.profile
       : undefined;
   const siteProfileProvider =
     profiles !== null && siteProfileName !== undefined
-      ? readProvider(readObject(profiles[siteProfileName]))
+      ? inferProvider(readObject(profiles[siteProfileName]))
       : undefined;
 
   if (callSite === "mainAgent") {


### PR DESCRIPTION
Addresses Codex P2 feedback on #30535.

For non-`mainAgent` call sites, migration 057 was picking `activeProfileProvider` ahead of `defaultProvider` when the site fragment had no explicit `provider` — but the runtime resolver applies catalog-based provider inference per layer, so a site fragment with `model = 'gemini-3-flash'` (a Gemini-catalog model) resolves to `provider = 'gemini'` at the highest precedence layer. The migration was skipping repairs in cases where the runtime would still hit the stale model.

This PR adds a self-contained `inferProvider` helper that mirrors the resolver's `withImpliedProviderForKnownModel` and applies it consistently to site, site-profile, active-profile, and profile-loop fragments. Adds a regression test for the Codex example (`llm.default.provider = 'gemini'`, Ollama `activeProfile`, `callSites.recall.model = 'gemini-3-flash'`) and removes the recall sub-case from the 'effective provider is not Gemini' test that encoded the buggy behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->