### PR TITLE
fix(cli): reset module mocks between test files via preload

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -1110,7 +1110,3 @@ registerPolicy("oauth/managed-connect/poll", {
   requiredScopes: ["settings.read"],
   allowedPrincipalTypes: ["local"],
 });
-registerPolicy("oauth/connection-changed", {
-  requiredScopes: ["settings.write"],
-  allowedPrincipalTypes: ["local"],
-});

--- a/cli/src/__tests__/preload.ts
+++ b/cli/src/__tests__/preload.ts
@@ -10,7 +10,7 @@
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll } from "bun:test";
+import { afterAll, mock } from "bun:test";
 
 const testDir = realpathSync(
   mkdtempSync(join(tmpdir(), "vellum-cli-test-workspace-")),
@@ -24,4 +24,8 @@ afterAll(() => {
   } catch {
     /* best-effort cleanup */
   }
+
+  // Reset all module mocks so mock.module() calls in one test file
+  // don't leak into the next file in the same bun test run.
+  mock.restore();
 });


### PR DESCRIPTION
## Summary
- Add `mock.restore()` to the CLI test preload's `afterAll` to prevent `mock.module()` leaks between test files in the same `bun test` run
- Fixes 10 test failures in `guardian-token.test.ts` and `setup.test.ts` caused by teleport.test.ts mock leaking on Bun 1.3.11
- Remove duplicate `registerPolicy('oauth/connection-changed')` in route-policy.ts

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/25890861262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->