### PR TITLE
feat: add google-connect-scan feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -304,6 +304,14 @@
       "label": "External Plugins",
       "description": "Enable the external-plugin install path: the `assistant plugins` CLI subcommand and the declarative external-plugin loader convention (`<workspaceDir>/plugins/<name>/` directories containing `package.json` plus interface dirs). Gates an unstable surface that may change shape before stabilizing.",
       "defaultEnabled": false
+    },
+    {
+      "id": "google-connect-scan",
+      "scope": "assistant",
+      "key": "google-connect-scan",
+      "label": "Google Connect Scan",
+      "description": "After Google OAuth completes during onboarding, spawn parallel subagents to scan Gmail and Calendar and synthesize actionable insights",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `google-connect-scan` feature flag to the feature flag registry
- Flag gates parallel Gmail+Calendar scan after Google OAuth during onboarding
- Default disabled, to be enabled when A/B test is ready

Part of plan: new-user-retention-integration.md (PR 1 of 5)

JARVIS-839
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->