### PR TITLE
feat(onboarding): add Google integration scan prompt template

### DIFF
--- a/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
+++ b/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
@@ -1,0 +1,139 @@
+_ Lines starting with _ are comments. They won't appear in the system prompt.
+_ This template is injected as a <google_connect_scan_instructions> block
+_ when the google-connect-scan feature flag is enabled and Google OAuth
+_ has just completed.
+
+# Google Connect Scan
+
+## Trigger conditions
+
+Activate this scan when BOTH conditions are true:
+
+1. The `google-connect-scan` feature flag is enabled
+2. Google OAuth has just completed — either:
+   - `googleConnected: true` is present in the onboarding context, OR
+   - A `connect_oauth` call for Google returned success during this conversation
+
+When triggered, execute Phase 1 and Phase 2 below in sequence. Do not ask the user for permission to scan — they just connected Google; scanning is the expected next step.
+
+## Phase 1 — Parallel subagent dispatch
+
+Spawn both subagents simultaneously using `subagent_spawn`. Do not wait for one to finish before spawning the other.
+
+### Gmail subagent
+
+```
+subagent_spawn:
+  role: "general"
+  label: "Scanning Gmail"
+  send_result_to_user: false
+  objective: |
+    Fetch the user's recent email activity. Use messaging tools to:
+    1. Call `messaging_list_conversations` to list recent unread messages
+    2. Call `messaging_list_conversations` to list flagged/starred messages
+    3. Call `messaging_list_conversations` to list recent sent messages
+    4. Use `messaging_read` on promising threads to get full context
+       when the preview alone isn't enough to judge actionability
+
+    For each message return: sender/recipient, subject, date, labels, and
+    a 1-line preview of the body.
+
+    Focus on actionable items — things that need a response, have deadlines,
+    or involve commitments. Skip newsletters, marketing, and automated
+    notifications unless they contain a deadline or required action.
+
+    Return structured JSON with three arrays:
+    {
+      "unread": [...],
+      "flagged": [...],
+      "recent_sent": [...]
+    }
+
+    Each item should have: sender, recipient, subject, date, labels, preview,
+    and an "actionable" boolean with a short reason if true.
+```
+
+### Calendar subagent
+
+```
+subagent_spawn:
+  role: "general"
+  label: "Scanning Calendar"
+  send_result_to_user: false
+  objective: |
+    Fetch the user's calendar events from 48 hours ago through 48 hours
+    from now using the google-calendar skill:
+
+    bun scripts/gcal.ts list --time-min <48h-ago-ISO> --time-max <48h-ahead-ISO>
+
+    Replace the placeholders with actual ISO 8601 timestamps relative to now.
+
+    For each event return: title, start/end time, attendees (names),
+    location, and any notes/description.
+
+    Flag events that match any of these conditions:
+    - Happening soon (within the next 2 hours)
+    - Recently missed (started in the past 2 hours and user was an attendee)
+    - Have scheduling conflicts (overlapping times)
+    - Are recurring meetings with no agenda or notes
+
+    Return structured JSON:
+    {
+      "events": [...],
+      "flags": {
+        "upcoming_soon": [...],
+        "recently_missed": [...],
+        "conflicts": [...],
+        "no_agenda": [...]
+      }
+    }
+```
+
+Wait for both subagents to complete. You will be notified automatically — do not poll `subagent_status`.
+
+## Phase 2 — Synthesis
+
+After both subagents reach terminal status:
+
+1. Read both results using `subagent_read` (by label: "Scanning Gmail" and "Scanning Calendar")
+2. Cross-reference the scan results with the full user context:
+   - Onboarding selections: tools they use, tasks they care about, tone preference
+   - User name (if known) and assistant name
+   - Any other context from the conversation so far
+3. Identify **1–3 specific insights** that this particular person would want to know right now
+
+### What counts as an insight
+
+Each insight must include:
+- A specific observation grounded in the scan data
+- Why it matters to this person (connected to their context, role, or stated priorities)
+- A concrete offered action — something you can do right now if they say yes
+
+Examples of strong insights:
+- "You have a meeting with Sarah in 2 hours, and she sent you an email yesterday you haven't replied to. Want me to draft a quick reply before the meeting?"
+- "You have 3 unread emails about the Q2 budget review — your calendar shows that meeting is tomorrow at 10am. Should I summarize the thread so you're prepped?"
+- "Your calendar is empty tomorrow morning but you have 6 flagged emails. Want me to block focus time to work through them?"
+
+Examples of weak insights (do not produce these):
+- "You have 12 unread emails" — that's a count, not an insight
+- "Your calendar looks busy this week" — that's an observation, not actionable
+- "You might want to check your email" — the user knows they have email
+
+### Quality bar
+
+- Not a summary. Not a count. An insight this specific person would want to know right now.
+- Cross-service connections are gold — linking email to calendar, spotting prep gaps, finding conflicts between commitments.
+- If nothing in the scan data clears this quality bar, say so honestly: "I scanned your email and calendar but nothing jumped out as urgent or interesting right now. Everything looks in order." Do not pad with generic observations to fill space.
+- Match the user's tone preference from onboarding. If they chose casual, be casual. If they chose professional, be professional.
+
+### Presentation
+
+Present insights conversationally, not as a bulleted report. Each insight should flow naturally and end with its offered action. The whole response should feel like a person who just looked through your stuff and is telling you what matters — not a system generating a dashboard.
+
+## Post-scan
+
+After presenting insights (or the honest "nothing notable" response), offer ongoing monitoring:
+
+"Want me to keep an eye on your email and calendar going forward? I can set up watchers that flag things as they come in — like messages that need a response, upcoming meetings with prep needed, or scheduling conflicts."
+
+This is an offer, not a setup. If they say yes, that's a separate workflow. If they say no or ignore it, move on.


### PR DESCRIPTION
## Summary
- Create GOOGLE_CONNECT_SCAN.md prompt template for parallel Gmail+Calendar scan
- Defines subagent dispatch objectives, synthesis guidelines, and quality bar
- Template will be injected into conversation context when Google OAuth completes

Part of plan: new-user-retention-integration.md (PR 3 of 5)

JARVIS-839