### PR TITLE
[LUM-1533] Fix heartbeat conversations missing from web sidebar background section

### DIFF
--- a/assistant/src/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/memory/__tests__/conversation-queries.test.ts
@@ -10,9 +10,13 @@ mock.module("../../util/logger.js", () => ({
 }));
 
 import { createConversation } from "../conversation-crud.js";
-import { countConversations } from "../conversation-queries.js";
+import {
+  countConversations,
+  listConversations,
+} from "../conversation-queries.js";
 import { getDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
+import { rawRun } from "../raw-query.js";
 import { conversations } from "../schema.js";
 
 initializeDb();
@@ -58,5 +62,110 @@ describe("countConversations", () => {
     setConversationType(priv.id, "private");
 
     expect(countConversations(true)).toBe(2);
+  });
+
+  test("includes standard conversations with group_id system:background in background count", () => {
+    // GIVEN a standard conversation routed to system:background (e.g. heartbeat)
+    createConversation({
+      title: "heartbeat-1",
+      source: "heartbeat",
+      groupId: "system:background",
+    });
+
+    // AND a regular foreground conversation
+    createConversation("foreground-1");
+
+    // WHEN counting background conversations
+    const bgCount = countConversations(true);
+
+    // THEN the heartbeat conversation is included
+    expect(bgCount).toBe(1);
+
+    // AND excluded from the foreground count
+    expect(countConversations(false)).toBe(1);
+  });
+
+  test("excludes standard conversations with group_id system:background from foreground count", () => {
+    // GIVEN two foreground conversations and one heartbeat
+    createConversation("foreground-1");
+    createConversation("foreground-2");
+    createConversation({
+      title: "heartbeat-1",
+      source: "heartbeat",
+      groupId: "system:background",
+    });
+
+    // WHEN counting foreground conversations
+    // THEN the heartbeat is excluded
+    expect(countConversations(false)).toBe(2);
+  });
+});
+
+describe("listConversations", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("background fetch includes conversations with group_id system:background regardless of conversationType", () => {
+    // GIVEN a heartbeat conversation (conversationType standard, group_id system:background)
+    createConversation({
+      title: "heartbeat-1",
+      source: "heartbeat",
+      groupId: "system:background",
+    });
+
+    // AND a real background conversation
+    createConversation({ title: "bg-1", conversationType: "background" });
+
+    // AND a foreground conversation
+    createConversation("foreground-1");
+
+    // WHEN listing background conversations
+    const bgList = listConversations(100, true);
+
+    // THEN both background and heartbeat conversations are returned
+    expect(bgList).toHaveLength(2);
+    const titles = bgList.map((c) => c.title);
+    expect(titles).toContain("heartbeat-1");
+    expect(titles).toContain("bg-1");
+  });
+
+  test("foreground fetch excludes conversations with group_id system:background", () => {
+    // GIVEN a heartbeat conversation (conversationType standard, group_id system:background)
+    createConversation({
+      title: "heartbeat-1",
+      source: "heartbeat",
+      groupId: "system:background",
+    });
+
+    // AND a foreground conversation
+    createConversation("foreground-1");
+
+    // WHEN listing foreground conversations
+    const fgList = listConversations(100, false);
+
+    // THEN only the foreground conversation is returned
+    expect(fgList).toHaveLength(1);
+    expect(fgList[0]!.title).toBe("foreground-1");
+  });
+
+  test("conversations with group_id system:scheduled are included in background fetch", () => {
+    // GIVEN a conversation with group_id system:scheduled but conversationType standard
+    const conv = createConversation("schedule-routed");
+    rawRun(
+      "UPDATE conversations SET group_id = 'system:scheduled' WHERE id = ?",
+      conv.id,
+    );
+
+    // WHEN listing background conversations
+    const bgList = listConversations(100, true);
+
+    // THEN it appears in the background list
+    expect(bgList).toHaveLength(1);
+    expect(bgList[0]!.title).toBe("schedule-routed");
+
+    // AND not in the foreground list
+    const fgList = listConversations(100, false);
+    expect(fgList).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -239,6 +239,7 @@ export function searchConversations(
 ): ConversationSearchResult[] {
   if (!query.trim()) return [];
 
+  ensureGroupMigration();
   const db = getDb();
   const limit = opts?.limit ?? 20;
   const maxMsgsPerConv = opts?.maxMessagesPerConversation ?? 3;
@@ -268,7 +269,7 @@ export function searchConversations(
         FROM messages_fts f
         JOIN messages m ON m.id = f.message_id
         JOIN conversations c ON c.id = m.conversation_id
-        WHERE messages_fts MATCH ? AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND c.archived_at IS NULL
+        WHERE messages_fts MATCH ? AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND COALESCE(c.group_id, 'system:all') NOT IN ('system:background', 'system:scheduled') AND c.archived_at IS NULL
         LIMIT 1000
       `,
         ftsMatch,
@@ -293,7 +294,7 @@ export function searchConversations(
       SELECT DISTINCT m.conversation_id
       FROM messages m
       JOIN conversations c ON c.id = m.conversation_id
-      WHERE m.content LIKE ? ESCAPE '\\' AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND c.archived_at IS NULL
+      WHERE m.content LIKE ? ESCAPE '\\' AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND COALESCE(c.group_id, 'system:all') NOT IN ('system:background', 'system:scheduled') AND c.archived_at IS NULL
       LIMIT 1000
     `,
       likePattern,
@@ -308,6 +309,7 @@ export function searchConversations(
     .where(
       and(
         sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`,
+        sql`COALESCE(group_id, 'system:all') NOT IN ('system:background', 'system:scheduled')`,
         sql`${conversations.title} LIKE ${titlePattern} ESCAPE '\\'`,
         sql`${conversations.archivedAt} IS NULL`,
       ),

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -156,6 +156,7 @@ export function listConversationsByTitlePrefix(
 }
 
 export function countConversations(backgroundOnly = false): number {
+  ensureGroupMigration();
   const db = getDb();
   const where = backgroundOnly
     ? sql`(${conversations.conversationType} IN ('background', 'scheduled') OR group_id IN ('system:background', 'system:scheduled')) AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -55,9 +55,14 @@ export function listConversations(
   // SQLite file without running migrations in-process, so legacy private rows
   // can briefly exist before migration cleanup. Hide them from foreground
   // lists until the next migration pass deletes them.
+  //
+  // group_id is checked alongside conversationType so that conversations
+  // routed to system:background (e.g. heartbeat) via conversationMetadata
+  // but created with conversationType "standard" (vellum channel strategy)
+  // appear in the correct bucket.
   const typeCond = backgroundOnly
-    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
-    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`;
+    ? sql`(${conversations.conversationType} IN ('background', 'scheduled') OR group_id IN ('system:background', 'system:scheduled')) AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
+    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private') AND COALESCE(group_id, 'system:all') NOT IN ('system:background', 'system:scheduled')`;
   const where = includeArchived
     ? typeCond
     : sql`${typeCond} AND ${conversations.archivedAt} IS NULL`;
@@ -153,8 +158,8 @@ export function listConversationsByTitlePrefix(
 export function countConversations(backgroundOnly = false): number {
   const db = getDb();
   const where = backgroundOnly
-    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
-    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`;
+    ? sql`(${conversations.conversationType} IN ('background', 'scheduled') OR group_id IN ('system:background', 'system:scheduled')) AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
+    : sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private') AND COALESCE(group_id, 'system:all') NOT IN ('system:background', 'system:scheduled')`;
   const [{ total }] = db
     .select({ total: count() })
     .from(conversations)


### PR DESCRIPTION
Heartbeat conversations are created with `conversationType: "standard"` (determined by the vellum channel's `start_new_conversation` strategy) but routed to `group_id: "system:background"` via `conversationMetadata`. The daemon's `listConversations`, `countConversations`, and `searchConversations` queries only filtered by `conversationType`, so heartbeat conversations were excluded from background fetches and competed with regular foreground conversations — meaning they rarely appeared in the sidebar and could leak into search results.

This updates all conversation query functions to also consider `group_id`, so conversations routed to `system:background` or `system:scheduled` via `conversationMetadata` appear in the correct bucket regardless of their `conversationType`.

**Root cause:** The notification pipeline determines `conversationType` from the channel's delivery strategy (`start_new_conversation` → `"standard"`). Heartbeat notifications go through the vellum channel, so they get `conversationType: "standard"` despite being background conversations. The `group_id` and `source` fields are set correctly via `conversationMetadata`, but the daemon query layer only used `conversationType` for filtering — a gap introduced when `group_id` was added as a raw-SQL-only column outside the Drizzle schema.

## Prompt / plan
Investigate and fix LUM-1533: heartbeat subgroups not appearing in web sidebar.

## Test plan
- Added 5 new tests to `conversation-queries.test.ts` covering `listConversations` and `countConversations` with `group_id`-based filtering
- All 7 tests pass (2 existing + 5 new)
- Type check passes (`bunx tsc --noEmit`)
- Lint passes (`bun run lint`)

Closes LUM-1533

Link to Devin session: https://app.devin.ai/sessions/678421759e7d46afa575af9395e8bb9c
Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->