### PR TITLE
docs(web): add frontend architecture conventions (CONVENTIONS.md)

### DIFF
--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -67,7 +67,6 @@ src/
         message-handlers.ts
         interaction-handlers.ts
         types.ts
-        index.ts              # barrel — re-exports public API
       use-stream-event-handler.ts
     interactions/
       interaction-state-machine.ts
@@ -75,26 +74,19 @@ src/
       use-interaction-actions.ts
 ```
 
-Do not create top-level `hooks/`, `utils/`, `types/` folders that lump
-unrelated code by technical role.
-
-**Cross-domain shared code lives at the nearest common ancestor.** If a
-utility or hook is consumed by multiple domains, hoist it — don't nest
-it inside one consumer's domain.
+Prefer domain folders over technical-layer folders (`hooks/`, `utils/`,
+`types/`). **Cross-domain shared code lives at the nearest common
+ancestor.** If a utility or hook is consumed by multiple domains, hoist
+it — sometimes that means a top-level shared directory, and that's
+fine.
 
 Reference: [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
 
-### Barrel files
+### No barrel files
 
-Use barrel files (`index.ts`) for multi-file modules that form a
-cohesive public API (e.g., `stream-handlers/index.ts` re-exporting 8+
-handler files + types). They provide clean import paths and
-encapsulation — internal reorganization doesn't break consumers.
-
-Avoid barrel files for single-file modules where `index.ts` just
-re-exports one sibling (pointless indirection).
-
-Reference: [TypeScript — Barrels](https://basarat.gitbook.io/typescript/main-1/barrel)
+Do not use barrel files (`index.ts` that re-export siblings). Import
+from the source file directly. If a genuine need arises in the future,
+discuss with the team before adding one.
 
 ---
 
@@ -343,9 +335,9 @@ why.
 
 - **Delete immediately.** When extracting logic into a new module or
   inlining it, remove the original in the same PR.
+- **Unrelated dead code spotted during a PR** gets its own separate PR
+  opened at the same time — never just filed as an issue and left.
 - **No commented-out code.** If code is removed, it lives in git
   history.
 - **Audit proactively.** When fixing a convention violation, audit the
   broader codebase for the same violation and fix all instances.
-
-Reference: [React — Keeping Components Pure](https://react.dev/learn/keeping-components-pure)

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -438,20 +438,57 @@ References:
 ### React Query for server state
 
 Use [TanStack React Query](https://tanstack.com/query/latest) for
-server-derived data. When multiple components need the same data, use a
-shared hook with a stable query key — not independent `useState` +
+server-derived data (API calls, caching, background refetching,
+mutations). When multiple components need the same data, use a shared
+hook with a stable query key — not independent `useState` +
 `useEffect` fetch cycles in each consumer.
 
-Reference: [React Query — Query Invalidation](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation)
+React Query handles **server state**. Zustand handles **client state**
+(UI interactions, streaming state, conversation selections). They do not
+overlap.
 
-### Generated API clients
+Why React Query over alternatives:
+- [HeyAPI `@tanstack/react-query` plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query)
+  auto-generates type-safe query/mutation hooks from the OpenAPI spec.
+  No equivalent plugin exists for SWR (still in proposal stage) or other
+  libraries.
+- First-class mutation support, optimistic updates, and DevTools.
+- 12M+ weekly downloads (2026), most feature-complete option.
 
-For backend API routes, prefer generated clients (e.g. HeyAPI
-`*Options()` helpers with `useQuery` / `useMutation`) over hand-written
-`fetch` wrappers. Do not create new direct `fetch()` calls with
-hardcoded backend prefixes unless the generated client cannot support the
-use case (e.g. SSE/streaming). If bypassing, add a comment explaining
-why.
+References:
+- [React Query — Overview](https://tanstack.com/query/latest/docs/framework/react/overview)
+- [React Query — Comparison](https://tanstack.com/query/latest/docs/framework/react/comparison)
+
+### HeyAPI for OpenAPI client generation
+
+The API client is generated from the platform's OpenAPI spec using
+[HeyAPI (`@hey-api/openapi-ts`)](https://heyapi.dev/). Codegen runs in
+this repo — the platform publishes the spec, we generate the client
+locally.
+
+Plugins:
+- `@tanstack/react-query` — generates `*Options()` helpers for
+  `useQuery` / `useMutation` / `useInfiniteQuery`
+- `@hey-api/client-fetch` — Fetch-based HTTP client (no Axios/Node
+  dependency)
+- `@hey-api/typescript` — generates TypeScript types from schemas
+
+Generated output lives in `src/generated/heyapi/`. This directory is
+fully auto-generated — do not hand-edit files in it. Run
+`bun run openapi-ts` to regenerate.
+
+References:
+- [HeyAPI — Configuration](https://heyapi.dev/openapi-ts/configuration)
+- [HeyAPI — TanStack Query plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query)
+
+### Prefer generated clients over hand-written fetch
+
+For backend API routes, use the generated HeyAPI hooks (`*Options()`
+helpers with `useQuery` / `useMutation`) over hand-written `fetch`
+wrappers. Do not create new direct `fetch()` calls with hardcoded
+backend prefixes unless the generated client cannot support the use case
+(e.g. SSE/streaming endpoints that need custom `EventSource` handling).
+If bypassing, add a comment explaining why.
 
 ---
 

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -48,39 +48,125 @@ References:
 ### Organize by domain, not technical layer
 
 Group code by what it does (messages, conversations, streaming,
-interactions), not by what it is (hooks, utils, components).
+interactions), not by what it is (hooks, utils, components). The
+top-level folder for domain modules is called **`domains/`**.
 
 ```
 src/
-  features/
-    messages/
+  domains/                         # business domain modules
+    messages/                      # message lifecycle
+      use-message-store.ts
       use-send-message.ts
       message-handlers.ts
       message-handlers.test.ts
       types.ts
-    conversations/
+      components/
+        chat-body.tsx
+    conversations/                 # conversation CRUD, grouping, selection
+      use-conversation-store.ts
       use-conversation-loader.ts
       conversation-reducer.ts
       conversation-reducer.test.ts
-    streaming/
-      stream-handlers/
+      types.ts
+    streaming/                     # SSE transport, event parsing
+      use-stream-store.ts
+      stream-transport.ts
+      event-parser.ts
+      event-types.ts
+      handlers/
         message-handlers.ts
         interaction-handlers.ts
         types.ts
-      use-stream-event-handler.ts
-    interactions/
+    interactions/                   # user-facing prompts
+      use-interaction-store.ts
       interaction-state-machine.ts
       interaction-state-machine.test.ts
-      use-interaction-actions.ts
+      types.ts
+  hooks/                           # cross-domain shared hooks
+    use-is-mobile.ts
+    use-visible-viewport.ts
+  utils/                           # cross-domain shared utilities
+    format.ts
+    browser.ts
+  types/                           # cross-domain shared types
+    window.d.ts
+  lib/                             # configured third-party wrappers
+    api-client.ts
+    csrf.ts
+    telemetry.ts
+  runtime/                         # framework adapters, platform bridges
+    native-auth.ts
+    route-adapter.ts
+  components/                      # cross-domain shared UI
+  pages/                           # route-level page components
 ```
 
-Prefer domain folders over technical-layer folders (`hooks/`, `utils/`,
-`types/`). **Cross-domain shared code lives at the nearest common
-ancestor.** If a utility or hook is consumed by multiple domains, hoist
-it — sometimes that means a top-level shared directory, and that's
-fine.
+#### Why `domains/` not `features/`
 
-Reference: [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
+The team chose `domains/` over the more common `features/` because
+"features" implies product-level concepts (like "chat" or
+"settings") that contain multiple domains. `messages`,
+`conversations`, and `streaming` are business domains with distinct
+data models and lifecycles — not features. `domains/` is more precise
+for a DDD-influenced architecture and signals that each folder
+represents a bounded context.
+
+References:
+- [Bulletproof React — Project Structure](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md)
+- [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
+
+### How to decide where the domain split is
+
+Think of domains like database tables, not nested documents. Split by
+**lifecycle and reason-to-change**, not by containment:
+
+- **Separate domain if:** it has its own API endpoints, its own data
+  model/types, its own state lifecycle, and could be worked on by a
+  different developer without merge conflicts.
+- **Same domain if:** two things always change together, share the same
+  store, and splitting them would create circular cross-imports.
+- **Cross-domain imports are normal.** `messages/` importing types from
+  `conversations/` is expected. The rule is: **no circular
+  dependencies** between domains. If A imports from B AND B imports
+  from A, either merge them or hoist the shared code to `types/`.
+
+Examples of correct splits:
+- `messages/` vs `conversations/`: messages are created, streamed,
+  delta-updated, and compacted — different lifecycle from conversation
+  CRUD and grouping.
+- `streaming/` vs `messages/`: SSE transport and reconnection logic
+  changes for different reasons than message state management.
+- `interactions/` vs `turn/`: user-facing prompts (secrets,
+  confirmations) have their own state machine, independent from the
+  turn lifecycle (idle → sending → receiving → complete).
+
+### Top-level shared directories
+
+Code used across multiple domains lives in top-level shared
+directories. If something is domain-specific, it belongs inside
+`domains/<name>/`.
+
+| Folder | Purpose | Example contents |
+|---|---|---|
+| `hooks/` | Cross-domain React hooks | `use-is-mobile.ts`, `use-visible-viewport.ts`, `use-keyboard-shortcuts.ts` |
+| `utils/` | Pure utility functions | `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts` |
+| `types/` | Shared type definitions | `window.d.ts`, `api-types.ts` |
+| `lib/` | Configured third-party wrappers | `api-client.ts` (HeyAPI + interceptors), `csrf.ts`, `telemetry.ts` (Sentry), `feature-flags.ts` |
+| `runtime/` | Framework adapters and native platform bridges | `route-adapter.ts`, `native-auth.ts`, `native-deep-link.ts`, `app-bridge.ts` |
+| `components/` | Cross-domain shared UI | `error-boundary.tsx`, `sign-in-gate.tsx`, `providers.tsx` |
+| `pages/` | Route-level page components | `conversation-detail.tsx`, `settings-tab.tsx` |
+| `generated/` | Auto-generated code (HeyAPI, catalogs) | `heyapi/`, `catalogs/` |
+
+#### Why `lib/` exists
+
+The platform repo has configured third-party wrappers (HeyAPI client
+with request/response interceptors, CSRF token management, Sentry
+configuration, feature flag providers) that don't fit `utils/` (they
+have side effects and configure instances — not pure functions) or
+`runtime/` (they're not framework adapters). `lib/` is the standard
+home for this category of code.
+
+Reference: [Bulletproof React — `lib/` directory](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md)
 
 ### No barrel files
 
@@ -120,6 +206,35 @@ const { messages } = useContext(ChatContext);
 References:
 - [Zustand docs](https://zustand.docs.pmnd.rs/)
 - [Zustand — Auto-generating selectors](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
+
+### Zustand store conventions
+
+Each domain owns its store, colocated within the domain folder:
+`domains/messages/use-message-store.ts`. File naming follows hook
+convention since stores are accessed as hooks: `use-{domain}-store.ts`.
+
+Store creation pattern:
+
+```ts
+import { create } from "zustand";
+import { messageReducer } from "./message-reducer.js";
+import type { MessageState, MessageAction } from "./types.js";
+
+interface MessageStore extends MessageState {
+  dispatch: (action: MessageAction) => void;
+}
+
+export const useMessageStore = create<MessageStore>((set) => ({
+  messages: [],
+  // ... initial state
+  dispatch: (action) => set((state) => messageReducer(state, action)),
+}));
+```
+
+Keep store definitions in their domain folder — adding or removing a
+domain means adding or removing a folder.
+
+Reference: [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)
 
 ### useReducer for related state within a component
 
@@ -291,6 +406,30 @@ This keeps the door open for future static prerendering or hybrid
 runtimes.
 
 Reference: [Vite — SSR guidance](https://vite.dev/guide/ssr.html)
+
+---
+
+## Design system
+
+### `packages/design-library/`
+
+Domain-agnostic UI primitives (Button, Card, Modal, Menu, Toast,
+Inputs, etc.) live in `packages/design-library/` outside `apps/web/`.
+The package is aliased as `@vellum/design-library` via Vite
+`resolve.alias` + tsconfig `paths` for monorepo HMR during
+development, with a clean path to npm publishing later.
+
+```ts
+import { Button } from "@vellum/design-library/button.js";
+import { Modal } from "@vellum/design-library/modal.js";
+```
+
+Design system components accept props and render UI. They must not
+import domain state, feature hooks, or application-specific logic.
+
+References:
+- [Vite — resolve.alias](https://vite.dev/config/shared-options.html#resolve-alias)
+- [TypeScript — paths](https://www.typescriptlang.org/tsconfig/#paths)
 
 ---
 

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -1,0 +1,351 @@
+# Web App — Frontend Conventions
+
+Architectural decisions, patterns, and rationale for the Vellum web app.
+Covers code organization, state management, component design, and
+framework strategy. For coding style, naming, and import rules see
+[`STYLE_GUIDE.md`](./STYLE_GUIDE.md).
+
+Subordinate to [`apps/AGENTS.md`](../AGENTS.md) and root
+[`AGENTS.md`](../../AGENTS.md).
+
+---
+
+## Architecture overview
+
+The web app is a **Vite + React Router v7 SPA** using
+[library / data-router mode](https://reactrouter.com/start/modes)
+(`createBrowserRouter` + `<RouterProvider>`). See
+[`apps/web/README.md`](./README.md) for the full stack description and
+local development commands.
+
+### Route-driven component boundaries
+
+Each route should only mount the hooks and state it actually needs.
+Avoid "god components" that render on every route with conditional logic
+to hide irrelevant sections.
+
+```
+routes.tsx
+  <App />            ← shared shell (nav, layout, providers)
+    <Outlet />
+      <ConversationNew />     ← only mounts conversation-creation hooks
+      <ConversationDetail />  ← mounts streaming, messages, interactions
+      <SettingsTab />         ← mounts settings-specific state
+```
+
+Push hooks down to the route component that needs them. Lift shared
+state to the nearest common ancestor — typically a layout route or a
+context provider mounted in `<App />`.
+
+References:
+- [React — Thinking in React](https://react.dev/learn/thinking-in-react)
+- [React Router — Layout Routes](https://reactrouter.com/start/framework/routing#layout-routes)
+
+---
+
+## Code organization
+
+### Organize by domain, not technical layer
+
+Group code by what it does (messages, conversations, streaming,
+interactions), not by what it is (hooks, utils, components).
+
+```
+src/
+  features/
+    messages/
+      use-send-message.ts
+      message-handlers.ts
+      message-handlers.test.ts
+      types.ts
+    conversations/
+      use-conversation-loader.ts
+      conversation-reducer.ts
+      conversation-reducer.test.ts
+    streaming/
+      stream-handlers/
+        message-handlers.ts
+        interaction-handlers.ts
+        types.ts
+        index.ts              # barrel — re-exports public API
+      use-stream-event-handler.ts
+    interactions/
+      interaction-state-machine.ts
+      interaction-state-machine.test.ts
+      use-interaction-actions.ts
+```
+
+Do not create top-level `hooks/`, `utils/`, `types/` folders that lump
+unrelated code by technical role.
+
+**Cross-domain shared code lives at the nearest common ancestor.** If a
+utility or hook is consumed by multiple domains, hoist it — don't nest
+it inside one consumer's domain.
+
+Reference: [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
+
+### Barrel files
+
+Use barrel files (`index.ts`) for multi-file modules that form a
+cohesive public API (e.g., `stream-handlers/index.ts` re-exporting 8+
+handler files + types). They provide clean import paths and
+encapsulation — internal reorganization doesn't break consumers.
+
+Avoid barrel files for single-file modules where `index.ts` just
+re-exports one sibling (pointless indirection).
+
+Reference: [TypeScript — Barrels](https://basarat.gitbook.io/typescript/main-1/barrel)
+
+---
+
+## State management
+
+### Zustand for shared mutable state
+
+Use [Zustand](https://github.com/pmndrs/zustand) for state shared
+across multiple components — messages, turn state, interactions,
+conversation list, viewer state. Zustand was chosen over Context +
+useReducer because:
+
+- **Selector support.** `useStore(selector)` lets each component
+  subscribe to only the slice it needs. Context has no selector
+  support — every consumer re-renders on any change, which is
+  unacceptable during streaming (messages update every ~50ms).
+- **Framework-agnostic store definitions.** Store logic is plain
+  TypeScript with no React dependency — portable across environments.
+- **Existing reducers drop in unchanged.** Reducer functions
+  (`turnReducer`, `interactionReducer`, `conversationListReducer`)
+  work as Zustand actions with no modification.
+
+```ts
+// Good — component only re-renders when its slice changes
+const messages = useChatStore((s) => s.messages);
+
+// Avoid — every consumer re-renders on any context change
+const { messages } = useContext(ChatContext);
+```
+
+References:
+- [Zustand docs](https://zustand.docs.pmnd.rs/)
+- [Zustand — Auto-generating selectors](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
+
+### useReducer for related state within a component
+
+When two or more pieces of state change together or have
+interdependent transitions *within a single component or hook*,
+consolidate them into a `useReducer` with typed action events.
+Reserve `useState` for independent, single-value state (a boolean
+toggle, a text input value).
+
+```ts
+// Good — related state transitions are atomic and self-documenting
+dispatch({ type: "SHOW_SECRET", requestId, prompt });
+
+// Avoid — multiple setState calls that must stay in sync
+setSecretRequestId(requestId);
+setSecretPrompt(prompt);
+setShowSecretOverlay(true);
+```
+
+Extract the reducer into its own file so it can be tested as a pure
+function.
+
+Reference: [React — Scaling Up with Reducer and Context](https://react.dev/learn/scaling-up-with-reducer-and-context)
+
+### State machine reducers
+
+State machines (turn state, interaction state) use typed domain events,
+not raw setters.
+
+- **Dispatch named events** (`SHOW_SECRET`, `DISMISS_CONFIRMATION`,
+  `RESET_ALL`) instead of calling multiple `setState` functions.
+- **Guard against stale events.** Check `requestId` matches before
+  applying updates.
+- **Test the reducer in isolation.** Reducers are pure functions —
+  verify transitions with unit tests before relying on integration
+  tests.
+
+Reference: [React — useReducer](https://react.dev/reference/react/useReducer)
+
+---
+
+## Component patterns
+
+### Components render UI; hooks perform side effects
+
+If something renders `null` and only performs side effects (`useEffect`
+subscriptions, syncing state), it should be a custom hook, not a
+component.
+
+```ts
+// Good — hook for side-effect-only logic
+function useKeyboardShortcuts() {
+  useEffect(() => { /* subscribe */ return () => { /* cleanup */ }; }, []);
+}
+
+// Avoid — component that renders nothing
+function KeyboardShortcuts() {
+  useEffect(() => { /* subscribe */ return () => { /* cleanup */ }; }, []);
+  return null;
+}
+```
+
+Reference: [React — Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)
+
+### Thin orchestrator hooks
+
+Top-level hooks that wire multiple domains together should be thin
+orchestrators: compose domain hooks, build a shared context object,
+delegate work. They should not contain business logic inline.
+
+Signs a hook needs decomposition:
+- A single `useCallback` with a switch/if-else over many cases
+  -> extract cases into domain handler functions
+- Multiple unrelated `useEffect` blocks -> split into focused hooks
+- The file exceeds ~300 lines of non-test code
+
+Reference: [React — Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)
+
+### Pure handler functions over inline logic
+
+Extract event-handling logic into pure functions that take a context
+object and return results, rather than closing over component state.
+
+```ts
+// Good — pure function, easy to unit test
+export function handleMessageDelta(
+  ctx: StreamHandlerContext,
+  event: MessageDeltaEvent
+): void {
+  ctx.setMessages((prev) => applyDelta(prev, event));
+}
+
+// Avoid — inline in useCallback, hard to test in isolation
+const handleStreamEvent = useCallback((event) => {
+  if (event.type === "message.delta") {
+    setMessages((prev) => /* 30 lines of logic */);
+  }
+}, [/* 15 deps */]);
+```
+
+Reference: [React — Keeping Components Pure](https://react.dev/learn/keeping-components-pure)
+
+### Extract sub-components by responsibility, not line count
+
+Inline JSX that has its own concerns (visibility gating, animation,
+multi-prop wiring, conditional rendering beyond a one-liner) should be
+extracted into a named component. Trivial inline JSX (a single element,
+a static label) stays inline.
+
+Reference: [React — Thinking in React: break the UI into a component hierarchy](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy)
+
+### Stabilize external callbacks with refs
+
+When a hook receives callbacks that may not be memoized upstream, store
+them in refs to keep the consuming `useCallback` identity stable:
+
+```ts
+const callbackRef = useRef(onSomeEvent);
+callbackRef.current = onSomeEvent;
+
+const stableHandler = useCallback(() => {
+  callbackRef.current(/* args */);
+}, []);
+```
+
+This is the standard workaround until
+[`useEffectEvent`](https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event)
+ships as stable.
+
+Reference: [React — useCallback: preventing an Effect from firing too often](https://react.dev/reference/react/useCallback#preventing-an-effect-from-firing-too-often)
+
+---
+
+## Framework strategy
+
+### Keep domain logic framework-agnostic
+
+Reducers, pure handler functions, state machines, and domain types must
+not import from any framework-specific module (`next/navigation`,
+`next/router`, `react-router`, etc.). They should be pure TypeScript
+that works in any React environment.
+
+Framework-specific routing calls (`navigate()`, `useParams`,
+`useSearchParams`) belong in thin adapter layers or the route components
+that wire domains to the framework — not in the domain modules
+themselves.
+
+References:
+- [React Router v7 — Data Loading](https://reactrouter.com/how-to/data-loading)
+- [React — Separating Events from Effects](https://react.dev/learn/separating-events-from-effects)
+
+### URL-driven routing is the target architecture
+
+The target architecture uses URL routing directly via React Router v7
+nested routes, eliminating custom navigation state and URL-to-state sync
+effects. Each view state maps to a route; the URL is the source of
+truth.
+
+References:
+- [React Router — Nested Routes](https://reactrouter.com/start/framework/routing#nested-routes)
+- [React Router — useSearchParams](https://reactrouter.com/hooks/use-search-params)
+
+### SSR/build-safe rendering
+
+Route and layout components must not access `window` /
+`localStorage` / `document` during synchronous render. Client-only
+reads belong in `useEffect` or in a runtime adapter implementation.
+This keeps the door open for future static prerendering or hybrid
+runtimes.
+
+Reference: [Vite — SSR guidance](https://vite.dev/guide/ssr.html)
+
+---
+
+## Data fetching
+
+### React Query for server state
+
+Use [TanStack React Query](https://tanstack.com/query/latest) for
+server-derived data. When multiple components need the same data, use a
+shared hook with a stable query key — not independent `useState` +
+`useEffect` fetch cycles in each consumer.
+
+Reference: [React Query — Query Invalidation](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation)
+
+### Generated API clients
+
+For backend API routes, prefer generated clients (e.g. HeyAPI
+`*Options()` helpers with `useQuery` / `useMutation`) over hand-written
+`fetch` wrappers. Do not create new direct `fetch()` calls with
+hardcoded backend prefixes unless the generated client cannot support the
+use case (e.g. SSE/streaming). If bypassing, add a comment explaining
+why.
+
+---
+
+## Testing
+
+- **Test framework:** `bun:test` (`describe`, `it`, `expect`, `mock`).
+- **Colocate tests with source.** `message-handlers.test.ts` lives
+  alongside `message-handlers.ts`.
+- **Test reducers and pure functions in isolation.** They are pure
+  functions — unit-test state transitions directly before relying on
+  integration tests.
+- **Mock at the right boundary.** Mock API clients (`client.get`,
+  `client.post`), not `globalThis.fetch`. This catches request-building
+  bugs that fetch-level mocks miss.
+- **Run tests:** `bun test src/path/to/file.test.ts`
+
+---
+
+## Dead code and cleanup
+
+- **Delete immediately.** When extracting logic into a new module or
+  inlining it, remove the original in the same PR.
+- **No commented-out code.** If code is removed, it lives in git
+  history.
+- **Audit proactively.** When fixing a convention violation, audit the
+  broader codebase for the same violation and fix all instances.
+
+Reference: [React — Keeping Components Pure](https://react.dev/learn/keeping-components-pure)


### PR DESCRIPTION
# Frontend Conventions — Meeting Outline

Companion PR: [#30684 — STYLE_GUIDE.md](https://github.com/vellum-ai/vellum-assistant/pull/30684)

This document (`CONVENTIONS.md`) covers **architecture decisions and patterns** for the new `apps/web` Vite + React Router v7 SPA. It consolidates decisions made across 30+ PRs in the `vellum-assistant-platform` refactoring series into a single reference doc so the team can align on conventions before feature work begins.

Each section includes the decision, the reasoning, and references. Sections with checkboxes had **multiple viable options** — checked items reflect what the team decided in the May 14 meeting.

## Updates since last revision

**Data fetching section finalized** with React Query + HeyAPI codegen decisions:

- **React Query confirmed as server-state library** (§14): After independent research comparing React Query, SWR, and RTK Query, React Query is the clear choice. The decisive factor: HeyAPI has a [production-ready `@tanstack/react-query` plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query) that auto-generates type-safe hooks from the OpenAPI spec. No equivalent plugin exists for SWR (still in proposal stage) or other libraries. Added explicit responsibility split: React Query = server state, Zustand = client state.
- **HeyAPI codegen strategy documented** (§14 new subsection): Per discussion with HeyAPI maintainer (Barry), the platform publishes the OpenAPI spec and the assistant repo runs HeyAPI codegen locally. This gives us full control over the HeyAPI version, React Query version, and regeneration timing. Starting on latest HeyAPI (0.97.1) since we're generating fresh — no migration needed, and the SSE POST mutation bug from 0.92.4 is already fixed.
- **Plugin configuration documented**: `@tanstack/react-query` for hooks, `@hey-api/client-fetch` for HTTP client, `@hey-api/typescript` for type generation. Generated output at `src/generated/heyapi/`.
- **"Prefer generated clients" rule**: Renamed and clarified the existing "Generated API clients" subsection — use HeyAPI hooks over hand-written `fetch`, with escape hatch for SSE/streaming endpoints.

### Human review checklist
- [ ] **React Query as finalized convention**: This was not discussed in the May 14 meeting but was confirmed via independent research afterward. The HeyAPI plugin integration is the decisive factor. Does the team agree this is settled?
- [ ] **HeyAPI codegen in assistant repo**: The strategy (platform publishes spec → assistant repo generates client) came from discussion with the HeyAPI maintainer. Does the team agree with this approach?
- [ ] **`src/generated/heyapi/` location**: Confirm this is the right output directory for generated code.
- [ ] **`bun run openapi-ts` command**: Referenced in the doc but doesn't exist yet — this is aspirational. Should we note it differently, or is it fine as a target convention?
- [ ] **`lib/` reinstatement**: Earlier meeting leaned "no `lib/`", but platform analysis found configured third-party wrappers (API client, CSRF, Sentry) that don't fit `utils/` or `runtime/`. Does the team agree `lib/` should stay for this specific category?
- [ ] **`domains/` naming**: Confirm the rationale matches the meeting consensus.
- [ ] **Domain split guidance**: Concrete rules ("think database tables, not nested documents"). Actionable enough? Too prescriptive?
- [ ] **Zustand store naming**: `use-{domain}-store.ts` convention. Not yet implemented — confirm the team wants to commit to this naming now.
- [ ] **Design system at `packages/design-library/`**: Confirm monorepo location and `@vellum/design-library` alias.
- [ ] **Store organization still deferred** (§6): Confirm this is still intentionally open.

---

## Prompt / plan

Update `CONVENTIONS.md` based on decisions from the May 14 FE team meeting (Ashlee, Tirman, Jason, Maddie) plus platform repo analysis and post-meeting research on data fetching strategy. Extract finalized decisions from the meeting transcript, analyze the platform repo's current code to validate the proposed structure, update the document to reflect those decisions, and flag deferred/undiscussed items.

## Test plan

Doc-only change — no code affected. CI passes (markdown lint only).

---

## Meeting outline (preserved for team context)

### 1. Architecture: Vite + React Router v7 SPA

**Decision:** The web app uses Vite + React Router v7 in [library / data-router mode](https://reactrouter.com/start/modes) (`createBrowserRouter` + `<RouterProvider>`).

**Why:** We're migrating off Next.js. Vite gives us sub-second HMR (vs. Next.js multi-second cold starts on large pages) and a simpler build pipeline — no server runtime, no edge functions, no middleware chain. React Router v7's data-router mode (loaders, actions, nested routes) gives us URL-driven routing without custom navigation state or URL-to-state sync effects. The platform's current Next.js setup uses almost none of the SSR/RSC features that justify Next.js complexity — we're paying the framework tax without using the framework features.

**References:**
- [React Router v7 — Modes](https://reactrouter.com/start/modes)
- [Vite docs](https://vite.dev/guide/)
- [Why Vite](https://vite.dev/guide/why.html) — HMR/bundling advantages over traditional toolchains

---

### 2. Route-driven component boundaries

**Decision:** Each route only mounts the hooks and state it actually needs. No "god components" that render on every route.

**Why:** `AssistantPageClient.tsx` in the platform repo was a 2,900+ line god component that mounted *everything* on every route — including routes like the identity route where most hooks were unnecessary. This caused needless re-renders, made the code impossible to reason about, and created a massive prop-drilling chain. Route-level splitting ensures each route only pays for what it uses — and makes lazy loading trivial (each route = one `React.lazy()` boundary).

**References:**
- [React — Thinking in React](https://react.dev/learn/thinking-in-react)
- [React Router — Layout Routes](https://reactrouter.com/start/framework/routing#layout-routes)

---

### 3. Code organization strategy

**Decision:** Group code by what it does (messages, conversations, streaming, interactions), not by what it is (hooks, utils, components). Top-level folder is **`domains/`**.

**Why:** This is the "folders by feature" vs. "folders by type" debate — one of the oldest in React. Technical-layer folders (`hooks/`, `utils/`, `components/`) work fine for small projects (~20 files) but become dumping grounds at scale — unrelated code sits side by side, and figuring out "what depends on what" requires jumping between 5 folders. Domain folders make dependencies explicit and map cleanly to lazy-loaded route chunks. Cross-domain shared code lives at the nearest common ancestor, not nested inside one consumer's folder.

**Team decision — organization approach:**
- [ ] **Feature/domain folders** — `features/messages/`, `features/streaming/`, `features/conversations/`. Each folder owns its hooks, components, utils, types, and tests. Scales well; used by React Router docs, [Bulletproof React](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md), and most 2025-2026 architecture guides
- [x] **Hybrid with `domains/`** — domain folders for business logic, plus top-level `hooks/`, `utils/`, `types/`, `lib/`, `runtime/`, `components/` for cross-domain shared primitives. Design system library lives outside `apps/web/` at `packages/design-library/` with `@vellum/design-library` alias. `domains/` chosen over `features/` because features implies product-level grouping while domains signals bounded contexts with distinct lifecycles.
- [ ] **Technical layer** (current platform pattern) — `hooks/`, `components/`, `utils/`, `types/`. Familiar to the team, but degrades as the app grows beyond ~50 files per folder

**References:**
- [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
- [Bulletproof React — Project Structure](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md)

---

### 4. Barrel files (`index.ts`)

**Decision:** Never use barrel files. Import from the source file directly.

**Team decision — barrel file policy:**
- [ ] **Barrel files for multi-file modules only** — `stream-handlers/index.ts` re-exporting 8 handlers = good. `components/Button/index.ts` re-exporting one file = skip it
- [ ] **Always use directory + index.ts** — every component/hook gets its own folder with `index.ts`. Clean imports (`@/domains/messages`) but lots of `index.ts` tabs in the editor
- [x] **Never use barrel files** — always import the exact file (`@/domains/messages/use-message-store.ts`). No indirection. Revisit if a genuine need arises.

**References:**
- [TypeScript — Barrels](https://basarat.gitbook.io/typescript/main-1/barrel)

---

### 5. Zustand for shared mutable state

**Decision:** Use [Zustand](https://github.com/pmndrs/zustand) for state shared across multiple components — messages, turn state, interactions, conversation list, viewer state.

**Why Zustand over Context + useReducer:**
- **Selector support.** `useStore(selector)` lets each component subscribe to only the slice it needs. Context has no selector support — *every* consumer re-renders on *any* change, which is unacceptable during streaming (messages update every ~50ms).
- **Framework-agnostic store definitions.** Store logic is plain TypeScript — portable across environments, easy to test without React rendering context.
- **Existing reducers drop in unchanged.** `turnReducer`, `interactionReducer`, `conversationListReducer` all work as Zustand actions with no modification.
- **~1.2KB gzipped, ~20M weekly npm downloads (2026).** Surpassed Redux Toolkit as the [#1 React state library](https://npmtrends.com/jotai-vs-react-redux-vs-recoil-vs-zustand).
- **Store organization.** Zustand maintainers [recommend](https://github.com/pmndrs/zustand/discussions/2486): multiple stores for independent data, slices for interdependent data within one store.

**Team decision — shared state library:**
- [x] **Zustand** — selector support, ~1.2KB, framework-agnostic stores, existing reducers drop in unchanged, massive adoption. Redux DevTools confirmed compatible.
- [ ] **Jotai** — atomic model (bottom-up), smaller API surface, great for derived state. But less ecosystem tooling for complex stores with actions, and our existing reducers would need restructuring into atoms
- [ ] **Redux Toolkit** — most mature ecosystem, excellent devtools, middleware support. But heavier boilerplate (slices, actions, selectors all separate), ~11KB gzipped, and the team would need to learn the RTK idioms
- [ ] **Context + useReducer** (current platform approach) — no extra dependency, built into React. But no selector support = unacceptable re-render cost during streaming (~50ms updates), and every consumer of a context re-renders on any state change

**References:**
- [Zustand docs](https://zustand.docs.pmnd.rs/)
- [Zustand — Auto-generating selectors](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
- [Zustand — One store or many?](https://github.com/pmndrs/zustand/discussions/2486) — maintainer guidance on store organization
- [npm trends: Zustand vs Redux vs Jotai](https://npmtrends.com/jotai-vs-react-redux-vs-recoil-vs-zustand)

---

### 6. Zustand store organization

**Decision:** How should we organize Zustand stores? One giant store, or many small ones?

**Why this matters:** The platform's current approach collapses all chat state into a single React context. This was a major source of re-render problems — updating the message list re-rendered the conversation list sidebar. Store boundaries determine re-render boundaries.

**Team decision — store granularity: DEFERRED.** The team agreed to decide when actually implementing Zustand. Ashlee leans toward one store per domain. When the first store PR is opened, the whole team will review to align on the pattern.
- [ ] **One store per domain** — `useChatStore`, `useConversationListStore`, `useStreamStore`, etc. Each store is independently subscribable. Cross-store reads use `getState()` in actions. This is what the Zustand maintainers recommend for [medium-to-large apps](https://github.com/pmndrs/zustand/discussions/2486)
- [ ] **Single store with slices** — one `useAppStore` with slices: `createMessageSlice`, `createConversationSlice`, etc. Simpler mental model (one store), middleware applies globally (devtools, persist). But all selectors must be careful to avoid over-subscribing. [Zustand docs on slices](https://zustand.docs.pmnd.rs/guides/slices-pattern)
- [ ] **One store per component tree** — stores scoped to route boundaries (e.g., chat route gets its own store instance via context). Maximum isolation, but more wiring overhead

**References:**
- [Zustand — Slices Pattern](https://zustand.docs.pmnd.rs/guides/slices-pattern)
- [Zustand — One store or many? (Discussion)](https://github.com/pmndrs/zustand/discussions/2486)

---

### 7. useReducer for related state within a component

**Decision:** When 2+ pieces of state change together within a single component/hook, use `useReducer` with typed action events. Reserve `useState` for independent, single-value state.

**Why:** Multiple `setState` calls that must stay in sync are a bug factory — we found several instances in the platform where `setIsLoading(false)` and `setError(err)` could get out of sync during race conditions. `useReducer` makes transitions atomic and self-documenting (`dispatch({ type: "FETCH_ERROR", error })` is clearer than two `setState` calls). Extracting the reducer to its own file makes it testable as a pure function with no React rendering needed.

**References:**
- [React — Scaling Up with Reducer and Context](https://react.dev/learn/scaling-up-with-reducer-and-context)
- [React — useReducer](https://react.dev/reference/react/useReducer)

---

### 8. Components render UI; hooks perform side effects

**Decision:** If something renders `null` and only performs side effects, it should be a custom hook, not a component.

**Why:** We found multiple "components" in the platform codebase that rendered `null` and only used `useEffect` (e.g., `ActiveAppPinSync`). These are hooks masquerading as components — they add nodes to the React tree, appear in DevTools, and participate in reconciliation, all for zero visual output. Hooks are React's mechanism for reusable side-effect logic; components are for rendering UI.

**References:**
- [React — Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)

---

### 9. Thin orchestrator hooks + pure handler functions

**Decision:** Top-level hooks that wire multiple domains together should be thin orchestrators (compose domain hooks, build context, delegate). Event-handling logic should be extracted into pure functions that take a context object and return results.

**Why:** The platform's `handleStreamEvent` was a single `useCallback` with a 32-case switch statement and 15+ closure dependencies. Each case captured stale closures differently, making bugs nearly impossible to reproduce. Extracting each case into a pure handler function (`(context, event) => result`) makes them individually unit-testable, eliminates closure-over-state bugs, and turns the orchestrator hook into a thin dispatcher.

**Signs a hook needs decomposition:**
- A single `useCallback` with a switch/if-else over many cases
- Multiple unrelated `useEffect` blocks
- The file exceeds ~300 lines

**References:**
- [React — Keeping Components Pure](https://react.dev/learn/keeping-components-pure)
- [React — Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)

---

### 10. Stabilize external callbacks with refs

**Decision:** When a hook receives callbacks that may not be memoized upstream, store them in refs to keep the consuming `useCallback` identity stable.

**Why:** Without this, every parent re-render that passes a new function reference causes the child's `useCallback` to get a new identity, defeating memoization and causing cascading re-renders. This is the standard workaround until [`useEffectEvent`](https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event) ships as stable. The React team [acknowledged this pain point](https://react.dev/reference/react/useCallback#preventing-an-effect-from-firing-too-often) and `useEffectEvent` is the official long-term solution.

**References:**
- [React — useCallback: preventing an Effect from firing too often](https://react.dev/reference/react/useCallback#preventing-an-effect-from-firing-too-often)
- [React — Separating Events from Effects](https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event)

---

### 11. Keep domain logic framework-agnostic

**Decision:** Reducers, pure handler functions, state machines, and domain types must not import from any framework-specific module (`next/navigation`, `react-router`, etc.). Framework-specific routing calls belong in thin adapter layers.

**Why:** We're migrating from Next.js to React Router v7. Every `next/navigation` import in a domain module is a migration tax. In the platform refactoring, we removed `next/navigation` from `useConversationLoader` — it had `useRouter` calls mixed into data-fetching logic, making it impossible to reuse outside Next.js. Pure TypeScript domain logic transfers cleanly between frameworks and is easier to test (no mocking router context).

**References:**
- [React Router v7 — Data Loading](https://reactrouter.com/how-to/data-loading)
- [React — Separating Events from Effects](https://react.dev/learn/separating-events-from-effects)

---

### 12. URL-driven routing as target architecture

**Decision:** The target architecture uses URL routing directly via React Router v7 nested routes. Each view state maps to a route; the URL is the source of truth. No custom navigation state or URL-to-state sync effects.

**Why:** The current platform architecture uses in-memory state (`mainView`, custom `navigationReducer`) synced to URLs via effects. This is fragile — state and URL can drift, causing ghost states where the URL says one thing but the UI shows another. We observed this in the platform when navigating between conversations during streaming. URL-driven routing eliminates this entire class of bugs — the URL *is* the state, not a reflection of it.

**References:**
- [React Router — Nested Routes](https://reactrouter.com/start/framework/routing#nested-routes)
- [React Router — useSearchParams](https://reactrouter.com/hooks/use-search-params)

---

### 13. SSR/build-safe rendering

**Decision:** Route and layout components must not access `window` / `localStorage` / `document` during synchronous render. Client-only reads belong in `useEffect` or runtime adapters.

**Why:** Keeps the door open for future static prerendering or hybrid runtimes. Even as an SPA, build-time rendering (Vite's SSG mode) and test environments (jsdom) break on unconditional `window` access. This is a low-cost constraint that prevents a class of bugs from ever appearing.

**References:**
- [Vite — SSR guidance](https://vite.dev/guide/ssr.html)

---

### 14. Data fetching: React Query + HeyAPI codegen

**Decision:** Use [TanStack React Query](https://tanstack.com/query/latest) for server-derived data. Generate API clients from the platform's OpenAPI spec using [HeyAPI (`@hey-api/openapi-ts`)](https://heyapi.dev/) with the `@tanstack/react-query` plugin.

**Why React Query:** HeyAPI has a production-ready `@tanstack/react-query` plugin that auto-generates type-safe query/mutation hooks from the OpenAPI spec. No equivalent plugin exists for SWR (still in proposal stage, [#1479](https://github.com/hey-api/openapi-ts/issues/1479)) or RTK Query. This makes React Query the only viable choice if we want generated hooks — and switching to SWR would mean writing manual wrapper hooks for every endpoint, negating the benefit of codegen. Beyond the plugin, React Query has first-class mutation support, optimistic updates, DevTools, and 12M+ weekly downloads (2026).

**Why codegen in assistant repo:** Per discussion with the HeyAPI maintainer, the platform publishes the OpenAPI spec and the assistant repo runs HeyAPI codegen locally. This gives us full control over the HeyAPI version, React Query version, and regeneration timing — no peer dependency coordination needed.

**Team decision — data-fetching library:**
- [x] **TanStack React Query** — HeyAPI plugin generates hooks automatically, first-class mutations, DevTools, ~13KB gzipped, 12M+ weekly downloads. React Query = server state; Zustand = client state — no overlap
- [ ] **SWR** — lighter weight (~4KB), but no HeyAPI plugin (still in proposal), weaker mutation support, would require manual hook wrappers for every endpoint
- [ ] **RTK Query** — requires Redux (contradicts Zustand decision), heavier boilerplate
- [ ] **Hand-written `useState` + `useEffect`** (current platform approach) — no dependency, but requires manually implementing caching, deduplication, retries, and race condition protection in every component

**References:**
- [React Query — Overview](https://tanstack.com/query/latest/docs/framework/react/overview)
- [React Query — Comparison](https://tanstack.com/query/latest/docs/framework/react/comparison)
- [HeyAPI — TanStack Query plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query)
- [HeyAPI — Configuration](https://heyapi.dev/openapi-ts/configuration)

---

### 15. Testing conventions

Testing strategy has multiple independent decisions. Let's walk through each.

#### 15a. Test runner

The platform currently uses `bun:test`. The new Vite app gives us an opportunity to re-evaluate.

**Team decision — test runner:** (not discussed in meeting — open for future decision)
- [ ] **Vitest** — native Vite integration (shared config, transforms, resolve aliases), ESM-first, [Jest-compatible API](https://vitest.dev/guide/comparisons.html), built-in coverage, ~4x faster cold starts and 30% less memory than Jest. Since we're using Vite for the build, Vitest shares the same pipeline — no separate transform config needed
- [ ] **bun:test** (current platform choice) — fast, built into the Bun runtime, zero-config if already using Bun. But smaller plugin ecosystem, no `--watch` UI, no official React Testing Library adapter
- [ ] **Jest** — most mature ecosystem, largest community, most Stack Overflow answers. But requires separate transform config for Vite projects (babel/swc), slower cold starts, CJS-first architecture requires workarounds for ESM

#### 15b. Test file location

Where do test files live relative to source files? This is one of the most debated patterns in the React ecosystem.

**Team decision — test file organization:**
- [x] **Colocated flat files** — `use-send-message.ts` + `use-send-message.test.ts` in the same folder. Most discoverable; when you move a source file, the test moves with it. This is the pattern [Vitest](https://main.vitest.dev/guide/learn/testing-in-practice) and most 2025-2026 guides recommend
- [ ] **Colocated `__tests__/` subdirectory** — `hooks/use-send-message.ts` + `hooks/__tests__/use-send-message.test.ts`. Keeps the source folder less cluttered; still colocated. [Jest docs](https://jestjs.io/docs/configuration#testmatch-arraystring) default to this
- [ ] **Directory-per-module** — `use-send-message/index.ts` + `use-send-message/use-send-message.test.ts`. The hook and its test live in a self-contained folder. Clean `import from "./use-send-message"` paths, and you can add fixtures, mocks, and stories alongside. But adds a folder for every hook/component, even simple ones
- [ ] **Root `tests/` mirror** — `src/domains/messages/...` mirrored in `tests/domains/messages/...`. Full separation of test and source code. Harder to keep in sync; tests can drift from source structure. Mostly used in older projects

#### 15c. Mock strategy

**Decision:** Mock at the API client level (`client.get`, `client.post`), not `globalThis.fetch`.

**Why:** Mocking `globalThis.fetch` is too low-level — it doesn't catch request-building bugs (wrong URL, missing headers, wrong body shape). Mocking `client.get(...)` catches those errors while still isolating from the network. We discovered this during the refactoring when a `fetch` mock passed but the actual API client was building the wrong URL.

**References:**
- [Vitest — Comparisons](https://vitest.dev/guide/comparisons.html) — official comparison with Jest
- [Vitest — Testing in Practice](https://main.vitest.dev/guide/learn/testing-in-practice) — official guide on test structure and organization

---

### 16. Dead code cleanup

**Decision:** Delete dead code immediately in the same PR. No commented-out code. Audit proactively when fixing convention violations.

**Why:** The platform codebase accumulated significant dead code — 120+ line functions that were never called, hooks with boolean flags that were declared but never set to `true`, entire components imported but rendered behind permanently-false conditions. This happened because extraction PRs didn't clean up the originals. Dead code creates false positives in code search ("I found where this is used... oh wait, that's dead code"), makes the codebase look bigger than it is, and confuses both humans and AI coding agents. The cost of deletion is near-zero with version control — if you need it back, it's in git history.

Link to Devin session: https://app.devin.ai/sessions/57905118879948a69946c94c6cd332d7
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
