### PR TITLE
feat: emit onboarding telemetry events via existing flush pipeline

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -32,6 +32,7 @@ import {
   createMessagesFts,
   createNotificationTables,
   createOAuthTables,
+  createOnboardingEventsTable,
   createScopedApprovalGrantsTable,
   createSequenceTables,
   createTasksAndWorkItemsTables,
@@ -426,6 +427,7 @@ export function initializeDb(): void {
     migrateMemoryRetrospectiveState,
     migrateBackfillProviderConnectionLabel,
     migrateExternalConversationBindingThreadId,
+    createOnboardingEventsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/248-create-onboarding-events.ts
+++ b/assistant/src/memory/migrations/248-create-onboarding-events.ts
@@ -1,0 +1,21 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the onboarding_events table for tracking pre-chat onboarding
+ * selections (tools, tasks, tone, Google connect status).
+ */
+export function createOnboardingEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS onboarding_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      screen TEXT NOT NULL,
+      tools_json TEXT,
+      tasks_json TEXT,
+      tone TEXT,
+      google_connected INTEGER,
+      google_scopes_json TEXT,
+      ab_variant TEXT
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -209,6 +209,7 @@ export { migrateProviderConnectionStatusLabel } from "./244-provider-connection-
 export { migrateMemoryRetrospectiveState } from "./245-memory-retrospective-state.js";
 export { migrateBackfillProviderConnectionLabel } from "./246-backfill-provider-connection-label.js";
 export { migrateExternalConversationBindingThreadId } from "./247-external-conversation-binding-thread-id.js";
+export { createOnboardingEventsTable } from "./248-create-onboarding-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/onboarding-events-store.ts
+++ b/assistant/src/memory/onboarding-events-store.ts
@@ -1,0 +1,106 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getConfig } from "../config/loader.js";
+import { getDb } from "./db-connection.js";
+import { onboardingEvents } from "./schema.js";
+
+export interface OnboardingEvent {
+  id: string;
+  createdAt: number;
+  screen: string;
+  toolsJson: string | null;
+  tasksJson: string | null;
+  tone: string | null;
+  googleConnected: boolean | null;
+  googleScopesJson: string | null;
+  abVariant: string | null;
+}
+
+export interface RecordOnboardingEventParams {
+  screen: string;
+  tools?: string[];
+  tasks?: string[];
+  tone?: string;
+  googleConnected?: boolean;
+  googleScopes?: string[];
+  abVariant?: string;
+}
+
+/**
+ * Record an onboarding event (pre-chat selections and Google connect status).
+ * Returns null when usage data collection is disabled.
+ */
+export function recordOnboardingEvent(
+  params: RecordOnboardingEventParams,
+): OnboardingEvent | null {
+  if (!getConfig().collectUsageData) return null;
+  const db = getDb();
+  const event: OnboardingEvent = {
+    id: uuid(),
+    createdAt: Date.now(),
+    screen: params.screen,
+    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
+    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
+    tone: params.tone ?? null,
+    googleConnected: params.googleConnected ?? null,
+    googleScopesJson: params.googleScopes
+      ? JSON.stringify(params.googleScopes)
+      : null,
+    abVariant: params.abVariant ?? null,
+  };
+  db.insert(onboardingEvents)
+    .values({
+      id: event.id,
+      createdAt: event.createdAt,
+      screen: event.screen,
+      toolsJson: event.toolsJson,
+      tasksJson: event.tasksJson,
+      tone: event.tone,
+      googleConnected: event.googleConnected,
+      googleScopesJson: event.googleScopesJson,
+      abVariant: event.abVariant,
+    })
+    .run();
+  return event;
+}
+
+/**
+ * Query onboarding events that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedOnboardingEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): OnboardingEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: onboardingEvents.id,
+      createdAt: onboardingEvents.createdAt,
+      screen: onboardingEvents.screen,
+      toolsJson: onboardingEvents.toolsJson,
+      tasksJson: onboardingEvents.tasksJson,
+      tone: onboardingEvents.tone,
+      googleConnected: onboardingEvents.googleConnected,
+      googleScopesJson: onboardingEvents.googleScopesJson,
+      abVariant: onboardingEvents.abVariant,
+    })
+    .from(onboardingEvents)
+    .where(
+      afterId
+        ? or(
+            gt(onboardingEvents.createdAt, afterCreatedAt),
+            and(
+              eq(onboardingEvents.createdAt, afterCreatedAt),
+              gt(onboardingEvents.id, afterId),
+            ),
+          )
+        : gt(onboardingEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(onboardingEvents.createdAt), asc(onboardingEvents.id))
+    .limit(limit)
+    .all();
+  return rows;
+}

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -232,6 +232,18 @@ export const lifecycleEvents = sqliteTable("lifecycle_events", {
   createdAt: integer("created_at").notNull(),
 });
 
+export const onboardingEvents = sqliteTable("onboarding_events", {
+  id: text("id").primaryKey(),
+  createdAt: integer("created_at").notNull(),
+  screen: text("screen").notNull(),
+  toolsJson: text("tools_json"),
+  tasksJson: text("tasks_json"),
+  tone: text("tone"),
+  googleConnected: integer("google_connected", { mode: "boolean" }),
+  googleScopesJson: text("google_scopes_json"),
+  abVariant: text("ab_variant"),
+});
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1407,13 +1407,6 @@ export async function handleSendMessage(
     !!body.onboarding && conversation.messages.length === 0;
   if (isFirstOnboarding) {
     conversation.setOnboardingContext(body.onboarding!);
-    recordOnboardingEvent({
-      screen: "complete",
-      tools: body.onboarding!.tools,
-      tasks: body.onboarding!.tasks,
-      tone: body.onboarding!.tone,
-      googleConnected: body.onboarding!.googleConnected,
-    });
   }
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.
@@ -1576,6 +1569,17 @@ export async function handleSendMessage(
 
       if (isFirstOnboarding) {
         persistOnboardingArtifacts(body.onboarding!);
+        try {
+          recordOnboardingEvent({
+            screen: "complete",
+            tools: body.onboarding!.tools,
+            tasks: body.onboarding!.tasks,
+            tone: body.onboarding!.tone,
+            googleConnected: body.onboarding!.googleConnected,
+          });
+        } catch (err) {
+          log.warn({ err }, "Failed to record onboarding telemetry event");
+        }
       }
 
       setTimeout(() => {
@@ -1618,6 +1622,17 @@ export async function handleSendMessage(
 
   if (isFirstOnboarding) {
     persistOnboardingArtifacts(body.onboarding!);
+    try {
+      recordOnboardingEvent({
+        screen: "complete",
+        tools: body.onboarding!.tools,
+        tasks: body.onboarding!.tasks,
+        tone: body.onboarding!.tone,
+        googleConnected: body.onboarding!.googleConnected,
+      });
+    } catch (err) {
+      log.warn({ err }, "Failed to record onboarding telemetry event");
+    }
   }
 
   const attachments = hasAttachments

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -90,6 +90,7 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { recordOnboardingEvent } from "../../memory/onboarding-events-store.js";
 import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
 import {
   readSlackMetadata,
@@ -1181,6 +1182,7 @@ export async function handleSendMessage(
       tone: string;
       userName?: string;
       assistantName?: string;
+      googleConnected?: boolean;
     };
   };
 
@@ -1405,6 +1407,13 @@ export async function handleSendMessage(
     !!body.onboarding && conversation.messages.length === 0;
   if (isFirstOnboarding) {
     conversation.setOnboardingContext(body.onboarding!);
+    recordOnboardingEvent({
+      screen: "complete",
+      tools: body.onboarding!.tools,
+      tasks: body.onboarding!.tasks,
+      tone: body.onboarding!.tone,
+      googleConnected: body.onboarding!.googleConnected,
+    });
   }
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -44,8 +44,21 @@ export interface LifecycleTelemetryEvent extends TelemetryEventBase {
   event_name: string;
 }
 
+/** Onboarding event — pre-chat selections and Google connect status. */
+export interface OnboardingTelemetryEvent extends TelemetryEventBase {
+  type: "onboarding";
+  screen: string;
+  tools?: string[];
+  tasks?: string[];
+  tone?: string;
+  google_connected?: boolean;
+  google_scopes?: string[];
+  ab_variant?: string;
+}
+
 /** Discriminated union of all telemetry event types. */
 export type TelemetryEvent =
   | LlmUsageTelemetryEvent
   | TurnTelemetryEvent
-  | LifecycleTelemetryEvent;
+  | LifecycleTelemetryEvent
+  | OnboardingTelemetryEvent;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -95,6 +95,25 @@ mock.module("../memory/lifecycle-events-store.js", () => ({
   queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
 }));
 
+const mockQueryUnreportedOnboardingEvents = mock(
+  () =>
+    [] as {
+      id: string;
+      createdAt: number;
+      screen: string;
+      toolsJson: string | null;
+      tasksJson: string | null;
+      tone: string | null;
+      googleConnected: boolean | null;
+      googleScopesJson: string | null;
+      abVariant: string | null;
+    }[],
+);
+
+mock.module("../memory/onboarding-events-store.js", () => ({
+  queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
+}));
+
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
@@ -149,6 +168,8 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   mockQueryUnreportedLifecycleEvents.mockReset();
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
+  mockQueryUnreportedOnboardingEvents.mockReset();
+  mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -597,15 +618,16 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 3 timestamp watermarks should have been advanced (IDs left untouched
+    // All 4 timestamp watermarks should have been advanced (IDs left untouched
     // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(3);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(4);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     expect(keys).toContain("telemetry:usage:last_reported_at");
     expect(keys).toContain("telemetry:turns:last_reported_at");
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
+    expect(keys).toContain("telemetry:onboarding:last_reported_at");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -21,6 +21,7 @@ import {
 } from "../memory/checkpoints.js";
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
+import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -42,6 +43,10 @@ const CHECKPOINT_KEY_LIFECYCLE_WATERMARK =
   "telemetry:lifecycle:last_reported_at";
 const CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID =
   "telemetry:lifecycle:last_reported_id";
+const CHECKPOINT_KEY_ONBOARDING_WATERMARK =
+  "telemetry:onboarding:last_reported_at";
+const CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID =
+  "telemetry:onboarding:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -133,6 +138,7 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
         return;
       }
 
@@ -157,6 +163,14 @@ export class UsageTelemetryReporter {
       const lifecycleWatermarkId =
         getMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID) ?? undefined;
 
+      // Read onboarding watermark (compound cursor: createdAt + id)
+      const onboardingWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK) ?? "0",
+      );
+      const onboardingWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID) ??
+        undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -173,11 +187,17 @@ export class UsageTelemetryReporter {
         lifecycleWatermarkId,
         BATCH_SIZE,
       );
+      const onboardingEvents = queryUnreportedOnboardingEvents(
+        onboardingWatermark,
+        onboardingWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
         turnEvents.length === 0 &&
-        lifecycleEvents.length === 0
+        lifecycleEvents.length === 0 &&
+        onboardingEvents.length === 0
       )
         return;
 
@@ -190,6 +210,7 @@ export class UsageTelemetryReporter {
           usageCount: events.length,
           turnCount: turnEvents.length,
           lifecycleCount: lifecycleEvents.length,
+          onboardingCount: onboardingEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -228,6 +249,24 @@ export class UsageTelemetryReporter {
             daemon_event_id: e.id,
             event_name: e.eventName,
             recorded_at: e.createdAt,
+          }),
+        ),
+        ...onboardingEvents.map(
+          (e): TelemetryEvent => ({
+            type: "onboarding",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            screen: e.screen,
+            ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
+            ...(e.tasksJson ? { tasks: JSON.parse(e.tasksJson) } : {}),
+            ...(e.tone ? { tone: e.tone } : {}),
+            ...(e.googleConnected != null
+              ? { google_connected: e.googleConnected }
+              : {}),
+            ...(e.googleScopesJson
+              ? { google_scopes: JSON.parse(e.googleScopesJson) }
+              : {}),
+            ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
           }),
         ),
       ];
@@ -302,11 +341,25 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance onboarding watermark (compound cursor)
+      if (onboardingEvents.length > 0) {
+        const lastOnboarding = onboardingEvents[onboardingEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_ONBOARDING_WATERMARK,
+          String(lastOnboarding.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID,
+          lastOnboarding.id,
+        );
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
         turnEvents.length === BATCH_SIZE ||
-        lifecycleEvents.length === BATCH_SIZE
+        lifecycleEvents.length === BATCH_SIZE ||
+        onboardingEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }


### PR DESCRIPTION
## Summary

Closes #30730

- Adds `onboarding_events` SQLite table for recording pre-chat onboarding data (tools, tasks, tone, Google connect status)
- Creates `onboarding-events-store.ts` with `recordOnboardingEvent` / `queryUnreportedOnboardingEvents` following the `lifecycle-events-store` pattern
- Extends `UsageTelemetryReporter` to flush onboarding events to platform ingest endpoint with watermark-based pagination
- Records onboarding event at `screen: "complete"` when the first message arrives with onboarding context

Part of JARVIS-839 (new user retention funnel dashboard). Platform-side changes (Django serializer, dbt staging model, Terraform BigQuery table) are already deployed.

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Lint passes (`bun run lint`)
- [x] All 18 existing `usage-telemetry-reporter.test.ts` tests pass (updated watermark count expectation and added onboarding mock)
- [ ] Manual: complete onboarding flow, verify `onboarding_events` row in SQLite
- [ ] Manual: confirm telemetry flush sends `type: "onboarding"` event to platform ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->