### PR TITLE
ci: sync published production releases to Linear scheduled pipeline

### DIFF
--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -1,0 +1,87 @@
+# Linear Release sync — connects published production releases of this repo
+# to Linear's release tracking so issues referenced in commit/PR titles between
+# the previous tagged release and the current one are automatically grouped
+# under the new release.
+#
+# This repo follows a tagged-release model (semver tags like `v0.5.3`), so the
+# Linear pipeline configured to consume this sync should be of type
+# **Scheduled** — not Continuous. The companion repo
+# `vellum-ai/vellum-assistant-platform` is continuously deployed and uses a
+# separate Continuous pipeline (see that repo's `linear-release-sync.yml`).
+#
+# The action scans commit history between the previous Linear release and the
+# tagged commit, extracts Linear issue identifiers (e.g. `LUM-1234`,
+# `JARVIS-123`), and creates or updates a Scheduled release identified by the
+# git tag.
+#
+# Filtering: only true production releases (clean semver tags such as
+# `v0.5.3`) advance the pipeline. The repo's release workflow also publishes
+# `-staging.N` pre-release tags (`v0.7.4-staging.2`) via `gh release create`;
+# those are skipped so Linear issues don't get marked as shipped to production
+# before they actually are.
+#
+# Setup prerequisites (one-time, in Linear and GitHub UIs):
+#   1. Create a Scheduled release pipeline in Linear:
+#      Settings → Releases → New pipeline → Type: Scheduled.
+#   2. Copy the pipeline access key from its settings page.
+#   3. Add the access key as a GitHub Actions secret on this repo named
+#      `LINEAR_ACCESS_KEY` (Settings → Secrets and variables → Actions).
+#
+# References:
+#   - Linear — Releases: https://linear.app/docs/releases
+#   - linear/linear-release-action: https://github.com/linear/linear-release-action
+#   - Linear Release CLI (pipeline semantics): https://github.com/linear/linear-release
+#   - GitHub — `release` event:
+#     https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
+name: Linear Release Sync
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize so two releases published back-to-back can't race the action
+  # into creating overlapping releases for the same commit window.
+  group: linear-release-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync Linear release
+    runs-on: ubuntu-latest
+    # Skip on forks (the secret isn't available there) and on pre-release tags
+    # such as `v0.7.4-staging.2`. The repo's release workflow publishes
+    # staging tags through the same `gh release create` path as production but
+    # encodes the channel in the tag suffix; matching on `-staging.` keeps
+    # Scheduled-pipeline releases aligned with actual production launches.
+    if: >-
+      github.repository == 'vellum-ai/vellum-assistant' &&
+      !contains(github.event.release.tag_name, '-staging.')
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The published release's tag — checkout this exact ref so the
+          # action scans the commit history that actually shipped, not
+          # whatever HEAD happens to be on the default branch when the event
+          # fires.
+          ref: ${{ github.event.release.tag_name }}
+          # Full commit history required so the action can walk back from the
+          # release tag to the previous Linear release and find every issue
+          # mentioned in commit titles, merge commits, and PR titles in
+          # between.
+          fetch-depth: 0
+
+      - name: Sync to Linear scheduled pipeline
+        uses: linear/linear-release-action@755d50b5adb7dd42b976ee9334952745d62ceb2d # v0.6.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          # For scheduled pipelines, the Linear Release CLI recommends always
+          # passing `version` in CI so the sync targets the exact Linear
+          # release matching this git tag instead of inferring from
+          # started/planned state. See "Command targeting" in the action's
+          # README.
+          version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/linear-release-sync.yml
+++ b/.github/workflows/linear-release-sync.yml
@@ -16,9 +16,12 @@
 #
 # Filtering: only true production releases (clean semver tags such as
 # `v0.5.3`) advance the pipeline. The repo's release workflow also publishes
-# `-staging.N` pre-release tags (`v0.7.4-staging.2`) via `gh release create`;
-# those are skipped so Linear issues don't get marked as shipped to production
-# before they actually are.
+# `-staging.N` pre-release tags (`v0.7.4-staging.2`) via `gh release create`,
+# and future workflows could plausibly publish other pre-release variants
+# (`-rc.N`, `-beta.N`, `-alpha.N`). All such tags share the property that the
+# semver-string contains a hyphen, so any tag with `-` in the suffix is
+# skipped. This keeps Linear issues from being marked as shipped to
+# production before they actually are.
 #
 # Setup prerequisites (one-time, in Linear and GitHub UIs):
 #   1. Create a Scheduled release pipeline in Linear:
@@ -52,14 +55,18 @@ jobs:
   sync:
     name: Sync Linear release
     runs-on: ubuntu-latest
-    # Skip on forks (the secret isn't available there) and on pre-release tags
-    # such as `v0.7.4-staging.2`. The repo's release workflow publishes
-    # staging tags through the same `gh release create` path as production but
-    # encodes the channel in the tag suffix; matching on `-staging.` keeps
+    # Skip on forks (the secret isn't available there) and on any pre-release
+    # tag (`vX.Y.Z-staging.N`, `vX.Y.Z-rc.N`, `vX.Y.Z-beta.N`, …). The repo's
+    # current release workflow publishes staging tags through the same
+    # `gh release create` path as production but encodes the channel in the
+    # tag suffix; the `prerelease` flag on the GitHub Release object is *not*
+    # set (no `--prerelease`), so we can't rely on
+    # `github.event.release.prerelease`. Filtering on a hyphen in the tag
+    # catches every pre-release shape semver allows and keeps
     # Scheduled-pipeline releases aligned with actual production launches.
     if: >-
       github.repository == 'vellum-ai/vellum-assistant' &&
-      !contains(github.event.release.tag_name, '-staging.')
+      !contains(github.event.release.tag_name, '-')
     steps:
       - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,3 +92,10 @@ jobs:
           # started/planned state. See "Command targeting" in the action's
           # README.
           version: ${{ github.event.release.tag_name }}
+          # Pin the underlying Linear Release CLI version. The action's input
+          # defaults to `latest`, which would let every production run pull a
+          # newer CLI build with potentially-changed behavior or flags. To
+          # upgrade: look up the new CLI tag at
+          # https://github.com/linear/linear-release/releases and bump the
+          # value below in the same PR as the action SHA bump.
+          cli_version: v0.10.0


### PR DESCRIPTION
## Prompt / plan

Wire up Linear's [Releases](https://linear.app/docs/releases) integration so issues referenced in commits between two consecutive `v*` releases of this repo are automatically grouped under the new release in Linear. Companion change for the platform monorepo: [vellum-ai/vellum-assistant-platform#6723](https://github.com/vellum-ai/vellum-assistant-platform/pull/6723) (Continuous pipeline). This PR wires the equivalent for the tagged-release model used by `vellum-assistant`.

## Summary

Adds [`.github/workflows/linear-release-sync.yml`](https://github.com/vellum-ai/vellum-assistant/blob/devin/1778704043-linear-release-sync/.github/workflows/linear-release-sync.yml) which runs [`linear/linear-release-action@v0`](https://github.com/linear/linear-release-action) on every published production release of this repo. The action scans commits between the previous Linear release and the tagged commit, extracts Linear issue identifiers (e.g. `LUM-1234`, `JARVIS-123`) from commit and PR titles, and creates or updates a release in the configured **Scheduled** pipeline.

The trigger is `release: types: [published]`, gated to clean semver tags (`v0.5.3`); pre-release tags such as `v0.7.4-staging.2` are filtered out so Linear issues aren't marked as shipped to production before they actually are.

## Why needed

Today, when an issue's PR merges, Linear automation marks it "Merged" but there's no signal back into Linear when the merge actually **ships** in a tagged release. For a tagged-release repo like `vellum-assistant` (macOS DMG, brain daemon, CLI), the gap between merge and tagged release can mask real questions:

- "Did this fix actually ship in `v0.8.1`, or is it still pending?"
- "Which set of issues went out in the last production release?"
- "If a customer reports a regression after upgrading to `v0.8.x`, which release introduced it (in Linear terms, not just git terms)?"

Linear's Releases feature answers those questions by maintaining a first-class "Release" property on every issue, populated automatically from CI. Combined with workflow automations ("when this pipeline's release ships, move included issues to Done"), the manual "did this go out yet?" loop disappears.

## Benefits

- **Automatic "did this ship?" answer.** Every Linear issue gains a Release property in the sidebar, computed without human intervention.
- **Status automation.** Linear can auto-move "Merged" issues to "Done" on release completion, replacing manual triage.
- **Release notes generation.** Linear can synthesize plain-language release notes from issues in a release range — useful for changelogs and customer-facing release announcements.
- **Single Linear release covers both surfaces.** The macOS DMG and brain daemon ship in lockstep from the same release tag, so a single Scheduled pipeline maps cleanly to both. If we ever want to split per-surface later, we can add a second pipeline with `include_paths` — that's not required today.
- **Complementary to existing Sentry releases.** Sentry releases group errors by deploy (`vellum-macos@0.8.1-staging.2`, `vellum-assistant@0.8.1`); Linear releases group issues by deploy. They answer different questions and can coexist without conflict.

## Safety

- **No effect until prerequisites are met in the Linear/GitHub UIs.** Without the `LINEAR_ACCESS_KEY` secret and a configured Linear pipeline, the `sync` command will fail loudly (the action exits non-zero). It will *not* silently corrupt or modify any Linear data. The first intentionally-broken run after merge can be ignored; subsequent runs after setup will succeed.
- **Pre-release tags never mark issues as shipped.** The `!contains(github.event.release.tag_name, '-staging.')` guard ensures only true production releases advance the Linear pipeline. The repo's release workflow publishes staging tags through the same `gh release create` path as production but encodes the channel in the tag suffix.
- **Read-only on the repo.** The job requests only `permissions: contents: read`. No write access to the repo, no write access to issues, no PR or comment manipulation. The action's writes go to Linear over HTTPS via the access key.
- **Forks are skipped.** Repository-name guard (`github.repository == 'vellum-ai/vellum-assistant'`) prevents the job from running on fork releases where the secret isn't available.
- **Concurrency-serialized.** A `concurrency: group: linear-release-sync` block with `cancel-in-progress: false` ensures two back-to-back releases can't race the action into creating overlapping releases for the same commit window.
- **Third-party action SHA-pinned.** `linear/linear-release-action@755d50b5adb7dd42b976ee9334952745d62ceb2d` (v0.6.0) and `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) — both pinned per [AGENTS.md GitHub Actions rules](https://github.com/vellum-ai/vellum-assistant/blob/main/AGENTS.md#github-actions).
- **Checkout pins to the published tag, not the default branch.** `ref: ${{ github.event.release.tag_name }}` ensures the action scans the commit history that actually shipped, regardless of what's merged to `main` by the time the event fires.

## Test plan

- CI green on this PR (workflow file is syntactically valid; lint/type checks unaffected since it's an isolated workflow file).
- Post-merge, no-op until the Linear pipeline is created and `LINEAR_ACCESS_KEY` is added to repo secrets.
- After setup, the next production release (`vX.Y.Z` tag without `-staging.`) will trigger the workflow. Verify by opening a recently-merged Linear issue from that release range → its sidebar should show a populated Release property.
- Pre-release tags (`vX.Y.Z-staging.N`) will not run the sync job; the workflow's `if` clause skips it.

## References

- [Linear — Releases (docs)](https://linear.app/docs/releases)
- [linear/linear-release-action README](https://github.com/linear/linear-release-action)
- [Linear Release CLI — pipeline semantics](https://github.com/linear/linear-release)
- [GitHub Actions — `release` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release)
- Companion PR (Continuous pipeline for the platform monorepo): [vellum-ai/vellum-assistant-platform#6723](https://github.com/vellum-ai/vellum-assistant-platform/pull/6723)

## Alternatives considered

- **Trigger on `workflow_run: Release completed` instead of `release: published`.** Rejected. The repo's `release.yml` workflow runs `gh release create` near the end, so by the time the `release: published` event fires, the entire release pipeline is already done. `release: published` is also more semantic ("a release exists") and naturally provides the release tag and SHA in the event payload, removing the need for a separate "find the deployed SHA" step.
- **Use a Continuous pipeline instead of Scheduled.** Rejected. Continuous pipelines model "every deploy is a release" — appropriate for `vellum-assistant-platform` (deploys multiple times per day, no marketing versions), but wrong here. `vellum-assistant` has real versioned releases that customers install on their own schedule; Scheduled pipelines preserve that mapping.
- **Track staging releases (`-staging.N`) under a separate pipeline.** Deferred. Could be valuable to know which issues shipped to staging vs. production, but starts to dilute the "shipped to production" signal that's the core point of this integration. Easy to add later with a second pipeline.
- **Split per-surface (macOS vs brain) pipelines on day one.** Deferred. Both surfaces ship in lockstep from the same release tag, so a single pipeline correctly captures every shipped issue. If we ever want to filter "which release did the macOS DMG actually deliver this fix in" separately from the brain daemon, we'd add a second Scheduled pipeline with `include_paths: clients/macos/**` — but that's a refinement, not a v1 requirement.
- **Use the floating `@v0` tag instead of a SHA pin.** Rejected per [AGENTS.md GitHub Actions rules](https://github.com/vellum-ai/vellum-assistant/blob/main/AGENTS.md#github-actions): all third-party actions must SHA-pin with a trailing `# vX.Y.Z` comment. The cost of bumping the SHA on each upstream release is small.

## Manual setup required after merge

These steps cannot be automated in CI — they require the Linear and GitHub UIs:

1. **Linear**: Settings → Releases → New pipeline → Type: **Scheduled** → Teams: Illuminati (+ JARVIS if relevant).
2. **Linear**: Copy the pipeline's access key from its settings page.
3. **GitHub**: `vellum-assistant` → Settings → Secrets and variables → Actions → New repo secret → name `LINEAR_ACCESS_KEY`, value = the key from step 2.

Once configured, the next published production release auto-creates the first Linear release.

Link to Devin session: https://app.devin.ai/sessions/8a3ce390e6e24deba0fac01d1b4a001e
Requested by: @ashleeradka