### PR TITLE
[codex] Retry empty post-tool responses after streamed text

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -470,7 +470,6 @@ describe("AgentLoop", () => {
     ).toBe(false);
   });
 
-
   // 9. Tool executor error results are forwarded correctly
   test("forwards tool error results to provider", async () => {
     const { provider, calls } = createMockProvider([
@@ -1767,18 +1766,20 @@ describe("AgentLoop", () => {
     ]);
 
     // message_complete emitted for tool_use response + retry text response (not the empty one)
-    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    const messageCompletes = events.filter(
+      (e) => e.type === "message_complete",
+    );
     expect(messageCompletes).toHaveLength(2);
   });
 
   // Regression: when the model emits [text, tool_use] in a single turn and then
-  // returns an empty response after the tool result, the loop must NOT nudge —
-  // the model already delivered its reply before the tool call, and nudging
-  // would trick it into re-sending the same text verbatim.
-  test("does not nudge empty response when prior turn had visible text", async () => {
+  // returns an empty response after the tool result, the loop must still ask
+  // for a text continuation. Otherwise the user sees the stream stop on the
+  // tool card and has to re-prompt for the actual answer.
+  test("nudges empty response after prior visible text with continuation prompt", async () => {
     const textPlusToolUseResponse: ProviderResponse = {
       content: [
-        { type: "text", text: "your move, husband." },
+        { type: "text", text: "I found the split." },
         {
           type: "tool_use",
           id: "t1",
@@ -1800,6 +1801,7 @@ describe("AgentLoop", () => {
     const { provider, calls } = createMockProvider([
       textPlusToolUseResponse,
       emptyResponse,
+      textResponse("The next step is to keep the client retry path boring."),
     ]);
 
     const toolExecutor = async () => ({
@@ -1817,35 +1819,45 @@ describe("AgentLoop", () => {
     const events: AgentEvent[] = [];
     const history = await loop.run([userMessage], collectEvents(events));
 
-    // Provider called exactly 2 times: initial [text+tool_use], then empty.
-    // No third (retry) call because the prior turn had visible text.
-    expect(calls).toHaveLength(2);
+    // Provider called 3 times: initial [text+tool_use], empty follow-up,
+    // then the continuation retry.
+    expect(calls).toHaveLength(3);
 
-    // No nudge message should appear anywhere in history.
-    const nudgeInHistory = history.some(
-      (m) =>
-        m.role === "user" &&
-        m.content.some(
-          (b) =>
-            b.type === "text" &&
-            "text" in b &&
-            (b as { text: string }).text.includes(
-              "previous response was empty",
-            ),
-        ),
-    );
-    expect(nudgeInHistory).toBe(false);
+    const retryMessages = calls[2].messages;
+    const lastRetryMessage = retryMessages[retryMessages.length - 1];
+    expect(lastRetryMessage.role).toBe("user");
+    expect(
+      lastRetryMessage.content.some(
+        (b) =>
+          b.type === "text" &&
+          "text" in b &&
+          (b as { text: string }).text.includes(
+            "without any final assistant text",
+          ),
+      ),
+    ).toBe(true);
 
     // The [text, tool_use] assistant message is preserved in history.
     const firstAssistant = history.find((m) => m.role === "assistant");
     expect(firstAssistant).toBeDefined();
     expect(firstAssistant!.content).toEqual([
-      { type: "text", text: "your move, husband." },
+      { type: "text", text: "I found the split." },
       {
         type: "tool_use",
         id: "t1",
         name: "read_file",
         input: { path: "/note.txt" },
+      },
+    ]);
+
+    const lastAssistant = [...history]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    expect(lastAssistant).toBeDefined();
+    expect(lastAssistant!.content).toEqual([
+      {
+        type: "text",
+        text: "The next step is to keep the client retry path boring.",
       },
     ]);
   });
@@ -1883,7 +1895,9 @@ describe("AgentLoop", () => {
     expect(calls).toHaveLength(3);
 
     // message_complete: tool_use response + final empty response (retry exhausted)
-    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    const messageCompletes = events.filter(
+      (e) => e.type === "message_complete",
+    );
     expect(messageCompletes).toHaveLength(2);
 
     // The last assistant message in history is the empty one

--- a/assistant/src/__tests__/empty-response-pipeline.test.ts
+++ b/assistant/src/__tests__/empty-response-pipeline.test.ts
@@ -5,7 +5,7 @@
  * - Default plugin decision matches the original inline loop logic for the
  *   canonical cases (empty-after-tools → nudge, visible-text → accept,
  *   tool-use-blocks-present → accept, retries-exhausted → accept,
- *   prior-visible-text-in-run → accept).
+ *   prior-visible-text-in-run → continuation nudge).
  * - Swapping in a custom middleware that returns `action: "accept"` prevents
  *   the nudge and lets the loop fall through to history append.
  * - Swapping in a custom middleware that returns `action: "error"` is
@@ -60,6 +60,9 @@ function makeCtx(): TurnContext {
  */
 const CANONICAL_NUDGE_TEXT =
   "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
+
+const CONTINUATION_NUDGE_TEXT =
+  "<system_notice>Your previous response ended after a tool result without any final assistant text. Continue the answer now, using the tool result if relevant. Do not repeat already-visible text verbatim. Do not use any tools — respond with text.</system_notice>";
 
 const emptyTextBlock: ContentBlock = { type: "text", text: "   " };
 
@@ -151,10 +154,10 @@ describe("emptyResponse pipeline — default decisions", () => {
     expect(decision.action).toBe("accept");
   });
 
-  test("prior assistant turn already delivered visible text → accept", async () => {
-    // Model said its piece earlier, ended with a side-effect tool, returned
-    // empty. Nudging would force a verbatim re-send of text the user already
-    // saw. Default must accept.
+  test("prior assistant turn already delivered visible text → continuation nudge", async () => {
+    // A preamble before a side-effect tool is not proof that the user got the
+    // final answer. Use a continuation-specific nudge so the model finishes
+    // the turn without repeating already-visible text verbatim.
     const decision = await runEmpty(
       makeArgs({
         responseContent: [],
@@ -162,7 +165,8 @@ describe("emptyResponse pipeline — default decisions", () => {
         priorAssistantHadVisibleText: true,
       }),
     );
-    expect(decision.action).toBe("accept");
+    expect(decision.action).toBe("nudge");
+    expect(decision.nudgeText).toBe(CONTINUATION_NUDGE_TEXT);
   });
 
   test("no prior tool-use turn (toolUseTurns === 0) → accept", async () => {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -693,12 +693,11 @@ export class AgentLoop {
         // receiving a large tool result. Retry once with a nudge before
         // the message is persisted.
         //
-        // Only nudge when the model hasn't already delivered text to the user
-        // earlier in this tool-use chain. If a prior assistant turn in history
-        // contained visible text (e.g. the model said its piece before calling
-        // a side-effect tool like `remember`), an empty follow-up is the model
-        // correctly ending its turn — nudging would mislead it into thinking
-        // its earlier text didn't land and cause a verbatim re-send.
+        // The empty-response pipeline receives whether the model already
+        // delivered text earlier in this tool-use chain. It still retries
+        // empty post-tool responses, but uses that signal to choose a
+        // continuation prompt rather than a generic "summarize" nudge, which
+        // avoids training the model to resend text the user already saw.
         //
         // Note: we check ANY prior assistant turn from this run()
         // invocation, not just the most recent one. In multi-step tool-use
@@ -794,12 +793,7 @@ export class AgentLoop {
         // action === "accept" — fall through. Emit a dedicated log line for
         // the specific "empty turn after tool results, retries exhausted"
         // case so ops dashboards that grep on this line keep working.
-        if (
-          !hasVisibleText &&
-          toolUseBlocks.length === 0 &&
-          toolUseTurns > 0 &&
-          !priorAssistantHadVisibleText
-        ) {
+        if (!hasVisibleText && toolUseBlocks.length === 0 && toolUseTurns > 0) {
           rlog.error(
             { turn: toolUseTurns, retries: emptyResponseRetries },
             "Model returned empty response after tool results — retries exhausted",

--- a/assistant/src/plugins/defaults/empty-response.ts
+++ b/assistant/src/plugins/defaults/empty-response.ts
@@ -20,15 +20,14 @@
  * The terminal inspects the turn snapshot and returns one of:
  *
  * 1. `"nudge"`  — the turn produced no visible text, no tool calls, follows
- *                 at least one prior tool-use turn, no earlier turn in this
- *                 run() has already delivered visible text, AND the retry
- *                 counter is below `maxEmptyResponseRetries`. The loop
- *                 appends `nudgeText` (the `<system_notice>…` message below)
- *                 as a `user` turn and re-queries the model.
- * 2. `"accept"` — every other case. The turn either legitimately ended
- *                 (model said its piece earlier), is still in progress
- *                 (tool calls pending), or exhausted its retry budget. The
- *                 loop pushes the assistant message and continues normally.
+ *                 at least one prior tool-use turn, and the retry counter is
+ *                 below `maxEmptyResponseRetries`. The loop appends `nudgeText`
+ *                 (one of the `<system_notice>…` messages below) as a `user`
+ *                 turn and re-queries the model.
+ * 2. `"accept"` — every other case. The turn either has visible output, is
+ *                 still in progress (tool calls pending), has no prior tool
+ *                 use, or exhausted its retry budget. The loop pushes the
+ *                 assistant message and continues normally.
  *
  * The default never returns `"error"` — that action is an escape hatch for
  * downstream plugins (e.g. a circuit breaker) that want to surface an
@@ -59,6 +58,15 @@ const NUDGE_TEXT =
   "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
 
 /**
+ * Variant used when the model streamed some text before a later tool call but
+ * then returned an empty follow-up after the tool result. This is the common
+ * "preamble + side-effect tool + silent end" failure mode; ask it to continue
+ * instead of re-sending text the user already saw.
+ */
+const CONTINUATION_NUDGE_TEXT =
+  "<system_notice>Your previous response ended after a tool result without any final assistant text. Continue the answer now, using the tool result if relevant. Do not repeat already-visible text verbatim. Do not use any tools — respond with text.</system_notice>";
+
+/**
  * Terminal handler for the `emptyResponse` pipeline. Exported so tests can
  * verify default behavior directly without going through `runPipeline`, and
  * so `agent/loop.ts` can pass it as the `terminal` argument to `runPipeline`.
@@ -74,13 +82,15 @@ export function defaultEmptyResponseTerminal(
   );
 
   const isEmptyTurn =
-    !hasVisibleText &&
-    args.toolUseBlocksLength === 0 &&
-    args.toolUseTurns > 0 &&
-    !args.priorAssistantHadVisibleText;
+    !hasVisibleText && args.toolUseBlocksLength === 0 && args.toolUseTurns > 0;
 
   if (isEmptyTurn && args.emptyResponseRetries < args.maxEmptyResponseRetries) {
-    return { action: "nudge", nudgeText: NUDGE_TEXT };
+    return {
+      action: "nudge",
+      nudgeText: args.priorAssistantHadVisibleText
+        ? CONTINUATION_NUDGE_TEXT
+        : NUDGE_TEXT,
+    };
   }
   return { action: "accept" };
 }

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -585,9 +585,9 @@ export type ToolResultTruncateResult = {
  * stateless across turns.
  *
  * `priorAssistantHadVisibleText` signals that an earlier turn in the current
- * `run()` invocation already delivered user-visible text. When true, an
- * empty follow-up is the model correctly ending its turn and nudging would
- * mislead it into resending text the user already saw.
+ * `run()` invocation already delivered user-visible text. The default
+ * pipeline still nudges empty post-tool responses in this case, but uses a
+ * continuation-specific prompt so the model does not resend text verbatim.
  */
 export interface EmptyResponseArgs {
   /** Content blocks produced by the assistant on this turn. */
@@ -1066,9 +1066,7 @@ export interface PluginSkillRegistration {
  * Unknown keys are populated by the loader for forward compatibility
  * but are not invoked by today's runtime.
  */
-export type PluginHookFn<TCtx = unknown> = (
-  ctx: TCtx,
-) => Promise<TCtx | void>;
+export type PluginHookFn<TCtx = unknown> = (ctx: TCtx) => Promise<TCtx | void>;
 
 /**
  * Map of lifecycle hooks contributed by a plugin. Keys match file


### PR DESCRIPTION
## Summary
- Retry empty post-tool responses even when the model already streamed visible text earlier in the same tool-use chain.
- Use a continuation-specific nudge in that case so the model finishes the answer without repeating already-visible text verbatim.
- Update the agent-loop and empty-response pipeline regression coverage for the preamble + tool call + empty follow-up case.

## Root Cause
The default empty-response policy treated prior visible assistant text before a tool call as proof that the turn had already completed. When the model then returned an empty `end_turn` after the tool result, the loop accepted it, persisted the empty assistant message, and the client stream ended on the tool card without a final answer.

## Validation
- `bun test src/__tests__/empty-response-pipeline.test.ts src/__tests__/agent-loop.test.ts --grep "empty response|prior visible|prior assistant"`
- `bunx tsc --noEmit`
- Pre-push hook: assistant typecheck and changed-file lint passed