### PR TITLE
feat: fix document editor surface_id persistence across turns (JARVIS-829)

### DIFF
--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -42,12 +42,10 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
-const { applyRuntimeInjections, composeInjectorChain } = await import(
-  "../daemon/conversation-runtime-assembly.js"
-);
-const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } = await import(
-  "../plugins/defaults/injectors.js"
-);
+const { applyRuntimeInjections, composeInjectorChain } =
+  await import("../daemon/conversation-runtime-assembly.js");
+const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
+  await import("../plugins/defaults/injectors.js");
 import {
   getInjectors,
   registerPlugin,
@@ -90,7 +88,7 @@ describe("injector chain", () => {
     resetPluginRegistryForTests();
   });
 
-  test("defaultInjectorsPlugin registers the ten defaults in the documented order", () => {
+  test("defaultInjectorsPlugin registers the defaults in the documented order", () => {
     registerPlugin(defaultInjectorsPlugin);
 
     const names = getInjectors().map((i) => i.name);
@@ -102,6 +100,7 @@ describe("injector chain", () => {
       "pkb-reminder",
       "memory-v2-static",
       "now-md",
+      "active-documents",
       "subagent-status",
       "slack-messages",
       "thread-focus",
@@ -158,6 +157,7 @@ describe("injector chain", () => {
       "pkb-reminder", // 35
       "memory-v2-static", // 38
       "now-md", // 40
+      "active-documents", // 45
       "subagent-status", // 50
       "slack-messages", // 60
       "thread-focus", // 70

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -126,6 +126,9 @@ describe("injector chain", () => {
       DEFAULT_INJECTOR_ORDER.memoryV2Static,
     );
     expect(byName.get("now-md")).toBe(DEFAULT_INJECTOR_ORDER.nowMd);
+    expect(byName.get("active-documents")).toBe(
+      DEFAULT_INJECTOR_ORDER.activeDocuments,
+    );
     expect(byName.get("subagent-status")).toBe(
       DEFAULT_INJECTOR_ORDER.subagentStatus,
     );

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -22,12 +22,28 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 - **document_list** - Lists all documents in the current conversation with their surface_ids, titles, and word counts.
 - **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
-## Workflow
+## Retrieving existing documents
+
+When the user asks to see, open, or pull up a document from this conversation:
+
+1. Check the `<active_documents>` block in your context — it lists all documents in this conversation with their `surface_id` and title.
+2. Call `document_read` with the matching `surface_id`. This is a single tool call — do NOT search files, conversations, or archives.
+3. If no `<active_documents>` block is present, call `document_list` to discover documents in this conversation.
+
+**Never** search the filesystem, conversation history, or archives to find a document that was created with the document editor. Always use `document_read` or `document_list`.
+
+## Creating a new document
 
 1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
 2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, *italic*, code blocks, tables, lists, blockquotes as appropriate.
 3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. The user experiences real-time content appearing as you write.
-4. **Respond to edits**: When the user requests changes via the docked chat, use `document_update` with `replace` for full rewrites or `append` for additions.
+
+## Editing an existing document
+
+When the user requests changes to a document:
+1. Find the `surface_id` from the `<active_documents>` context block.
+2. Use `document_update` with the existing `surface_id` — do NOT call `document_create` again.
+3. Use `mode: "replace"` for full rewrites or `mode: "append"` for additions.
 
 ## Usage Notes
 

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -18,6 +18,7 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
+- **document_read** - Reads the current content of a document by `surface_id`. Use to verify content before editing.
 
 ## Workflow
 

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -19,6 +19,8 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
 - **document_read** - Reads the current content of a document by `surface_id`. Use to verify content before editing.
+- **document_list** - Lists all documents in the current conversation with their surface_ids, titles, and word counts.
+- **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
 ## Workflow
 

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -19,18 +19,18 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
 - **document_read** - Reads the current content of a document by `surface_id`. Use to verify content before editing.
-- **document_list** - Lists all documents in the current conversation with their surface_ids, titles, and word counts.
+- **document_list** - Lists documents. Without `query`, lists the current conversation's documents. With `query`, searches all documents by title across all conversations.
 - **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
 ## Retrieving existing documents
 
-When the user asks to see, open, or pull up a document from this conversation:
+When the user asks to see, open, or pull up a document:
 
-1. Check the `<active_documents>` block in your context — it lists all documents in this conversation with their `surface_id` and title.
-2. Call `document_read` with the matching `surface_id`. This is a single tool call — do NOT search files, conversations, or archives.
-3. If no `<active_documents>` block is present, call `document_list` to discover documents in this conversation.
+1. Check the `<active_documents>` block in your context — it lists all documents in this conversation with their `surface_id` and title. If the document is there, call `document_read` with its `surface_id`. Done in one call.
+2. If the document is NOT in `<active_documents>`, call `document_list` with a `query` matching the document title. This searches across all conversations and previous sessions.
+3. Once you have the `surface_id`, call `document_read` to retrieve the content.
 
-**Never** search the filesystem, conversation history, or archives to find a document that was created with the document editor. Always use `document_read` or `document_list`.
+**Never** search the filesystem, conversation history, or archives to find a document. Always use `document_list` with a `query`.
 
 ## Creating a new document
 

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -48,6 +48,24 @@
       },
       "executor": "tools/document-update.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "document_read",
+      "description": "Read the current content of an open document by its surface_id. Use this to verify document state before making edits.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The ID of the document to read"
+          }
+        },
+        "required": ["surface_id"]
+      },
+      "executor": "tools/document-read.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -66,6 +66,36 @@
       },
       "executor": "tools/document-read.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "document_list",
+      "description": "List all documents in the current conversation.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "executor": "tools/document-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "document_delete",
+      "description": "Delete a document by its surface_id.",
+      "category": "document",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The ID of the document to delete"
+          }
+        },
+        "required": ["surface_id"]
+      },
+      "executor": "tools/document-delete.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -69,12 +69,17 @@
     },
     {
       "name": "document_list",
-      "description": "List all documents in the current conversation.",
+      "description": "List documents. Without a query, lists documents in the current conversation. With a query, searches all documents by title across all conversations.",
       "category": "document",
       "risk": "low",
       "input_schema": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search documents by title across all conversations. Omit to list only the current conversation's documents."
+          }
+        }
       },
       "executor": "tools/document-list.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/document/tools/document-delete.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-delete.ts
@@ -1,0 +1,12 @@
+import { executeDocumentDelete } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentDelete(input, context);
+}

--- a/assistant/src/config/bundled-skills/document/tools/document-list.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-list.ts
@@ -1,0 +1,12 @@
+import { executeDocumentList } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentList(input, context);
+}

--- a/assistant/src/config/bundled-skills/document/tools/document-read.ts
+++ b/assistant/src/config/bundled-skills/document/tools/document-read.ts
@@ -1,0 +1,12 @@
+import { executeDocumentRead } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentRead(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -52,6 +52,7 @@ import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.j
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
+import * as documentRead from "./bundled-skills/document/tools/document-read.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
@@ -168,6 +169,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // document
   ["document:tools/document-create.ts", documentCreate],
+  ["document:tools/document-read.ts", documentRead],
   ["document:tools/document-update.ts", documentUpdate],
 
   // followups

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -52,6 +52,8 @@ import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.j
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
+import * as documentDelete from "./bundled-skills/document/tools/document-delete.js";
+import * as documentList from "./bundled-skills/document/tools/document-list.js";
 import * as documentRead from "./bundled-skills/document/tools/document-read.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
@@ -169,6 +171,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // document
   ["document:tools/document-create.ts", documentCreate],
+  ["document:tools/document-delete.ts", documentDelete],
+  ["document:tools/document-list.ts", documentList],
   ["document:tools/document-read.ts", documentRead],
   ["document:tools/document-update.ts", documentUpdate],
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -42,6 +42,7 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
+import { getDocumentsForConversation } from "../documents/document-store.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { writeRelationshipState } from "../home/relationship-state-writer.js";
 import {
@@ -1350,6 +1351,20 @@ export async function runAgentLoopImpl(
       }
     }
 
+    // Query active documents for this conversation so the injector chain
+    // can surface them to the assistant (prevents duplicate document_create
+    // calls when existing documents should be targeted with document_update).
+    const conversationDocs = getDocumentsForConversation(ctx.conversationId);
+    const activeDocuments =
+      conversationDocs.length > 0
+        ? conversationDocs.map((d) => ({
+            surfaceId: d.surfaceId,
+            title: d.title,
+            wordCount: d.wordCount,
+            updatedAt: d.updatedAt,
+          }))
+        : null;
+
     ctx.refreshWorkspaceTopLevelContextIfNeeded();
 
     // Compute fresh turn timestamp for date grounding.
@@ -1561,6 +1576,7 @@ export async function runAgentLoopImpl(
     const injectionOpts = {
       diskPressureContext,
       activeSurface,
+      activeDocuments,
       workspaceTopLevelContext: shouldInjectWorkspace
         ? ctx.workspaceTopLevelContext
         : null,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1989,6 +1989,7 @@ export interface RuntimeInjectionOptions {
    * `undefined` when the inbound is a top-level (non-thread) post.
    */
   slackActiveThreadFocusBlock?: string | null;
+  activeDocuments?: TurnInjectionInputs["activeDocuments"];
   mode?: InjectionMode;
   /**
    * Per-turn {@link TurnContext} forwarded to plugin-registered
@@ -2042,6 +2043,7 @@ function buildTurnInjectionInputs(
     voiceCallControlPrompt: options.voiceCallControlPrompt,
     transportHints: options.transportHints,
     isNonInteractive: options.isNonInteractive,
+    activeDocuments: options.activeDocuments,
   };
 }
 

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -216,7 +216,7 @@ export function updateDocumentContent(
   surfaceId: string,
   markdown: string,
   mode: string,
-): void {
+): { success: true } | { success: false; error: string } {
   try {
     const existing = rawGet<{ content: string }>(
       /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
@@ -224,7 +224,7 @@ export function updateDocumentContent(
     );
     if (!existing) {
       log.info({ surfaceId }, "No persisted document to update");
-      return;
+      return { success: false, error: "Document not found" };
     }
     const sep = mode === "append" && existing.content.length > 0 ? "\n\n" : "";
     const newContent =
@@ -240,7 +240,12 @@ export function updateDocumentContent(
       surfaceId,
     );
     log.info({ surfaceId, mode }, "Updated document content");
+    return { success: true };
   } catch (error) {
     log.error({ err: error, surfaceId }, "Document content update error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 }

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -132,6 +132,40 @@ export function getDocumentsForConversation(
 }
 
 /**
+ * Search documents across all conversations by title substring (case-insensitive).
+ * Returns documents ordered by most recently updated.
+ */
+export function searchDocumentsByTitle(
+  query: string,
+): Omit<DocumentRecord, "content">[] {
+  try {
+    const rows = rawAll<DocumentListRow>(
+      /*sql*/ `
+      SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
+      FROM documents
+      WHERE title LIKE '%' || ? || '%' COLLATE NOCASE
+      ORDER BY updated_at DESC
+      LIMIT 20
+      `,
+      query,
+    );
+
+    log.info({ query, count: rows.length }, "Searched documents by title");
+    return rows.map((row) => ({
+      surfaceId: row.surface_id,
+      conversationId: row.conversation_id,
+      title: row.title,
+      wordCount: row.word_count,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  } catch (error) {
+    log.error({ err: error, query }, "Search error");
+    return [];
+  }
+}
+
+/**
  * Delete a document and its conversation associations.
  * Returns `true` if the document existed and was deleted, `false` otherwise.
  */

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -5,10 +5,25 @@
  * background jobs (e.g. proactive artifact generation) can persist documents
  * without going through the HTTP layer.
  */
-import { rawGet, rawRun } from "../memory/raw-query.js";
+import { rawAll, rawGet, rawRun } from "../memory/raw-query.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("document-store");
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/** A document record with camelCase field names, mapped from the SQLite row. */
+export interface DocumentRecord {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
 
 // ---------------------------------------------------------------------------
 // Junction table helper
@@ -25,6 +40,118 @@ export function addDocumentConversation(
     conversationId,
     Date.now(),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Shared query helpers
+// ---------------------------------------------------------------------------
+
+interface DocumentRow {
+  surface_id: string;
+  conversation_id: string;
+  title: string;
+  content: string;
+  word_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
+type DocumentListRow = Omit<DocumentRow, "content">;
+
+function mapRowToRecord(row: DocumentRow): DocumentRecord {
+  return {
+    surfaceId: row.surface_id,
+    conversationId: row.conversation_id,
+    title: row.title,
+    content: row.content,
+    wordCount: row.word_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Look up a single document by surface ID. Returns `null` when not found. */
+export function getDocumentById(surfaceId: string): DocumentRecord | null {
+  try {
+    const row = rawGet<DocumentRow>(
+      /*sql*/ `SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
+       FROM documents
+       WHERE surface_id = ?`,
+      surfaceId,
+    );
+
+    if (!row) {
+      log.info({ surfaceId }, "Document not found");
+      return null;
+    }
+
+    log.info({ surfaceId }, "Loaded document");
+    return mapRowToRecord(row);
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Load error");
+    return null;
+  }
+}
+
+/**
+ * List documents for a given conversation (via the junction table).
+ * Returns an empty array when the conversation has no documents or on error.
+ */
+export function getDocumentsForConversation(
+  conversationId: string,
+): Omit<DocumentRecord, "content">[] {
+  try {
+    const rows = rawAll<DocumentListRow>(
+      /*sql*/ `
+      SELECT d.surface_id, dc.conversation_id AS conversation_id,
+             d.title, d.word_count, d.created_at, d.updated_at
+      FROM documents d
+      INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
+      WHERE dc.conversation_id = ?
+      ORDER BY d.updated_at DESC
+      `,
+      conversationId,
+    );
+
+    log.info(
+      { conversationId, count: rows.length },
+      "Listed documents for conversation",
+    );
+    return rows.map((row) => ({
+      surfaceId: row.surface_id,
+      conversationId: row.conversation_id,
+      title: row.title,
+      wordCount: row.word_count,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  } catch (error) {
+    log.error({ err: error, conversationId }, "List error");
+    return [];
+  }
+}
+
+/**
+ * Delete a document and its conversation associations.
+ * Returns `true` if the document existed and was deleted, `false` otherwise.
+ */
+export function deleteDocument(surfaceId: string): boolean {
+  try {
+    const changes = rawRun(
+      /*sql*/ `DELETE FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    rawRun(
+      /*sql*/ `DELETE FROM document_conversations WHERE surface_id = ?`,
+      surfaceId,
+    );
+    const existed = changes > 0;
+    log.info({ surfaceId, existed }, "Deleted document");
+    return existed;
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Delete error");
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -19,6 +19,7 @@
  * | `pkb-reminder`           | 35    | after-memory-prefix     |
  * | `memory-v2-static`       | 38    | after-memory-prefix     |
  * | `now-md`                 | 40    | after-memory-prefix     |
+ * | `active-documents`       | 45    | prepend-user-tail       |
  * | `subagent-status`        | 50    | append-user-tail        |
  * | `slack-messages`         | 60    | replace-run-messages    |
  * | `thread-focus`           | 70    | append-user-tail        |
@@ -91,6 +92,7 @@ export const DEFAULT_INJECTOR_ORDER = {
   pkbReminder: 35,
   memoryV2Static: 38,
   nowMd: 40,
+  activeDocuments: 45,
   subagentStatus: 50,
   slackMessages: 60,
   threadFocus: 70,
@@ -439,6 +441,39 @@ const nowMdInjector: Injector = {
 };
 
 /**
+ * `active-documents` injector — order 45, prepend-user-tail.
+ *
+ * Injects an `<active_documents>` block listing open documents in the
+ * conversation so the assistant can target them with `document_update`
+ * instead of creating duplicates via `document_create`.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `activeDocuments` has at least one entry.
+ */
+const activeDocumentsInjector: Injector = {
+  name: "active-documents",
+  order: DEFAULT_INJECTOR_ORDER.activeDocuments,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const docs = inputs.activeDocuments;
+    if (!docs || docs.length === 0) return null;
+    const lines = docs.map(
+      (d) =>
+        `- surface_id: "${d.surfaceId}", title: "${d.title}", words: ${d.wordCount}`,
+    );
+    const text = `<active_documents>\nThe following documents are open in this conversation. Use document_update with the surface_id to edit them — do NOT call document_create for documents that already exist.\n${lines.join("\n")}\n</active_documents>`;
+    return {
+      id: "active-documents",
+      text,
+      placement: "prepend-user-tail",
+    };
+  },
+};
+
+/**
  * `subagent-status` injector — order 50, append-user-tail.
  *
  * Appends a pre-built `<active_subagents>` block to the tail user message
@@ -571,6 +606,7 @@ export const defaultInjectorsPlugin: Plugin = {
     pkbReminderInjector,
     memoryV2StaticInjector,
     nowMdInjector,
+    activeDocumentsInjector,
     subagentStatusInjector,
     slackMessagesInjector,
     threadFocusInjector,

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -835,6 +835,17 @@ export interface TurnInjectionInputs {
    * knows no human is present to answer clarification questions.
    */
   readonly isNonInteractive?: boolean;
+  /**
+   * Active documents open in this conversation — surfaced by the
+   * `active-documents` injector so the assistant can target existing docs
+   * with `document_update` instead of creating duplicates.
+   */
+  readonly activeDocuments?: ReadonlyArray<{
+    surfaceId: string;
+    title: string;
+    wordCount: number;
+    updatedAt: number;
+  }> | null;
 }
 
 export interface DiskPressureInjectionContext {
@@ -1066,9 +1077,7 @@ export interface PluginSkillRegistration {
  * Unknown keys are populated by the loader for forward compatibility
  * but are not invoked by today's runtime.
  */
-export type PluginHookFn<TCtx = unknown> = (
-  ctx: TCtx,
-) => Promise<TCtx | void>;
+export type PluginHookFn<TCtx = unknown> = (ctx: TCtx) => Promise<TCtx | void>;
 
 /**
  * Map of lifecycle hooks contributed by a plugin. Keys match file

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -6,8 +6,12 @@
  */
 import { z } from "zod";
 
-import { saveDocument } from "../../documents/document-store.js";
-import { rawAll, rawGet } from "../../memory/raw-query.js";
+import {
+  getDocumentById,
+  getDocumentsForConversation,
+  saveDocument,
+} from "../../documents/document-store.js";
+import { rawAll } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -16,65 +20,16 @@ import { RouteResponse } from "./types.js";
 
 const log = getLogger("documents-routes");
 
-interface DocumentRow {
+interface DocumentListRow {
   surface_id: string;
   conversation_id: string;
   title: string;
-  content: string;
   word_count: number;
   created_at: number;
   updated_at: number;
 }
 
-type DocumentListRow = Omit<DocumentRow, "content">;
-
-function loadDocument(surfaceId: string):
-  | {
-      success: true;
-      surfaceId: string;
-      conversationId: string;
-      title: string;
-      content: string;
-      wordCount: number;
-      createdAt: number;
-      updatedAt: number;
-    }
-  | { success: false; error: string } {
-  try {
-    const result = rawGet<DocumentRow>(
-      /*sql*/ `
-      SELECT surface_id, conversation_id, title, content, word_count, created_at, updated_at
-      FROM documents
-      WHERE surface_id = ?
-    `,
-      surfaceId,
-    );
-
-    if (result) {
-      log.info({ surfaceId }, "Loaded document");
-      return {
-        success: true,
-        surfaceId: result.surface_id,
-        conversationId: result.conversation_id,
-        title: result.title,
-        content: result.content,
-        wordCount: result.word_count,
-        createdAt: result.created_at,
-        updatedAt: result.updated_at,
-      };
-    }
-    log.info({ surfaceId }, "Document not found");
-    return { success: false, error: "Document not found" };
-  } catch (error) {
-    log.error({ err: error, surfaceId }, "Load error");
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
-
-function listDocuments(conversationId?: string): Array<{
+function listAllDocuments(): Array<{
   surfaceId: string;
   conversationId: string;
   title: string;
@@ -83,29 +38,11 @@ function listDocuments(conversationId?: string): Array<{
   updatedAt: number;
 }> {
   try {
-    let results: DocumentListRow[];
-
-    if (conversationId) {
-      // Query via junction table so we return the *matched* conversation_id
-      // (not the origin conversation_id from the documents table).
-      results = rawAll<DocumentListRow>(
-        /*sql*/ `
-        SELECT d.surface_id, dc.conversation_id AS conversation_id,
-               d.title, d.word_count, d.created_at, d.updated_at
-        FROM documents d
-        INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
-        WHERE dc.conversation_id = ?
-        ORDER BY d.updated_at DESC
-        `,
-        conversationId,
-      );
-    } else {
-      results = rawAll<DocumentListRow>(/*sql*/ `
-        SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
-        FROM documents
-        ORDER BY updated_at DESC
-        `);
-    }
+    const results = rawAll<DocumentListRow>(/*sql*/ `
+      SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
+      FROM documents
+      ORDER BY updated_at DESC
+      `);
 
     log.info({ count: results.length }, "Listed documents");
     return results.map((row) => ({
@@ -148,7 +85,9 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ queryParams }) => {
       const conversationId = queryParams?.conversationId ?? undefined;
-      const documents = listDocuments(conversationId);
+      const documents = conversationId
+        ? getDocumentsForConversation(conversationId)
+        : listAllDocuments();
       return { documents };
     },
   },
@@ -173,11 +112,11 @@ export const ROUTES: RouteDefinition[] = [
       updatedAt: z.number(),
     }),
     handler: ({ pathParams }) => {
-      const result = loadDocument(pathParams!.id);
-      if (!result.success) {
-        throw new NotFoundError(result.error);
+      const doc = getDocumentById(pathParams!.id);
+      if (!doc) {
+        throw new NotFoundError("Document not found");
       }
-      return result;
+      return { success: true, ...doc };
     },
   },
 
@@ -252,13 +191,13 @@ export const ROUTES: RouteDefinition[] = [
     description: "Render a document to PDF and return the binary content.",
     tags: ["documents"],
     handler: async ({ pathParams }) => {
-      const result = loadDocument(pathParams!.id);
-      if (!result.success) {
-        throw new NotFoundError(result.error);
+      const doc = getDocumentById(pathParams!.id);
+      if (!doc) {
+        throw new NotFoundError("Document not found");
       }
-      const pdfBuffer = await renderMarkdownToPDF(result.title, result.content);
+      const pdfBuffer = await renderMarkdownToPDF(doc.title, doc.content);
       const filename =
-        result.title
+        doc.title
           .replace(/[^a-zA-Z0-9_-]/g, "-")
           .replace(/-+/g, "-")
           .replace(/^-|-$/g, "") || "document";

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -85,7 +85,17 @@ export function executeDocumentUpdate(
   const content = input.content as string;
   const mode = (input.mode as string | undefined) || "append";
 
-  updateDocumentContent(surfaceId, content, mode);
+  const result = updateDocumentContent(surfaceId, content, mode);
+  if (!result.success) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: result.error,
+      }),
+      isError: true,
+    };
+  }
 
   // Send document_editor_update message to update the built-in RTE
   if (context.sendToClient) {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  deleteDocument,
   getDocumentById,
+  getDocumentsForConversation,
   saveDocument,
   updateDocumentContent,
 } from "../../documents/document-store.js";
@@ -153,6 +155,52 @@ export function executeDocumentRead(
       content: doc.content,
       word_count: doc.wordCount,
       updated_at: doc.updatedAt,
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentList(
+  _input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const docs = getDocumentsForConversation(context.conversationId);
+  return {
+    content: JSON.stringify({
+      success: true,
+      documents: docs.map((d) => ({
+        surface_id: d.surfaceId,
+        title: d.title,
+        word_count: d.wordCount,
+        created_at: d.createdAt,
+        updated_at: d.updatedAt,
+      })),
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentDelete(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const deleted = deleteDocument(surfaceId);
+  if (!deleted) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: "Document not found",
+      }),
+      isError: true,
+    };
+  }
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: surfaceId,
+      message: "Document deleted",
     }),
     isError: false,
   };

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -5,6 +5,7 @@ import {
   getDocumentById,
   getDocumentsForConversation,
   saveDocument,
+  searchDocumentsByTitle,
   updateDocumentContent,
 } from "../../documents/document-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
@@ -161,10 +162,13 @@ export function executeDocumentRead(
 }
 
 export function executeDocumentList(
-  _input: Record<string, unknown>,
+  input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const docs = getDocumentsForConversation(context.conversationId);
+  const query = input.query as string | undefined;
+  const docs = query
+    ? searchDocumentsByTitle(query)
+    : getDocumentsForConversation(context.conversationId);
   return {
     content: JSON.stringify({
       success: true,

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  getDocumentById,
   saveDocument,
   updateDocumentContent,
 } from "../../documents/document-store.js";
@@ -125,5 +126,34 @@ export function executeDocumentUpdate(
       error: "No client connected to update document",
     }),
     isError: true,
+  };
+}
+
+export function executeDocumentRead(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const doc = getDocumentById(surfaceId);
+  if (!doc) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: "Document not found",
+      }),
+      isError: true,
+    };
+  }
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: doc.surfaceId,
+      title: doc.title,
+      content: doc.content,
+      word_count: doc.wordCount,
+      updated_at: doc.updatedAt,
+    }),
+    isError: false,
   };
 }


### PR DESCRIPTION
## Summary
Fix the document editor's core usability issue: when an assistant creates a document in one turn and the user requests an edit in the next turn, the assistant loses its handle on the open document and creates a new blank document instead of updating the existing one.

The fix injects active document state (surface_id, title, word count) into the assistant's per-turn context via a new `active-documents` injector at order 45. This ensures the assistant always knows which documents are open and can target them with `document_update`.

Additionally:
- `document_update` now fails loudly on invalid surface_ids instead of silently succeeding
- New `document_read` tool for verifying document content
- New `document_list` and `document_delete` tools for discovery and cleanup
- Shared document query functions extracted for reuse

## Self-review result
GAPS FOUND — 1 critical gap fixed (activeDocuments not wired through RuntimeInjectionOptions/buildTurnInjectionInputs)

## PRs merged into feature branch
- #30647: refactor: extract getDocumentById, getDocumentsForConversation, deleteDocument into document-store
- #30646: fix: return error from document_update when surface_id is invalid
- #30648: feat: add document_read tool to retrieve document content by surface_id
- #30650: feat: inject active document state into per-turn context so assistant can target existing docs
- #30649: feat: add document_list and document_delete tools for discovery and cleanup

### Fix PRs
- #30651: fix: wire activeDocuments through RuntimeInjectionOptions and buildTurnInjectionInputs

Part of plan: doc-editor-persist.md
Closes JARVIS-829
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->