### PR TITLE
fix(macos): unbreak SettingsStoreInferenceProfiles test compilation

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -221,12 +221,14 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
 
         // Resolve B first — daemon-confirmed value becomes B.
         continuationB?.resume(returning: true)
-        XCTAssertTrue(await resultB)
+        let bSucceeded = await resultB
+        XCTAssertTrue(bSucceeded)
         XCTAssertEqual(store.activeProfile, "B")
 
         // Resolve A's late success. The guard must drop the stale write.
         continuationA?.resume(returning: true)
-        XCTAssertTrue(await resultA)
+        let aSucceeded = await resultA
+        XCTAssertTrue(aSucceeded)
         XCTAssertEqual(
             store.activeProfile,
             "B",


### PR DESCRIPTION
## Summary
- Await `async let resultA`/`resultB` into local constants before passing to `XCTAssertTrue`. `XCTAssertTrue` takes an autoclosure, and Swift rejects capturing `async let` variables inside autoclosures.

## Original prompt
Fix the macOS Tests CI failure on run 25821930867: `SettingsStoreInferenceProfilesTests.swift:224/229` was failing to compile with `capturing 'async let' variables is not supported` and `'async let' in an autoclosure that does not support concurrency`. Scope is just to fix that compile error in the new stale-completion guard test introduced by #30605.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->