### PR TITLE
feat(macos): show assistant avatar on subagent group header

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -281,6 +281,7 @@ struct MessageCellView: View, Equatable {
             HStack(spacing: 0) {
                 SubagentGroupContainer(
                     subagents: subagents,
+                    headerAvatar: AvatarAppearanceManager.shared.chatAvatarImage,
                     onAbort: { id in onAbortSubagent?(id) },
                     onTap: { id in onSubagentTap?(id) },
                     avatarProvider: { SubagentAvatarProvider.avatar(for: $0, size: 20) }

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// expanding reveals individual rows. Tapping a row opens its detail panel.
 public struct SubagentGroupContainer: View {
     let subagents: [SubagentInfo]
+    var headerAvatar: NSImage?
     var onAbort: ((String) -> Void)?
     var onTap: ((String) -> Void)?
     var avatarProvider: ((String) -> NSImage?)?
@@ -16,11 +17,13 @@ public struct SubagentGroupContainer: View {
 
     public init(
         subagents: [SubagentInfo],
+        headerAvatar: NSImage? = nil,
         onAbort: ((String) -> Void)? = nil,
         onTap: ((String) -> Void)? = nil,
         avatarProvider: ((String) -> NSImage?)? = nil
     ) {
         self.subagents = subagents
+        self.headerAvatar = headerAvatar
         self.onAbort = onAbort
         self.onTap = onTap
         self.avatarProvider = avatarProvider
@@ -76,7 +79,9 @@ public struct SubagentGroupContainer: View {
             }
         }) {
             HStack(spacing: VSpacing.sm) {
-                if allTerminal {
+                if let headerAvatar {
+                    VAvatarImage(image: headerAvatar, size: 20, showBorder: false)
+                } else if allTerminal {
                     VIconView(failedCount > 0 ? .triangleAlert : .circleCheck, size: 12)
                         .foregroundStyle(failedCount > 0 ? VColor.systemNegativeStrong : VColor.primaryBase)
                 } else {


### PR DESCRIPTION
## Summary
- Display the assistant's own avatar in the subagent group container header row
- Individual subagent rows keep their randomized avatars
- Adds `headerAvatar` parameter to `SubagentGroupContainer`

## Test plan
- [ ] Spawn subagents — verify the collapsible group header shows the assistant's avatar (custom image or character avatar)
- [ ] Verify individual subagent rows still show randomized emoji avatars
- [ ] Change the assistant's avatar — verify the group header updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->