### PR TITLE
fix(macos): guard setActiveProfile success path against stale completions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3308,37 +3308,30 @@ public final class SettingsStore: ObservableObject {
     }
 
     /// Persists `llm.activeProfile` so the daemon's resolver layers the
-    /// named profile into every callsite resolution. The mock client
-    /// captures the patch payload for assertion in tests.
+    /// named profile into every callsite resolution. Optimistically updates
+    /// `self.activeProfile` synchronously so SwiftUI bindings render the new
+    /// value without waiting for the round-trip.
     ///
-    /// Optimistically updates `self.activeProfile` synchronously before
-    /// the await so SwiftUI bindings reading the published value (e.g.
-    /// the dropdown selection in `InferenceServiceCard`) see the new
-    /// value on the next render cycle without waiting for the network
-    /// round-trip. Reverts on failure to `lastConfirmedActiveProfile` —
-    /// the last daemon-confirmed value — so a failed pick never reverts
-    /// to a sibling optimistic value that itself never landed on the
-    /// daemon. The current-value guard ensures a newer call that has
-    /// already overwritten the published state is not stomped by a
-    /// stale revert. On success, also resyncs `self.activeProfile` to
-    /// the confirmed name so a late-arriving success (after a competing
-    /// later pick failed and reverted) lands the UI on the
-    /// daemon-persisted value rather than leaving it stuck on the prior
-    /// confirmed profile.
+    /// Both branches gate post-PATCH state mutation on `self.activeProfile
+    /// == name` — i.e. apply only if the published state still reflects
+    /// this call's pick. Guards against stale async completions when picks
+    /// resolve out of order: e.g. user picks A then B; B succeeds first; A's
+    /// delayed success then arrives and would otherwise stomp the newer
+    /// confirmed value.
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
         self.activeProfile = name
         let success = await settingsClient.patchConfig([
             "llm": ["activeProfile": name]
         ])
+        if !success {
+            log.error("Failed to patch config for llm.activeProfile")
+        }
+        guard self.activeProfile == name else { return success }
         if success {
             lastConfirmedActiveProfile = name
-            self.activeProfile = name
         } else {
-            if self.activeProfile == name {
-                self.activeProfile = lastConfirmedActiveProfile
-            }
-            log.error("Failed to patch config for llm.activeProfile")
+            self.activeProfile = lastConfirmedActiveProfile
         }
         return success
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -188,6 +188,52 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         )
     }
 
+    /// When two `setActiveProfile` calls are in flight and responses resolve
+    /// out of order, the late-arriving success must not overwrite the newer
+    /// in-flight pick. The user picks A then B; B's PATCH succeeds first
+    /// (UI and daemon become B); A's delayed success then arrives. The
+    /// current-value guard must prevent the success branch from resetting
+    /// `activeProfile` back to A.
+    func testSetActiveProfileIgnoresStaleSuccessFromOlderInflightCall() async {
+        var continuationA: CheckedContinuation<Bool, Never>?
+        var continuationB: CheckedContinuation<Bool, Never>?
+        let bothSuspended = expectation(description: "both PATCH calls suspended")
+        bothSuspended.expectedFulfillmentCount = 2
+        mockSettingsClient.patchConfigHandler = { partial in
+            let name = (partial["llm"] as? [String: Any])?["activeProfile"] as? String
+            return await withCheckedContinuation { cont in
+                if name == "A" {
+                    continuationA = cont
+                } else {
+                    continuationB = cont
+                }
+                bothSuspended.fulfill()
+            }
+        }
+
+        async let resultA: Bool = store.setActiveProfile("A")
+        async let resultB: Bool = store.setActiveProfile("B")
+
+        await fulfillment(of: [bothSuspended], timeout: 1.0)
+
+        // Optimistic writes ran synchronously; the later pick (B) is current.
+        XCTAssertEqual(store.activeProfile, "B")
+
+        // Resolve B first — daemon-confirmed value becomes B.
+        continuationB?.resume(returning: true)
+        XCTAssertTrue(await resultB)
+        XCTAssertEqual(store.activeProfile, "B")
+
+        // Resolve A's late success. The guard must drop the stale write.
+        continuationA?.resume(returning: true)
+        XCTAssertTrue(await resultA)
+        XCTAssertEqual(
+            store.activeProfile,
+            "B",
+            "Late success of an older pick must not overwrite a newer confirmed pick"
+        )
+    }
+
     // MARK: - setProfile
 
     func testSetProfileRoundTripsAndUpdatesPublishedState() async {

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -53,6 +53,12 @@ final class MockSettingsClient: SettingsClientProtocol {
     var fetchSuggestionResponse: SuggestionResponseMessage?
     var patchConfigCalls: [[String: Any]] = []
     var patchConfigResponse: Bool = true
+    /// Optional per-call handler. When set, replaces the default
+    /// `patchConfigResponse` return path so tests can control completion
+    /// timing (e.g. resolve responses out of order to verify async-race
+    /// guards). The handler receives the same `partial` payload that was
+    /// captured into `patchConfigCalls`.
+    var patchConfigHandler: (([String: Any]) async -> Bool)?
     var replaceInferenceProfileCalls: [(name: String, fragment: [String: Any])] = []
     var replaceInferenceProfileResponse: Bool = true
     var callSiteCatalogResponse: CallSiteCatalogResponse? = MockSettingsClient.defaultCallSiteCatalogResponse
@@ -209,6 +215,9 @@ final class MockSettingsClient: SettingsClientProtocol {
 
     func patchConfig(_ partial: [String: Any]) async -> Bool {
         patchConfigCalls.append(partial)
+        if let handler = patchConfigHandler {
+            return await handler(partial)
+        }
         return patchConfigResponse
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #30570. Codex flagged a P1 race in the new success-path
resync: `self.activeProfile = name` on success was unconditional, so a
late-arriving older PATCH could stomp a newer confirmed pick (user picks
A then B; B's PATCH lands first; A's delayed success then resets the UI
back to A).

Mirrors the failure-branch guard so both branches now gate on
`self.activeProfile == name` — apply only if the published state still
reflects this call's pick. The optimistic write at entry already sets
`activeProfile = name`, so on success the explicit re-assignment is
redundant once the guard is in place, and the success branch collapses
to just `lastConfirmedActiveProfile = name`.

## Test plan
- [x] New regression test `testSetActiveProfileIgnoresStaleSuccessFromOlderInflightCall` — two in-flight picks resolve out of order; the later pick (B) confirms first, then the older pick (A) resolves success late; asserts `activeProfile` stays B.
- [x] Existing `testSetActiveProfileRoundTrips` / `testSetActiveProfileFailureLeavesLocalStateUntouched` still cover the single-call paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->