### PR TITLE
Unwrap legacy external_content envelopes in history and search display

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -91,6 +91,49 @@ describe("renderHistoryContent", () => {
     expect(renderHistoryContent(42).text).toBe("42");
   });
 
+  test("unwraps complete legacy external_content envelopes for plain string content", () => {
+    const output = renderHistoryContent(
+      '<external_content source="slack">\nVisible Slack text\n</external_content>',
+    );
+
+    expect(output.text).toBe("Visible Slack text");
+    expect(output.textSegments).toEqual(["Visible Slack text"]);
+    expect(output.contentOrder).toEqual(["text:0"]);
+  });
+
+  test("unwraps complete legacy external_content envelopes in text blocks", () => {
+    const output = renderHistoryContent([
+      {
+        type: "text",
+        text: '<external_content source="slack">\nVisible block text\n</external_content>',
+      },
+      { type: "text", text: "Plain follow-up." },
+    ]);
+
+    expect(output.text).toBe("Visible block text Plain follow-up.");
+    expect(output.textSegments).toEqual([
+      "Visible block text Plain follow-up.",
+    ]);
+    expect(output.contentOrder).toEqual(["text:0"]);
+  });
+
+  test("leaves malformed or mixed external_content text unchanged", () => {
+    const malformed =
+      '<external_content source="slack">Visible text</external_content>';
+    const mixed =
+      'prefix <external_content source="slack">\nVisible text\n</external_content>';
+
+    const malformedOutput = renderHistoryContent([
+      { type: "text", text: malformed },
+    ]);
+    expect(malformedOutput.text).toBe(malformed);
+    expect(malformedOutput.textSegments).toEqual([malformed]);
+
+    const mixedOutput = renderHistoryContent(mixed);
+    expect(mixedOutput.text).toBe(mixed);
+    expect(mixedOutput.textSegments).toEqual([mixed]);
+  });
+
   test("preserves JSON object content as JSON string", () => {
     expect(renderHistoryContent({ foo: "bar" }).text).toBe('{"foo":"bar"}');
   });

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -6,6 +6,7 @@ import type { SecretPromptResult } from "../../permissions/secret-prompter.js";
 import { isPlaceholderSentinelText } from "../../providers/anthropic/client.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../../runtime/auth/types.js";
+import { unwrapExternalContentForDisplay } from "../../security/untrusted-content.js";
 import { getLogger } from "../../util/logger.js";
 import { estimateBase64Bytes } from "../assistant-attachments.js";
 import type { ConversationTransportMetadata } from "../message-protocol.js";
@@ -224,7 +225,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     } else if (typeof content === "object") {
       text = JSON.stringify(content);
     } else {
-      text = String(content);
+      text = unwrapExternalContentForDisplay(String(content));
     }
     return {
       text,
@@ -329,20 +330,21 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     }
 
     if (block.type === "text" && typeof block.text === "string") {
+      const displayText = unwrapExternalContentForDisplay(block.text);
       // Skip empty/whitespace-only text blocks. During streaming the client
       // discards empty text deltas (guard !text.isEmpty), so including them
       // here produces a contentOrder that differs from the live streaming
       // path — e.g. empty segments between consecutive tool_use blocks that
       // break tool-call grouping in the UI.
-      if (block.text.trim().length === 0) continue;
+      if (displayText.trim().length === 0) continue;
       // Drop Anthropic provider placeholder sentinels. These are injected
       // into outbound API requests to preserve role alternation and must
       // never be rendered to users. Belt-and-suspenders with the persist-
       // time filter in cleanAssistantContent and migration 222.
-      if (isPlaceholderSentinelText(block.text)) continue;
-      textParts.push(block.text);
+      if (isPlaceholderSentinelText(displayText)) continue;
+      textParts.push(displayText);
       ensureSegment();
-      currentSegmentParts.push(block.text);
+      currentSegmentParts.push(displayText);
       seenText = true;
       continue;
     }

--- a/assistant/src/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/memory/__tests__/conversation-queries.test.ts
@@ -11,6 +11,7 @@ mock.module("../../util/logger.js", () => ({
 
 import { createConversation } from "../conversation-crud.js";
 import {
+  buildExcerpt,
   countConversations,
   listConversations,
 } from "../conversation-queries.js";
@@ -34,6 +35,35 @@ function setConversationType(conversationId: string, type: string): void {
     .where(eq(conversations.id, conversationId))
     .run();
 }
+
+describe("buildExcerpt", () => {
+  test("does not expose external_content tags for legacy plain-string rows", () => {
+    const excerpt = buildExcerpt(
+      '<external_content source="slack">\nSearchable Slack text\n</external_content>',
+      "external_content",
+    );
+
+    expect(excerpt).toBe("Searchable Slack text");
+    expect(excerpt).not.toContain("<external_content");
+    expect(excerpt).not.toContain("</external_content>");
+  });
+
+  test("does not expose external_content tags for legacy text block rows", () => {
+    const excerpt = buildExcerpt(
+      JSON.stringify([
+        {
+          type: "text",
+          text: '<external_content source="slack">\nSearchable block text\n</external_content>',
+        },
+      ]),
+      "external_content",
+    );
+
+    expect(excerpt).toBe("Searchable block text");
+    expect(excerpt).not.toContain("<external_content");
+    expect(excerpt).not.toContain("</external_content>");
+  });
+});
 
 describe("countConversations", () => {
   beforeEach(() => {

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -1,5 +1,6 @@
 import { and, count, desc, eq, sql } from "drizzle-orm";
 
+import { unwrapExternalContentForDisplay } from "../security/untrusted-content.js";
 import { getLogger } from "../util/logger.js";
 import type { ConversationRow } from "./conversation-crud.js";
 import { parseConversation } from "./conversation-crud.js";
@@ -420,7 +421,7 @@ export function buildExcerpt(rawContent: string, query: string): string {
       for (const block of parsed) {
         if (typeof block === "object" && block != null) {
           if (block.type === "text" && typeof block.text === "string") {
-            parts.push(block.text);
+            parts.push(unwrapExternalContentForDisplay(block.text));
           } else if (
             block.type === "tool_result" ||
             block.type === "web_search_tool_result"
@@ -428,7 +429,7 @@ export function buildExcerpt(rawContent: string, query: string): string {
             const inner = Array.isArray(block.content) ? block.content : [];
             for (const ib of inner) {
               if (ib?.type === "text" && typeof ib.text === "string")
-                parts.push(ib.text);
+                parts.push(unwrapExternalContentForDisplay(ib.text));
             }
           }
         }
@@ -440,6 +441,8 @@ export function buildExcerpt(rawContent: string, query: string): string {
   } catch {
     // Not JSON — use as-is
   }
+
+  text = unwrapExternalContentForDisplay(text);
 
   const WINDOW = 100;
   const lowerText = text.toLowerCase();


### PR DESCRIPTION
## Summary
- Hide complete legacy external_content envelopes in conversation history rendering.
- Hide complete legacy external_content envelopes in search excerpts.

Part of plan: slack-runtime-content-wrapping.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->