### PR TITLE
Migrate persisted Slack external_content rows back to raw content

### DIFF
--- a/assistant/src/__tests__/db-slack-external-content-normalization.test.ts
+++ b/assistant/src/__tests__/db-slack-external-content-normalization.test.ts
@@ -1,0 +1,198 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { createMessagesFts } from "../memory/migrations/116-messages-fts.js";
+import { migrateNormalizeSlackExternalContent } from "../memory/migrations/249-normalize-slack-external-content.js";
+import * as schema from "../memory/schema.js";
+import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { wrapUntrustedContent } from "../security/untrusted-content.js";
+
+interface MessageRow {
+  id: string;
+  content: string;
+  metadata: string | null;
+}
+
+interface FtsRow {
+  content: string;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapConversationTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      metadata TEXT
+    );
+
+    INSERT INTO conversations (id, title, created_at, updated_at)
+    VALUES ('conv-slack', 'Slack conversation', 1000, 1000);
+  `);
+}
+
+function slackEnvelope(
+  channelTs: string,
+  extra: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    userMessageChannel: "slack",
+    assistantMessageChannel: "slack",
+    slackMeta: writeSlackMetadata({
+      source: "slack",
+      channelId: "C0123",
+      channelTs,
+      eventKind: "message",
+      displayName: "@alice",
+    }),
+    ...extra,
+  });
+}
+
+function insertMessage(
+  raw: Database,
+  id: string,
+  content: string,
+  metadata: string,
+): void {
+  raw
+    .query(
+      /*sql*/ `
+        INSERT INTO messages (id, conversation_id, role, content, created_at, metadata)
+        VALUES (?, 'conv-slack', 'user', ?, 1000, ?)
+      `,
+    )
+    .run(id, content, metadata);
+}
+
+function getRows(raw: Database): Record<string, MessageRow> {
+  const rows = raw
+    .query(`SELECT id, content, metadata FROM messages ORDER BY id`)
+    .all() as MessageRow[];
+  return Object.fromEntries(rows.map((row) => [row.id, row]));
+}
+
+function getFtsContent(raw: Database, messageId: string): string {
+  const row = raw
+    .query(`SELECT content FROM messages_fts WHERE message_id = ?`)
+    .get(messageId) as FtsRow | null;
+  return row?.content ?? "";
+}
+
+describe("migrateNormalizeSlackExternalContent", () => {
+  test("normalizes complete Slack envelopes and leaves unrelated rows unchanged", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapConversationTables(raw);
+    createMessagesFts(db);
+
+    const wrappedPlain = wrapUntrustedContent("plain Slack text", {
+      source: "slack",
+      sourceDetail: "@alice",
+    });
+    const wrappedBlock = wrapUntrustedContent("block Slack text", {
+      source: "slack",
+      sourceDetail: "@alice",
+    });
+    const jsonContent = JSON.stringify([
+      { type: "text", text: wrappedBlock },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+      { type: "file", source: { type: "file_id", file_id: "file_1" } },
+    ]);
+    const nonSlackWrapped = wrapUntrustedContent("web text", {
+      source: "web",
+      sourceDetail: "https://example.com",
+    });
+    const guardianMetadata = slackEnvelope("1700000003.000000", {
+      provenanceTrustClass: "guardian",
+    });
+
+    insertMessage(
+      raw,
+      "slack-plain",
+      wrappedPlain,
+      slackEnvelope("1700000000.000000"),
+    );
+    insertMessage(
+      raw,
+      "slack-json",
+      jsonContent,
+      slackEnvelope("1700000001.000000"),
+    );
+    insertMessage(
+      raw,
+      "non-slack",
+      nonSlackWrapped,
+      JSON.stringify({ userMessageChannel: "web" }),
+    );
+    insertMessage(raw, "guardian-raw", "guardian Slack text", guardianMetadata);
+
+    migrateNormalizeSlackExternalContent(db);
+    const afterFirstRun = getRows(raw);
+    migrateNormalizeSlackExternalContent(db);
+    const afterSecondRun = getRows(raw);
+
+    expect(afterSecondRun).toEqual(afterFirstRun);
+
+    expect(afterFirstRun["slack-plain"]?.content).toBe("plain Slack text");
+    const plainMetadata = JSON.parse(
+      afterFirstRun["slack-plain"]!.metadata!,
+    ) as Record<string, unknown>;
+    expect(plainMetadata.provenanceTrustClass).toBe("unknown");
+    expect(typeof plainMetadata.slackMeta).toBe("string");
+
+    const normalizedBlocks = JSON.parse(afterFirstRun["slack-json"]!.content);
+    expect(normalizedBlocks).toEqual([
+      { type: "text", text: "block Slack text" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+      { type: "file", source: { type: "file_id", file_id: "file_1" } },
+    ]);
+    const jsonMetadata = JSON.parse(
+      afterFirstRun["slack-json"]!.metadata!,
+    ) as Record<string, unknown>;
+    expect(jsonMetadata.provenanceTrustClass).toBe("unknown");
+
+    expect(afterFirstRun["non-slack"]?.content).toBe(nonSlackWrapped);
+    expect(afterFirstRun["non-slack"]?.metadata).toBe(
+      JSON.stringify({ userMessageChannel: "web" }),
+    );
+
+    expect(afterFirstRun["guardian-raw"]?.content).toBe("guardian Slack text");
+    expect(afterFirstRun["guardian-raw"]?.metadata).toBe(guardianMetadata);
+
+    expect(getFtsContent(raw, "slack-plain")).toBe("plain Slack text");
+    expect(getFtsContent(raw, "slack-json")).toContain("block Slack text");
+    expect(getFtsContent(raw, "slack-json")).not.toContain("<external_content");
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -124,6 +124,7 @@ import {
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
+  migrateNormalizeSlackExternalContent,
   migrateNormalizeUserFileByPrincipal,
   migrateNotificationDeliveryThreadDecision,
   migrateOAuthAppsClientSecretPath,
@@ -428,6 +429,7 @@ export function initializeDb(): void {
     migrateBackfillProviderConnectionLabel,
     migrateExternalConversationBindingThreadId,
     createOnboardingEventsTable,
+    migrateNormalizeSlackExternalContent,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/249-normalize-slack-external-content.ts
+++ b/assistant/src/memory/migrations/249-normalize-slack-external-content.ts
@@ -1,0 +1,150 @@
+import { readSlackMetadata } from "../../messaging/providers/slack/message-metadata.js";
+import {
+  parseExternalContentEnvelope,
+  unwrapExternalContentForDisplay,
+} from "../../security/untrusted-content.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_normalize_slack_external_content_v1";
+const BATCH_SIZE = 100;
+
+interface CandidateMessageRow {
+  rowid: number;
+  id: string;
+  content: string;
+  metadata: string;
+}
+
+interface NormalizedMessageRow {
+  content: string;
+  metadata: string;
+}
+
+export function migrateNormalizeSlackExternalContent(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    const tableExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages'`,
+      )
+      .get();
+    if (!tableExists) return;
+
+    let lastRowid = 0;
+
+    for (;;) {
+      const rows = raw
+        .query(
+          /*sql*/ `
+            SELECT rowid, id, content, metadata
+            FROM messages
+            WHERE rowid > ?
+              AND content LIKE '%<external_content%'
+              AND metadata LIKE '%"slackMeta"%'
+            ORDER BY rowid
+            LIMIT ?
+          `,
+        )
+        .all(lastRowid, BATCH_SIZE) as CandidateMessageRow[];
+
+      if (rows.length === 0) break;
+
+      for (const row of rows) {
+        lastRowid = row.rowid;
+        const normalized = normalizeSlackMessageRow(row);
+        if (!normalized) continue;
+
+        raw
+          .query(`UPDATE messages SET content = ?, metadata = ? WHERE id = ?`)
+          .run(normalized.content, normalized.metadata, row.id);
+      }
+    }
+  });
+}
+
+export function downNormalizeSlackExternalContent(_database: DrizzleDb): void {
+  // Irreversible by design: this migration discards redundant persisted
+  // wrappers and leaves runtime assembly responsible for model boundaries.
+}
+
+function normalizeSlackMessageRow(
+  row: CandidateMessageRow,
+): NormalizedMessageRow | null {
+  const metadata = parseSlackMetadataEnvelope(row.metadata);
+  if (!metadata) return null;
+
+  const normalizedContent = normalizeMessageContent(row.content);
+  if (normalizedContent === null) return null;
+
+  if (!Object.prototype.hasOwnProperty.call(metadata, "provenanceTrustClass")) {
+    metadata.provenanceTrustClass = "unknown";
+  }
+
+  return {
+    content: normalizedContent,
+    metadata: JSON.stringify(metadata),
+  };
+}
+
+function parseSlackMetadataEnvelope(
+  rawMetadata: string,
+): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawMetadata);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const metadata = parsed as Record<string, unknown>;
+  if (typeof metadata.slackMeta !== "string") return null;
+  if (!readSlackMetadata(metadata.slackMeta)) return null;
+  return metadata;
+}
+
+function normalizeMessageContent(content: string): string | null {
+  const wholeEnvelope = parseExternalContentEnvelope(content);
+  if (wholeEnvelope) {
+    return wholeEnvelope.content;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+
+  let changed = false;
+  const normalizedBlocks = parsed.map((block) => {
+    if (block === null || typeof block !== "object" || Array.isArray(block)) {
+      return block;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type !== "text" || typeof record.text !== "string") {
+      return block;
+    }
+
+    const unwrapped = unwrapExternalContentForDisplay(record.text);
+    if (unwrapped === record.text) {
+      return block;
+    }
+
+    changed = true;
+    return { ...record, text: unwrapped };
+  });
+
+  return changed ? JSON.stringify(normalizedBlocks) : null;
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -211,6 +211,10 @@ export { migrateBackfillProviderConnectionLabel } from "./246-backfill-provider-
 export { migrateExternalConversationBindingThreadId } from "./247-external-conversation-binding-thread-id.js";
 export { createOnboardingEventsTable } from "./248-create-onboarding-events.js";
 export {
+  downNormalizeSlackExternalContent,
+  migrateNormalizeSlackExternalContent,
+} from "./249-normalize-slack-external-content.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -48,6 +48,7 @@ import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
 import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
+import { downNormalizeSlackExternalContent } from "./249-normalize-slack-external-content.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -411,6 +412,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
     down: downHeartbeatRuns,
+  },
+  {
+    key: "migration_normalize_slack_external_content_v1",
+    version: 48,
+    description:
+      "Normalize legacy persisted Slack external_content wrappers back to raw message content",
+    down: downNormalizeSlackExternalContent,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds an idempotent migration to normalize legacy Slack external_content rows back to raw stored text.
- Preserves non-Slack envelopes and stamps missing Slack provenance as unknown for runtime wrapping.

Part of plan: slack-runtime-content-wrapping.md (PR 7 of 7)