### PR TITLE
fix(notifications): allow conversationMetadata.conversationType to override channel strategy

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -815,6 +815,60 @@ describe("pairDeliveryWithConversation", () => {
     expect(getBindingByChannelChatMock).not.toHaveBeenCalled();
   });
 
+  // ── conversationMetadata.conversationType override ─────────────────
+
+  test("uses conversationMetadata.conversationType when set, overriding channel strategy", async () => {
+    const signal = makeSignal({
+      conversationMetadata: {
+        source: "heartbeat",
+        groupId: "system:background",
+        conversationType: "background",
+      },
+    });
+    const copy = makeCopy({ conversationTitle: "Heartbeat Alert" });
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.strategy).toBe("start_new_conversation");
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    // vellum channel normally yields "standard", but the metadata override wins
+    expect(callArgs.conversationType).toBe("background");
+  });
+
+  test("falls back to channel strategy when conversationMetadata.conversationType is not set", async () => {
+    const signal = makeSignal({
+      conversationMetadata: {
+        source: "scheduler",
+        groupId: "group-1",
+      },
+    });
+    const copy = makeCopy();
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    const callArgs = createConversationMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    // No override — vellum (start_new_conversation) defaults to "standard"
+    expect(callArgs.conversationType).toBe("standard");
+  });
+
   // ── not_deliverable (voice) ───────────────────────────────────────
 
   test("returns null conversationId and messageId for not_deliverable strategy", async () => {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -262,6 +262,11 @@ export class HeartbeatService {
               isAsyncBackground: true,
               visibleInSourceNow: false,
             },
+            conversationMetadata: {
+              source: "heartbeat",
+              groupId: "system:background",
+              conversationType: "background",
+            },
           }).catch((err) => {
             log.warn(
               { err },
@@ -648,6 +653,7 @@ export class HeartbeatService {
           conversationMetadata: {
             source: "heartbeat",
             groupId: "system:background",
+            conversationType: "background",
           },
         });
       } catch (err) {
@@ -714,6 +720,7 @@ export class HeartbeatService {
       conversationMetadata: {
         source: "heartbeat",
         groupId: "system:background",
+        conversationType: "background",
       },
     });
   }

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -120,7 +120,8 @@ export async function pairDeliveryWithConversation(
     // Channels with continue_existing_conversation reuse bound external conversations
     // and mark them as background so they don't clutter the sidebar UI.
     const conversationType =
-      strategy === "start_new_conversation" ? "standard" : "background";
+      signal.conversationMetadata?.conversationType ??
+      (strategy === "start_new_conversation" ? "standard" : "background");
 
     // Prefer model-provided conversationSeedMessage when present and sane;
     // fall back to the runtime composer which adapts verbosity to the

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -13,6 +13,7 @@ import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import type { ConversationCreateType } from "../memory/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
 import { type BroadcastFn, VellumAdapter } from "./adapters/macos.js";
 import { PlatformPushAdapter } from "./adapters/platform.js";
@@ -204,6 +205,7 @@ export interface EmitSignalParams<TEventName extends string = string> {
     groupId?: string;
     scheduleJobId?: string;
     source?: string;
+    conversationType?: ConversationCreateType;
   };
 }
 

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -4,6 +4,7 @@
  * decision engine route contextually.
  */
 
+import type { ConversationCreateType } from "../memory/conversation-crud.js";
 import type { GuardianQuestionPayload } from "./guardian-question-mode.js";
 
 // ── Source channel registry ────────────────────────────────────────────
@@ -214,5 +215,6 @@ export interface NotificationSignal<TEventName extends string = string> {
     groupId?: string;
     scheduleJobId?: string;
     source?: string;
+    conversationType?: ConversationCreateType;
   };
 }


### PR DESCRIPTION
## Summary
Heartbeat alert conversations routed through the notification pipeline were getting `conversationType: "standard"` (from the vellum channel's `start_new_conversation` strategy) despite having `conversationMetadata.groupId: "system:background"`. Since `listConversations`, `countConversations`, and `searchConversations` filter by `conversationType` only — not `groupId` — these conversations were excluded from background fetches, competed with regular foreground conversations, and leaked into search results.

This adds an optional `conversationType` field to `conversationMetadata` that overrides the channel-derived default, and updates all three heartbeat alert signal emissions to use `conversationType: "background"`.

## Changes
- Added `conversationType?: ConversationCreateType` to `conversationMetadata` in `NotificationSignal` and `EmitSignalParams`
- Updated `conversation-pairing.ts` to check `signal.conversationMetadata?.conversationType` via nullish coalescing before falling back to channel strategy
- Added `conversationType: "background"` to all three heartbeat signal emissions (credential health alert, heartbeat alert, startup missed-heartbeat)
- Added tests verifying the override behavior and backward compatibility

## Milestone PRs (merged into feature branch)
- #30626: fix(notifications): allow conversationMetadata.conversationType to override channel strategy

## Project issue
Closes #30623

## Test plan
- [ ] Verify heartbeat alert conversations now get `conversationType: "background"` instead of "standard"
- [ ] Verify existing notification signals without `conversationType` in metadata still use channel strategy default
- [ ] Run conversation-pairing tests: `cd assistant && bun test src/__tests__/conversation-pairing.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->