### PR TITLE
fix: remove dead code from manual verify feature

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -256,11 +256,6 @@ struct GuardianChannelsDetailView: View {
         } else if (isGuardian && store?.channelVerificationState(for: type).verified == true)
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
-            if showCardBorders && !isGuardian, let channel = existingChannels.first {
-                VButton(label: "Mark Verified", style: .outlined, isDisabled: actionInProgress != nil) {
-                    verifyChannel(channelId: channel.id, type: type)
-                }
-            }
             verificationFlowContent(for: type)
         } else {
             VButton(label: setupButtonLabel, style: .outlined) {

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -104,18 +104,6 @@ public final class ContactsStore {
         }
     }
 
-    /// Verify a contact channel by ID.
-    public func verifyContactChannel(channelId: String) {
-        Task {
-            do {
-                _ = try await contactClient.verifyContactChannel(channelId: channelId)
-                loadContacts()
-            } catch {
-                // Silently ignore — matches existing updateContactChannel pattern
-            }
-        }
-    }
-
     /// Delete a contact by ID.
     public func deleteContact(id: String) {
         Task {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for manual-verify-contact-channel.md.

- Remove unused `ContactsStore.verifyContactChannel` method (the view calls the client directly, matching the existing `disconnectChannel` pattern)
- Remove unreachable "Mark Verified" button in `channelCardContent` (`showCardBorders` is always `false` for non-guardian contacts)

Part of plan: manual-verify-contact-channel.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->