### PR TITLE
feat(onboarding): inject Google connect scan instructions into conversation context

### DIFF
--- a/assistant/src/__tests__/scan-context-injection.test.ts
+++ b/assistant/src/__tests__/scan-context-injection.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for Google Connect Scan context injection in buildSystemPrompt.
+ *
+ * The scan instructions are injected only when:
+ *   1. The `google-connect-scan` feature flag is enabled
+ *   2. BOOTSTRAP.md is present (first conversation)
+ *   3. `googleConnected: true` in onboarding context
+ *
+ * When any condition is unmet, the scan instructions must be absent.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+// Mutable flag overrides — tests flip these to control feature gate.
+const _mockFlagOverrides: Record<string, boolean> = {};
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
+    const explicit = _mockFlagOverrides[key];
+    if (typeof explicit === "boolean") return explicit;
+    return false; // default to disabled for test isolation
+  },
+  loadDefaultsRegistry: () => ({}),
+  initFeatureFlagOverrides: () => Promise.resolve(),
+  clearFeatureFlagOverridesCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
+
+const SCAN_OPEN_TAG = "<google_connect_scan_instructions>";
+const SCAN_CLOSE_TAG = "</google_connect_scan_instructions>";
+
+function seedBootstrap(): void {
+  writeFileSync(
+    join(TEST_DIR, "BOOTSTRAP.md"),
+    "# First run\n\nWelcome aboard.",
+  );
+}
+
+describe("Google Connect Scan context injection", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    // Clean up files from prior tests.
+    for (const name of ["BOOTSTRAP.md", "IDENTITY.md", "SOUL.md"]) {
+      const p = join(TEST_DIR, name);
+      if (existsSync(p)) rmSync(p, { force: true });
+    }
+    // Reset flag overrides between tests.
+    for (const key of Object.keys(_mockFlagOverrides)) {
+      delete _mockFlagOverrides[key];
+    }
+  });
+
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected: true", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
+    expect(result).toContain("# Google Connect Scan");
+  });
+
+  test("NOT injected when flag is off", () => {
+    _mockFlagOverrides["google-connect-scan"] = false;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+    expect(result).not.toContain("# Google Connect Scan");
+  });
+
+  test("NOT injected when flag is on but googleConnected is false", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: false,
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+  });
+
+  test("NOT injected when flag is on but googleConnected is undefined", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+  });
+
+  test("NOT injected when flag is on + googleConnected but no BOOTSTRAP.md", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    // Do NOT seed BOOTSTRAP.md — simulate a non-first conversation.
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+  });
+
+  test("NOT injected when flag is on but no onboarding context at all", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({});
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+  });
+
+  test("scan block contains subagent dispatch instructions", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    // The template should include key scan phases.
+    expect(result).toContain("Phase 1");
+    expect(result).toContain("Phase 2");
+    expect(result).toContain("subagent_spawn");
+  });
+});

--- a/assistant/src/__tests__/scan-context-injection.test.ts
+++ b/assistant/src/__tests__/scan-context-injection.test.ts
@@ -1,12 +1,12 @@
 /**
  * Tests for Google Connect Scan context injection in buildSystemPrompt.
  *
- * The scan instructions are injected only when:
+ * The scan instructions are injected when:
  *   1. The `google-connect-scan` feature flag is enabled
  *   2. BOOTSTRAP.md is present (first conversation)
- *   3. `googleConnected: true` in onboarding context
  *
- * When any condition is unmet, the scan instructions must be absent.
+ * The `googleConnected` flag is NOT a gate — the template covers both
+ * Variant A (already connected) and Variant B (connects mid-conversation).
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -134,7 +134,7 @@ describe("Google Connect Scan context injection", () => {
     expect(result).not.toContain("# Google Connect Scan");
   });
 
-  test("NOT injected when flag is on but googleConnected is false", () => {
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected is false (Variant B)", () => {
     _mockFlagOverrides["google-connect-scan"] = true;
     seedBootstrap();
 
@@ -147,10 +147,11 @@ describe("Google Connect Scan context injection", () => {
       },
     });
 
-    expect(result).not.toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
   });
 
-  test("NOT injected when flag is on but googleConnected is undefined", () => {
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected is undefined (Variant B)", () => {
     _mockFlagOverrides["google-connect-scan"] = true;
     seedBootstrap();
 
@@ -162,7 +163,8 @@ describe("Google Connect Scan context injection", () => {
       },
     });
 
-    expect(result).not.toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
   });
 
   test("NOT injected when flag is on + googleConnected but no BOOTSTRAP.md", () => {
@@ -181,13 +183,14 @@ describe("Google Connect Scan context injection", () => {
     expect(result).not.toContain(SCAN_OPEN_TAG);
   });
 
-  test("NOT injected when flag is on but no onboarding context at all", () => {
+  test("injected when flag is on + BOOTSTRAP exists + no onboarding context at all", () => {
     _mockFlagOverrides["google-connect-scan"] = true;
     seedBootstrap();
 
     const result = buildSystemPrompt({});
 
-    expect(result).not.toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
   });
 
   test("scan block contains subagent dispatch instructions", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -7,7 +7,9 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
+import { getConfig } from "../config/loader.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
@@ -349,6 +351,17 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // tool routing lives in tool descriptions.
   // External Communications Identity removed — guidance lives in messaging
   // and phone-calls skill SKILL.md files.
+
+  // Inject Google Connect Scan instructions when the feature flag is
+  // enabled and the user has connected Google OAuth.  The template is
+  // loaded only when both conditions are met so non-scan conversations
+  // pay zero I/O cost.
+  const scanInstructions = buildGoogleConnectScanSection(
+    includeBootstrap,
+    options?.onboardingContext,
+  );
+  if (scanInstructions) systemParts.push(scanInstructions);
+
   const integrationSection = buildIntegrationSection();
   if (integrationSection) systemParts.push(integrationSection);
 
@@ -382,6 +395,68 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Build the Google Connect Scan instruction block when the
+ * `google-connect-scan` feature flag is enabled AND the user has
+ * connected Google OAuth (indicated by `googleConnected: true` in the
+ * onboarding context).
+ *
+ * The scan template is read from the bundled `GOOGLE_CONNECT_SCAN.md`
+ * only when both conditions are satisfied, so non-scan conversations
+ * pay zero file-system cost.
+ *
+ * The instructions are injected during the first conversation
+ * (BOOTSTRAP.md present) when `googleConnected: true`.  Once
+ * BOOTSTRAP.md is deleted the scan instructions also stop being
+ * injected — ongoing scan behavior is handled by watchers, not the
+ * system prompt.
+ */
+function buildGoogleConnectScanSection(
+  includeBootstrap: boolean,
+  onboardingContext?: OnboardingContext,
+): string | null {
+  // Gate 1: feature flag must be enabled.
+  const config = getConfig();
+  if (!isAssistantFeatureFlagEnabled("google-connect-scan", config)) {
+    return null;
+  }
+
+  // Gate 2: only inject during the first conversation (bootstrap present)
+  // AND when the user has connected Google.
+  if (!includeBootstrap || !onboardingContext?.googleConnected) {
+    return null;
+  }
+
+  // Load the template from the bundled assets.
+  const templatesDir = resolveBundledDir(
+    import.meta.dirname ?? __dirname,
+    "templates",
+    "templates",
+  );
+  const scanTemplatePath = join(templatesDir, "GOOGLE_CONNECT_SCAN.md");
+
+  try {
+    if (!existsSync(scanTemplatePath)) {
+      log.warn(
+        { scanTemplatePath },
+        "GOOGLE_CONNECT_SCAN.md template not found",
+      );
+      return null;
+    }
+    const content = stripCommentLines(readFileSync(scanTemplatePath, "utf-8"));
+    if (content.length === 0) return null;
+
+    return (
+      "<google_connect_scan_instructions>\n" +
+      content +
+      "\n</google_connect_scan_instructions>"
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to read GOOGLE_CONNECT_SCAN.md template");
+    return null;
+  }
 }
 
 // Re-export from shared util so existing importers don't break.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -353,13 +353,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // and phone-calls skill SKILL.md files.
 
   // Inject Google Connect Scan instructions when the feature flag is
-  // enabled and the user has connected Google OAuth.  The template is
-  // loaded only when both conditions are met so non-scan conversations
-  // pay zero I/O cost.
-  const scanInstructions = buildGoogleConnectScanSection(
-    includeBootstrap,
-    options?.onboardingContext,
-  );
+  // enabled and this is the first conversation (BOOTSTRAP.md present).
+  // The template covers both Variant A (Google already connected) and
+  // Variant B (user connects mid-conversation via in-chat OAuth).
+  const scanInstructions = buildGoogleConnectScanSection(includeBootstrap);
   if (scanInstructions) systemParts.push(scanInstructions);
 
   const integrationSection = buildIntegrationSection();
@@ -399,23 +396,24 @@ function buildIntegrationSection(): string {
 
 /**
  * Build the Google Connect Scan instruction block when the
- * `google-connect-scan` feature flag is enabled AND the user has
- * connected Google OAuth (indicated by `googleConnected: true` in the
- * onboarding context).
+ * `google-connect-scan` feature flag is enabled AND this is the first
+ * conversation (BOOTSTRAP.md present).
  *
  * The scan template is read from the bundled `GOOGLE_CONNECT_SCAN.md`
  * only when both conditions are satisfied, so non-scan conversations
  * pay zero file-system cost.
  *
- * The instructions are injected during the first conversation
- * (BOOTSTRAP.md present) when `googleConnected: true`.  Once
- * BOOTSTRAP.md is deleted the scan instructions also stop being
+ * The instructions cover both onboarding variants:
+ * - **Variant A**: `googleConnected: true` — model triggers scan immediately
+ * - **Variant B**: `googleConnected` is false/undefined — model knows what
+ *   to do if/when the user connects Google mid-conversation via in-chat OAuth
+ *
+ * Once BOOTSTRAP.md is deleted the scan instructions stop being
  * injected — ongoing scan behavior is handled by watchers, not the
  * system prompt.
  */
 function buildGoogleConnectScanSection(
   includeBootstrap: boolean,
-  onboardingContext?: OnboardingContext,
 ): string | null {
   // Gate 1: feature flag must be enabled.
   const config = getConfig();
@@ -423,9 +421,11 @@ function buildGoogleConnectScanSection(
     return null;
   }
 
-  // Gate 2: only inject during the first conversation (bootstrap present)
-  // AND when the user has connected Google.
-  if (!includeBootstrap || !onboardingContext?.googleConnected) {
+  // Gate 2: only inject during the first conversation (bootstrap present).
+  // The googleConnected check is intentionally omitted — the template
+  // handles both Variant A (already connected) and Variant B (connects
+  // mid-conversation via in-chat OAuth).
+  if (!includeBootstrap) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Wire GOOGLE_CONNECT_SCAN.md template into conversation context injection
- Scan instructions injected only when `google-connect-scan` flag is enabled AND Google is connected
- Tests cover all flag/connection state combinations

Part of plan: new-user-retention-integration.md (PR 5 of 5)

JARVIS-839
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->