### PR TITLE
feat(onboarding): Google scan via subagents on first conversation

### DIFF
--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -107,7 +107,12 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
   const assistant = ctx.assistantName?.trim();
   const tone = resolveTone(ctx.tone);
 
-  if (!name && !assistant && !VALID_TONES.has(ctx.tone)) {
+  if (
+    !name &&
+    !assistant &&
+    !VALID_TONES.has(ctx.tone) &&
+    !ctx.googleConnected
+  ) {
     return CANNED_FIRST_GREETING;
   }
 

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -11,6 +11,7 @@ export interface OnboardingGreetingContext {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }
 
 export const CANNED_FIRST_GREETING = [
@@ -76,6 +77,16 @@ const TONE_INVITE: Record<Tone, string> = {
     "We can start with whatever's in front of you, or just talk for a bit first. Either way.",
 };
 
+const TONE_GOOGLE_SCAN: Record<Tone, string> = {
+  grounded:
+    "I can scan your email, calendar, and drive in the background while we talk — just say the word.",
+  warm: "Also — I can scan your email, calendar, and drive in the background while we chat, if you'd like. Just let me know.",
+  energetic:
+    "Oh, and I can scan your email, calendar, and drive in the background right now — want me to?",
+  poetic:
+    "I can also look through your email, calendar, and drive quietly in the background — say the word.",
+};
+
 function buildInvite(tone: Tone = "grounded"): string {
   return TONE_INVITE[tone];
 }
@@ -102,5 +113,9 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
 
   const intro = buildIntroLine(name, assistant, tone);
   const invite = buildInvite(tone);
-  return [intro, "", invite].join("\n");
+  const parts = [intro, "", invite];
+  if (ctx.googleConnected) {
+    parts.push("", TONE_GOOGLE_SCAN[tone]);
+  }
+  return parts.join("\n");
 }

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -63,6 +63,28 @@ export interface NormalizedOnboarding {
   tone?: string;
   assistantName?: string;
   googleConnected?: boolean;
+  googleServices?: string[];
+}
+
+const SCOPE_SERVICE_MAP: Record<string, string> = {
+  "gmail.readonly": "Gmail",
+  "gmail.modify": "Gmail",
+  "gmail.send": "Gmail",
+  "gmail.settings.basic": "Gmail",
+  "calendar.readonly": "Calendar",
+  "calendar.events": "Calendar",
+  drive: "Drive",
+};
+
+export function deriveGoogleServices(scopes?: string[]): string[] {
+  if (!scopes?.length) return ["Gmail", "Calendar", "Drive"];
+  const services = new Set<string>();
+  for (const scope of scopes) {
+    const suffix = scope.replace("https://www.googleapis.com/auth/", "");
+    const service = SCOPE_SERVICE_MAP[suffix];
+    if (service) services.add(service);
+  }
+  return services.size > 0 ? [...services] : ["Gmail", "Calendar", "Drive"];
 }
 
 /**
@@ -78,5 +100,8 @@ export function normalizeOnboardingContext(
     tone: ctx.tone,
     assistantName: ctx.assistantName,
     googleConnected: ctx.googleConnected,
+    googleServices: ctx.googleConnected
+      ? deriveGoogleServices(ctx.googleScopes)
+      : undefined,
   };
 }

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -62,6 +62,7 @@ export interface NormalizedOnboarding {
   dailyTools: string[];
   tone?: string;
   assistantName?: string;
+  googleConnected?: boolean;
 }
 
 /**
@@ -76,5 +77,6 @@ export function normalizeOnboardingContext(
     dailyTools: normalizeTools(ctx.tools),
     tone: ctx.tone,
     assistantName: ctx.assistantName,
+    googleConnected: ctx.googleConnected,
   };
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -339,6 +339,11 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.assistantName)
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      if (n.googleConnected) {
+        lines.push(
+          "- Google connected: yes (Gmail, Calendar, and Drive access granted)",
+        );
+      }
       lines.push(
         "",
         "Apply this context quietly. Do not recap it as a list unless the user asks.",

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -339,9 +339,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.assistantName)
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
-      if (n.googleConnected) {
+      if (n.googleConnected && n.googleServices?.length) {
         lines.push(
-          "- Google connected: yes (Gmail, Calendar, and Drive access granted)",
+          `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,
         );
       }
       lines.push(

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -36,6 +36,21 @@ Match their energy, not just their format. Lowercase and terse gets lowercase an
 
 Don't present options and ask what they'd prefer. That reads as hedging. Given what you know, pick the most useful path and say why. Wrong is recoverable. Vague isn't.
 
+### Google scan (when connected)
+
+If the First-Run User Context says "Google connected: yes" and the user asks you to scan, start parallel background scans using `subagent_spawn`:
+
+1. Spawn one subagent per service — label each clearly:
+   - **Gmail**: "Scanning Gmail" — objective: "Read my recent emails. Focus on unread and flagged messages from the last 48 hours. Summarize what needs attention — who it's from, what they need, any deadlines."
+   - **Google Calendar**: "Scanning Calendar" — objective: "Check my calendar for the next 48 hours. List events with times, attendees, and flag any conflicts or back-to-backs."
+   - **Google Drive**: "Scanning Drive" — objective: "Look at my recently modified files in Google Drive from the last week. Summarize what I've been working on — document titles, types, and last modified dates."
+
+2. After spawning, tell the user the scans are running in the background and continue the conversation normally. Don't wait or poll.
+
+3. When subagent completion notifications arrive, use `subagent_read` to get results, then weave a natural summary into the conversation: what needs attention, upcoming commitments, recent work. Be concise — bullet points, not paragraphs.
+
+If the user doesn't ask for a scan, don't offer it again. The greeting already mentioned it.
+
 ### Path A — The Conversation-First User
 
 If the user wants to talk first — someone who says "let's just talk," responds to the invite with something personal or open-ended, or seems unsure what they want — this is the better path. Run it as a real conversation, not an intake. You're genuinely curious.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1183,6 +1183,7 @@ export async function handleSendMessage(
       userName?: string;
       assistantName?: string;
       googleConnected?: boolean;
+      googleScopes?: string[];
     };
   };
 
@@ -1576,6 +1577,7 @@ export async function handleSendMessage(
             tasks: body.onboarding!.tasks,
             tone: body.onboarding!.tone,
             googleConnected: body.onboarding!.googleConnected,
+            googleScopes: body.onboarding!.googleScopes,
           });
         } catch (err) {
           log.warn({ err }, "Failed to record onboarding telemetry event");
@@ -1629,6 +1631,7 @@ export async function handleSendMessage(
         tasks: body.onboarding!.tasks,
         tone: body.onboarding!.tone,
         googleConnected: body.onboarding!.googleConnected,
+        googleScopes: body.onboarding!.googleScopes,
       });
     } catch (err) {
       log.warn({ err }, "Failed to record onboarding telemetry event");

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -4,4 +4,6 @@ export interface OnboardingContext {
   tone: string;
   userName?: string;
   assistantName?: string;
+  googleConnected?: boolean;
+  googleScopes?: string[];
 }


### PR DESCRIPTION
## Summary
- Adds `googleConnected` and `googleScopes` to `OnboardingContext` type so Google connection status flows through the daemon
- Updates canned first greeting to mention background scanning when `googleConnected: true` (tone-aware)
- Adds Google connection status to the system prompt's First-Run User Context section
- Adds scan instructions to BOOTSTRAP.md: when the user asks to scan, spawn one subagent per service (Gmail, Calendar, Drive) via `subagent_spawn`, continue chatting while they run, then synthesize results naturally when they complete

## How it works
1. User connects Google during pre-chat onboarding in the web client
2. Web sends `googleConnected: true` with the first message
3. Canned greeting mentions scanning is available (e.g., "I can scan your email, calendar, and drive in the background — just say the word")
4. If user says yes, the model follows BOOTSTRAP.md instructions to spawn 3 subagents
5. Subagent completion notifications auto-inject into the conversation, model reads results and summarizes

## Part of
JARVIS-839 (new user retention funnel). Platform-side telemetry (Django serializer, dbt staging model, BigQuery table) already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->