### PR TITLE
fix(macos): switch transcript stack from VStack to LazyVStack to eliminate ≥2s hangs

### DIFF
--- a/clients/macos/SCROLL_STRATEGY.md
+++ b/clients/macos/SCROLL_STRATEGY.md
@@ -40,7 +40,7 @@ The ScrollView gets `.flipped()`, and each row inside also gets `.flipped()`. Th
 
 1. **No scroll-to-bottom management.** In a normal ScrollView, new content added at the bottom pushes the viewport up — you need imperative `scrollTo(.bottom)` to follow. In an inverted ScrollView, new content is added at the coordinate "top" (visual bottom), which is where the viewport already sits. The viewport stays put naturally.
 
-2. **No LazyVStack materialization hang.** With a normal bottom-anchored ScrollView, SwiftUI had to materialize all items to compute content height before it could position at the bottom. With inverted scroll, the "top" (visual bottom) is the natural starting position — SwiftUI only materializes visible items.
+2. **No bottom-anchoring materialization hang.** With a normal bottom-anchored ScrollView, SwiftUI had to materialize all items to compute content height before it could position at the bottom. With inverted scroll, the "top" (visual bottom) is the natural starting position — SwiftUI only materializes visible items. The transcript uses a `LazyVStack` (`MessageTranscriptStack`) so only visible rows are measured per layout pass. The `.transaction { $0.animation = nil }` modifier on the stack is critical — without it, animated insertions trigger `motionVectors`, an O(n) `sizeThatFits` sweep that defeats lazy loading. See [WWDC23: Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/).
 
 3. **No multi-stage scroll restore.** The old architecture needed `switchRestoreTask`, `isScrollRestored` opacity fade, and deferred scroll calls to restore position on conversation switch. With inverted scroll, `.id(conversationId)` recreates the ScrollView and it naturally opens at visual bottom (coordinate top).
 
@@ -244,6 +244,7 @@ These were removed for a reason. Do not re-introduce:
 | `.defaultScrollAnchor(.bottom)` | Was needed to start at bottom in normal scroll; inverted scroll starts at visual bottom naturally |
 | `turnMinHeight` / minHeight wrapper | Filled viewport below user message on send; inverted scroll keeps user message visible without it |
 | `containerHeight` property | Drove the minHeight calculation; removed along with minHeight wrapper |
+| Plain `VStack` transcript | Eagerly measures ALL rows per layout pass — O(N) cost causing ≥ 2 s hangs on conversation switch, resize, and typography changes. `LazyVStack` measures only visible rows. Trade-off: minor scroll-position drift on first scroll through unmeasured history (progressive, self-correcting). |
 
 ---
 
@@ -256,7 +257,8 @@ These were removed for a reason. Do not re-introduce:
 | `MessageListView.swift` | ScrollView setup — `.flipped()`, position binding, indicators, overlay |
 | `MessageListView+ScrollHandling.swift` | Geometry handler — updates state, triggers pagination using `distanceFromTop` |
 | `MessageListView+Lifecycle.swift` | Send detection, conversation switch, anchor resolution |
-| `MessageListContentView.swift` | History rendering, pinned latest-turn section, spacer math, thinking placeholder |
+| `MessageListContentView.swift` | History rendering, pinned latest-turn section, spacer math, thinking placeholder, `.transaction { $0.animation = nil }` suppressor |
+| `MessageHeightCache.swift` | `MessageTranscriptStack` (`LazyVStack` container), `CachedHeightRow` (height recording), `MessageHeightCache` (diagnostic cache) |
 | `MessageListHelperViews.swift` | ScrollToLatestOverlayView — CTA button |
 | `TranscriptProjector.swift` | Thinking placeholder row injection |
 | `TranscriptRenderModel.swift` | `isThinkingPlaceholder` flag on row model |

--- a/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
@@ -3,13 +3,12 @@ import SwiftUI
 
 /// Per-conversation cache of each transcript row's measured height, keyed by
 /// the row's `TranscriptItem.id`. Written on every render via the geometry
-/// reader inside `CachedHeightRow`; read only by the scroll debug HUD today
-/// (and by future diagnostics that want a ground-truth height per row).
+/// reader inside `CachedHeightRow`; read by the scroll debug HUD and
+/// future diagnostics that want a ground-truth height per row.
 ///
-/// The transcript uses a plain `VStack` inside `MessageListContentView`,
-/// which measures every cell so the scroll view reports the true total height
-/// without estimator drift. The cache records every row's measured height as
-/// a byproduct, useful for inspection.
+/// The transcript uses a `LazyVStack` inside `MessageListContentView`,
+/// so only visible rows are measured per layout pass. The cache records
+/// each row's measured height as it is materialised.
 ///
 /// Propagated through `EnvironmentValues.messageHeightCache` alongside the
 /// other transcript stores. Not annotated `@MainActor` because `EnvironmentKey`
@@ -53,12 +52,10 @@ extension EnvironmentValues {
 // MARK: - CachedHeightRow
 
 /// Wraps a transcript row so its measured height is recorded into the shared
-/// `MessageHeightCache`. Does NOT pin the row's frame — an earlier version
-/// applied `.frame(height: cached)` and produced catastrophic overlap when a
-/// row's content grew past its first-measured height (streaming, thinking
-/// block expanding). The row-height fix lives at the stack level: the
-/// enclosing `MessageListContentView` uses a plain `VStack`, which
-/// eliminates the estimator that caused jerky scroll.
+/// `MessageHeightCache`. Does NOT pin the row's frame — the enclosing
+/// `MessageListContentView` uses a `LazyVStack`, which only measures
+/// visible rows per layout pass. `LazyVStack` remembers each cell's last
+/// measured height internally for off-screen sizing.
 struct CachedHeightRow<Content: View>: View {
     let itemId: UUID
     @ViewBuilder let content: () -> Content
@@ -76,15 +73,29 @@ struct CachedHeightRow<Content: View>: View {
 
 // MARK: - MessageTranscriptStack
 
-/// Container for the transcript's main content stack. Uses a plain `VStack`
-/// so every row is materialised eagerly and `scrollContentHeight` equals the
-/// true sum of row heights with no estimator in the middle to drift.
+/// Container for the transcript's main content stack. Uses a `LazyVStack`
+/// so only visible rows are measured per layout pass — preventing the
+/// O(N) eager measurement that caused ≥ 2 000 ms main-thread hangs on
+/// conversation switch, window resize, and typography changes.
+///
+/// The enclosing `MessageListContentView` applies
+/// `.transaction { $0.animation = nil }` to suppress all insertion
+/// animations. Without that suppressor, any animated insertion in a
+/// `LazyVStack` triggers `motionVectors` — an O(n) `sizeThatFits` sweep
+/// over ALL children that defeats lazy loading.
+///
+/// Trade-off vs the previous plain `VStack`: `LazyVStack` estimates
+/// off-screen row heights from the average of measured rows instead of
+/// knowing the true sum. This can cause minor scroll-position drift the
+/// first time the user scrolls through unmeasured history. The drift is
+/// bounded (progressive, not sudden) and corrects itself as rows are
+/// materialised. The ≥ 2 s hang elimination is a net-positive trade.
 struct MessageTranscriptStack<Content: View>: View {
     let spacing: CGFloat
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: spacing) {
+        LazyVStack(alignment: .leading, spacing: spacing) {
             content()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -310,11 +310,11 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        // WARNING: This VStack uses .transaction { $0.animation = nil } to suppress
-        // all insertion/removal animations. Without this, SwiftUI calls motionVectors()
+        // WARNING: .transaction { $0.animation = nil } below suppresses all
+        // insertion/removal animations. Without it, SwiftUI calls motionVectors()
         // during any item insertion, which measures ALL children via sizeThatFits —
         // causing multi-minute hangs on long conversations. Do NOT remove the
-        // .transaction modifier or wrap content changes in withAnimation.
+        // .transaction modifier or wrap content mutations in withAnimation.
         MessageTranscriptStack(spacing: VSpacing.md) {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -140,8 +140,8 @@ struct MessageListView: View {
     /// Owned here (same level as `thinkingBlockExpansionStore`) so the state
     /// survives view-tree destruction. See `FilePreviewExpansionStore.swift`.
     @State var filePreviewExpansionStore = FilePreviewExpansionStore()
-    /// Caches each transcript row's measured height so the VStack reports
-    /// an accurate `contentSize`. `.id(conversationId)` is applied to the
+    /// Caches each transcript row's measured height for diagnostic and
+    /// scroll-debug HUD use. `.id(conversationId)` is applied to the
     /// inner `ScrollView` (not `MessageListView`), so SwiftUI preserves
     /// this `@State` across conversation switches — the cache must be
     /// cleared explicitly in `handleConversationSwitched()` to avoid


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1569

### Problem

The `MessageTranscriptStack` used a plain `VStack` that eagerly measured **all** ~50–100 transcript rows per layout pass. On conversation switch (`.id(conversationId)` destroys the view graph), window/column resize (caches invalidated), and typography changes, this O(N) measurement caused ≥ 2 000 ms main-thread hangs.

**Sentry impact:** MACOS-G — 7,456 events across 313 users since March 11.

### Root cause

The plain `VStack` was introduced intentionally to eliminate scroll-content-height drift that occurred with `LazyVStack`'s off-screen height estimator. The trade-off (eager O(N) measurement) was acceptable at the time but became untenable as conversation lengths grew and the Sentry data proved the hang affects a significant user population.

### Fix

Switch `MessageTranscriptStack` from `VStack` to `LazyVStack`. Only visible rows (~15–20) are measured per layout pass instead of all ~50–100.

**Key safety properties preserved:**
- **`.transaction { $0.animation = nil }`** remains on the `MessageTranscriptStack` at `MessageListContentView.swift:394`. This is critical — without it, any animated insertion in a `LazyVStack` triggers `motionVectors`, an O(n) `sizeThatFits` sweep over ALL children that defeats lazy loading. See [WWDC23: Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/).
- **No `.withAnimation` calls** flow into the transcript subtree (verified by search).
- **No `.animation()` modifiers** inside `MessageListContentView` that could override the transaction suppressor.
- **`.equatable()` on `MessageCellView`** still prevents redundant body re-evaluations for unchanged cells.
- **Inverted scroll (`.flipped()`)** works correctly with `LazyVStack` — the geometric transform doesn't affect layout-space visibility determination.

### Trade-off: scroll-position drift

`LazyVStack` estimates off-screen row heights from the average of measured rows instead of knowing the true sum. This can cause minor scroll-position drift the **first time** the user scrolls through unmeasured history in a given conversation. The drift is:

- **Progressive** — corrects cell-by-cell as rows materialise, not a sudden jump
- **One-time** — `LazyVStack` remembers each cell's last measured height; subsequent scrolls through the same cells have no drift
- **Bounded** — only affects the ~35–85 off-screen cells in the initial page (pageSize=50, maxWindow=100)

The ≥ 2 s hang elimination is a clear net-positive vs minor first-scroll drift.

### Documentation updates

Updated `SCROLL_STRATEGY.md` to reflect the architectural change:
- Renamed "No LazyVStack materialization hang" → "No bottom-anchoring materialization hang" and documented the `LazyVStack` + `.transaction` suppressor
- Added plain `VStack` transcript to the "What NOT To Add Back" table
- Added `MessageHeightCache.swift` to the "Files That Own Scroll Behavior" table

### Alternatives not taken

1. **Selective height pinning** (`.frame(height: cached)` on finalized cells) — would reduce drift but introduces overlap risk when cell content changes (thinking block expansion, image loading). Can be added as a follow-up if drift proves problematic.
2. **Reducing `messagePageSize`** from 50 to 20 — reduces O(N) cost but doesn't eliminate it.
3. **Replacing `.transition(.move)` with `.transition(.opacity)`** — targets the wrong code path (transitions are outside the transcript VStack) and is a workaround per AGENTS.md.

### Root cause analysis

1. **How did the code get into this state?** The plain `VStack` was a deliberate choice to fix scroll-height drift. The hang was an accepted trade-off that proved worse than anticipated.
2. **What decisions led to it?** Prioritising scroll-position stability over layout performance. The severity of the O(N) cost wasn't fully apparent until Sentry data accumulated.
3. **Were there warning signs?** The commit introducing the `VStack` swap acknowledged "slower on long conversations." The 7,456 Sentry events confirmed the impact.
4. **What prevents recurrence?** The AGENTS.md rule at line 302 documents the `motionVectors` risk and `.transaction` requirement. The "What NOT To Add Back" table in `SCROLL_STRATEGY.md` now lists plain `VStack` transcript with the performance rationale.
5. **AGENTS.md addition needed?** No — existing guidance at line 302 ("No animated insertions in chat `LazyVStack`") already covers the critical constraint. The `SCROLL_STRATEGY.md` update provides the architectural context.

### Apple refs checked (2025-05-14)

- [`LazyVStack`](https://developer.apple.com/documentation/swiftui/lazyvstack) — lazy materialisation behavior
- [`.transaction` modifier](https://developer.apple.com/documentation/swiftui/view/transaction(_:)) — animation suppression propagation
- [WWDC23: Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/) — `motionVectors` and layout cost analysis

## Test plan

- **Code review**: 4 files changed — `MessageHeightCache.swift` (VStack → LazyVStack + comment updates), `MessageListContentView.swift` (comment update), `MessageListView.swift` (comment update), `SCROLL_STRATEGY.md` (architecture doc update)
- **CI**: macOS builds are skipped in CI; user must verify Xcode build locally
- **No behavioral changes** to the view hierarchy, data flow, or interaction patterns — only the layout container type changed
- **`.transaction` suppressor verified** in place at line 394 of `MessageListContentView.swift`

Link to Devin session: https://app.devin.ai/sessions/cdd5738f3fc6430bb91457cdb7fc89d9
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->