### PR TITLE
fix: address remaining Slack fallback review gaps

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -316,6 +316,37 @@ describe("channel-delivery-store", () => {
     ).toBe(afterReset.conversationId);
   });
 
+  test("reset legacy Slack thread before alias exists does not reattach to old legacy conversation", async () => {
+    const channelId = "C0123ABCDEF";
+    const threadTs = "1710000000.000100";
+    const legacy = recordInbound("slack", channelId, "legacy-event", {
+      sourceMessageId: threadTs,
+    });
+
+    const req = new Request("http://localhost/channels/conversation", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChannel: "slack",
+        conversationExternalId: channelId,
+        sourceThreadId: threadTs,
+      }),
+    });
+    const res = await handleDeleteConversation(req);
+    expect(res.status).toBe(200);
+
+    const afterReset = recordInbound("slack", channelId, "after-reset-reply", {
+      sourceThreadId: threadTs,
+      sourceMessageId: "1710000002.000100",
+    });
+
+    expect(afterReset.conversationId).not.toBe(legacy.conversationId);
+    expect(
+      getConversationByKey(`asst:self:slack:${channelId}:thread:${threadTs}`)
+        ?.conversationId,
+    ).toBe(afterReset.conversationId);
+  });
+
   test("different chats get different conversations", () => {
     const r1 = recordInbound("telegram", "chat-1", "msg-1");
     const r2 = recordInbound("telegram", "chat-2", "msg-1");

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1047,22 +1047,23 @@ export function getMessages(conversationId: string): MessageRow[] {
 }
 
 /**
- * Return raw `metadata` strings for messages whose metadata contains the
- * literal substring `"slackMeta"`, capped at `limit` and skipping the first
- * `offset` matches. Pushes `LIKE` + `LIMIT`/`OFFSET` into SQL so warm Slack
- * DM conversations don't require a full-table scan on the webhook critical
- * path. The substring match is an indexable prefilter only — callers must
- * parse and validate each returned string against the Slack metadata schema,
- * because a malformed row (partial write, legacy format, unrelated key
- * accidentally containing the literal) can still slip through the substring
- * match. Callers that need a fixed number of *valid* rows should iterate
- * with increasing offsets until the target is reached (capped at a
- * reasonable maximum to bound scan cost).
+ * Return raw `metadata` strings for messages whose metadata looks like it may
+ * contain Slack metadata, capped at `limit` and skipping the first `offset`
+ * matches. Pushes `LIKE` + `LIMIT`/`OFFSET` into SQL so warm Slack DM
+ * conversations don't require a full-table scan on the webhook critical path.
+ * The substring match is an indexable prefilter only — callers must parse and
+ * validate each returned string against the Slack metadata schema, because a
+ * malformed row (partial write, legacy format, unrelated key accidentally
+ * containing the literal) can still slip through the substring match. Callers
+ * that need a fixed number of *valid* rows should iterate with increasing
+ * offsets until the target is reached (capped at a reasonable maximum to bound
+ * scan cost).
  */
 export function selectSlackMetaCandidateMetadata(
   conversationId: string,
   limit: number,
   offset = 0,
+  opts?: { includeFlatLegacy?: boolean },
 ): string[] {
   const db = getDb();
   const rows = db
@@ -1071,7 +1072,12 @@ export function selectSlackMetaCandidateMetadata(
     .where(
       and(
         eq(messages.conversationId, conversationId),
-        like(messages.metadata, '%"slackMeta"%'),
+        opts?.includeFlatLegacy
+          ? or(
+              like(messages.metadata, '%"slackMeta"%'),
+              like(messages.metadata, '%"source":"slack"%'),
+            )
+          : like(messages.metadata, '%"slackMeta"%'),
       ),
     )
     .orderBy(asc(messages.createdAt))

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -5,18 +5,19 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, asc, eq, isNotNull, like, or } from "drizzle-orm";
+import { and, eq, isNotNull, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { selectSlackMetaCandidateMetadata } from "./conversation-crud.js";
 import {
   getConversationByKey,
   getOrCreateConversation,
   setConversationKeyIfAbsent,
 } from "./conversation-key-store.js";
 import { getDb } from "./db-connection.js";
-import { channelInboundEvents, conversations, messages } from "./schema.js";
+import { channelInboundEvents, conversations } from "./schema.js";
 
 export interface InboundResult {
   accepted: boolean;
@@ -93,27 +94,16 @@ function legacySlackConversationHasThreadEvidence(
       SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE,
       remaining,
     );
-    const metadataRows = db
-      .select({ metadata: messages.metadata })
-      .from(messages)
-      .where(
-        and(
-          eq(messages.conversationId, conversationId),
-          isNotNull(messages.metadata),
-          or(
-            like(messages.metadata, '%"slackMeta"%'),
-            like(messages.metadata, '%"source":"slack"%'),
-          ),
-        ),
-      )
-      .orderBy(asc(messages.createdAt))
-      .limit(batchLimit)
-      .offset(offset)
-      .all();
+    const metadataRows = selectSlackMetaCandidateMetadata(
+      conversationId,
+      batchLimit,
+      offset,
+      { includeFlatLegacy: true },
+    );
 
     if (metadataRows.length === 0) return false;
-    for (const row of metadataRows) {
-      const slackMeta = readSlackMetadataFromMessageMetadata(row.metadata, {
+    for (const metadata of metadataRows) {
+      const slackMeta = readSlackMetadataFromMessageMetadata(metadata, {
         allowFlatLegacy: true,
       });
       if (

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -92,7 +92,7 @@ import {
 import { searchConversations } from "../../memory/conversation-queries.js";
 import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
 import {
-  readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
 } from "../../messaging/providers/slack/message-metadata.js";
 import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
@@ -144,22 +144,6 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
     typeof value === "string" &&
     VALID_RISK_THRESHOLDS.includes(value as RiskThreshold)
   );
-}
-
-function readSlackMetadataFromEnvelope(
-  metadata: string | null | undefined,
-): SlackMessageMetadata | null {
-  if (!metadata) return null;
-  try {
-    const parsed = JSON.parse(metadata) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-    const slackMeta = (parsed as Record<string, unknown>).slackMeta;
-    return typeof slackMeta === "string" ? readSlackMetadata(slackMeta) : null;
-  } catch {
-    return null;
-  }
 }
 
 function buildSlackHistoryMessage(
@@ -572,7 +556,7 @@ export function handleListMessages(
       }
     }
     const slackMessage = buildSlackHistoryMessage(
-      readSlackMetadataFromEnvelope(msg.metadata),
+      readSlackMetadataFromMessageMetadata(msg.metadata),
     );
 
     // Strip <no_response/> markers from assistant messages so web/API

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -3,7 +3,6 @@
  */
 import {
   deleteConversationKey,
-  getConversationByKey,
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { buildScopedConversationKey } from "../../memory/delivery-crud.js";
@@ -35,22 +34,14 @@ export function handleDeleteConversation({ body = {} }: RouteHandlerArgs) {
     conversationExternalId,
     normalizedThreadId,
   );
-  const scopedMapping = getConversationByKey(scopedKey);
   deleteConversationKey(scopedKey);
   const legacyKey = `${sourceChannel}:${conversationExternalId}`;
   if (!normalizedThreadId) {
     deleteConversationKey(legacyKey);
     deleteBindingByChannelChat(sourceChannel, conversationExternalId);
   } else {
-    if (sourceChannel === "slack" && scopedMapping) {
-      const legacyScopedKey = buildScopedConversationKey(
-        sourceChannel,
-        conversationExternalId,
-      );
-      const legacyScopedMapping = getConversationByKey(legacyScopedKey);
-      if (legacyScopedMapping?.conversationId === scopedMapping.conversationId) {
-        getOrCreateConversation(scopedKey);
-      }
+    if (sourceChannel === "slack") {
+      getOrCreateConversation(scopedKey);
     }
     deleteBindingByChannelChatThread(
       sourceChannel,


### PR DESCRIPTION
Closes #30742

Fixes the final self-review gaps for legacy-slack-thread-fallback.md:
- prevent Slack thread reset-before-alias from resurrecting the legacy conversation
- reuse shared Slack metadata parsing and candidate scan helpers for the legacy evidence path

Validation:
- cd assistant && bun test src/__tests__/channel-delivery-store.test.ts
- cd assistant && bun test src/messaging/providers/slack/message-metadata.test.ts src/__tests__/list-messages-page-latest.test.ts src/__tests__/edit-propagation.test.ts
- cd assistant && bunx tsc --noEmit
- cd assistant && bun run lint src/__tests__/channel-delivery-store.test.ts src/memory/conversation-crud.ts src/memory/delivery-crud.ts src/runtime/routes/conversation-routes.ts src/runtime/routes/inbound-conversation.ts
- cd assistant && bunx prettier --check src/__tests__/channel-delivery-store.test.ts src/memory/conversation-crud.ts src/memory/delivery-crud.ts src/runtime/routes/conversation-routes.ts src/runtime/routes/inbound-conversation.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->