### PR TITLE
assistant(app_create): add next_steps directive to tool result

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -1,13 +1,31 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type CompileResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  durationMs: number;
+};
+
+let compileResultOverride: CompileResult = {
+  ok: true,
+  errors: [],
+  warnings: [],
+  durationMs: 0,
+};
 
 mock.module("../bundler/app-compiler.js", () => ({
-  compileApp: async () => ({
+  compileApp: async () => compileResultOverride,
+}));
+
+beforeEach(() => {
+  compileResultOverride = {
     ok: true,
     errors: [],
     warnings: [],
     durationMs: 0,
-  }),
-}));
+  };
+});
 
 import type { AppDefinition } from "../memory/app-store.js";
 import type { AppStore } from "../tools/apps/executors.js";
@@ -181,6 +199,78 @@ describe("executeAppCreate", () => {
     expect(parsed.auto_opened).toBe(false);
     expect(parsed.next_steps).toContain("placeholder src/main.tsx");
     expect(parsed.next_steps).toContain("app_refresh");
+  });
+
+  test("omits next_steps when main.tsx was pre-written before app_create", async () => {
+    // The agent's supported workflow is to write the real source files first
+    // and then call app_create. In that case the placeholder directive would
+    // be false and risk triggering a destructive rewrite of correct code.
+    const files: Record<string, string> = {
+      "src/main.tsx": "// real code from the agent",
+    };
+    const app = makeMultifileApp({ name: "Pre-written App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+
+    const result = await executeAppCreate({ name: "Pre-written App" }, store);
+
+    expect(result.isError).toBe(false);
+    // The pre-written file must be preserved
+    expect(files["src/main.tsx"]).toBe("// real code from the agent");
+    const parsed = JSON.parse(result.content);
+    expect(parsed.next_steps).toBeUndefined();
+  });
+
+  test("includes next_steps when compile fails on the scaffold", async () => {
+    compileResultOverride = {
+      ok: false,
+      errors: ["unexpected token"],
+      warnings: [],
+      durationMs: 3,
+    };
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "Broken App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+
+    const result = await executeAppCreate({ name: "Broken App" }, store);
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.compile_errors).toEqual(["unexpected token"]);
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+    expect(parsed.next_steps).toContain("app_refresh");
+  });
+
+  test("omits next_steps when compile fails on pre-written files", async () => {
+    compileResultOverride = {
+      ok: false,
+      errors: ["unexpected token"],
+      warnings: [],
+      durationMs: 3,
+    };
+    const files: Record<string, string> = {
+      "src/main.tsx": "// agent's real (but broken) code",
+    };
+    const app = makeMultifileApp({ name: "Broken Pre-written App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+
+    const result = await executeAppCreate(
+      { name: "Broken Pre-written App" },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.compile_errors).toEqual(["unexpected token"]);
+    expect(parsed.next_steps).toBeUndefined();
   });
 
   test("rejects retired html shortcut", async () => {

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -102,6 +102,85 @@ describe("executeAppCreate", () => {
     expect(files["src/main.tsx"]).toBeDefined();
     expect(files["src/main.tsx"]).toContain("import { render } from 'preact'");
     expect(files["src/main.tsx"]).toContain('{"Hello, New App!"}');
+    // next_steps directive must be present so the model keeps writing
+    // real source files instead of treating the scaffold as done.
+    const parsed = JSON.parse(result.content);
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+    expect(parsed.next_steps).toContain("app_refresh");
+  });
+
+  test("includes next_steps when auto_open succeeds", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+    const proxyResolver = async () => ({
+      content: JSON.stringify({ opened: true }),
+      isError: false,
+    });
+
+    const result = await executeAppCreate(
+      { name: "New App" },
+      store,
+      proxyResolver,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.auto_opened).toBe(true);
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+    expect(parsed.next_steps).toContain("app_refresh");
+  });
+
+  test("includes next_steps when auto_open returns error", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+    const proxyResolver = async () => ({
+      content: "open failed",
+      isError: true,
+    });
+
+    const result = await executeAppCreate(
+      { name: "New App" },
+      store,
+      proxyResolver,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.auto_opened).toBe(false);
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+    expect(parsed.next_steps).toContain("app_refresh");
+  });
+
+  test("includes next_steps when auto_open proxy throws", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+    const proxyResolver = async () => {
+      throw new Error("proxy unavailable");
+    };
+
+    const result = await executeAppCreate(
+      { name: "New App" },
+      store,
+      proxyResolver,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.auto_opened).toBe(false);
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+    expect(parsed.next_steps).toContain("app_refresh");
   });
 
   test("rejects retired html shortcut", async () => {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -217,6 +217,8 @@ render(<App />, document.getElementById('app')!);
             ...app,
             auto_opened: false,
             auto_open_error: openResult.content,
+            next_steps:
+              "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
           }),
           isError: false,
         };
@@ -226,6 +228,8 @@ render(<App />, document.getElementById('app')!);
           ...app,
           auto_opened: true,
           open_result: openResult.content,
+          next_steps:
+            "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
         }),
         isError: false,
       };
@@ -237,13 +241,22 @@ render(<App />, document.getElementById('app')!);
           auto_opened: false,
           auto_open_error:
             "Failed to auto-open app. Use app_open to open it manually.",
+          next_steps:
+            "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
         }),
         isError: false,
       };
     }
   }
 
-  return { content: JSON.stringify(app), isError: false };
+  return {
+    content: JSON.stringify({
+      ...app,
+      next_steps:
+        "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+    }),
+    isError: false,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -176,12 +176,25 @@ render(<App />, document.getElementById('app')!);
   // The LLM may have written custom source files via file_write before
   // calling app_create, and overwriting them would destroy the real app
   // content, leaving only the scaffold placeholder.
+  const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
   if (!store.appFileExists(app.id, "src/index.html")) {
     store.writeAppFile(app.id, "src/index.html", indexHtml);
   }
-  if (!store.appFileExists(app.id, "src/main.tsx")) {
+  if (mainTsxScaffolded) {
     store.writeAppFile(app.id, "src/main.tsx", mainTsx);
   }
+
+  // When the placeholder main.tsx was actually scaffolded, the tool result
+  // must steer the agent toward writing the real source files instead of
+  // treating success + inline AppCard as task-done. When the agent pre-wrote
+  // src/main.tsx before calling app_create, this directive would be false
+  // and risks prompting a destructive rewrite, so omit it in that case.
+  const nextStepsField = mainTsxScaffolded
+    ? {
+        next_steps:
+          "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+      }
+    : {};
 
   // Compile src/ → dist/
   const appDir = getAppDirPath(app.id);
@@ -193,6 +206,7 @@ render(<App />, document.getElementById('app')!);
         compile_errors: compileResult.errors,
         compile_warnings: compileResult.warnings,
         compile_duration_ms: compileResult.durationMs,
+        ...nextStepsField,
       }),
       isError: false,
     };
@@ -217,8 +231,7 @@ render(<App />, document.getElementById('app')!);
             ...app,
             auto_opened: false,
             auto_open_error: openResult.content,
-            next_steps:
-              "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+            ...nextStepsField,
           }),
           isError: false,
         };
@@ -228,8 +241,7 @@ render(<App />, document.getElementById('app')!);
           ...app,
           auto_opened: true,
           open_result: openResult.content,
-          next_steps:
-            "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+          ...nextStepsField,
         }),
         isError: false,
       };
@@ -241,8 +253,7 @@ render(<App />, document.getElementById('app')!);
           auto_opened: false,
           auto_open_error:
             "Failed to auto-open app. Use app_open to open it manually.",
-          next_steps:
-            "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+          ...nextStepsField,
         }),
         isError: false,
       };
@@ -252,8 +263,7 @@ render(<App />, document.getElementById('app')!);
   return {
     content: JSON.stringify({
       ...app,
-      next_steps:
-        "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+      ...nextStepsField,
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary

- App-builder agent often stopped after `app_create` because the tool result looked successful and nothing in the fresh tool output told the model to continue. Added a `next_steps` field to every `isError: false` return in `executeAppCreate` instructing the agent to write the real source files and call `app_refresh`.
- Same string at all four success return sites (no-auto-open, auto-open success, auto-open returns isError, auto-open proxy throws) — the directive doesn't branch on auto_open state.
- `next_steps` sits as a top-level sibling to the spread `...app` fields, so existing callers reading `name`/`id` are unaffected. Tool input schema, executor signature, and error-path returns are untouched.

Note: the original bug spec called out three return sites, but the file actually has four `isError: false` returns post-compile-success (it missed the proxy-`isError` branch). Added to all four so the directive can't be missed in any auto-open outcome.

Out of scope (deliberate, easy revert): `SKILL.md` and `TOOLS.json` updates land separately.

Closes #30667

## Test plan

- [x] `bun test src/__tests__/app-executors.test.ts` — 9 pass / 0 fail
- [x] `bun run lint src/tools/apps/executors.ts src/__tests__/app-executors.test.ts` — clean
- [x] `bunx tsc --noEmit` (assistant package) — clean
- [ ] Spot-check in a real conversation: create an app via app-builder agent and confirm it now writes source files + calls `app_refresh` instead of stopping at the scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->