### PR TITLE
fix(oura-setup): use api.ouraring.com for OAuth endpoints

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -468,7 +468,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-12T14:56:19-04:00"
+      "updatedAt": "2026-05-14T17:45:04Z"
     },
     {
       "id": "outlook",
@@ -848,7 +848,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T10:02:12-07:00"
+      "updatedAt": "2026-05-14T10:12:39-07:00"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -16,7 +16,7 @@ Connect the user's Oura Ring to pull sleep, heart rate, readiness, activity, and
 
 - An Oura Ring (Gen 3 or Ring 4) with an active Oura Membership ($6/mo required for API access)
 - The Oura app installed and paired with the ring
-- An Oura Cloud account at https://cloud.ouraring.com
+- An Oura Cloud account at https://api.ouraring.com
 
 ## Setup
 
@@ -59,7 +59,7 @@ class Handler(BaseHTTPRequestHandler):
                 'redirect_uri': REDIRECT_URI, 'scope': SCOPES, 'state': 'assistant'
             })
             self.send_response(302)
-            self.send_header('Location', f'https://cloud.ouraring.com/oauth/authorize?{params}')
+            self.send_header('Location', f'https://api.ouraring.com/oauth/authorize?{params}')
             self.end_headers()
         elif parsed.path == '/callback':
             code = parse_qs(parsed.query).get('code', [''])[0]


### PR DESCRIPTION
## Summary

- Update Oura Cloud account URL and OAuth authorize endpoint to use `api.ouraring.com` instead of `cloud.ouraring.com` so the setup flow points users (and the OAuth redirect) at the correct host.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->