### PR TITLE
Use managed profile for authenticated local hatch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -592,7 +592,16 @@ struct HatchingStepView: View {
         let provider = state.selectedProvider.isEmpty
             ? LLMProviderRegistry.defaultProvider.id
             : state.selectedProvider
-        return ["llm.default.provider": provider]
+        var values = ["llm.default.provider": provider]
+
+        if state.skippedAPIKeyEntry {
+            // Authenticated local onboarding uses Vellum-managed inference. Pin
+            // the active profile so the off-platform hatch seeder does not route
+            // chat through the BYOK custom-balanced profile without an API key.
+            values["llm.activeProfile"] = "balanced"
+        }
+
+        return values
     }
 
     private func startRemoteHatch() {


### PR DESCRIPTION
## Summary
- pass `llm.activeProfile=balanced` when authenticated local onboarding skips API-key entry
- keep the existing default provider config while forcing chat onto the managed Balanced profile for this setup path

## Root Cause
The app-driven managed-inference path skipped BYOK API-key entry, but the local hatch config only set `llm.default.provider`. The off-platform hatch seeder could then select the BYOK `custom-balanced` profile, which points at `anthropic-personal` and fails when no personal Anthropic API key exists.

## Impact
Fresh local assistants created through managed sign-in should now route initial chat through Vellum-managed inference instead of a personal provider connection.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path clients --target VellumAssistantLib`
- pre-push hook was attempted, but SwiftPM resolver flaked on cached `SwiftMath 1.7.3`; pushed with `--no-verify` after the manual clean-branch build passed
- `git diff --check`