### PR TITLE
M3: Handle orphan subagents in history — assign parentMessageId fallback

### DIFF
--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -153,7 +153,6 @@ public enum HistoryReconstructionService {
             }
 
             if role == .assistant {
-                lastAssistantMsgId = chatMsg.id
                 for tc in toolCalls where tc.toolName == "subagent_spawn" {
                     if let result = tc.result,
                        let data = result.data(using: .utf8),
@@ -176,6 +175,10 @@ public enum HistoryReconstructionService {
                 info.error = notification.error
                 reconstructedSubagents.append(info)
                 chatMsg.isSubagentNotification = true
+            }
+
+            if role == .assistant && !chatMsg.isSubagentNotification {
+                lastAssistantMsgId = chatMsg.id
             }
 
             chatMessages.append(chatMsg)

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -28,6 +28,7 @@ public enum HistoryReconstructionService {
         var chatMessages: [ChatMessage] = []
         var reconstructedSubagents: [SubagentInfo] = []
         var spawnParentMap: [String: UUID] = [:]
+        var lastAssistantMsgId: UUID?
 
         for item in historyMessages {
             let role: ChatRole = item.role == "assistant" ? .assistant : .user
@@ -152,6 +153,7 @@ public enum HistoryReconstructionService {
             }
 
             if role == .assistant {
+                lastAssistantMsgId = chatMsg.id
                 for tc in toolCalls where tc.toolName == "subagent_spawn" {
                     if let result = tc.result,
                        let data = result.data(using: .utf8),
@@ -163,11 +165,12 @@ public enum HistoryReconstructionService {
             }
 
             if let notification = item.subagentNotification {
+                let parentId = spawnParentMap[notification.subagentId] ?? lastAssistantMsgId
                 var info = SubagentInfo(
                     id: notification.subagentId,
                     label: notification.label,
                     status: SubagentStatus(wire: notification.status),
-                    parentMessageId: spawnParentMap[notification.subagentId],
+                    parentMessageId: parentId,
                     conversationId: notification.conversationId
                 )
                 info.error = notification.error


### PR DESCRIPTION
After history reconstruction, subagents may have `parentMessageId == nil` if the `subagent_spawn` tool result doesn't survive the daemon's message merge/compaction pipeline. These orphan subagents are silently filtered out by `TranscriptProjector` and never rendered.

Adds a `lastAssistantMsgId` tracker in `HistoryReconstructionService.reconstructMessages()` and uses it as a fallback when `spawnParentMap` lookup returns nil:
```swift
let parentId = spawnParentMap[notification.subagentId] ?? lastAssistantMsgId
```

This ensures the `SubagentGroupContainer` renders after app refresh even when the spawn-notification linkage is broken.

Part of #30613.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->