### PR TITLE
Add testing skill for macOS/Swift native client code

### DIFF
--- a/.agents/skills/testing-macos-native/SKILL.md
+++ b/.agents/skills/testing-macos-native/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: testing-macos-native
+description: Test macOS/Swift native client code changes (clients/macos, clients/shared) when no Xcode or Swift toolchain is available. Use when verifying Swift code correctness from a Linux environment.
+---
+
+# Testing macOS/Swift Native Client Code
+
+## Overview
+The macOS client is a Swift/SwiftUI app under `clients/macos/` with shared code in `clients/shared/`. CI skips macOS builds and tests (no macOS build environment). The Devin Linux VM has no Swift toolchain or Xcode.
+
+## What You CAN Test (Script-Based Verification)
+
+Since you cannot compile or run Swift code, focus on verifiable logic using Python or shell scripts:
+
+### 1. Regex Pattern Verification
+When changes involve regex patterns (e.g., Sentry `failedRequestTargets`, URL matching), verify correctness with Python's `re` module:
+- `NSRegularExpression` patterns are compatible with Python `re` syntax for common features (lookahead, anchors, character classes)
+- Sentry SDK uses `NSRegularExpression.firstMatch(in:range:)` — equivalent to Python `re.search()`
+- Test against comprehensive URL sets covering both positive (should match) and negative (should not match) cases
+- Include edge cases: trailing slashes, query params, substrings that look similar but aren't endpoints
+
+### 2. Math/Formula Verification
+For algorithmic changes (backoff intervals, retry logic, timing calculations):
+- Replicate the formula in Python and verify against documented expected values
+- Test boundary conditions (0, 1, max, overflow)
+- Verify caps/limits are applied correctly
+- Check that override conditions (e.g., `isUpdateInProgress`) bypass the formula
+
+### 3. Code Path Analysis
+Use grep/Python scripts to verify structural correctness:
+- All required reset/initialization points exist for state variables
+- Configuration is applied at all init sites (e.g., `SentrySDK.start` blocks)
+- Properties have correct annotations (`@ObservationIgnored`, etc.)
+- No unexpected call sites exist that bypass the change
+
+### 4. Sentry SDK Configuration
+When modifying Sentry config (`failedRequestTargets`, `failedRequestStatusCodes`, etc.):
+- Verify all `SentrySDK.start { }` init sites are updated (search with `grep -rn 'SentrySDK.start {' clients/`)
+- There are typically 2 init sites: `AppDelegate.swift` (early crash capture) and `MetricKitManager.restartSentryInline()` (re-enable after settings toggle)
+- Both must reference the same constants
+- Ref: https://docs.sentry.io/platforms/apple/configuration/http-client-errors/
+
+## What You CANNOT Test
+
+- **Swift compilation** — no Swift toolchain on Linux
+- **Unit tests** — `./build.sh test` requires Xcode
+- **Runtime behavior** — cannot run the macOS app
+- **Sentry event capture** — requires live SDK in running app
+- **UI changes** — no macOS GUI environment
+
+## Reporting
+
+Always clearly state these limitations in test reports. The reviewer must verify:
+1. Local Xcode build compiles without errors
+2. Runtime behavior matches expectations (if applicable)
+3. Post-deploy monitoring confirms the fix (for observability changes like Sentry filtering)
+
+## CI Notes
+
+- CI runs Socket Security + FlexFrame Lint (always pass for Swift-only changes)
+- macOS Build and macOS Tests are skipped in CI
+- No preview deployments for native client changes
+
+## Devin Secrets Needed
+None — script-based verification requires no credentials.

--- a/.agents/skills/testing-macos-native/SKILL.md
+++ b/.agents/skills/testing-macos-native/SKILL.md
@@ -6,7 +6,7 @@ description: Test macOS/Swift native client code changes (clients/macos, clients
 # Testing macOS/Swift Native Client Code
 
 ## Overview
-The macOS client is a Swift/SwiftUI app under `clients/macos/` with shared code in `clients/shared/`. CI skips macOS builds and tests (no macOS build environment). The Devin Linux VM has no Swift toolchain or Xcode.
+The macOS client is a Swift/SwiftUI app under `clients/macos/` with shared code in `clients/shared/`. CI runs macOS builds and tests only when the PR has the `preview` label (see CI Notes below). The Devin Linux VM has no Swift toolchain or Xcode.
 
 ## What You CAN Test (Script-Based Verification)
 
@@ -57,8 +57,9 @@ Always clearly state these limitations in test reports. The reviewer must verify
 
 ## CI Notes
 
-- CI runs Socket Security + FlexFrame Lint (always pass for Swift-only changes)
-- macOS Build and macOS Tests are skipped in CI
+- CI runs Socket Security + FlexFrame Lint unconditionally (always pass for Swift-only changes)
+- **macOS Build and macOS Tests require the `preview` label** on the PR to run (defined in `.github/workflows/pr-macos.yaml`). Without the label, these jobs show as skipped. Add the `preview` label to trigger Xcode compilation and `./build.sh test` on `macos-15` runners.
+- `ci-main-macos.yaml` runs macOS CI on pushes to `main` for `clients/**` changes
 - No preview deployments for native client changes
 
 ## Devin Secrets Needed

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,8 @@ temp.sh
 context.md
 CLAUDE.md
 !assistant/CLAUDE.md
-.agents
+.agents/*
+!.agents/skills/
 .codex
 .vellum
 


### PR DESCRIPTION
Documents testing approaches for macOS/Swift native client code changes when no Xcode/Swift toolchain is available (e.g., Devin Linux VM). Covers script-based verification techniques and known limitations.

Devin Session: https://app.devin.ai/sessions/97192d80dcc2469ba763c2a24ae46fca
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->