### PR TITLE
fix(llm-cost-optimizer): promote user-facing call-sites to balanced

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -329,7 +329,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-14T15:51:06-04:00"
+      "updatedAt": "2026-05-14T15:59:51-04:00"
     },
     {
       "id": "macos-automation",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -329,7 +329,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-14T15:46:27-04:00"
+      "updatedAt": "2026-05-14T15:51:06-04:00"
     },
     {
       "id": "macos-automation",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -329,7 +329,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-05-13T17:24:14-04:00"
+      "updatedAt": "2026-05-14T15:46:27-04:00"
     },
     {
       "id": "macos-automation",
@@ -468,7 +468,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T17:45:04Z"
+      "updatedAt": "2026-05-14T12:47:52-05:00"
     },
     {
       "id": "outlook",

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -63,11 +63,11 @@ assistant inference providers connections list
 
 ## Step 3 — Recommended profile assignment
 
-| Profile                    | Call Sites                                                                                                                                                                |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation`, `emptyStateGreeting` |
-| `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                                                  |
-| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                                       |
+| Profile                    | Call Sites                                                                                                                                                                                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation`, `recall`, `callAgent`, `emptyStateGreeting`, `conversationStarters`, `identityIntro`, `proactiveArtifactBuild` |
+| `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                                                                                                                                            |
+| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                                                                                                                                 |
 
 ---
 
@@ -129,15 +129,15 @@ assistant config set llm.callSites '{
 
   "heartbeatAgent":           {"profile":"cost-optimized","maxTokens":2048,"effort":"low","temperature":0,"thinking":{"enabled":false,"streamThinking":false},"contextWindow":{"maxInputTokens":16000}},
   "filingAgent":              {"profile":"cost-optimized"},
-  "callAgent":                {"profile":"cost-optimized"},
+  "callAgent":                {"profile":"balanced"},
   "proactiveArtifactDecision":{"profile":"cost-optimized"},
-  "proactiveArtifactBuild":   {"profile":"cost-optimized"},
+  "proactiveArtifactBuild":   {"profile":"balanced"},
 
   "memoryExtraction":         {"profile":"cost-optimized"},
   "memoryConsolidation":      {"profile":"balanced"},
   "memoryRetrieval":          {"profile":"cost-optimized"},
   "memoryRetrospective":      {"profile":"cost-optimized"},
-  "recall":                   {"profile":"cost-optimized","maxTokens":4096,"effort":"low","thinking":{"enabled":false,"streamThinking":false},"temperature":0},
+  "recall":                   {"profile":"balanced","maxTokens":4096,"effort":"low","thinking":{"enabled":false,"streamThinking":false},"temperature":0},
   "memoryV2Migration":        {"profile":"cost-optimized"},
   "memoryV2Sweep":            {"profile":"cost-optimized"},
   "memoryV2Consolidation":    {"profile":"cost-optimized"},
@@ -145,10 +145,10 @@ assistant config set llm.callSites '{
   "conversationSummarization":{"profile":"cost-optimized"},
   "commitMessage":            {"profile":"cost-optimized","maxTokens":120,"temperature":0.2,"effort":"low","thinking":{"enabled":false}},
 
-  "conversationStarters":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
+  "conversationStarters":     {"profile":"balanced","effort":"low","thinking":{"enabled":false}},
   "replySuggestion":          {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
   "conversationTitle":        {"profile":"cost-optimized"},
-  "identityIntro":            {"profile":"cost-optimized"},
+  "identityIntro":            {"profile":"balanced"},
   "emptyStateGreeting":       {"profile":"balanced"},
   "guardianQuestionCopy":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
   "approvalCopy":             {"profile":"cost-optimized"},

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -63,11 +63,11 @@ assistant inference providers connections list
 
 ## Step 3 — Recommended profile assignment
 
-| Profile                    | Call Sites                                                                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Profile                    | Call Sites                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation`, `emptyStateGreeting` |
-| `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                            |
-| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                 |
+| `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                                                  |
+| `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                                       |
 
 ---
 

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -65,7 +65,7 @@ assistant inference providers connections list
 
 | Profile                    | Call Sites                                                                                                                                          |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation` |
+| `balanced` (Sonnet)        | `mainAgent`, `subagentSpawn`, `compactionAgent`, `analyzeConversation`, `patternScan`, `narrativeRefinement`, `memoryRouter`, `memoryConsolidation`, `emptyStateGreeting` |
 | `cost-optimized` (Haiku)   | **Everything else** — memory extraction/retrieval, UI copy, classifiers, summarization, background tasks                                            |
 | `quality-optimized` (Opus) | **Do not pin.** Reserved for on-demand user escalation via `/model`                                                                                 |
 

--- a/skills/llm-cost-optimizer/SKILL.md
+++ b/skills/llm-cost-optimizer/SKILL.md
@@ -149,7 +149,7 @@ assistant config set llm.callSites '{
   "replySuggestion":          {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
   "conversationTitle":        {"profile":"cost-optimized"},
   "identityIntro":            {"profile":"cost-optimized"},
-  "emptyStateGreeting":       {"profile":"cost-optimized"},
+  "emptyStateGreeting":       {"profile":"balanced"},
   "guardianQuestionCopy":     {"profile":"cost-optimized","effort":"low","thinking":{"enabled":false}},
   "approvalCopy":             {"profile":"cost-optimized"},
   "approvalConversation":     {"profile":"cost-optimized"},


### PR DESCRIPTION
Several call-sites were on cost-optimized (Haiku) but produce output the user actually sees or hears — the result felt low-quality.

Promoted to balanced (Sonnet):
- `emptyStateGreeting` — welcome screen copy
- `callAgent` — voice calls (user is literally talking to it)
- `recall` — mid-turn memory search feeds back into agent answers
- `conversationStarters` — starter chips on empty page
- `identityIntro` — assistant intro text
- `proactiveArtifactBuild` — new-user welcome artifact

Left on cost-optimized: classifiers, background memory ops, titles, commit messages, approval copy, notifications. Pure background or low-stakes utility copy stays on Haiku.