### PR TITLE
fix: preserve external content in recall evidence

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -225,6 +225,27 @@ describe("searchConversationSource", () => {
     );
   });
 
+  test("preserves external_content boundaries in recall evidence", async () => {
+    const { conversation, message } = await seedConversation({
+      title: "Slack recall",
+      content:
+        '<external_content source="slack" origin="@alice">\nThe recalltoken decision came from Slack.\n</external_content>',
+    });
+
+    const result = await searchConversationSource(
+      "recalltoken",
+      makeContext(),
+      1,
+    );
+
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0]).toMatchObject({
+      locator: `${conversation.id}#${message.id}`,
+      excerpt:
+        '<external_content source="slack" origin="@alice">\nThe recalltoken decision came from Slack.\n</external_content>',
+    });
+  });
+
   test("broadens overconstrained recall queries to salient terms", async () => {
     const specific = await seedConversation({
       title: "Birthday cake plan",

--- a/assistant/src/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/memory/__tests__/conversation-queries.test.ts
@@ -12,6 +12,7 @@ mock.module("../../util/logger.js", () => ({
 import { createConversation } from "../conversation-crud.js";
 import {
   buildExcerpt,
+  buildRecallEvidenceExcerpt,
   countConversations,
   listConversations,
 } from "../conversation-queries.js";
@@ -62,6 +63,67 @@ describe("buildExcerpt", () => {
     expect(excerpt).toBe("Searchable block text");
     expect(excerpt).not.toContain("<external_content");
     expect(excerpt).not.toContain("</external_content>");
+  });
+});
+
+describe("buildRecallEvidenceExcerpt", () => {
+  test("preserves external_content boundaries for legacy plain-string rows", () => {
+    const excerpt = buildRecallEvidenceExcerpt(
+      '<external_content source="slack" origin="@alice">\nSearchable Slack text\n</external_content>',
+      "Slack",
+    );
+
+    expect(excerpt).toBe(
+      '<external_content source="slack" origin="@alice">\nSearchable Slack text\n</external_content>',
+    );
+  });
+
+  test("preserves external_content boundaries for legacy text block rows", () => {
+    const excerpt = buildRecallEvidenceExcerpt(
+      JSON.stringify([
+        {
+          type: "text",
+          text: '<external_content source="slack">\nSearchable block text\n</external_content>',
+        },
+      ]),
+      "block",
+    );
+
+    expect(excerpt).toBe(
+      '<external_content source="slack">\nSearchable block text\n</external_content>',
+    );
+  });
+
+  test("preserves external_content boundaries when joined with other text blocks", () => {
+    const excerpt = buildRecallEvidenceExcerpt(
+      JSON.stringify([
+        {
+          type: "text",
+          text: '<external_content source="slack">\nSearchable block text\n</external_content>',
+        },
+        {
+          type: "text",
+          text: "Local follow-up text.",
+        },
+      ]),
+      "block",
+    );
+
+    expect(excerpt).toBe(
+      '<external_content source="slack">\nSearchable block text\n</external_content> Local follow-up text.',
+    );
+  });
+
+  test("does not unwrap malformed or mixed external_content text", () => {
+    const malformed =
+      '<external_content source="slack">Malformed Slack text</external_content>';
+    const mixed =
+      'prefix <external_content source="slack">\nMixed Slack text\n</external_content>';
+
+    expect(buildRecallEvidenceExcerpt(malformed, "Slack")).toBe(malformed);
+    expect(buildRecallEvidenceExcerpt(mixed, "Slack")).toBe(
+      'prefix <external_content source="slack"> Mixed Slack text </external_content>',
+    );
   });
 });
 

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -1,7 +1,7 @@
 import { AUTO_ANALYSIS_SOURCE } from "../../auto-analysis-guard.js";
 import {
-  buildExcerpt,
   buildFtsMatchQuery,
+  buildRecallEvidenceExcerpt,
 } from "../../conversation-queries.js";
 import { rawAll } from "../../raw-query.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
@@ -118,7 +118,7 @@ export async function searchConversationSource(
       source: "conversations",
       title: row.title?.trim() || "Untitled conversation",
       locator: `${row.conversation_id}#${row.message_id}`,
-      excerpt: buildExcerpt(row.content, trimmedQuery),
+      excerpt: buildRecallEvidenceExcerpt(row.content, trimmedQuery),
       timestampMs: row.created_at,
       score,
       metadata: {

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -1,6 +1,11 @@
 import { and, count, desc, eq, sql } from "drizzle-orm";
 
-import { unwrapExternalContentForDisplay } from "../security/untrusted-content.js";
+import {
+  parseExternalContentEnvelope,
+  type UntrustedContentSource,
+  unwrapExternalContentForDisplay,
+  wrapUntrustedContent,
+} from "../security/untrusted-content.js";
 import { getLogger } from "../util/logger.js";
 import type { ConversationRow } from "./conversation-crud.js";
 import { parseConversation } from "./conversation-crud.js";
@@ -412,29 +417,68 @@ export function searchConversations(
  * text; we extract a readable snippet in either case.
  */
 export function buildExcerpt(rawContent: string, query: string): string {
+  return buildExcerptWithExternalContentMode(rawContent, query, "display");
+}
+
+/**
+ * Build an excerpt for model-facing recall evidence. Unlike display excerpts,
+ * this keeps complete external_content envelopes around untrusted snippets so
+ * the model still sees clear third-party content boundaries.
+ */
+export function buildRecallEvidenceExcerpt(
+  rawContent: string,
+  query: string,
+): string {
+  return buildExcerptWithExternalContentMode(rawContent, query, "preserve");
+}
+
+function buildExcerptWithExternalContentMode(
+  rawContent: string,
+  query: string,
+  externalContentMode: "display" | "preserve",
+): string {
   // Try to extract plain text from JSON content blocks first.
   let text = rawContent;
   try {
     const parsed = JSON.parse(rawContent);
     if (Array.isArray(parsed)) {
       const parts: string[] = [];
+      let preservedExternalContent = false;
       for (const block of parsed) {
         if (typeof block === "object" && block != null) {
           if (block.type === "text" && typeof block.text === "string") {
-            parts.push(unwrapExternalContentForDisplay(block.text));
+            if (externalContentMode === "display") {
+              parts.push(unwrapExternalContentForDisplay(block.text));
+            } else {
+              const excerpt = buildRecallEvidenceText(block.text, query);
+              parts.push(excerpt.text);
+              preservedExternalContent ||= excerpt.preservedExternalContent;
+            }
           } else if (
             block.type === "tool_result" ||
             block.type === "web_search_tool_result"
           ) {
             const inner = Array.isArray(block.content) ? block.content : [];
             for (const ib of inner) {
-              if (ib?.type === "text" && typeof ib.text === "string")
-                parts.push(unwrapExternalContentForDisplay(ib.text));
+              if (ib?.type === "text" && typeof ib.text === "string") {
+                if (externalContentMode === "display") {
+                  parts.push(unwrapExternalContentForDisplay(ib.text));
+                } else {
+                  const excerpt = buildRecallEvidenceText(ib.text, query);
+                  parts.push(excerpt.text);
+                  preservedExternalContent ||= excerpt.preservedExternalContent;
+                }
+              }
             }
           }
         }
       }
-      if (parts.length > 0) text = parts.join(" ");
+      if (parts.length > 0) {
+        text = parts.join(" ");
+        if (externalContentMode === "preserve" && preservedExternalContent) {
+          return text;
+        }
+      }
     } else if (typeof parsed === "string") {
       text = parsed;
     }
@@ -442,8 +486,53 @@ export function buildExcerpt(rawContent: string, query: string): string {
     // Not JSON — use as-is
   }
 
-  text = unwrapExternalContentForDisplay(text);
+  if (externalContentMode === "display") {
+    text = unwrapExternalContentForDisplay(text);
+  } else {
+    const envelope = parseExternalContentEnvelope(text);
+    if (envelope) {
+      const innerExcerpt = buildExcerptFromText(envelope.content, query);
+      return wrapRecallEvidenceExcerpt(
+        innerExcerpt,
+        envelope.source,
+        envelope.origin,
+      );
+    }
+  }
 
+  return buildExcerptFromText(text, query);
+}
+
+function buildRecallEvidenceText(
+  text: string,
+  query: string,
+): { text: string; preservedExternalContent: boolean } {
+  const envelope = parseExternalContentEnvelope(text);
+  if (!envelope) {
+    return { text, preservedExternalContent: false };
+  }
+  const innerExcerpt = buildExcerptFromText(envelope.content, query);
+  return {
+    text: wrapRecallEvidenceExcerpt(
+      innerExcerpt,
+      envelope.source,
+      envelope.origin,
+    ),
+    preservedExternalContent: true,
+  };
+}
+
+function wrapRecallEvidenceExcerpt(
+  excerpt: string,
+  source: UntrustedContentSource,
+  origin?: string,
+): string {
+  return origin
+    ? wrapUntrustedContent(excerpt, { source, sourceDetail: origin })
+    : wrapUntrustedContent(excerpt, { source });
+}
+
+function buildExcerptFromText(text: string, query: string): string {
   const WINDOW = 100;
   const lowerText = text.toLowerCase();
   const lowerQuery = query.toLowerCase();


### PR DESCRIPTION
## Summary
Fixes self-review gap for slack-runtime-content-wrapping.md.

**Gap:** Recall evidence must preserve external_content boundaries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->