### PR TITLE
Expose Slack message links in conversation UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -515,7 +515,8 @@ final class ConversationListStore {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             },
             forkParent: item.forkParent,
-            originChannel: item.channelBinding?.sourceChannel ?? item.conversationOriginChannel
+            originChannel: item.channelBinding?.sourceChannel ?? item.conversationOriginChannel,
+            channelBinding: item.channelBinding
         )
         // Automated conversations (heartbeat, schedule, background/task) should never
         // show unread indicators, regardless of what the server reports.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -51,8 +51,9 @@ struct ConversationModel: Identifiable, Hashable {
     var lastSeenAssistantMessageAt: Date?
     var forkParent: ConversationForkParent?
     var originChannel: String?
+    var channelBinding: ChannelBinding?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, source: String? = nil, conversationType: String? = nil, inferenceProfile: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, source: String? = nil, conversationType: String? = nil, inferenceProfile: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil, originChannel: String? = nil, channelBinding: ChannelBinding? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -70,6 +71,7 @@ struct ConversationModel: Identifiable, Hashable {
         self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
         self.forkParent = forkParent
         self.originChannel = originChannel
+        self.channelBinding = channelBinding
     }
 
     /// Whether this conversation was created by a background process (heartbeat, etc.).
@@ -129,6 +131,21 @@ struct ConversationModel: Identifiable, Hashable {
         return true
     }
 
+    var slackChannelId: String? {
+        guard originChannel == "slack" else { return nil }
+        return channelBinding?.externalChatId
+    }
+
+    var slackThreadTimestamp: String? {
+        guard originChannel == "slack" else { return nil }
+        return channelBinding?.slackThread?.threadTs ?? channelBinding?.externalThreadId
+    }
+
+    var slackThreadURL: URL? {
+        guard originChannel == "slack" else { return nil }
+        return channelBinding?.slackThread?.link?.preferredURL
+    }
+
     /// Derive the groupId for a conversation from server metadata when the server
     /// doesn't provide an explicit groupId. Shared by ConversationManager and
     /// ConversationRestorer to avoid duplicated classification logic.
@@ -166,7 +183,8 @@ struct ConversationModel: Identifiable, Hashable {
             lhs.forkParent?.conversationId == rhs.forkParent?.conversationId &&
             lhs.forkParent?.messageId == rhs.forkParent?.messageId &&
             lhs.forkParent?.title == rhs.forkParent?.title &&
-            lhs.originChannel == rhs.originChannel
+            lhs.originChannel == rhs.originChannel &&
+            lhs.channelBinding == rhs.channelBinding
     }
 
     func hash(into hasher: inout Hasher) {
@@ -189,5 +207,6 @@ struct ConversationModel: Identifiable, Hashable {
         hasher.combine(forkParent?.messageId)
         hasher.combine(forkParent?.title)
         hasher.combine(originChannel)
+        hasher.combine(channelBinding)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -459,6 +459,7 @@ final class ConversationRestorer {
                 existing.source = session.source
                 existing.conversationType = session.conversationType
                 existing.originChannel = session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
+                existing.channelBinding = session.channelBinding
                 existing.inferenceProfile = session.inferenceProfile
                 existing.scheduleJobId = session.scheduleJobId
                 // Attention merge reconciles pendingAttentionOverrides (e.g. a
@@ -503,7 +504,8 @@ final class ConversationRestorer {
                     Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
                 },
                 forkParent: session.forkParent,
-                originChannel: session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
+                originChannel: session.channelBinding?.sourceChannel ?? session.conversationOriginChannel,
+                channelBinding: session.channelBinding
             )
             // Suppress unread indicators for automated conversations on initial load.
             // The server tracks attention for all conversations, but automated threads

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1655,6 +1655,7 @@ public struct ChatMessage: Identifiable, Equatable {
         && lhs.isSubagentNotification == rhs.isSubagentNotification
         && lhs.isContentStripped == rhs.isContentStripped
         && lhs.streamingCodePreview == rhs.streamingCodePreview
+        && lhs.slackMessage == rhs.slackMessage
     }
     public let id: UUID
     public let role: ChatRole
@@ -1698,6 +1699,8 @@ public struct ChatMessage: Identifiable, Equatable {
     /// Nil for freshly streamed messages until completion or history backfills it.
     /// Used for fork-from-message, inspect LLM context, TTS, and other daemon-anchored actions.
     public var daemonMessageId: String?
+    /// Slack source metadata and deep links for rows mirrored from Slack.
+    public var slackMessage: SlackMessageReference?
     /// Client-generated correlation nonce stamped on the optimistic row at
     /// send time. Matched against `user_message_echo.clientMessageId` so the
     /// originating client can dedupe its echo even when the SSE event beats
@@ -1745,7 +1748,7 @@ public struct ChatMessage: Identifiable, Equatable {
         textSegments.joined(separator: "\n")
     }
 
-    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], attachmentWarnings: [String] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], isError: Bool = false, conversationError: ConversationError? = nil) {
+    public init(id: UUID = UUID(), role: ChatRole, text: String, timestamp: Date = Date(), isStreaming: Bool = false, status: ChatMessageStatus = .sent, confirmation: ToolConfirmationData? = nil, guardianDecision: GuardianDecisionData? = nil, skillInvocation: SkillInvocationData? = nil, attachments: [ChatAttachment] = [], attachmentWarnings: [String] = [], toolCalls: [ToolCallData] = [], inlineSurfaces: [InlineSurfaceData] = [], slackMessage: SlackMessageReference? = nil, isError: Bool = false, conversationError: ConversationError? = nil) {
         self.id = id
         self.role = role
         self.textSegments = text.isEmpty ? [] : [text]
@@ -1761,6 +1764,7 @@ public struct ChatMessage: Identifiable, Equatable {
         self.toolCalls = toolCalls
         self.toolCallsRevision = Self.toolCallsFingerprint(toolCalls)
         self.inlineSurfaces = inlineSurfaces
+        self.slackMessage = slackMessage
         self.isError = isError
         self.conversationError = conversationError
     }

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -137,6 +137,7 @@ public enum HistoryReconstructionService {
 
             chatMsg.displayMessageId = item.id
             chatMsg.daemonMessageId = item.daemonMessageId ?? item.id
+            chatMsg.slackMessage = item.slackMessage
             chatMsg.wasTruncated = item.wasTruncated ?? false
             for i in chatMsg.attachments.indices {
                 chatMsg.attachments[i].data = ""

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -122,6 +122,10 @@ public struct MessageBubbleView: View {
                     }
                 }
 
+                if let slackURL = message.slackMessage?.preferredMessageURL {
+                    slackMessageLink(destination: slackURL)
+                }
+
                 // Offline-pending indicator: shown when the message is buffered
                 // locally awaiting daemon reconnect. Replaces the streaming dots.
                 if message.status == .pendingOffline {
@@ -314,6 +318,23 @@ public struct MessageBubbleView: View {
         }
     }
 
+    private func slackMessageLink(destination: URL) -> some View {
+        Link(destination: destination) {
+            HStack(spacing: VSpacing.xs) {
+                VIconView(.externalLink, size: 11)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text("Open in Slack")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.sm)
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+        .nativeTooltip("Open message in Slack")
+        .accessibilityLabel("Open message in Slack")
+    }
+
     /// Parse markdown in text using SwiftUI's native AttributedString support.
     /// Kept for backward compatibility (used by macOS ChatView and other callers).
     public static func markdownString(_ text: String) -> AttributedString {
@@ -331,4 +352,3 @@ public struct MessageBubbleView: View {
         return 1.0 + 0.4 * sin(normalized * 2 * .pi)
     }
 }
-

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -576,19 +576,45 @@ public struct CancelRequest: Codable, Sendable {
 }
 
 /// Channel binding metadata exposed in conversation list APIs.
-public struct ChannelBinding: Codable, Sendable {
+public struct ChannelBinding: Codable, Sendable, Hashable {
     public let sourceChannel: String
     public let externalChatId: String
+    public let externalThreadId: String?
     public let externalUserId: String?
     public let displayName: String?
     public let username: String?
+    public let slackThread: SlackThreadReference?
 
-    public init(sourceChannel: String, externalChatId: String, externalUserId: String? = nil, displayName: String? = nil, username: String? = nil) {
+    public init(sourceChannel: String, externalChatId: String, externalThreadId: String? = nil, externalUserId: String? = nil, displayName: String? = nil, username: String? = nil, slackThread: SlackThreadReference? = nil) {
         self.sourceChannel = sourceChannel
         self.externalChatId = externalChatId
+        self.externalThreadId = externalThreadId
         self.externalUserId = externalUserId
         self.displayName = displayName
         self.username = username
+        self.slackThread = slackThread
+    }
+}
+
+public struct SlackDeepLinks: Codable, Sendable, Hashable {
+    public let appUrl: String?
+    public let webUrl: String?
+
+    public init(appUrl: String? = nil, webUrl: String? = nil) {
+        self.appUrl = appUrl
+        self.webUrl = webUrl
+    }
+}
+
+public struct SlackThreadReference: Codable, Sendable, Hashable {
+    public let channelId: String
+    public let threadTs: String
+    public let link: SlackDeepLinks?
+
+    public init(channelId: String, threadTs: String, link: SlackDeepLinks? = nil) {
+        self.channelId = channelId
+        self.threadTs = threadTs
+        self.link = link
     }
 }
 
@@ -2169,10 +2195,12 @@ public struct HistoryResponseMessage: Codable, Sendable {
     public let surfaces: [HistoryResponseSurface]?
     /// Present when this message is a subagent lifecycle notification (running/completed/failed/aborted).
     public let subagentNotification: HistoryResponseMessageSubagentNotification?
+    /// Slack channel/message metadata and deep links when the row originated in Slack.
+    public let slackMessage: SlackMessageReference?
     /// True when text or tool result content was truncated due to maxTextChars/maxToolResultChars.
     public let wasTruncated: Bool?
 
-    public init(id: String? = nil, daemonMessageId: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, thinkingSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, wasTruncated: Bool? = nil) {
+    public init(id: String? = nil, daemonMessageId: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, thinkingSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, slackMessage: SlackMessageReference? = nil, wasTruncated: Bool? = nil) {
         self.id = id
         self.daemonMessageId = daemonMessageId
         self.role = role
@@ -2186,7 +2214,24 @@ public struct HistoryResponseMessage: Codable, Sendable {
         self.contentOrder = contentOrder
         self.surfaces = surfaces
         self.subagentNotification = subagentNotification
+        self.slackMessage = slackMessage
         self.wasTruncated = wasTruncated
+    }
+}
+
+public struct SlackMessageReference: Codable, Sendable, Hashable {
+    public let channelId: String
+    public let channelTs: String
+    public let threadTs: String?
+    public let messageLink: SlackDeepLinks?
+    public let threadLink: SlackDeepLinks?
+
+    public init(channelId: String, channelTs: String, threadTs: String? = nil, messageLink: SlackDeepLinks? = nil, threadLink: SlackDeepLinks? = nil) {
+        self.channelId = channelId
+        self.channelTs = channelTs
+        self.threadTs = threadTs
+        self.messageLink = messageLink
+        self.threadLink = threadLink
     }
 }
 

--- a/clients/shared/Network/SlackMetadataLinks.swift
+++ b/clients/shared/Network/SlackMetadataLinks.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public extension SlackDeepLinks {
+    var preferredURL: URL? {
+        Self.parse(appUrl) ?? Self.parse(webUrl)
+    }
+
+    private static func parse(_ value: String?) -> URL? {
+        guard let value, !value.isEmpty else { return nil }
+        return URL(string: value)
+    }
+}
+
+public extension SlackMessageReference {
+    var preferredMessageURL: URL? {
+        messageLink?.preferredURL
+    }
+
+    var preferredThreadURL: URL? {
+        threadLink?.preferredURL
+    }
+}

--- a/clients/shared/Network/SlackMetadataLinks.swift
+++ b/clients/shared/Network/SlackMetadataLinks.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension SlackDeepLinks {
     var preferredURL: URL? {
-        Self.parse(appUrl) ?? Self.parse(webUrl)
+        Self.parse(webUrl) ?? Self.parse(appUrl)
     }
 
     private static func parse(_ value: String?) -> URL? {

--- a/clients/shared/Tests/SlackMessageMetadataDecodingTests.swift
+++ b/clients/shared/Tests/SlackMessageMetadataDecodingTests.swift
@@ -31,7 +31,7 @@ final class SlackMessageMetadataDecodingTests: XCTestCase {
         XCTAssertEqual(message.slackMessage?.threadTs, "1710000000.000001")
         XCTAssertEqual(
             message.slackMessage?.preferredMessageURL?.absoluteString,
-            "slack://channel?team=T123&id=C123&message=1710000000.000100"
+            "https://example.slack.com/archives/C123/p1710000000000100"
         )
         XCTAssertEqual(
             message.slackMessage?.preferredThreadURL?.absoluteString,

--- a/clients/shared/Tests/SlackMessageMetadataDecodingTests.swift
+++ b/clients/shared/Tests/SlackMessageMetadataDecodingTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class SlackMessageMetadataDecodingTests: XCTestCase {
+    func testHistoryMessageDecodesSlackMessageLinks() throws {
+        let data = """
+        {
+          "id": "msg-123",
+          "role": "user",
+          "text": "Hello from Slack",
+          "timestamp": 1710000000000,
+          "slackMessage": {
+            "channelId": "C123",
+            "channelTs": "1710000000.000100",
+            "threadTs": "1710000000.000001",
+            "messageLink": {
+              "appUrl": "slack://channel?team=T123&id=C123&message=1710000000.000100",
+              "webUrl": "https://example.slack.com/archives/C123/p1710000000000100"
+            },
+            "threadLink": {
+              "webUrl": "https://example.slack.com/archives/C123/p1710000000000001"
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let message = try JSONDecoder().decode(HistoryResponseMessage.self, from: data)
+
+        XCTAssertEqual(message.slackMessage?.channelId, "C123")
+        XCTAssertEqual(message.slackMessage?.channelTs, "1710000000.000100")
+        XCTAssertEqual(message.slackMessage?.threadTs, "1710000000.000001")
+        XCTAssertEqual(
+            message.slackMessage?.preferredMessageURL?.absoluteString,
+            "slack://channel?team=T123&id=C123&message=1710000000.000100"
+        )
+        XCTAssertEqual(
+            message.slackMessage?.preferredThreadURL?.absoluteString,
+            "https://example.slack.com/archives/C123/p1710000000000001"
+        )
+    }
+
+    func testHistoryReconstructionPreservesSlackMessageMetadata() {
+        let slackMessage = SlackMessageReference(
+            channelId: "C123",
+            channelTs: "1710000000.000100",
+            messageLink: SlackDeepLinks(webUrl: "https://example.slack.com/archives/C123/p1710000000000100")
+        )
+        let history = HistoryResponseMessage(
+            id: "msg-123",
+            role: "user",
+            text: "Hello from Slack",
+            timestamp: 1710000000000,
+            slackMessage: slackMessage
+        )
+
+        let result = HistoryReconstructionService.reconstructMessages(
+            from: [history],
+            conversationId: "conv-123"
+        )
+
+        XCTAssertEqual(result.messages.count, 1)
+        XCTAssertEqual(result.messages[0].slackMessage, slackMessage)
+        XCTAssertEqual(
+            result.messages[0].slackMessage?.preferredMessageURL?.absoluteString,
+            "https://example.slack.com/archives/C123/p1710000000000100"
+        )
+    }
+
+    func testChannelBindingDecodesSlackThreadMetadata() throws {
+        let data = """
+        {
+          "sourceChannel": "slack",
+          "externalChatId": "C123",
+          "externalThreadId": "1710000000.000001",
+          "slackThread": {
+            "channelId": "C123",
+            "threadTs": "1710000000.000001",
+            "link": {
+              "webUrl": "https://example.slack.com/archives/C123/p1710000000000001"
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let binding = try JSONDecoder().decode(ChannelBinding.self, from: data)
+
+        XCTAssertEqual(binding.sourceChannel, "slack")
+        XCTAssertEqual(binding.externalChatId, "C123")
+        XCTAssertEqual(binding.externalThreadId, "1710000000.000001")
+        XCTAssertEqual(binding.slackThread?.threadTs, "1710000000.000001")
+        XCTAssertEqual(
+            binding.slackThread?.link?.preferredURL?.absoluteString,
+            "https://example.slack.com/archives/C123/p1710000000000001"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve Slack channel/thread binding metadata on conversation models so UI code can tell when a conversation originated in Slack and identify its Slack channel/thread.
- Decode and carry per-message Slack channel timestamps plus app/web deep links through chat history reconstruction.
- Render a compact "Open in Slack" link on message bubbles that have Slack deep-link metadata.

Apple refs checked (2026-05-14): SwiftUI Link; EnvironmentValues.openURL.

## Original prompt
The user asked what data Conversation UI components have to know whether a conversation originated in Slack, what Slack channel it is in, and what metadata would be needed to make individual Slack messages clickable. Backend inspection showed the assistant already emits conversation-level `channelBinding` and per-message `slackMessage` metadata, but the Swift client did not decode or preserve enough of it. This PR plumbs that existing backend metadata into the shared/macOS conversation UI models and surfaces the per-message Slack link.

Closes #30754
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->