### PR TITLE
fix(macos): skip pending-turn decrement for stale cancel echoes

### DIFF
--- a/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
+++ b/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
@@ -163,4 +163,52 @@ final class InteractiveTurnCompletionTickTests: XCTestCase {
         XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1,
                        "Per-message daemon cancel should consume one pending interactive turn")
     }
+
+    func testStaleCancelEchoDoesNotConsumeNewSendTurnCount() {
+        // Repro for the regression: after a user cancel-batch, the daemon
+        // emits one `generation_cancelled` per cancelled queue entry. The
+        // first arrives with `isCancelling = true`; subsequent echoes
+        // arrive with `isCancelling = false`. If a new user send is
+        // dispatched after the batch (e.g. via `dispatchPendingSendDirect`),
+        // those late echoes must not consume the new turn's count — the
+        // matching `message_complete` for the new send must still bump
+        // `interactiveTurnCompletionTick`.
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        // Simulate the daemon having queued 2 items behind the in-flight.
+        // `pendingQueuedCount` reflects only still-queued entries (the
+        // in-flight already triggered `message_dequeued`), so the cancel
+        // batch emits 3 events total — 1 for the in-flight (handled by the
+        // first event) and 2 trailing echoes for the queued items.
+        viewModel.pendingQueuedCount = 2
+
+        // User cancels; daemon emits 3 `generation_cancelled` events. The
+        // first carries `isCancelling = true` and runs the batch reset.
+        viewModel.isCancelling = true
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0)
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 2,
+                       "Two trailing echoes should be expected after the batch reset")
+
+        // User starts a new send before the stale echoes arrive.
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1)
+
+        // Two stale echoes arrive with `isCancelling = false`. Neither
+        // should decrement the new send's pending turn count.
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1,
+                       "Stale cancel echoes from a prior batch must not consume the new send's count")
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 0,
+                       "Stale-echo budget should drain to zero after both echoes")
+
+        // `message_complete` for the new send should still bump the tick.
+        let beforeTick = viewModel.messageManager.interactiveTurnCompletionTick
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeTick &+ 1,
+                       "New send's completion must still bump the interactive tick")
+    }
 }

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -778,8 +778,15 @@ final class ChatActionHandler {
         // Per-message daemon cancel (e.g. queue eviction): the matching
         // `message_complete` will never arrive. Decrement here, above the
         // stale-event early-return below, which per-message cancels also hit.
-        if !wasCancelling && vm.messageManager.pendingUserTurnCount > 0 {
-            vm.messageManager.pendingUserTurnCount -= 1
+        // Stale echoes from a prior cancel batch (primed via
+        // `staleCancelEventsExpected`) must not decrement — they would
+        // consume counts belonging to sends started after that batch.
+        if !wasCancelling {
+            if vm.messageManager.staleCancelEventsExpected > 0 {
+                vm.messageManager.staleCancelEventsExpected -= 1
+            } else if vm.messageManager.pendingUserTurnCount > 0 {
+                vm.messageManager.pendingUserTurnCount -= 1
+            }
         }
         // Stale cancel event from a previous cancel cycle — the daemon
         // emits generation_cancelled for each queued entry during abort,
@@ -800,6 +807,12 @@ final class ChatActionHandler {
         vm.isThinking = false
         if wasCancelling {
             vm.isSending = false
+            // Prime the stale-echo budget before zeroing `pendingQueuedCount`.
+            // The in-flight cancel is the event we just handled; the daemon
+            // will emit one more for each still-queued entry, and a new
+            // send dispatched via `dispatchPendingSendDirect()` below must
+            // not have its turn count consumed by those trailing echoes.
+            vm.messageManager.staleCancelEventsExpected = vm.pendingQueuedCount
             vm.pendingQueuedCount = 0
             vm.pendingMessageIds = []
             vm.requestIdToMessageId = [:]

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -216,6 +216,13 @@ public final class ChatMessageManager {
     /// turns (subagents, schedulers, watchers, opportunity wakes) never touch
     /// this counter, so they cannot trigger the `task_complete` chime.
     public var pendingUserTurnCount: Int = 0
+    /// Trailing `generation_cancelled` echoes still expected from the
+    /// in-flight cancel batch. Primed by the `wasCancelling=true` branch
+    /// in `handleGenerationCancelled` so later `wasCancelling=false`
+    /// echoes skip the per-message decrement and don't consume
+    /// `pendingUserTurnCount` belonging to sends started after the batch.
+    /// Internal cancel-protocol bookkeeping — not surfaced to views.
+    @ObservationIgnored public var staleCancelEventsExpected: Int = 0
     /// Monotonic counter that bumps only when a `message_complete` matches a
     /// pending user-typed send from this client. Observed by
     /// `ConversationActivityStore` to gate the `task_complete` chime to

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -248,6 +248,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.discardPartialOutputBuffer()
                     self.messageManager.isSending = false
                     self.messageManager.pendingUserTurnCount = 0
+                    self.messageManager.staleCancelEventsExpected = 0
                     self.sendingWatchdogTask?.cancel()
                     self.sendingWatchdogTask = nil
                     self.thinkingWatchdogTask = nil
@@ -385,6 +386,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.activeRequestIdToMessageId.removeAll()
                     self.pendingLocalDeletions.removeAll()
                     self.messageManager.pendingUserTurnCount = 0
+                    self.messageManager.staleCancelEventsExpected = 0
                     // Cancel stale cancel-timeout task
                     self.cancelTimeoutTask?.cancel()
                     self.cancelTimeoutTask = nil
@@ -1515,6 +1517,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 // so clear pending turns to avoid bumping
                 // `interactiveTurnCompletionTick` on the next turn.
                 self?.messageManager.pendingUserTurnCount = 0
+                self?.messageManager.staleCancelEventsExpected = 0
                 if let existingId = self?.currentAssistantMessageId {
                     self?.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
                 }

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -712,6 +712,7 @@ final class MessageSendCoordinator {
         delegate.activeRequestIdToMessageId = [:]
         delegate.pendingLocalDeletions.removeAll()
         messageManager.pendingUserTurnCount = 0
+        messageManager.staleCancelEventsExpected = 0
     }
 
     // MARK: - Offline Queue Flush


### PR DESCRIPTION
Codex P2 follow-up on #30553.

## Problem

PR #30553 hoisted the `pendingUserTurnCount` decrement above the `!wasCancelling && vm.isSending` early-return in `handleGenerationCancelled` so that per-message daemon cancels (queue eviction) actually decrement the counter. The unconditional hoist also fires for stale `generation_cancelled` echoes from a previous cancel cycle — the daemon emits one event per cancelled queue entry during abort, and only the first carries `wasCancelling = true`. If a user starts a new send before the trailing echoes arrive, those echoes consume the new turn's count and the matching `message_complete` fails to bump `interactiveTurnCompletionTick`, silencing the `task_complete` chime.

## Fix

Introduce `staleCancelEventsExpected: Int` on `ChatMessageManager`. In the `wasCancelling = true` branch (the first event in a cancel batch), prime it to `vm.pendingQueuedCount` — `pendingQueuedCount` at that point reflects only still-queued entries (`message_dequeued` already decremented for the in-flight), so it equals the number of trailing echoes the daemon will still emit.

For each subsequent `!wasCancelling` event, consume the stale budget first and only decrement `pendingUserTurnCount` once the budget is drained. The counter is also reset alongside `pendingUserTurnCount = 0` in the cancel/sending watchdog paths and the stream-end recovery path so it cannot drift if echoes are lost in flight.

Marked `@ObservationIgnored` because it is pure internal cancel-protocol bookkeeping with no view consumers.

## Test

Added `testStaleCancelEchoDoesNotConsumeNewSendTurnCount` covering the regression: cancel batch primes the budget, a new send increments `pendingUserTurnCount`, two trailing echoes are absorbed without touching the new send's count, and `message_complete` for the new send still bumps `interactiveTurnCompletionTick`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->