### PR TITLE
fix(oauth): register auth policy for connection-changed route

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -1110,7 +1110,3 @@ registerPolicy("oauth/managed-connect/poll", {
   requiredScopes: ["settings.read"],
   allowedPrincipalTypes: ["local"],
 });
-registerPolicy("oauth/connection-changed", {
-  requiredScopes: ["settings.write"],
-  allowedPrincipalTypes: ["local"],
-});

--- a/assistant/src/runtime/routes/oauth-lifecycle-routes.ts
+++ b/assistant/src/runtime/routes/oauth-lifecycle-routes.ts
@@ -30,6 +30,7 @@ export const ROUTES: RouteDefinition[] = [
     operationId: "oauth_connection_changed",
     endpoint: "oauth/connection-changed",
     method: "POST",
+    policyKey: "oauth/connection-changed",
     handler: handleOAuthConnectionChanged,
     summary: "Notify the assistant that an OAuth connection changed",
     description:


### PR DESCRIPTION
Closes #30744

## Summary
- Add explicit `policyKey` to the `POST /v1/oauth/connection-changed` route definition so the policy association is explicit rather than relying on implicit endpoint derivation
- Remove duplicate `registerPolicy("oauth/connection-changed")` call in route-policy.ts

## Test plan
- [ ] Verify route policy guard test passes
- [ ] Verify the route is properly gated with settings.write scope and local principal type

🤖 Generated with [Claude Code](https://claude.com/claude-code)