### PR TITLE
Fix stale Velay heartbeat reconnect

### DIFF
--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -975,7 +975,7 @@ describe("VelayTunnelClient", () => {
     expect(sockets[0].sent).toEqual([
       JSON.stringify({ type: VELAY_FRAME_TYPES.heartbeat }),
     ]);
-    expect(delays).toEqual([100, 100]);
+    expect(delays).toEqual([100, 1000, 100]);
 
     await client.stop();
   });
@@ -1006,17 +1006,19 @@ describe("VelayTunnelClient", () => {
     await flushPromises();
     expect(delays).toEqual([100]);
 
+    callbacks[0]();
+    await flushPromises();
     sendFrame(sockets[0], { type: VELAY_FRAME_TYPES.heartbeat });
     await flushPromises();
-    expect(delays).toEqual([100, 1000]);
+    expect(delays).toEqual([100, 1000, 100, 1000]);
 
-    callbacks[1]();
+    callbacks[3]();
     await flushPromises();
 
     expect(sockets[0].closes).toEqual([
       { code: 1000, reason: "heartbeat read timeout" },
     ]);
-    expect(delays).toEqual([100, 1000, 10]);
+    expect(delays).toEqual([100, 1000, 100, 1000, 10]);
   });
 
   test("resets the read-timeout when an inbound frame arrives", async () => {
@@ -1045,20 +1047,24 @@ describe("VelayTunnelClient", () => {
     await flushPromises();
     expect(delays).toEqual([100]);
 
+    callbacks[0]();
+    await flushPromises();
+    expect(delays).toEqual([100, 1000, 100]);
+
     sendFrame(sockets[0], { type: VELAY_FRAME_TYPES.heartbeat });
     await flushPromises();
-    expect(delays).toEqual([100, 1000]);
+    expect(delays).toEqual([100, 1000, 100, 1000]);
 
     sendFrame(sockets[0], { type: VELAY_FRAME_TYPES.heartbeat });
     await flushPromises();
 
-    expect(delays).toEqual([100, 1000, 1000]);
+    expect(delays).toEqual([100, 1000, 100, 1000, 1000]);
     expect(sockets[0].closes).toEqual([]);
 
     await client.stop();
   });
 
-  test("does not start the read-timeout until the peer echoes a heartbeat", async () => {
+  test("starts the read-timeout after sending the first heartbeat", async () => {
     const sockets: FakeWebSocket[] = [];
     const delays: number[] = [];
     const callbacks: Array<() => void> = [];
@@ -1083,17 +1089,20 @@ describe("VelayTunnelClient", () => {
     sockets[0].emit("open");
     await flushPromises();
 
-    // Only the heartbeat send is scheduled; read-timeout stays gated.
+    // Only the heartbeat send is scheduled before the first beat is written.
     expect(delays).toEqual([100]);
 
     callbacks[0]();
     await flushPromises();
+    expect(delays).toEqual([100, 1000, 100]);
+    expect(sockets[0].closes).toEqual([]);
+
     callbacks[1]();
     await flushPromises();
 
-    expect(delays).toEqual([100, 100, 100]);
-    expect(sockets[0].closes).toEqual([]);
-
-    await client.stop();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "heartbeat read timeout" },
+    ]);
+    expect(delays).toEqual([100, 1000, 100, 10]);
   });
 });

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -289,7 +289,7 @@ export class VelayTunnelClient {
       this.peerHeartbeatConfirmed = true;
       log.info("Velay peer confirmed heartbeat support");
     }
-    if (this.peerHeartbeatConfirmed) {
+    if (this.peerHeartbeatConfirmed || this.readTimeoutTimer) {
       this.resetReadTimeout(originWs);
     }
 
@@ -422,10 +422,23 @@ export class VelayTunnelClient {
       });
   }
 
-  private sendFrame(frame: VelayFrame): void {
+  private sendFrame(frame: VelayFrame): boolean {
     const ws = this.ws;
-    if (!this.running || !ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify(frame));
+    if (!this.running || !ws || ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    try {
+      ws.send(JSON.stringify(frame));
+      return true;
+    } catch (err) {
+      log.warn(
+        { err },
+        "Velay tunnel WebSocket send failed; forcing reconnect",
+      );
+      this.disconnectActiveWebSocket(ws, 1000, "websocket send failed");
+      return false;
+    }
   }
 
   private startHeartbeat(ws: WebSocket): void {
@@ -454,7 +467,10 @@ export class VelayTunnelClient {
       if (this.ws !== ws || !this.running || ws.readyState !== WebSocket.OPEN) {
         return;
       }
-      this.sendFrame({ type: VELAY_FRAME_TYPES.heartbeat });
+      if (!this.sendFrame({ type: VELAY_FRAME_TYPES.heartbeat })) {
+        return;
+      }
+      this.resetReadTimeout(ws);
       this.scheduleHeartbeatSend(ws);
     }, this.heartbeatIntervalMs);
   }


### PR DESCRIPTION
## Summary
- arm the Velay heartbeat read timeout as soon as the gateway writes a heartbeat frame
- reset the timeout on any inbound Velay frame once heartbeat monitoring is armed
- force reconnect when WebSocket sends throw instead of leaving stale `OPEN` state behind

Closes #30729

## Test plan
- `cd gateway && bun test src/velay/client.test.ts`
- `cd gateway && bunx tsc --noEmit`

## Reviewer notes
This is intentionally client-side only: the platform Velay relay already echoes heartbeat frames. The risk area is version skew with very old relays that do not echo heartbeats; those clients will now reconnect instead of treating a non-responsive tunnel as healthy.