### PR TITLE
refactor: extract getDocumentById, getDocumentsForConversation, deleteDocument into document-store

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -5,10 +5,25 @@
  * background jobs (e.g. proactive artifact generation) can persist documents
  * without going through the HTTP layer.
  */
-import { rawGet, rawRun } from "../memory/raw-query.js";
+import { rawAll, rawGet, rawRun } from "../memory/raw-query.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("document-store");
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/** A document record with camelCase field names, mapped from the SQLite row. */
+export interface DocumentRecord {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
 
 // ---------------------------------------------------------------------------
 // Junction table helper
@@ -25,6 +40,118 @@ export function addDocumentConversation(
     conversationId,
     Date.now(),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Shared query helpers
+// ---------------------------------------------------------------------------
+
+interface DocumentRow {
+  surface_id: string;
+  conversation_id: string;
+  title: string;
+  content: string;
+  word_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+type DocumentListRow = Omit<DocumentRow, "content">;
+
+function mapRowToRecord(row: DocumentRow): DocumentRecord {
+  return {
+    surfaceId: row.surface_id,
+    conversationId: row.conversation_id,
+    title: row.title,
+    content: row.content,
+    wordCount: row.word_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Look up a single document by surface ID. Returns `null` when not found. */
+export function getDocumentById(surfaceId: string): DocumentRecord | null {
+  try {
+    const row = rawGet<DocumentRow>(
+      /*sql*/ `SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
+       FROM documents
+       WHERE surface_id = ?`,
+      surfaceId,
+    );
+
+    if (!row) {
+      log.info({ surfaceId }, "Document not found");
+      return null;
+    }
+
+    log.info({ surfaceId }, "Loaded document");
+    return mapRowToRecord(row);
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Load error");
+    return null;
+  }
+}
+
+/**
+ * List documents for a given conversation (via the junction table).
+ * Returns an empty array when the conversation has no documents or on error.
+ */
+export function getDocumentsForConversation(
+  conversationId: string,
+): Omit<DocumentRecord, "content">[] {
+  try {
+    const rows = rawAll<DocumentListRow>(
+      /*sql*/ `
+      SELECT d.surface_id, dc.conversation_id AS conversation_id,
+             d.title, d.word_count, d.created_at, d.updated_at
+      FROM documents d
+      INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
+      WHERE dc.conversation_id = ?
+      ORDER BY d.updated_at DESC
+      `,
+      conversationId,
+    );
+
+    log.info(
+      { conversationId, count: rows.length },
+      "Listed documents for conversation",
+    );
+    return rows.map((row) => ({
+      surfaceId: row.surface_id,
+      conversationId: row.conversation_id,
+      title: row.title,
+      wordCount: row.word_count,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  } catch (error) {
+    log.error({ err: error, conversationId }, "List error");
+    return [];
+  }
+}
+
+/**
+ * Delete a document and its conversation associations.
+ * Returns `true` if the document existed and was deleted, `false` otherwise.
+ */
+export function deleteDocument(surfaceId: string): boolean {
+  try {
+    const changes = rawRun(
+      /*sql*/ `DELETE FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    rawRun(
+      /*sql*/ `DELETE FROM document_conversations WHERE surface_id = ?`,
+      surfaceId,
+    );
+    const existed = changes > 0;
+    log.info({ surfaceId, existed }, "Deleted document");
+    return existed;
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Delete error");
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -6,8 +6,12 @@
  */
 import { z } from "zod";
 
-import { saveDocument } from "../../documents/document-store.js";
-import { rawAll, rawGet } from "../../memory/raw-query.js";
+import {
+  getDocumentById,
+  getDocumentsForConversation,
+  saveDocument,
+} from "../../documents/document-store.js";
+import { rawAll } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -16,65 +20,16 @@ import { RouteResponse } from "./types.js";
 
 const log = getLogger("documents-routes");
 
-interface DocumentRow {
+interface DocumentListRow {
   surface_id: string;
   conversation_id: string;
   title: string;
-  content: string;
   word_count: number;
   created_at: number;
   updated_at: number;
 }
 
-type DocumentListRow = Omit<DocumentRow, "content">;
-
-function loadDocument(surfaceId: string):
-  | {
-      success: true;
-      surfaceId: string;
-      conversationId: string;
-      title: string;
-      content: string;
-      wordCount: number;
-      createdAt: number;
-      updatedAt: number;
-    }
-  | { success: false; error: string } {
-  try {
-    const result = rawGet<DocumentRow>(
-      /*sql*/ `
-      SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
-      FROM documents
-      WHERE surface_id = ?
-    `,
-      surfaceId,
-    );
-
-    if (result) {
-      log.info({ surfaceId }, "Loaded document");
-      return {
-        success: true,
-        surfaceId: result.surface_id,
-        conversationId: result.conversation_id,
-        title: result.title,
-        content: result.content,
-        wordCount: result.word_count,
-        createdAt: result.created_at,
-        updatedAt: result.updated_at,
-      };
-    }
-    log.info({ surfaceId }, "Document not found");
-    return { success: false, error: "Document not found" };
-  } catch (error) {
-    log.error({ err: error, surfaceId }, "Load error");
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
-
-function listDocuments(conversationId?: string): Array<{
+function listAllDocuments(): Array<{
   surfaceId: string;
   conversationId: string;
   title: string;
@@ -83,29 +38,11 @@ function listDocuments(conversationId?: string): Array<{
   updatedAt: number;
 }> {
   try {
-    let results: DocumentListRow[];
-
-    if (conversationId) {
-      // Query via junction table so we return the *matched* conversation_id
-      // (not the origin conversation_id from the documents table).
-      results = rawAll<DocumentListRow>(
-        /*sql*/ `
-        SELECT d.surface_id, dc.conversation_id AS conversation_id,
-               d.title, d.word_count, d.created_at, d.updated_at
-        FROM documents d
-        INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
-        WHERE dc.conversation_id = ?
-        ORDER BY d.updated_at DESC
-        `,
-        conversationId,
-      );
-    } else {
-      results = rawAll<DocumentListRow>(/*sql*/ `
-        SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
-        FROM documents
-        ORDER BY updated_at DESC
-        `);
-    }
+    const results = rawAll<DocumentListRow>(/*sql*/ `
+      SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
+      FROM documents
+      ORDER BY updated_at DESC
+      `);
 
     log.info({ count: results.length }, "Listed documents");
     return results.map((row) => ({
@@ -148,7 +85,9 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ queryParams }) => {
       const conversationId = queryParams?.conversationId ?? undefined;
-      const documents = listDocuments(conversationId);
+      const documents = conversationId
+        ? getDocumentsForConversation(conversationId)
+        : listAllDocuments();
       return { documents };
     },
   },
@@ -173,11 +112,11 @@ export const ROUTES: RouteDefinition[] = [
       updatedAt: z.number(),
     }),
     handler: ({ pathParams }) => {
-      const result = loadDocument(pathParams!.id);
-      if (!result.success) {
-        throw new NotFoundError(result.error);
+      const doc = getDocumentById(pathParams!.id);
+      if (!doc) {
+        throw new NotFoundError("Document not found");
       }
-      return result;
+      return { success: true, ...doc };
     },
   },
 
@@ -252,13 +191,13 @@ export const ROUTES: RouteDefinition[] = [
     description: "Render a document to PDF and return the binary content.",
     tags: ["documents"],
     handler: async ({ pathParams }) => {
-      const result = loadDocument(pathParams!.id);
-      if (!result.success) {
-        throw new NotFoundError(result.error);
+      const doc = getDocumentById(pathParams!.id);
+      if (!doc) {
+        throw new NotFoundError("Document not found");
       }
-      const pdfBuffer = await renderMarkdownToPDF(result.title, result.content);
+      const pdfBuffer = await renderMarkdownToPDF(doc.title, doc.content);
       const filename =
-        result.title
+        doc.title
           .replace(/[^a-zA-Z0-9_-]/g, "-")
           .replace(/-+/g, "-")
           .replace(/^-|-$/g, "") || "document";


### PR DESCRIPTION
## Summary
- Extract shared document query functions (getDocumentById, getDocumentsForConversation, deleteDocument) from route handlers into document-store.ts
- Refactor documents-routes.ts to use shared functions instead of inline queries
- No behavioral changes to existing HTTP routes

Part of JARVIS-829
Part of plan: doc-editor-persist.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->