### PR TITLE
feat(providers): add MiniMax provider support

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -95,6 +95,7 @@ mock.module("openai", () => ({
 
 // Import after mocking
 import { FireworksProvider } from "../providers/fireworks/client.js";
+import { MinimaxProvider } from "../providers/minimax/client.js";
 import { OllamaProvider } from "../providers/ollama/client.js";
 import { OpenAIChatCompletionsProvider } from "../providers/openai/chat-completions-provider.js";
 import { OpenAIProvider } from "../providers/openai/client.js";
@@ -1146,6 +1147,27 @@ describe("custom baseURL initialization", () => {
     expect(lastConstructorOptions).toEqual({
       apiKey: "or-user-key",
       baseURL: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  test("MinimaxProvider forwards a custom baseURL", () => {
+    const managed = new MinimaxProvider("ast-key-123", "MiniMax-M2.7", {
+      baseURL: "https://platform.example.com/v1/runtime-proxy/minimax",
+    });
+
+    expect(managed.name).toBe("minimax");
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "ast-key-123",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/minimax",
+    });
+  });
+
+  test("MinimaxProvider without custom baseURL uses default MiniMax URL", () => {
+    new MinimaxProvider("mm-user-key", "MiniMax-M2.7");
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "mm-user-key",
+      baseURL: "https://api.minimax.io/v1",
     });
   });
 });

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -329,10 +329,10 @@ function buildTitlePrompt(
   }
 
   if (userMessage) {
-    parts.push(`User: ${userMessage}`);
+    parts.push(`User: ${stripThinkingTags(userMessage)}`);
   }
   if (assistantResponse) {
-    parts.push(`Assistant: ${assistantResponse}`);
+    parts.push(`Assistant: ${stripThinkingTags(assistantResponse)}`);
   }
 
   return parts.join("\n");
@@ -356,10 +356,23 @@ const META_FAILURE_TITLES = new Set([
 function normalizeTitle(raw: string): string {
   let title = raw.trim().replace(/^["']|["']$/g, "");
   title = stripMarkdown(title);
+  title = stripThinkingTags(title);
   if (META_FAILURE_TITLES.has(title.toLowerCase())) {
     return "";
   }
   return title;
+}
+
+/** Strip thinking tags so they don't bleed into generated titles. */
+function stripThinkingTags(text: string): string {
+  return text
+    .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
+    .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
+    .replace(/<thought>/gi, "")
+    .replace(/<\/thought>/gi, "")
+    .replace(/<thinking>/gi, "")
+    .replace(/<\/thinking>/gi, "")
+    .replace(/<:[^>]*>/gi, "");
 }
 
 /** Strip common markdown formatting so titles render as plain text. */

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -368,10 +368,13 @@ function stripThinkingTags(text: string): string {
   return text
     .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
     .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
     .replace(/<thought>/gi, "")
     .replace(/<\/thought>/gi, "")
     .replace(/<thinking>/gi, "")
     .replace(/<\/thinking>/gi, "")
+    .replace(/<think>/gi, "")
+    .replace(/<\/think>/gi, "")
     .replace(/<:[^>]*>/gi, "");
 }
 

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -21,6 +21,7 @@
 import { AnthropicProvider } from "../anthropic/client.js";
 import { FireworksProvider } from "../fireworks/client.js";
 import { GeminiProvider } from "../gemini/client.js";
+import { MinimaxProvider } from "../minimax/client.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { OllamaProvider } from "../ollama/client.js";
 import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
@@ -52,7 +53,13 @@ type AdapterFactory = (opts: AdapterCreateOpts) => Provider;
  * module-load time.
  */
 const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
-  anthropic: ({ apiKey, model, streamTimeoutMs, baseURL, useNativeWebSearch }) =>
+  anthropic: ({
+    apiKey,
+    model,
+    streamTimeoutMs,
+    baseURL,
+    useNativeWebSearch,
+  }) =>
     new AnthropicProvider(apiKey, model, {
       useNativeWebSearch,
       streamTimeoutMs,
@@ -84,6 +91,8 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       useNativeWebSearch,
       streamTimeoutMs,
     }),
+  minimax: ({ apiKey, model, streamTimeoutMs }) =>
+    new MinimaxProvider(apiKey, model, { streamTimeoutMs }),
 };
 
 /**
@@ -138,7 +147,11 @@ export function buildProviderAdapter(
 export function createAdapterFromConnection(
   connection: ProviderConnection,
   resolvedAuth: ResolvedAuth,
-  opts: { model: string; streamTimeoutMs?: number; useNativeWebSearch?: boolean },
+  opts: {
+    model: string;
+    streamTimeoutMs?: number;
+    useNativeWebSearch?: boolean;
+  },
 ): Provider | null {
   const { provider } = connection;
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);

--- a/assistant/src/providers/minimax/client.ts
+++ b/assistant/src/providers/minimax/client.ts
@@ -1,0 +1,106 @@
+import OpenAI from "openai";
+
+import { getLogger } from "../../util/logger.js";
+import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+
+const log = getLogger("minimax-client");
+
+/** Validation-specific timeout (10s) so a stalled network doesn't block key submission. */
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+export interface MinimaxProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+  streamTimeoutMs?: number;
+}
+
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+const FALLBACK_MINIMAX_BASE_URL = "https://api.minimaxi.com/v1";
+
+/**
+ * Validate a MiniMax API key by testing against the default URL first,
+ * then the fallback URL if the default fails. Both URLs must fail with
+ * definitive errors (401/403) for the key to be rejected. Transient errors
+ * (429, 5xx, network) allow the key to be stored.
+ */
+export async function validateMinimaxApiKey(
+  apiKey: string,
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+  // Try default URL first
+  const defaultResult = await tryValidate(apiKey, DEFAULT_MINIMAX_BASE_URL);
+  if (defaultResult.valid && !defaultResult.transient) {
+    return { valid: true };
+  }
+
+  // Default failed or was transient — try fallback URL
+  const fallbackResult = await tryValidate(apiKey, FALLBACK_MINIMAX_BASE_URL);
+  if (fallbackResult.valid) {
+    return { valid: true };
+  }
+
+  // Both URLs failed definitively — reject the key
+  return { valid: false, reason: fallbackResult.reason };
+}
+
+async function tryValidate(
+  apiKey: string,
+  baseURL: string,
+): Promise<
+  | { valid: true; transient: false }
+  | { valid: true; transient: true }
+  | { valid: false; reason: string }
+> {
+  try {
+    const client = new OpenAI({
+      apiKey,
+      baseURL,
+      timeout: VALIDATION_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+    await client.models.list();
+    return { valid: true, transient: false };
+  } catch (error) {
+    if (error instanceof OpenAI.APIError) {
+      if (error.status === 401) {
+        return { valid: false, reason: "API key is invalid or expired." };
+      }
+      if (error.status === 403) {
+        return {
+          valid: false,
+          reason: `MiniMax API error (${error.status}): ${error.message}`,
+        };
+      }
+      // Transient errors (429, 5xx, etc.) — try the other URL
+      log.warn(
+        { status: error.status, baseURL },
+        "MiniMax API returned a transient error during key validation — trying fallback",
+      );
+      return { valid: true, transient: true };
+    }
+    // Network errors — try the other URL
+    log.warn(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        baseURL,
+      },
+      "Network error during MiniMax key validation — trying fallback",
+    );
+    return { valid: true, transient: true };
+  }
+}
+
+export class MinimaxProvider extends OpenAIChatCompletionsProvider {
+  constructor(
+    apiKey: string,
+    model: string,
+    options: MinimaxProviderOptions = {},
+  ) {
+    const baseURL = options.baseURL?.trim() || DEFAULT_MINIMAX_BASE_URL;
+    super(apiKey, model, {
+      baseURL,
+      providerName: "minimax",
+      providerLabel: "MiniMax",
+      streamTimeoutMs: options.streamTimeoutMs,
+    });
+  }
+}

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -868,6 +868,34 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyUrl: "https://openrouter.ai/keys",
     apiKeyPlaceholder: "sk-or-v1-...",
   },
+  {
+    id: "minimax",
+    displayName: "MiniMax",
+    subtitle: "MiniMax AI models. Requires a MiniMax API key.",
+    setupMode: "api-key",
+    setupHint: "Enter your MiniMax API key to enable MiniMax models.",
+    envVar: "MINIMAX_API_KEY",
+    credentialsGuide: {
+      description: "Sign in to the MiniMax dashboard and create an API key.",
+      url: "https://platform.minimax.io/",
+      linkLabel: "Open MiniMax Dashboard",
+    },
+    models: [
+      {
+        id: "MiniMax-M2.7",
+        displayName: "MiniMax M2.7",
+        contextWindowTokens: 200000,
+        maxOutputTokens: 16384,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+      },
+    ],
+    defaultModel: "MiniMax-M2.7",
+    apiKeyUrl: "https://platform.minimax.io/",
+    apiKeyPlaceholder: "sk-cp-...",
+  },
 ];
 
 export const PROVIDER_CATALOG: ProviderCatalogEntry[] =

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -27,6 +27,7 @@ import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { validateGeminiApiKey } from "../../providers/gemini/client.js";
+import { validateMinimaxApiKey } from "../../providers/minimax/client.js";
 import { validateOpenAIApiKey } from "../../providers/openai/client.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -195,9 +196,21 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
           );
           return { success: false, error: validation.reason };
         }
+      } else if (name === "minimax") {
+        const validation = await validateMinimaxApiKey(value);
+        if (!validation.valid) {
+          log.warn(
+            { provider: name, reason: validation.reason },
+            "API key validation failed",
+          );
+          return { success: false, error: validation.reason };
+        }
       }
 
-      const stored = await setSecureKeyAsync(credentialKey(name, "api_key"), value);
+      const stored = await setSecureKeyAsync(
+        credentialKey(name, "api_key"),
+        value,
+      );
       if (!stored) {
         throw new InternalError(
           `Failed to store API key in secure storage (backend: ${getActiveBackendName()})`,
@@ -339,7 +352,9 @@ async function handleReadSecret({ body }: RouteHandlerArgs) {
 
   try {
     let accountKey: string;
-    let prefetchedResult: Awaited<ReturnType<typeof getSecureKeyResultAsync>> | undefined;
+    let prefetchedResult:
+      | Awaited<ReturnType<typeof getSecureKeyResultAsync>>
+      | undefined;
 
     if (type === "api_key") {
       if (
@@ -350,7 +365,9 @@ async function handleReadSecret({ body }: RouteHandlerArgs) {
         );
       }
       // Check credential namespace first; fall back to bare key only if not found and store is reachable.
-      const credResult = await getSecureKeyResultAsync(credentialKey(name, "api_key"));
+      const credResult = await getSecureKeyResultAsync(
+        credentialKey(name, "api_key"),
+      );
       if (credResult.value === undefined && !credResult.unreachable) {
         accountKey = name;
       } else {
@@ -373,7 +390,8 @@ async function handleReadSecret({ body }: RouteHandlerArgs) {
       );
     }
 
-    const { value, unreachable } = prefetchedResult ?? await getSecureKeyResultAsync(accountKey);
+    const { value, unreachable } =
+      prefetchedResult ?? (await getSecureKeyResultAsync(accountKey));
     if (value === undefined) {
       return { found: false, unreachable };
     }
@@ -543,7 +561,9 @@ async function handleListSecrets() {
         const field = rest.slice(slashIdx + 1);
         if (
           field === "api_key" &&
-          API_KEY_PROVIDERS.includes(service as (typeof API_KEY_PROVIDERS)[number])
+          API_KEY_PROVIDERS.includes(
+            service as (typeof API_KEY_PROVIDERS)[number],
+          )
         ) {
           return [service];
         }

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -26,6 +26,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   gemini: "GEMINI_API_KEY",
   fireworks: "FIREWORKS_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
+  minimax: "MINIMAX_API_KEY",
 };
 
 /** Search-provider env var names. Mirrors `SEARCH_PROVIDER_CATALOG` BYOK entries. */

--- a/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
@@ -47,6 +47,14 @@ func parseInlineThinkingTags(_ text: String) -> [InlineContentChunk] {
             break
         }
 
+        // Capture any text between the previous cursor and the opening tag.
+        if openRange.lowerBound > cursor {
+            let preceding = String(text[cursor..<openRange.lowerBound])
+            if !preceding.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                chunks.append(.text(preceding))
+            }
+        }
+
         // Find the corresponding closing tag
         guard let pair = tagPairs.first(where: { $0.open == openTag }) else {
             break

--- a/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/InlineThinkingTagParser.swift
@@ -9,42 +9,51 @@ enum InlineContentChunk: Hashable {
     case thinking(String)
 }
 
-/// Parses assistant response text for `<thinking>...</thinking>` tags,
-/// returning an ordered list of chunks. Chunks preserve source order so
-/// the caller can render thinking blocks inline at the position they
-/// appear in the text.
-///
-/// An unclosed `<thinking>` tag (common while a response is still
-/// streaming in) is treated as an in-progress thinking block containing
-/// all remaining text — this way the thinking content streams into the
-/// collapsible block as soon as the opening tag arrives, instead of
-/// flashing the raw tag until the close tag finally shows up.
-///
-/// The parser is case-sensitive and only matches the exact lowercase
-/// `<thinking>` / `</thinking>` pair emitted by the model.
+/// Parses assistant response text for `<thinking>...</thinking>` or
+/// `<think>...</think>` thinking tags, returning an ordered list of chunks.
+/// The `<think>` format is used by MiniMax models.
 func parseInlineThinkingTags(_ text: String) -> [InlineContentChunk] {
     // Fast path: no opening tag, return the whole string as a single
-    // text chunk. Cheap contains check avoids the full scan below for
-    // the vast majority of messages that don't use thinking tags.
-    guard text.contains("<thinking>") else {
+    // text chunk.
+    guard containsInlineThinkingTag(text) else {
         return [.text(text)]
     }
 
     var chunks: [InlineContentChunk] = []
     var cursor = text.startIndex
 
-    while let openRange = text.range(of: "<thinking>", range: cursor..<text.endIndex) {
-        // Capture any text between the previous cursor and the opening
-        // tag. Keep the original substring (not trimmed) so markdown
-        // spacing is preserved when it renders.
-        if openRange.lowerBound > cursor {
-            let preceding = String(text[cursor..<openRange.lowerBound])
-            if !preceding.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                chunks.append(.text(preceding))
+    // Define tag pairs: opening -> closing
+    // Note: <think>/</think> is MiniMax's format; <thinking>/</thinking> is the standard format
+    let tagPairs: [(open: String, close: String)] = [
+        ("<thinking>", "</thinking>"),
+        ("<think>", "</think>"),
+    ]
+
+    while true {
+        // Find the next opening tag of either type
+        var earliestRange: Range<String.Index>? = nil
+        var earliestOpenTag: String? = nil
+
+        for pair in tagPairs {
+            if let range = text.range(of: pair.open, range: cursor..<text.endIndex) {
+                if earliestRange == nil || range.lowerBound < earliestRange!.lowerBound {
+                    earliestRange = range
+                    earliestOpenTag = pair.open
+                }
             }
         }
 
-        if let closeRange = text.range(of: "</thinking>", range: openRange.upperBound..<text.endIndex) {
+        guard let openRange = earliestRange, let openTag = earliestOpenTag else {
+            break
+        }
+
+        // Find the corresponding closing tag
+        guard let pair = tagPairs.first(where: { $0.open == openTag }) else {
+            break
+        }
+        let closeTag = pair.close
+
+        if let closeRange = text.range(of: closeTag, range: openRange.upperBound..<text.endIndex) {
             let body = String(text[openRange.upperBound..<closeRange.lowerBound])
             let bodyTrimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
             if !bodyTrimmed.isEmpty {
@@ -52,9 +61,7 @@ func parseInlineThinkingTags(_ text: String) -> [InlineContentChunk] {
             }
             cursor = closeRange.upperBound
         } else {
-            // Unclosed tag: treat the remainder of the text as
-            // streaming thinking content so the user sees it accumulate
-            // inside the collapsible block rather than as raw markup.
+            // Unclosed tag: streaming thinking content
             let body = String(text[openRange.upperBound..<text.endIndex])
             let bodyTrimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
             if !bodyTrimmed.isEmpty {
@@ -75,9 +82,9 @@ func parseInlineThinkingTags(_ text: String) -> [InlineContentChunk] {
     return chunks
 }
 
-/// Whether the given text contains at least one `<thinking>` opening
+/// Whether the given text contains at least one thinking opening
 /// tag. Exposed as a cheap check callers can run before calling
 /// `parseInlineThinkingTags` to decide whether to take the fast path.
 func containsInlineThinkingTag(_ text: String) -> Bool {
-    text.contains("<thinking>")
+    text.contains("<thinking>") || text.contains("<think>")
 }

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -897,7 +897,7 @@
           "maxOutputTokens": 16384,
           "defaultContextWindowTokens": 200000,
           "longContextMode": "unsupported",
-          "supportsThinking": false,
+          "supportsThinking": true,
           "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -873,6 +873,36 @@
           }
         }
       ]
+    },
+    {
+      "id": "minimax",
+      "displayName": "MiniMax",
+      "subtitle": "MiniMax AI models. Requires a MiniMax API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your MiniMax API key to enable MiniMax models.",
+      "envVar": "MINIMAX_API_KEY",
+      "apiKeyPlaceholder": "sk-cp-...",
+      "credentialsGuide": {
+        "description": "Sign in to the MiniMax dashboard and create an API key.",
+        "url": "https://platform.minimax.io/",
+        "linkLabel": "Open MiniMax Dashboard"
+      },
+      "supportsPlatformAuth": false,
+      "defaultModel": "MiniMax-M2.7",
+      "models": [
+        {
+          "id": "MiniMax-M2.7",
+          "displayName": "MiniMax M2.7",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 16384,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "unsupported",
+          "supportsThinking": false,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true
+        }
+      ]
     }
   ]
 }

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -897,7 +897,7 @@
           "maxOutputTokens": 16384,
           "defaultContextWindowTokens": 200000,
           "longContextMode": "unsupported",
-          "supportsThinking": false,
+          "supportsThinking": true,
           "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -873,6 +873,36 @@
           }
         }
       ]
+    },
+    {
+      "id": "minimax",
+      "displayName": "MiniMax",
+      "subtitle": "MiniMax AI models. Requires a MiniMax API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your MiniMax API key to enable MiniMax models.",
+      "envVar": "MINIMAX_API_KEY",
+      "apiKeyPlaceholder": "sk-cp-...",
+      "credentialsGuide": {
+        "description": "Sign in to the MiniMax dashboard and create an API key.",
+        "url": "https://platform.minimax.io/",
+        "linkLabel": "Open MiniMax Dashboard"
+      },
+      "supportsPlatformAuth": false,
+      "defaultModel": "MiniMax-M2.7",
+      "models": [
+        {
+          "id": "MiniMax-M2.7",
+          "displayName": "MiniMax M2.7",
+          "contextWindowTokens": 200000,
+          "maxOutputTokens": 16384,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "unsupported",
+          "supportsThinking": false,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add MiniMax provider with `MiniMax-M2.7` model to `PROVIDER_CATALOG` and model catalog
- Add `src/providers/minimax/client.ts` with API key validation (tries default URL, falls back to secondary URL on transient failure)
- Fix `validateMinimaxApiKey` to use `fallbackResult.reason` instead of `defaultResult.reason` — `defaultResult` may be a transient success lacking `reason`
- Regenerate `llm-provider-catalog.json` (meta + SwiftPM mirror) with correct MiniMax fields

## Test plan

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes
- [x] Swift build passes (pre-push hook)
- [ ] Confirm `llm-catalog-parity` test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->