### PR TITLE
fix: surface googleConnected in system prompt for Variant A/B detection

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -340,6 +340,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.assistantName)
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      if (options.onboardingContext.googleConnected)
+        lines.push("- Google connected: yes");
       lines.push(
         "",
         "Apply this context quietly. Do not recap it as a list unless the user asks.",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for new-user-retention-integration.md.

**Gap:** googleConnected is never surfaced to the model in the system prompt
**What was expected:** Model should see googleConnected to distinguish Variant A from B
**What was found:** normalizeOnboardingContext drops the field; model never sees it

JARVIS-839
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->