### PR TITLE
Fix long truncated conversation titles in sidebar (#29945)

### DIFF
--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -91,4 +91,4 @@ After rendering the card, end your turn. The click pipeline handles everything:
 - Don't invent options. Only surface branches the user has actually discussed or implied.
 - 2–5 buttons is the sweet spot. One option? Just reply inline. More than five? Trim or group.
 - Keep the card body to one sentence. The buttons carry the payload; the body just frames the choice.
-- All titles should be highly concise, context-specific, and ideally under 5 words.
+- Conversation titles should be highly concise, context-specific, and 3–5 words.

--- a/skills/conversation-launcher/SKILL.md
+++ b/skills/conversation-launcher/SKILL.md
@@ -91,3 +91,4 @@ After rendering the card, end your turn. The click pipeline handles everything:
 - Don't invent options. Only surface branches the user has actually discussed or implied.
 - 2–5 buttons is the sweet spot. One option? Just reply inline. More than five? Trim or group.
 - Keep the card body to one sentence. The buttons carry the payload; the body just frames the choice.
+- All titles should be highly concise, context-specific, and ideally under 5 words.


### PR DESCRIPTION
<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->
Updated the `conversation-launcher` skill guidance in `skills.md` to encourage shorter, more context-aware generated conversation titles.

Approach:
- Added explicit guidance that titles should be highly concise
- Encouraged context-specific naming
- Added a soft constraint to keep titles under 5 words whenever possible

This addresses sidebar truncation issues caused by overly long auto-generated conversation names.


## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

Manual verification:
- Reviewed generated title guidance for clarity and consistency
- Confirmed the updated instructions encourage short, scannable sidebar titles
- Ensured the change is isolated to instruction/prompt behavior with no runtime impact

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->