### PR TITLE
fix(oauth): config invalidation route and multi-account logging

### DIFF
--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -230,11 +230,15 @@ async function resolvePlatformConnectionId(
   }
 
   if (connections.length > 1 && !account) {
+    const allAccounts = connections
+      .map((c) => c.account_label ?? c.id)
+      .join(", ");
     log.warn(
       {
         provider,
         count: connections.length,
         selectedId: connections[0].id,
+        allAccounts,
       },
       "Multiple active platform connections found; using the most recently created. " +
         "Pass an account option to select a specific connection.",

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -91,6 +91,7 @@ import { ROUTES as NOTIFICATION_ROUTES } from "./notification-routes.js";
 import { ROUTES as OAUTH_APPS_ROUTES } from "./oauth-apps.js";
 import { ROUTES as OAUTH_COMMANDS_ROUTES } from "./oauth-commands-routes.js";
 import { ROUTES as OAUTH_CONNECT_ROUTES } from "./oauth-connect-routes.js";
+import { ROUTES as OAUTH_LIFECYCLE_ROUTES } from "./oauth-lifecycle-routes.js";
 import { ROUTES as OAUTH_PROVIDERS_ROUTES } from "./oauth-providers.js";
 import { ROUTES as PLATFORM_ROUTES } from "./platform-routes.js";
 import { ROUTES as PLAYGROUND_ROUTES } from "./playground/index.js";
@@ -207,6 +208,7 @@ export const ROUTES: RouteDefinition[] = [
   ...MIGRATION_ROUTES,
   ...NOTIFICATION_ROUTES,
   ...OAUTH_APPS_ROUTES,
+  ...OAUTH_LIFECYCLE_ROUTES,
   ...OAUTH_COMMANDS_ROUTES,
   ...OAUTH_PROVIDERS_ROUTES,
   ...PLATFORM_ROUTES,

--- a/assistant/src/runtime/routes/oauth-lifecycle-routes.ts
+++ b/assistant/src/runtime/routes/oauth-lifecycle-routes.ts
@@ -1,0 +1,42 @@
+/**
+ * Transport-agnostic routes for OAuth lifecycle events.
+ *
+ * Allows CLI commands to notify the daemon when OAuth state changes
+ * (e.g. after `assistant oauth connect`) so the daemon can refresh its
+ * cached config and credential state.
+ */
+
+import { z } from "zod";
+
+import { getConfig, invalidateConfigCache } from "../../config/loader.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+function handleOAuthConnectionChanged(_args: RouteHandlerArgs): {
+  refreshed: boolean;
+} {
+  invalidateConfigCache();
+  // Force re-read from disk so subsequent resolveOAuthConnection() calls
+  // in this process see the current mode setting.
+  getConfig();
+  return { refreshed: true };
+}
+
+// ── Routes ────────────────────────────────────────────────────────────
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "oauth_connection_changed",
+    endpoint: "oauth/connection-changed",
+    method: "POST",
+    handler: handleOAuthConnectionChanged,
+    summary: "Notify the assistant that an OAuth connection changed",
+    description:
+      "Invalidates the config cache so the assistant picks up mode and credential changes immediately.",
+    tags: ["oauth"],
+    responseBody: z.object({
+      refreshed: z.boolean(),
+    }),
+  },
+];


### PR DESCRIPTION
## Summary
- Add `oauth_connection_changed` IPC route so CLI commands can notify the daemon to refresh its config cache after OAuth state changes (fixes stale config when mode switches between managed/BYO)
- Enhance multi-account logging in `resolvePlatformConnectionId()` to include all connected account labels for easier debugging

Note: The main credential health managed-provider checks (Bug 1 from the bug report) were already landed upstream. These changes address the remaining gaps.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/__tests__/credential-health-service.test.ts` — 23/23 pass
- [x] `bun test src/oauth/connection-resolver.test.ts` — 16/16 pass
- [x] `bun test src/__tests__/heartbeat-service.test.ts` — 79/79 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->