### PR TITLE
feat: New User Retention — Google integration scan (Days 1-3 strategy)

### DIFF
--- a/assistant/src/__tests__/onboarding-context.test.ts
+++ b/assistant/src/__tests__/onboarding-context.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { OnboardingContext } from "../types/onboarding-context.js";
+
+// Dynamic import so WORKSPACE_DIR override takes effect before module init.
+const { getOnboardingSidecarPath, writeOnboardingSidecar } =
+  await import("../home/relationship-state-writer.js");
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "onboarding-ctx-test-"));
+  origWorkspaceDir = process.env.WORKSPACE_DIR;
+  process.env.WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.WORKSPACE_DIR;
+  } else {
+    process.env.WORKSPACE_DIR = origWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("OnboardingContext googleConnected field", () => {
+  test("googleConnected: true is persisted to the sidecar file", () => {
+    const ctx: OnboardingContext = {
+      tools: ["Gmail"],
+      tasks: ["Inbox triage"],
+      tone: "Friendly",
+      userName: "Alex",
+      assistantName: "Nova",
+      googleConnected: true,
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    expect(existsSync(path)).toBe(true);
+
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBe(true);
+    // Verify other fields are still present
+    expect(decoded.tools).toEqual(["Gmail"]);
+    expect(decoded.tasks).toEqual(["Inbox triage"]);
+    expect(decoded.tone).toBe("Friendly");
+    expect(decoded.userName).toBe("Alex");
+    expect(decoded.assistantName).toBe("Nova");
+  });
+
+  test("omitting googleConnected still works (backward compat)", () => {
+    const ctx: OnboardingContext = {
+      tools: ["Slack"],
+      tasks: ["Meeting prep"],
+      tone: "Dry and precise",
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    expect(existsSync(path)).toBe(true);
+
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBeUndefined();
+    expect(decoded.tools).toEqual(["Slack"]);
+    expect(decoded.tasks).toEqual(["Meeting prep"]);
+    expect(decoded.tone).toBe("Dry and precise");
+  });
+
+  test("googleConnected: false is persisted correctly", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "",
+      googleConnected: false,
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleConnected).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/onboarding-context.test.ts
+++ b/assistant/src/__tests__/onboarding-context.test.ts
@@ -92,4 +92,27 @@ describe("OnboardingContext googleConnected field", () => {
     ) as OnboardingContext;
     expect(decoded.googleConnected).toBe(false);
   });
+
+  test("googleScopes and abVariant round-trip through the sidecar", () => {
+    const ctx: OnboardingContext = {
+      tools: ["Gmail"],
+      tasks: ["Inbox triage"],
+      tone: "Friendly",
+      googleConnected: true,
+      googleScopes: ["gmail.readonly", "calendar.readonly"],
+      abVariant: "pre-chat-oauth",
+    };
+
+    writeOnboardingSidecar(ctx);
+
+    const path = getOnboardingSidecarPath();
+    const decoded = JSON.parse(
+      readFileSync(path, "utf-8"),
+    ) as OnboardingContext;
+    expect(decoded.googleScopes).toEqual([
+      "gmail.readonly",
+      "calendar.readonly",
+    ]);
+    expect(decoded.abVariant).toBe("pre-chat-oauth");
+  });
 });

--- a/assistant/src/__tests__/scan-context-injection.test.ts
+++ b/assistant/src/__tests__/scan-context-injection.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for Google Connect Scan context injection in buildSystemPrompt.
+ *
+ * The scan instructions are injected when:
+ *   1. The `google-connect-scan` feature flag is enabled
+ *   2. BOOTSTRAP.md is present (first conversation)
+ *
+ * The `googleConnected` flag is NOT a gate — the template covers both
+ * Variant A (already connected) and Variant B (connects mid-conversation).
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+// Mutable flag overrides — tests flip these to control feature gate.
+const _mockFlagOverrides: Record<string, boolean> = {};
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
+    const explicit = _mockFlagOverrides[key];
+    if (typeof explicit === "boolean") return explicit;
+    return false; // default to disabled for test isolation
+  },
+  loadDefaultsRegistry: () => ({}),
+  initFeatureFlagOverrides: () => Promise.resolve(),
+  clearFeatureFlagOverridesCache: () => {},
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
+
+const SCAN_OPEN_TAG = "<google_connect_scan_instructions>";
+const SCAN_CLOSE_TAG = "</google_connect_scan_instructions>";
+
+function seedBootstrap(): void {
+  writeFileSync(
+    join(TEST_DIR, "BOOTSTRAP.md"),
+    "# First run\n\nWelcome aboard.",
+  );
+}
+
+describe("Google Connect Scan context injection", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    // Clean up files from prior tests.
+    for (const name of ["BOOTSTRAP.md", "IDENTITY.md", "SOUL.md"]) {
+      const p = join(TEST_DIR, name);
+      if (existsSync(p)) rmSync(p, { force: true });
+    }
+    // Reset flag overrides between tests.
+    for (const key of Object.keys(_mockFlagOverrides)) {
+      delete _mockFlagOverrides[key];
+    }
+  });
+
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected: true", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
+    expect(result).toContain("# Google Connect Scan");
+  });
+
+  test("NOT injected when flag is off", () => {
+    _mockFlagOverrides["google-connect-scan"] = false;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+    expect(result).not.toContain("# Google Connect Scan");
+  });
+
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected is false (Variant B)", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: false,
+      },
+    });
+
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
+  });
+
+  test("injected when flag is on + BOOTSTRAP exists + googleConnected is undefined (Variant B)", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+      },
+    });
+
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
+  });
+
+  test("NOT injected when flag is on + googleConnected but no BOOTSTRAP.md", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    // Do NOT seed BOOTSTRAP.md — simulate a non-first conversation.
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    expect(result).not.toContain(SCAN_OPEN_TAG);
+  });
+
+  test("injected when flag is on + BOOTSTRAP exists + no onboarding context at all", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({});
+
+    expect(result).toContain(SCAN_OPEN_TAG);
+    expect(result).toContain(SCAN_CLOSE_TAG);
+  });
+
+  test("scan block contains subagent dispatch instructions", () => {
+    _mockFlagOverrides["google-connect-scan"] = true;
+    seedBootstrap();
+
+    const result = buildSystemPrompt({
+      onboardingContext: {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        googleConnected: true,
+      },
+    });
+
+    // The template should include key scan phases.
+    expect(result).toContain("Phase 1");
+    expect(result).toContain("Phase 2");
+    expect(result).toContain("subagent_spawn");
+  });
+});

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -7,7 +7,9 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
+import { getConfig } from "../config/loader.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
@@ -349,6 +351,14 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // tool routing lives in tool descriptions.
   // External Communications Identity removed — guidance lives in messaging
   // and phone-calls skill SKILL.md files.
+
+  // Inject Google Connect Scan instructions when the feature flag is
+  // enabled and this is the first conversation (BOOTSTRAP.md present).
+  // The template covers both Variant A (Google already connected) and
+  // Variant B (user connects mid-conversation via in-chat OAuth).
+  const scanInstructions = buildGoogleConnectScanSection(includeBootstrap);
+  if (scanInstructions) systemParts.push(scanInstructions);
+
   const integrationSection = buildIntegrationSection();
   if (integrationSection) systemParts.push(integrationSection);
 
@@ -382,6 +392,71 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Build the Google Connect Scan instruction block when the
+ * `google-connect-scan` feature flag is enabled AND this is the first
+ * conversation (BOOTSTRAP.md present).
+ *
+ * The scan template is read from the bundled `GOOGLE_CONNECT_SCAN.md`
+ * only when both conditions are satisfied, so non-scan conversations
+ * pay zero file-system cost.
+ *
+ * The instructions cover both onboarding variants:
+ * - **Variant A**: `googleConnected: true` — model triggers scan immediately
+ * - **Variant B**: `googleConnected` is false/undefined — model knows what
+ *   to do if/when the user connects Google mid-conversation via in-chat OAuth
+ *
+ * Once BOOTSTRAP.md is deleted the scan instructions stop being
+ * injected — ongoing scan behavior is handled by watchers, not the
+ * system prompt.
+ */
+function buildGoogleConnectScanSection(
+  includeBootstrap: boolean,
+): string | null {
+  // Gate 1: feature flag must be enabled.
+  const config = getConfig();
+  if (!isAssistantFeatureFlagEnabled("google-connect-scan", config)) {
+    return null;
+  }
+
+  // Gate 2: only inject during the first conversation (bootstrap present).
+  // The googleConnected check is intentionally omitted — the template
+  // handles both Variant A (already connected) and Variant B (connects
+  // mid-conversation via in-chat OAuth).
+  if (!includeBootstrap) {
+    return null;
+  }
+
+  // Load the template from the bundled assets.
+  const templatesDir = resolveBundledDir(
+    import.meta.dirname ?? __dirname,
+    "templates",
+    "templates",
+  );
+  const scanTemplatePath = join(templatesDir, "GOOGLE_CONNECT_SCAN.md");
+
+  try {
+    if (!existsSync(scanTemplatePath)) {
+      log.warn(
+        { scanTemplatePath },
+        "GOOGLE_CONNECT_SCAN.md template not found",
+      );
+      return null;
+    }
+    const content = stripCommentLines(readFileSync(scanTemplatePath, "utf-8"));
+    if (content.length === 0) return null;
+
+    return (
+      "<google_connect_scan_instructions>\n" +
+      content +
+      "\n</google_connect_scan_instructions>"
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to read GOOGLE_CONNECT_SCAN.md template");
+    return null;
+  }
 }
 
 // Re-export from shared util so existing importers don't break.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -342,6 +342,17 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
       if (options.onboardingContext.googleConnected)
         lines.push("- Google connected: yes");
+      if (
+        options.onboardingContext.googleScopes &&
+        options.onboardingContext.googleScopes.length > 0
+      )
+        lines.push(
+          `- Google scopes: ${options.onboardingContext.googleScopes.join(", ")}`,
+        );
+      if (options.onboardingContext.abVariant)
+        lines.push(
+          `- Onboarding variant: ${options.onboardingContext.abVariant}`,
+        );
       lines.push(
         "",
         "Apply this context quietly. Do not recap it as a list unless the user asks.",

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -340,6 +340,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.assistantName)
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      if (options.onboardingContext.googleConnected)
+        lines.push("- Google connected: yes");
       lines.push(
         "",
         "Apply this context quietly. Do not recap it as a list unless the user asks.",

--- a/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
@@ -21,7 +21,11 @@ ui_show({
 
 ## Task Card (Email Already Connected)
 
-Use this `ui_show` payload when Google or Outlook IS in the Connected Services section:
+Use this `ui_show` payload when Google or Outlook IS in the Connected Services section.
+
+When the `google-connect-scan` feature flag is enabled and `googleConnected: true` is present in the onboarding context, skip this card entirely — the Google integration scan (GOOGLE_CONNECT_SCAN.md) replaces the static suggestions below. The scan will produce personalized, actionable insights from the user's actual email and calendar data instead of generic prompts.
+
+When the flag is off, or for non-Google email providers, use this card as before:
 
 ui_show({
   surface_type: "card",

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -66,25 +66,7 @@ When onboarding context gives you real signal, use it — but don't over-infer f
 
 Task-first users may become conversation-first users by their second or third conversation once they trust the assistant is useful. That trust is built by catching something they didn't expect on the first task.
 
-### Google connect scan (when `google-connect-scan` flag is enabled)
-
-This section only applies when the `google-connect-scan` feature flag is enabled. When the flag is off, ignore this section entirely and follow the existing Path A / Path B flow above.
-
-**Variant A — Pre-chat OAuth (`googleConnected: true`)**
-
-If the onboarding context includes `googleConnected: true`, the user completed Google OAuth before entering chat. Immediately initiate the Google integration scan (see GOOGLE_CONNECT_SCAN.md instructions). Do not ask for permission — the user already consented by connecting. While subagents are working, you may greet the user briefly ("I'm scanning your email and calendar to find things that matter right now...") but keep it short.
-
-**Variant B — In-chat OAuth (no `googleConnected` in onboarding context)**
-
-If the onboarding context does NOT include `googleConnected: true` and the `google-connect-scan` feature flag is enabled, offer the user three options in your opening message:
-
-- Do something for me — proceed with normal task-oriented flow (Path B above)
-- Let's chat first — proceed with existing conversational onboarding (Path A above)
-- Connect to Google — initiate Google OAuth by running the CLI command `assistant oauth connect google --scopes gmail.readonly calendar.readonly`, then run the Google integration scan on completion (see GOOGLE_CONNECT_SCAN.md)
-
-Present these as natural conversation options, not a numbered list. Match the user's tone preference. The model owns how to present the Google connect scan results — tone, ordering, emphasis should match the user's style.
-
-Note: This overrides the general guidance about not presenting options — when the `google-connect-scan` flag is enabled and no Google connection exists, offering these three paths is the intended behavior.
+If a <google_connect_scan_instructions> block is present below, follow those instructions for the Google integration scan.
 
 ## Identity
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -66,6 +66,26 @@ When onboarding context gives you real signal, use it — but don't over-infer f
 
 Task-first users may become conversation-first users by their second or third conversation once they trust the assistant is useful. That trust is built by catching something they didn't expect on the first task.
 
+### Google connect scan (when `google-connect-scan` flag is enabled)
+
+This section only applies when the `google-connect-scan` feature flag is enabled. When the flag is off, ignore this section entirely and follow the existing Path A / Path B flow above.
+
+**Variant A — Pre-chat OAuth (`googleConnected: true`)**
+
+If the onboarding context includes `googleConnected: true`, the user completed Google OAuth before entering chat. Immediately initiate the Google integration scan (see GOOGLE_CONNECT_SCAN.md instructions). Do not ask for permission — the user already consented by connecting. While subagents are working, you may greet the user briefly ("I'm scanning your email and calendar to find things that matter right now...") but keep it short.
+
+**Variant B — In-chat OAuth (no `googleConnected` in onboarding context)**
+
+If the onboarding context does NOT include `googleConnected: true` and the `google-connect-scan` feature flag is enabled, offer the user three options in your opening message:
+
+- Do something for me — proceed with normal task-oriented flow (Path B above)
+- Let's chat first — proceed with existing conversational onboarding (Path A above)
+- Connect to Google — initiate Google OAuth by running the CLI command `assistant oauth connect google --scopes gmail.readonly calendar.readonly`, then run the Google integration scan on completion (see GOOGLE_CONNECT_SCAN.md)
+
+Present these as natural conversation options, not a numbered list. Match the user's tone preference. The model owns how to present the Google connect scan results — tone, ordering, emphasis should match the user's style.
+
+Note: This overrides the general guidance about not presenting options — when the `google-connect-scan` flag is enabled and no Google connection exists, offering these three paths is the intended behavior.
+
 ## Identity
 
 You're not a blank tool and not a service rep running intake. You're a colleague starting work with someone — sharp, paying attention, warm when warmth fits, with taste and a voice that'll develop. That shows up in how you do the work, not in announcements about it.

--- a/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
+++ b/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
@@ -1,18 +1,32 @@
 _ Lines starting with _ are comments. They won't appear in the system prompt.
 _ This template is injected as a <google_connect_scan_instructions> block
-_ when the google-connect-scan feature flag is enabled and Google OAuth
-_ has just completed.
+_ when the google-connect-scan feature flag is enabled AND BOOTSTRAP.md
+_ is present (first conversation only).
 
 # Google Connect Scan
 
+## Variant routing
+
+Determine which variant applies based on the Known context in the system prompt:
+
+**Variant A (pre-chat OAuth):** If the Known context includes `Google connected: yes`, the user completed OAuth before entering chat. Skip directly to Phase 1 immediately. Do not ask for permission — the user already consented by connecting. While subagents are working, you may greet the user briefly ("I'm scanning your email and calendar to find things that matter right now...") but keep it short.
+
+**Variant B (in-chat OAuth):** If there is no `Google connected: yes` line, offer three options in your opening message:
+
+- Do something for me — proceed with normal task-oriented flow (Path B in BOOTSTRAP.md)
+- Let's chat first — proceed with existing conversational onboarding (Path A in BOOTSTRAP.md)
+- Connect to Google — initiate Google OAuth by running `assistant oauth connect google`, then proceed to Phase 1 on success
+
+Present these as natural conversation options, not a numbered list. Match the user's tone preference.
+
+Note: This overrides the general guidance about not presenting options — when these instructions are active, offering these three paths is the intended behavior.
+
 ## Trigger conditions
 
-Activate this scan when BOTH conditions are true:
+Activate the scan (Phase 1 + Phase 2) when Google OAuth has completed:
 
-1. The `google-connect-scan` feature flag is enabled
-2. Google OAuth has just completed — either:
-   - `googleConnected: true` is present in the onboarding context, OR
-   - The CLI command `assistant oauth connect google` completed successfully during this conversation
+- **Variant A:** Immediately on conversation start (Google is already connected).
+- **Variant B:** When the CLI command `assistant oauth connect google` returns a success result during this conversation. For Variant B, the model detects successful OAuth via the tool result from `assistant oauth connect google` — when the CLI command returns success, that IS the trigger. The model does not need `Google connected: yes` in the system prompt for this case; it observes the OAuth completion in the conversation itself.
 
 When triggered, execute Phase 1 and Phase 2 below in sequence. Do not ask the user for permission to scan — they just connected Google; scanning is the expected next step.
 
@@ -129,6 +143,12 @@ Examples of weak insights (do not produce these):
 ### Presentation
 
 Present insights conversationally, not as a bulleted report. Each insight should flow naturally and end with its offered action. The whole response should feel like a person who just looked through your stuff and is telling you what matters — not a system generating a dashboard.
+
+## Handling partial results
+
+- If one subagent fails (permission denied, API timeout, empty results), proceed with whatever data is available from the other subagent. Note the gap to the user honestly: "I was able to scan your calendar but couldn't access your email — [reason]. Here's what I found from your calendar:"
+- Don't fail the entire flow because one scan failed.
+- If both subagents fail, tell the user honestly and offer to try again or proceed with conversation: "I wasn't able to access your email or calendar — [reason]. Want me to try again, or shall we move on?"
 
 ## Post-scan
 

--- a/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
+++ b/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
@@ -1,0 +1,139 @@
+_ Lines starting with _ are comments. They won't appear in the system prompt.
+_ This template is injected as a <google_connect_scan_instructions> block
+_ when the google-connect-scan feature flag is enabled and Google OAuth
+_ has just completed.
+
+# Google Connect Scan
+
+## Trigger conditions
+
+Activate this scan when BOTH conditions are true:
+
+1. The `google-connect-scan` feature flag is enabled
+2. Google OAuth has just completed — either:
+   - `googleConnected: true` is present in the onboarding context, OR
+   - A `connect_oauth` call for Google returned success during this conversation
+
+When triggered, execute Phase 1 and Phase 2 below in sequence. Do not ask the user for permission to scan — they just connected Google; scanning is the expected next step.
+
+## Phase 1 — Parallel subagent dispatch
+
+Spawn both subagents simultaneously using `subagent_spawn`. Do not wait for one to finish before spawning the other.
+
+### Gmail subagent
+
+```
+subagent_spawn:
+  role: "general"
+  label: "Scanning Gmail"
+  send_result_to_user: false
+  objective: |
+    Fetch the user's recent email activity. Use messaging tools to:
+    1. Call `messaging_list_conversations` to list recent unread messages
+    2. Call `messaging_list_conversations` to list flagged/starred messages
+    3. Call `messaging_list_conversations` to list recent sent messages
+    4. Use `messaging_read` on promising threads to get full context
+       when the preview alone isn't enough to judge actionability
+
+    For each message return: sender/recipient, subject, date, labels, and
+    a 1-line preview of the body.
+
+    Focus on actionable items — things that need a response, have deadlines,
+    or involve commitments. Skip newsletters, marketing, and automated
+    notifications unless they contain a deadline or required action.
+
+    Return structured JSON with three arrays:
+    {
+      "unread": [...],
+      "flagged": [...],
+      "recent_sent": [...]
+    }
+
+    Each item should have: sender, recipient, subject, date, labels, preview,
+    and an "actionable" boolean with a short reason if true.
+```
+
+### Calendar subagent
+
+```
+subagent_spawn:
+  role: "general"
+  label: "Scanning Calendar"
+  send_result_to_user: false
+  objective: |
+    Fetch the user's calendar events from 48 hours ago through 48 hours
+    from now using the google-calendar skill:
+
+    bun scripts/gcal.ts list --time-min <48h-ago-ISO> --time-max <48h-ahead-ISO>
+
+    Replace the placeholders with actual ISO 8601 timestamps relative to now.
+
+    For each event return: title, start/end time, attendees (names),
+    location, and any notes/description.
+
+    Flag events that match any of these conditions:
+    - Happening soon (within the next 2 hours)
+    - Recently missed (started in the past 2 hours and user was an attendee)
+    - Have scheduling conflicts (overlapping times)
+    - Are recurring meetings with no agenda or notes
+
+    Return structured JSON:
+    {
+      "events": [...],
+      "flags": {
+        "upcoming_soon": [...],
+        "recently_missed": [...],
+        "conflicts": [...],
+        "no_agenda": [...]
+      }
+    }
+```
+
+Wait for both subagents to complete. You will be notified automatically — do not poll `subagent_status`.
+
+## Phase 2 — Synthesis
+
+After both subagents reach terminal status:
+
+1. Read both results using `subagent_read` (by label: "Scanning Gmail" and "Scanning Calendar")
+2. Cross-reference the scan results with the full user context:
+   - Onboarding selections: tools they use, tasks they care about, tone preference
+   - User name (if known) and assistant name
+   - Any other context from the conversation so far
+3. Identify **1–3 specific insights** that this particular person would want to know right now
+
+### What counts as an insight
+
+Each insight must include:
+- A specific observation grounded in the scan data
+- Why it matters to this person (connected to their context, role, or stated priorities)
+- A concrete offered action — something you can do right now if they say yes
+
+Examples of strong insights:
+- "You have a meeting with Sarah in 2 hours, and she sent you an email yesterday you haven't replied to. Want me to draft a quick reply before the meeting?"
+- "You have 3 unread emails about the Q2 budget review — your calendar shows that meeting is tomorrow at 10am. Should I summarize the thread so you're prepped?"
+- "Your calendar is empty tomorrow morning but you have 6 flagged emails. Want me to block focus time to work through them?"
+
+Examples of weak insights (do not produce these):
+- "You have 12 unread emails" — that's a count, not an insight
+- "Your calendar looks busy this week" — that's an observation, not actionable
+- "You might want to check your email" — the user knows they have email
+
+### Quality bar
+
+- Not a summary. Not a count. An insight this specific person would want to know right now.
+- Cross-service connections are gold — linking email to calendar, spotting prep gaps, finding conflicts between commitments.
+- If nothing in the scan data clears this quality bar, say so honestly: "I scanned your email and calendar but nothing jumped out as urgent or interesting right now. Everything looks in order." Do not pad with generic observations to fill space.
+- Match the user's tone preference from onboarding. If they chose casual, be casual. If they chose professional, be professional.
+
+### Presentation
+
+Present insights conversationally, not as a bulleted report. Each insight should flow naturally and end with its offered action. The whole response should feel like a person who just looked through your stuff and is telling you what matters — not a system generating a dashboard.
+
+## Post-scan
+
+After presenting insights (or the honest "nothing notable" response), offer ongoing monitoring:
+
+"Want me to keep an eye on your email and calendar going forward? I can set up watchers that flag things as they come in — like messages that need a response, upcoming meetings with prep needed, or scheduling conflicts."
+
+This is an offer, not a setup. If they say yes, that's a separate workflow. If they say no or ignore it, move on.

--- a/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
+++ b/assistant/src/prompts/templates/GOOGLE_CONNECT_SCAN.md
@@ -12,7 +12,7 @@ Activate this scan when BOTH conditions are true:
 1. The `google-connect-scan` feature flag is enabled
 2. Google OAuth has just completed — either:
    - `googleConnected: true` is present in the onboarding context, OR
-   - A `connect_oauth` call for Google returned success during this conversation
+   - The CLI command `assistant oauth connect google` completed successfully during this conversation
 
 When triggered, execute Phase 1 and Phase 2 below in sequence. Do not ask the user for permission to scan — they just connected Google; scanning is the expected next step.
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1046,6 +1046,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1121,6 +1122,7 @@ export async function handleSendMessage(
       tone: string;
       userName?: string;
       assistantName?: string;
+      googleConnected?: boolean;
     };
   };
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1047,6 +1047,8 @@ export function persistOnboardingArtifacts(onboarding: {
   userName?: string;
   assistantName?: string;
   googleConnected?: boolean;
+  googleScopes?: string[];
+  abVariant?: "pre-chat-oauth" | "in-chat-chips";
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1123,6 +1125,8 @@ export async function handleSendMessage(
       userName?: string;
       assistantName?: string;
       googleConnected?: boolean;
+      googleScopes?: string[];
+      abVariant?: "pre-chat-oauth" | "in-chat-chips";
     };
   };
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -4,4 +4,5 @@ export interface OnboardingContext {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -5,4 +5,6 @@ export interface OnboardingContext {
   userName?: string;
   assistantName?: string;
   googleConnected?: boolean;
+  googleScopes?: string[];
+  abVariant?: "pre-chat-oauth" | "in-chat-chips";
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -304,6 +304,14 @@
       "label": "External Plugins",
       "description": "Enable the external-plugin install path: the `assistant plugins` CLI subcommand and the declarative external-plugin loader convention (`<workspaceDir>/plugins/<name>/` directories containing `package.json` plus interface dirs). Gates an unstable surface that may change shape before stabilizing.",
       "defaultEnabled": false
+    },
+    {
+      "id": "google-connect-scan",
+      "scope": "assistant",
+      "key": "google-connect-scan",
+      "label": "Google Connect Scan",
+      "description": "After Google OAuth completes during onboarding, spawn parallel subagents to scan Gmail and Calendar and synthesize actionable insights",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Implements the assistant-side changes for the [New User Retention: Days 1–3 Integration Strategy](https://www.notion.so/vellum-ai/35f9035c57bd80199128db5d4347f065). When a new user connects Google (Gmail + Calendar), parallel subagents scan their email and calendar, and the main agent synthesizes 1–3 actionable insights.

Supports two A/B variants:
- **Variant A (pre-chat OAuth):** `googleConnected: true` triggers immediate parallel scan
- **Variant B (in-chat OAuth):** Assistant offers three conversational options; scan fires after user connects Google mid-conversation

All behind the `google-connect-scan` feature flag (default off).

## Self-review result
PASS — 1 gap found and fixed (googleConnected not surfaced to model in system prompt)

## PRs merged into feature branch
- #30677: feat: add google-connect-scan feature flag
- #30678: feat(onboarding): add googleConnected flag to OnboardingContext
- #30679: feat(onboarding): add Google integration scan prompt template
- #30681: feat(onboarding): update BOOTSTRAP.md for Google connect scan flow
- #30682: feat(onboarding): inject Google connect scan instructions into conversation context

### Fix PRs
- #30685: fix: surface googleConnected in system prompt for Variant A/B detection

Part of plan: new-user-retention-integration.md

JARVIS-839
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->