### PR TITLE
feat(cli): add `assistant telemetry flush` command

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14980,6 +14980,39 @@ paths:
                   type: string
                   minLength: 1
               additionalProperties: false
+  /v1/telemetry/flush:
+    post:
+      operationId: telemetry_flush_post
+      summary: Flush pending telemetry events
+      description: Force-flush all pending usage, turn, and lifecycle telemetry events to the platform.
+      tags:
+        - telemetry
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      flushed:
+                        type: boolean
+                        const: true
+                    required:
+                      - flushed
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      flushed:
+                        type: boolean
+                        const: false
+                      reason:
+                        type: string
+                    required:
+                      - flushed
+                      - reason
+                    additionalProperties: false
   /v1/telemetry/lifecycle:
     post:
       operationId: telemetry_lifecycle_post

--- a/assistant/src/cli/commands/telemetry.ts
+++ b/assistant/src/cli/commands/telemetry.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { registerCommand } from "../lib/register-command.js";
+import { log } from "../logger.js";
+
+export function registerTelemetryCommand(program: Command): void {
+  registerCommand(program, {
+    name: "telemetry",
+    transport: "ipc",
+    description: "Manage telemetry reporting",
+    build: (telemetry) => {
+      telemetry
+        .command("flush")
+        .description(
+          "Force-flush all pending telemetry events to the platform",
+        )
+        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+          const r = await cliIpcCall<
+            { flushed: true } | { flushed: false; reason: string }
+          >("telemetry_flush", {});
+          if (!r.ok)
+            return exitFromIpcResult({
+              ok: false,
+              error: r.error,
+              statusCode: r.statusCode,
+            }, cmd);
+
+          const result = r.result!;
+          if (result.flushed) {
+            log.info("Telemetry flushed successfully.");
+          } else {
+            log.info(
+              `Telemetry flush skipped: ${result.reason}`,
+            );
+          }
+        });
+    },
+  });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -45,6 +45,7 @@ import { registerSkillsCommand } from "./commands/skills.js";
 import { registerStatusCommand } from "./commands/status.js";
 import { registerSttCommand } from "./commands/stt.js";
 import { registerTaskCommand } from "./commands/task.js";
+import { registerTelemetryCommand } from "./commands/telemetry.js";
 import { registerTrustCommand } from "./commands/trust.js";
 import { registerTtsCommand } from "./commands/tts.js";
 import { registerUiCommand } from "./commands/ui.js";
@@ -126,6 +127,7 @@ Examples:
   registerSkillsCommand(program);
   registerSttCommand(program);
   registerTaskCommand(program);
+  registerTelemetryCommand(program);
   registerTrustCommand(program);
   registerTtsCommand(program);
   registerUiCommand(program);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -75,7 +75,10 @@ import {
   setCesClient,
   setCesReconnect,
 } from "../security/secure-keys.js";
-import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
+import {
+  UsageTelemetryReporter,
+  setUsageTelemetryReporter,
+} from "../telemetry/usage-telemetry-reporter.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
@@ -567,6 +570,7 @@ export async function runDaemon(): Promise<void> {
     let telemetryReporter: UsageTelemetryReporter | null = null;
     if (collectUsageData) {
       telemetryReporter = new UsageTelemetryReporter();
+      setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
       log.info("Usage telemetry reporter started");
     }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -76,8 +76,8 @@ import {
   setCesReconnect,
 } from "../security/secure-keys.js";
 import {
-  UsageTelemetryReporter,
   setUsageTelemetryReporter,
+  UsageTelemetryReporter,
 } from "../telemetry/usage-telemetry-reporter.js";
 import { registerBuiltinTtsProviders } from "../tts/providers/register-builtins.js";
 import { getDeviceId } from "../util/device-id.js";

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 
 import { recordLifecycleEvent } from "../../memory/lifecycle-events-store.js";
+import { getUsageTelemetryReporter } from "../../telemetry/usage-telemetry-reporter.js";
 import { getLogger } from "../../util/logger.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -30,6 +31,15 @@ function handleRecordLifecycleEvent({ body }: RouteHandlerArgs) {
   log.info({ eventName, eventId: event.id }, "Recorded lifecycle event");
 
   return { id: event.id, event_name: event.eventName };
+}
+
+async function handleTelemetryFlush() {
+  const reporter = getUsageTelemetryReporter();
+  if (!reporter) {
+    return { flushed: false, reason: "disabled" };
+  }
+  await reporter.flush();
+  return { flushed: true };
 }
 
 export const ROUTES: RouteDefinition[] = [
@@ -57,5 +67,22 @@ export const ROUTES: RouteDefinition[] = [
       }),
     ]),
     handler: handleRecordLifecycleEvent,
+  },
+  {
+    operationId: "telemetry_flush",
+    endpoint: "telemetry/flush",
+    method: "POST",
+    summary: "Flush pending telemetry events",
+    description:
+      "Force-flush all pending usage, turn, and lifecycle telemetry events to the platform.",
+    tags: ["telemetry"],
+    responseBody: z.union([
+      z.object({ flushed: z.literal(true) }),
+      z.object({
+        flushed: z.literal(false),
+        reason: z.string(),
+      }),
+    ]),
+    handler: handleTelemetryFlush,
   },
 ];

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -49,6 +49,22 @@ const MAX_CONSECUTIVE_BATCHES = 10;
 const TELEMETRY_PATH = "/v1/telemetry/ingest/";
 
 // ---------------------------------------------------------------------------
+// Singleton access
+// ---------------------------------------------------------------------------
+
+let _instance: UsageTelemetryReporter | null = null;
+
+export function getUsageTelemetryReporter(): UsageTelemetryReporter | null {
+  return _instance;
+}
+
+export function setUsageTelemetryReporter(
+  reporter: UsageTelemetryReporter | null,
+): void {
+  _instance = reporter;
+}
+
+// ---------------------------------------------------------------------------
 // Reporter
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `assistant telemetry flush` CLI command to force-flush pending telemetry events to the platform
- Exposes the `UsageTelemetryReporter` singleton via `getUsageTelemetryReporter()` / `setUsageTelemetryReporter()` so the route layer can reach it
- Adds a `POST /v1/telemetry/flush` shared route that triggers the flush and returns success/disabled status

## Original prompt
The user wanted a way to force-flush the `UsageTelemetryReporter` on demand (rather than waiting for the periodic 5-minute interval). We discussed placing it under `assistant platform telemetry flush` vs top-level, and settled on `assistant telemetry flush` for cleaner command hierarchy.

## Test plan
- [ ] Run `assistant telemetry flush` with usage data collection enabled — should print "Telemetry flushed successfully."
- [ ] Run `assistant telemetry flush` with `collectUsageData: false` — should print "Telemetry flush skipped: disabled"
- [ ] Verify `assistant telemetry --help` shows the flush subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->