### PR TITLE
feat(onboarding): add googleConnected flag to OnboardingContext

### DIFF
--- a/assistant/src/__tests__/onboarding-context.test.ts
+++ b/assistant/src/__tests__/onboarding-context.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { OnboardingContext } from "../types/onboarding-context.js";
+
+// Dynamic import so WORKSPACE_DIR override takes effect before module init.
+const { getOnboardingSidecarPath, writeOnboardingSidecar } =
+  await import("../home/relationship-state-writer.js");
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "onboarding-ctx-test-"));
+  origWorkspaceDir = process.env.WORKSPACE_DIR;
+  process.env.WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.WORKSPACE_DIR;
+  } else {
+    process.env.WORKSPACE_DIR = origWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("OnboardingContext googleConnected field", () => {
+  test("googleConnected: true is persisted to the sidecar file", () => {
+    const ctx: OnboardingContext = {
+      tools: ["Gmail"],
+      tasks: ["Inbox triage"],
+      tone: "Friendly",
+      userName: "Alex",
+      assistantName: "Nova",
+      googleConnected: true,
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    expect(existsSync(path)).toBe(true);
+
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBe(true);
+    // Verify other fields are still present
+    expect(decoded.tools).toEqual(["Gmail"]);
+    expect(decoded.tasks).toEqual(["Inbox triage"]);
+    expect(decoded.tone).toBe("Friendly");
+    expect(decoded.userName).toBe("Alex");
+    expect(decoded.assistantName).toBe("Nova");
+  });
+
+  test("omitting googleConnected still works (backward compat)", () => {
+    const ctx: OnboardingContext = {
+      tools: ["Slack"],
+      tasks: ["Meeting prep"],
+      tone: "Dry and precise",
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    expect(existsSync(path)).toBe(true);
+
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBeUndefined();
+    expect(decoded.tools).toEqual(["Slack"]);
+    expect(decoded.tasks).toEqual(["Meeting prep"]);
+    expect(decoded.tone).toBe("Dry and precise");
+  });
+
+  test("googleConnected: false is persisted correctly", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "",
+      googleConnected: false,
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1046,6 +1046,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1121,6 +1122,7 @@ export async function handleSendMessage(
       tone: string;
       userName?: string;
       assistantName?: string;
+      googleConnected?: boolean;
     };
   };
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -4,4 +4,5 @@ export interface OnboardingContext {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add optional `googleConnected` boolean to `OnboardingContext` interface
- Field flows through existing onboarding persistence to sidecar JSON
- Enables frontend to signal that Google OAuth was completed during pre-chat onboarding

Part of plan: new-user-retention-integration.md (PR 2 of 5)

JARVIS-839
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->