### PR TITLE
[codex] Clean up vellum setup provider secrets

### DIFF
--- a/cli/src/__tests__/provider-secrets.test.ts
+++ b/cli/src/__tests__/provider-secrets.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import {
+  ensureProviderApiKey,
+  injectGatewayApiKey,
+  promptSecret,
+  readGatewayApiKey,
+  resolveHatchProvider,
+  type ProviderSecretFetch,
+} from "../lib/provider-secrets.js";
+
+interface RecordedFetchCall {
+  url: string;
+  init?: RequestInit;
+  body: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeFetch(responses: Response[]): {
+  calls: RecordedFetchCall[];
+  fetchImpl: ProviderSecretFetch;
+} {
+  const calls: RecordedFetchCall[] = [];
+  const fetchImpl: ProviderSecretFetch = async (input, init) => {
+    calls.push({
+      url: String(input),
+      init,
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call.");
+    }
+    return response;
+  };
+
+  return { calls, fetchImpl };
+}
+
+class FakePromptInput extends EventEmitter {
+  isTTY = true;
+  isRaw = false;
+  private paused = false;
+  pauseCount = 0;
+  rawModes: boolean[] = [];
+
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  resume(): this {
+    this.paused = false;
+    return this;
+  }
+
+  pause(): this {
+    this.paused = true;
+    this.pauseCount += 1;
+    return this;
+  }
+
+  setRawMode(value: boolean): this {
+    this.isRaw = value;
+    this.rawModes.push(value);
+    return this;
+  }
+}
+
+describe("provider secret helpers", () => {
+  test("defaults hatch provider to anthropic", () => {
+    expect(resolveHatchProvider({})).toBe("anthropic");
+  });
+
+  test("skips provider key setup for ollama", () => {
+    expect(
+      resolveHatchProvider({ "llm.default.provider": "ollama" }),
+    ).toBeNull();
+  });
+
+  test("rejects unsupported hatch providers", () => {
+    expect(() =>
+      resolveHatchProvider({ "llm.default.provider": "custom" }),
+    ).toThrow("supported API-key setup flow");
+  });
+
+  test("reads provider keys from the api_key namespace", async () => {
+    const { calls, fetchImpl } = makeFetch([jsonResponse({ found: true })]);
+
+    await readGatewayApiKey(
+      "http://127.0.0.1:3000/",
+      "anthropic",
+      "guardian-token",
+      fetchImpl,
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://127.0.0.1:3000/v1/secrets/read");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer guardian-token",
+      "Content-Type": "application/json",
+    });
+    expect(calls[0].body).toEqual({
+      type: "api_key",
+      name: "anthropic",
+      reveal: false,
+    });
+  });
+
+  test("explains a missing secret route as a wrong active assistant URL", async () => {
+    const { fetchImpl } = makeFetch([
+      jsonResponse(
+        {
+          error: {
+            code: "not_found",
+            message: "Not found",
+            path: "/v1/secrets/read",
+          },
+        },
+        404,
+      ),
+    ]);
+
+    await expect(
+      readGatewayApiKey(
+        "https://platform.vellum.ai",
+        "anthropic",
+        undefined,
+        fetchImpl,
+      ),
+    ).rejects.toThrow("does not expose /v1/secrets/read");
+  });
+
+  test("injects provider keys into the api_key namespace", async () => {
+    const { calls, fetchImpl } = makeFetch([jsonResponse({ success: true })]);
+
+    await injectGatewayApiKey(
+      "http://127.0.0.1:3000",
+      "openai",
+      "test-provider-key",
+      "guardian-token",
+      fetchImpl,
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://127.0.0.1:3000/v1/secrets");
+    expect(calls[0].body).toEqual({
+      type: "api_key",
+      name: "openai",
+      value: "test-provider-key",
+    });
+  });
+
+  test("does not prompt or rewrite an existing provider key", async () => {
+    const { calls, fetchImpl } = makeFetch([jsonResponse({ found: true })]);
+    let prompted = false;
+
+    const result = await ensureProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:3000",
+      provider: "anthropic",
+      env: { ANTHROPIC_API_KEY: "test-provider-key" },
+      fetchImpl,
+      prompt: async () => {
+        prompted = true;
+        return "unused";
+      },
+    });
+
+    expect(result).toEqual({
+      status: "already_configured",
+      provider: "anthropic",
+    });
+    expect(prompted).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("stores a provider key from the matching environment variable", async () => {
+    const { calls, fetchImpl } = makeFetch([
+      jsonResponse({ found: false }),
+      jsonResponse({ success: true }),
+    ]);
+
+    const result = await ensureProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:3000",
+      provider: "anthropic",
+      env: { ANTHROPIC_API_KEY: " test-provider-key " },
+      fetchImpl,
+      stdinIsTTY: false,
+    });
+
+    expect(result).toEqual({
+      status: "configured",
+      provider: "anthropic",
+      source: "env",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].body).toEqual({
+      type: "api_key",
+      name: "anthropic",
+      value: "test-provider-key",
+    });
+  });
+
+  test("prompts when no matching provider key is in the environment", async () => {
+    const { calls, fetchImpl } = makeFetch([
+      jsonResponse({ found: false }),
+      jsonResponse({ success: true }),
+    ]);
+    let promptText = "";
+
+    const result = await ensureProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:3000",
+      provider: "openai",
+      env: {},
+      fetchImpl,
+      prompt: async (prompt) => {
+        promptText = prompt;
+        return "test-openai-key";
+      },
+    });
+
+    expect(result).toEqual({
+      status: "configured",
+      provider: "openai",
+      source: "prompt",
+    });
+    expect(promptText).toContain("OpenAI");
+    expect(promptText).toContain("OPENAI_API_KEY");
+    expect(calls[1].body).toEqual({
+      type: "api_key",
+      name: "openai",
+      value: "test-openai-key",
+    });
+  });
+
+  test("pauses prompt input after reading a secret", async () => {
+    const input = new FakePromptInput();
+    let outputText = "";
+    const output = {
+      write: (text: string) => {
+        outputText += text;
+        return true;
+      },
+    };
+
+    const resultPromise = promptSecret("Enter key: ", {
+      input: input as unknown as NodeJS.ReadStream,
+      output: output as unknown as NodeJS.WriteStream,
+    });
+    input.emit("data", Buffer.from("test-provider-key\n"));
+
+    await expect(resultPromise).resolves.toBe("test-provider-key");
+    expect(input.pauseCount).toBe(1);
+    expect(input.listenerCount("data")).toBe(0);
+    expect(input.rawModes).toEqual([true, false]);
+    expect(outputText).toBe("Enter key: \n");
+  });
+
+  test("returns a missing-key result in non-interactive shells", async () => {
+    const { calls, fetchImpl } = makeFetch([jsonResponse({ found: false })]);
+
+    const result = await ensureProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:3000",
+      provider: "anthropic",
+      env: {},
+      fetchImpl,
+      stdinIsTTY: false,
+    });
+
+    expect(result).toEqual({
+      status: "missing",
+      provider: "anthropic",
+      message:
+        "Missing ANTHROPIC_API_KEY. Set it in the environment or run vellum setup from an interactive terminal.",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("reports an unavailable credential store without prompting", async () => {
+    const { calls, fetchImpl } = makeFetch([
+      jsonResponse({ found: false, unreachable: true }),
+    ]);
+    let prompted = false;
+
+    const result = await ensureProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:3000",
+      provider: "anthropic",
+      env: {},
+      fetchImpl,
+      prompt: async () => {
+        prompted = true;
+        return "unused";
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(prompted).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/cli/src/__tests__/provider-secrets.test.ts
+++ b/cli/src/__tests__/provider-secrets.test.ts
@@ -6,7 +6,6 @@ import {
   injectGatewayApiKey,
   promptSecret,
   readGatewayApiKey,
-  resolveHatchProvider,
   type ProviderSecretFetch,
 } from "../lib/provider-secrets.js";
 
@@ -74,22 +73,6 @@ class FakePromptInput extends EventEmitter {
 }
 
 describe("provider secret helpers", () => {
-  test("defaults hatch provider to anthropic", () => {
-    expect(resolveHatchProvider({})).toBe("anthropic");
-  });
-
-  test("skips provider key setup for ollama", () => {
-    expect(
-      resolveHatchProvider({ "llm.default.provider": "ollama" }),
-    ).toBeNull();
-  });
-
-  test("rejects unsupported hatch providers", () => {
-    expect(() =>
-      resolveHatchProvider({ "llm.default.provider": "custom" }),
-    ).toThrow("supported API-key setup flow");
-  });
-
   test("reads provider keys from the api_key namespace", async () => {
     const { calls, fetchImpl } = makeFetch([jsonResponse({ found: true })]);
 

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -1,48 +1,72 @@
-import {
-  afterAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from "bun:test";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { AssistantEntry } from "../lib/assistant-config.js";
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as guardianToken from "../lib/guardian-token.js";
+import * as providerSecrets from "../lib/provider-secrets.js";
 
 let activeAssistant: AssistantEntry | null = null;
 
-interface SetupEnsureOptions {
-  gatewayUrl: string;
-  provider: string;
-  bearerToken?: string;
-  env?: NodeJS.ProcessEnv;
+type SetupEnsureOptions = Parameters<
+  typeof providerSecrets.ensureProviderApiKey
+>[0];
+type SetupEnsureResult = Awaited<
+  ReturnType<typeof providerSecrets.ensureProviderApiKey>
+>;
+
+function guardianTokenFixture(
+  overrides: Partial<
+    NonNullable<ReturnType<typeof guardianToken.loadGuardianToken>>
+  > = {},
+): NonNullable<ReturnType<typeof guardianToken.loadGuardianToken>> {
+  return {
+    guardianPrincipalId: "guardian-principal-123",
+    accessToken: "guardian-token",
+    accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    refreshToken: "refresh-token",
+    refreshTokenExpiresAt: new Date(Date.now() + 120_000).toISOString(),
+    refreshAfter: new Date(Date.now() + 30_000).toISOString(),
+    isNew: false,
+    deviceId: "device-123",
+    leasedAt: new Date().toISOString(),
+    ...overrides,
+  };
 }
 
-const resolveAssistantMock = mock((): AssistantEntry | null => activeAssistant);
-const loadGuardianTokenMock = mock(
-  (_assistantId: string): { accessToken: string } | null => ({
-    accessToken: "guardian-token",
-  }),
+const resolveAssistantMock = spyOn(
+  assistantConfig,
+  "resolveAssistant",
+).mockImplementation((): AssistantEntry | null => activeAssistant);
+const loadGuardianTokenMock = spyOn(
+  guardianToken,
+  "loadGuardianToken",
+).mockImplementation(
+  (_assistantId: string): ReturnType<typeof guardianToken.loadGuardianToken> =>
+    guardianTokenFixture(),
 );
-const ensureProviderApiKeyMock = mock(async (options: SetupEnsureOptions) => ({
-  status: "configured" as const,
-  provider: options.provider,
-  source: "prompt" as const,
-}));
-
-mock.module("../lib/assistant-config.js", () => ({
-  resolveAssistant: resolveAssistantMock,
-}));
-
-mock.module("../lib/guardian-token.js", () => ({
-  loadGuardianToken: loadGuardianTokenMock,
-}));
-
-mock.module("../lib/provider-secrets.js", () => ({
-  ensureProviderApiKey: ensureProviderApiKeyMock,
-  formatProviderName: (provider: string) =>
-    provider === "openai" ? "OpenAI" : "Anthropic",
-}));
+const refreshGuardianTokenMock = spyOn(
+  guardianToken,
+  "refreshGuardianToken",
+).mockResolvedValue(null);
+const configuredResult = (provider: string | null): SetupEnsureResult => ({
+  status: "configured",
+  provider:
+    provider && providerSecrets.isSupportedLlmProvider(provider)
+      ? provider
+      : "anthropic",
+  source: "prompt",
+});
+const ensureProviderApiKeyMock = spyOn(
+  providerSecrets,
+  "ensureProviderApiKey",
+).mockImplementation(async (options: SetupEnsureOptions) =>
+  configuredResult(options.provider),
+);
+const formatProviderNameMock = spyOn(
+  providerSecrets,
+  "formatProviderName",
+).mockImplementation((provider: string) =>
+  provider === "openai" ? "OpenAI" : "Anthropic",
+);
 
 import { setup } from "../commands/setup.js";
 
@@ -61,14 +85,12 @@ describe("setup command", () => {
     };
     resolveAssistantMock.mockClear();
     loadGuardianTokenMock.mockReset();
-    loadGuardianTokenMock.mockReturnValue({ accessToken: "guardian-token" });
+    loadGuardianTokenMock.mockReturnValue(guardianTokenFixture());
+    refreshGuardianTokenMock.mockReset();
+    refreshGuardianTokenMock.mockResolvedValue(null);
     ensureProviderApiKeyMock.mockReset();
-    ensureProviderApiKeyMock.mockImplementation(
-      async (options: SetupEnsureOptions) => ({
-        status: "configured" as const,
-        provider: options.provider,
-        source: "prompt" as const,
-      }),
+    ensureProviderApiKeyMock.mockImplementation(async (options) =>
+      configuredResult(options.provider),
     );
     consoleLogSpy.mockClear();
     consoleErrorSpy.mockClear();
@@ -78,6 +100,11 @@ describe("setup command", () => {
     process.argv = originalArgv;
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    resolveAssistantMock.mockRestore();
+    loadGuardianTokenMock.mockRestore();
+    refreshGuardianTokenMock.mockRestore();
+    ensureProviderApiKeyMock.mockRestore();
+    formatProviderNameMock.mockRestore();
   });
 
   test("configures the default provider through the active assistant gateway", async () => {
@@ -120,5 +147,53 @@ describe("setup command", () => {
     const options = ensureProviderApiKeyMock.mock.calls[0][0];
     expect(options.gatewayUrl).toBe("https://assistant.example");
     expect(options.bearerToken).toBe("entry-token");
+  });
+
+  test("falls back to the lockfile bearer token when guardian token is expired", async () => {
+    activeAssistant = {
+      assistantId: "assistant-123",
+      runtimeUrl: "https://assistant.example",
+      bearerToken: "entry-token",
+      cloud: "vellum",
+    };
+    loadGuardianTokenMock.mockReturnValue(
+      guardianTokenFixture({
+        accessToken: "expired-guardian-token",
+        accessTokenExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    );
+    refreshGuardianTokenMock.mockResolvedValue(null);
+
+    await setup();
+
+    expect(refreshGuardianTokenMock).toHaveBeenCalledWith(
+      "https://assistant.example",
+      "assistant-123",
+    );
+    const options = ensureProviderApiKeyMock.mock.calls[0][0];
+    expect(options.bearerToken).toBe("entry-token");
+  });
+
+  test("uses a refreshed guardian token before lockfile fallback", async () => {
+    activeAssistant = {
+      assistantId: "assistant-123",
+      runtimeUrl: "https://assistant.example",
+      bearerToken: "entry-token",
+      cloud: "vellum",
+    };
+    loadGuardianTokenMock.mockReturnValue(
+      guardianTokenFixture({
+        accessToken: "expired-guardian-token",
+        accessTokenExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    );
+    refreshGuardianTokenMock.mockResolvedValue(
+      guardianTokenFixture({ accessToken: "fresh-guardian-token" }),
+    );
+
+    await setup();
+
+    const options = ensureProviderApiKeyMock.mock.calls[0][0];
+    expect(options.bearerToken).toBe("fresh-guardian-token");
   });
 });

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -1,0 +1,124 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import type { AssistantEntry } from "../lib/assistant-config.js";
+
+let activeAssistant: AssistantEntry | null = null;
+
+interface SetupEnsureOptions {
+  gatewayUrl: string;
+  provider: string;
+  bearerToken?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+const resolveAssistantMock = mock((): AssistantEntry | null => activeAssistant);
+const loadGuardianTokenMock = mock(
+  (_assistantId: string): { accessToken: string } | null => ({
+    accessToken: "guardian-token",
+  }),
+);
+const ensureProviderApiKeyMock = mock(async (options: SetupEnsureOptions) => ({
+  status: "configured" as const,
+  provider: options.provider,
+  source: "prompt" as const,
+}));
+
+mock.module("../lib/assistant-config.js", () => ({
+  resolveAssistant: resolveAssistantMock,
+}));
+
+mock.module("../lib/guardian-token.js", () => ({
+  loadGuardianToken: loadGuardianTokenMock,
+}));
+
+mock.module("../lib/provider-secrets.js", () => ({
+  ensureProviderApiKey: ensureProviderApiKeyMock,
+  formatProviderName: (provider: string) =>
+    provider === "openai" ? "OpenAI" : "Anthropic",
+}));
+
+import { setup } from "../commands/setup.js";
+
+const originalArgv = [...process.argv];
+const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+describe("setup command", () => {
+  beforeEach(() => {
+    process.argv = ["bun", "vellum", "setup"];
+    activeAssistant = {
+      assistantId: "assistant-123",
+      runtimeUrl: "http://runtime.example",
+      localUrl: "http://127.0.0.1:3000",
+      cloud: "local",
+    };
+    resolveAssistantMock.mockClear();
+    loadGuardianTokenMock.mockReset();
+    loadGuardianTokenMock.mockReturnValue({ accessToken: "guardian-token" });
+    ensureProviderApiKeyMock.mockReset();
+    ensureProviderApiKeyMock.mockImplementation(
+      async (options: SetupEnsureOptions) => ({
+        status: "configured" as const,
+        provider: options.provider,
+        source: "prompt" as const,
+      }),
+    );
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("configures the default provider through the active assistant gateway", async () => {
+    await setup();
+
+    expect(resolveAssistantMock).toHaveBeenCalled();
+    expect(loadGuardianTokenMock).toHaveBeenCalledWith("assistant-123");
+    expect(ensureProviderApiKeyMock).toHaveBeenCalledTimes(1);
+
+    const options = ensureProviderApiKeyMock.mock.calls[0][0];
+    expect(options.gatewayUrl).toBe("http://127.0.0.1:3000");
+    expect(options.provider).toBe("anthropic");
+    expect(options.bearerToken).toBe("guardian-token");
+    expect(options.env).toBe(process.env);
+  });
+
+  test("honors an explicit provider option", async () => {
+    process.argv = ["bun", "vellum", "setup", "--provider", "openai"];
+
+    await setup();
+
+    const options = ensureProviderApiKeyMock.mock.calls[0][0];
+    expect(options.provider).toBe("openai");
+    expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
+      "OpenAI API key saved to assistant.",
+    );
+  });
+
+  test("falls back to runtime URL and lockfile bearer token", async () => {
+    activeAssistant = {
+      assistantId: "assistant-123",
+      runtimeUrl: "https://assistant.example",
+      bearerToken: "entry-token",
+      cloud: "vellum",
+    };
+    loadGuardianTokenMock.mockReturnValue(null);
+
+    await setup();
+
+    const options = ensureProviderApiKeyMock.mock.calls[0][0];
+    expect(options.gatewayUrl).toBe("https://assistant.example");
+    expect(options.bearerToken).toBe("entry-token");
+  });
+});

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -1,23 +1,49 @@
-import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+  type Mock,
+} from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import type { AssistantEntry } from "../lib/assistant-config.js";
-import * as assistantConfig from "../lib/assistant-config.js";
-import * as guardianToken from "../lib/guardian-token.js";
-import * as providerSecrets from "../lib/provider-secrets.js";
+import {
+  saveGuardianToken,
+  type GuardianTokenData,
+} from "../lib/guardian-token.js";
+import { setup } from "../commands/setup.js";
 
-let activeAssistant: AssistantEntry | null = null;
+interface RecordedFetchCall {
+  url: string;
+  method?: string;
+  headers: Headers;
+  body: unknown;
+}
 
-type SetupEnsureOptions = Parameters<
-  typeof providerSecrets.ensureProviderApiKey
->[0];
-type SetupEnsureResult = Awaited<
-  ReturnType<typeof providerSecrets.ensureProviderApiKey>
->;
+const originalArgv = [...process.argv];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  openaiApiKey: process.env.OPENAI_API_KEY,
+  xdgConfigHome: process.env.XDG_CONFIG_HOME,
+  xdgDataHome: process.env.XDG_DATA_HOME,
+  vellumEnvironment: process.env.VELLUM_ENVIRONMENT,
+  vellumLockfileDir: process.env.VELLUM_LOCKFILE_DIR,
+};
+
+let testDir = "";
+let fetchCalls: RecordedFetchCall[] = [];
+let consoleLogSpy: Mock<(...args: unknown[]) => void>;
+let consoleErrorSpy: Mock<(...args: unknown[]) => void>;
 
 function guardianTokenFixture(
-  overrides: Partial<
-    NonNullable<ReturnType<typeof guardianToken.loadGuardianToken>>
-  > = {},
-): NonNullable<ReturnType<typeof guardianToken.loadGuardianToken>> {
+  overrides: Partial<GuardianTokenData> = {},
+): GuardianTokenData {
   return {
     guardianPrincipalId: "guardian-principal-123",
     accessToken: "guardian-token",
@@ -32,168 +58,239 @@ function guardianTokenFixture(
   };
 }
 
-const resolveAssistantMock = spyOn(
-  assistantConfig,
-  "resolveAssistant",
-).mockImplementation((): AssistantEntry | null => activeAssistant);
-const loadGuardianTokenMock = spyOn(
-  guardianToken,
-  "loadGuardianToken",
-).mockImplementation(
-  (_assistantId: string): ReturnType<typeof guardianToken.loadGuardianToken> =>
-    guardianTokenFixture(),
-);
-const refreshGuardianTokenMock = spyOn(
-  guardianToken,
-  "refreshGuardianToken",
-).mockResolvedValue(null);
-const configuredResult = (provider: string | null): SetupEnsureResult => ({
-  status: "configured",
-  provider:
-    provider && providerSecrets.isSupportedLlmProvider(provider)
-      ? provider
-      : "anthropic",
-  source: "prompt",
-});
-const ensureProviderApiKeyMock = spyOn(
-  providerSecrets,
-  "ensureProviderApiKey",
-).mockImplementation(async (options: SetupEnsureOptions) =>
-  configuredResult(options.provider),
-);
-const formatProviderNameMock = spyOn(
-  providerSecrets,
-  "formatProviderName",
-).mockImplementation((provider: string) =>
-  provider === "openai" ? "OpenAI" : "Anthropic",
-);
+function writeLockfile(entry: AssistantEntry): void {
+  const lockfileDir = process.env.VELLUM_LOCKFILE_DIR!;
+  mkdirSync(lockfileDir, { recursive: true });
+  writeFileSync(
+    join(lockfileDir, ".vellum.lock.json"),
+    JSON.stringify(
+      {
+        assistants: [entry],
+        activeAssistant: entry.assistantId,
+      },
+      null,
+      2,
+    ),
+  );
+}
 
-import { setup } from "../commands/setup.js";
+function installFetchStub(
+  options: { refreshedToken?: GuardianTokenData } = {},
+) {
+  fetchCalls = [];
+  globalThis.fetch = (async (input, init) => {
+    const headers = new Headers(init?.headers);
+    const body =
+      typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
+    const url = String(input);
+    fetchCalls.push({
+      url,
+      method: init?.method,
+      headers,
+      body,
+    });
 
-const originalArgv = [...process.argv];
-const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
-const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    if (url.endsWith("/v1/guardian/refresh")) {
+      if (!options.refreshedToken) {
+        return new Response(JSON.stringify({ error: "expired" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(options.refreshedToken), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/v1/secrets/read")) {
+      return new Response(JSON.stringify({ found: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/v1/secrets")) {
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "Unexpected URL" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function secretWriteCall(): RecordedFetchCall {
+  const call = fetchCalls.find((record) => record.url.endsWith("/v1/secrets"));
+  if (!call) {
+    throw new Error("Expected /v1/secrets call.");
+  }
+  return call;
+}
 
 describe("setup command", () => {
   beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "vellum-setup-test-"));
     process.argv = ["bun", "vellum", "setup"];
-    activeAssistant = {
+    process.env.XDG_CONFIG_HOME = join(testDir, "config");
+    process.env.XDG_DATA_HOME = join(testDir, "data");
+    process.env.VELLUM_LOCKFILE_DIR = join(testDir, "lockfile");
+    delete process.env.VELLUM_ENVIRONMENT;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    globalThis.fetch = originalFetch;
+    setOptionalEnv("ANTHROPIC_API_KEY", originalEnv.anthropicApiKey);
+    setOptionalEnv("OPENAI_API_KEY", originalEnv.openaiApiKey);
+    setOptionalEnv("XDG_CONFIG_HOME", originalEnv.xdgConfigHome);
+    setOptionalEnv("XDG_DATA_HOME", originalEnv.xdgDataHome);
+    setOptionalEnv("VELLUM_ENVIRONMENT", originalEnv.vellumEnvironment);
+    setOptionalEnv("VELLUM_LOCKFILE_DIR", originalEnv.vellumLockfileDir);
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("configures the default provider through the active assistant gateway", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
       assistantId: "assistant-123",
       runtimeUrl: "http://runtime.example",
       localUrl: "http://127.0.0.1:3000",
       cloud: "local",
-    };
-    resolveAssistantMock.mockClear();
-    loadGuardianTokenMock.mockReset();
-    loadGuardianTokenMock.mockReturnValue(guardianTokenFixture());
-    refreshGuardianTokenMock.mockReset();
-    refreshGuardianTokenMock.mockResolvedValue(null);
-    ensureProviderApiKeyMock.mockReset();
-    ensureProviderApiKeyMock.mockImplementation(async (options) =>
-      configuredResult(options.provider),
-    );
-    consoleLogSpy.mockClear();
-    consoleErrorSpy.mockClear();
-  });
+    });
+    saveGuardianToken("assistant-123", guardianTokenFixture());
 
-  afterAll(() => {
-    process.argv = originalArgv;
-    consoleLogSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
-    resolveAssistantMock.mockRestore();
-    loadGuardianTokenMock.mockRestore();
-    refreshGuardianTokenMock.mockRestore();
-    ensureProviderApiKeyMock.mockRestore();
-    formatProviderNameMock.mockRestore();
-  });
-
-  test("configures the default provider through the active assistant gateway", async () => {
     await setup();
 
-    expect(resolveAssistantMock).toHaveBeenCalled();
-    expect(loadGuardianTokenMock).toHaveBeenCalledWith("assistant-123");
-    expect(ensureProviderApiKeyMock).toHaveBeenCalledTimes(1);
-
-    const options = ensureProviderApiKeyMock.mock.calls[0][0];
-    expect(options.gatewayUrl).toBe("http://127.0.0.1:3000");
-    expect(options.provider).toBe("anthropic");
-    expect(options.bearerToken).toBe("guardian-token");
-    expect(options.env).toBe(process.env);
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:3000/v1/secrets/read");
+    expect(fetchCalls[0].headers.get("Authorization")).toBe(
+      "Bearer guardian-token",
+    );
+    expect(secretWriteCall().body).toEqual({
+      type: "api_key",
+      name: "anthropic",
+      value: "test-anthropic-key",
+    });
+    expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
+      "Anthropic API key saved to assistant from the environment.",
+    );
   });
 
   test("honors an explicit provider option", async () => {
     process.argv = ["bun", "vellum", "setup", "--provider", "openai"];
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    writeLockfile({
+      assistantId: "assistant-123",
+      runtimeUrl: "http://127.0.0.1:3000",
+      cloud: "local",
+    });
+    saveGuardianToken("assistant-123", guardianTokenFixture());
 
     await setup();
 
-    const options = ensureProviderApiKeyMock.mock.calls[0][0];
-    expect(options.provider).toBe("openai");
+    expect(secretWriteCall().body).toEqual({
+      type: "api_key",
+      name: "openai",
+      value: "test-openai-key",
+    });
     expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
-      "OpenAI API key saved to assistant.",
+      "OpenAI API key saved to assistant from the environment.",
     );
   });
 
   test("falls back to runtime URL and lockfile bearer token", async () => {
-    activeAssistant = {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
       assistantId: "assistant-123",
       runtimeUrl: "https://assistant.example",
       bearerToken: "entry-token",
       cloud: "vellum",
-    };
-    loadGuardianTokenMock.mockReturnValue(null);
+    });
 
     await setup();
 
-    const options = ensureProviderApiKeyMock.mock.calls[0][0];
-    expect(options.gatewayUrl).toBe("https://assistant.example");
-    expect(options.bearerToken).toBe("entry-token");
+    expect(fetchCalls[0].url).toBe("https://assistant.example/v1/secrets/read");
+    expect(fetchCalls[0].headers.get("Authorization")).toBe(
+      "Bearer entry-token",
+    );
   });
 
   test("falls back to the lockfile bearer token when guardian token is expired", async () => {
-    activeAssistant = {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
       assistantId: "assistant-123",
       runtimeUrl: "https://assistant.example",
       bearerToken: "entry-token",
       cloud: "vellum",
-    };
-    loadGuardianTokenMock.mockReturnValue(
+    });
+    saveGuardianToken(
+      "assistant-123",
       guardianTokenFixture({
         accessToken: "expired-guardian-token",
         accessTokenExpiresAt: new Date(Date.now() - 60_000).toISOString(),
       }),
     );
-    refreshGuardianTokenMock.mockResolvedValue(null);
 
     await setup();
 
-    expect(refreshGuardianTokenMock).toHaveBeenCalledWith(
-      "https://assistant.example",
-      "assistant-123",
+    expect(fetchCalls[0].url).toBe(
+      "https://assistant.example/v1/guardian/refresh",
     );
-    const options = ensureProviderApiKeyMock.mock.calls[0][0];
-    expect(options.bearerToken).toBe("entry-token");
+    expect(fetchCalls[0].headers.get("Authorization")).toBe(
+      "Bearer expired-guardian-token",
+    );
+    expect(fetchCalls[1].headers.get("Authorization")).toBe(
+      "Bearer entry-token",
+    );
   });
 
   test("uses a refreshed guardian token before lockfile fallback", async () => {
-    activeAssistant = {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
       assistantId: "assistant-123",
       runtimeUrl: "https://assistant.example",
       bearerToken: "entry-token",
       cloud: "vellum",
-    };
-    loadGuardianTokenMock.mockReturnValue(
+    });
+    saveGuardianToken(
+      "assistant-123",
       guardianTokenFixture({
         accessToken: "expired-guardian-token",
         accessTokenExpiresAt: new Date(Date.now() - 60_000).toISOString(),
       }),
     );
-    refreshGuardianTokenMock.mockResolvedValue(
-      guardianTokenFixture({ accessToken: "fresh-guardian-token" }),
-    );
+    installFetchStub({
+      refreshedToken: guardianTokenFixture({
+        accessToken: "fresh-guardian-token",
+      }),
+    });
 
     await setup();
 
-    const options = ensureProviderApiKeyMock.mock.calls[0][0];
-    expect(options.bearerToken).toBe("fresh-guardian-token");
+    expect(fetchCalls[0].url).toBe(
+      "https://assistant.example/v1/guardian/refresh",
+    );
+    expect(fetchCalls[1].headers.get("Authorization")).toBe(
+      "Bearer fresh-guardian-token",
+    );
   });
 });
+
+function setOptionalEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,5 +1,9 @@
 import { resolveAssistant } from "../lib/assistant-config.js";
-import { loadGuardianToken } from "../lib/guardian-token.js";
+import {
+  loadGuardianToken,
+  refreshGuardianToken,
+  type GuardianTokenData,
+} from "../lib/guardian-token.js";
 import {
   ensureProviderApiKey,
   formatProviderName,
@@ -25,6 +29,16 @@ function parseSetupArgs(args: string[]): { provider: string } {
   }
 
   return { provider };
+}
+
+function isGuardianAccessTokenUsable(
+  tokenData: GuardianTokenData | null,
+): tokenData is GuardianTokenData {
+  if (!tokenData?.accessToken) {
+    return false;
+  }
+  const expiresAt = new Date(tokenData.accessTokenExpiresAt).getTime();
+  return Number.isFinite(expiresAt) && expiresAt > Date.now();
 }
 
 export async function setup(): Promise<void> {
@@ -71,8 +85,18 @@ export async function setup(): Promise<void> {
   }
 
   const gatewayUrl = entry.localUrl ?? entry.runtimeUrl;
-  const bearerToken =
-    loadGuardianToken(entry.assistantId)?.accessToken ?? entry.bearerToken;
+  let bearerToken: string | undefined;
+  const guardianToken = loadGuardianToken(entry.assistantId);
+  if (isGuardianAccessTokenUsable(guardianToken)) {
+    bearerToken = guardianToken.accessToken;
+  } else {
+    const refreshedToken = guardianToken
+      ? await refreshGuardianToken(gatewayUrl, entry.assistantId)
+      : null;
+    bearerToken = isGuardianAccessTokenUsable(refreshedToken)
+      ? refreshedToken.accessToken
+      : entry.bearerToken;
+  }
 
   console.log("Vellum Setup");
   console.log("============\n");

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,78 +1,65 @@
-import { createInterface } from "readline";
-
 import { resolveAssistant } from "../lib/assistant-config.js";
+import { loadGuardianToken } from "../lib/guardian-token.js";
+import {
+  ensureProviderApiKey,
+  formatProviderName,
+} from "../lib/provider-secrets.js";
 
-async function promptMasked(prompt: string): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
+function parseSetupArgs(args: string[]): { provider: string } {
+  let provider = "anthropic";
 
-    process.stdout.write(prompt);
-
-    const stdin = process.stdin;
-    const wasRaw = stdin.isRaw;
-    if (stdin.isTTY) {
-      stdin.setRawMode(true);
-    }
-
-    let input = "";
-    const onData = (key: Buffer): void => {
-      const char = key.toString("utf-8");
-
-      if (char === "\r" || char === "\n") {
-        stdin.removeListener("data", onData);
-        if (stdin.isTTY) {
-          stdin.setRawMode(wasRaw ?? false);
-        }
-        process.stdout.write("\n");
-        rl.close();
-        resolve(input);
-      } else if (char === "\u0003") {
-        process.stdout.write("\n");
-        process.exit(1);
-      } else if (char === "\u007F" || char === "\b") {
-        if (input.length > 0) {
-          input = input.slice(0, -1);
-          process.stdout.write("\b \b");
-        }
-      } else if (char.length === 1 && char >= " ") {
-        input += char;
-        process.stdout.write("*");
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--provider") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error("--provider requires a provider name.");
       }
-    };
-
-    stdin.on("data", onData);
-  });
-}
-
-async function validateAnthropicKey(apiKey: string): Promise<boolean> {
-  try {
-    const resp = await fetch("https://api.anthropic.com/v1/models", {
-      headers: {
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-    return resp.ok;
-  } catch {
-    return false;
+      provider = value;
+      i++;
+    } else if (arg.startsWith("--provider=")) {
+      provider = arg.slice("--provider=".length);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
   }
+
+  return { provider };
 }
 
 export async function setup(): Promise<void> {
   const args = process.argv.slice(3);
 
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum setup");
+    console.log("Usage: vellum setup [--provider <provider>]");
     console.log("");
-    console.log("Interactive wizard to configure API keys.");
+    console.log("Configure a provider API key on the active assistant.");
+    console.log("");
+    console.log("Options:");
     console.log(
-      "Injects secrets into your running assistant via the gateway API.",
+      "  --provider <provider>  Provider to configure. Defaults to anthropic.",
     );
+    console.log("");
+    console.log("Behavior:");
+    console.log(
+      "  - Checks the active assistant for an existing provider key.",
+    );
+    console.log("  - Uses the matching environment variable when it is set.");
+    console.log("  - Otherwise prompts securely without echoing the key.");
+    console.log("");
+    console.log("Examples:");
+    console.log("  vellum setup");
+    console.log("  ANTHROPIC_API_KEY=... vellum setup");
+    console.log("  vellum setup --provider openai");
     process.exit(0);
+  }
+
+  let parsed: { provider: string };
+  try {
+    parsed = parseSetupArgs(args);
+  } catch (error) {
+    console.error(error instanceof Error ? `Error: ${error.message}` : error);
+    process.exit(1);
   }
 
   const entry = resolveAssistant();
@@ -84,54 +71,48 @@ export async function setup(): Promise<void> {
   }
 
   const gatewayUrl = entry.localUrl ?? entry.runtimeUrl;
+  const bearerToken =
+    loadGuardianToken(entry.assistantId)?.accessToken ?? entry.bearerToken;
 
   console.log("Vellum Setup");
   console.log("============\n");
 
-  const apiKey = await promptMasked(
-    "Enter your Anthropic API key (sk-ant-...): ",
-  );
+  try {
+    const result = await ensureProviderApiKey({
+      gatewayUrl,
+      provider: parsed.provider,
+      bearerToken,
+      env: process.env,
+    });
 
-  if (!apiKey.trim()) {
-    console.error("Error: API key cannot be empty.");
+    if (result.status === "already_configured") {
+      console.log(
+        `${formatProviderName(result.provider)} API key is already configured.`,
+      );
+      return;
+    }
+
+    if (result.status === "configured") {
+      const providerName = formatProviderName(result.provider);
+      const source = result.source === "env" ? " from the environment" : "";
+      console.log(`\n${providerName} API key saved to assistant${source}.`);
+      console.log("Setup complete.");
+      return;
+    }
+
+    if (result.status === "skipped") {
+      console.log(result.message);
+      return;
+    }
+
+    console.error(`Error: ${result.message}`);
     process.exit(1);
-  }
-
-  console.log("Validating key...");
-  const valid = await validateAnthropicKey(apiKey.trim());
-
-  if (!valid) {
+  } catch (error) {
     console.error(
-      "Error: Invalid API key. Could not authenticate with the Anthropic API.",
+      error instanceof Error
+        ? `Error: ${error.message}`
+        : "Error: Setup failed.",
     );
     process.exit(1);
   }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "application/json",
-  };
-  if (entry.bearerToken) {
-    headers["Authorization"] = `Bearer ${entry.bearerToken}`;
-  }
-
-  const response = await fetch(`${gatewayUrl}/v1/secrets`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      type: "credential",
-      name: "ANTHROPIC_API_KEY",
-      value: apiKey.trim(),
-    }),
-    signal: AbortSignal.timeout(10_000),
-  });
-
-  if (!response.ok) {
-    console.error(
-      `Error: Failed to store API key in assistant (${response.status}).`,
-    );
-    process.exit(1);
-  }
-
-  console.log("\nAPI key saved to assistant. Setup complete.");
 }

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -70,26 +70,6 @@ export function isSupportedLlmProvider(
   return Object.hasOwn(LLM_PROVIDER_ENV_VAR_NAMES, provider);
 }
 
-export function resolveHatchProvider(
-  configValues: Record<string, string | undefined>,
-): LlmProviderId | null {
-  const provider = (
-    configValues["llm.default.provider"]?.trim() || "anthropic"
-  ).toLowerCase();
-
-  if (provider === "ollama") {
-    return null;
-  }
-
-  if (!isSupportedLlmProvider(provider)) {
-    throw new Error(
-      `Provider '${provider}' does not have a supported API-key setup flow.`,
-    );
-  }
-
-  return provider;
-}
-
 function gatewayUrlWithPath(gatewayUrl: string, path: string): string {
   return `${gatewayUrl.replace(/\/+$/, "")}${path}`;
 }

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -1,0 +1,433 @@
+import { spawnSync } from "node:child_process";
+
+import { LLM_PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
+
+export type LlmProviderId = keyof typeof LLM_PROVIDER_ENV_VAR_NAMES;
+
+export type ProviderApiKeySource = "env" | "prompt";
+export type ProviderSecretFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => ReturnType<typeof fetch>;
+
+export type EnsureProviderApiKeyResult =
+  | {
+      status: "already_configured";
+      provider: LlmProviderId;
+    }
+  | {
+      status: "configured";
+      provider: LlmProviderId;
+      source: ProviderApiKeySource;
+    }
+  | {
+      status: "missing";
+      provider: LlmProviderId;
+      message: string;
+    }
+  | {
+      status: "failed";
+      provider: LlmProviderId;
+      message: string;
+    }
+  | {
+      status: "skipped";
+      message: string;
+    };
+
+export interface EnsureProviderApiKeyOptions {
+  gatewayUrl: string;
+  provider: string | null;
+  bearerToken?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: ProviderSecretFetch;
+  prompt?: (prompt: string) => Promise<string>;
+  stdinIsTTY?: boolean;
+  input?: NodeJS.ReadStream;
+  output?: NodeJS.WriteStream;
+}
+
+export interface GatewayApiKeyReadResult {
+  found: boolean;
+  unreachable: boolean;
+}
+
+const PROVIDER_LABELS: Record<LlmProviderId, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  gemini: "Gemini",
+  fireworks: "Fireworks",
+  openrouter: "OpenRouter",
+};
+
+export function formatProviderName(provider: LlmProviderId): string {
+  return PROVIDER_LABELS[provider];
+}
+
+export function isSupportedLlmProvider(
+  provider: string,
+): provider is LlmProviderId {
+  return Object.hasOwn(LLM_PROVIDER_ENV_VAR_NAMES, provider);
+}
+
+export function resolveHatchProvider(
+  configValues: Record<string, string | undefined>,
+): LlmProviderId | null {
+  const provider = (
+    configValues["llm.default.provider"]?.trim() || "anthropic"
+  ).toLowerCase();
+
+  if (provider === "ollama") {
+    return null;
+  }
+
+  if (!isSupportedLlmProvider(provider)) {
+    throw new Error(
+      `Provider '${provider}' does not have a supported API-key setup flow.`,
+    );
+  }
+
+  return provider;
+}
+
+function gatewayUrlWithPath(gatewayUrl: string, path: string): string {
+  return `${gatewayUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function secretHeaders(bearerToken?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  };
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+  return headers;
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+  let text = "";
+  try {
+    text = await response.text();
+  } catch {
+    // Fall through to status text.
+  }
+
+  try {
+    const body = JSON.parse(text) as {
+      error?: unknown;
+    };
+    const message = extractErrorMessage(body.error);
+    if (message) return message;
+  } catch {
+    // Fall back to raw text below.
+  }
+
+  if (text.trim().length > 0) {
+    return text.trim();
+  }
+
+  return response.statusText || `HTTP ${response.status}`;
+}
+
+function extractErrorMessage(error: unknown): string | null {
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error.trim();
+  }
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const maybeMessage = (error as { message?: unknown }).message;
+  if (typeof maybeMessage === "string" && maybeMessage.trim().length > 0) {
+    return maybeMessage.trim();
+  }
+
+  return null;
+}
+
+export async function readGatewayApiKey(
+  gatewayUrl: string,
+  provider: LlmProviderId,
+  bearerToken?: string,
+  fetchImpl: ProviderSecretFetch = fetch,
+): Promise<GatewayApiKeyReadResult> {
+  const response = await fetchImpl(
+    gatewayUrlWithPath(gatewayUrl, "/v1/secrets/read"),
+    {
+      method: "POST",
+      headers: secretHeaders(bearerToken),
+      body: JSON.stringify({
+        type: "api_key",
+        name: provider,
+        reveal: false,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response);
+    if (response.status === 404) {
+      throw new Error(
+        `Active assistant at ${gatewayUrl} does not expose /v1/secrets/read (${message}). Run \`vellum ps\` to confirm the active assistant, then select a self-hosted assistant with \`vellum use <assistant>\` or wake a current assistant before running setup.`,
+      );
+    }
+    throw new Error(
+      `Failed to check ${formatProviderName(provider)} API key: ${message}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    found?: unknown;
+    unreachable?: unknown;
+  };
+  return {
+    found: body.found === true,
+    unreachable: body.unreachable === true,
+  };
+}
+
+export async function injectGatewayApiKey(
+  gatewayUrl: string,
+  provider: LlmProviderId,
+  value: string,
+  bearerToken?: string,
+  fetchImpl: ProviderSecretFetch = fetch,
+): Promise<void> {
+  const response = await fetchImpl(
+    gatewayUrlWithPath(gatewayUrl, "/v1/secrets"),
+    {
+      method: "POST",
+      headers: secretHeaders(bearerToken),
+      body: JSON.stringify({
+        type: "api_key",
+        name: provider,
+        value,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response);
+    throw new Error(
+      `Failed to store ${formatProviderName(provider)} API key: ${message}`,
+    );
+  }
+
+  const body = (await response.json().catch(() => ({}))) as {
+    success?: unknown;
+    error?: unknown;
+  };
+  if (body.success === false) {
+    const message =
+      typeof body.error === "string" && body.error.trim().length > 0
+        ? body.error
+        : "Assistant rejected the API key.";
+    throw new Error(message);
+  }
+}
+
+export async function promptSecret(
+  prompt: string,
+  streams: {
+    input?: NodeJS.ReadStream;
+    output?: NodeJS.WriteStream;
+  } = {},
+): Promise<string> {
+  const input = streams.input ?? process.stdin;
+  const output = streams.output ?? process.stdout;
+
+  const restoreEcho = disableTerminalEcho(input);
+  output.write(prompt);
+
+  return new Promise((resolve, reject) => {
+    const wasRaw = input.isRaw;
+    if (input.isTTY) {
+      input.setRawMode(true);
+    }
+    input.resume();
+
+    let value = "";
+
+    const cleanup = (): void => {
+      input.removeListener("data", onData);
+      if (input.isTTY) {
+        input.setRawMode(wasRaw ?? false);
+      }
+      restoreEcho();
+      input.pause();
+    };
+
+    const finish = (): void => {
+      cleanup();
+      output.write("\n");
+      resolve(value);
+    };
+
+    const cancel = (): void => {
+      cleanup();
+      output.write("\n");
+      reject(new Error("Input cancelled."));
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (bytes[0] === 27) {
+        return;
+      }
+
+      for (const byte of bytes) {
+        if (byte === 3) {
+          cancel();
+          return;
+        }
+        if (byte === 10 || byte === 13) {
+          finish();
+          return;
+        }
+        if (byte === 8 || byte === 127) {
+          value = value.slice(0, -1);
+          continue;
+        }
+        if (byte >= 32 && byte <= 126) {
+          value += String.fromCharCode(byte);
+        }
+      }
+    };
+
+    input.on("data", onData);
+  });
+}
+
+function disableTerminalEcho(input: NodeJS.ReadStream): () => void {
+  if (input !== process.stdin || !input.isTTY || process.platform === "win32") {
+    return () => {};
+  }
+
+  const currentState = spawnSync("stty", ["-g"], {
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "ignore"],
+  });
+  const state = currentState.stdout.trim();
+  if (currentState.status !== 0 || state.length === 0) {
+    return () => {};
+  }
+
+  const disabled = spawnSync("stty", ["-echo"], {
+    stdio: ["inherit", "ignore", "ignore"],
+  });
+  if (disabled.status !== 0) {
+    return () => {};
+  }
+
+  let restored = false;
+  return () => {
+    if (restored) {
+      return;
+    }
+    restored = true;
+    spawnSync("stty", [state], {
+      stdio: ["inherit", "ignore", "ignore"],
+    });
+  };
+}
+
+export async function ensureProviderApiKey(
+  options: EnsureProviderApiKeyOptions,
+): Promise<EnsureProviderApiKeyResult> {
+  if (options.provider === null) {
+    return {
+      status: "skipped",
+      message: "Selected provider does not require an API key.",
+    };
+  }
+
+  const normalizedProvider = options.provider.trim().toLowerCase();
+  if (!isSupportedLlmProvider(normalizedProvider)) {
+    throw new Error(
+      `Provider '${options.provider}' does not have a supported API-key setup flow.`,
+    );
+  }
+  const provider = normalizedProvider;
+  const providerName = formatProviderName(provider);
+  const envVarName = LLM_PROVIDER_ENV_VAR_NAMES[provider];
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const existing = await readGatewayApiKey(
+    options.gatewayUrl,
+    provider,
+    options.bearerToken,
+    fetchImpl,
+  );
+  if (existing.unreachable) {
+    return {
+      status: "failed",
+      provider,
+      message:
+        "Assistant credential store is unavailable. Try again after the assistant finishes starting.",
+    };
+  }
+  if (existing.found) {
+    return {
+      status: "already_configured",
+      provider,
+    };
+  }
+
+  const envValue = options.env?.[envVarName]?.trim();
+  let apiKey = envValue;
+  let source: ProviderApiKeySource = "env";
+
+  if (!apiKey) {
+    source = "prompt";
+    if (options.prompt) {
+      apiKey = (
+        await options.prompt(
+          `Enter your ${providerName} API key (${envVarName}): `,
+        )
+      ).trim();
+    } else {
+      const stdinIsTTY = options.stdinIsTTY ?? process.stdin.isTTY;
+      if (!stdinIsTTY) {
+        return {
+          status: "missing",
+          provider,
+          message: `Missing ${envVarName}. Set it in the environment or run vellum setup from an interactive terminal.`,
+        };
+      }
+      apiKey = (
+        await promptSecret(
+          `Enter your ${providerName} API key (${envVarName}): `,
+          {
+            input: options.input,
+            output: options.output,
+          },
+        )
+      ).trim();
+    }
+  }
+
+  if (!apiKey) {
+    return {
+      status: "missing",
+      provider,
+      message: "API key cannot be empty.",
+    };
+  }
+
+  await injectGatewayApiKey(
+    options.gatewayUrl,
+    provider,
+    apiKey,
+    options.bearerToken,
+    fetchImpl,
+  );
+
+  return {
+    status: "configured",
+    provider,
+    source,
+  };
+}


### PR DESCRIPTION
## Summary
- move `vellum setup` provider-key handling behind a reusable provider secret helper
- use the assistant gateway `api_key` secret namespace instead of writing `ANTHROPIC_API_KEY` as a generic credential
- default setup to Anthropic, support `--provider`, check existing keys first, read matching env vars, and prompt without echoing secrets
- add focused tests for provider secret requests and setup command routing

## Why
`vellum setup` was validating Anthropic directly from the CLI and then storing the key with the wrong gateway secret shape. The assistant already owns provider validation and storage through `/v1/secrets`, so the CLI should delegate to that endpoint and avoid handling provider-specific validation itself.

## Validation
- `bun test src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts`
- `bunx tsc --noEmit`
- `bun run lint src/lib/provider-secrets.ts src/commands/setup.ts src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts`
- `bunx prettier --check src/lib/provider-secrets.ts src/commands/setup.ts src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts`