### PR TITLE
fix: return error from document_update when surface_id is invalid

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -89,7 +89,7 @@ export function updateDocumentContent(
   surfaceId: string,
   markdown: string,
   mode: string,
-): void {
+): { success: true } | { success: false; error: string } {
   try {
     const existing = rawGet<{ content: string }>(
       /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
@@ -97,7 +97,7 @@ export function updateDocumentContent(
     );
     if (!existing) {
       log.info({ surfaceId }, "No persisted document to update");
-      return;
+      return { success: false, error: "Document not found" };
     }
     const sep = mode === "append" && existing.content.length > 0 ? "\n\n" : "";
     const newContent =
@@ -113,7 +113,12 @@ export function updateDocumentContent(
       surfaceId,
     );
     log.info({ surfaceId, mode }, "Updated document content");
+    return { success: true };
   } catch (error) {
     log.error({ err: error, surfaceId }, "Document content update error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 }

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -85,7 +85,17 @@ export function executeDocumentUpdate(
   const content = input.content as string;
   const mode = (input.mode as string | undefined) || "append";
 
-  updateDocumentContent(surfaceId, content, mode);
+  const result = updateDocumentContent(surfaceId, content, mode);
+  if (!result.success) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: result.error,
+      }),
+      isError: true,
+    };
+  }
 
   // Send document_editor_update message to update the built-in RTE
   if (context.sendToClient) {


### PR DESCRIPTION
## Summary
- Change updateDocumentContent to return success/error result instead of void
- Update executeDocumentUpdate to propagate errors when surface_id is invalid
- Invalid surface_ids now return isError: true with descriptive message

Part of plan: doc-editor-persist.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->