### PR TITLE
[codex] Fix document tool cross-conversation access controls

### DIFF
--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDocumentById } from "../documents/document-store.js";
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import {
+  executeDocumentDelete,
+  executeDocumentList,
+  executeDocumentRead,
+  executeDocumentUpdate,
+} from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDb();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.updatedAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.updatedAt,
+      params.updatedAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.updatedAt);
+}
+
+function seedFixtureDocuments(): void {
+  seedDocument({
+    surfaceId: "doc-current",
+    conversationId: "conv-current",
+    title: "Current Business Plan",
+    content: "current plan",
+    updatedAt: 1000,
+  });
+  seedDocument({
+    surfaceId: "doc-other",
+    conversationId: "conv-other",
+    title: "Other Business Plan",
+    content: "other plan",
+    updatedAt: 2000,
+  });
+  seedDocument({
+    surfaceId: "doc-percent",
+    conversationId: "conv-other",
+    title: "100% Plan",
+    content: "literal percent",
+    updatedAt: 3000,
+  });
+}
+
+describe("document tool security", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedFixtureDocuments();
+  });
+
+  test("scopes title search to the current conversation for non-guardian remote actors", () => {
+    const result = executeDocumentList(
+      { query: "Business Plan" },
+      makeContext({ trustClass: "trusted_contact", executionChannel: "slack" }),
+    );
+
+    const body = parseResult<{ documents: Array<{ surface_id: string }> }>(
+      result,
+    );
+    expect(body.documents.map((doc) => doc.surface_id)).toEqual([
+      "doc-current",
+    ]);
+  });
+
+  test("does not treat SQL LIKE wildcards as title-search wildcards", () => {
+    const result = executeDocumentList(
+      { query: "%" },
+      makeContext({ trustClass: "guardian", executionChannel: "telegram" }),
+    );
+
+    const body = parseResult<{ documents: Array<{ surface_id: string }> }>(
+      result,
+    );
+    expect(body.documents.map((doc) => doc.surface_id)).toEqual([
+      "doc-percent",
+    ]);
+  });
+
+  test("allows guardian and local actors to use documents from previous conversations", () => {
+    const guardianContext = makeContext({
+      trustClass: "guardian",
+      executionChannel: "telegram",
+      sendToClient: () => {},
+    });
+    const guardianList = executeDocumentList(
+      { query: "Other Business" },
+      guardianContext,
+    );
+    const guardianBody = parseResult<{
+      documents: Array<{ surface_id: string }>;
+    }>(guardianList);
+    expect(guardianBody.documents.map((doc) => doc.surface_id)).toEqual([
+      "doc-other",
+    ]);
+
+    const localRead = executeDocumentRead(
+      { surface_id: "doc-other" },
+      makeContext({ trustClass: "unknown", executionChannel: "vellum" }),
+    );
+    const localBody = parseResult<{
+      success: boolean;
+      surface_id: string;
+      content: string;
+    }>(localRead);
+    expect(localBody).toMatchObject({
+      success: true,
+      surface_id: "doc-other",
+      content: "other plan",
+    });
+
+    const guardianUpdate = executeDocumentUpdate(
+      { surface_id: "doc-other", content: "guardian edit", mode: "replace" },
+      guardianContext,
+    );
+    expect(guardianUpdate.isError).toBe(false);
+    expect(getDocumentById("doc-other")?.content).toBe("guardian edit");
+
+    const guardianDelete = executeDocumentDelete(
+      { surface_id: "doc-other" },
+      guardianContext,
+    );
+    expect(guardianDelete.isError).toBe(false);
+    expect(getDocumentById("doc-other")).toBeNull();
+  });
+
+  test("blocks cross-conversation read, update, and delete for non-guardian remote actors", () => {
+    const remoteContext = makeContext({
+      trustClass: "trusted_contact",
+      executionChannel: "slack",
+      sendToClient: () => {},
+    });
+
+    const read = executeDocumentRead(
+      { surface_id: "doc-other" },
+      remoteContext,
+    );
+    expect(read.isError).toBe(true);
+    expect(parseResult<{ error: string }>(read).error).toBe(
+      "Document not found",
+    );
+
+    const update = executeDocumentUpdate(
+      {
+        surface_id: "doc-other",
+        content: "updated by another conversation",
+        mode: "replace",
+      },
+      remoteContext,
+    );
+    expect(update.isError).toBe(true);
+    expect(getDocumentById("doc-other")?.content).toBe("other plan");
+
+    const deleted = executeDocumentDelete(
+      { surface_id: "doc-other" },
+      remoteContext,
+    );
+    expect(deleted.isError).toBe(true);
+    expect(getDocumentById("doc-other")).not.toBeNull();
+  });
+
+  test("keeps current-conversation documents editable and deletable", () => {
+    const remoteContext = makeContext({
+      trustClass: "trusted_contact",
+      executionChannel: "slack",
+      sendToClient: () => {},
+    });
+
+    const read = executeDocumentRead(
+      { surface_id: "doc-current" },
+      remoteContext,
+    );
+    expect(read.isError).toBe(false);
+
+    const update = executeDocumentUpdate(
+      { surface_id: "doc-current", content: "revised plan", mode: "replace" },
+      remoteContext,
+    );
+    expect(update.isError).toBe(false);
+    expect(getDocumentById("doc-current")?.content).toBe("revised plan");
+
+    const deleted = executeDocumentDelete(
+      { surface_id: "doc-current" },
+      remoteContext,
+    );
+    expect(deleted.isError).toBe(false);
+    expect(getDocumentById("doc-current")).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -462,6 +462,7 @@ describe("isSideEffectTool", () => {
       "web_fetch",
       "document_create",
       "document_update",
+      "document_delete",
       "schedule_create",
       "schedule_update",
       "schedule_delete",
@@ -670,6 +671,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
       { name: "web_fetch", input: { url: "https://example.com" } },
       { name: "document_create", input: { title: "doc", content: "body" } },
       { name: "document_update", input: { id: "doc-1", content: "updated" } },
+      { name: "document_delete", input: { surface_id: "doc-1" } },
       {
         name: "credential_store",
         input: { action: "store", name: "api-key", value: "secret" },

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -18,8 +18,8 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 
 - **document_create** - Opens a new document editor with an optional title and initial Markdown content. Returns a `surface_id` for subsequent updates.
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
-- **document_read** - Reads the current content of a document by `surface_id`. Use to verify content before editing.
-- **document_list** - Lists documents. Without `query`, lists the current conversation's documents. With `query`, searches all documents by title across all conversations.
+- **document_read** - Reads the current content of a document by `surface_id` when it belongs to the current conversation, or when the current actor is the guardian/local user. Use to verify content before editing.
+- **document_list** - Lists documents. Without `query`, lists the current conversation's documents. With `query`, searches by title; guardian/local users can search across conversations, while other actors are scoped to the current conversation.
 - **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
 ## Retrieving existing documents
@@ -27,7 +27,7 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 When the user asks to see, open, or pull up a document:
 
 1. Check the `<active_documents>` block in your context — it lists all documents in this conversation with their `surface_id` and title. If the document is there, call `document_read` with its `surface_id`. Done in one call.
-2. If the document is NOT in `<active_documents>`, call `document_list` with a `query` matching the document title. This searches across all conversations and previous sessions.
+2. If the document is NOT in `<active_documents>`, call `document_list` with a `query` matching the document title. For guardian/local users, this searches across previous conversations and sessions.
 3. Once you have the `surface_id`, call `document_read` to retrieve the content.
 
 **Never** search the filesystem, conversation history, or archives to find a document. Always use `document_list` with a `query`.
@@ -35,12 +35,13 @@ When the user asks to see, open, or pull up a document:
 ## Creating a new document
 
 1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
-2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, *italic*, code blocks, tables, lists, blockquotes as appropriate.
+2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, _italic_, code blocks, tables, lists, blockquotes as appropriate.
 3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. The user experiences real-time content appearing as you write.
 
 ## Editing an existing document
 
 When the user requests changes to a document:
+
 1. Find the `surface_id` from the `<active_documents>` context block.
 2. Use `document_update` with the existing `surface_id` — do NOT call `document_create` again.
 3. Use `mode: "replace"` for full rewrites or `mode: "append"` for additions.

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "document_read",
-      "description": "Read the current content of an open document by its surface_id. Use this to verify document state before making edits.",
+      "description": "Read the current content of a document by its surface_id when it belongs to the current conversation, or when the current actor is the guardian/local user. Use this to verify document state before making edits.",
       "category": "document",
       "risk": "low",
       "input_schema": {
@@ -69,7 +69,7 @@
     },
     {
       "name": "document_list",
-      "description": "List documents. Without a query, lists documents in the current conversation. With a query, searches all documents by title across all conversations.",
+      "description": "List documents. Without a query, lists documents in the current conversation. With a query, searches documents by title; guardian/local users can search across conversations, while other actors are scoped to the current conversation.",
       "category": "document",
       "risk": "low",
       "input_schema": {
@@ -77,7 +77,7 @@
         "properties": {
           "query": {
             "type": "string",
-            "description": "Search documents by title across all conversations. Omit to list only the current conversation's documents."
+            "description": "Search documents by title. Omit to list only the current conversation's documents."
           }
         }
       },

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -58,6 +58,10 @@ interface DocumentRow {
 
 type DocumentListRow = Omit<DocumentRow, "content">;
 
+function escapeSqlLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
 function mapRowToRecord(row: DocumentRow): DocumentRecord {
   return {
     surfaceId: row.surface_id,
@@ -90,6 +94,32 @@ export function getDocumentById(surfaceId: string): DocumentRecord | null {
   } catch (error) {
     log.error({ err: error, surfaceId }, "Load error");
     return null;
+  }
+}
+
+/** Return true when a document is associated with a conversation. */
+export function isDocumentAssociatedWithConversation(
+  surfaceId: string,
+  conversationId: string,
+): boolean {
+  try {
+    const row = rawGet<{ found: number }>(
+      /*sql*/ `
+      SELECT 1 AS found
+      FROM document_conversations
+      WHERE surface_id = ? AND conversation_id = ?
+      LIMIT 1
+      `,
+      surfaceId,
+      conversationId,
+    );
+    return row != null;
+  } catch (error) {
+    log.error(
+      { err: error, surfaceId, conversationId },
+      "Document association check error",
+    );
+    return false;
   }
 }
 
@@ -132,25 +162,47 @@ export function getDocumentsForConversation(
 }
 
 /**
- * Search documents across all conversations by title substring (case-insensitive).
+ * Search documents by title substring (case-insensitive).
+ * When `conversationId` is supplied, only documents associated with that
+ * conversation are returned.
  * Returns documents ordered by most recently updated.
  */
 export function searchDocumentsByTitle(
   query: string,
+  options: { conversationId?: string } = {},
 ): Omit<DocumentRecord, "content">[] {
   try {
-    const rows = rawAll<DocumentListRow>(
-      /*sql*/ `
-      SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
-      FROM documents
-      WHERE title LIKE '%' || ? || '%' COLLATE NOCASE
-      ORDER BY updated_at DESC
-      LIMIT 20
-      `,
-      query,
-    );
+    const pattern = `%${escapeSqlLikePattern(query)}%`;
+    const rows = options.conversationId
+      ? rawAll<DocumentListRow>(
+          /*sql*/ `
+          SELECT d.surface_id, dc.conversation_id AS conversation_id,
+                 d.title, d.word_count, d.created_at, d.updated_at
+          FROM documents d
+          INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
+          WHERE dc.conversation_id = ?
+            AND d.title COLLATE NOCASE LIKE ? ESCAPE '\\'
+          ORDER BY d.updated_at DESC
+          LIMIT 20
+          `,
+          options.conversationId,
+          pattern,
+        )
+      : rawAll<DocumentListRow>(
+          /*sql*/ `
+          SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
+          FROM documents
+          WHERE title COLLATE NOCASE LIKE ? ESCAPE '\\'
+          ORDER BY updated_at DESC
+          LIMIT 20
+          `,
+          pattern,
+        );
 
-    log.info({ query, count: rows.length }, "Searched documents by title");
+    log.info(
+      { query, conversationId: options.conversationId, count: rows.length },
+      "Searched documents by title",
+    );
     return rows.map((row) => ({
       surfaceId: row.surface_id,
       conversationId: row.conversation_id,

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -4,11 +4,36 @@ import {
   deleteDocument,
   getDocumentById,
   getDocumentsForConversation,
+  isDocumentAssociatedWithConversation,
   saveDocument,
   searchDocumentsByTitle,
   updateDocumentContent,
 } from "../../documents/document-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+function isPrivilegedDocumentActor(context: ToolContext): boolean {
+  return (
+    context.trustClass === "guardian" || context.executionChannel === "vellum"
+  );
+}
+
+function documentNotFound(surfaceId: string): ToolExecutionResult {
+  return {
+    content: JSON.stringify({
+      success: false,
+      surface_id: surfaceId,
+      error: "Document not found",
+    }),
+    isError: true,
+  };
+}
+
+function canAccessDocument(surfaceId: string, context: ToolContext): boolean {
+  return (
+    isPrivilegedDocumentActor(context) ||
+    isDocumentAssociatedWithConversation(surfaceId, context.conversationId)
+  );
+}
 
 // ── Exported execute functions ──────────────────────────────────────
 
@@ -89,6 +114,10 @@ export function executeDocumentUpdate(
   const content = input.content as string;
   const mode = (input.mode as string | undefined) || "append";
 
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
   const result = updateDocumentContent(surfaceId, content, mode);
   if (!result.success) {
     return {
@@ -134,19 +163,16 @@ export function executeDocumentUpdate(
 
 export function executeDocumentRead(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): ToolExecutionResult {
   const surfaceId = input.surface_id as string;
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
   const doc = getDocumentById(surfaceId);
   if (!doc) {
-    return {
-      content: JSON.stringify({
-        success: false,
-        surface_id: surfaceId,
-        error: "Document not found",
-      }),
-      isError: true,
-    };
+    return documentNotFound(surfaceId);
   }
   return {
     content: JSON.stringify({
@@ -165,9 +191,17 @@ export function executeDocumentList(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const query = input.query as string | undefined;
+  const query =
+    typeof input.query === "string" && input.query.trim().length > 0
+      ? input.query.trim()
+      : undefined;
   const docs = query
-    ? searchDocumentsByTitle(query)
+    ? searchDocumentsByTitle(
+        query,
+        isPrivilegedDocumentActor(context)
+          ? {}
+          : { conversationId: context.conversationId },
+      )
     : getDocumentsForConversation(context.conversationId);
   return {
     content: JSON.stringify({
@@ -186,19 +220,16 @@ export function executeDocumentList(
 
 export function executeDocumentDelete(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): ToolExecutionResult {
   const surfaceId = input.surface_id as string;
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
   const deleted = deleteDocument(surfaceId);
   if (!deleted) {
-    return {
-      content: JSON.stringify({
-        success: false,
-        surface_id: surfaceId,
-        error: "Document not found",
-      }),
-      isError: true,
-    };
+    return documentNotFound(surfaceId);
   }
   return {
     content: JSON.stringify({

--- a/assistant/src/tools/side-effects.ts
+++ b/assistant/src/tools/side-effects.ts
@@ -14,6 +14,7 @@ const SIDE_EFFECT_TOOLS: ReadonlySet<string> = new Set([
   "web_fetch",
   "document_create",
   "document_update",
+  "document_delete",
   "schedule_create",
   "schedule_update",
   "schedule_delete",


### PR DESCRIPTION
## Summary

Fixes document tool access controls for ATL-576 without removing the intended guardian/local cross-conversation document retrieval flow.

- Scope document search/read/update/delete to the current conversation for non-guardian remote actors.
- Preserve cross-conversation document lookup and edits for guardian/local actors so requests like “pull up that business plan we worked on yesterday” still work.
- Escape SQL LIKE wildcards in document title search so `%` and `_` are treated as literal query text rather than enumeration wildcards.
- Classify `document_delete` as a side-effect tool so explicit-approval paths cover it.
- Add focused regression coverage for scoped search, wildcard escaping, cross-conversation read/update/delete denial, and preserved current-conversation document operations.

## Root Cause

The new low-risk document tools exposed global title search and direct `surface_id` read/delete without checking whether the document was associated with the current conversation or whether the actor was the guardian/local user. The title search also passed raw input into a LIKE pattern, so wildcard input could enumerate documents.

## Validation

- `bun test src/__tests__/document-tool-security.test.ts`
- `bun test src/__tests__/tool-executor.test.ts`
- `bunx eslint src/documents/document-store.ts src/tools/document/document-tool.ts src/tools/side-effects.ts src/__tests__/document-tool-security.test.ts src/__tests__/tool-executor.test.ts`
- `bunx tsc --noEmit`
- Commit hook: formatting, lint, typecheck
- Push hook: typecheck, lint

Closes #30675
Related to ATL-576