### PR TITLE
docs(apps/web): mark scaffold-in-progress

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@
 
 # --- Broad directory catch-alls (DRI defaults) ---
 
-# Web app repo move landing zone (Ashlee).
-# `apps/web/` is scaffolding for an in-progress move from
-# vellum-ai/vellum-assistant-platform/web/ — no application code lives
-# here yet. Code-owner review keeps unrelated feature work from landing
-# in the scaffold before the move is ready. See apps/web/README.md.
+# Web app scaffold landing zone (Ashlee).
+# `apps/web/` is the future open-source home for the Vellum web app;
+# no application code lives here yet. Code-owner review keeps
+# unrelated feature work from landing in the scaffold before the
+# migration completes. See apps/web/README.md.
 apps/web/ @ashleeradka
 
 # Memory system (Sidd)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,13 @@
 
 # --- Broad directory catch-alls (DRI defaults) ---
 
+# Web app repo move landing zone (Ashlee).
+# `apps/web/` is scaffolding for an in-progress move from
+# vellum-ai/vellum-assistant-platform/web/ — no application code lives
+# here yet. Code-owner review keeps unrelated feature work from landing
+# in the scaffold before the move is ready. See apps/web/README.md.
+apps/web/ @ashleeradka
+
 # Memory system (Sidd)
 assistant/src/memory/ @siddseethepalli
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,19 @@ bun run typecheck
 
 For deeper architectural context, see [ARCHITECTURE.md](ARCHITECTURE.md) and the domain-specific docs linked from it.
 
+## Active migrations
+
+Some directories in this repo are landing zones for in-progress moves
+from other repos. They build green but are not the live source of
+truth for the corresponding product yet. Please avoid landing feature
+work in these directories until the move is complete — target the
+live source instead.
+
+| Directory | Status | Live source |
+|---|---|---|
+| `apps/web/` | Scaffold only — Vite + React Router v7 toolchain landed, no app code yet | [`vellum-ai/vellum-assistant-platform/web`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web) |
+| `apps/chrome-extension/` | Move in progress | [`vellum-ai/vellum-assistant/clients/chrome-extension`](https://github.com/vellum-ai/vellum-assistant/tree/main/clients/chrome-extension) |
+
 ## Submitting a pull request
 
 1. Fork the repo and create a branch from `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,16 +81,15 @@ For deeper architectural context, see [ARCHITECTURE.md](ARCHITECTURE.md) and the
 
 ## Active migrations
 
-Some directories in this repo are landing zones for in-progress moves
-from other repos. They build green but are not the live source of
-truth for the corresponding product yet. Please avoid landing feature
-work in these directories until the move is complete — target the
-live source instead.
+Some directories in this repo are landing zones for in-progress
+relocations. They build green but are not the live source for the
+corresponding surface yet. Please avoid landing feature work in these
+directories until the move is complete.
 
-| Directory | Status | Live source |
-|---|---|---|
-| `apps/web/` | Scaffold only — Vite + React Router v7 toolchain landed, no app code yet | [`vellum-ai/vellum-assistant-platform/web`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web) |
-| `apps/chrome-extension/` | Move in progress | [`vellum-ai/vellum-assistant/clients/chrome-extension`](https://github.com/vellum-ai/vellum-assistant/tree/main/clients/chrome-extension) |
+| Directory | Status |
+|---|---|
+| `apps/web/` | Scaffold only — Vite + React Router v7 toolchain landed, no app code yet. The live web app is currently maintained in a separate, non-public repository and will land here as the migration completes. |
+| `apps/chrome-extension/` | Move in progress from [`clients/chrome-extension/`](https://github.com/vellum-ai/vellum-assistant/tree/main/clients/chrome-extension). |
 
 ## Submitting a pull request
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,5 +1,21 @@
 # apps/web
 
+> ## Status: scaffold in progress
+>
+> This directory is the landing zone for a planned move of the web app
+> from
+> [`vellum-ai/vellum-assistant-platform`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web)
+> into this repo. **No application code lives here yet** — only the
+> Vite + React Router v7 toolchain, an empty shell, and placeholder
+> routes that exist to validate the build.
+>
+> The live web app is still served from
+> [`vellum-assistant-platform/web/`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web).
+> Feature work, bug fixes, and other contributions for the web app
+> should target that repo until the move is complete. PRs against
+> `apps/web/` that add product features or non-scaffold code will be
+> redirected.
+
 Vite + [React Router v7](https://reactrouter.com/) SPA for the
 vellum-assistant web app surfaces (assistant + docs).
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,19 +2,16 @@
 
 > ## Status: scaffold in progress
 >
-> This directory is the landing zone for a planned move of the web app
-> from
-> [`vellum-ai/vellum-assistant-platform`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web)
-> into this repo. **No application code lives here yet** — only the
-> Vite + React Router v7 toolchain, an empty shell, and placeholder
-> routes that exist to validate the build.
+> This directory is the future open-source home for the Vellum web
+> app. **No application code lives here yet** — only the Vite + React
+> Router v7 toolchain, an empty shell, and placeholder routes that
+> exist to validate the build.
 >
-> The live web app is still served from
-> [`vellum-assistant-platform/web/`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web).
-> Feature work, bug fixes, and other contributions for the web app
-> should target that repo until the move is complete. PRs against
-> `apps/web/` that add product features or non-scaffold code will be
-> redirected.
+> The live web app is currently maintained in a separate, non-public
+> repository and will land here as the migration completes. Feature
+> work, bug fixes, and other contributions for the web app are not
+> accepted in `apps/web/` during the scaffold phase — PRs that add
+> product features or non-scaffold code will be redirected.
 
 Vite + [React Router v7](https://reactrouter.com/) SPA for the
 vellum-assistant web app surfaces (assistant + docs).


### PR DESCRIPTION
## Prompt / plan

Make it visible to contributors that `apps/web/` is the future open-source home for the Vellum web app — currently a toolchain scaffold, not the live source. The live web app is maintained in a separate, non-public repository during the migration. Add markers at the three places a contributor is most likely to encounter the directory before submitting work there:

1. The directory's own `README.md` (first thing GitHub shows when navigating into the folder).
2. The repo-level `CONTRIBUTING.md` (read by anyone preparing a contribution).
3. `.github/CODEOWNERS` (auto-requests review on any PR touching the path, providing soft enforcement without locking the directory).

## What changed

- **`apps/web/README.md`** — `Status: scaffold in progress` blockquote at the top of the file, above the existing stack documentation. Explains that no application code lives in `apps/web/` yet (only the Vite + React Router v7 toolchain and placeholder routes), notes that the live web app is currently maintained in a separate, non-public repository and will land here as the migration completes, and states that feature-level PRs against `apps/web/` will be redirected.
- **`CONTRIBUTING.md`** — new `## Active migrations` section between the project structure table and the PR-submission instructions. Table form, two rows today:
  - `apps/web/` → scaffold only; the live web app is currently maintained in a separate, non-public repository and will land here as the migration completes
  - `apps/chrome-extension/` → move in progress (PR [#30635](https://github.com/vellum-ai/vellum-assistant/pull/30635)) from `clients/chrome-extension/`
- **`.github/CODEOWNERS`** — add `apps/web/ @ashleeradka` under the existing "Broad directory catch-alls" section. Comment block explains the scaffolding context so the entry isn't mistaken for a permanent feature DRI claim once the move completes.

## Why this approach

Three independent markers because each catches a different contributor path:

- A contributor who lands on the directory directly on GitHub sees the README banner first.
- A contributor who reads `CONTRIBUTING.md` end-to-end before opening a PR sees the migrations table.
- A contributor who opens a PR without reading either gets `@ashleeradka` auto-requested as a reviewer via `CODEOWNERS`, which is friction enough to prompt a conversation before the work merges.

`CODEOWNERS` provides soft enforcement: GitHub auto-requests the listed owner on any PR matching the path. If the repo's branch protection requires code-owner approval (or is configured to in the future), this becomes a merge-blocking gate. Without that branch-protection setting, the auto-request is still a visible nudge.

## Why this is safe

- All three changes are additive documentation. No code, no build, no CI behavior changes.
- The new `CODEOWNERS` line is **additive** — no existing entries are modified or removed. Last-match-wins ordering is preserved (the new `apps/web/` rule sits in the "Broad directory catch-alls" block at the top, so any future `apps/web/**`-specific overrides could be added later without conflict).
- The README banner sits above existing content rather than replacing it. The existing stack / mode-choice / runtime-adapter / SSR-safety documentation is unchanged.
- The `CONTRIBUTING.md` section is inserted between two existing sections, not modifying either.
- All in-repo paths referenced from the new docs exist on `main` of this repo at PR-creation time. The single off-repo reference (the closed-source live web app location) is described in prose only, with no link or path that would 404 for external readers or disclose internal infrastructure.

## Test plan

- `git diff --stat` confirms 3 files changed, 36 insertions, 0 deletions.
- Repo-wide grep shows no other files that need updating to reference `apps/web/` status (the `apps/AGENTS.md` and `apps/README.md` already describe the scaffolding nature; this PR adds the user-facing version of that signal).
- `apps/web/README.md` renders correctly on GitHub (verified locally via markdown preview — blockquote + heading + link syntax all standard).
- `.github/CODEOWNERS` syntax conforms to the file's existing pattern (`<path> @<handle>`, no glob wildcards needed since `apps/web/` already implies the subtree).
- CI on this PR will exercise the new `CODEOWNERS` entry by auto-requesting `@ashleeradka` for review, which is itself a validation that the entry parses correctly.

## Alternatives considered (and rejected)

- **`shields.io` status badge in the README** — visual decoration only; adds no information beyond the prose banner. Skipped.
- **Branch protection rule locking `apps/web/**` to specific reviewers/teams** — overkill, requires admin permission, can't be done in a PR, and would block the migration team's own work alongside everyone else's. The `CODEOWNERS` auto-request achieves the same effect with less ceremony and is reversible by editing one line.
- **Directory-specific GitHub PR template** — GitHub does not natively support different PR templates per directory; the only workaround uses URL query parameters that contributors who don't already know to read the README also won't know to follow. Marginal value.
- **GitHub repository label (e.g. `migration: apps/web`)** — useful for issue/PR triage after the fact but doesn't deter feature contributions in the first place. Easy to add later if signal-to-noise becomes a problem.
- **Marking the directory archived / read-only** — Git has no per-directory "archived" flag. Repository-level archive would shut down the entire repo. `CODEOWNERS` is the closest available mechanism.
- **Adding a backup reviewer alongside `@ashleeradka`** — declined per migration owner's call to keep the entry focused while the move is in flight. Easy to add later if PR volume becomes a problem.

## References

- [GitHub: about code owners](https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners) — `CODEOWNERS` matching semantics and review-request behavior.
- [GitHub: `CODEOWNERS` file location](https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners#codeowners-file-location) — confirms that `.github/CODEOWNERS` is one of the three searched locations.
- [GitHub: requiring reviews from code owners](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-review-from-code-owners) — describes how branch protection makes `CODEOWNERS` enforcement merge-blocking.
- [PR #30630 — `apps/`: scaffold landing zone](https://github.com/vellum-ai/vellum-assistant/pull/30630) — original scaffolding precedent.
- [PR #30643 — `apps/web`: Vite + React Router v7 SPA scaffold](https://github.com/vellum-ai/vellum-assistant/pull/30643) — the scaffold this PR documents the status of.

Link to Devin session: https://app.devin.ai/sessions/b248fca817384acf800388c7e8d82e3c
