### PR TITLE
Remove Gmail settings scope from Google setup docs

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -848,7 +848,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T10:02:12-07:00"
+      "updatedAt": "2026-05-14T10:27:02-07:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
@@ -87,7 +87,7 @@ Tell the user:
 >
 > - Click **Add or Remove Scopes** - a panel will open
 > - Scroll down to the **"Manually add scopes"** text box and paste these (comma-separated):
->   `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/gmail.settings.basic,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
+>   `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
 > - Click **Update** at the bottom of the panel
 > - Back on the main page, scroll down and click **Save**
 >

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -157,10 +157,10 @@ On macOS desktop, before proceeding, copy the comma-separated scope string below
 The scopes to paste:
 
 ```
-https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/gmail.settings.basic,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly
+https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly
 ```
 
-> You should see all 9 scopes listed across the three categories (Non-sensitive, Sensitive, Restricted):
+> You should see all 8 scopes listed across the three categories (Non-sensitive, Sensitive, Restricted):
 >
 > - `userinfo.email`
 > - `contacts.readonly`
@@ -170,9 +170,8 @@ https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/g
 > - `gmail.send`
 > - `gmail.modify`
 > - `gmail.readonly`
-> - `gmail.settings.basic`
 >
-> **Note:** GCP may categorize these scopes differently than you'd expect — that's fine, as long as all 9 are present.
+> **Note:** GCP may categorize these scopes differently than you'd expect — that's fine, as long as all 8 are present.
 >
 > **Quick note on email safety:** The `gmail.modify` and `gmail.send` scopes let me create drafts and, when you explicitly ask, send them. By default I only create drafts — nothing leaves your outbox without your approval. If you'd rather I only have read access to your email for now, you can uncheck those two - everything else will still work fine, and you can always come back and add them later.
 


### PR DESCRIPTION
## Summary
- remove gmail.settings.basic from the Google OAuth setup guide paste strings
- restore the setup guide count to the 8 scopes we actually want users to configure
- regenerate skills/catalog.json

## Verification
- node scripts/skills/check-catalog.mjs