### PR TITLE
[codex] Skip empty Anthropic system cache blocks

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -223,6 +223,22 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(system[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
+  test("omits empty dynamic system block after cache boundary", async () => {
+    const staticBlock = "You are a helpful assistant.";
+    const prompt = staticBlock + SYSTEM_PROMPT_CACHE_BOUNDARY;
+
+    await provider.sendMessage([userMsg("Hi")], undefined, prompt);
+
+    const system = lastStreamParams!.system as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    expect(system).toHaveLength(1);
+    expect(system[0].text).toBe(staticBlock);
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
   test("drops static system block cache_control when total would exceed 4", async () => {
     const staticBlock = "You are a helpful assistant.";
     const dynamicBlock = "User workspace files here.";

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1007,18 +1007,16 @@ export class AnthropicProvider implements Provider {
           const dynamicBlock = systemPrompt.slice(
             boundaryIdx + SYSTEM_PROMPT_CACHE_BOUNDARY.length,
           );
-          params.system = [
-            {
+          const systemBlocks = [staticBlock, dynamicBlock]
+            .filter((text) => text.length > 0)
+            .map((text) => ({
               type: "text" as const,
-              text: staticBlock,
+              text,
               cache_control: cacheControl,
-            },
-            {
-              type: "text" as const,
-              text: dynamicBlock,
-              cache_control: cacheControl,
-            },
-          ];
+            }));
+          if (systemBlocks.length > 0) {
+            params.system = systemBlocks;
+          }
         } else {
           params.system = [
             {


### PR DESCRIPTION
## Summary
- omit empty system prompt split blocks before applying Anthropic cache_control
- preserve the existing two-block cache behavior when both static and dynamic system prompt content exist
- add regression coverage for a boundary-delimited prompt with an empty dynamic section

## Context
The google-email-management desktop QA run in playwright-desktop-results-1 (13) got past fixture setup and completed Gmail OAuth successfully, then failed on the inbox turn before any Gmail tool work could happen. Anthropic rejected the request twice with:

```text
system.1: cache_control cannot be set for empty text blocks
```

The root cause is that buildSystemPrompt() can produce:

```text
staticPrompt + SYSTEM_PROMPT_CACHE_BOUNDARY + ""
```

when there is no dynamic workspace or integration content. The Anthropic adapter split that into two cached text blocks and attached cache_control to the empty second block, which Anthropic rejects. This PR makes the adapter skip empty split blocks so the outbound payload remains valid.

## Validation
- `bun test src/__tests__/anthropic-provider.test.ts --grep "empty dynamic system block|splits system prompt"`
- `bunx tsc --noEmit`
- `bun test src/__tests__/anthropic-provider.test.ts`
- `bun run lint`
- `git diff --check`

Note: the pre-push hook also reran assistant typecheck and changed-file lint successfully. It printed a non-fatal shell compatibility warning in a later package-scan section but exited 0 and pushed the branch.
