### PR TITLE
fix(tests): update HomePageView test helpers for non-generic signature

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Home/HomeOpenItemRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomeOpenItemRoutingTests.swift
@@ -55,7 +55,7 @@ final class HomeOpenItemRoutingTests: XCTestCase {
         feedStore: HomeFeedStore,
         onDetailPanelSelected: @escaping (FeedItem) -> Void = { _ in },
         onFeedConversationOpened: @escaping (String) -> Void = { _ in }
-    ) -> HomePageView<EmptyView> {
+    ) -> HomePageView {
         let (meetStream, _) = AsyncStream<ServerMessage>.makeStream()
         let meetVM = MeetStatusViewModel(
             messageStream: meetStream,

--- a/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
@@ -68,21 +68,15 @@ final class HomePageViewGroupingTests: XCTestCase {
         return MeetStatusViewModel(messageStream: stream)
     }
 
-    /// Constructs a fully-specialized `HomePageView` wired to the supplied
-    /// feed store. All callbacks are no-ops and `detailPanel` resolves to
-    /// `EmptyView` — the tests never exercise the view body, just the
-    /// pure `groupedFeed` helper.
-    private func makeView(feedStore: HomeFeedStore) -> HomePageView<EmptyView> {
-        HomePageView<EmptyView>(
+    private func makeView(feedStore: HomeFeedStore) -> HomePageView {
+        HomePageView(
             store: makeHomeStore(),
             feedStore: feedStore,
             meetStatusViewModel: makeMeetStatus(),
             onFeedConversationOpened: { _ in },
             onStartNewChat: {},
             onDismissSuggestions: {},
-            onSuggestionSelected: { _ in },
-            isDetailPanelVisible: false,
-            detailPanel: { EmptyView() }
+            onSuggestionSelected: { _ in }
         )
     }
 


### PR DESCRIPTION
## Summary
HomePageView changed from `HomePageView<DetailPanel: View>` to a non-generic struct in #30482 (VSplitView refactor). Two test files still reference the old generic signature, causing macOS Tests and macOS Builds CI to fail.

## Changes
- **HomeOpenItemRoutingTests.swift**: `HomePageView<EmptyView>` → `HomePageView`
- **HomePageViewGroupingTests.swift**: `HomePageView<EmptyView>(...)` → `HomePageView(...)`, removed `isDetailPanelVisible` and `detailPanel` parameters

## Test plan
- [ ] macOS Tests CI passes
- [ ] macOS Builds CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->