### PR TITLE
feat: add document_list and document_delete tools for discovery and cleanup

### DIFF
--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -18,6 +18,8 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
+- **document_list** - Lists all documents in the current conversation with their surface_ids, titles, and word counts.
+- **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
 ## Workflow
 

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -48,6 +48,36 @@
       },
       "executor": "tools/document-update.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "document_list",
+      "description": "List all documents in the current conversation.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "executor": "tools/document-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "document_delete",
+      "description": "Delete a document by its surface_id.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The ID of the document to delete"
+          }
+        },
+        "required": ["surface_id"]
+      },
+      "executor": "tools/document-delete.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/document/tools/document-delete.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-delete.ts
@@ -1,0 +1,12 @@
+import { executeDocumentDelete } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/document/tools/document-list.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-list.ts
@@ -1,0 +1,12 @@
+import { executeDocumentList } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentList(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -52,6 +52,8 @@ import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.j
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
+import * as documentDelete from "./bundled-skills/document/tools/document-delete.js";
+import * as documentList from "./bundled-skills/document/tools/document-list.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
@@ -168,6 +170,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // document
   ["document:tools/document-create.ts", documentCreate],
+  ["document:tools/document-delete.ts", documentDelete],
+  ["document:tools/document-list.ts", documentList],
   ["document:tools/document-update.ts", documentUpdate],
 
   // followups

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  deleteDocument,
+  getDocumentsForConversation,
   saveDocument,
   updateDocumentContent,
 } from "../../documents/document-store.js";
@@ -125,5 +127,51 @@ export function executeDocumentUpdate(
       error: "No client connected to update document",
     }),
     isError: true,
+  };
+}
+
+export function executeDocumentList(
+  _input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const docs = getDocumentsForConversation(context.conversationId);
+  return {
+    content: JSON.stringify({
+      success: true,
+      documents: docs.map((d) => ({
+        surface_id: d.surfaceId,
+        title: d.title,
+        word_count: d.wordCount,
+        created_at: d.createdAt,
+        updated_at: d.updatedAt,
+      })),
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentDelete(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const deleted = deleteDocument(surfaceId);
+  if (!deleted) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: "Document not found",
+      }),
+      isError: true,
+    };
+  }
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: surfaceId,
+      message: "Document deleted",
+    }),
+    isError: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add document_list tool that returns all documents in the current conversation
- Add document_delete tool that removes a document by surface_id with proper error handling
- Both tools registered in the document bundled skill

Part of plan: doc-editor-persist.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->