### PR TITLE
fix: address legacy Slack thread fallback gaps

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -196,6 +196,40 @@ describe("channel-delivery-store", () => {
     ).toBe(legacy.conversationId);
   });
 
+  test("legacy Slack thread evidence scan is bounded when metadata does not prove the thread", () => {
+    const channelId = "C0123ABCDEF";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: "1710000000.000100",
+    });
+    for (let i = 0; i < 550; i++) {
+      insertMessage(`legacy-thread-message-${i}`, legacy.conversationId, {
+        slackMeta: JSON.stringify({
+          source: "slack",
+          channelId,
+          channelTs: `1710000001.${String(i).padStart(6, "0")}`,
+          threadTs: "1710000000.000100",
+          eventKind: "message",
+        }),
+      });
+    }
+    insertMessage("legacy-thread-message-target", legacy.conversationId, {
+      slackMeta: JSON.stringify({
+        source: "slack",
+        channelId,
+        channelTs: "1710000002.000600",
+        threadTs: "1710000000.000600",
+        eventKind: "message",
+      }),
+    });
+
+    const threaded = recordInbound("slack", channelId, "thread-reply", {
+      sourceThreadId: "1710000000.000600",
+      sourceMessageId: "1710000003.000600",
+    });
+
+    expect(threaded.conversationId).not.toBe(legacy.conversationId);
+  });
+
   test("legacy Slack channel key without evidence for the requested thread is not reused", () => {
     const channelId = "C0123ABCDEF";
     const legacy = recordInbound("slack", channelId, "legacy-event", {
@@ -244,6 +278,42 @@ describe("channel-delivery-store", () => {
     expect(aliased.conversationId).toBe(legacy.conversationId);
     expect(separate.conversationId).not.toBe(legacy.conversationId);
     expect(separate.conversationId).not.toBe(aliased.conversationId);
+  });
+
+  test("reset legacy-aliased Slack thread does not reattach to old legacy conversation", async () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000100";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: threadTs,
+    });
+    const aliased = recordInbound("slack", channelId, "legacy-thread-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000001.000100",
+    });
+    expect(aliased.conversationId).toBe(legacy.conversationId);
+
+    const req = new Request("http://localhost/channels/conversation", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChannel: "slack",
+        conversationExternalId: channelId,
+        sourceThreadId: threadTs,
+      }),
+    });
+    const res = await handleDeleteConversation(req);
+    expect(res.status).toBe(200);
+
+    const afterReset = recordInbound("slack", channelId, "after-reset-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000002.000100",
+    });
+
+    expect(afterReset.conversationId).not.toBe(legacy.conversationId);
+    expect(
+      getConversationByKey(`asst:self:slack:${channelId}:thread:${threadTs}`)
+        ?.conversationId,
+    ).toBe(afterReset.conversationId);
   });
 
   test("different chats get different conversations", () => {

--- a/assistant/src/__tests__/edit-propagation.test.ts
+++ b/assistant/src/__tests__/edit-propagation.test.ts
@@ -19,6 +19,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import { addMessage } from "../memory/conversation-crud.js";
+import { getConversationByKey } from "../memory/conversation-key-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { linkMessage, recordInbound } from "../memory/delivery-crud.js";
@@ -158,6 +159,38 @@ describe("Slack edit propagation", () => {
     expect(slackMeta!.eventKind).toBe("message");
     expect(typeof slackMeta!.editedAt).toBe("number");
     expect(slackMeta!.editedAt!).toBeGreaterThanOrEqual(t0);
+  });
+
+  test("threaded Slack edits use the threaded conversation key and preserve thread metadata", async () => {
+    const conversationExternalId = "C0123CHANNEL";
+    const threadTs = "1234.0000";
+    const seeded = await seedSlackMessage({
+      conversationExternalId,
+      channelTs: "1234.5678",
+      initialContent: "original text",
+    });
+
+    const resp = await handleEditIntercept({
+      sourceChannel: "slack",
+      conversationExternalId,
+      externalMessageId: nextEditEventId(),
+      sourceMessageId: seeded.channelTs,
+      sourceThreadId: threadTs,
+      canonicalAssistantId: "self",
+      assistantId: "self",
+      content: "new text",
+    });
+
+    expect((resp as Record<string, unknown>).accepted).toBe(true);
+    const threadedKey = `asst:self:slack:${conversationExternalId}:thread:${threadTs}`;
+    const editConversation = getConversationByKey(threadedKey);
+    expect(editConversation).not.toBeNull();
+    expect(editConversation!.conversationId).not.toBe(seeded.conversationId);
+
+    const after = readMessageRow(seeded.messageId);
+    const outer = JSON.parse(after.metadata!) as Record<string, unknown>;
+    const slackMeta = readSlackMetadata(outer.slackMeta as string);
+    expect(slackMeta?.threadTs).toBe(threadTs);
   });
 
   test("is idempotent across successive edits", async () => {

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -5,9 +5,10 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, eq, isNotNull, like, or } from "drizzle-orm";
+import { and, asc, eq, isNotNull, like, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import {
   getConversationByKey,
@@ -29,6 +30,9 @@ export interface RecordInboundOptions {
   assistantId?: string;
   sourceThreadId?: string;
 }
+
+const SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE = 50;
+const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
 
 function buildScopedConversationKeyForAssistant(
   assistantId: string,
@@ -54,66 +58,6 @@ export function buildScopedConversationKey(
     externalChatId,
     sourceThreadId,
   );
-}
-
-function readSlackMetadataEvidence(
-  raw: string | null,
-): { channelId: string; threadTs?: string } | null {
-  if (!raw) {
-    return null;
-  }
-
-  const candidates: string[] = [raw];
-  try {
-    const envelope: unknown = JSON.parse(raw);
-    if (
-      envelope !== null &&
-      typeof envelope === "object" &&
-      !Array.isArray(envelope)
-    ) {
-      const slackMeta = (envelope as { slackMeta?: unknown }).slackMeta;
-      if (typeof slackMeta === "string") {
-        candidates.unshift(slackMeta);
-      }
-    }
-  } catch {
-    // Fall through to parsing the raw value as a flat Slack metadata blob.
-  }
-
-  for (const candidate of candidates) {
-    try {
-      const parsed: unknown = JSON.parse(candidate);
-      if (
-        parsed === null ||
-        typeof parsed !== "object" ||
-        Array.isArray(parsed)
-      ) {
-        continue;
-      }
-
-      const record = parsed as Record<string, unknown>;
-      const eventKind = record.eventKind;
-      if (
-        record.source !== "slack" ||
-        typeof record.channelId !== "string" ||
-        typeof record.channelTs !== "string" ||
-        (eventKind !== "message" && eventKind !== "reaction")
-      ) {
-        continue;
-      }
-
-      return {
-        channelId: record.channelId,
-        ...(typeof record.threadTs === "string"
-          ? { threadTs: record.threadTs }
-          : {}),
-      };
-    } catch {
-      // Try the next candidate.
-    }
-  }
-
-  return null;
 }
 
 function legacySlackConversationHasThreadEvidence(
@@ -142,28 +86,49 @@ function legacySlackConversationHasThreadEvidence(
     return true;
   }
 
-  const metadataRows = db
-    .select({ metadata: messages.metadata })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        isNotNull(messages.metadata),
-        or(
-          like(messages.metadata, '%"slackMeta"%'),
-          like(messages.metadata, '%"source":"slack"%'),
-        ),
-      ),
-    )
-    .all();
-
-  return metadataRows.some((row) => {
-    const slackMeta = readSlackMetadataEvidence(row.metadata);
-    return (
-      slackMeta?.channelId === externalChatId &&
-      slackMeta.threadTs === sourceThreadId
+  let offset = 0;
+  while (offset < SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN) {
+    const remaining = SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN - offset;
+    const batchLimit = Math.min(
+      SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE,
+      remaining,
     );
-  });
+    const metadataRows = db
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          isNotNull(messages.metadata),
+          or(
+            like(messages.metadata, '%"slackMeta"%'),
+            like(messages.metadata, '%"source":"slack"%'),
+          ),
+        ),
+      )
+      .orderBy(asc(messages.createdAt))
+      .limit(batchLimit)
+      .offset(offset)
+      .all();
+
+    if (metadataRows.length === 0) return false;
+    for (const row of metadataRows) {
+      const slackMeta = readSlackMetadataFromMessageMetadata(row.metadata, {
+        allowFlatLegacy: true,
+      });
+      if (
+        slackMeta?.channelId === externalChatId &&
+        slackMeta.threadTs === sourceThreadId
+      ) {
+        return true;
+      }
+    }
+
+    if (metadataRows.length < batchLimit) return false;
+    offset += metadataRows.length;
+  }
+
+  return false;
 }
 
 function resolveInboundConversation(

--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "./message-metadata.js";
@@ -135,6 +136,35 @@ describe("readSlackMetadata", () => {
     };
     const parsed = readSlackMetadata(JSON.stringify(meta));
     expect(parsed).toEqual(meta);
+  });
+});
+
+describe("readSlackMetadataFromMessageMetadata", () => {
+  const meta: SlackMessageMetadata = {
+    source: "slack",
+    channelId: "C123",
+    channelTs: "1700000000.000100",
+    threadTs: "1699999999.000000",
+    eventKind: "message",
+  };
+
+  test("reads nested slackMeta from a message metadata envelope", () => {
+    expect(
+      readSlackMetadataFromMessageMetadata(
+        JSON.stringify({
+          userMessageChannel: "slack",
+          slackMeta: writeSlackMetadata(meta),
+        }),
+      ),
+    ).toEqual(meta);
+  });
+
+  test("can read flat legacy Slack metadata when explicitly allowed", () => {
+    const raw = writeSlackMetadata(meta);
+    expect(readSlackMetadataFromMessageMetadata(raw)).toBeNull();
+    expect(
+      readSlackMetadataFromMessageMetadata(raw, { allowFlatLegacy: true }),
+    ).toEqual(meta);
   });
 });
 

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -75,6 +75,32 @@ export function readSlackMetadata(
   return result.success ? result.data : null;
 }
 
+export function readSlackMetadataFromMessageMetadata(
+  metadata: string | null | undefined,
+  opts?: { allowFlatLegacy?: boolean },
+): SlackMessageMetadata | null {
+  if (!metadata) return null;
+
+  let parent: Record<string, unknown> | null = null;
+  try {
+    const parsed = JSON.parse(metadata) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      parent = parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  if (!parent) return null;
+
+  const nested = parent.slackMeta;
+  if (typeof nested === "string") {
+    const parsedNested = readSlackMetadata(nested);
+    if (parsedNested) return parsedNested;
+  }
+
+  return opts?.allowFlatLegacy ? readSlackMetadata(metadata) : null;
+}
+
 /**
  * Serialize `SlackMessageMetadata` to a JSON string suitable for a fresh
  * write to the `messages.metadata` column. Use `mergeSlackMetadata` when an

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -1,7 +1,11 @@
 /**
  * Channel conversation deletion handler.
  */
-import { deleteConversationKey } from "../../memory/conversation-key-store.js";
+import {
+  deleteConversationKey,
+  getConversationByKey,
+  getOrCreateConversation,
+} from "../../memory/conversation-key-store.js";
 import { buildScopedConversationKey } from "../../memory/delivery-crud.js";
 import {
   deleteBindingByChannelChat,
@@ -31,12 +35,23 @@ export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
     conversationExternalId,
     normalizedThreadId,
   );
+  const scopedMapping = getConversationByKey(scopedKey);
   deleteConversationKey(scopedKey);
   const legacyKey = `${sourceChannel}:${conversationExternalId}`;
   if (!normalizedThreadId) {
     deleteConversationKey(legacyKey);
     deleteBindingByChannelChat(sourceChannel, conversationExternalId);
   } else {
+    if (sourceChannel === "slack" && scopedMapping) {
+      const legacyScopedKey = buildScopedConversationKey(
+        sourceChannel,
+        conversationExternalId,
+      );
+      const legacyScopedMapping = getConversationByKey(legacyScopedKey);
+      if (legacyScopedMapping?.conversationId === scopedMapping.conversationId) {
+        getOrCreateConversation(scopedKey);
+      }
+    }
     deleteBindingByChannelChatThread(
       sourceChannel,
       conversationExternalId,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -64,7 +64,6 @@ import {
 import { downloadSlackFile } from "../../messaging/providers/slack/download.js";
 import {
   mergeSlackMetadata,
-  readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackFileMetadata,
   type SlackMessageMetadata,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -65,6 +65,7 @@ import { downloadSlackFile } from "../../messaging/providers/slack/download.js";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
   type SlackFileMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
@@ -485,6 +486,7 @@ export async function handleChannelInbound({
       conversationExternalId,
       externalMessageId,
       sourceMessageId,
+      sourceThreadId: slackThreadTs,
       canonicalAssistantId,
       assistantId,
       content,
@@ -1352,25 +1354,6 @@ function countSlackMetaMessages(conversationId: string): number {
     offset += candidates.length;
   }
   return count;
-}
-
-function readSlackMetadataFromMessageMetadata(
-  metadata: string | null | undefined,
-): SlackMessageMetadata | null {
-  if (!metadata) return null;
-  let parent: Record<string, unknown> | null = null;
-  try {
-    const parsed = JSON.parse(metadata) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      parent = parsed as Record<string, unknown>;
-    }
-  } catch {
-    return null;
-  }
-  if (!parent) return null;
-  const raw = parent.slackMeta;
-  if (typeof raw !== "string") return null;
-  return readSlackMetadata(raw);
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -20,7 +20,10 @@ import {
   updateMessageContent,
   updateMessageContentAndMetadata,
 } from "../../../memory/conversation-crud.js";
-import { findMessageBySourceId, recordInbound } from "../../../memory/delivery-crud.js";
+import {
+  findMessageBySourceId,
+  recordInbound,
+} from "../../../memory/delivery-crud.js";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
@@ -39,6 +42,7 @@ export interface EditInterceptParams {
   conversationExternalId: string;
   externalMessageId: string;
   sourceMessageId: string;
+  sourceThreadId?: string;
   canonicalAssistantId: string;
   assistantId: string;
   content: string | undefined;
@@ -61,6 +65,7 @@ export async function handleEditIntercept(
     conversationExternalId,
     externalMessageId,
     sourceMessageId,
+    sourceThreadId,
     canonicalAssistantId,
     assistantId,
     content,
@@ -71,7 +76,7 @@ export async function handleEditIntercept(
     sourceChannel,
     conversationExternalId,
     externalMessageId,
-    { sourceMessageId, assistantId: canonicalAssistantId },
+    { sourceMessageId, sourceThreadId, assistantId: canonicalAssistantId },
   );
 
   if (editResult.duplicate) {
@@ -145,6 +150,7 @@ export async function handleEditIntercept(
         messageId: original.messageId,
         conversationExternalId,
         sourceMessageId,
+        sourceThreadId,
         newContent,
       });
     } else {
@@ -203,10 +209,16 @@ function applySlackEditMetadata(params: {
   messageId: string;
   conversationExternalId: string;
   sourceMessageId: string;
+  sourceThreadId?: string;
   newContent: string;
 }): void {
-  const { messageId, conversationExternalId, sourceMessageId, newContent } =
-    params;
+  const {
+    messageId,
+    conversationExternalId,
+    sourceMessageId,
+    sourceThreadId,
+    newContent,
+  } = params;
 
   const row = getMessageById(messageId);
   const outerMetadata: Record<string, unknown> =
@@ -230,6 +242,7 @@ function applySlackEditMetadata(params: {
           source: "slack" as const,
           channelId: conversationExternalId,
           channelTs: sourceMessageId,
+          ...(sourceThreadId ? { threadTs: sourceThreadId } : {}),
           eventKind: "message" as const,
         }),
     editedAt,


### PR DESCRIPTION
## Summary
- Prevent reset Slack threads that were aliased from legacy channel conversations from reattaching to old context.
- Propagate Slack thread IDs through edit-event dedup and fallback metadata synthesis.
- Reuse a shared Slack metadata envelope reader and cap legacy fallback metadata scans.

Closes #30735
Fixes gap identified during plan review for legacy-slack-thread-fallback.md.