### PR TITLE
fix(providers): throw ProviderNotConfiguredError instead of raw Error on null provider resolution

### DIFF
--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -1,6 +1,8 @@
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { loadConfig } from "../config/loader.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import { resolveDefaultProvider } from "../providers/connection-resolution.js";
+import { listProviders } from "../providers/registry.js";
 import type { Provider } from "../providers/types.js";
 import {
   APPROVAL_COPY_MAX_TOKENS,
@@ -16,6 +18,7 @@ import type {
   ApprovalConversationResult,
   ApprovalCopyGenerator,
 } from "../runtime/http-types.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 
 // ---------------------------------------------------------------------------
 // Approval conversation generator constants
@@ -142,14 +145,13 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     // Connection-aware default + per-call routing. `resolveDefaultProvider`
     // throws `ConnectionResolutionError` on hard config errors (missing /
     // unknown / mismatched connection) and returns null on soft credential
-    // failures (vault miss, transient auth) — we treat null as "no
-    // provider available" and throw a domain-specific error below. We do
-    // not pre-gate on `listProviders()` because the default provider lives
-    // behind a `provider_connection` and never appears in the registry's
-    // initialization-time provider list.
+    // failures (missing credential, platform auth unavailable).
     const baseProvider = await resolveDefaultProvider(config);
     if (!baseProvider) {
-      throw new Error("No provider available for approval conversation");
+      const resolved = resolveCallSiteConfig("mainAgent", config.llm);
+      throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
+        connectionName: resolved.provider_connection,
+      });
     }
     const provider = wrapWithCallSiteRouting(baseProvider, config);
 

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -21,7 +21,9 @@ import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import { resolveDefaultProvider } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
+import { listProviders } from "../providers/registry.js";
 import { getSubagentManager } from "../subagent/index.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import { Conversation } from "./conversation.js";
 import type { ConversationEvictor } from "./conversation-evictor.js";
@@ -226,12 +228,17 @@ export async function getOrCreateConversation(
       // Connection-aware default-provider resolution. Throws
       // `ConnectionResolutionError` when the default profile's
       // `provider_connection` is unset / unknown / mismatched (config
-      // bugs). Returns null on soft credential failures (handled below
-      // as "default provider not registered").
+      // bugs). Returns null on soft credential failures (missing
+      // credential, platform auth unavailable).
       const baseProvider = await resolveDefaultProvider(config);
       if (!baseProvider) {
-        throw new Error(
-          `Conversation: default provider '${resolveCallSiteConfig("mainAgent", config.llm).provider}' is not registered`,
+        const resolved = resolveCallSiteConfig("mainAgent", config.llm);
+        throw new ProviderNotConfiguredError(
+          resolved.provider,
+          listProviders(),
+          {
+            connectionName: resolved.provider_connection,
+          },
         );
       }
       // Per-call `callSite` routing layered on top, with connection-awareness

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -110,6 +110,13 @@ export async function tryResolveProviderForConnectionName(
       `provider_connection "${connectionName}" has provider="${connection.provider}" but resolving profile declared provider="${expectedProvider}" — set the profile's provider_connection to a row matching its provider`,
     );
   }
+  if (connection.status === "disabled") {
+    log.debug(
+      { connectionName },
+      "provider_connection is disabled — returning null",
+    );
+    return null;
+  }
   // `resolveProviderFromConnection` reaches into auth resolution (credential
   // reads, managed-proxy context). A transient failure there is a soft
   // miss — log and return null so the caller can treat it the same as

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -19,7 +19,9 @@ import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
 import { resolveDefaultProvider } from "../providers/connection-resolution.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
+import { listProviders } from "../providers/registry.js";
 import { createAbortReason } from "../util/abort-reasons.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
@@ -186,14 +188,14 @@ export class SubagentManager {
     // Connection-aware default-provider resolution. Throws
     // `ConnectionResolutionError` if `llm.default.provider_connection` is
     // unset or the connection row is missing/mismatched (config bugs).
-    // Returns null on soft credential failures (vault miss, transient
-    // auth) — handled below as "no provider available". Per-call
-    // `callSite` routing is layered next.
+    // Returns null on soft credential failures (missing credential,
+    // platform auth unavailable).
     const baseProvider = await resolveDefaultProvider(appConfig);
     if (!baseProvider) {
-      throw new Error(
-        `Subagent: default provider '${resolveCallSiteConfig("mainAgent", appConfig.llm).provider}' is not registered`,
-      );
+      const resolved = resolveCallSiteConfig("mainAgent", appConfig.llm);
+      throw new ProviderNotConfiguredError(resolved.provider, listProviders(), {
+        connectionName: resolved.provider_connection,
+      });
     }
     // Per-call `options.config.callSite` (e.g. `subagentSpawn`) can resolve
     // to a profile that differs from `llm.default`. The shared wrapper


### PR DESCRIPTION
Closes #30714
Part of JARVIS-765

## Prompt / plan

Sentry audit of 0.8.1 revealed [BRAIN-EJ](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-BRAIN-EJ) (166 events, 13 unique production devices) — satellite callers throwing a generic `Error` when `resolveDefaultProvider()` returns null, bypassing the existing error classification pipeline.

## Changes

### 1. Replace raw `Error` with `ProviderNotConfiguredError` in three satellite callers

**`conversation-store.ts`**, **`subagent/manager.ts`**, and **`approval-generators.ts`** all threw `new Error("...default provider 'anthropic' is not registered")` when `resolveDefaultProvider()` returned null. This bypassed the classification pipeline in `conversation-error.ts` which specifically checks `instanceof ProviderNotConfiguredError` and provides actionable user-facing messages ("API key required for connection X"). Users saw a generic unhelpful error instead of guidance.

Now they throw `ProviderNotConfiguredError` with `connectionName` attribution, so the macOS chat banner renders the correct actionable message.

### 2. Early `connection.status === "disabled"` check in `tryResolveProviderForConnectionName`

A disabled connection (e.g. managed connections on BYOK installs, flipped by `disableManagedConnectionsForByokHatch`) was still going through auth resolution, which failed with a confusing transient-failure log. Now it short-circuits to `null` immediately with a `debug`-level log.

## Root cause analysis

1. **How did the code get into this state?** PR #30217 removed the legacy `getProvider(name)` fallback and made `resolveDefaultProvider()` return `null` on soft credential failures. The satellite callers were updated to handle null, but they threw raw `Error` instead of `ProviderNotConfiguredError`. The error type mismatch was not caught because the test mocks supply a working provider.

2. **What decisions led to it?** The satellite callers were updated in a single refactoring PR that focused on the resolution architecture. The error classification pipeline (which checks `instanceof ProviderNotConfiguredError`) was in a different file and the mismatch between the thrown type and the expected type wasn't flagged.

3. **Warning signs missed?** The `conversation-error.ts` pipeline explicitly checks for `ProviderNotConfiguredError` — any caller that throws a different error type for the same condition will bypass classification. This coupling is implicit and easy to miss.

4. **Prevention:** When throwing errors in provider resolution paths, always use `ProviderNotConfiguredError` (not raw `Error`) so the existing classification pipeline can provide actionable messages.

5. **AGENTS.md update:** Not warranted — this is a specific error-type mismatch, not a general pattern. The error-handling docs already cover the convention.

## Alternatives NOT taken

- **Retry with backoff:** Initial investigation considered retry, but Sentry data showed the same devices failing repeatedly over days (19 events from one device). The failures are permanent per-device (missing credentials, platform auth unavailable), not transient I/O blips. Retry would add latency before the same failure.

- **Propagating auth failure reason through the chain:** Changing `tryResolveProviderForConnectionName`'s return type from `Provider | null` to a result object with error codes would give more precise error messages ("Platform auth unavailable" vs "Credential not found") but touches 8+ callers. The existing `ProviderNotConfiguredError` + `classifyConversationError` pipeline already handles the distinction via `getProviderRoutingSource()` (managed vs user-key), so the benefit is marginal vs the blast radius.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- All 523 affected tests run via pre-push hook — 3 pre-existing failures (compaction benchmark, inference-no-mode-boot-e2e, provider-commit-message-generator) confirmed identical on main
- `dispatch-connection-routing.test.ts` — 4/4 pass
- `inference-no-mode-boot-e2e.test.ts` — all connection-resolution tests pass (the 1 failure is pre-existing on main)

Link to Devin session: https://app.devin.ai/sessions/056fc283f36e4364868105d8eeb64d8c
Requested by: @ashleeradka