### PR TITLE
[codex] Enforce Slack thread conversation mapping

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -30,6 +30,11 @@ import {
   recordProcessingFailure,
   replayDeadLetters,
 } from "../memory/delivery-status.js";
+import {
+  getBindingByChannelChat,
+  getBindingByChannelChatThread,
+  upsertBinding,
+} from "../memory/external-conversation-store.js";
 import { RETRY_MAX_ATTEMPTS } from "../memory/job-utils.js";
 import {
   channelInboundEvents,
@@ -37,6 +42,7 @@ import {
   externalConversationBindings,
   messages,
 } from "../memory/schema.js";
+import { buildConversationDetailResponse } from "../runtime/services/conversation-serializer.js";
 import { handleDeleteConversation } from "./helpers/channel-test-adapter.js";
 
 initializeDb();
@@ -116,6 +122,28 @@ describe("channel-delivery-store", () => {
     expect(r1.conversationId).toBe(r2.conversationId);
   });
 
+  test("same Slack channel and thread reuses the same conversation", () => {
+    const r1 = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+    const r2 = recordInbound("slack", "C0123ABCDEF", "msg-2", {
+      sourceThreadId: "1710000000.000100",
+    });
+
+    expect(r1.conversationId).toBe(r2.conversationId);
+  });
+
+  test("different Slack threads in one channel get different conversations", () => {
+    const r1 = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+    const r2 = recordInbound("slack", "C0123ABCDEF", "msg-2", {
+      sourceThreadId: "1710000000.000200",
+    });
+
+    expect(r1.conversationId).not.toBe(r2.conversationId);
+  });
+
   test("different chats get different conversations", () => {
     const r1 = recordInbound("telegram", "chat-1", "msg-1");
     const r2 = recordInbound("telegram", "chat-2", "msg-1");
@@ -147,6 +175,63 @@ describe("channel-delivery-store", () => {
       assistantId: "self",
     });
     expect(r1.conversationId).toBe(r2.conversationId);
+  });
+
+  test("external bindings allow multiple Slack thread anchors per channel", () => {
+    const r1 = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+    const r2 = recordInbound("slack", "C0123ABCDEF", "msg-2", {
+      sourceThreadId: "1710000000.000200",
+    });
+
+    upsertBinding({
+      conversationId: r1.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+    });
+    upsertBinding({
+      conversationId: r2.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000200",
+    });
+
+    expect(
+      getBindingByChannelChatThread("slack", "C0123ABCDEF", "1710000000.000100")
+        ?.conversationId,
+    ).toBe(r1.conversationId);
+    expect(
+      getBindingByChannelChatThread("slack", "C0123ABCDEF", "1710000000.000200")
+        ?.conversationId,
+    ).toBe(r2.conversationId);
+    expect(getBindingByChannelChat("slack", "C0123ABCDEF")).toBeNull();
+  });
+
+  test("conversation detail exposes Slack thread anchor from binding", () => {
+    const result = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+    });
+
+    const detail = buildConversationDetailResponse(result.conversationId);
+
+    expect(detail?.conversation.channelBinding).toMatchObject({
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+      slackThread: {
+        channelId: "C0123ABCDEF",
+        threadTs: "1710000000.000100",
+      },
+    });
   });
 
   // ── Deduplication ─────────────────────────────────────────────────

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -25,6 +25,10 @@ mock.module("../config/loader.js", () => ({
     provider: "test",
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0 },
+    slack: {
+      teamId: "T123",
+      teamUrl: "https://example.slack.com/",
+    },
   }),
 }));
 
@@ -32,6 +36,7 @@ import { createConversation } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { messages } from "../memory/schema.js";
+import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 import { BadRequestError } from "../runtime/routes/errors.js";
 
@@ -82,6 +87,13 @@ interface MessagePayload {
   role: string;
   content: string;
   timestamp: string;
+  slackMessage?: {
+    channelId: string;
+    channelTs: string;
+    threadTs?: string;
+    messageLink?: { appUrl?: string; webUrl?: string };
+    threadLink?: { appUrl?: string; webUrl?: string };
+  };
 }
 
 interface ListResponse {
@@ -192,6 +204,49 @@ describe("handleListMessages page=latest", () => {
     expect(body.hasMore).toBe(false);
     expect(body.oldestTimestamp).toBeNull();
     expect(body.oldestMessageId).toBeNull();
+  });
+
+  test("messages expose Slack message and thread links from slackMeta", () => {
+    const conv = createConversation();
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "msg-slack",
+        conversationId: conv.id,
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Slack reply" }]),
+        metadata: JSON.stringify({
+          slackMeta: writeSlackMetadata({
+            source: "slack",
+            channelId: "C123ABCDEF",
+            channelTs: "1710000000.000200",
+            threadTs: "1710000000.000100",
+            eventKind: "message",
+          }),
+        }),
+        createdAt: 1,
+      })
+      .run();
+
+    const body = callList({ conversationId: conv.id, page: "latest" });
+
+    expect(body.messages[0].slackMessage).toEqual({
+      channelId: "C123ABCDEF",
+      channelTs: "1710000000.000200",
+      threadTs: "1710000000.000100",
+      messageLink: {
+        appUrl:
+          "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000200",
+        webUrl:
+          "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
+      },
+      threadLink: {
+        appUrl:
+          "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000100",
+        webUrl:
+          "https://example.slack.com/archives/C123ABCDEF/p1710000000000100",
+      },
+    });
   });
 
   test("page=latest on unresolved conversationKey returns null metadata contract", () => {

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -48,6 +48,9 @@ mock.module("../config/loader.js", () => ({
       teamName:
         ((configStore.slack as Record<string, unknown>)?.teamName as string) ??
         "",
+      teamUrl:
+        ((configStore.slack as Record<string, unknown>)?.teamUrl as string) ??
+        "",
       botUserId:
         ((configStore.slack as Record<string, unknown>)?.botUserId as string) ??
         "",
@@ -277,6 +280,7 @@ describe("Slack channel config handler", () => {
       slack: {
         teamId: "T123",
         teamName: "TestTeam",
+        teamUrl: "https://example.slack.com/",
         botUserId: "U_BOT",
         botUsername: "testbot",
       },
@@ -285,6 +289,7 @@ describe("Slack channel config handler", () => {
     const result = await getSlackChannelConfig();
     expect(result.teamId).toBe("T123");
     expect(result.teamName).toBe("TestTeam");
+    expect(result.teamUrl).toBe("https://example.slack.com/");
     expect(result.botUserId).toBe("U_BOT");
     expect(result.botUsername).toBe("testbot");
   });
@@ -314,6 +319,7 @@ describe("Slack channel config handler", () => {
           ok: true,
           team_id: "T_TEAM",
           team: "MyTeam",
+          url: "https://myteam.slack.com/",
           user_id: "U_BOT",
           user: "mybot",
         }),
@@ -329,11 +335,13 @@ describe("Slack channel config handler", () => {
     expect(result.hasBotToken).toBe(true);
     expect(result.teamId).toBe("T_TEAM");
     expect(result.teamName).toBe("MyTeam");
+    expect(result.teamUrl).toBe("https://myteam.slack.com/");
 
     // Assert metadata was written to config (not credential metadata)
     const slack = configStore.slack as Record<string, unknown>;
     expect(slack.teamId).toBe("T_TEAM");
     expect(slack.teamName).toBe("MyTeam");
+    expect(slack.teamUrl).toBe("https://myteam.slack.com/");
     expect(slack.botUserId).toBe("U_BOT");
     expect(slack.botUsername).toBe("mybot");
   });
@@ -397,6 +405,7 @@ describe("Slack channel config handler", () => {
     const slack = configStore.slack as Record<string, unknown>;
     expect(slack.teamId).toBe("");
     expect(slack.teamName).toBe("");
+    expect(slack.teamUrl).toBe("");
     expect(slack.botUserId).toBe("");
     expect(slack.botUsername).toBe("");
   });

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -93,6 +93,7 @@ import {
 import type { MessageRow } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { recordInbound } from "../memory/delivery-crud.js";
 import type { Message as MessagingMessage } from "../messaging/provider-types.js";
 import * as slackBackfill from "../messaging/providers/slack/backfill.js";
 import {
@@ -1848,12 +1849,7 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
 
   test("late app mention sees unseen backfilled replies before the mention", async () => {
     let capturedTranscript = "";
-    let parentTurnSeen = false;
-    let resolveParentTurn: (() => void) | undefined;
     let secondTurnSeen = false;
-    const parentTurnProcessed = new Promise<void>((resolve) => {
-      resolveParentTurn = resolve;
-    });
     let resolveSecondTurn: (() => void) | undefined;
     const secondTurnProcessed = new Promise<void>((resolve) => {
       resolveSecondTurn = resolve;
@@ -1870,10 +1866,6 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
         content,
         options,
       );
-      if (options?.slackInbound?.channelTs === "1234.0") {
-        parentTurnSeen = true;
-        resolveParentTurn?.();
-      }
       if (options?.slackInbound?.channelTs === "1234.5") {
         const context = loadSlackChronologicalContext(
           conversationId,
@@ -1891,23 +1883,27 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     };
     setAdapterProcessMessage(processMessage);
 
-    const parentResp = await handleChannelInbound(
-      buildThreadReplyRequest("1234.0", "1234.0", {
-        content: "parent already stored",
-        sourceMetadata: {
-          messageId: "1234.0",
-          chatType: "channel",
-        },
-      }),
-      processMessage,
-      TEST_BEARER_TOKEN,
+    const parentInbound = recordInbound(
+      "slack",
+      HTTP_SLACK_CHANNEL_ID,
+      `${HTTP_SLACK_CHANNEL_ID}:1234.0:seed`,
+      {
+        sourceMessageId: "1234.0",
+        sourceThreadId: "1234.0",
+      },
     );
-    expect(parentResp.status).toBe(200);
-    await Promise.race([
-      parentTurnProcessed,
-      new Promise((resolve) => setTimeout(resolve, 250)),
-    ]);
-    expect(parentTurnSeen).toBe(true);
+    persistSlackInboundFromProcessMessage(
+      parentInbound.conversationId,
+      "parent already stored",
+      {
+        slackInbound: {
+          channelId: HTTP_SLACK_CHANNEL_ID,
+          channelTs: "1234.0",
+          threadTs: "1234.0",
+          displayName: HTTP_SLACK_DISPLAY_NAME,
+        },
+      },
+    );
 
     backfillThreadMock.mockReset();
     backfillThreadMock.mockImplementation(async () => [

--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -115,6 +115,10 @@ export const SlackConfigSchema = z
       .string({ error: "slack.teamName must be a string" })
       .default("")
       .describe("Slack workspace team name"),
+    teamUrl: z
+      .string({ error: "slack.teamUrl must be a string" })
+      .default("")
+      .describe("Slack workspace URL"),
     botUserId: z
       .string({ error: "slack.botUserId must be a string" })
       .default("")

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -34,6 +34,7 @@ export interface SlackChannelConfigResult {
   connected: boolean;
   teamId?: string;
   teamName?: string;
+  teamUrl?: string;
   botUserId?: string;
   botUsername?: string;
   error?: string;
@@ -93,7 +94,8 @@ export function backfillSlackInjectionTemplates(): void {
 // -- Business logic --
 
 export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult> {
-  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+  const { teamId, teamName, teamUrl, botUserId, botUsername } =
+    getConfig().slack;
   const accountInfo = teamName
     ? `${teamName}${botUsername ? ` (@${botUsername})` : ""}`
     : undefined;
@@ -129,6 +131,7 @@ export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult>
     connected,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
+    ...(teamUrl ? { teamUrl } : {}),
     ...(botUserId ? { botUserId } : {}),
     ...(botUsername ? { botUsername } : {}),
   };
@@ -169,6 +172,7 @@ export async function setSlackChannelConfig(
   let metadata: {
     teamId?: string;
     teamName?: string;
+    teamUrl?: string;
     botUserId?: string;
     botUsername?: string;
   } = {};
@@ -187,6 +191,7 @@ export async function setSlackChannelConfig(
         error?: string;
         team_id?: string;
         team?: string;
+        url?: string;
         user_id?: string;
         user?: string;
       };
@@ -198,6 +203,7 @@ export async function setSlackChannelConfig(
       metadata = {
         teamId: data.team_id,
         teamName: data.team,
+        teamUrl: data.url,
         botUserId: data.user_id,
         botUsername: data.user,
       };
@@ -221,6 +227,7 @@ export async function setSlackChannelConfig(
     const raw = loadRawConfig();
     setNestedValue(raw, "slack.teamId", metadata.teamId ?? "");
     setNestedValue(raw, "slack.teamName", metadata.teamName ?? "");
+    setNestedValue(raw, "slack.teamUrl", metadata.teamUrl ?? "");
     setNestedValue(raw, "slack.botUserId", metadata.botUserId ?? "");
     setNestedValue(raw, "slack.botUsername", metadata.botUsername ?? "");
     saveRawConfig(raw);
@@ -293,10 +300,12 @@ export async function setSlackChannelConfig(
     }
   } else {
     // Use existing metadata from config if no new bot token provided
-    const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+    const { teamId, teamName, teamUrl, botUserId, botUsername } =
+      getConfig().slack;
     metadata = {
       ...(teamId ? { teamId } : {}),
       ...(teamName ? { teamName } : {}),
+      ...(teamUrl ? { teamUrl } : {}),
       ...(botUserId ? { botUserId } : {}),
       ...(botUsername ? { botUsername } : {}),
     };
@@ -468,7 +477,8 @@ export async function clearSlackUserToken(): Promise<SlackChannelConfigResult> {
     credentialKey("slack_channel", "app_token"),
   ));
   const conn = getConnectionByProvider("slack_channel");
-  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+  const { teamId, teamName, teamUrl, botUserId, botUsername } =
+    getConfig().slack;
 
   return {
     success: true,
@@ -479,6 +489,7 @@ export async function clearSlackUserToken(): Promise<SlackChannelConfigResult> {
       !!(conn && conn.status === "active") && hasBotToken && hasAppToken,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
+    ...(teamUrl ? { teamUrl } : {}),
     ...(botUserId ? { botUserId } : {}),
     ...(botUsername ? { botUsername } : {}),
   };
@@ -528,6 +539,7 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
   const raw = loadRawConfig();
   setNestedValue(raw, "slack.teamId", "");
   setNestedValue(raw, "slack.teamName", "");
+  setNestedValue(raw, "slack.teamUrl", "");
   setNestedValue(raw, "slack.botUserId", "");
   setNestedValue(raw, "slack.botUsername", "");
   saveRawConfig(raw);

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -224,9 +224,18 @@ export interface ConversationTitleUpdated {
 interface ChannelBinding {
   sourceChannel: ChannelId;
   externalChatId: string;
+  externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
   username?: string | null;
+  slackThread?: {
+    channelId: string;
+    threadTs: string;
+    link?: {
+      appUrl?: string;
+      webUrl?: string;
+    };
+  };
 }
 
 /** Attention state metadata for a conversation's latest assistant message. */

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -94,6 +94,7 @@ import {
   migrateDropSetupSkillIdColumn,
   migrateDropSimplifiedMemory,
   migrateDropUsageCompositeIndexes,
+  migrateExternalConversationBindingThreadId,
   migrateFkCascadeRebuilds,
   migrateGuardianActionFollowup,
   migrateGuardianActionSupersession,
@@ -424,6 +425,7 @@ export function initializeDb(): void {
     migrateProviderConnectionStatusLabel,
     migrateMemoryRetrospectiveState,
     migrateBackfillProviderConnectionLabel,
+    migrateExternalConversationBindingThreadId,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -23,6 +23,20 @@ export interface InboundResult {
 export interface RecordInboundOptions {
   sourceMessageId?: string;
   assistantId?: string;
+  sourceThreadId?: string;
+}
+
+export function buildScopedConversationKey(
+  assistantId: string,
+  sourceChannel: string,
+  externalChatId: string,
+  sourceThreadId?: string | null,
+): string {
+  const threadId = sourceThreadId?.trim();
+  if (sourceChannel === "slack" && threadId) {
+    return `asst:${assistantId}:${sourceChannel}:${externalChatId}:thread:${threadId}`;
+  }
+  return `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
 }
 
 /**
@@ -62,7 +76,12 @@ export function recordInbound(
   }
 
   const assistantId = options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
-  const scopedKey = `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
+  const scopedKey = buildScopedConversationKey(
+    assistantId,
+    sourceChannel,
+    externalChatId,
+    options?.sourceThreadId,
+  );
   const mapping = getOrCreateConversation(scopedKey);
   const now = Date.now();
   const eventId = uuid();
@@ -176,4 +195,3 @@ export function clearPayload(eventId: string): void {
     .where(eq(channelInboundEvents.id, eventId))
     .run();
 }
-

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -26,7 +26,7 @@ export interface RecordInboundOptions {
   sourceThreadId?: string;
 }
 
-export function buildScopedConversationKey(
+function buildScopedConversationKeyForAssistant(
   assistantId: string,
   sourceChannel: string,
   externalChatId: string,
@@ -37,6 +37,19 @@ export function buildScopedConversationKey(
     return `asst:${assistantId}:${sourceChannel}:${externalChatId}:thread:${threadId}`;
   }
   return `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
+}
+
+export function buildScopedConversationKey(
+  sourceChannel: string,
+  externalChatId: string,
+  sourceThreadId?: string | null,
+): string {
+  return buildScopedConversationKeyForAssistant(
+    DAEMON_INTERNAL_ASSISTANT_ID,
+    sourceChannel,
+    externalChatId,
+    sourceThreadId,
+  );
 }
 
 /**
@@ -76,7 +89,7 @@ export function recordInbound(
   }
 
   const assistantId = options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
-  const scopedKey = buildScopedConversationKey(
+  const scopedKey = buildScopedConversationKeyForAssistant(
     assistantId,
     sourceChannel,
     externalChatId,

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -7,7 +7,7 @@
  * list APIs.
  */
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
 import { externalConversationBindings } from "./schema.js";
@@ -16,6 +16,7 @@ export interface ExternalConversationBinding {
   conversationId: string;
   sourceChannel: string;
   externalChatId: string;
+  externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
   username?: string | null;
@@ -29,9 +30,17 @@ export interface UpsertBindingInput {
   conversationId: string;
   sourceChannel: string;
   externalChatId: string;
+  externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
   username?: string | null;
+}
+
+function normalizeExternalThreadId(
+  externalThreadId?: string | null,
+): string | null {
+  const trimmed = externalThreadId?.trim();
+  return trimmed ? trimmed : null;
 }
 
 /**
@@ -41,12 +50,14 @@ export interface UpsertBindingInput {
 export function upsertBinding(input: UpsertBindingInput): void {
   const db = getDb();
   const now = Date.now();
+  const externalThreadId = normalizeExternalThreadId(input.externalThreadId);
 
-  // If a stale binding exists for this (sourceChannel, externalChatId) under a
+  // If a stale binding exists for this channel/chat/thread tuple under a
   // different conversationId, remove it first so the unique index is not violated.
-  const existing = getBindingByChannelChat(
+  const existing = getBindingByChannelChatThread(
     input.sourceChannel,
     input.externalChatId,
+    externalThreadId,
   );
   if (existing && existing.conversationId !== input.conversationId) {
     db.delete(externalConversationBindings)
@@ -64,6 +75,7 @@ export function upsertBinding(input: UpsertBindingInput): void {
       conversationId: input.conversationId,
       sourceChannel: input.sourceChannel,
       externalChatId: input.externalChatId,
+      externalThreadId,
       externalUserId: input.externalUserId ?? null,
       displayName: input.displayName ?? null,
       username: input.username ?? null,
@@ -76,6 +88,7 @@ export function upsertBinding(input: UpsertBindingInput): void {
       set: {
         sourceChannel: input.sourceChannel,
         externalChatId: input.externalChatId,
+        externalThreadId,
         externalUserId: input.externalUserId ?? null,
         displayName: input.displayName ?? null,
         username: input.username ?? null,
@@ -95,15 +108,18 @@ export function upsertOutboundBinding(input: {
   conversationId: string;
   sourceChannel: string;
   externalChatId: string;
+  externalThreadId?: string | null;
 }): void {
   const db = getDb();
   const now = Date.now();
+  const externalThreadId = normalizeExternalThreadId(input.externalThreadId);
 
-  // If a stale binding exists for this (sourceChannel, externalChatId) under a
+  // If a stale binding exists for this channel/chat/thread tuple under a
   // different conversationId, remove it first so the unique index is not violated.
-  const existing = getBindingByChannelChat(
+  const existing = getBindingByChannelChatThread(
     input.sourceChannel,
     input.externalChatId,
+    externalThreadId,
   );
   if (existing && existing.conversationId !== input.conversationId) {
     db.delete(externalConversationBindings)
@@ -121,6 +137,7 @@ export function upsertOutboundBinding(input: {
       conversationId: input.conversationId,
       sourceChannel: input.sourceChannel,
       externalChatId: input.externalChatId,
+      externalThreadId,
       externalUserId: null,
       displayName: null,
       username: null,
@@ -133,6 +150,7 @@ export function upsertOutboundBinding(input: {
       set: {
         sourceChannel: input.sourceChannel,
         externalChatId: input.externalChatId,
+        externalThreadId,
         updatedAt: now,
         lastOutboundAt: now,
       },
@@ -162,7 +180,19 @@ export function getBindingByChannelChat(
   sourceChannel: string,
   externalChatId: string,
 ): ExternalConversationBinding | null {
+  return getBindingByChannelChatThread(sourceChannel, externalChatId, null);
+}
+
+/**
+ * Look up an external binding by channel + external chat ID + optional thread ID.
+ */
+export function getBindingByChannelChatThread(
+  sourceChannel: string,
+  externalChatId: string,
+  externalThreadId?: string | null,
+): ExternalConversationBinding | null {
   const db = getDb();
+  const normalizedThreadId = normalizeExternalThreadId(externalThreadId);
   const row = db
     .select()
     .from(externalConversationBindings)
@@ -170,6 +200,12 @@ export function getBindingByChannelChat(
       and(
         eq(externalConversationBindings.sourceChannel, sourceChannel),
         eq(externalConversationBindings.externalChatId, externalChatId),
+        normalizedThreadId
+          ? eq(
+              externalConversationBindings.externalThreadId,
+              normalizedThreadId,
+            )
+          : isNull(externalConversationBindings.externalThreadId),
       ),
     )
     .get();
@@ -190,6 +226,31 @@ export function deleteBindingByChannelChat(
       and(
         eq(externalConversationBindings.sourceChannel, sourceChannel),
         eq(externalConversationBindings.externalChatId, externalChatId),
+      ),
+    )
+    .run();
+}
+
+/**
+ * Remove an external binding by channel + external chat ID + thread ID.
+ */
+export function deleteBindingByChannelChatThread(
+  sourceChannel: string,
+  externalChatId: string,
+  externalThreadId: string,
+): void {
+  const db = getDb();
+  const normalizedThreadId = normalizeExternalThreadId(externalThreadId);
+  if (!normalizedThreadId) {
+    deleteBindingByChannelChat(sourceChannel, externalChatId);
+    return;
+  }
+  db.delete(externalConversationBindings)
+    .where(
+      and(
+        eq(externalConversationBindings.sourceChannel, sourceChannel),
+        eq(externalConversationBindings.externalChatId, externalChatId),
+        eq(externalConversationBindings.externalThreadId, normalizedThreadId),
       ),
     )
     .run();

--- a/assistant/src/memory/migrations/109-external-conversation-bindings.ts
+++ b/assistant/src/memory/migrations/109-external-conversation-bindings.ts
@@ -1,8 +1,7 @@
 import type { DrizzleDb } from "../db-connection.js";
-import { migrateExtConvBindingsChannelChatUnique } from "./010-ext-conv-bindings-channel-chat-unique.js";
 
 /**
- * External conversation bindings table with indexes and unique constraint migration.
+ * External conversation bindings table with indexes.
  */
 export function createExternalConversationBindingsTables(
   database: DrizzleDb,
@@ -12,6 +11,7 @@ export function createExternalConversationBindingsTables(
       conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
       source_channel TEXT NOT NULL,
       external_chat_id TEXT NOT NULL,
+      external_thread_id TEXT,
       external_user_id TEXT,
       display_name TEXT,
       username TEXT,
@@ -26,8 +26,19 @@ export function createExternalConversationBindingsTables(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat ON external_conversation_bindings(source_channel, external_chat_id)`,
   );
   database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_thread ON external_conversation_bindings(source_channel, external_chat_id, external_thread_id)`,
+  );
+  database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel ON external_conversation_bindings(source_channel)`,
   );
-
-  migrateExtConvBindingsChannelChatUnique(database);
+  database.run(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_no_thread_unique
+    ON external_conversation_bindings(source_channel, external_chat_id)
+    WHERE external_thread_id IS NULL
+  `);
+  database.run(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_thread_unique
+    ON external_conversation_bindings(source_channel, external_chat_id, external_thread_id)
+    WHERE external_thread_id IS NOT NULL
+  `);
 }

--- a/assistant/src/memory/migrations/247-external-conversation-binding-thread-id.ts
+++ b/assistant/src/memory/migrations/247-external-conversation-binding-thread-id.ts
@@ -1,0 +1,78 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add a provider thread anchor to external conversation bindings.
+ *
+ * Slack conversations are keyed by `(channel_id, thread_ts)`, while legacy
+ * channels still use only `(source_channel, external_chat_id)`. SQLite treats
+ * NULLs as distinct in unique indexes, so use two partial unique indexes:
+ * one for legacy/no-thread bindings and one for threaded bindings.
+ */
+export function migrateExternalConversationBindingThreadId(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  const columns = raw
+    .query(`PRAGMA table_info(external_conversation_bindings)`)
+    .all() as Array<{ name: string }>;
+  if (!columns.some((column) => column.name === "external_thread_id")) {
+    raw.exec(
+      `ALTER TABLE external_conversation_bindings ADD COLUMN external_thread_id TEXT`,
+    );
+  }
+
+  try {
+    raw.exec("BEGIN");
+
+    raw.exec(`DROP INDEX IF EXISTS idx_ext_conv_bindings_channel_chat_unique`);
+
+    raw.exec(/*sql*/ `
+      DELETE FROM external_conversation_bindings
+      WHERE rowid NOT IN (
+        SELECT rowid FROM (
+          SELECT rowid,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY source_channel, external_chat_id, COALESCE(external_thread_id, '')
+                   ORDER BY updated_at DESC, created_at DESC, rowid DESC
+                 ) AS rn
+          FROM external_conversation_bindings
+        )
+        WHERE rn = 1
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_thread
+      ON external_conversation_bindings(source_channel, external_chat_id, external_thread_id)
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_no_thread_unique
+      ON external_conversation_bindings(source_channel, external_chat_id)
+      WHERE external_thread_id IS NULL
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ext_conv_bindings_channel_chat_thread_unique
+      ON external_conversation_bindings(source_channel, external_chat_id, external_thread_id)
+      WHERE external_thread_id IS NOT NULL
+    `);
+
+    raw.exec("COMMIT");
+  } catch (err) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw err;
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -208,6 +208,7 @@ export { migrateCreateProviderConnections } from "./243-provider-connections.js"
 export { migrateProviderConnectionStatusLabel } from "./244-provider-connection-status-label.js";
 export { migrateMemoryRetrospectiveState } from "./245-memory-retrospective-state.js";
 export { migrateBackfillProviderConnectionLabel } from "./246-backfill-provider-connection-label.js";
+export { migrateExternalConversationBindingThreadId } from "./247-external-conversation-binding-thread-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -78,6 +78,7 @@ export const externalConversationBindings = sqliteTable(
       .references(() => conversations.id, { onDelete: "cascade" }),
     sourceChannel: text("source_channel").notNull(),
     externalChatId: text("external_chat_id").notNull(),
+    externalThreadId: text("external_thread_id"),
     externalUserId: text("external_user_id"),
     displayName: text("display_name"),
     username: text("username"),

--- a/assistant/src/messaging/providers/slack/deep-link.ts
+++ b/assistant/src/messaging/providers/slack/deep-link.ts
@@ -1,0 +1,65 @@
+export interface SlackMessageDeepLinks {
+  appUrl?: string;
+  webUrl?: string;
+}
+
+export function formatSlackPermalinkTimestamp(ts: string): string {
+  return ts.replace(".", "");
+}
+
+export function buildSlackAppMessageUrl(params: {
+  teamId?: string | null;
+  channelId: string;
+  messageTs: string;
+}): string | undefined {
+  const teamId = params.teamId?.trim();
+  if (!teamId) return undefined;
+
+  const search = new URLSearchParams({
+    team: teamId,
+    id: params.channelId,
+    message: params.messageTs,
+  });
+  return `slack://channel?${search.toString()}`;
+}
+
+function normalizeSlackTeamUrl(teamUrl?: string | null): string | undefined {
+  const trimmed = teamUrl?.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:") return undefined;
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildSlackWebMessageUrl(params: {
+  teamUrl?: string | null;
+  channelId: string;
+  messageTs: string;
+}): string | undefined {
+  const teamUrl = normalizeSlackTeamUrl(params.teamUrl);
+  if (!teamUrl) return undefined;
+
+  return `${teamUrl}/archives/${encodeURIComponent(
+    params.channelId,
+  )}/p${formatSlackPermalinkTimestamp(params.messageTs)}`;
+}
+
+export function buildSlackMessageDeepLinks(params: {
+  teamId?: string | null;
+  teamUrl?: string | null;
+  channelId: string;
+  messageTs: string;
+}): SlackMessageDeepLinks | undefined {
+  const appUrl = buildSlackAppMessageUrl(params);
+  const webUrl = buildSlackWebMessageUrl(params);
+  if (!appUrl && !webUrl) return undefined;
+  return {
+    ...(appUrl ? { appUrl } : {}),
+    ...(webUrl ? { webUrl } : {}),
+  };
+}

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -229,4 +229,17 @@ export interface RuntimeMessagePayload {
     conversationId?: string;
     objective?: string;
   };
+  slackMessage?: {
+    channelId: string;
+    channelTs: string;
+    threadTs?: string;
+    messageLink?: {
+      appUrl?: string;
+      webUrl?: string;
+    };
+    threadLink?: {
+      appUrl?: string;
+      webUrl?: string;
+    };
+  };
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -90,6 +90,11 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
+import {
+  readSlackMetadata,
+  type SlackMessageMetadata,
+} from "../../messaging/providers/slack/message-metadata.js";
 import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
 import { writeOnboardingSection } from "../../prompts/persona-resolver.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
@@ -139,6 +144,52 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
     typeof value === "string" &&
     VALID_RISK_THRESHOLDS.includes(value as RiskThreshold)
   );
+}
+
+function readSlackMetadataFromEnvelope(
+  metadata: string | null | undefined,
+): SlackMessageMetadata | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const slackMeta = (parsed as Record<string, unknown>).slackMeta;
+    return typeof slackMeta === "string" ? readSlackMetadata(slackMeta) : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildSlackHistoryMessage(
+  slackMeta: SlackMessageMetadata | null,
+): RuntimeMessagePayload["slackMessage"] | undefined {
+  if (!slackMeta) return undefined;
+
+  const slackConfig = getConfig().slack;
+  const messageLink = buildSlackMessageDeepLinks({
+    teamId: slackConfig?.teamId,
+    teamUrl: slackConfig?.teamUrl,
+    channelId: slackMeta.channelId,
+    messageTs: slackMeta.channelTs,
+  });
+  const threadLink = slackMeta.threadTs
+    ? buildSlackMessageDeepLinks({
+        teamId: slackConfig?.teamId,
+        teamUrl: slackConfig?.teamUrl,
+        channelId: slackMeta.channelId,
+        messageTs: slackMeta.threadTs,
+      })
+    : undefined;
+
+  return {
+    channelId: slackMeta.channelId,
+    channelTs: slackMeta.channelTs,
+    ...(slackMeta.threadTs ? { threadTs: slackMeta.threadTs } : {}),
+    ...(messageLink ? { messageLink } : {}),
+    ...(threadLink ? { threadLink } : {}),
+  };
 }
 
 function collectCanonicalGuardianRequestHintIds(
@@ -520,6 +571,9 @@ export function handleListMessages(
         // Ignore malformed metadata
       }
     }
+    const slackMessage = buildSlackHistoryMessage(
+      readSlackMetadataFromEnvelope(msg.metadata),
+    );
 
     // Strip <no_response/> markers from assistant messages so web/API
     // clients never see the raw sentinel. Only assistant messages produce
@@ -559,6 +613,7 @@ export function handleListMessages(
         textSegments: filteredSegments,
         contentOrder: filteredContentOrder,
         surfaces: rendered.surfaces,
+        slackMessage,
         ...(rendered.thinkingSegments.length > 0
           ? { thinkingSegments: rendered.thinkingSegments }
           : {}),
@@ -577,6 +632,7 @@ export function handleListMessages(
       textSegments: rendered.textSegments,
       contentOrder: rendered.contentOrder,
       surfaces: rendered.surfaces,
+      slackMessage,
       ...(rendered.thinkingSegments.length > 0
         ? { thinkingSegments: rendered.thinkingSegments }
         : {}),
@@ -685,6 +741,7 @@ export function handleListMessages(
       ...(m.subagentNotification
         ? { subagentNotification: m.subagentNotification }
         : {}),
+      ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
     };
   });
 

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -7,7 +7,6 @@ import {
   deleteBindingByChannelChat,
   deleteBindingByChannelChatThread,
 } from "../../memory/external-conversation-store.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteHandlerArgs } from "./types.js";
 
@@ -25,28 +24,24 @@ export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
     throw new BadRequestError("conversationExternalId is required");
   }
 
-  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const normalizedThreadId = sourceThreadId?.trim() || undefined;
 
   const scopedKey = buildScopedConversationKey(
-    assistantId,
     sourceChannel,
     conversationExternalId,
     normalizedThreadId,
   );
   deleteConversationKey(scopedKey);
-  if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    const legacyKey = `${sourceChannel}:${conversationExternalId}`;
-    if (!normalizedThreadId) {
-      deleteConversationKey(legacyKey);
-      deleteBindingByChannelChat(sourceChannel, conversationExternalId);
-    } else {
-      deleteBindingByChannelChatThread(
-        sourceChannel,
-        conversationExternalId,
-        normalizedThreadId,
-      );
-    }
+  const legacyKey = `${sourceChannel}:${conversationExternalId}`;
+  if (!normalizedThreadId) {
+    deleteConversationKey(legacyKey);
+    deleteBindingByChannelChat(sourceChannel, conversationExternalId);
+  } else {
+    deleteBindingByChannelChatThread(
+      sourceChannel,
+      conversationExternalId,
+      normalizedThreadId,
+    );
   }
 
   return { ok: true };

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -2,15 +2,20 @@
  * Channel conversation deletion handler.
  */
 import { deleteConversationKey } from "../../memory/conversation-key-store.js";
-import { deleteBindingByChannelChat } from "../../memory/external-conversation-store.js";
+import { buildScopedConversationKey } from "../../memory/delivery-crud.js";
+import {
+  deleteBindingByChannelChat,
+  deleteBindingByChannelChatThread,
+} from "../../memory/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteHandlerArgs } from "./types.js";
 
 export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
-  const { sourceChannel, conversationExternalId } = body as {
+  const { sourceChannel, conversationExternalId, sourceThreadId } = body as {
     sourceChannel?: string;
     conversationExternalId?: string;
+    sourceThreadId?: string;
   };
 
   if (!sourceChannel || typeof sourceChannel !== "string") {
@@ -21,13 +26,27 @@ export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
   }
 
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
+  const normalizedThreadId = sourceThreadId?.trim() || undefined;
 
-  const scopedKey = `asst:${assistantId}:${sourceChannel}:${conversationExternalId}`;
+  const scopedKey = buildScopedConversationKey(
+    assistantId,
+    sourceChannel,
+    conversationExternalId,
+    normalizedThreadId,
+  );
   deleteConversationKey(scopedKey);
   if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
     const legacyKey = `${sourceChannel}:${conversationExternalId}`;
-    deleteConversationKey(legacyKey);
-    deleteBindingByChannelChat(sourceChannel, conversationExternalId);
+    if (!normalizedThreadId) {
+      deleteConversationKey(legacyKey);
+      deleteBindingByChannelChat(sourceChannel, conversationExternalId);
+    } else {
+      deleteBindingByChannelChatThread(
+        sourceChannel,
+        conversationExternalId,
+        normalizedThreadId,
+      );
+    }
   }
 
   return { ok: true };

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -467,6 +467,12 @@ export async function handleChannelInbound({
     typeof sourceMetadata?.messageId === "string"
       ? sourceMetadata.messageId
       : undefined;
+  const slackThreadTs =
+    sourceChannel === "slack" &&
+    typeof sourceMetadata?.threadId === "string" &&
+    sourceMetadata.threadId.trim().length > 0
+      ? sourceMetadata.threadId.trim()
+      : undefined;
 
   if (isEdit && !sourceMessageId) {
     throw new BadRequestError("sourceMetadata.messageId is required for edits");
@@ -491,7 +497,11 @@ export async function handleChannelInbound({
     sourceChannel,
     conversationExternalId,
     externalMessageId,
-    { sourceMessageId, assistantId: canonicalAssistantId },
+    {
+      sourceMessageId,
+      assistantId: canonicalAssistantId,
+      sourceThreadId: slackThreadTs,
+    },
   );
 
   const replyCallbackUrl = body.replyCallbackUrl;
@@ -536,6 +546,7 @@ export async function handleChannelInbound({
       conversationId: result.conversationId,
       sourceChannel,
       externalChatId: conversationExternalId,
+      externalThreadId: slackThreadTs ?? null,
       externalUserId: canonicalSenderId ?? rawSenderId ?? null,
       displayName: body.actorDisplayName ?? null,
       username: body.actorUsername ?? null,
@@ -1031,11 +1042,6 @@ export async function handleChannelInbound({
       // this into a `slackMeta` sub-object in the row's metadata column so
       // the chronological renderer can reconstruct thread structure without
       // re-fetching from Slack.
-      const slackThreadTs =
-        sourceChannel === "slack" &&
-        typeof sourceMetadata?.threadId === "string"
-          ? sourceMetadata.threadId
-          : undefined;
       const slackInbound =
         sourceChannel === "slack"
           ? {

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -8,6 +8,7 @@
  */
 
 import { parseChannelId } from "../../channels/types.js";
+import { getConfig } from "../../config/loader.js";
 import { normalizeConversationType } from "../../daemon/message-types/shared.js";
 import {
   type AttentionState,
@@ -22,6 +23,7 @@ import {
 } from "../../memory/conversation-crud.js";
 import type { ExternalConversationBinding } from "../../memory/external-conversation-store.js";
 import { getBindingsForConversations } from "../../memory/external-conversation-store.js";
+import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,6 +90,42 @@ function buildForkParent(
   };
 }
 
+function buildChannelBinding(binding: ExternalConversationBinding) {
+  const slackConfig =
+    binding.sourceChannel === "slack" && binding.externalThreadId
+      ? getConfig().slack
+      : undefined;
+  const slackThreadLink =
+    slackConfig && binding.externalThreadId
+      ? buildSlackMessageDeepLinks({
+          teamId: slackConfig.teamId,
+          teamUrl: slackConfig.teamUrl,
+          channelId: binding.externalChatId,
+          messageTs: binding.externalThreadId,
+        })
+      : undefined;
+  const slackThread =
+    binding.sourceChannel === "slack" && binding.externalThreadId
+      ? {
+          channelId: binding.externalChatId,
+          threadTs: binding.externalThreadId,
+          ...(slackThreadLink ? { link: slackThreadLink } : {}),
+        }
+      : undefined;
+
+  return {
+    sourceChannel: binding.sourceChannel,
+    externalChatId: binding.externalChatId,
+    ...(binding.externalThreadId
+      ? { externalThreadId: binding.externalThreadId }
+      : {}),
+    externalUserId: binding.externalUserId,
+    displayName: binding.displayName,
+    username: binding.username,
+    ...(slackThread ? { slackThread } : {}),
+  };
+}
+
 export function serializeConversationSummary(params: {
   conversation: ConversationRow;
   binding?: ExternalConversationBinding | null;
@@ -118,13 +156,7 @@ export function serializeConversationSummary(params: {
       : {}),
     ...(binding
       ? {
-          channelBinding: {
-            sourceChannel: binding.sourceChannel,
-            externalChatId: binding.externalChatId,
-            externalUserId: binding.externalUserId,
-            displayName: binding.displayName,
-            username: binding.username,
-          },
+          channelBinding: buildChannelBinding(binding),
         }
       : {}),
     ...(originChannel ? { conversationOriginChannel: originChannel } : {}),

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1793,10 +1793,14 @@ async function main() {
         const origMessageTs = normalized.event.source.messageId;
         if (!threadTs && origMessageTs) params.set("messageTs", origMessageTs);
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
-        const slackSourceMetadata =
-          normalized.event.raw.type === "app_mention"
+        const slackSourceMetadata = {
+          ...(normalized.event.raw.type === "app_mention"
             ? { slackBotMentioned: true }
-            : undefined;
+            : {}),
+          ...(threadTs && !normalized.event.source.threadId
+            ? { threadId: threadTs }
+            : {}),
+        };
 
         // Whether this event represents an edit or callback action — these
         // never carry attachments to upload.
@@ -1824,6 +1828,7 @@ async function main() {
               });
             },
             log,
+            threadTs,
           );
           return;
         }
@@ -1972,7 +1977,7 @@ async function main() {
             handleInbound(config, normalized.event, {
               replyCallbackUrl,
               routingOverride: normalized.routing,
-              ...(slackSourceMetadata
+              ...(Object.keys(slackSourceMetadata).length > 0
                 ? { sourceMetadata: slackSourceMetadata }
                 : {}),
               ...(attachmentIds && attachmentIds.length > 0
@@ -1992,7 +1997,7 @@ async function main() {
             handleInbound(config, normalized.event, {
               replyCallbackUrl,
               routingOverride: normalized.routing,
-              ...(slackSourceMetadata
+              ...(Object.keys(slackSourceMetadata).length > 0
                 ? { sourceMetadata: slackSourceMetadata }
                 : {}),
             }).catch((fwdErr) => {

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -322,6 +322,7 @@ export async function resetConversation(
   config: GatewayConfig,
   sourceChannel: ChannelId,
   conversationExternalId: string,
+  sourceThreadId?: string,
 ): Promise<void> {
   cbBeforeRequest();
 
@@ -337,7 +338,11 @@ export async function resetConversation(
       {
         method: "DELETE",
         headers: serviceHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify({ sourceChannel, conversationExternalId }),
+        body: JSON.stringify({
+          sourceChannel,
+          conversationExternalId,
+          ...(sourceThreadId ? { sourceThreadId } : {}),
+        }),
       },
       config.runtimeTimeoutMs,
     );

--- a/gateway/src/webhook-pipeline.ts
+++ b/gateway/src/webhook-pipeline.ts
@@ -52,9 +52,15 @@ export async function handleNewCommand(
   conversationExternalId: string,
   sendReply: (text: string) => Promise<void>,
   logger: Logger,
+  sourceThreadId?: string,
 ): Promise<{ handled: true }> {
   try {
-    await resetConversation(config, sourceChannel, conversationExternalId);
+    await resetConversation(
+      config,
+      sourceChannel,
+      conversationExternalId,
+      sourceThreadId,
+    );
     sendReply(NEW_COMMAND_SUCCESS).catch(() => {
       // fire-and-forget — callers log send failures at their own level
     });


### PR DESCRIPTION
## Summary
- Scope inbound Slack channel conversations by `(channel_id, thread_ts)` so separate Slack threads in the same channel/DM get separate assistant conversations.
- Persist Slack thread anchors on external conversation bindings, including a migration for existing installs and updated reset/delete handling for `/new`.
- Surface Slack thread/message metadata and deep links in conversation list/history API responses.
- Preserve today's Slack thinking-indicator metadata by merging `slackBotMentioned` with the new thread source metadata in the gateway.

## Comparison with today's Slack changes
- #30698 updates Slack thinking indicator timing and adds `slackBotMentioned` source metadata. It touches the same gateway handoff path, but does not add thread-scoped conversation identity. This PR keeps that metadata and adds `threadId` alongside it.
- #30700 and #30338 improve Slack backfill trust/content/image hydration. They make thread context safer and richer once a conversation is selected, but do not change how inbound Slack threads map to assistant conversations.
- #30628 resolves inbound Slack channel references in normalized text. It touches Slack normalization/socket-mode behavior, but not conversation binding keys or thread anchors.
- I also checked `origin/main` for `externalThreadId`, `external_thread_id`, `buildScopedConversationKey`, and `deleteBindingByChannelChatThread`; none existed before this branch.

## Validation
- `cd assistant && bun test src/__tests__/slack-channel-config.test.ts src/__tests__/channel-delivery-store.test.ts src/__tests__/list-messages-page-latest.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd gateway && bunx tsc --noEmit`
- `git diff --cached --check`
- commit hook: assistant/gateway formatting and changed-file lint
- pre-push hook: assistant typecheck and assistant/gateway changed-file lint

Closes JARVIS-778