### PR TITLE
fix: honor empty display content persistence

### DIFF
--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -204,7 +204,31 @@ function makeTestConversation() {
   return conversation;
 }
 
-async function expectEmptyDisplayContentFallsBackToModelContent(
+async function expectEmptyDisplayContentHonored(modelContent: string) {
+  const conversation = makeTestConversation();
+  activeConversation = conversation;
+
+  const result = await processMessage(
+    "conv-display-content",
+    modelContent,
+    undefined,
+    { displayContent: "" },
+    "slack",
+    "slack",
+  );
+
+  expect(result.messageId).toBe("persisted-1");
+  expect(addMessageCalls).toHaveLength(2);
+  expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([]);
+  expect(conversation.getMessages()[0]).toEqual({
+    role: "user",
+    content: [{ type: "text", text: modelContent }],
+  });
+
+  return conversation;
+}
+
+async function expectOmittedDisplayContentPersistsModelContent(
   modelContent: string,
 ) {
   const conversation = makeTestConversation();
@@ -214,7 +238,7 @@ async function expectEmptyDisplayContentFallsBackToModelContent(
     "conv-display-content",
     modelContent,
     undefined,
-    { displayContent: "" },
+    undefined,
     "slack",
     "slack",
   );
@@ -267,7 +291,104 @@ describe("processMessage displayContent", () => {
     expect(conversation.runAgentLoop.mock.calls[0]![0]).toBe(modelContent);
   });
 
-  test("empty displayContent falls back to model content for unknown slash results", async () => {
+  test("persists explicit empty displayContent while keeping model content in memory", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="slack">\n\n</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      { displayContent: "" },
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([]);
+    expect(conversation.getMessages()).toEqual([
+      { role: "user", content: [{ type: "text", text: modelContent }] },
+    ]);
+  });
+
+  test("omitted displayContent persists model content", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="webhook">wrapped content</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      undefined,
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([
+      { type: "text", text: modelContent },
+    ]);
+  });
+
+  test("persists attachment blocks without wrapped text when displayContent is empty", async () => {
+    const conversation = makeTestConversation();
+    const modelContent =
+      '<external_content source="slack">\n\n</external_content>';
+
+    await conversation.persistUserMessage(
+      modelContent,
+      [
+        {
+          id: "att-1",
+          filename: "attachment.pdf",
+          mimeType: "application/pdf",
+          data: Buffer.from("pdf bytes").toString("base64"),
+        },
+      ],
+      "req-display-content",
+      undefined,
+      "",
+    );
+
+    expect(addMessageCalls).toHaveLength(1);
+    const persistedBlocks = JSON.parse(addMessageCalls[0]!.content);
+    expect(persistedBlocks).toEqual([
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: Buffer.from("pdf bytes").toString("base64"),
+          filename: "attachment.pdf",
+        },
+      },
+    ]);
+    expect(addMessageCalls[0]!.content).not.toContain("<external_content");
+    expect(conversation.getMessages()[0]).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: modelContent },
+        {
+          type: "file",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: Buffer.from("pdf bytes").toString("base64"),
+            filename: "attachment.pdf",
+          },
+          extracted_text: undefined,
+        },
+      ],
+    });
+  });
+
+  test("empty displayContent is honored for unknown slash results", async () => {
     resolveSlashForTest = () => ({
       kind: "unknown",
       message: "Unknown slash command.",
@@ -275,16 +396,26 @@ describe("processMessage displayContent", () => {
     const modelContent =
       '<external_content source="webhook">/missing-command</external_content>';
 
-    await expectEmptyDisplayContentFallsBackToModelContent(modelContent);
+    await expectEmptyDisplayContentHonored(modelContent);
   });
 
-  test("empty displayContent falls back to model content for compact slash results", async () => {
+  test("omitted displayContent persists model content for unknown slash results", async () => {
+    resolveSlashForTest = () => ({
+      kind: "unknown",
+      message: "Unknown slash command.",
+    });
+    const modelContent =
+      '<external_content source="webhook">/missing-command</external_content>';
+
+    await expectOmittedDisplayContentPersistsModelContent(modelContent);
+  });
+
+  test("empty displayContent is honored for compact slash results", async () => {
     resolveSlashForTest = () => ({ kind: "compact" });
     const modelContent =
       '<external_content source="webhook">/compact</external_content>';
 
-    const conversation =
-      await expectEmptyDisplayContentFallsBackToModelContent(modelContent);
+    const conversation = await expectEmptyDisplayContentHonored(modelContent);
     expect(conversation.forceCompact).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -1836,7 +1836,27 @@ function flattenText(messages: Message[]): string {
 interface CapturedSlackProcessMessage {
   conversationId: string;
   content: string;
+  attachmentIds?: string[];
   options?: SlackInboundProcessOptions;
+}
+
+function seedAttachment(id: string): void {
+  getDb()
+    .$client.prepare(
+      `INSERT INTO attachments (
+          id, original_filename, mime_type, size_bytes, kind, data_base64, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      "attachment.pdf",
+      "application/pdf",
+      Buffer.byteLength("pdf bytes"),
+      "upload",
+      Buffer.from("pdf bytes").toString("base64"),
+      Date.now(),
+    );
 }
 
 async function handleAndCaptureLiveSlackProcessMessage(
@@ -1851,10 +1871,10 @@ async function handleAndCaptureLiveSlackProcessMessage(
   const processMessage = async (
     conversationId: string,
     content: string,
-    _attachmentIds?: string[],
+    attachmentIds?: string[],
     options?: SlackInboundProcessOptions,
   ): Promise<{ messageId: string }> => {
-    captured = { conversationId, content, options };
+    captured = { conversationId, content, attachmentIds, options };
     const messageId = persistSlackInboundFromProcessMessage(
       conversationId,
       content,
@@ -2004,6 +2024,28 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     const persisted = readMessagesByConversation(captured.conversationId);
     expect(persisted).toHaveLength(1);
     expect(persisted[0].content).toBe(rawContent);
+  });
+
+  test("live Slack attachment-only passes empty raw displayContent for persistence", async () => {
+    seedAttachment("att-slack-file");
+
+    const captured = await handleAndCaptureLiveSlackProcessMessage(
+      buildSlackChannelRequest("1700000000.000350", {
+        content: "",
+        attachmentIds: ["att-slack-file"],
+      }),
+    );
+
+    expect(captured.content.match(/<external_content/g)?.length).toBe(1);
+    expect(captured.content).toContain('<external_content source="slack"');
+    expect(captured.content).toContain("\n\n</external_content>");
+    expect(captured.attachmentIds).toEqual(["att-slack-file"]);
+    expect(captured.options?.displayContent).toBe("");
+
+    const persisted = readMessagesByConversation(captured.conversationId);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].content).toBe("");
+    expect(persisted[0].content).not.toContain("<external_content");
   });
 
   test("live Slack guardian keeps raw content without displayContent", async () => {

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -7,7 +7,10 @@
 
 import { v4 as uuid } from "uuid";
 
-import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
+import {
+  enrichMessageWithSourcePaths,
+  type MessageAttachmentInput,
+} from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
   TurnChannelContext,
@@ -189,6 +192,19 @@ export interface MessagingConversationContext {
   trustContext?: TrustContext;
   getTurnChannelContext(): TurnChannelContext | null;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
+}
+
+export function serializePersistedUserMessageContent(
+  content: string,
+  attachments: MessageAttachmentInput[],
+  displayContent: string | undefined,
+): string {
+  return JSON.stringify(
+    createUserMessage(
+      displayContent !== undefined ? displayContent : content,
+      attachments,
+    ).content,
+  );
 }
 
 function extractTurnChannelContext(
@@ -457,11 +473,11 @@ export async function persistQueuedMessageBody(
     // intent stripping), persist that to DB so users see the full message
     // after restart. The in-memory userMessage (sent to the LLM) still uses
     // the stripped content.
-    const contentToPersist = displayContent
-      ? JSON.stringify(
-          createUserMessage(displayContent, attachmentInputs).content,
-        )
-      : JSON.stringify(cleanMessage.content);
+    const contentToPersist = serializePersistedUserMessageContent(
+      content,
+      attachmentInputs,
+      displayContent,
+    );
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -33,7 +33,10 @@ import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
-import { persistQueuedMessageBody } from "./conversation-messaging.js";
+import {
+  persistQueuedMessageBody,
+  serializePersistedUserMessageContent,
+} from "./conversation-messaging.js";
 import type {
   MessageQueue,
   QueuedMessage,
@@ -514,11 +517,11 @@ async function drainSingleMessage(
       // When displayContent is provided (e.g. original text before recording
       // intent stripping), persist that to DB so users see the full message.
       // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-      const contentToPersist = next.displayContent
-        ? JSON.stringify(
-            createUserMessage(next.displayContent, next.attachments).content,
-          )
-        : JSON.stringify(cleanUserMsg.content);
+      const contentToPersist = serializePersistedUserMessageContent(
+        next.content,
+        next.attachments,
+        next.displayContent,
+      );
       await addMessage(
         conversation.conversationId,
         "user",
@@ -1401,9 +1404,11 @@ export async function processMessage(
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message.
     // The in-memory userMessage (sent to the LLM) still uses the stripped content.
-    const contentToPersist = displayContent
-      ? JSON.stringify(createUserMessage(displayContent, attachments).content)
-      : JSON.stringify(cleanUserMsg.content);
+    const contentToPersist = serializePersistedUserMessageContent(
+      content,
+      attachments,
+      displayContent,
+    );
     const persisted = await addMessage(
       conversation.conversationId,
       "user",

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -33,7 +33,10 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
-import { buildSlackMetaForPersistence } from "./conversation-messaging.js";
+import {
+  buildSlackMetaForPersistence,
+  serializePersistedUserMessageContent,
+} from "./conversation-messaging.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import {
@@ -311,14 +314,15 @@ export async function processMessage(
       ? { ...serverChannelMeta, slackMeta }
       : serverChannelMeta;
     const cleanMsg = createUserMessage(content, attachments);
-    const persistedContent = options?.displayContent
-      ? createUserMessage(options.displayContent, attachments).content
-      : cleanMsg.content;
     const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
     const persisted = await addMessage(
       conversationId,
       "user",
-      JSON.stringify(persistedContent),
+      serializePersistedUserMessageContent(
+        content,
+        attachments,
+        options?.displayContent,
+      ),
       userMetaWithSlack,
     );
     conversation.getMessages().push(llmMsg);
@@ -401,13 +405,14 @@ export async function processMessage(
       ? { ...compactChannelMeta, slackMeta }
       : compactChannelMeta;
     const cleanMsg = createUserMessage(content, attachments);
-    const persistedContent = options?.displayContent
-      ? createUserMessage(options.displayContent, attachments).content
-      : cleanMsg.content;
     const persisted = await addMessage(
       conversationId,
       "user",
-      JSON.stringify(persistedContent),
+      serializePersistedUserMessageContent(
+        content,
+        attachments,
+        options?.displayContent,
+      ),
       compactUserMeta,
     );
     conversation.getMessages().push(cleanMsg);


### PR DESCRIPTION
## Summary
Fixes self-review gap for slack-runtime-content-wrapping.md.

**Gap:** Empty displayContent must be honored for raw Slack persistence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->