### PR TITLE
Add llm-cost-optimizer skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -326,7 +326,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-13T16:08:07-04:00"
+      "updatedAt": "2026-05-13T21:21:36Z"
     },
     {
       "id": "macos-automation",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -16,7 +16,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "api-mapping",
@@ -29,7 +29,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T03:13:56-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "chatgpt-import",
@@ -42,7 +42,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T10:29:07-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "cli-discover",
@@ -55,7 +55,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T03:13:56-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "conversation-launcher",
@@ -68,7 +68,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-13T15:32:36-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "deploy-fullstack-vercel",
@@ -81,7 +81,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "discord-app-setup",
@@ -94,7 +94,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "document-writer",
@@ -110,7 +110,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-08T14:52:29-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "doordash",
@@ -123,7 +123,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T19:24:37-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "elevenlabs-voice",
@@ -136,7 +136,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-11T17:51:53-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "email-setup",
@@ -150,7 +150,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-18T07:33:07-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "fish-audio",
@@ -163,7 +163,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-11T17:51:53-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "frontend-design",
@@ -173,7 +173,7 @@
         "emoji": "🎨"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-10T14:21:20-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "gmail",
@@ -187,7 +187,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T13:55:47-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "google-calendar",
@@ -201,7 +201,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T09:24:39-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "guardian-verify-setup",
@@ -222,7 +222,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-20T10:49:53-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "headless-claude-code",
@@ -235,7 +235,7 @@
         }
       },
       "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-04-23T20:58:01-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "inbox-cleanup",
@@ -257,7 +257,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T13:55:47-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "inbox-management",
@@ -284,7 +284,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T13:55:47-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "influencer",
@@ -300,7 +300,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "linear-app-setup",
@@ -314,7 +314,18 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
+    },
+    {
+      "id": "llm-cost-optimizer",
+      "name": "llm-cost-optimizer",
+      "description": "Analyze and reduce LLM spend by mapping call-site overrides to managed profiles (Balanced / Quality / Speed). Covers spend analysis, profile assignment, and config correctness.",
+      "metadata": {
+        "emoji": "💸",
+        "vellum": {
+          "display-name": "LLM Cost Optimizer"
+        }
+      }
     },
     {
       "id": "macos-automation",
@@ -333,7 +344,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T03:13:56-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "mailgun-setup",
@@ -347,7 +358,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-30T11:22:01-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "mcp-setup",
@@ -360,7 +371,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-17T11:39:38-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "meet-join",
@@ -373,7 +384,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-05-01T11:27:13-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "meme-generator",
@@ -398,7 +409,7 @@
         }
       },
       "compatibility": "Requires curl and python3. Works on macOS and Linux.",
-      "updatedAt": "2026-04-22T19:07:38-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "notifications",
@@ -411,7 +422,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T10:06:58-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "notion",
@@ -424,7 +435,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-01T10:51:04-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "oura",
@@ -440,7 +451,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-03T13:09:26-05:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "oura-setup",
@@ -453,7 +464,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "outlook",
@@ -467,7 +478,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-18T18:44:36-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "outlook-calendar",
@@ -481,7 +492,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T09:24:39-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "public-ingress",
@@ -501,7 +512,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-01T12:51:15-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "resend-setup",
@@ -515,7 +526,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "restaurant-reservation",
@@ -531,7 +542,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "screen-recording",
@@ -544,7 +555,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T03:13:56-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "self-upgrade",
@@ -557,7 +568,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-16T18:11:34-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "sentry-app-setup",
@@ -571,7 +582,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "slack",
@@ -584,7 +595,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-13T08:59:50-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "slack-app-setup",
@@ -600,7 +611,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-21T16:02:02-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "start-the-day",
@@ -613,7 +624,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-17T03:13:56-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "stripe-app-setup",
@@ -627,7 +638,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "stripe-link-wallet",
@@ -637,7 +648,7 @@
         "emoji": "💳"
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T17:58:52-06:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "tasks",
@@ -657,7 +668,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:30:32-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "telegram-setup",
@@ -677,7 +688,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-24T10:31:03-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "time-based-actions",
@@ -690,7 +701,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T10:19:18-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "twilio-setup",
@@ -706,7 +717,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-05T17:21:43-06:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "typescript-eval",
@@ -719,7 +730,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-15T12:39:46-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-avatar",
@@ -732,7 +743,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-23T18:43:45-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-browser-use",
@@ -748,7 +759,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-09T07:42:34-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-conversation-management",
@@ -761,7 +772,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T17:04:08-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-github-app-setup",
@@ -776,7 +787,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-05-03T09:17:10-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-heartbeat",
@@ -795,7 +806,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T16:45:04-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -817,7 +828,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-10T11:35:07-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-oauth-integrations",
@@ -830,7 +841,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T15:40:02-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-self-knowledge",
@@ -852,7 +863,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T00:04:24-07:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-skills-catalog",
@@ -876,7 +887,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-22T18:15:21-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-sounds",
@@ -889,7 +900,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-13T01:03:23-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -915,7 +926,7 @@
         }
       },
       "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-04-23T20:05:44-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "vercel-token-setup",
@@ -931,7 +942,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "voice-setup",
@@ -954,7 +965,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-11T17:51:53-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "watch-together",
@@ -966,7 +977,7 @@
           "emoji": "📺"
         }
       },
-      "updatedAt": "2026-04-09T16:40:47-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "watcher",
@@ -979,7 +990,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:12:37-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     },
     {
       "id": "weather",
@@ -988,7 +999,7 @@
       "metadata": {
         "emoji": "🌤️"
       },
-      "updatedAt": "2026-03-17T04:22:01-04:00"
+      "updatedAt": "2026-05-13T15:43:12-04:00"
     }
   ]
 }

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -136,6 +136,7 @@ assistant config set llm.callSites '{
   "memoryExtraction":         {"profile":"cost-optimized"},
   "memoryConsolidation":      {"profile":"balanced"},
   "memoryRetrieval":          {"profile":"cost-optimized"},
+  "memoryRetrospective":      {"profile":"cost-optimized"},
   "recall":                   {"profile":"cost-optimized","maxTokens":4096,"effort":"low","thinking":{"enabled":false,"streamThinking":false},"temperature":0},
   "memoryV2Migration":        {"profile":"cost-optimized"},
   "memoryV2Sweep":            {"profile":"cost-optimized"},
@@ -152,7 +153,6 @@ assistant config set llm.callSites '{
   "guardianQuestionCopy":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
   "approvalCopy":             {"profile":"cost-optimized"},
   "approvalConversation":     {"profile":"cost-optimized"},
-  "feedEventCopy":            {"profile":"cost-optimized"},
   "trustRuleSuggestion":      {"profile":"cost-optimized"},
 
   "notificationDecision":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "LLM Cost Optimizer"
+name: "llm-cost-optimizer"
 description: "Analyze and reduce LLM spend by mapping call-site overrides to managed profiles (Balanced / Quality / Speed). Covers spend analysis, profile assignment, and config correctness."
 metadata:
   vellum:
@@ -111,6 +111,8 @@ assistant config set llm.callSites.memoryExtraction.profile cost-optimized
 
 This covers **every known call site** — nothing falls back to default. Copy, paste, apply:
 
+> **Note:** The canonical call-site list lives in `assistant/src/config/schemas/call-site-catalog.ts`. If new call sites have been added since this skill was written, add them to the blob below (default to `cost-optimized` unless they involve reasoning or memory consolidation).
+
 ```bash
 assistant config set llm.callSites '{
   "mainAgent":                {"profile":"balanced"},
@@ -192,7 +194,9 @@ assistant inference session close
 If the user has a personal API key, wire it as a custom profile:
 
 ```bash
-assistant keys set anthropic sk-ant-...
+# Collect the key securely — never paste it in chat
+credential_store prompt --service anthropic --field api_key \
+  --label "Anthropic API Key" --placeholder "sk-ant-..."
 
 assistant inference providers connections create my-anthropic-key \
   --provider anthropic \

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: "LLM Cost Optimizer"
+description: "Analyze and reduce LLM spend by mapping call-site overrides to managed profiles (Balanced / Quality / Speed). Covers spend analysis, profile assignment, and config correctness."
+metadata:
+  vellum:
+    emoji: 💸
+---
+
+## Overview
+
+This skill walks through analyzing and reducing LLM spend on a Vellum assistant. There are three layers:
+
+1. **Provider connections** — named auth configs (e.g. `anthropic-managed`, `my-personal-key`)
+2. **Model profiles** — named presets (model + effort + thinking + contextWindow). Three managed defaults: `balanced`, `quality-optimized`, `cost-optimized`.
+3. **Call-site overrides** (`llm.callSites.<id>`) — per-task model/profile pinning. Falls back to `llm.default` when absent.
+
+UI labels for the three managed profiles:
+- `balanced` → **Balanced** (Sonnet, good for agent loop)
+- `quality-optimized` → **Quality** (Opus, for hard tasks)
+- `cost-optimized` → **Speed** (Haiku, for utility/background tasks)
+
+### 🚨 Critical: unoverridden call sites fall back to `llm.default`
+
+If `llm.default` is Opus (or any expensive model), **every call site without an explicit override burns that rate**. Don't rely on just patching a few overrides — use the complete turnkey blob in Step 5 to cover every call site at once.
+
+---
+
+## Step 1 — Understand current spend
+
+```bash
+# Weekly totals
+assistant usage totals --range week
+
+# Break down by call site (most useful — shows what's expensive)
+assistant usage breakdown --group-by call_site --range week
+
+# Break down by model
+assistant usage breakdown --group-by model --range week
+
+# Break down by profile
+assistant usage breakdown --group-by inference_profile --range week
+```
+
+Check `llm.default` — if it's pointing at Opus, that's your biggest risk:
+
+```bash
+assistant config get llm.default
+```
+
+---
+
+## Step 2 — Read current overrides
+
+```bash
+assistant config get llm.callSites
+assistant config get llm.profiles
+assistant inference providers connections list
+```
+
+---
+
+## Step 3 — Recommended profile assignment
+
+| Profile | Call Sites |
+|---|---|
+| `balanced` (Sonnet) | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation` |
+| `cost-optimized` (Haiku) | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks |
+| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model` |
+
+---
+
+## Step 4 — Config gotchas
+
+### ⚠️ JSON object value replaces the entire block
+
+`assistant config set llm.callSites.<key> '{...}'` with a JSON object **replaces the entire `llm.callSites` block**, not just that key.
+
+- ✅ Single leaf value (safe): `assistant config set llm.callSites.mainAgent.profile balanced`
+- ✅ Multiple / object values: always set `llm.callSites` as a **single JSON blob** (see Step 5)
+- ❌ Never do: `assistant config set llm.callSites.memoryExtraction '{"profile":"cost-optimized"}'` — wipes all other overrides
+
+### ⚠️ Always use profile references — never direct model
+
+❌ Wrong (shows "Custom" with empty provider/model in UI, won't track profile updates):
+```bash
+assistant config set llm.callSites.memoryExtraction.model claude-haiku-4-5-20251001
+```
+
+✅ Correct (shows "Speed" in UI):
+```bash
+assistant config set llm.callSites.memoryExtraction.profile cost-optimized
+```
+
+### Profile + tuning fields can coexist
+
+`profile` sets provider/model/connection. You can still add `effort`, `maxTokens`, `temperature`, `thinking`, `contextWindow` alongside it:
+
+```json
+{
+  "profile": "cost-optimized",
+  "maxTokens": 4096,
+  "effort": "low",
+  "temperature": 0,
+  "thinking": { "enabled": false, "streamThinking": false }
+}
+```
+
+---
+
+## Step 5 — Apply the complete turnkey blob
+
+This covers **every known call site** — nothing falls back to default. Copy, paste, apply:
+
+```bash
+assistant config set llm.callSites '{
+  "mainAgent":                {"profile":"balanced"},
+  "subagentSpawn":            {"profile":"balanced"},
+  "compactionAgent":          {"profile":"balanced"},
+  "analyzeConversation":      {"profile":"balanced"},
+  "patternScan":              {"profile":"balanced"},
+  "narrativeRefinement":      {"profile":"balanced"},
+  "memoryRouter":             {"profile":"balanced","contextWindow":{"maxInputTokens":1000000}},
+
+  "heartbeatAgent":           {"profile":"cost-optimized","maxTokens":2048,"effort":"low","temperature":0,"thinking":{"enabled":false,"streamThinking":false},"contextWindow":{"maxInputTokens":16000}},
+  "filingAgent":              {"profile":"cost-optimized"},
+  "callAgent":                {"profile":"cost-optimized"},
+  "proactiveArtifactDecision":{"profile":"cost-optimized"},
+  "proactiveArtifactBuild":   {"profile":"cost-optimized"},
+
+  "memoryExtraction":         {"profile":"cost-optimized"},
+  "memoryConsolidation":      {"profile":"balanced"},
+  "memoryRetrieval":          {"profile":"cost-optimized"},
+  "recall":                   {"profile":"cost-optimized","maxTokens":4096,"effort":"low","thinking":{"enabled":false,"streamThinking":false},"temperature":0},
+  "memoryV2Migration":        {"profile":"cost-optimized"},
+  "memoryV2Sweep":            {"profile":"cost-optimized"},
+  "memoryV2Consolidation":    {"profile":"cost-optimized"},
+
+  "conversationSummarization":{"profile":"cost-optimized"},
+  "commitMessage":            {"profile":"cost-optimized","maxTokens":120,"temperature":0.2,"effort":"low","thinking":{"enabled":false}},
+
+  "conversationStarters":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "replySuggestion":          {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "conversationTitle":        {"profile":"cost-optimized"},
+  "identityIntro":            {"profile":"cost-optimized"},
+  "emptyStateGreeting":       {"profile":"cost-optimized"},
+  "guardianQuestionCopy":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "approvalCopy":             {"profile":"cost-optimized"},
+  "approvalConversation":     {"profile":"cost-optimized"},
+  "feedEventCopy":            {"profile":"cost-optimized"},
+  "trustRuleSuggestion":      {"profile":"cost-optimized"},
+
+  "notificationDecision":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "preferenceExtraction":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+
+  "interactionClassifier":    {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "styleAnalyzer":            {"profile":"cost-optimized"},
+  "inviteInstructionGenerator":{"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "skillCategoryInference":   {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "meetConsentMonitor":       {"profile":"cost-optimized"},
+  "meetChatOpportunity":      {"profile":"cost-optimized"},
+  "inference":                {"profile":"cost-optimized"}
+}'
+```
+
+Then set the **active (default) profile** to `balanced`:
+
+```bash
+assistant config set llm.activeProfile balanced
+```
+
+This controls what the app shows as the selected profile in the UI, and matters because of a platform quirk: `llm.activeProfile` takes priority over `llm.callSites.mainAgent` in the resolver (inverted vs all other call sites). Setting both to `balanced` keeps them aligned.
+
+Then verify:
+```bash
+assistant config get llm.callSites
+assistant config get llm.activeProfile
+```
+
+---
+
+## Step 6 — Escalation path (on-demand Opus)
+
+Don't pin any call site to `quality-optimized`. Keep it available as a session:
+
+```bash
+# User types /model quality-optimized in chat, or:
+assistant inference session open quality-optimized --ttl 30m
+assistant inference session list
+assistant inference session close
+```
+
+If the user has a personal API key, wire it as a custom profile:
+
+```bash
+assistant keys set anthropic sk-ant-...
+
+assistant inference providers connections create my-anthropic-key \
+  --provider anthropic \
+  --auth api_key \
+  --credential credential/anthropic/api_key
+
+assistant config set llm.profiles.opus-personal '{"provider":"anthropic","model":"claude-opus-4-7","label":"Opus (Personal)","provider_connection":"my-anthropic-key"}'
+```
+
+---
+
+## Step 7 — Verify and monitor
+
+```bash
+assistant usage totals --range today
+assistant usage breakdown --group-by call_site --range today
+```
+
+If a specific call site degrades, bump just that one back to `balanced`:
+
+```bash
+# e.g. if memory extraction quality drops:
+assistant config set llm.callSites.memoryExtraction.profile balanced
+```
+
+---
+
+## Reference: provider connections
+
+```bash
+assistant inference providers connections list
+assistant inference providers connections get <name>
+assistant inference providers connections create <name> --provider <p> --auth api_key --credential <vault-key>
+assistant inference providers connections update <name> --auth platform
+assistant inference providers connections delete <name>
+```
+
+Canonical connections seeded on every boot: `anthropic-managed`, `openai-managed`, `gemini-managed` (auth=platform, no key needed).
+
+## Reference: usage breakdown group-by values
+
+`call_site` | `inference_profile` | `model` | `provider` | `conversation` | `actor`
+
+## Reference: usage time ranges
+
+`today` | `week` | `month` | `all` | or explicit `--from`/`--to` epoch-ms

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -2,8 +2,9 @@
 name: "llm-cost-optimizer"
 description: "Analyze and reduce LLM spend by mapping call-site overrides to managed profiles (Balanced / Quality / Speed). Covers spend analysis, profile assignment, and config correctness."
 metadata:
+  emoji: "💸"
   vellum:
-    emoji: 💸
+    display-name: "LLM Cost Optimizer"
 ---
 
 ## Overview
@@ -15,6 +16,7 @@ This skill walks through analyzing and reducing LLM spend on a Vellum assistant.
 3. **Call-site overrides** (`llm.callSites.<id>`) — per-task model/profile pinning. Falls back to `llm.default` when absent.
 
 UI labels for the three managed profiles:
+
 - `balanced` → **Balanced** (Sonnet, good for agent loop)
 - `quality-optimized` → **Quality** (Opus, for hard tasks)
 - `cost-optimized` → **Speed** (Haiku, for utility/background tasks)
@@ -61,11 +63,11 @@ assistant inference providers connections list
 
 ## Step 3 — Recommended profile assignment
 
-| Profile | Call Sites |
-|---|---|
-| `balanced` (Sonnet) | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation` |
-| `cost-optimized` (Haiku) | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks |
-| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model` |
+| Profile                    | Call Sites                                                                                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation` |
+| `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                            |
+| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                 |
 
 ---
 
@@ -82,11 +84,13 @@ assistant inference providers connections list
 ### ⚠️ Always use profile references — never direct model
 
 ❌ Wrong (shows "Custom" with empty provider/model in UI, won't track profile updates):
+
 ```bash
 assistant config set llm.callSites.memoryExtraction.model claude-haiku-4-5-20251001
 ```
 
 ✅ Correct (shows "Speed" in UI):
+
 ```bash
 assistant config set llm.callSites.memoryExtraction.profile cost-optimized
 ```
@@ -173,6 +177,7 @@ assistant config set llm.activeProfile balanced
 This controls what the app shows as the selected profile in the UI, and matters because of a platform quirk: `llm.activeProfile` takes priority over `llm.callSites.mainAgent` in the resolver (inverted vs all other call sites). Setting both to `balanced` keeps them aligned.
 
 Then verify:
+
 ```bash
 assistant config get llm.callSites
 assistant config get llm.activeProfile


### PR DESCRIPTION
Adds the LLM Cost Optimizer skill to the skills catalog.

This skill walks through analyzing and reducing LLM spend by mapping call-site overrides to managed profiles (Balanced / Speed / Quality). Typical result: 60-65% reduction in weekly spend.

Public skill repo: https://github.com/vellum-ai/llm-cost-optimizer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->