### PR TITLE
Add reusable external_content parse and display helpers

### DIFF
--- a/assistant/src/security/__tests__/untrusted-content.test.ts
+++ b/assistant/src/security/__tests__/untrusted-content.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   escapeContentBoundaries,
+  parseExternalContentEnvelope,
+  unwrapExternalContentForDisplay,
   wrapUntrustedContent,
 } from "../untrusted-content.js";
 
@@ -105,5 +107,89 @@ describe("escapeContentBoundaries", () => {
   test("handles content with no boundary sequences", () => {
     const safe = "Hello, this is a normal email about <html> tags.";
     expect(escapeContentBoundaries(safe)).toBe(safe);
+  });
+});
+
+describe("parseExternalContentEnvelope", () => {
+  test("parses a complete envelope with source and content", () => {
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="slack">\nhello world\n</external_content>',
+      ),
+    ).toEqual({
+      source: "slack",
+      content: "hello world",
+    });
+  });
+
+  test("parses optional origin and multiline content from wrapped output", () => {
+    const wrapped = wrapUntrustedContent("line one\nline two", {
+      source: "slack",
+      sourceDetail: "channel-123",
+    });
+
+    expect(parseExternalContentEnvelope(wrapped)).toEqual({
+      source: "slack",
+      origin: "channel-123",
+      content: "line one\nline two",
+    });
+  });
+
+  test("returns null for malformed wrappers", () => {
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="slack">body\n</external_content>',
+      ),
+    ).toBeNull();
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="slack">\nbody</external_content>',
+      ),
+    ).toBeNull();
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="slack" extra="ignored">\nbody\n</external_content>',
+      ),
+    ).toBeNull();
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="slack">\nbody\n</external_content>\n</external_content>',
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null for mixed prefix or suffix content", () => {
+    const envelope =
+      '<external_content source="email">\nbody\n</external_content>';
+
+    expect(parseExternalContentEnvelope(`prefix ${envelope}`)).toBeNull();
+    expect(parseExternalContentEnvelope(`${envelope} suffix`)).toBeNull();
+  });
+
+  test("returns null for unknown sources", () => {
+    expect(
+      parseExternalContentEnvelope(
+        '<external_content source="chat">\nbody\n</external_content>',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("unwrapExternalContentForDisplay", () => {
+  test("returns only the inner body for a complete envelope", () => {
+    expect(
+      unwrapExternalContentForDisplay(
+        '<external_content source="slack">\nvisible text\n</external_content>',
+      ),
+    ).toBe("visible text");
+  });
+
+  test("leaves partial or malformed external content unchanged", () => {
+    const partial = '<external_content source="slack">\nvisible text';
+    const malformed =
+      '<external_content source="slack">visible text</external_content>';
+
+    expect(unwrapExternalContentForDisplay(partial)).toBe(partial);
+    expect(unwrapExternalContentForDisplay(malformed)).toBe(malformed);
   });
 });

--- a/assistant/src/security/untrusted-content.ts
+++ b/assistant/src/security/untrusted-content.ts
@@ -15,14 +15,23 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type UntrustedContentSource =
-  | "email"
-  | "slack"
-  | "web"
-  | "calendar"
-  | "webhook"
-  | "search"
-  | "tool_result";
+const UNTRUSTED_CONTENT_SOURCES = [
+  "email",
+  "slack",
+  "web",
+  "calendar",
+  "webhook",
+  "search",
+  "tool_result",
+] as const;
+
+export type UntrustedContentSource = (typeof UNTRUSTED_CONTENT_SOURCES)[number];
+
+export interface ExternalContentEnvelope {
+  source: UntrustedContentSource;
+  origin?: string;
+  content: string;
+}
 
 export interface WrapOptions {
   /** Which external source produced this content. */
@@ -47,6 +56,14 @@ const DEFAULT_BUDGETS: Record<UntrustedContentSource, number> = {
   tool_result: 20_000,
 };
 
+const UNTRUSTED_CONTENT_SOURCE_SET = new Set<string>(UNTRUSTED_CONTENT_SOURCES);
+
+const EXTERNAL_CONTENT_ENVELOPE_PATTERN =
+  /^<external_content\s+([^\r\n<>]*)>\n([\s\S]*)\n<\/external_content>$/;
+
+const EXTERNAL_CONTENT_ATTRIBUTE_PATTERN =
+  /(?:^|\s+)(source|origin)="([^"\r\n]*)"/g;
+
 // ---------------------------------------------------------------------------
 // Core API
 // ---------------------------------------------------------------------------
@@ -70,6 +87,31 @@ export function wrapUntrustedContent(
   return `<external_content source="${options.source}"${detail}>\n${truncated}\n</external_content>`;
 }
 
+export function parseExternalContentEnvelope(
+  value: string,
+): ExternalContentEnvelope | null {
+  const match = EXTERNAL_CONTENT_ENVELOPE_PATTERN.exec(value);
+  if (!match || match[0] !== value) {
+    return null;
+  }
+
+  const attributes = parseExternalContentAttributes(match[1]);
+  if (!attributes) {
+    return null;
+  }
+
+  const content = match[2];
+  if (/<\/external_content/gi.test(content)) {
+    return null;
+  }
+
+  return { ...attributes, content };
+}
+
+export function unwrapExternalContentForDisplay(value: string): string {
+  return parseExternalContentEnvelope(value)?.content ?? value;
+}
+
 /**
  * Escape sequences that could break out of the `<external_content>` wrapper.
  * Case-insensitive to cover mixed-case evasion attempts.
@@ -88,6 +130,49 @@ export function escapeContentBoundaries(content: string): string {
 /** Sanitize a value for use as an XML attribute (no quotes, angle brackets, newlines). */
 function sanitizeAttr(value: string): string {
   return value.replace(/[<>"&\r\n]/g, "").slice(0, 200);
+}
+
+function parseExternalContentAttributes(
+  attributes: string,
+): Pick<ExternalContentEnvelope, "source" | "origin"> | null {
+  let source: UntrustedContentSource | undefined;
+  let origin: string | undefined;
+  let originSeen = false;
+  let cursor = 0;
+
+  EXTERNAL_CONTENT_ATTRIBUTE_PATTERN.lastIndex = 0;
+  for (const match of attributes.matchAll(EXTERNAL_CONTENT_ATTRIBUTE_PATTERN)) {
+    if (match.index !== cursor) {
+      return null;
+    }
+
+    const [, name, value] = match;
+    if (name === "source") {
+      if (source || !isUntrustedContentSource(value)) {
+        return null;
+      }
+      source = value;
+    } else {
+      if (originSeen) {
+        return null;
+      }
+      originSeen = true;
+      origin = value;
+    }
+    cursor = match.index + match[0].length;
+  }
+
+  if (cursor !== attributes.length || !source) {
+    return null;
+  }
+
+  return originSeen ? { source, origin } : { source };
+}
+
+function isUntrustedContentSource(
+  value: string,
+): value is UntrustedContentSource {
+  return UNTRUSTED_CONTENT_SOURCE_SET.has(value);
 }
 
 /** Truncate content to a character budget, appending a notice if truncated. */


### PR DESCRIPTION
## Summary
- Add parse and display helpers for complete external_content envelopes.
- Cover strict parsing and display unwrapping behavior.

Part of plan: slack-runtime-content-wrapping.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->