### PR TITLE
feat: inject active document state into per-turn context so assistant can target existing docs

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -42,12 +42,10 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
-const { applyRuntimeInjections, composeInjectorChain } = await import(
-  "../daemon/conversation-runtime-assembly.js"
-);
-const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } = await import(
-  "../plugins/defaults/injectors.js"
-);
+const { applyRuntimeInjections, composeInjectorChain } =
+  await import("../daemon/conversation-runtime-assembly.js");
+const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
+  await import("../plugins/defaults/injectors.js");
 import {
   getInjectors,
   registerPlugin,
@@ -90,7 +88,7 @@ describe("injector chain", () => {
     resetPluginRegistryForTests();
   });
 
-  test("defaultInjectorsPlugin registers the ten defaults in the documented order", () => {
+  test("defaultInjectorsPlugin registers the defaults in the documented order", () => {
     registerPlugin(defaultInjectorsPlugin);
 
     const names = getInjectors().map((i) => i.name);
@@ -102,6 +100,7 @@ describe("injector chain", () => {
       "pkb-reminder",
       "memory-v2-static",
       "now-md",
+      "active-documents",
       "subagent-status",
       "slack-messages",
       "thread-focus",
@@ -158,6 +157,7 @@ describe("injector chain", () => {
       "pkb-reminder", // 35
       "memory-v2-static", // 38
       "now-md", // 40
+      "active-documents", // 45
       "subagent-status", // 50
       "slack-messages", // 60
       "thread-focus", // 70

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -42,6 +42,7 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
+import { getDocumentsForConversation } from "../documents/document-store.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { writeRelationshipState } from "../home/relationship-state-writer.js";
 import {
@@ -1350,6 +1351,20 @@ export async function runAgentLoopImpl(
       }
     }
 
+    // Query active documents for this conversation so the injector chain
+    // can surface them to the assistant (prevents duplicate document_create
+    // calls when existing documents should be targeted with document_update).
+    const conversationDocs = getDocumentsForConversation(ctx.conversationId);
+    const activeDocuments =
+      conversationDocs.length > 0
+        ? conversationDocs.map((d) => ({
+            surfaceId: d.surfaceId,
+            title: d.title,
+            wordCount: d.wordCount,
+            updatedAt: d.updatedAt,
+          }))
+        : null;
+
     ctx.refreshWorkspaceTopLevelContextIfNeeded();
 
     // Compute fresh turn timestamp for date grounding.
@@ -1561,6 +1576,7 @@ export async function runAgentLoopImpl(
     const injectionOpts = {
       diskPressureContext,
       activeSurface,
+      activeDocuments,
       workspaceTopLevelContext: shouldInjectWorkspace
         ? ctx.workspaceTopLevelContext
         : null,

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -19,6 +19,7 @@
  * | `pkb-reminder`           | 35    | after-memory-prefix     |
  * | `memory-v2-static`       | 38    | after-memory-prefix     |
  * | `now-md`                 | 40    | after-memory-prefix     |
+ * | `active-documents`       | 45    | prepend-user-tail       |
  * | `subagent-status`        | 50    | append-user-tail        |
  * | `slack-messages`         | 60    | replace-run-messages    |
  * | `thread-focus`           | 70    | append-user-tail        |
@@ -91,6 +92,7 @@ export const DEFAULT_INJECTOR_ORDER = {
   pkbReminder: 35,
   memoryV2Static: 38,
   nowMd: 40,
+  activeDocuments: 45,
   subagentStatus: 50,
   slackMessages: 60,
   threadFocus: 70,
@@ -439,6 +441,39 @@ const nowMdInjector: Injector = {
 };
 
 /**
+ * `active-documents` injector — order 45, prepend-user-tail.
+ *
+ * Injects an `<active_documents>` block listing open documents in the
+ * conversation so the assistant can target them with `document_update`
+ * instead of creating duplicates via `document_create`.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `activeDocuments` has at least one entry.
+ */
+const activeDocumentsInjector: Injector = {
+  name: "active-documents",
+  order: DEFAULT_INJECTOR_ORDER.activeDocuments,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const docs = inputs.activeDocuments;
+    if (!docs || docs.length === 0) return null;
+    const lines = docs.map(
+      (d) =>
+        `- surface_id: "${d.surfaceId}", title: "${d.title}", words: ${d.wordCount}`,
+    );
+    const text = `<active_documents>\nThe following documents are open in this conversation. Use document_update with the surface_id to edit them — do NOT call document_create for documents that already exist.\n${lines.join("\n")}\n</active_documents>`;
+    return {
+      id: "active-documents",
+      text,
+      placement: "prepend-user-tail",
+    };
+  },
+};
+
+/**
  * `subagent-status` injector — order 50, append-user-tail.
  *
  * Appends a pre-built `<active_subagents>` block to the tail user message
@@ -571,6 +606,7 @@ export const defaultInjectorsPlugin: Plugin = {
     pkbReminderInjector,
     memoryV2StaticInjector,
     nowMdInjector,
+    activeDocumentsInjector,
     subagentStatusInjector,
     slackMessagesInjector,
     threadFocusInjector,

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -835,6 +835,17 @@ export interface TurnInjectionInputs {
    * knows no human is present to answer clarification questions.
    */
   readonly isNonInteractive?: boolean;
+  /**
+   * Active documents open in this conversation — surfaced by the
+   * `active-documents` injector so the assistant can target existing docs
+   * with `document_update` instead of creating duplicates.
+   */
+  readonly activeDocuments?: ReadonlyArray<{
+    surfaceId: string;
+    title: string;
+    wordCount: number;
+    updatedAt: number;
+  }> | null;
 }
 
 export interface DiskPressureInjectionContext {
@@ -1066,9 +1077,7 @@ export interface PluginSkillRegistration {
  * Unknown keys are populated by the loader for forward compatibility
  * but are not invoked by today's runtime.
  */
-export type PluginHookFn<TCtx = unknown> = (
-  ctx: TCtx,
-) => Promise<TCtx | void>;
+export type PluginHookFn<TCtx = unknown> = (ctx: TCtx) => Promise<TCtx | void>;
 
 /**
  * Map of lifecycle hooks contributed by a plugin. Keys match file


### PR DESCRIPTION
## Summary
- Add activeDocuments field to TurnInjectionInputs for passing document state to the injector chain
- Create active-documents injector (order 45) that emits an <active_documents> block listing open documents with their surface_ids
- Wire up conversation-agent-loop to query documents for the conversation and pass them to injection opts

This is the core fix for the document editor surface_id persistence issue — assistants now see which documents are open and can target them with document_update instead of creating duplicates.

Part of plan: doc-editor-persist.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->