### PR TITLE
fix(macos): filter health check noise from Sentry and add polling backoff

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -457,6 +457,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 options.sendDefaultPii = false
                 options.maxAttachmentSize = MetricKitManager.sentryMaxAttachmentSize
+                options.failedRequestTargets = MetricKitManager.sentryFailedRequestTargets
 
                 if !crashLogURLs.isEmpty {
                     options.onCrashedLastRun = { _ in crashedLastRun = true }

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -56,6 +56,19 @@ import os
     nonisolated static let macosDSN: String =
         ProcessInfo.processInfo.environment["SENTRY_DSN_MACOS"] ?? ""
 
+    /// URL targets for Sentry's automatic HTTP client error capture.
+    ///
+    /// The default (`[".*"]`) captures every 5xx response, including health
+    /// check probes that legitimately return 502/500 when pods are sleeping.
+    /// This regex matches all URLs except `/health` and `/readyz` endpoints,
+    /// eliminating the noise while preserving error capture for real API calls.
+    ///
+    /// Ref: https://docs.sentry.io/platforms/apple/configuration/http-client-errors/
+    nonisolated static let sentryFailedRequestTargets: [Any] = [
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: #"^(?!.*/(?:health|readyz)(?:/|$|\?))"#),
+    ]
+
     /// Closes the Sentry SDK through `sentrySerialQueue` to prevent races with
     /// concurrent `captureSentryEvent` calls.
     /// Use this instead of calling `SentrySDK.close()` directly.
@@ -102,6 +115,7 @@ import os
             }
             options.sendDefaultPii = false
             options.maxAttachmentSize = sentryMaxAttachmentSize
+            options.failedRequestTargets = sentryFailedRequestTargets
         }
         SentryDeviceInfo.configureSentryScope()
     }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -92,12 +92,16 @@ public final class GatewayConnectionManager {
     @ObservationIgnored private var healthCheckTask: Task<Void, Never>?
     @ObservationIgnored private let authFailureTracker = AuthFailureTracker()
     private let healthCheckInterval: TimeInterval = 15.0
+    private static let maxHealthCheckBackoffInterval: TimeInterval = 300.0
     @ObservationIgnored private var shouldReconnect = true
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
     @ObservationIgnored private var conversationKey: String?
     /// Number of consecutive successful health checks. Used to suppress
     /// repetitive "Health check passed" logs after the first three passes.
     @ObservationIgnored private var consecutiveHealthCheckSuccesses = 0
+    /// Number of consecutive health check failures in the periodic loop.
+    /// Drives exponential backoff: 15 s → 30 s → 60 s → 120 s → 240 s → 300 s cap.
+    @ObservationIgnored private var consecutiveHealthCheckFailures = 0
     func setUpdateInProgress(_ value: Bool) {
         let wasInProgress = _isUpdateInProgress
         if value != wasInProgress { isUpdateInProgress = value }
@@ -255,6 +259,7 @@ public final class GatewayConnectionManager {
         healthCheckTask?.cancel()
         healthCheckTask = nil
         consecutiveHealthCheckSuccesses = 0
+        consecutiveHealthCheckFailures = 0
         setConnected(false)
 
         // Reset auth-failed state on teardown. Every reconnect should start
@@ -463,6 +468,7 @@ public final class GatewayConnectionManager {
 
     private func startHealthCheckLoop() {
         healthCheckTask?.cancel()
+        consecutiveHealthCheckFailures = 0
 
         // The loop runs on a detached task at `.utility` priority so the
         // 15 s `Task.sleep` scheduling and between-check overhead do not
@@ -474,7 +480,10 @@ public final class GatewayConnectionManager {
             while !Task.isCancelled {
                 let interval: TimeInterval = await MainActor.run { [weak self] in
                     guard let self else { return 15.0 }
-                    return self.isUpdateInProgress ? 2.0 : self.healthCheckInterval
+                    if self.isUpdateInProgress { return 2.0 }
+                    let backoff = self.healthCheckInterval
+                        * pow(2.0, Double(min(self.consecutiveHealthCheckFailures, 5)))
+                    return min(backoff, Self.maxHealthCheckBackoffInterval)
                 }
                 do {
                     try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
@@ -489,8 +498,16 @@ public final class GatewayConnectionManager {
 
                 do {
                     try await self.performHealthCheck()
+                    await MainActor.run { [weak self] in
+                        self?.consecutiveHealthCheckFailures = 0
+                    }
                 } catch {
-                    log.warning("Periodic health check failed: \(error.localizedDescription, privacy: .public)")
+                    let failures = await MainActor.run { [weak self] () -> Int in
+                        guard let self else { return 0 }
+                        self.consecutiveHealthCheckFailures += 1
+                        return self.consecutiveHealthCheckFailures
+                    }
+                    log.warning("Periodic health check failed (attempt \(failures, privacy: .public)): \(error.localizedDescription, privacy: .public)")
                 }
 
                 await self.checkUpdateTimeoutIfNeeded()


### PR DESCRIPTION
## Prompt / plan

Addresses [LUM-1570](https://linear.app/vellum/issue/LUM-1570): 363k Sentry error events from `HTTPClientError` 500/502 on `/health/` endpoint since March 9, 2026 — all captured by Sentry's `SentryNetworkTracker` auto-instrumenting URLSession 5xx responses. The app already handles these gracefully (`isReachable → false`); no crash, no user-visible error. Two root causes drive the volume:

1. **Sentry SDK 8.58.0** enables `enableCaptureFailedRequests` by default (since 8.0.0), capturing every 5xx HTTP response as an error event. The codebase had zero configuration for `failedRequestTargets` — so health check 502s (pod sleeping) and 500s (vembda 401 masked per PR #1091) generated events identical to real API errors.

2. **The health check loop polls every 15 seconds with no backoff**, even after hundreds of consecutive failures. For sleeping managed assistant pods (~2-minute wake time, 3-day idle threshold), this means ~4 Sentry events/minute per user indefinitely.

### Why these fixes are correct (first-principles analysis)

**Sentry config (Fix 1):** `failedRequestTargets` is the purpose-built SDK feature for this ([docs](https://docs.sentry.io/platforms/apple/configuration/http-client-errors/)). A negative-lookahead regex excludes `/health` and `/readyz` URLs while preserving error capture for all other API calls (20+ client modules: Settings, Conversations, Contacts, WorkItems, etc.). Disabling `enableCaptureFailedRequests` entirely was rejected — it would hide real 5xx errors from non-health endpoints.

**Backoff (Fix 2):** Exponential backoff (15s → 30s → 60s → 120s → 240s → 300s cap) reduces server load from sleeping pods. Resets immediately on success or when the loop restarts (reconnect, update). The `isUpdateInProgress` 2-second fast-poll is unaffected — backoff only applies to the normal polling path.

### Alternatives considered and rejected

- **Backend 500→503:** The 401→500 masking was intentionally introduced (commit d5f6533bb, PR #1091) to prevent clients from misinterpreting vembda's internal auth errors as user auth failures. The 502 for unreachable pods is semantically correct. Neither change would reduce Sentry noise.
- **`connection-status` API:** The platform exposes a rich connection-status endpoint (`READY/WAKING/CRASH_LOOP/UNREACHABLE`), but switching the macOS client to use it would be a larger architectural change that doesn't verify end-to-end connectivity and doesn't trigger activity tracking (which keeps pods alive).
- **`beforeSend` callback:** Works but is a workaround — `failedRequestTargets` is the SDK's dedicated feature for URL-based filtering.

### Backwards compatibility

Both changes are client-only (no wire format or protocol changes). Old macOS + new platform and new macOS + old platform are both safe — the Sentry config is local to the SDK init, and the backoff only affects polling frequency within the client.

### Root cause analysis

1. **How did the code get into this state?** Sentry SDK 8.0.0 (Dec 2022) changed `enableCaptureFailedRequests` from opt-in to opt-out. The codebase never configured `failedRequestTargets`, so the new default silently captured all 5xx responses including expected health check failures.
2. **What decisions led to it?** The health check loop was designed for fast reconnection (15s fixed interval) without considering the Sentry noise implications. No one noticed because the events accumulated gradually.
3. **Warning signs missed?** The Sentry event volume (363k) was the signal — this issue was caught via monitoring.
4. **Prevention:** When adding or upgrading SDKs with auto-instrumentation, audit their default capture behavior and configure exclusion filters for expected operational traffic.

## Test plan

- Manual verification: reviewed the regex against health check URLs (`/v1/assistants/{id}/health/`, `/readyz`, `/v1/assistants/{id}/conversations`) — correctly excludes health, includes everything else.
- Verified `consecutiveHealthCheckFailures` counter resets in `startHealthCheckLoop()`, on success in the loop, and in `disconnectInternal()`.
- CI skips macOS builds — local Xcode verification needed by reviewer.

Part of LUM-1570

Link to Devin session: https://app.devin.ai/sessions/97192d80dcc2469ba763c2a24ae46fca
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->