### PR TITLE
fix(prompts): periodic managed connection cache refresh and cleanup

### DIFF
--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -67,20 +67,10 @@ export interface FetchManagedCatalogResult {
   error?: string;
 }
 
-/**
- * Fetch the managed credential catalog from the platform.
- *
- * Requires managed proxy prerequisites (platform base URL + assistant API key).
- * Returns an empty list with `ok: true` when prerequisites are missing —
- * callers should not treat a missing platform as an error.
- *
- * Errors from the platform are captured and returned as `ok: false` with an
- * error message that never contains secret material.
- */
 // ---------------------------------------------------------------------------
 // Managed connection cache — provides a synchronous view of platform-managed
 // connections for use in the system prompt (which is built synchronously).
-// Refresh is triggered at daemon startup and periodically thereafter.
+// Refresh is triggered at daemon startup and periodically via setInterval.
 // ---------------------------------------------------------------------------
 
 export interface CachedManagedConnection {
@@ -114,6 +104,16 @@ export async function refreshManagedConnectionCache(): Promise<void> {
   }
 }
 
+/**
+ * Fetch the managed credential catalog from the platform.
+ *
+ * Requires managed proxy prerequisites (platform base URL + assistant API key).
+ * Returns an empty list with `ok: true` when prerequisites are missing —
+ * callers should not treat a missing platform as an error.
+ *
+ * Errors from the platform are captured and returned as `ok: false` with an
+ * error message that never contains secret material.
+ */
 export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> {
   const client = await VellumPlatformClient.create();
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -425,16 +425,6 @@ export async function runDaemon(): Promise<void> {
         );
       }
 
-      // Populate the managed-connection cache so buildIntegrationSection()
-      // can include platform-managed OAuth connections (e.g. Twitter) in the
-      // system prompt's "Connected Services" section from the first turn.
-      void refreshManagedConnectionCache().catch((err) =>
-        log.warn(
-          { err },
-          "Managed connection cache refresh failed — continuing startup",
-        ),
-      );
-
       // One-time backfill of `relationship-state.json` for existing or
       // upgraded users so they don't land on an empty Home page after the
       // Phase 3 ship. Runs after DB init + workspace migrations so the
@@ -519,6 +509,25 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Call recovery failed — continuing startup");
       }
     } // end if (dbReady)
+
+    // Populate the managed-connection cache so buildIntegrationSection()
+    // can include platform-managed OAuth connections (e.g. Twitter) in the
+    // system prompt's "Connected Services" section from the first turn.
+    // This is an HTTP-only call with no DB dependency, so it runs regardless
+    // of dbReady. A periodic refresh keeps the cache current when users
+    // connect/disconnect managed providers while the assistant is running.
+    void refreshManagedConnectionCache().catch((err) =>
+      log.warn(
+        { err },
+        "Managed connection cache refresh failed — continuing startup",
+      ),
+    );
+    const MANAGED_CONNECTION_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+    setInterval(() => {
+      void refreshManagedConnectionCache().catch((err) =>
+        log.warn({ err }, "Periodic managed connection cache refresh failed"),
+      );
+    }, MANAGED_CONNECTION_REFRESH_INTERVAL_MS);
 
     // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
     // into the workspace config file before profile seeding and the first

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -383,7 +383,10 @@ function buildIntegrationSection(): string {
   // daemon startup and refreshed periodically).
   const managed = getCachedManagedConnections();
   for (const mc of managed) {
-    // Avoid duplicates — a provider with a local row is already listed.
+    // Provider-level dedup is intentional: this section is a summary of
+    // connected services for the system prompt, not an exhaustive account
+    // list. Multiple accounts for the same provider (e.g. two Google
+    // accounts) collapse into a single line to keep the prompt compact.
     if (!entries.some((e) => e.provider === mc.provider)) {
       entries.push(mc);
     }


### PR DESCRIPTION
Closes #30727

## Summary
- Add periodic refresh (setInterval, 5min) for managed connection cache so prompt stays current when users connect/disconnect providers
- Move refreshManagedConnectionCache() outside if(dbReady) block since it has no DB dependency
- Fix misattached JSDoc comment on fetchManagedCatalog
- Fix misleading comment about periodic refresh (now accurate)
- Add clarifying comment about intentional provider-level dedup in system prompt

## Test plan
- [ ] Verify managed connection cache refreshes periodically after startup
- [ ] Verify cache refresh works even when DB init fails
- [ ] Verify JSDoc attaches to correct function

🤖 Generated with [Claude Code](https://claude.com/claude-code)