### PR TITLE
Improve subagent detail panel — scroll, blur, usage persistence

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14304,6 +14304,20 @@ paths:
                     type: string
                   objective:
                     type: string
+                  usage:
+                    type: object
+                    properties:
+                      inputTokens:
+                        type: number
+                      outputTokens:
+                        type: number
+                      estimatedCost:
+                        type: number
+                    required:
+                      - inputTokens
+                      - outputTokens
+                      - estimatedCost
+                    additionalProperties: false
                   events:
                     type: array
                     items: {}

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -26,6 +26,7 @@ export interface SubagentDetailResponse {
   type: "subagent_detail_response";
   subagentId: string;
   objective?: string;
+  usage?: UsageStats;
   events: Array<{
     type: string;
     content: string;

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -253,6 +253,37 @@ interface GroupRow {
 }
 
 /**
+ * Return aggregate usage for a single conversation (e.g. a subagent).
+ */
+export function getConversationUsageTotals(conversationId: string): {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+} {
+  const rows = rawAll<{
+    total_input: number;
+    total_output: number;
+    total_cost: number | null;
+  }>(
+    /*sql*/ `
+    SELECT
+      COALESCE(SUM(input_tokens + COALESCE(cache_creation_input_tokens, 0) + COALESCE(cache_read_input_tokens, 0)), 0) AS total_input,
+      COALESCE(SUM(output_tokens), 0) AS total_output,
+      COALESCE(SUM(estimated_cost_usd), 0) AS total_cost
+    FROM llm_usage_events
+    WHERE conversation_id = ?1
+    `,
+    conversationId,
+  );
+  const row = rows[0];
+  return {
+    inputTokens: row.total_input,
+    outputTokens: row.total_output,
+    estimatedCost: row.total_cost ?? 0,
+  };
+}
+
+/**
  * Return aggregate totals for all usage events within the given time range.
  */
 export function getUsageTotals(range: UsageTimeRange): UsageTotals {

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -11,6 +11,7 @@ import {
   getMessages,
   type MessageRow,
 } from "../../memory/conversation-crud.js";
+import { getConversationUsageTotals } from "../../memory/llm-usage-store.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { getLogger } from "../../util/logger.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
@@ -29,6 +30,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export interface SubagentDetailResult {
   subagentId: string;
   objective?: string;
+  usage?: { inputTokens: number; outputTokens: number; estimatedCost: number };
   events: Array<{
     type: string;
     content: string;
@@ -142,7 +144,30 @@ function getSubagentDetail(
   subagentId: string,
   conversationId: string,
 ): SubagentDetailResult {
-  return parseSubagentMessages(subagentId, getMessages(conversationId));
+  const messages = getMessages(conversationId);
+  log.info(
+    {
+      subagentId,
+      conversationId,
+      messageCount: messages.length,
+      roles: messages.map((m) => m.role),
+    },
+    "getSubagentDetail: raw messages from DB",
+  );
+  const result = parseSubagentMessages(subagentId, messages);
+  log.info(
+    {
+      subagentId,
+      eventCount: result.events.length,
+      eventTypes: result.events.map((e) => `${e.type}:${e.toolName ?? ""}`),
+    },
+    "getSubagentDetail: parsed events",
+  );
+  const usage = getConversationUsageTotals(conversationId);
+  if (usage.inputTokens > 0 || usage.outputTokens > 0) {
+    result.usage = usage;
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,9 +198,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: ({ pathParams, queryParams }) => {
       const conversationId = queryParams?.conversationId;
       if (!conversationId) {
-        throw new BadRequestError(
-          "conversationId query parameter is required",
-        );
+        throw new BadRequestError("conversationId query parameter is required");
       }
 
       const manager = getSubagentManager();
@@ -209,11 +232,7 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       const manager = getSubagentManager();
-      const aborted = manager.abort(
-        pathParams!.id,
-        () => {},
-        conversationId,
-      );
+      const aborted = manager.abort(pathParams!.id, () => {}, conversationId);
 
       if (!aborted) {
         log.warn(

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -193,6 +193,13 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       subagentId: z.string(),
       objective: z.string(),
+      usage: z
+        .object({
+          inputTokens: z.number(),
+          outputTokens: z.number(),
+          estimatedCost: z.number(),
+        })
+        .optional(),
       events: z.array(z.unknown()).describe("Subagent event objects"),
     }),
     handler: ({ pathParams, queryParams }) => {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -29,6 +29,7 @@ struct SubagentDetailPanel: View {
     @State private var panelHeight: CGFloat = 0
     @State private var objectiveContentHeight: CGFloat = 0
     @State private var objectiveScrollHeight: CGFloat = 0
+    @State private var objectiveScrolledToBottom = false
 
     var body: some View {
         VSidePanel(title: "", titleFont: VFont.titleSmall, onClose: onClose, titleAccessory: {
@@ -124,9 +125,16 @@ struct SubagentDetailPanel: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { objectiveContentHeight = $0 }
                     }
+                    .onScrollGeometryChange(for: Bool.self) { geo in
+                        let maxOffset = geo.contentSize.height - geo.containerSize.height
+                        return maxOffset > 0 && geo.contentOffset.y >= maxOffset - 1
+                    } action: { _, atBottom in
+                        objectiveScrolledToBottom = atBottom
+                    }
                     .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { objectiveScrollHeight = $0 }
                     .mask {
-                        if objectiveContentHeight > objectiveScrollHeight + 1 {
+                        let overflows = objectiveContentHeight > objectiveScrollHeight + 1
+                        if overflows && !objectiveScrolledToBottom {
                             VStack(spacing: 0) {
                                 Color.black
                                 LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -26,6 +26,9 @@ struct SubagentDetailPanel: View {
     /// `MarkdownSegmentView.maxContentWidth` so markdown wraps to the panel
     /// instead of the default `chatBubbleMaxWidth` (760pt).
     @State private var panelContentWidth: CGFloat = 0
+    @State private var panelHeight: CGFloat = 0
+    @State private var objectiveContentHeight: CGFloat = 0
+    @State private var objectiveScrollHeight: CGFloat = 0
 
     var body: some View {
         VSidePanel(title: "", titleFont: VFont.titleSmall, onClose: onClose, titleAccessory: {
@@ -56,8 +59,6 @@ struct SubagentDetailPanel: View {
             }
         }, pinnedContent: {
             pinnedBody
-
-            Divider().background(VColor.borderBase)
         }) {
             Color.clear
                 .frame(height: 0)
@@ -78,6 +79,11 @@ struct SubagentDetailPanel: View {
             }
         }
         .background(VColor.surfaceLift)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newHeight in
+            panelHeight = newHeight
+        }
         .onAppear {
             // Lazy-load events from DB when the panel opens for a completed subagent with no cached events
             if events.isEmpty, subagentInfo?.conversationId != nil {
@@ -110,12 +116,29 @@ struct SubagentDetailPanel: View {
                     Text("Objective")
                         .font(VFont.bodyMediumEmphasised)
                         .foregroundStyle(VColor.contentEmphasized)
-                    Text(objective)
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundStyle(VColor.contentDefault)
-                        .lineSpacing(18 - 14)
+                    ScrollView {
+                        Text(objective)
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentDefault)
+                            .lineSpacing(18 - 14)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { objectiveContentHeight = $0 }
+                    }
+                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { objectiveScrollHeight = $0 }
+                    .mask {
+                        if objectiveContentHeight > objectiveScrollHeight + 1 {
+                            VStack(spacing: 0) {
+                                Color.black
+                                LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                                    .frame(height: 24)
+                            }
+                        } else {
+                            Color.black
+                        }
+                    }
                 }
                 .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.md, bottom: VSpacing.lg, trailing: VSpacing.md))
+                .frame(maxHeight: panelHeight > 0 ? panelHeight / 4 : nil)
                 .vCard(background: VColor.surfaceOverlay)
             }
 
@@ -140,7 +163,8 @@ struct SubagentDetailPanel: View {
             }
         }
         .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.lg)
+        .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.sm)
     }
 
     // MARK: - Event List
@@ -601,6 +625,10 @@ private struct SubagentCollapsibleText: View {
     @Binding var isExpanded: Bool
     private let collapsedLineLimit = 4
 
+    @State private var truncatedHeight: CGFloat = 0
+    @State private var fullHeight: CGFloat = 0
+    private var isTruncated: Bool { fullHeight > truncatedHeight + 1 }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text(text)
@@ -608,16 +636,34 @@ private struct SubagentCollapsibleText: View {
                 .foregroundStyle(VColor.contentDefault)
                 .lineLimit(isExpanded ? nil : collapsedLineLimit)
                 .textSelection(.enabled)
+                .background {
+                    Text(text)
+                        .font(VFont.bodyMediumLighter)
+                        .lineLimit(collapsedLineLimit)
+                        .hidden()
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { truncatedHeight = $0 }
+                }
+                .background {
+                    Text(text)
+                        .font(VFont.bodyMediumLighter)
+                        .lineLimit(nil)
+                        .hidden()
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { fullHeight = $0 }
+                }
 
-            Button {
-                withAnimation(VAnimation.fast) { isExpanded.toggle() }
-            } label: {
-                Text(isExpanded ? "Show less" : "Show more")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.primaryBase)
+            if isTruncated || isExpanded {
+                Button {
+                    withAnimation(VAnimation.fast) { isExpanded.toggle() }
+                } label: {
+                    Text(isExpanded ? "Show less" : "Show more")
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(VColor.primaryBase)
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
             }
-            .buttonStyle(.plain)
-            .pointerCursor()
         }
     }
 }

--- a/clients/scripts/flexframe-allowlist.txt
+++ b/clients/scripts/flexframe-allowlist.txt
@@ -218,4 +218,4 @@ clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift|.frame(min
 clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift|.frame(maxWidth: .infinity, maxHeight: .infinity)
 clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift|.frame(minWidth: 320)
 clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift|.frame(minWidth: 320)
-clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift|.frame(maxHeight: .infinity)
+clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift|.frame(maxHeight: panelHeight > 0 ? panelHeight / 4 : nil)

--- a/clients/scripts/flexframe-allowlist.txt
+++ b/clients/scripts/flexframe-allowlist.txt
@@ -219,3 +219,4 @@ clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift|.frame(maxWi
 clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift|.frame(minWidth: 320)
 clients/macos/vellum-assistant/Features/MainWindow/UpgradeProgressOverlay.swift|.frame(minWidth: 320)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift|.frame(maxHeight: panelHeight > 0 ? panelHeight / 4 : nil)
+clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift|.frame(maxHeight: .infinity)

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -393,6 +393,14 @@ public final class SubagentDetailStore {
             stagedObjectives[subagentId] = objective
             scheduleFlush()
         }
+        if let usage = response.usage {
+            stagedUsage[subagentId] = SubagentUsageStats(
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                estimatedCost: usage.estimatedCost
+            )
+            scheduleFlush()
+        }
         // Only populate if we don't already have events (avoid duplicates on re-open)
         let existing = currentEvents(for: subagentId)
         guard existing.isEmpty else { return }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4496,14 +4496,22 @@ public struct SubagentDetailResponse: Codable, Sendable {
     public let type: String
     public let subagentId: String
     public let objective: String?
+    public let usage: SubagentDetailUsage?
     public let events: [SubagentDetailResponseEvent]
 
-    public init(type: String, subagentId: String, objective: String? = nil, events: [SubagentDetailResponseEvent]) {
+    public init(type: String, subagentId: String, objective: String? = nil, usage: SubagentDetailUsage? = nil, events: [SubagentDetailResponseEvent]) {
         self.type = type
         self.subagentId = subagentId
         self.objective = objective
+        self.usage = usage
         self.events = events
     }
+}
+
+public struct SubagentDetailUsage: Codable, Sendable {
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let estimatedCost: Double
 }
 
 public struct SubagentDetailResponseEvent: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Cap objective section at 25% panel height with scrollable overflow and a bottom fade gradient that dismisses when scrolled to bottom
- Remove divider between Objective and Timeline sections, set 24px spacing
- Only show "Show more/less" button on tool call/result content that actually overflows
- Persist usage stats (input/output/cost) across app restart by querying `llm_usage_events` in the detail route, including cache tokens for accurate input count
- Add diagnostic logging to the detail route to investigate events discrepancy after restart

## Test plan
- [ ] Open a subagent panel with a long objective — verify it caps at ~25% height, shows bottom blur, and blur disappears when scrolled to bottom
- [ ] Open a subagent panel with a short objective — verify no blur, no scroll
- [ ] Check that tool calls with short content don't show "Show more/Show less"
- [ ] Restart the app and open a completed subagent panel — verify Input/Output/Cost metrics appear with correct values
- [ ] Compare live vs restart usage numbers — input tokens should now match (cache tokens included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)