### PR TITLE
fix(memory-v2): scope skill backfill to known IDs; add kind payload index

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -51,6 +51,7 @@ interface PruneCall {
 interface BackfillCall {
   prefix: string;
   kind: string;
+  allowedSuffixes: ReadonlySet<string>;
 }
 
 interface TestState {
@@ -139,10 +140,14 @@ mock.module("../qdrant.js", () => ({
     state.callSequence.push("prune");
     state.pruneCalls.push({ prefix, activeSuffixes, options });
   },
-  backfillKindOnPointsWithPrefix: async (prefix: string, kind: string) => {
+  backfillKindOnPointsWithPrefix: async (
+    prefix: string,
+    kind: string,
+    allowedSuffixes: ReadonlySet<string>,
+  ) => {
     if (state.backfillThrows) throw state.backfillThrows;
     state.callSequence.push("backfill");
-    state.backfillCalls.push({ prefix, kind });
+    state.backfillCalls.push({ prefix, kind, allowedSuffixes });
     return state.backfillReturn;
   },
 }));
@@ -501,7 +506,12 @@ describe("seedV2SkillEntries", () => {
 
     await seedV2SkillEntries();
 
-    expect(state.backfillCalls).toEqual([{ prefix: "skills/", kind: "skill" }]);
+    expect(state.backfillCalls).toHaveLength(1);
+    expect(state.backfillCalls[0].prefix).toBe("skills/");
+    expect(state.backfillCalls[0].kind).toBe("skill");
+    expect([...state.backfillCalls[0].allowedSuffixes].sort()).toEqual([
+      "example-skill-a",
+    ]);
     expect(state.pruneCalls).toHaveLength(1);
     expect(state.pruneCalls[0].options).toEqual({ kind: "skill" });
     expect(state.callSequence.filter((s) => s !== "upsert")).toEqual([
@@ -547,6 +557,33 @@ describe("seedV2SkillEntries", () => {
     // Prune still ran despite the backfill failure — we don't want to block
     // the steady-state prune when the legacy scan trips.
     expect(state.pruneCalls).toHaveLength(1);
+  });
+
+  test("backfill allowlist spans installed + remote catalog ids so user-authored skills/* pages stay untagged", async () => {
+    // Regression: backfilling kind on every `skills/*` point would also tag
+    // user-authored concept pages slugged like `skills/my-notes` — those
+    // would then be pruned as stale skills. The allowlist must contain
+    // every legitimate skill id we know about (installed + remote catalog)
+    // and nothing else.
+    const installed = makeSummary({ id: "installed-skill" });
+    state.catalog = [installed];
+    state.resolved = [{ summary: installed, state: "enabled" }];
+    state.fullCatalog = [
+      { id: "installed-skill", name: "installed-skill", description: "X" },
+      { id: "remote-only-skill", name: "remote-only-skill", description: "Y" },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2SkillEntries();
+
+    expect(state.backfillCalls).toHaveLength(1);
+    expect([...state.backfillCalls[0].allowedSuffixes].sort()).toEqual([
+      "installed-skill",
+      "remote-only-skill",
+    ]);
   });
 
   test("skips pruning when catalog fetch returns empty (network failure guard)", async () => {

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -200,6 +200,9 @@ async function ensureConceptPageCollectionOnce(): Promise<{
 
       const missing = missingNamedVectors(info);
       if (missing.length === 0) {
+        // Long-lived installs may predate the `kind` payload index; ensure
+        // every required index exists before declaring the collection ready.
+        await ensurePayloadIndexes();
         _collectionReady = true;
         return { migrated: false };
       }
@@ -271,15 +274,43 @@ async function ensureConceptPageCollectionOnce(): Promise<{
     throw err;
   }
 
-  // Slug is the only payload field we filter on; index it once at create-time
-  // so upserts and slug-restricted queries don't pay a per-call indexing cost.
-  await client.createPayloadIndex(MEMORY_V2_COLLECTION, {
-    field_name: "slug",
-    field_schema: "keyword",
-  });
+  await ensurePayloadIndexes();
 
   _collectionReady = true;
   return { migrated };
+}
+
+/**
+ * Idempotently create the payload indexes the collection's query and
+ * filter paths rely on:
+ *
+ *   - `slug` (keyword): every slug-restricted query and prefix scan filters on it.
+ *   - `kind` (keyword): the skill-backfill scroll filters with `is_empty` on
+ *     `kind`. Strict-mode Qdrant deployments reject filters on unindexed
+ *     payload fields, so without this the backfill consistently fails and
+ *     legacy skill points remain untagged.
+ *
+ * `createPayloadIndex` is idempotent in Qdrant; re-issuing on an existing
+ * index is a no-op. We tolerate other failure shapes so that an upgrade of
+ * a long-lived install — where the collection existed before this index
+ * set — converges on the next ensure call without aborting the boot path.
+ */
+async function ensurePayloadIndexes(): Promise<void> {
+  const client = getClient();
+  const indexes = [
+    { field_name: "slug", field_schema: "keyword" as const },
+    { field_name: "kind", field_schema: "keyword" as const },
+  ];
+  for (const index of indexes) {
+    try {
+      await client.createPayloadIndex(MEMORY_V2_COLLECTION, index);
+    } catch (err) {
+      log.warn(
+        { err, collection: MEMORY_V2_COLLECTION, index },
+        "createPayloadIndex non-fatal — assuming index already present",
+      );
+    }
+  }
 }
 
 /**
@@ -422,7 +453,10 @@ export async function deleteConceptPageEmbedding(slug: string): Promise<void> {
  * `payload.kind` matches are eligible for deletion. This is critical because
  * `validateSlug` permits user-authored concept pages slugged like
  * `skills/foo`; without a kind filter they would collide with the skill
- * namespace and be repeatedly pruned every seed run.
+ * namespace and be repeatedly pruned every seed run. The companion
+ * {@link backfillKindOnPointsWithPrefix} preserves this invariant for legacy
+ * untagged rows by tagging only suffixes the caller knows are skills —
+ * user-authored `skills/<slug>` rows stay kindless and outside this prune.
  *
  * Idempotent: when the live `<prefix>*` slugs already match `activeSuffixes`,
  * the function performs a single scroll and no deletes.
@@ -492,10 +526,17 @@ export async function pruneSlugsWithPrefixExcept(
 }
 
 /**
- * Set `payload.kind` on every point whose slug starts with `prefix` and is
- * currently missing the `kind` discriminator. Used to tag legacy rows that
- * predate the kind field so the kind-scoped
- * {@link pruneSlugsWithPrefixExcept} no longer leaves them as orphans.
+ * Set `payload.kind` on every point whose slug starts with `prefix`, whose
+ * suffix is in `allowedSuffixes`, and is currently missing the `kind`
+ * discriminator. Used to tag legacy rows that predate the kind field so the
+ * kind-scoped {@link pruneSlugsWithPrefixExcept} no longer leaves them as
+ * orphans.
+ *
+ * `allowedSuffixes` is required because `validateSlug` permits user-authored
+ * concept pages slugged like `skills/my-notes` — those rows also lack `kind`
+ * and would otherwise be tagged here and then deleted by the kind-scoped
+ * prune. Callers must pass the closed set of legitimate suffixes (e.g. the
+ * union of installed + remote-catalog skill IDs) so user pages stay untagged.
  *
  * The "missing kind" predicate is pushed to Qdrant via `is_empty`, so once
  * every legacy row has been tagged the scroll returns the bounded set of
@@ -506,7 +547,9 @@ export async function pruneSlugsWithPrefixExcept(
 export async function backfillKindOnPointsWithPrefix(
   prefix: string,
   kind: string,
+  allowedSuffixes: ReadonlySet<string>,
 ): Promise<number> {
+  if (allowedSuffixes.size === 0) return 0;
   await ensureConceptPageCollection();
 
   const client = getClient();
@@ -528,6 +571,8 @@ export async function backfillKindOnPointsWithPrefix(
         const slug = (point.payload as { slug?: unknown } | null)?.slug;
         if (typeof slug !== "string") continue;
         if (!slug.startsWith(prefix)) continue;
+        const suffix = slug.slice(prefix.length);
+        if (!allowedSuffixes.has(suffix)) continue;
         pointIds.push(point.id);
       }
       const next = result.next_page_offset;

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -168,11 +168,19 @@ async function runSeedOnce(): Promise<void> {
     // Seed uninstalled catalog skills so their activation hints are
     // discoverable by intent. Track whether the catalog was available so we
     // can guard pruning below.
+    //
+    // Build the legacy-backfill allowlist in parallel: every locally
+    // installed skill id (regardless of enabled state) plus every remote
+    // catalog id. Restricting the backfill to this set keeps user-authored
+    // concept pages that happen to live under `skills/<slug>` from being
+    // mis-tagged and then pruned. See `backfillKindOnPointsWithPrefix`.
+    const knownSkillIds = new Set<string>(installedIds);
     let catalogAvailable = false;
     try {
       const fullCatalog = await getCatalog();
       catalogAvailable = fullCatalog.length > 0;
       for (const entry of fullCatalog) {
+        knownSkillIds.add(entry.id);
         if (installedIds.has(entry.id)) continue;
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
         if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
@@ -250,6 +258,7 @@ async function runSeedOnce(): Promise<void> {
           await backfillKindOnPointsWithPrefix(
             SKILL_SLUG_PREFIX,
             SKILL_PAYLOAD_KIND,
+            knownSkillIds,
           );
           legacyKindBackfillDone = true;
         } catch (err) {


### PR DESCRIPTION
## Summary

Addresses review feedback on #30576.

- **Devin (BUG)**: `backfillKindOnPointsWithPrefix` tagged every kindless `skills/*` point, including user-authored concept pages, so the kind-scoped prune deleted their embeddings. Now requires `allowedSuffixes` — the union of installed + remote-catalog skill IDs is passed from `skill-store.ts`.
- **Codex (P1)**: Strict-mode Qdrant rejects `is_empty` filters on unindexed payload fields, so the backfill silently failed against Cloud defaults. Added a `kind` keyword payload index in `ensureConceptPageCollection`, applied to both fresh and pre-existing collections.

## Test plan

- [x] `bun test src/memory/v2/__tests__/skill-store.test.ts` — 24 pass
- [x] `bunx tsc --noEmit`
- [x] New regression test: backfill allowlist spans installed + remote catalog IDs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->