### PR TITLE
feat(contacts): add guardian manual verify button for contact channels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -256,7 +256,7 @@ struct GuardianChannelsDetailView: View {
         } else if (isGuardian && store?.channelVerificationState(for: type).verified == true)
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
-            if !isGuardian, let channel = existingChannels.first {
+            if showCardBorders && !isGuardian, let channel = existingChannels.first {
                 VButton(label: "Mark Verified", style: .outlined, isDisabled: actionInProgress != nil) {
                     verifyChannel(channelId: channel.id, type: type)
                 }

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -234,6 +234,10 @@ struct GuardianChannelsDetailView: View {
                                 setupExpanded.insert(type)
                             }
                         }
+                    } else if !isGuardian, let channel = existingChannels.first {
+                        VButton(label: "Mark Verified", style: .outlined, isDisabled: actionInProgress != nil) {
+                            verifyChannel(channelId: channel.id, type: type)
+                        }
                     }
                 }
                 .frame(minHeight: 36)
@@ -252,6 +256,11 @@ struct GuardianChannelsDetailView: View {
         } else if (isGuardian && store?.channelVerificationState(for: type).verified == true)
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
+            if !isGuardian, let channel = existingChannels.first {
+                VButton(label: "Mark Verified", style: .outlined, isDisabled: actionInProgress != nil) {
+                    verifyChannel(channelId: channel.id, type: type)
+                }
+            }
             verificationFlowContent(for: type)
         } else {
             VButton(label: setupButtonLabel, style: .outlined) {
@@ -403,9 +412,10 @@ struct GuardianChannelsDetailView: View {
         }
     }
 
-    // MARK: - Disconnect Channel
+    // MARK: - Channel Actions
 
-    private func disconnectChannel(channelId: String, type: String) {
+    /// Runs an async channel action with shared loading/error/refresh handling.
+    private func performChannelAction(channelId: String, type: String, errorLabel: String, action: () async throws -> Void) {
         guard actionInProgress == nil else { return }
         actionInProgress = channelId
         errorMessage = nil
@@ -413,16 +423,28 @@ struct GuardianChannelsDetailView: View {
 
         Task {
             do {
-                _ = try await contactClient.updateContactChannel(channelId: channelId, status: "revoked", policy: nil, reason: nil)
+                try await action()
                 let refreshed = try await contactClient.fetchContact(contactId: displayContact.id)
                 if let refreshed {
                     currentContact = refreshed
                 }
             } catch {
-                errorMessage = "Failed to update channel: \(error.localizedDescription)"
+                errorMessage = "Failed to \(errorLabel) channel: \(error.localizedDescription)"
                 errorChannelType = type
             }
             actionInProgress = nil
+        }
+    }
+
+    private func disconnectChannel(channelId: String, type: String) {
+        performChannelAction(channelId: channelId, type: type, errorLabel: "update") {
+            _ = try await contactClient.updateContactChannel(channelId: channelId, status: "revoked", policy: nil, reason: nil)
+        }
+    }
+
+    private func verifyChannel(channelId: String, type: String) {
+        performChannelAction(channelId: channelId, type: type, errorLabel: "verify") {
+            _ = try await contactClient.verifyContactChannel(channelId: channelId)
         }
     }
 

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -104,6 +104,18 @@ public final class ContactsStore {
         }
     }
 
+    /// Verify a contact channel by ID.
+    public func verifyContactChannel(channelId: String) {
+        Task {
+            do {
+                _ = try await contactClient.verifyContactChannel(channelId: channelId)
+                loadContacts()
+            } catch {
+                // Silently ignore — matches existing updateContactChannel pattern
+            }
+        }
+    }
+
     /// Delete a contact by ID.
     public func deleteContact(id: String) {
         Task {

--- a/clients/shared/Network/ContactClient.swift
+++ b/clients/shared/Network/ContactClient.swift
@@ -34,6 +34,7 @@ public protocol ContactClientProtocol {
     func fetchContact(contactId: String) async throws -> ContactPayload?
     func deleteContact(contactId: String) async throws -> Bool
     func updateContactChannel(channelId: String, status: String?, policy: String?, reason: String?) async throws -> ContactPayload?
+    func verifyContactChannel(channelId: String) async throws -> Bool
 }
 
 /// A channel to attach when creating a new contact.
@@ -254,5 +255,16 @@ public struct ContactClient: ContactClientProtocol {
             throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
         }
         return try JSONDecoder().decode(SingleContactResponse.self, from: response.data).contact
+    }
+
+    public func verifyContactChannel(channelId: String) async throws -> Bool {
+        let response = try await GatewayHTTPClient.post(
+            path: "contact-channels/\(channelId)/verify", json: [:], timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("verifyContactChannel failed (HTTP \(response.statusCode))")
+            throw ContactClientError.httpError(statusCode: response.statusCode, serverMessage: Self.parseServerError(from: response.data))
+        }
+        return true
     }
 }


### PR DESCRIPTION
## Summary
- Add `verifyContactChannel` method to `ContactClientProtocol` and `ContactClient` (POST `/v1/contact-channels/:id/verify`)
- Wire verify action through `ContactsStore`
- Add "Mark Verified" button in `GuardianChannelsDetailView` for non-guardian contacts with unverified channels
- Extract shared `performChannelAction` helper to deduplicate disconnect/verify boilerplate

Part of plan: manual-verify-contact-channel.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->