### PR TITLE
Fix escaping closure capture in GuardianChannelsDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -410,7 +410,7 @@ struct GuardianChannelsDetailView: View {
     // MARK: - Channel Actions
 
     /// Runs an async channel action with shared loading/error/refresh handling.
-    private func performChannelAction(channelId: String, type: String, errorLabel: String, action: () async throws -> Void) {
+    private func performChannelAction(channelId: String, type: String, errorLabel: String, action: @escaping () async throws -> Void) {
         guard actionInProgress == nil else { return }
         actionInProgress = channelId
         errorMessage = nil


### PR DESCRIPTION
## Summary
- `performChannelAction` captures its `action` parameter inside a `Task { ... }`, which requires the closure to outlive the function call.
- Mark `action` as `@escaping` so the Swift compiler accepts the capture, fixing the macOS build failure on CI.

## Original prompt
CI failed compiling `GuardianChannelsDetailView.swift` with `error: escaping closure captures non-escaping parameter 'action'` at line 419, where the `Task { try await action() }` block captures the closure passed into `performChannelAction`. The fix is to annotate the parameter as `@escaping` so it can be retained by the spawned `Task`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->