### PR TITLE
Mark surface action user messages as automated

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1242,6 +1242,7 @@ export async function processMessage(
   currentPage?: string,
   options?: { isInteractive?: boolean; callSite?: LLMCallSite },
   displayContent?: string,
+  metadata?: Record<string, unknown>,
 ): Promise<string> {
   await conversation.ensureActorScopedHistory();
   // Snapshot persona context at turn start so later tool turns can't pick up
@@ -1573,7 +1574,7 @@ export async function processMessage(
       resolvedContent,
       attachments,
       requestId,
-      undefined,
+      metadata,
       displayContent,
     );
     publishConversationMessagesChanged(conversation.conversationId);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -506,6 +506,7 @@ export interface SurfaceConversationContext {
     currentPage?: string,
     options?: { isInteractive?: boolean },
     displayContent?: string,
+    metadata?: Record<string, unknown>,
   ): Promise<string>;
   /** Serialize operations on a given surface to prevent read-modify-write races. */
   withSurface<T>(surfaceId: string, fn: () => T | Promise<T>): Promise<T>;
@@ -1436,6 +1437,7 @@ export async function handleSurfaceAction(
         undefined,
         undefined,
         displayContent,
+        { automated: true },
       )
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -1714,6 +1716,7 @@ export async function handleSurfaceAction(
       undefined,
       undefined,
       displayContent,
+      { automated: true },
     )
     .catch((err) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1626,7 +1626,7 @@ export async function handleSurfaceAction(
     requestId,
     surfaceId,
     undefined,
-    undefined,
+    { automated: true },
     undefined,
     displayContent,
   );

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1326,6 +1326,7 @@ export class Conversation {
     currentPage?: string,
     options?: { isInteractive?: boolean; callSite?: LLMCallSite },
     displayContent?: string,
+    metadata?: Record<string, unknown>,
   ): Promise<string> {
     this.cacheWarmAbort?.abort();
     this.cacheWarmAbort = undefined;
@@ -1339,6 +1340,7 @@ export class Conversation {
       currentPage,
       options,
       displayContent,
+      metadata,
     );
   }
 


### PR DESCRIPTION
## Summary
- Pass `{ automated: true }` in metadata when `enqueueMessage` is called for non-relay surface actions in `conversation-surfaces.ts`.
- This marks the daemon-persisted user message so clients can filter it from the chat transcript — the inline completion indicator on the surface is sufficient visual feedback.

## Companion PR
**`vellum-assistant-platform`**: [PR #6821](https://github.com/vellum-ai/vellum-assistant-platform/pull/6821) — filters messages with `metadata.automated === true` from the web transcript.

## Merge order
1. Merge this PR first (marks messages as automated)
2. Then merge the platform PR (filters them from the transcript)

Merging the platform PR first is also safe — the filter is a no-op until this change starts setting `automated: true`.

## Test plan
- [x] `bun test src/__tests__/conversation-surfaces-action-delivery.test.ts` — all 7 tests pass
- [x] Pre-push hook passes (typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->