### PR TITLE
fix: wire activeDocuments through RuntimeInjectionOptions and buildTurnInjectionInputs

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1989,6 +1989,7 @@ export interface RuntimeInjectionOptions {
    * `undefined` when the inbound is a top-level (non-thread) post.
    */
   slackActiveThreadFocusBlock?: string | null;
+  activeDocuments?: TurnInjectionInputs["activeDocuments"];
   mode?: InjectionMode;
   /**
    * Per-turn {@link TurnContext} forwarded to plugin-registered
@@ -2042,6 +2043,7 @@ function buildTurnInjectionInputs(
     voiceCallControlPrompt: options.voiceCallControlPrompt,
     transportHints: options.transportHints,
     isNonInteractive: options.isNonInteractive,
+    activeDocuments: options.activeDocuments,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes critical gap where activeDocuments was computed in the agent loop but never reached the injector because:
1. RuntimeInjectionOptions didn't declare the field
2. buildTurnInjectionInputs() didn't map it through

Without this fix, the active-documents injector always receives undefined and silently returns null.

Part of plan: doc-editor-persist.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->