### PR TITLE
test(cli): restore guardian-token spies in backup tests

### DIFF
--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -81,12 +81,20 @@ const localRuntimePollJobStatusMock = spyOn(
 
 // Mode 1 (runtime-direct local backup) uses guardian tokens. Don't exercise
 // it here, but the spies need to exist so the module under test can import
-// them without surprises.
-spyOn(guardianToken, "loadGuardianToken").mockReturnValue({
+// them without surprises. Saved to variables so afterAll can restore them —
+// otherwise the spied loadGuardianToken leaks into guardian-token.test.ts and
+// setup.test.ts when they run later in the same `bun test` invocation.
+const loadGuardianTokenSpy = spyOn(
+  guardianToken,
+  "loadGuardianToken",
+).mockReturnValue({
   accessToken: "local-token",
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 } as unknown as ReturnType<typeof guardianToken.loadGuardianToken>);
-spyOn(guardianToken, "leaseGuardianToken").mockResolvedValue({
+const leaseGuardianTokenSpy = spyOn(
+  guardianToken,
+  "leaseGuardianToken",
+).mockResolvedValue({
   accessToken: "leased-token",
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 } as unknown as Awaited<ReturnType<typeof guardianToken.leaseGuardianToken>>);
@@ -177,6 +185,8 @@ afterAll(() => {
   getBackupsDirMock.mockRestore();
   mkdirSyncMock.mockRestore();
   writeFileSyncMock.mockRestore();
+  loadGuardianTokenSpy.mockRestore();
+  leaseGuardianTokenSpy.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- Capture the spy returns from `spyOn(guardianToken, 'loadGuardianToken')` and `spyOn(guardianToken, 'leaseGuardianToken')` so the existing `afterAll` can call `mockRestore()` on them
- Stops backup.test.ts's spies from bleeding into guardian-token.test.ts and setup.test.ts when bun test runs the whole suite

## Original prompt
CI was failing on main with 10 expectation errors across cli/src/__tests__/setup.test.ts and cli/src/__tests__/guardian-token.test.ts — every failure pointed at `loadGuardianToken` returning `{accessToken: 'local-token', accessTokenExpiresAt: ...}` instead of the real disk-backed value. That stub literal is unique to backup.test.ts, which spies on the same export at module scope but never restores it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->