### PR TITLE
[codex] Preserve proven legacy Slack thread conversations

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -56,7 +56,11 @@ function resetTables() {
 }
 
 /** Insert a message row so FK constraints on channel_inbound_events.message_id pass. */
-function insertMessage(id: string, conversationId: string): void {
+function insertMessage(
+  id: string,
+  conversationId: string,
+  metadata?: Record<string, unknown>,
+): void {
   const db = getDb();
   db.insert(messages)
     .values({
@@ -65,6 +69,7 @@ function insertMessage(id: string, conversationId: string): void {
       role: "user",
       content: "test message",
       createdAt: Date.now(),
+      metadata: metadata ? JSON.stringify(metadata) : null,
     })
     .run();
 }
@@ -142,6 +147,103 @@ describe("channel-delivery-store", () => {
     });
 
     expect(r1.conversationId).not.toBe(r2.conversationId);
+  });
+
+  test("legacy Slack channel key with matching inbound root ts gets aliased to the threaded key", () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000100";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: threadTs,
+    });
+
+    const threaded = recordInbound("slack", channelId, "thread-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000001.000100",
+    });
+
+    expect(threaded.conversationId).toBe(legacy.conversationId);
+    expect(
+      getConversationByKey(`asst:self:slack:${channelId}:thread:${threadTs}`)
+        ?.conversationId,
+    ).toBe(legacy.conversationId);
+  });
+
+  test("legacy Slack channel key with matching slackMeta.threadTs evidence gets aliased to the threaded key", () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000200";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: "1710000000.999999",
+    });
+    insertMessage("legacy-thread-message", legacy.conversationId, {
+      slackMeta: JSON.stringify({
+        source: "slack",
+        channelId,
+        channelTs: "1710000001.000200",
+        threadTs,
+        eventKind: "message",
+      }),
+    });
+
+    const threaded = recordInbound("slack", channelId, "thread-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000002.000200",
+    });
+
+    expect(threaded.conversationId).toBe(legacy.conversationId);
+    expect(
+      getConversationByKey(`asst:self:slack:${channelId}:thread:${threadTs}`)
+        ?.conversationId,
+    ).toBe(legacy.conversationId);
+  });
+
+  test("legacy Slack channel key without evidence for the requested thread is not reused", () => {
+    const channelId = "C0123ABCDEF";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: "1710000000.000100",
+    });
+    insertMessage("legacy-other-thread-message", legacy.conversationId, {
+      slackMeta: JSON.stringify({
+        source: "slack",
+        channelId,
+        channelTs: "1710000001.000100",
+        threadTs: "1710000000.000100",
+        eventKind: "message",
+      }),
+    });
+
+    const threaded = recordInbound("slack", channelId, "new-thread-reply", {
+      sourceThreadId: "1710000000.000300",
+      sourceMessageId: "1710000001.000300",
+    });
+
+    expect(threaded.conversationId).not.toBe(legacy.conversationId);
+    expect(
+      getConversationByKey(
+        `asst:self:slack:${channelId}:thread:1710000000.000300`,
+      )?.conversationId,
+    ).toBe(threaded.conversationId);
+  });
+
+  test("aliasing a proven legacy Slack thread does not collapse different thread IDs", () => {
+    const channelId = "C0123ABCDEF";
+    const legacyThreadTs = "1710000000.000100";
+    const newThreadTs = "1710000000.000200";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: legacyThreadTs,
+    });
+
+    const aliased = recordInbound("slack", channelId, "legacy-thread-reply", {
+      sourceThreadId: legacyThreadTs,
+      sourceMessageId: "1710000001.000100",
+    });
+    const separate = recordInbound("slack", channelId, "new-thread-reply", {
+      sourceThreadId: newThreadTs,
+      sourceMessageId: "1710000001.000200",
+    });
+
+    expect(aliased.conversationId).toBe(legacy.conversationId);
+    expect(separate.conversationId).not.toBe(legacy.conversationId);
+    expect(separate.conversationId).not.toBe(aliased.conversationId);
   });
 
   test("different chats get different conversations", () => {

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -5,13 +5,17 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, isNotNull, like, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
-import { getOrCreateConversation } from "./conversation-key-store.js";
+import {
+  getConversationByKey,
+  getOrCreateConversation,
+  setConversationKeyIfAbsent,
+} from "./conversation-key-store.js";
 import { getDb } from "./db-connection.js";
-import { channelInboundEvents, conversations } from "./schema.js";
+import { channelInboundEvents, conversations, messages } from "./schema.js";
 
 export interface InboundResult {
   accepted: boolean;
@@ -52,6 +56,164 @@ export function buildScopedConversationKey(
   );
 }
 
+function readSlackMetadataEvidence(
+  raw: string | null,
+): { channelId: string; threadTs?: string } | null {
+  if (!raw) {
+    return null;
+  }
+
+  const candidates: string[] = [raw];
+  try {
+    const envelope: unknown = JSON.parse(raw);
+    if (
+      envelope !== null &&
+      typeof envelope === "object" &&
+      !Array.isArray(envelope)
+    ) {
+      const slackMeta = (envelope as { slackMeta?: unknown }).slackMeta;
+      if (typeof slackMeta === "string") {
+        candidates.unshift(slackMeta);
+      }
+    }
+  } catch {
+    // Fall through to parsing the raw value as a flat Slack metadata blob.
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed: unknown = JSON.parse(candidate);
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        Array.isArray(parsed)
+      ) {
+        continue;
+      }
+
+      const record = parsed as Record<string, unknown>;
+      const eventKind = record.eventKind;
+      if (
+        record.source !== "slack" ||
+        typeof record.channelId !== "string" ||
+        typeof record.channelTs !== "string" ||
+        (eventKind !== "message" && eventKind !== "reaction")
+      ) {
+        continue;
+      }
+
+      return {
+        channelId: record.channelId,
+        ...(typeof record.threadTs === "string"
+          ? { threadTs: record.threadTs }
+          : {}),
+      };
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+function legacySlackConversationHasThreadEvidence(
+  conversationId: string,
+  externalChatId: string,
+  sourceThreadId: string,
+): boolean {
+  const db = getDb();
+  const inboundEvidence = db
+    .select({ id: channelInboundEvents.id })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.conversationId, conversationId),
+        eq(channelInboundEvents.sourceChannel, "slack"),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        or(
+          eq(channelInboundEvents.sourceMessageId, sourceThreadId),
+          eq(channelInboundEvents.externalMessageId, sourceThreadId),
+        ),
+      ),
+    )
+    .get();
+
+  if (inboundEvidence) {
+    return true;
+  }
+
+  const metadataRows = db
+    .select({ metadata: messages.metadata })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        isNotNull(messages.metadata),
+        or(
+          like(messages.metadata, '%"slackMeta"%'),
+          like(messages.metadata, '%"source":"slack"%'),
+        ),
+      ),
+    )
+    .all();
+
+  return metadataRows.some((row) => {
+    const slackMeta = readSlackMetadataEvidence(row.metadata);
+    return (
+      slackMeta?.channelId === externalChatId &&
+      slackMeta.threadTs === sourceThreadId
+    );
+  });
+}
+
+function resolveInboundConversation(
+  assistantId: string,
+  sourceChannel: string,
+  externalChatId: string,
+  sourceThreadId?: string | null,
+): { conversationId: string } {
+  const threadedKey = buildScopedConversationKeyForAssistant(
+    assistantId,
+    sourceChannel,
+    externalChatId,
+    sourceThreadId,
+  );
+
+  const threadId = sourceThreadId?.trim();
+  if (sourceChannel !== "slack" || !threadId) {
+    return getOrCreateConversation(threadedKey);
+  }
+
+  const threadedMapping = getConversationByKey(threadedKey);
+  if (threadedMapping) {
+    return { conversationId: threadedMapping.conversationId };
+  }
+
+  const legacyKey = buildScopedConversationKeyForAssistant(
+    assistantId,
+    sourceChannel,
+    externalChatId,
+    null,
+  );
+  const legacyMapping = getConversationByKey(legacyKey);
+  if (
+    legacyMapping &&
+    legacySlackConversationHasThreadEvidence(
+      legacyMapping.conversationId,
+      externalChatId,
+      threadId,
+    )
+  ) {
+    setConversationKeyIfAbsent(threadedKey, legacyMapping.conversationId);
+    const aliasedMapping = getConversationByKey(threadedKey);
+    if (aliasedMapping) {
+      return { conversationId: aliasedMapping.conversationId };
+    }
+  }
+
+  return getOrCreateConversation(threadedKey);
+}
+
 /**
  * Record an inbound channel event. Returns `duplicate: true` if this
  * exact (channel, chat, message) combination was already seen.
@@ -89,13 +251,12 @@ export function recordInbound(
   }
 
   const assistantId = options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
-  const scopedKey = buildScopedConversationKeyForAssistant(
+  const mapping = resolveInboundConversation(
     assistantId,
     sourceChannel,
     externalChatId,
     options?.sourceThreadId,
   );
-  const mapping = getOrCreateConversation(scopedKey);
   const now = Date.now();
   const eventId = uuid();
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -344,6 +344,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Lifecycle telemetry
   { endpoint: "telemetry/lifecycle", scopes: ["settings.write"] },
+  { endpoint: "telemetry/flush", scopes: ["settings.write"] },
 
   // Debug / introspection
   { endpoint: "clients", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Add a Slack-only compatibility resolver that aliases threaded keys to a legacy channel conversation only when stored evidence proves that exact thread.
- Cover inbound-row evidence, persisted slackMeta evidence, no-evidence isolation, and distinct-thread behavior.

Closes #30725
Part of plan: legacy-slack-thread-fallback.md (PR 1 of 1)