### PR TITLE
[codex] Update Slack thinking indicator timing

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2500,45 +2500,52 @@ export async function runAgentLoopImpl(
       // the agent's most recent action context while aggressively
       // compressing history. Falls through to reducer tiers on failure.
       {
-        const emergencyConfig = getConfig().compaction;
-        const emergencyResult = await runEmergencyCompaction({
-          conversationId: ctx.conversationId,
-          messages: ctx.messages,
-          provider: ctx.provider,
-          systemPrompt: ctx.systemPrompt,
-          tools: undefined,
-          compaction: emergencyConfig,
-          maxInputTokens: effectiveContextWindow.maxInputTokens,
-          previousEstimatedInputTokens: estimatedTokensAtOverflow,
-          force: true,
-          signal: abortController.signal,
-          overrideProfile: turnOverrideProfile ?? null,
-          nonPersistedPrefixCount:
-            ctx.contextWindowManager.nonPersistedPrefixCount,
-        });
-        if (emergencyResult.compacted) {
-          rlog.info(
-            {
-              phase: "convergence",
-              compactedMessages: emergencyResult.compactedMessages,
-              summaryChars: emergencyResult.summaryText.length,
-            },
-            "Emergency mid-turn compaction succeeded — bypassing reducer tiers",
-          );
-          if (emergencyResult.summaryFailed !== undefined) {
-            await trackCompactionOutcome(
-              ctx,
-              emergencyResult.summaryFailed,
-              onEvent,
-            );
-          }
+        try {
+          const emergencyConfig = getConfig().compaction;
+          const emergencyResult = await runEmergencyCompaction({
+            conversationId: ctx.conversationId,
+            messages: ctx.messages,
+            provider: ctx.provider,
+            systemPrompt: ctx.systemPrompt,
+            tools: undefined,
+            compaction: emergencyConfig,
+            maxInputTokens: effectiveContextWindow.maxInputTokens,
+            previousEstimatedInputTokens: estimatedTokensAtOverflow,
+            force: true,
+            signal: abortController.signal,
+            overrideProfile: turnOverrideProfile ?? null,
+            nonPersistedPrefixCount:
+              ctx.contextWindowManager.nonPersistedPrefixCount,
+          });
           if (emergencyResult.compacted) {
-            await applySuccessfulCompaction(emergencyResult, ctx.messages);
-            shouldInjectWorkspace = true;
+            rlog.info(
+              {
+                phase: "convergence",
+                compactedMessages: emergencyResult.compactedMessages,
+                summaryChars: emergencyResult.summaryText.length,
+              },
+              "Emergency mid-turn compaction succeeded — bypassing reducer tiers",
+            );
+            if (emergencyResult.summaryFailed !== undefined) {
+              await trackCompactionOutcome(
+                ctx,
+                emergencyResult.summaryFailed,
+                onEvent,
+              );
+            }
+            if (emergencyResult.compacted) {
+              await applySuccessfulCompaction(emergencyResult, ctx.messages);
+              shouldInjectWorkspace = true;
+            }
+            // Clear the overflow flag and re-run the agent loop with
+            // the compacted context.
+            state.contextTooLargeDetected = false;
           }
-          // Clear the overflow flag and re-run the agent loop with
-          // the compacted context.
-          state.contextTooLargeDetected = false;
+        } catch (err) {
+          rlog.warn(
+            { phase: "convergence", err },
+            "Emergency mid-turn compaction failed; continuing to reducer tiers",
+          );
         }
         // If emergency compaction failed, fall through to reducer tiers.
       }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1061,6 +1061,8 @@ export async function handleChannelInbound({
         sourceMetadata.account.length > 0
           ? sourceMetadata.account
           : undefined;
+      const slackBotMentioned =
+        sourceChannel === "slack" && sourceMetadata?.slackBotMentioned === true;
 
       // ── DM cold-start backfill ──
       // First time a Slack DM lands in a conversation that has fewer than
@@ -1146,6 +1148,7 @@ export async function handleChannelInbound({
         assistantId: canonicalAssistantId,
         approvalCopyGenerator,
         chatType: sourceChatType,
+        slackBotMentioned,
         slackInbound,
       });
     }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -50,6 +50,7 @@ import {
   isBoundGuardianActor,
   processChannelMessageInBackground,
   shouldStartSlackThinkingStatusForText,
+  shouldStartSlackThinkingStatusImmediately,
 } from "./background-dispatch.js";
 
 describe("isBoundGuardianActor", () => {
@@ -199,6 +200,116 @@ describe("Slack thinking status timing", () => {
     expect(
       shouldStartSlackThinkingStatusForText("<no_response/>\nReal response."),
     ).toBe(true);
+  });
+
+  test("starts Slack thinking status immediately for DMs and direct mentions", () => {
+    expect(
+      shouldStartSlackThinkingStatusImmediately({
+        sourceChannel: "slack",
+        chatType: "im",
+      }),
+    ).toBe(true);
+    expect(
+      shouldStartSlackThinkingStatusImmediately({
+        sourceChannel: "slack",
+        slackBotMentioned: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldStartSlackThinkingStatusImmediately({
+        sourceChannel: "slack",
+        chatType: "channel",
+      }),
+    ).toBe(false);
+    expect(
+      shouldStartSlackThinkingStatusImmediately({
+        sourceChannel: "telegram",
+        chatType: "im",
+        slackBotMentioned: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("sets Slack thinking indicator immediately for a DM", async () => {
+    const conversationId = "conv-dm-immediate-status";
+    const channelId = "D-DM-IMMEDIATE";
+    const messageTs = "1700000000.000010";
+
+    const processMessage: MessageProcessor = async () => {
+      expect(deliveredChannelReplies).toHaveLength(1);
+      expect(deliveredChannelReplies[0]!.payload.reaction).toEqual({
+        action: "add",
+        name: "eyes",
+        messageTs,
+      });
+      return { messageId: "user-msg-dm-immediate" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-dm-immediate-status",
+      content: "dm message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&messageTs=${messageTs}`,
+    });
+
+    await flush();
+
+    const reactions = deliveredChannelReplies.map(
+      (entry) => entry.payload.reaction,
+    );
+    expect(reactions).toEqual([
+      { action: "add", name: "eyes", messageTs },
+      { action: "remove", name: "eyes", messageTs },
+    ]);
+  });
+
+  test("sets Slack thinking status immediately for an app mention", async () => {
+    const conversationId = "conv-mention-immediate-status";
+    const channelId = "C-MENTION-IMMEDIATE";
+    const threadTs = "1700000000.000011";
+
+    const processMessage: MessageProcessor = async () => {
+      expect(deliveredChannelReplies).toHaveLength(1);
+      expect(deliveredChannelReplies[0]!.payload.assistantThreadStatus).toEqual(
+        {
+          channel: channelId,
+          threadTs,
+          status: "is thinking...",
+        },
+      );
+      return { messageId: "user-msg-mention-immediate" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-mention-immediate-status",
+      content: "@assistant please respond",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      slackBotMentioned: true,
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map((entry) => {
+      const status = entry.payload.assistantThreadStatus as
+        | { status?: string }
+        | undefined;
+      return status?.status;
+    });
+    expect(statuses).toEqual(["is thinking...", ""]);
   });
 
   test("does not set Slack thinking status for no_response text deltas", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -84,6 +84,8 @@ export interface BackgroundProcessingParams {
   sourceLanguageCode?: string;
   /** Chat type from the gateway (e.g. "private", "group", "supergroup"). */
   chatType?: string;
+  /** Slack app_mention/direct bot mention signal from the gateway. */
+  slackBotMentioned?: boolean;
   /**
    * Slack-specific inbound metadata extracted at the HTTP boundary. Threaded
    * through to `persistUserMessage` so the row can be tagged with a
@@ -118,6 +120,7 @@ export function processChannelMessageInBackground(
     commandIntent,
     sourceLanguageCode,
     chatType,
+    slackBotMentioned,
     slackInbound,
   } = params;
 
@@ -141,6 +144,11 @@ export function processChannelMessageInBackground(
       replyCallbackUrl,
       chatId: externalChatId,
       assistantId,
+      startImmediately: shouldStartSlackThinkingStatusImmediately({
+        sourceChannel,
+        chatType,
+        slackBotMentioned,
+      }),
     });
     const stopApprovalWatcher = replyCallbackUrl
       ? startPendingApprovalPromptWatcher({
@@ -388,13 +396,29 @@ function shouldEmitSlackThinkingStatus(
   }
 }
 
+export function shouldStartSlackThinkingStatusImmediately(params: {
+  sourceChannel: ChannelId;
+  chatType?: string;
+  slackBotMentioned?: boolean;
+}): boolean {
+  if (params.sourceChannel !== "slack") return false;
+  return params.chatType === "im" || params.slackBotMentioned === true;
+}
+
 function createSlackThinkingStatusController(params: {
   sourceChannel: ChannelId;
   replyCallbackUrl?: string;
   chatId: string;
   assistantId?: string;
+  startImmediately?: boolean;
 }): SlackThinkingStatusController | undefined {
-  const { sourceChannel, replyCallbackUrl, chatId, assistantId } = params;
+  const {
+    sourceChannel,
+    replyCallbackUrl,
+    chatId,
+    assistantId,
+    startImmediately,
+  } = params;
   if (
     !replyCallbackUrl ||
     !shouldEmitSlackThinkingStatus(sourceChannel, replyCallbackUrl)
@@ -415,6 +439,10 @@ function createSlackThinkingStatusController(params: {
       assistantId,
     );
   };
+
+  if (startImmediately) {
+    start();
+  }
 
   return {
     observeEvent(msg) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1793,6 +1793,10 @@ async function main() {
         const origMessageTs = normalized.event.source.messageId;
         if (!threadTs && origMessageTs) params.set("messageTs", origMessageTs);
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
+        const slackSourceMetadata =
+          normalized.event.raw.type === "app_mention"
+            ? { slackBotMentioned: true }
+            : undefined;
 
         // Whether this event represents an edit or callback action — these
         // never carry attachments to upload.
@@ -1968,6 +1972,9 @@ async function main() {
             handleInbound(config, normalized.event, {
               replyCallbackUrl,
               routingOverride: normalized.routing,
+              ...(slackSourceMetadata
+                ? { sourceMetadata: slackSourceMetadata }
+                : {}),
               ...(attachmentIds && attachmentIds.length > 0
                 ? { attachmentIds }
                 : {}),
@@ -1985,6 +1992,9 @@ async function main() {
             handleInbound(config, normalized.event, {
               replyCallbackUrl,
               routingOverride: normalized.routing,
+              ...(slackSourceMetadata
+                ? { sourceMetadata: slackSourceMetadata }
+                : {}),
             }).catch((fwdErr) => {
               log.error(
                 { err: fwdErr, channel, threadTs },


### PR DESCRIPTION
## Summary
- Start Slack thinking indicators immediately for DMs and direct app mentions.
- Keep ambient Slack channel/thread/group-DM turns deferred until deliverable assistant text starts.
- Preserve silence when the assistant outputs only `<no_response/>`.
- Harden the emergency-compaction fallback so a failed emergency attempt continues into reducer tiers instead of aborting overflow recovery.

## Root Cause
The prior Slack status controller only started after observing deliverable assistant text, which avoided false indicators for `<no_response/>` but also delayed feedback for directly addressed messages.

CI also selected conversation-loop overflow tests after the required assistant lint cleanup. Those tests exposed that emergency mid-turn compaction could throw before returning its documented fall-through result, bypassing reducer recovery.

## Validation
- `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts`
- `cd assistant && bun test src/__tests__/conversation-provider-retry-repair.test.ts`
- `cd assistant && bun test src/__tests__/conversation-agent-loop-overflow.test.ts`
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts`
- `cd assistant && bunx eslint src/daemon/conversation-agent-loop.ts src/runtime/routes/inbound-message-handler.ts src/runtime/routes/inbound-stages/background-dispatch.ts src/runtime/routes/inbound-stages/background-dispatch.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd gateway && bunx tsc --noEmit`
- `git diff --check`
- Pre-push hook reran assistant typecheck and changed-file lint.

Closes #30696