### PR TITLE
fix(gateway): register telemetry CLI commands in bash risk registry

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -344,6 +344,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Lifecycle telemetry
   { endpoint: "telemetry/lifecycle", scopes: ["settings.write"] },
+  { endpoint: "telemetry/flush", scopes: ["settings.write"] },
 
   // Debug / introspection
   { endpoint: "clients", scopes: ["settings.read"] },

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -220,6 +220,8 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "task queue update",
   "task queue remove",
   "task queue run",
+  "telemetry",
+  "telemetry flush",
   "trust",
   "trust list",
   "tts",


### PR DESCRIPTION
## Summary
- Adds `telemetry` and `telemetry flush` to `ASSISTANT_SUPPORTED_COMMAND_PATHS` in the gateway bash risk registry
- Follow-up from #30720 which added the `assistant telemetry flush` CLI command but missed the risk registry update

## Original prompt
PR #30720 added a new `assistant telemetry flush` CLI command but did not register it in the gateway's bash risk registry. A reviewer flagged that when the assistant invokes `assistant telemetry flush` through bash, the risk classifier would treat it as an unknown command and potentially trigger incorrect permission prompts. This follow-up adds the missing entries.

## Test plan
- [ ] Verify CI passes (the command registry has validation tests)
- [ ] `assistant telemetry flush` invoked through bash should not trigger unknown-command permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->