### PR TITLE
feat: add document_read tool to retrieve document content by surface_id

### DIFF
--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -18,6 +18,7 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
+- **document_read** - Reads the current content of a document by `surface_id`. Use to verify content before editing.
 
 ## Workflow
 

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -48,6 +48,24 @@
       },
       "executor": "tools/document-update.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "document_read",
+      "description": "Read the current content of an open document by its surface_id. Use this to verify document state before making edits.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The ID of the document to read"
+          }
+        },
+        "required": ["surface_id"]
+      },
+      "executor": "tools/document-read.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/document/tools/document-read.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-read.ts
@@ -1,0 +1,12 @@
+import { executeDocumentRead } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentRead(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -52,6 +52,7 @@ import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.j
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
+import * as documentRead from "./bundled-skills/document/tools/document-read.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
@@ -168,6 +169,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // document
   ["document:tools/document-create.ts", documentCreate],
+  ["document:tools/document-read.ts", documentRead],
   ["document:tools/document-update.ts", documentUpdate],
 
   // followups

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  getDocumentById,
   saveDocument,
   updateDocumentContent,
 } from "../../documents/document-store.js";
@@ -125,5 +126,34 @@ export function executeDocumentUpdate(
       error: "No client connected to update document",
     }),
     isError: true,
+  };
+}
+
+export function executeDocumentRead(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const doc = getDocumentById(surfaceId);
+  if (!doc) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: "Document not found",
+      }),
+      isError: true,
+    };
+  }
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: doc.surfaceId,
+      title: doc.title,
+      content: doc.content,
+      word_count: doc.wordCount,
+      updated_at: doc.updatedAt,
+    }),
+    isError: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add document_read tool that retrieves document content, title, word count by surface_id
- Returns isError: true with 'Document not found' for invalid surface_ids
- Registered in the document bundled skill alongside document_create and document_update

Part of plan: doc-editor-persist.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->