### PR TITLE
fix(gmail): filter out own runs in auto-filter detection and wire up safelist

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -190,7 +190,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T13:55:47-04:00"
+      "updatedAt": "2026-05-14T20:18:40-04:00"
     },
     {
       "id": "google-calendar",
@@ -637,7 +637,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T17:44:22-06:00"
+      "updatedAt": "2026-05-14T17:56:59-06:00"
     },
     {
       "id": "start-the-day",

--- a/skills/gmail/scripts/gmail-auto-filters.ts
+++ b/skills/gmail/scripts/gmail-auto-filters.ts
@@ -13,16 +13,8 @@
  *   preview   — show what filters would be created without creating them
  */
 
-import {
-  parseArgs,
-  printError,
-  ok,
-  optionalArg,
-} from "./lib/common.js";
-import {
-  gmailGet,
-  gmailPost,
-} from "./lib/gmail-client.js";
+import { parseArgs, printError, ok, optionalArg } from "./lib/common.js";
+import { gmailGet, gmailPost } from "./lib/gmail-client.js";
 import {
   readLog,
   generateRunId,
@@ -142,7 +134,9 @@ function extractSenderFromEntry(entry: OpEntry): string {
     if (emailMatch) return emailMatch[0].toLowerCase();
 
     // Try to extract a domain reference (e.g. "from example.com")
-    const domainMatch = entry.reason.match(/(?:from|domain[:\s]+)([\w.-]+\.\w+)/i);
+    const domainMatch = entry.reason.match(
+      /(?:from|domain[:\s]+)([\w.-]+\.\w+)/i,
+    );
     if (domainMatch) return `@${domainMatch[1].toLowerCase()}`;
   }
 
@@ -201,20 +195,14 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
     if (phase.includes("sketchy") || phase.includes("tld")) {
       const domain = extractDomain(from);
       if (domain && isSketchyTld(domain)) {
-        sketchyTldDomains.set(
-          domain,
-          (sketchyTldDomains.get(domain) ?? 0) + 1,
-        );
+        sketchyTldDomains.set(domain, (sketchyTldDomains.get(domain) ?? 0) + 1);
       }
     }
 
     // Track newsletters (Pass 4)
     if (phase.includes("newsletter") || phase.includes("digest")) {
       if (from) {
-        newsletterSenders.set(
-          from,
-          (newsletterSenders.get(from) ?? 0) + 1,
-        );
+        newsletterSenders.set(from, (newsletterSenders.get(from) ?? 0) + 1);
       }
     }
   }
@@ -331,9 +319,7 @@ function isDuplicateFilter(
 
 /** Format filter candidates into a human-readable confirmation message. */
 function formatFilterPlan(candidates: FilterCandidate[]): string {
-  const lines: string[] = [
-    `${candidates.length} filter(s) will be created:\n`,
-  ];
+  const lines: string[] = [`${candidates.length} filter(s) will be created:\n`];
   for (const c of candidates) {
     const criteria = c.criteria.from
       ? `from: ${c.criteria.from}`
@@ -404,7 +390,9 @@ const ARCHIVE_PHASES = new Set([
 ]);
 
 /** Check if a run contains archive operations (i.e. is a cleanup run, not a filter-creation run). */
-function isCleanupRun(summary: NonNullable<ReturnType<typeof summarizeRun>>): boolean {
+function isCleanupRun(
+  summary: NonNullable<ReturnType<typeof summarizeRun>>,
+): boolean {
   const phases = Object.keys(summary.phases);
   // A cleanup run has at least one phase that isn't "auto_filter" or "unknown"
   return phases.some(
@@ -441,8 +429,7 @@ async function handleGenerate(
   const account = optionalArg(args, "account");
   const dryRun = args["dry-run"] === true;
   const skipConfirm = args["skip-confirm"] === true;
-  const sourceRunId =
-    optionalArg(args, "run-id") ?? findLatestCleanupRun();
+  const sourceRunId = optionalArg(args, "run-id") ?? findLatestCleanupRun();
 
   if (!sourceRunId) {
     printError(
@@ -474,9 +461,7 @@ async function handleGenerate(
     account,
   );
   if (!existingRes.ok) {
-    printError(
-      `Failed to list existing filters (HTTP ${existingRes.status})`,
-    );
+    printError(`Failed to list existing filters (HTTP ${existingRes.status})`);
   }
   const existingFilters = existingRes.data.filter ?? [];
 

--- a/skills/gmail/scripts/gmail-auto-filters.ts
+++ b/skills/gmail/scripts/gmail-auto-filters.ts
@@ -128,14 +128,42 @@ async function requestConfirmation(opts: {
 // ---------------------------------------------------------------------------
 
 /**
+ * Extract sender information from an op-log entry.
+ * Falls back to parsing the `reason` field when `from` is not populated,
+ * since cleanup archive logs may not always include sender metadata directly.
+ */
+function extractSenderFromEntry(entry: OpEntry): string {
+  if (entry.from) return entry.from.toLowerCase();
+
+  // Try to extract sender/domain from the reason field
+  if (entry.reason) {
+    // Reason may contain an email address or domain
+    const emailMatch = entry.reason.match(/[\w.+-]+@[\w.-]+\.\w+/);
+    if (emailMatch) return emailMatch[0].toLowerCase();
+
+    // Try to extract a domain reference (e.g. "from example.com")
+    const domainMatch = entry.reason.match(/(?:from|domain[:\s]+)([\w.-]+\.\w+)/i);
+    if (domainMatch) return `@${domainMatch[1].toLowerCase()}`;
+  }
+
+  return "";
+}
+
+/**
  * Derive filter candidates from a cleanup run's op-log entries.
  *
  * Only extracts patterns that the SKILL.md explicitly marks as safe for
  * permanent auto-archiving. Patterns like generic phrases or name/company
  * subject patterns are intentionally excluded — they're too broad.
+ *
+ * Cross-references the user's safelist to exclude safe-listed senders/domains.
  */
 function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
   const candidates: FilterCandidate[] = [];
+
+  // Load safelist to exclude protected senders
+  const prefs = loadPreferences();
+  const safelist = new Set(prefs.safelist.map((s) => s.toLowerCase()));
 
   const noReplySenders = new Set<string>();
   let calendarCount = 0;
@@ -146,7 +174,10 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
     if (entry.status !== "staged" || entry.op !== "archive") continue;
 
     const phase = entry.phase ?? "";
-    const from = entry.from?.toLowerCase() ?? "";
+    const from = extractSenderFromEntry(entry);
+
+    // Skip safe-listed senders
+    if (from && isSafeListed(from, safelist)) continue;
 
     // Track no-reply senders (Pass 4)
     if (
@@ -256,6 +287,15 @@ function extractDomain(email: string): string | undefined {
   return email.slice(atIndex + 1).toLowerCase();
 }
 
+/** Check if a sender is on the safelist (matches exact email or domain). */
+function isSafeListed(sender: string, safelist: Set<string>): boolean {
+  if (safelist.has(sender)) return true;
+  const domain = extractDomain(sender);
+  if (domain && safelist.has(domain)) return true;
+  if (domain && safelist.has(`@${domain}`)) return true;
+  return false;
+}
+
 const SKETCHY_TLDS = new Set([
   ".shop",
   ".biz",
@@ -347,12 +387,44 @@ async function getOrCreateLabel(
 // Find latest completed cleanup run
 // ---------------------------------------------------------------------------
 
+/** Phases that indicate a genuine inbox-cleanup run (not a filter-creation run). */
+const ARCHIVE_PHASES = new Set([
+  "noise_archive",
+  "cold_outreach",
+  "no_reply",
+  "noreply",
+  "calendar",
+  "sketchy",
+  "tld",
+  "newsletter",
+  "digest",
+  "bulk",
+  "promo",
+  "social",
+]);
+
+/** Check if a run contains archive operations (i.e. is a cleanup run, not a filter-creation run). */
+function isCleanupRun(summary: NonNullable<ReturnType<typeof summarizeRun>>): boolean {
+  const phases = Object.keys(summary.phases);
+  // A cleanup run has at least one phase that isn't "auto_filter" or "unknown"
+  return phases.some(
+    (phase) =>
+      ARCHIVE_PHASES.has(phase) ||
+      // Fallback: any phase that isn't the auto_filter phase itself
+      (phase !== "auto_filter" && phase !== "unknown"),
+  );
+}
+
 function findLatestCleanupRun(): string | null {
   const runs = listRuns();
   for (const runId of runs) {
     const summary = summarizeRun(runId);
     if (!summary) continue;
-    if (summary.status === "completed" && summary.total_committed > 0) {
+    if (
+      summary.status === "completed" &&
+      summary.total_committed > 0 &&
+      isCleanupRun(summary)
+    ) {
       return runId;
     }
   }


### PR DESCRIPTION
Closes #29123

## Summary
- Fix findLatestCleanupRun to skip filter-creation runs by checking phases for archive operations
- Enrich archive log entries with sender/domain metadata for filter candidate derivation via reason field fallback
- Wire up loadPreferences safelist cross-reference before generating filter candidates

## Test plan
- [ ] Verify auto-filter generation correctly identifies cleanup runs after previous filter runs exist
- [ ] Verify newsletter candidates are derived from enriched archive metadata
- [ ] Verify safelist cross-reference excludes safe-listed senders from filter candidates