### PR TITLE
Prompt for provider credentials during hatch

### DIFF
--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync, rmSync } from "fs";
 import { describe, expect, test } from "bun:test";
 
-import { buildNestedConfig, writeInitialConfig } from "../lib/config-utils.js";
+import {
+  buildHatchConfigValues,
+  buildNestedConfig,
+  writeInitialConfig,
+} from "../lib/config-utils.js";
 
 function readInitialConfig(
   configValues: Record<string, string>,
@@ -30,6 +34,32 @@ describe("config-utils", () => {
         },
       },
     });
+  });
+
+  test("buildHatchConfigValues adds the default hatch provider when no config exists", () => {
+    expect(buildHatchConfigValues({}, "anthropic")).toEqual({
+      "llm.default.provider": "anthropic",
+    });
+  });
+
+  test("buildHatchConfigValues preserves explicit provider config", () => {
+    expect(
+      buildHatchConfigValues(
+        {
+          "llm.default.provider": "openai",
+          "llm.default.model": "gpt-5.4",
+        },
+        "anthropic",
+      ),
+    ).toEqual({
+      "llm.default.provider": "openai",
+      "llm.default.model": "gpt-5.4",
+    });
+  });
+
+  test("buildHatchConfigValues skips internal hatches without provider setup", () => {
+    expect(buildHatchConfigValues({}, undefined)).toEqual({});
+    expect(buildHatchConfigValues({}, null)).toEqual({});
   });
 
   test("writeInitialConfig does not add a mainAgent callSite for Anthropic defaults", () => {

--- a/cli/src/__tests__/hatch-provider-secrets.test.ts
+++ b/cli/src/__tests__/hatch-provider-secrets.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  configureHatchProviderApiKey,
+  resolveHatchProvider,
+  type ProviderSecretFetch,
+} from "../lib/provider-secrets.js";
+
+interface RecordedFetchCall {
+  url: string;
+  init?: RequestInit;
+  body: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeFetch(responses: Response[]): {
+  calls: RecordedFetchCall[];
+  fetchImpl: ProviderSecretFetch;
+} {
+  const calls: RecordedFetchCall[] = [];
+  const fetchImpl: ProviderSecretFetch = async (input, init) => {
+    calls.push({
+      url: String(input),
+      init,
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call.");
+    }
+    return response;
+  };
+
+  return { calls, fetchImpl };
+}
+
+describe("hatch provider secrets", () => {
+  test("defaults hatch provider setup to Anthropic", () => {
+    expect(resolveHatchProvider({})).toBe("anthropic");
+  });
+
+  test("uses llm.default.provider override for hatch provider setup", () => {
+    expect(resolveHatchProvider({ "llm.default.provider": "openai" })).toBe(
+      "openai",
+    );
+  });
+
+  test("uses active profile provider for hatch provider setup", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.activeProfile": "work",
+        "llm.profiles.work.provider": "openai",
+      }),
+    ).toBe("openai");
+  });
+
+  test("infers active profile provider from model for hatch provider setup", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.activeProfile": "work",
+        "llm.profiles.work.model": "gpt-5.4",
+      }),
+    ).toBe("openai");
+  });
+
+  test("active profile provider wins over main agent call-site provider", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.activeProfile": "work",
+        "llm.profiles.work.provider": "openai",
+        "llm.callSites.mainAgent.provider": "gemini",
+      }),
+    ).toBe("openai");
+  });
+
+  test("uses default provider before static main agent call-site provider", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.default.provider": "anthropic",
+        "llm.callSites.mainAgent.provider": "gemini",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("uses default provider before static main agent call-site profile", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.default.provider": "anthropic",
+        "llm.callSites.mainAgent.profile": "work",
+        "llm.profiles.work.provider": "openai",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("uses main agent call-site provider when no hatch default exists", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.callSites.mainAgent.provider": "gemini",
+      }),
+    ).toBe("gemini");
+  });
+
+  test("uses main agent call-site profile when no hatch default exists", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.callSites.mainAgent.profile": "work",
+        "llm.profiles.work.provider": "openai",
+      }),
+    ).toBe("openai");
+  });
+
+  test("infers default provider from model before falling back to Anthropic", () => {
+    expect(
+      resolveHatchProvider({ "llm.default.model": "gemini-2.5-flash" }),
+    ).toBe("gemini");
+  });
+
+  test("skips hatch provider setup for ollama", () => {
+    expect(
+      resolveHatchProvider({ "llm.default.provider": "ollama" }),
+    ).toBeNull();
+  });
+
+  test("skips hatch provider setup for active Ollama profile", () => {
+    expect(
+      resolveHatchProvider({
+        "llm.activeProfile": "local",
+        "llm.profiles.local.model": "llama3.2",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects unsupported hatch providers before hatch starts", () => {
+    expect(() =>
+      resolveHatchProvider({ "llm.default.provider": "custom" }),
+    ).toThrow("supported API-key setup flow");
+  });
+
+  test("configures default Anthropic credentials from the environment", async () => {
+    const { calls, fetchImpl } = makeFetch([
+      jsonResponse({ found: false }),
+      jsonResponse({ success: true }),
+    ]);
+    const logs: string[] = [];
+
+    await configureHatchProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:7830",
+      provider: resolveHatchProvider({}),
+      bearerToken: "guardian-token",
+      env: { ANTHROPIC_API_KEY: "test-anthropic-key" },
+      fetchImpl,
+      log: (message) => logs.push(message),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].body).toEqual({
+      type: "api_key",
+      name: "anthropic",
+      reveal: false,
+    });
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer guardian-token",
+    });
+    expect(calls[1].body).toEqual({
+      type: "api_key",
+      name: "anthropic",
+      value: "test-anthropic-key",
+    });
+    expect(logs.join("\n")).toContain(
+      "Configured Anthropic credentials from ANTHROPIC_API_KEY.",
+    );
+    expect(logs.join("\n")).not.toContain("test-anthropic-key");
+  });
+
+  test("uses OpenAI override and skips prompt when credentials already exist", async () => {
+    const { calls, fetchImpl } = makeFetch([jsonResponse({ found: true })]);
+    const logs: string[] = [];
+    let prompted = false;
+
+    await configureHatchProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:7830",
+      provider: resolveHatchProvider({ "llm.default.provider": "openai" }),
+      bearerToken: "guardian-token",
+      env: {},
+      fetchImpl,
+      prompt: async () => {
+        prompted = true;
+        return "unused";
+      },
+      log: (message) => logs.push(message),
+    });
+
+    expect(prompted).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toEqual({
+      type: "api_key",
+      name: "openai",
+      reveal: false,
+    });
+    expect(logs.join("\n")).toContain(
+      "Provider credentials already configured for OpenAI.",
+    );
+  });
+
+  test("uses active profile provider when selecting environment credential", async () => {
+    const { calls, fetchImpl } = makeFetch([
+      jsonResponse({ found: false }),
+      jsonResponse({ success: true }),
+    ]);
+
+    await configureHatchProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:7830",
+      provider: resolveHatchProvider({
+        "llm.activeProfile": "work",
+        "llm.profiles.work.provider": "openai",
+      }),
+      bearerToken: "guardian-token",
+      env: { OPENAI_API_KEY: "test-openai-key" },
+      fetchImpl,
+      log: () => {},
+    });
+
+    expect(calls[0].body).toEqual({
+      type: "api_key",
+      name: "openai",
+      reveal: false,
+    });
+    expect(calls[1].body).toEqual({
+      type: "api_key",
+      name: "openai",
+      value: "test-openai-key",
+    });
+  });
+
+  test("keeps hatch recoverable when provider credentials are missing in a non-interactive shell", async () => {
+    const { fetchImpl } = makeFetch([jsonResponse({ found: false })]);
+    const logs: string[] = [];
+
+    await configureHatchProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:7830",
+      provider: "anthropic",
+      env: {},
+      fetchImpl,
+      stdinIsTTY: false,
+      log: (message) => logs.push(message),
+    });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Provider credential setup skipped");
+    expect(output).toContain("Missing ANTHROPIC_API_KEY");
+    expect(output).toContain("vellum setup --provider anthropic");
+  });
+
+  test("surfaces gateway validation failures without throwing or logging the key", async () => {
+    const { fetchImpl } = makeFetch([
+      jsonResponse({ found: false }),
+      jsonResponse(
+        { error: { message: "API key is invalid or expired." } },
+        400,
+      ),
+    ]);
+    const logs: string[] = [];
+
+    await configureHatchProviderApiKey({
+      gatewayUrl: "http://127.0.0.1:7830",
+      provider: "anthropic",
+      env: { ANTHROPIC_API_KEY: "test-anthropic-key" },
+      fetchImpl,
+      log: (message) => logs.push(message),
+    });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Provider credential setup failed");
+    expect(output).toContain("API key is invalid or expired.");
+    expect(output).toContain("vellum setup --provider anthropic");
+    expect(output).not.toContain("test-anthropic-key");
+  });
+});

--- a/cli/src/__tests__/setup.test.ts
+++ b/cli/src/__tests__/setup.test.ts
@@ -75,7 +75,10 @@ function writeLockfile(entry: AssistantEntry): void {
 }
 
 function installFetchStub(
-  options: { refreshedToken?: GuardianTokenData } = {},
+  options: {
+    leasedToken?: GuardianTokenData;
+    refreshedToken?: GuardianTokenData;
+  } = {},
 ) {
   fetchCalls = [];
   globalThis.fetch = (async (input, init) => {
@@ -98,6 +101,19 @@ function installFetchStub(
         });
       }
       return new Response(JSON.stringify(options.refreshedToken), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/v1/guardian/init")) {
+      if (!options.leasedToken) {
+        return new Response(JSON.stringify({ error: "not allowed" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(options.leasedToken), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -206,6 +222,54 @@ describe("setup command", () => {
     });
     expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
       "OpenAI API key saved to assistant from the environment.",
+    );
+  });
+
+  test("leases a guardian token for local assistants when no token exists", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
+      assistantId: "assistant-123",
+      runtimeUrl: "http://runtime.example",
+      localUrl: "http://127.0.0.1:3000",
+      cloud: "local",
+    });
+    installFetchStub({
+      leasedToken: guardianTokenFixture({
+        accessToken: "leased-guardian-token",
+      }),
+    });
+
+    await setup();
+
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:3000/v1/guardian/init");
+    expect(fetchCalls[1].url).toBe("http://127.0.0.1:3000/v1/secrets/read");
+    expect(fetchCalls[1].headers.get("Authorization")).toBe(
+      "Bearer leased-guardian-token",
+    );
+  });
+
+  test("uses saved bootstrap secret when leasing a Docker guardian token", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    writeLockfile({
+      assistantId: "assistant-123",
+      runtimeUrl: "http://localhost:7831",
+      cloud: "docker",
+      guardianBootstrapSecret: "test-bootstrap-secret",
+    });
+    installFetchStub({
+      leasedToken: guardianTokenFixture({
+        accessToken: "leased-docker-token",
+      }),
+    });
+
+    await setup();
+
+    expect(fetchCalls[0].url).toBe("http://localhost:7831/v1/guardian/init");
+    expect(fetchCalls[0].headers.get("x-bootstrap-secret")).toBe(
+      "test-bootstrap-secret",
+    );
+    expect(fetchCalls[1].headers.get("Authorization")).toBe(
+      "Bearer leased-docker-token",
     );
   });
 

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -779,6 +779,7 @@ describe("resolveOrHatchTarget", () => {
       "new-one",
       false,
       {},
+      { setupProviderCredentials: false },
     );
     expect(result).toBe(newEntry);
   });

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -1,5 +1,6 @@
 import { resolveAssistant } from "../lib/assistant-config.js";
 import {
+  leaseGuardianToken,
   loadGuardianToken,
   refreshGuardianToken,
   type GuardianTokenData,
@@ -39,6 +40,50 @@ function isGuardianAccessTokenUsable(
   }
   const expiresAt = new Date(tokenData.accessTokenExpiresAt).getTime();
   return Number.isFinite(expiresAt) && expiresAt > Date.now();
+}
+
+async function resolveSetupBearerToken(
+  entry: NonNullable<ReturnType<typeof resolveAssistant>>,
+  gatewayUrl: string,
+): Promise<string | undefined> {
+  const guardianToken = loadGuardianToken(entry.assistantId);
+  if (isGuardianAccessTokenUsable(guardianToken)) {
+    return guardianToken.accessToken;
+  }
+
+  if (guardianToken) {
+    const refreshedToken = await refreshGuardianToken(
+      gatewayUrl,
+      entry.assistantId,
+    );
+    if (isGuardianAccessTokenUsable(refreshedToken)) {
+      return refreshedToken.accessToken;
+    }
+  }
+
+  const canLeaseGuardianToken =
+    entry.cloud === "local" || entry.cloud === "docker" || entry.localUrl;
+  if (canLeaseGuardianToken) {
+    try {
+      const bootstrapSecret =
+        typeof entry.guardianBootstrapSecret === "string"
+          ? entry.guardianBootstrapSecret
+          : undefined;
+      const leasedToken = await leaseGuardianToken(
+        gatewayUrl,
+        entry.assistantId,
+        bootstrapSecret,
+      );
+      if (isGuardianAccessTokenUsable(leasedToken)) {
+        return leasedToken.accessToken;
+      }
+    } catch {
+      // Fall through to any lockfile bearer token, or let the setup request
+      // surface the gateway's auth error below.
+    }
+  }
+
+  return entry.bearerToken;
 }
 
 export async function setup(): Promise<void> {
@@ -85,18 +130,7 @@ export async function setup(): Promise<void> {
   }
 
   const gatewayUrl = entry.localUrl ?? entry.runtimeUrl;
-  let bearerToken: string | undefined;
-  const guardianToken = loadGuardianToken(entry.assistantId);
-  if (isGuardianAccessTokenUsable(guardianToken)) {
-    bearerToken = guardianToken.accessToken;
-  } else {
-    const refreshedToken = guardianToken
-      ? await refreshGuardianToken(gatewayUrl, entry.assistantId)
-      : null;
-    bearerToken = isGuardianAccessTokenUsable(refreshedToken)
-      ? refreshedToken.accessToken
-      : entry.bearerToken;
-  }
+  const bearerToken = await resolveSetupBearerToken(entry, gatewayUrl);
 
   console.log("Vellum Setup");
   console.log("============\n");

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -877,7 +877,16 @@ export async function resolveOrHatchTarget(
   // Hatch a new assistant in the target environment
   if (targetEnv === "local") {
     const beforeIds = new Set(loadAllAssistants().map((e) => e.assistantId));
-    await hatchLocal("vellum", targetName ?? null, false, false, {});
+    await hatchLocal(
+      "vellum",
+      targetName ?? null,
+      false,
+      false,
+      {},
+      {
+        setupProviderCredentials: false,
+      },
+    );
     const entry = targetName
       ? findAssistantByName(targetName)
       : (loadAllAssistants().find((e) => !beforeIds.has(e.assistantId)) ??
@@ -892,7 +901,16 @@ export async function resolveOrHatchTarget(
 
   if (targetEnv === "docker") {
     const beforeIds = new Set(loadAllAssistants().map((e) => e.assistantId));
-    await hatchDocker("vellum", false, targetName ?? null, false, {});
+    await hatchDocker(
+      "vellum",
+      false,
+      targetName ?? null,
+      false,
+      {},
+      {
+        setupProviderCredentials: false,
+      },
+    );
     const entry = targetName
       ? findAssistantByName(targetName)
       : (loadAllAssistants().find((e) => !beforeIds.has(e.assistantId)) ??

--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -5,6 +5,7 @@ import {
   dockerResourceNames,
   resolveAvatarDevicePath,
   resolveDockerHatchMode,
+  resolveDockerProviderCredentialSetupAction,
   type ServiceName,
 } from "../docker.js";
 import { buildServiceRunArgs } from "../statefulset.js";
@@ -101,6 +102,51 @@ describe("buildServiceRunArgs — assistant", () => {
     expect(args.some((a) => a.startsWith("GUARDIAN_BOOTSTRAP_SECRET="))).toBe(
       false,
     );
+  });
+});
+
+describe("resolveDockerProviderCredentialSetupAction", () => {
+  test("defers provider setup in detached mode", () => {
+    expect(
+      resolveDockerProviderCredentialSetupAction({
+        provider: "anthropic",
+        detached: true,
+      }),
+    ).toBe("defer");
+  });
+
+  test("reports missing guardian token only when a lease was expected", () => {
+    expect(
+      resolveDockerProviderCredentialSetupAction({
+        provider: "anthropic",
+        detached: false,
+      }),
+    ).toBe("missing-token");
+  });
+
+  test("configures provider setup when a guardian token is available", () => {
+    expect(
+      resolveDockerProviderCredentialSetupAction({
+        provider: "anthropic",
+        guardianAccessToken: "guardian-token",
+        detached: false,
+      }),
+    ).toBe("configure");
+  });
+
+  test("skips provider setup for internal hatches and detached keyless hatches", () => {
+    expect(
+      resolveDockerProviderCredentialSetupAction({
+        provider: undefined,
+        detached: false,
+      }),
+    ).toBe("skip");
+    expect(
+      resolveDockerProviderCredentialSetupAction({
+        provider: null,
+        detached: true,
+      }),
+    ).toBe("skip");
   });
 });
 

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -89,6 +89,8 @@ export interface AssistantEntry {
   resources?: LocalInstanceResources;
   /** PID of the file watcher process for docker instances hatched with --watch. */
   watcherPid?: number;
+  /** Local bootstrap secret used to lease guardian tokens for Docker assistants after detached hatch. */
+  guardianBootstrapSecret?: string;
   /** Docker image metadata for rollback. Only present for docker topology entries. */
   containerInfo?: ContainerInfo;
   /** Docker image metadata from before the last upgrade. Enables rollback to the prior version. */

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -33,6 +33,24 @@ export function buildNestedConfig(
 }
 
 /**
+ * Ensure hatch always provides enough initial LLM config for the assistant to
+ * detect a fresh off-platform hatch and seed BYOK profiles.
+ */
+export function buildHatchConfigValues(
+  configValues: Record<string, string>,
+  provider: string | null | undefined,
+): Record<string, string> {
+  if (!provider || configValues["llm.default.provider"]) {
+    return configValues;
+  }
+
+  return {
+    ...configValues,
+    "llm.default.provider": provider,
+  };
+}
+
+/**
  * Write arbitrary key-value pairs to a temporary JSON file and return its
  * path. The caller passes this path to the daemon via the
  * VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH env var so the daemon can merge the

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -12,15 +12,21 @@ import {
   setActiveAssistant,
 } from "./assistant-config";
 import type { AssistantEntry } from "./assistant-config";
-import { writeInitialConfig } from "./config-utils";
+import { buildHatchConfigValues, writeInitialConfig } from "./config-utils";
 import { buildServiceRunArgs } from "./statefulset.js";
 import type { Species } from "./constants";
 import { getDefaultPorts } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
 import { leaseGuardianToken } from "./guardian-token";
+import { logHatchNextSteps } from "./hatch-next-steps.js";
 import { isVellumProcess, stopProcess } from "./process";
 import { generateInstanceName } from "./random-name";
 import { resolveImageRefs } from "./platform-releases.js";
+import {
+  configureHatchProviderApiKey,
+  formatProviderName,
+  resolveHatchProvider,
+} from "./provider-secrets.js";
 import { exec, execOutput } from "./step-runner";
 import {
   closeLogFile,
@@ -248,6 +254,28 @@ function ensureLocalBinOnPath(): void {
   if (!currentPath.includes(LOCAL_BIN_DIR)) {
     process.env.PATH = `${LOCAL_BIN_DIR}:${currentPath}`;
   }
+}
+
+export interface HatchDockerOptions {
+  setupProviderCredentials?: boolean;
+}
+
+export type DockerProviderCredentialSetupAction =
+  | "configure"
+  | "defer"
+  | "missing-token"
+  | "skip";
+
+export function resolveDockerProviderCredentialSetupAction(options: {
+  provider: string | null | undefined;
+  guardianAccessToken?: string;
+  detached: boolean;
+}): DockerProviderCredentialSetupAction {
+  if (options.provider === undefined) return "skip";
+  if (options.provider === null) return options.detached ? "skip" : "configure";
+  if (options.detached) return "defer";
+  if (!options.guardianAccessToken) return "missing-token";
+  return "configure";
 }
 
 /**
@@ -928,6 +956,10 @@ export async function hatchDocker(
   options: HatchDockerOptions = {},
 ): Promise<void> {
   resetLogFile("hatch.log");
+  const provider =
+    options.setupProviderCredentials === false
+      ? undefined
+      : resolveHatchProvider(configValues);
 
   let logFd = openLogFile("hatch.log");
   const log = (msg: string): void => {
@@ -1082,7 +1114,8 @@ export async function hatchDocker(
 
     // Write --config key=value pairs to a temp file that gets bind-mounted
     // into the assistant container and read via VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH.
-    const defaultWorkspaceConfigPath = writeInitialConfig(configValues);
+    const hatchConfigValues = buildHatchConfigValues(configValues, provider);
+    const defaultWorkspaceConfigPath = writeInitialConfig(hatchConfigValues);
 
     const cesServiceToken = randomBytes(32).toString("hex");
     const signingKey = randomBytes(32).toString("hex");
@@ -1122,6 +1155,7 @@ export async function hatchDocker(
       cloud: "docker",
       species,
       hatchedAt: new Date().toISOString(),
+      guardianBootstrapSecret: ownSecret,
       containerInfo: {
         assistantImage: imageTags.assistant,
         gatewayImage: imageTags.gateway,
@@ -1137,10 +1171,11 @@ export async function hatchDocker(
     setActiveAssistant(instanceName);
 
     emitProgress(6, 6, "Waiting for services...");
-    const { ready } = await waitForGatewayAndLease({
+    const waitDetached = watch ? false : detached;
+    const { ready, guardianAccessToken } = await waitForGatewayAndLease({
       bootstrapSecret: ownSecret,
       containerName: res.assistantContainer,
-      detached: watch ? false : detached,
+      detached: waitDetached,
       instanceName,
       logFd,
       runtimeUrl,
@@ -1148,6 +1183,43 @@ export async function hatchDocker(
 
     if (!ready && !(watch && repoRoot)) {
       throw new Error("Timed out waiting for assistant to become ready");
+    }
+
+    if (ready) {
+      const providerSetupAction = resolveDockerProviderCredentialSetupAction({
+        provider,
+        guardianAccessToken,
+        detached: waitDetached,
+      });
+
+      if (providerSetupAction === "defer" && provider !== null) {
+        log(
+          `Provider credential setup deferred in detached mode.\n` +
+            `Run \`vellum setup --provider ${provider}\` after the assistant is ready.`,
+        );
+      } else if (providerSetupAction === "missing-token" && provider !== null) {
+        log(
+          `⚠️  Provider credential setup skipped because the guardian token was not leased.\n` +
+            `   The assistant is still hatched. Run \`vellum setup --provider ${provider}\` after fixing the connection.`,
+        );
+      } else if (
+        providerSetupAction === "configure" &&
+        provider !== undefined
+      ) {
+        log(
+          provider === null
+            ? "Checking provider credentials..."
+            : `Checking ${formatProviderName(provider)} credentials...`,
+        );
+        await configureHatchProviderApiKey({
+          gatewayUrl: runtimeUrl,
+          provider,
+          bearerToken: guardianAccessToken,
+          env: process.env,
+          log,
+        });
+      }
+      logHatchNextSteps(log, instanceName);
     }
 
     if (watch && repoRoot) {
@@ -1205,7 +1277,7 @@ async function waitForGatewayAndLease(opts: {
   instanceName: string;
   logFd: number | "ignore";
   runtimeUrl: string;
-}): Promise<{ ready: boolean }> {
+}): Promise<{ ready: boolean; guardianAccessToken?: string }> {
   const {
     bootstrapSecret,
     containerName,
@@ -1284,6 +1356,7 @@ async function waitForGatewayAndLease(opts: {
   const leaseDeadline = start + DOCKER_READY_TIMEOUT_MS;
   let leaseSuccess = false;
   let lastLeaseError: string | undefined;
+  let guardianAccessToken: string | undefined;
 
   while (Date.now() < leaseDeadline) {
     try {
@@ -1296,6 +1369,7 @@ async function waitForGatewayAndLease(opts: {
       log(
         `Guardian token lease: success after ${leaseElapsed}s (principalId=${tokenData.guardianPrincipalId}, expiresAt=${tokenData.accessTokenExpiresAt})`,
       );
+      guardianAccessToken = tokenData.accessToken;
       leaseSuccess = true;
       break;
     } catch (err) {
@@ -1326,5 +1400,5 @@ async function waitForGatewayAndLease(opts: {
   log(`   Name: ${instanceName}`);
   log(`   Runtime: ${runtimeUrl}`);
   log("");
-  return { ready: true };
+  return { ready: true, guardianAccessToken };
 }

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -22,7 +22,7 @@ import {
 } from "./assistant-config.js";
 import type { AssistantEntry } from "./assistant-config.js";
 import type { Species } from "./constants.js";
-import { writeInitialConfig } from "./config-utils.js";
+import { buildHatchConfigValues, writeInitialConfig } from "./config-utils.js";
 import {
   generateLocalSigningKey,
   startLocalDaemon,
@@ -34,6 +34,12 @@ import { generateInstanceName } from "./random-name.js";
 import { leaseGuardianToken } from "./guardian-token.js";
 import { archiveLogFile, resetLogFile } from "./xdg-log.js";
 import { emitProgress } from "./desktop-progress.js";
+import {
+  configureHatchProviderApiKey,
+  formatProviderName,
+  resolveHatchProvider,
+} from "./provider-secrets.js";
+import { logHatchNextSteps } from "./hatch-next-steps.js";
 
 /**
  * Attempts to place a symlink at the given path pointing to cliBinary.
@@ -125,13 +131,22 @@ function installCLISymlink(): void {
   );
 }
 
+export interface HatchLocalOptions {
+  setupProviderCredentials?: boolean;
+}
+
 export async function hatchLocal(
   species: Species,
   name: string | null,
   watch: boolean = false,
   keepAlive: boolean = false,
   configValues: Record<string, string> = {},
+  options: HatchLocalOptions = {},
 ): Promise<void> {
+  const provider =
+    options.setupProviderCredentials === false
+      ? undefined
+      : resolveHatchProvider(configValues);
   const instanceName = generateInstanceName(
     species,
     name ?? process.env.VELLUM_ASSISTANT_NAME,
@@ -168,7 +183,8 @@ export async function hatchLocal(
   }
 
   emitProgress(2, 6, "Writing configuration...");
-  const defaultWorkspaceConfigPath = writeInitialConfig(configValues);
+  const hatchConfigValues = buildHatchConfigValues(configValues, provider);
+  const defaultWorkspaceConfigPath = writeInitialConfig(hatchConfigValues);
 
   emitProgress(3, 6, "Starting assistant...");
   const signingKey = generateLocalSigningKey();
@@ -198,9 +214,11 @@ export async function hatchLocal(
   emitProgress(5, 6, "Securing connection...");
   const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
   const maxLeaseAttempts = 3;
+  let guardianAccessToken: string | undefined;
   for (let attempt = 1; attempt <= maxLeaseAttempts; attempt++) {
     try {
-      await leaseGuardianToken(loopbackUrl, instanceName);
+      const tokenData = await leaseGuardianToken(loopbackUrl, instanceName);
+      guardianAccessToken = tokenData.accessToken;
       break;
     } catch (err) {
       if (attempt < maxLeaseAttempts) {
@@ -238,6 +256,26 @@ export async function hatchLocal(
     installCLISymlink();
   }
 
+  if (provider !== undefined && provider !== null && !guardianAccessToken) {
+    console.error(
+      `⚠️  Provider credential setup skipped because the guardian token was not leased.\n` +
+        `   The assistant is still hatched. Run \`vellum setup --provider ${provider}\` after fixing the connection.`,
+    );
+  } else if (provider !== undefined) {
+    console.log("");
+    console.log(
+      provider === null
+        ? "Checking provider credentials..."
+        : `Checking ${formatProviderName(provider)} credentials...`,
+    );
+    await configureHatchProviderApiKey({
+      gatewayUrl: loopbackUrl,
+      provider,
+      bearerToken: guardianAccessToken,
+      env: process.env,
+    });
+  }
+
   console.log("");
   console.log(`✅ Local assistant hatched!`);
   console.log("");
@@ -245,6 +283,7 @@ export async function hatchLocal(
   console.log(`  Name: ${instanceName}`);
   console.log(`  Runtime: ${runtimeUrl}`);
   console.log("");
+  logHatchNextSteps(console.log, instanceName);
 
   if (keepAlive) {
     const healthUrl = `http://127.0.0.1:${resources.gatewayPort}/healthz`;

--- a/cli/src/lib/hatch-next-steps.ts
+++ b/cli/src/lib/hatch-next-steps.ts
@@ -1,0 +1,12 @@
+export function logHatchNextSteps(
+  log: (message: string) => void,
+  instanceName: string,
+): void {
+  log("Next steps:");
+  log("  vellum client");
+  log('  vellum message "hello"');
+  log("  vellum events");
+  log("  vellum ps");
+  log(`  vellum use ${instanceName}`);
+  log("");
+}

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -52,12 +52,28 @@ export interface GatewayApiKeyReadResult {
   unreachable: boolean;
 }
 
+export interface HatchProviderApiKeyOptions {
+  gatewayUrl: string;
+  provider: LlmProviderId | null;
+  bearerToken?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: ProviderSecretFetch;
+  log?: (message: string) => void;
+  prompt?: (prompt: string) => Promise<string>;
+  stdinIsTTY?: boolean;
+  input?: NodeJS.ReadStream;
+  output?: NodeJS.WriteStream;
+}
+
 const PROVIDER_LABELS: Record<LlmProviderId, string> = {
   anthropic: "Anthropic",
   openai: "OpenAI",
   gemini: "Gemini",
   fireworks: "Fireworks",
   openrouter: "OpenRouter",
+  zai: "z.ai",
+  deepseek: "DeepSeek",
+  minimax: "MiniMax",
 };
 
 export function formatProviderName(provider: LlmProviderId): string {
@@ -68,6 +84,87 @@ export function isSupportedLlmProvider(
   provider: string,
 ): provider is LlmProviderId {
   return Object.hasOwn(LLM_PROVIDER_ENV_VAR_NAMES, provider);
+}
+
+export function resolveHatchProvider(
+  configValues: Record<string, string | undefined>,
+): LlmProviderId | null {
+  const provider = (
+    resolveConfiguredMainAgentProvider(configValues) || "anthropic"
+  ).toLowerCase();
+
+  if (provider === "ollama") {
+    return null;
+  }
+
+  if (!isSupportedLlmProvider(provider)) {
+    throw new Error(
+      `Provider '${provider}' does not have a supported API-key setup flow.`,
+    );
+  }
+
+  return provider;
+}
+
+function resolveConfiguredMainAgentProvider(
+  configValues: Record<string, string | undefined>,
+): string | undefined {
+  // Fresh hatches seed the active custom profile from llm.default and then
+  // that active profile wins over static mainAgent call-site defaults. Match
+  // that startup behavior so hatch prompts for the provider the assistant will
+  // actually use on first chat.
+  return (
+    resolveProfileProvider(
+      configValues,
+      readConfigValue(configValues, "llm.activeProfile"),
+    ) ??
+    resolveFragmentProvider(configValues, "llm.default") ??
+    resolveFragmentProvider(configValues, "llm.callSites.mainAgent") ??
+    resolveProfileProvider(
+      configValues,
+      readConfigValue(configValues, "llm.callSites.mainAgent.profile"),
+    )
+  );
+}
+
+function resolveProfileProvider(
+  configValues: Record<string, string | undefined>,
+  profileName: string | undefined,
+): string | undefined {
+  if (!profileName) return undefined;
+  return resolveFragmentProvider(configValues, `llm.profiles.${profileName}`);
+}
+
+function resolveFragmentProvider(
+  configValues: Record<string, string | undefined>,
+  prefix: string,
+): string | undefined {
+  const provider = readConfigValue(configValues, `${prefix}.provider`);
+  if (provider) return provider;
+
+  const model = readConfigValue(configValues, `${prefix}.model`);
+  return model ? inferProviderFromModel(model) : undefined;
+}
+
+function readConfigValue(
+  configValues: Record<string, string | undefined>,
+  key: string,
+): string | undefined {
+  const value = configValues[key]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function inferProviderFromModel(model: string): string | undefined {
+  if (model.startsWith("claude-")) return "anthropic";
+  if (model.startsWith("gpt-")) return "openai";
+  if (model.startsWith("gemini-")) return "gemini";
+  if (model.startsWith("accounts/fireworks/models/")) return "fireworks";
+  if (model.includes("/")) return "openrouter";
+  if (model.startsWith("glm-")) return "zai";
+  if (model.startsWith("deepseek-")) return "deepseek";
+  if (model.startsWith("MiniMax-")) return "minimax";
+  if (model === "llama3.2" || model === "mistral") return "ollama";
+  return undefined;
 }
 
 function gatewayUrlWithPath(gatewayUrl: string, path: string): string {
@@ -410,4 +507,64 @@ export async function ensureProviderApiKey(
     provider,
     source,
   };
+}
+
+export async function configureHatchProviderApiKey(
+  options: HatchProviderApiKeyOptions,
+): Promise<void> {
+  const log = options.log ?? console.log;
+  const { provider } = options;
+
+  if (provider === null) {
+    log("Provider credentials not required for the selected provider.");
+    return;
+  }
+
+  try {
+    const result = await ensureProviderApiKey({
+      gatewayUrl: options.gatewayUrl,
+      provider,
+      bearerToken: options.bearerToken,
+      env: options.env,
+      fetchImpl: options.fetchImpl,
+      prompt: options.prompt,
+      stdinIsTTY: options.stdinIsTTY,
+      input: options.input,
+      output: options.output,
+    });
+
+    if (result.status === "already_configured") {
+      log(
+        `Provider credentials already configured for ${formatProviderName(result.provider)}.`,
+      );
+      return;
+    }
+
+    if (result.status === "configured") {
+      if (result.source === "env") {
+        log(
+          `Configured ${formatProviderName(result.provider)} credentials from ${LLM_PROVIDER_ENV_VAR_NAMES[result.provider]}.`,
+        );
+      } else {
+        log(`Configured ${formatProviderName(result.provider)} credentials.`);
+      }
+      return;
+    }
+
+    if (result.status === "skipped") {
+      log(result.message);
+      return;
+    }
+
+    log(
+      `⚠️  Provider credential setup skipped: ${result.message}\n` +
+        `   The assistant is still hatched. Run \`vellum setup --provider ${provider}\` to finish setup.`,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(
+      `⚠️  Provider credential setup failed: ${message}\n` +
+        `   The assistant is still hatched. Run \`vellum setup --provider ${provider}\` after fixing the issue.`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- resolve hatch provider credentials from `llm.default.provider`, defaulting to Anthropic and skipping Ollama
- configure missing provider API keys after local/Docker hatches obtain a guardian token, using env vars or a hidden prompt without leaking secrets
- keep credential setup recoverable with `vellum setup --provider ...`, add post-hatch next steps, and skip prompts for teleport-internal hatches
- let `vellum setup` lease a guardian token for local/self-hosted assistants when a failed hatch never wrote one

## Original prompt
This is PR 2 for the Milestone 1 lifecycle trust work. The goal is to make `vellum hatch` reliably prompt for or import provider API keys after a self-hosted local/Docker assistant starts, while keeping failed credential setup recoverable and not surprising automation paths. PR #30706 has merged, so this PR targets `main` directly.

## Validation
- `bun test src/__tests__/hatch-provider-secrets.test.ts src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts src/lib/__tests__/docker.test.ts src/__tests__/teleport.test.ts --grep "resolveOrHatchTarget|hatch provider secrets|provider secret helpers|setup command|buildServiceRunArgs"`
- `bunx tsc --noEmit`
- `bun run lint src/lib/provider-secrets.ts src/lib/hatch-local.ts src/lib/docker.ts src/lib/hatch-next-steps.ts src/commands/teleport.ts src/commands/setup.ts src/__tests__/hatch-provider-secrets.test.ts src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts src/lib/__tests__/docker.test.ts src/__tests__/teleport.test.ts`
- `bunx prettier --check src/lib/provider-secrets.ts src/lib/hatch-local.ts src/lib/docker.ts src/lib/hatch-next-steps.ts src/commands/teleport.ts src/commands/setup.ts src/__tests__/hatch-provider-secrets.test.ts src/__tests__/provider-secrets.test.ts src/__tests__/setup.test.ts src/lib/__tests__/docker.test.ts src/__tests__/teleport.test.ts`
- Live recovery check: after installing missing worktree deps, `ANTHROPIC_API_KEY=test-anthropic-key bun src/index.ts setup --provider anthropic` reached provider validation instead of failing `Unauthorized`