### PR TITLE
M1: Ensure SubagentDetailPanel triggers lazy-load after history reconstruction

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -84,6 +84,14 @@ struct SubagentDetailPanel: View {
                 onRequestDetail?()
             }
         }
+        .onChange(of: subagentInfo?.conversationId) { _, newConversationId in
+            // Safety net: if conversationId becomes available after the panel is
+            // already visible (e.g. history reconstruction merges it after .onAppear
+            // already fired with conversationId == nil), trigger the lazy-load.
+            if events.isEmpty, newConversationId != nil {
+                onRequestDetail?()
+            }
+        }
     }
 
     // MARK: - Pinned Content


### PR DESCRIPTION
After app refresh, clicking a completed subagent chip now correctly lazy-loads the full event history from the daemon.

Adds an `.onChange(of: subagentInfo?.conversationId)` handler to `SubagentDetailPanel` as a safety net for the race between `.onAppear` and history reconstruction. When `.onAppear` fires before the `conversationId` is available (because history reconstruction hasn't merged it yet), the `.onChange` handler catches the moment the `conversationId` becomes available and triggers the lazy-load.

Part of #30613.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->