### PR TITLE
test(memory-v2): align qdrant lifecycle tests with kind payload index

### DIFF
--- a/assistant/src/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/qdrant.test.ts
@@ -278,9 +278,10 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     });
     expect(params.on_disk_payload).toBe(true);
 
-    // Slug payload index is created up front.
+    // Slug + kind payload indexes are created up front.
     expect(state.createIndexCalls).toEqual([
       { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
     ]);
   });
 
@@ -295,9 +296,14 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     await ensureConceptPageCollection();
 
     // Existence check fired exactly once thanks to the in-memory readiness
-    // cache; createCollection / createPayloadIndex never ran.
+    // cache; createCollection never ran. Payload indexes are (idempotently)
+    // ensured on the existing-collection path to backfill long-lived installs
+    // that predate the `kind` index.
     expect(state.createCollectionCalls).toBe(0);
-    expect(state.createIndexCalls).toEqual([]);
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
+    ]);
     expect(state.collectionExistsCalls).toBe(1);
   });
 
@@ -314,6 +320,7 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     expect(state.createCollectionCalls).toBe(1);
     expect(state.createIndexCalls).toEqual([
       { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Update three failing tests in \`qdrant.test.ts\` to expect both \`slug\` and \`kind\` payload indexes, matching the current \`ensurePayloadIndexes\` implementation.
- Refresh the \"re-running ensure on existing collection\" comment to note that indexes are now backfilled on the existing-collection path for long-lived installs.

## Original prompt
Fix the specific CI issue in the Test job at https://github.com/vellum-ai/vellum-assistant/actions/runs/25821918688/job/75865132469 only. The job failed because \`src/memory/v2/__tests__/qdrant.test.ts\` still expected the legacy single-index behavior (\`slug\` only), but \`ensurePayloadIndexes\` now also creates a \`kind\` keyword index and is called on the existing-collection path. Update the three impacted assertions so test expectations match the implementation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->