### PR TITLE
fix(oauth): remove CLI command suggestions from OAuth error messages

### DIFF
--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -92,7 +92,7 @@ export async function resolveOAuthConnection(
       ? ` matching ${filters.join(" and ")}`
       : "";
     throw new Error(
-      `No active OAuth connection found for "${provider}"${qualifier}. Connect the service first with \`assistant oauth connect ${provider}\`.`,
+      `No active OAuth connection found for "${provider}"${qualifier}. The ${provider} service needs to be connected before it can be used.`,
     );
   }
 
@@ -102,7 +102,7 @@ export async function resolveOAuthConnection(
   });
   if (!tokenResult.value) {
     throw new Error(
-      `OAuth connection for "${provider}" exists but has no access token. Re-authorize with \`assistant oauth connect ${provider}\`.`,
+      `OAuth connection for "${provider}" exists but the access token is missing or expired. The ${provider} service needs to be reconnected.`,
     );
   }
 
@@ -223,9 +223,9 @@ async function resolvePlatformConnectionId(
 
   if (connections.length === 0) {
     throw new Error(
-      `No active platform OAuth connection found for provider "${provider}"` +
+      `No active OAuth connection found for provider "${provider}"` +
         (account ? ` with account "${account}"` : "") +
-        ". Connect the service on the Vellum platform first.",
+        `. The ${provider} service needs to be connected.`,
     );
   }
 

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -10,14 +10,18 @@ import type {
 const MAX_RETRIES = 3;
 
 export class CredentialRequiredError extends BackendError {
-  constructor(message = "Connection not set up on platform") {
+  constructor(
+    message = "OAuth credential for this provider has expired or been revoked. The service needs to be reconnected.",
+  ) {
     super(message);
     this.name = "CredentialRequiredError";
   }
 }
 
 export class ProviderUnreachableError extends BackendError {
-  constructor(message = "Provider is unreachable") {
+  constructor(
+    message = "The external service provider is temporarily unreachable. This may be a transient issue — retry after a brief pause.",
+  ) {
     super(message);
     this.name = "ProviderUnreachableError";
   }


### PR DESCRIPTION
## Summary
- Remove `assistant oauth connect` CLI command suggestions from `connection-resolver.ts` error messages — replaced with descriptive text ("The service needs to be connected/reconnected").
- Update `CredentialRequiredError` default message to describe the problem ("expired or revoked") instead of the vague "Connection not set up on platform".
- Update `ProviderUnreachableError` to suggest transient retry instead of implying a permanent failure.
- Root cause: LLMs follow the most proximate instruction. Error messages with CLI commands override the SKILL.md's correct recovery flow (load `vellum-oauth-integrations`), causing the assistant to tell web users to open a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->