### PR TITLE
apps/: scaffold landing zone for unified app surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 Bun + TypeScript monorepo with multiple packages:
 
+- `apps/` — End-user app surfaces (web, iOS, macOS/Electron, Chrome extension). Scaffolding-only today; surfaces will move here in follow-up PRs. See `apps/AGENTS.md`.
 - `assistant/` — Main backend service (Bun + TypeScript)
 - `cli/` — Multi-assistant management CLI (Bun + TypeScript). See `cli/AGENTS.md`.
 - `clients/` — Client apps (macOS, browser extension, etc). See `clients/AGENTS.md` and platform docs like `clients/macos/AGENTS.md`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Assistant runtime                           | [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md)                                           |
 | Gateway ingress/webhooks                    | [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md)                                               |
 | Clients (macOS, browser extension)          | [`clients/ARCHITECTURE.md`](clients/ARCHITECTURE.md)                                               |
+| Apps (end-user surfaces, scaffold)          | [`apps/README.md`](apps/README.md)                                                                 |
 | Assistant memory deep dive                  | [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md)                   |
 | Assistant integrations deep dive            | [`assistant/docs/architecture/integrations.md`](assistant/docs/architecture/integrations.md)       |
 | Assistant scheduling deep dive              | [`assistant/docs/architecture/scheduling.md`](assistant/docs/architecture/scheduling.md)           |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ bun run typecheck
 | `gateway/` | Public ingress — webhooks, API routes, OAuth callbacks |
 | `cli/` | The `vellum` CLI |
 | `clients/` | Native clients (macOS) and browser extension |
+| `apps/` | End-user app surfaces (web, iOS, macOS/Electron, Chrome extension) — scaffold |
 | `credential-executor/` | Isolated credential execution service |
 | `packages/` | Shared internal packages |
 | `skills/` | Skill definitions |

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,0 +1,19 @@
+# apps/ — Agent Guidance
+
+Applies to all code under `apps/`. Subordinate to root [`AGENTS.md`](../AGENTS.md).
+
+## Conventions
+
+- Each subdirectory is its own self-contained Bun package with its own
+  `bun.lock`, `package.json`, `tsconfig.json`, and lint config.
+- No workspaces, no Turborepo. Per-package `bun install`. Exact version
+  pinning is enforced repo-wide; see root `AGENTS.md` for the dependency,
+  license, and tool-version rules.
+- TypeScript imports use `.js` extensions (NodeNext module resolution).
+
+## Adding a new app
+
+When adding a new subdirectory under `apps/`, add a corresponding `paths:`
+glob to relevant PR/CI workflows in `.github/workflows/`, and add an
+appropriate ignore pattern to `.gitignore` if the app produces build
+artifacts.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,38 @@
+# apps/
+
+Home for end-user app surfaces of the Vellum assistant — browser, mobile, and
+desktop wrappers that users interact with directly. This directory is part of
+the ongoing Web App Repo Move; surfaces will be migrated here incrementally in
+follow-up PRs.
+
+## What belongs here
+
+- End-user app surfaces (e.g. the Chrome extension, future web app, iOS
+  Capacitor wrapper, macOS/Electron wrapper).
+
+## What does not belong here
+
+- Shared libraries — these live in `packages/` or `clients/shared/`.
+- Native Swift clients — `clients/macos/` remains the source of truth for the
+  macOS app.
+- The local-daemon web interface — `clients/web/` is an internal control plane
+  served by `vellum client --interface web`, not an end-user surface.
+- Backend services — `assistant/`, `gateway/`, `credential-executor/`, `cli/`
+  stay at the repo root.
+
+## Conventions
+
+- Each app subdirectory is its own self-contained Bun package with its own
+  `bun.lock`, `package.json`, `tsconfig.json`, and lint config — matching the
+  existing pattern used by other TypeScript packages in this repo.
+- No workspaces, no Turborepo. Per-package dependency installs with
+  `bun install`. Exact version pinning (see root [`AGENTS.md`](../AGENTS.md)).
+- When a new app is added under `apps/`, add corresponding `paths:` globs to
+  any relevant PR/CI workflows in `.github/workflows/`.
+
+## Planned moves
+
+The current Chrome extension at `clients/chrome-extension/` is the first
+candidate for relocation under this directory. That move is intentionally
+scoped to a separate follow-up PR so its impact on Chrome Web Store release
+workflows can be reviewed in isolation.


### PR DESCRIPTION
## Prompt / plan

Part of LUM-1541 (Web Move scaffolding in `vellum-assistant`).

This is Phase 1 of a phased plan: introduce an `apps/` directory at the repo root as the future home for end-user app surfaces (browser, mobile, desktop). No code is moved in this PR. The first surface to relocate — the Chrome extension at `clients/chrome-extension/` — will land in a focused follow-up so its impact on Chrome Web Store release workflows can be reviewed in isolation.

### Why this is split into phases

Moving the Chrome extension touches a wide set of release and CI configuration in a single change: `release.yml` (path-based change detection, working directories, artifact paths, CWS `sparse-checkout`), `dev-release.yaml` (per repo convention these two stay in sync), `build-chrome-extension.yaml`, `pr-chrome-extension.yaml`, `ci-main-chrome-extension.yaml`, `create-release-branch.yml`, `socket-autofix.yml`, and `.githooks/pre-push`. The PR workflow is path-filtered on `clients/chrome-extension/**`, so a same-PR move can't exercise the new path filter in CI before merge. Scaffolding-only first lets reviewers ratify the target structure without functional risk; the move PR can then be reviewed on its own merits.

### Why an `apps/` directory at all

A separate `apps/` area gives end-user surfaces (web, iOS Capacitor wrapper, macOS/Electron wrapper, Chrome extension) a single, semantically clear home. `clients/` currently mixes Swift native clients, a Bun-built browser extension, and an internal control-plane web interface; over time `apps/` will own end-user app surfaces and `clients/` will continue to own the native Swift clients.

### What this PR does

- Adds `apps/README.md` describing scope and conventions (what belongs, what doesn't, Bun-native per-package pattern).
- Adds `apps/AGENTS.md`, subordinate to root `AGENTS.md`, capturing per-package conventions (each subdir is its own self-contained Bun package; no workspaces / no Turborepo; exact version pinning; `.js` import extensions per NodeNext).
- Adds one-line entries for `apps/` to:
  - root `AGENTS.md` "Project Structure"
  - `ARCHITECTURE.md` "Architecture Docs" table
  - `CONTRIBUTING.md` project structure table

### What this PR does NOT do

- Does not move `clients/chrome-extension/` (planned follow-up).
- Does not touch `clients/web/` — the local-daemon web interface served by `vellum client --interface web` is an internal control plane, not an end-user surface, and is explicitly out of scope.
- Does not touch the Swift macOS/iOS clients (`clients/macos/`, `clients/shared/`, `clients/Package.swift`).
- Does not modify any `.github/workflows/`, `.gitignore`, `.githooks/`, or `setup.sh`. No CI path filters need updating for an empty-of-code scaffold.

### Alternatives considered and rejected

- **Single PR that also moves the Chrome extension.** Feasible (no other package imports from chrome-extension; it's a leaf), but bundles a wide release-workflow edit with the scaffold. Rejected to keep blast radius small and reviewability high.
- **`apps/.gitkeep` placeholder only, no README/AGENTS.md.** Rejected because the README and AGENTS.md document scope and prevent future drift (e.g. someone moving a shared library or the local-daemon `clients/web/` here by mistake).
- **Workspaces (`bun` workspaces) or Turborepo.** Explicitly out of scope per the task constraints and the existing repo convention — each package owns its own `bun.lock` and runs Bun commands per-package. See root `AGENTS.md` "Development" section.

### Conventions documented in `apps/AGENTS.md`

Lightweight and link-heavy by design: states the per-package Bun rule, points at root `AGENTS.md` for the dependency/license/tool-version specifics rather than restating them. Adding a new app under `apps/` should be accompanied by adding the corresponding `paths:` glob to relevant PR/CI workflows in `.github/workflows/`.

## Test plan

- Docs-only change; no runtime behavior, no TS/Swift source touched.
- Pre-commit hooks ran cleanly on commit (`scripts/check-generic-examples.ts`, plain-text-key scan).
- No path-scoped workflow matches `apps/**`, so the chrome-extension, assistant, gateway, and macOS PR workflows are expected to skip. Generic repo checks should pass unchanged.
- Manual review: `apps/README.md`, `apps/AGENTS.md`, the additions in root `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md`.

## CLI verb checklist

N/A — no new IPC routes.

Link to Devin session: https://app.devin.ai/sessions/b248fca817384acf800388c7e8d82e3c
Requested by: @ashleeradka