### PR TITLE
fix(daemon): ask_question review followups

### DIFF
--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -361,6 +361,41 @@ describe("QuestionPrompter", () => {
     expect(_piStore.has(req.requestId)).toBe(false);
   });
 
+  test("abort after removeByConversation still resolves the Promise (no hang)", async () => {
+    // Regression test for the race exposed by post-merge review of #30581:
+    // when `removeByConversation()` (auto-deny on enqueue) deregisters the
+    // question interaction before the abort signal fires, the abort handler
+    // must still resolve the prompt Promise. Previously, the handler used
+    // `pendingInteractions.resolve(id) === undefined` as the idempotency
+    // guard — which returned `undefined` after the registry was cleared,
+    // causing the handler to early-return and the Promise to hang forever.
+    // Now an internal `settled` flag guards every resolution path.
+    const { prompter, sent } = makePrompter();
+    const ac = new AbortController();
+
+    const promise = prompter.prompt({
+      ...threeQuestionParams,
+      signal: ac.signal,
+    });
+    const req = sent[0] as QuestionRequest;
+    expect(_piStore.has(req.requestId)).toBe(true);
+
+    // Simulate `removeByConversation` clearing the registry entry before
+    // the abort signal fires.
+    const interaction = _piStore.get(req.requestId);
+    if (interaction?.timer != null) clearTimeout(interaction.timer);
+    _piStore.delete(req.requestId);
+
+    ac.abort();
+    const result = await promise;
+    expect(result.overall).toBe("aborted");
+    expect(result.entries).toEqual([
+      { questionId: "q1", decision: "aborted" },
+      { questionId: "q2", decision: "aborted" },
+      { questionId: "q3", decision: "aborted" },
+    ]);
+  });
+
   test("pre-aborted signal short-circuits before broadcasting with aborted entries", async () => {
     const { prompter, sent } = makePrompter();
     const ac = new AbortController();

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -214,7 +214,6 @@ export class QuestionPrompter {
       // our local handlers fire — using the registry as the guard in that
       // case would leave the Promise unresolved and the tool hung.
       let settled = false;
-      let timer: ReturnType<typeof setTimeout>;
       let onAbort: (() => void) | undefined;
       const finish = (fn: () => void): void => {
         if (settled) return;
@@ -229,7 +228,7 @@ export class QuestionPrompter {
         fn();
       };
 
-      timer = setTimeout(() => {
+      const timer = setTimeout(() => {
         log.warn({ requestId, conversationId }, "Question prompt timed out");
         finish(() =>
           resolve({

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -205,47 +205,73 @@ export class QuestionPrompter {
     return new Promise<QuestionPromptResult>((resolve, reject) => {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
 
-      const timer = setTimeout(() => {
+      // Closure-scoped idempotency guard. Every resolution path (timeout,
+      // abort, route resolution via `rpcResolve`/`rpcReject`) routes through
+      // `finish()`, which tears down the timer + abort listener exactly
+      // once. We cannot use `pendingInteractions.resolve(requestId) ===
+      // undefined` as the guard because `removeByConversation()` (called
+      // during auto-deny on enqueue) can deregister the entry before any of
+      // our local handlers fire — using the registry as the guard in that
+      // case would leave the Promise unresolved and the tool hung.
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout>;
+      let onAbort: (() => void) | undefined;
+      const finish = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (signal && onAbort) {
+          signal.removeEventListener("abort", onAbort);
+        }
+        // Idempotent: a no-op if the entry was already removed (e.g. by
+        // `removeByConversation`) or by an earlier path.
         pendingInteractions.resolve(requestId);
+        fn();
+      };
+
+      timer = setTimeout(() => {
         log.warn({ requestId, conversationId }, "Question prompt timed out");
-        resolve({
-          entries: orderedIds.map((id) => ({
-            questionId: id,
-            decision: "timed_out",
-          })),
-          overall: "timed_out",
-        });
+        finish(() =>
+          resolve({
+            entries: orderedIds.map((id) => ({
+              questionId: id,
+              decision: "timed_out",
+            })),
+            overall: "timed_out",
+          }),
+        );
       }, timeoutMs);
+
+      if (signal) {
+        onAbort = () => {
+          finish(() =>
+            resolve({
+              entries: orderedIds.map((id) => ({
+                questionId: id,
+                decision: "aborted",
+              })),
+              overall: "aborted",
+            }),
+          );
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
 
       // Stash the per-question metadata on the interaction so the route can
       // validate batched submissions without holding a prompter reference.
+      // Route resolution funnels through `finish()` so the same teardown +
+      // idempotency guard applies whether the response comes from the route,
+      // a timeout, or an abort.
       pendingInteractions.register(requestId, {
         conversationId,
         kind: "question",
-        rpcResolve: resolve as (value: unknown) => void,
-        rpcReject: reject,
+        rpcResolve: (value: unknown) =>
+          finish(() => resolve(value as QuestionPromptResult)),
+        rpcReject: (err: unknown) => finish(() => reject(err)),
         timer,
         toolUseId,
         metadata: { orderedIds, optionsById } satisfies QuestionBatchMetadata,
       });
-
-      if (signal) {
-        const onAbort = () => {
-          // `pendingInteractions.resolve(requestId)` returns the deregistered
-          // entry on first call and undefined thereafter — use that as the
-          // idempotency guard so a late abort after route/timeout resolution
-          // is a no-op.
-          if (pendingInteractions.resolve(requestId) === undefined) return;
-          resolve({
-            entries: orderedIds.map((id) => ({
-              questionId: id,
-              decision: "aborted",
-            })),
-            overall: "aborted",
-          });
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-      }
 
       // Populate both shapes on the wire: `questions[]` is the canonical
       // batched payload, and the flat fields mirror `questions[0]` for


### PR DESCRIPTION
## Summary
Addresses post-merge review feedback on #30581:
- Fixes the abort handler race Devin flagged (yellow): closure-scoped `settled` flag prevents the prompt Promise from hanging when `removeByConversation` clears the pendingInteractions entry before the abort signal fires. The previous `pendingInteractions.resolve(requestId) === undefined` guard treated a pre-cleared registry as an already-settled Promise, causing the abort handler to early-return and leak the pending Promise.
- All resolution paths (timeout, abort, route resolution via rpcResolve/rpcReject) now funnel through a single `finish()` helper that uses a closure-scoped `settled` flag for one-shot idempotency, clears the timer, detaches the abort listener, and best-effort-clears the pending-interactions entry.
- Adds a regression test that deletes the pending-interactions entry directly (simulating `removeByConversation`) and then fires the abort signal — the Promise must still resolve with `overall: "aborted"`.

awlevin's request to remove the `04-ask-question.md` workspace section and codify the convention in root AGENTS.md was already landed in the squash-merged commit (`f5aff0c195`); no further changes there.

Follow-up to: #30581