### PR TITLE
fix(voice): only reset client sender in cleanup if this turn installed it

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1311,6 +1311,76 @@ describe("voice-session-bridge", () => {
     expect(session.forcePromptSideEffects).toBe(false);
   });
 
+  test("cleanup on early persistUserMessage throw does not detach prior client sender", async () => {
+    const conversation = createConversation(
+      "voice bridge sender detach guard test",
+    );
+
+    const updateClientCalls: Array<{
+      callback: unknown;
+      replace: boolean | undefined;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      forcePromptSideEffects: false,
+      callSessionId: undefined as string | undefined,
+      persistUserMessage: async () => {
+        throw new Error("persist failed before bridge installed callback");
+      },
+      memoryPolicy: {
+        scopeId: "default",
+        includeDefaultFallback: false,
+      },
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setTrustContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      setVoiceCallControlPrompt: () => {},
+      updateClient: (callback: unknown, replace?: boolean) => {
+        updateClientCalls.push({ callback, replace });
+      },
+      ensureActorScopedHistory: async () => {},
+      runAgentLoop: async () => {},
+      handleConfirmationResponse: () => {},
+      abort: () => {},
+    } as unknown as Conversation & {
+      forcePromptSideEffects: boolean;
+      callSessionId?: string;
+    };
+
+    injectDeps(() => session);
+
+    let caught: Error | null = null;
+    try {
+      await startVoiceTurn({
+        conversationId: conversation.id,
+        voiceSessionId: "session-sender-detach-test",
+        content: "Hello",
+        isInbound: true,
+        trustContext: {
+          sourceChannel: "phone",
+          trustClass: "trusted_contact",
+        },
+        onTextDelta: () => {},
+        onComplete: () => {},
+        onError: () => {},
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught?.message).toBe(
+      "persist failed before bridge installed callback",
+    );
+    // The bridge never reached its `conversation.updateClient(...)` install
+    // site, so cleanup must not touch updateClient — otherwise it would
+    // detach a sender installed by a prior turn on the same conversation.
+    expect(updateClientCalls).toEqual([]);
+  });
+
   test("pre-aborted signal triggers immediate abort", async () => {
     const conversation = createConversation("voice bridge pre-abort test");
     let abortCalled = false;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -395,7 +395,10 @@ export async function startVoiceTurn(
   // Hoisted so the catch below can clear partially-applied turn state
   // when a setter or `persistUserMessage` throws — otherwise `trustContext`,
   // `callSessionId`, etc. leak into subsequent non-voice turns on the same
-  // conversation.
+  // conversation. The client callback is only reset when this turn actually
+  // installed it (tracked via `clientCallbackInstalled`); otherwise cleanup
+  // would detach an active sender installed by a prior turn.
+  let clientCallbackInstalled = false;
   const cleanup = () => {
     conversation.setChannelCapabilities(null);
     conversation.setTrustContext(null);
@@ -404,9 +407,11 @@ export async function startVoiceTurn(
     conversation.setVoiceCallControlPrompt(null);
     conversation.callSessionId = undefined;
     conversation.forcePromptSideEffects = false;
-    // Reset the client callback to a no-op so the stale closure doesn't
-    // intercept events from future turns on the same conversation.
-    conversation.updateClient(() => {}, true);
+    if (clientCallbackInstalled) {
+      // Reset the client callback to a no-op so the stale closure doesn't
+      // intercept events from future turns on the same conversation.
+      conversation.updateClient(() => {}, true);
+    }
   };
 
   const requestId = crypto.randomUUID();
@@ -575,6 +580,7 @@ export async function startVoiceTurn(
     }
     broadcastMessage(msg);
   });
+  clientCallbackInstalled = true;
 
   // Fire-and-forget the agent loop
   void (async () => {


### PR DESCRIPTION
Follow-up to #30602 addressing Codex P2 feedback.

The cleanup path added in #30602 calls `conversation.updateClient(() => {}, true)` unconditionally when `persistUserMessage` throws. But that cleanup runs **before** the voice bridge installs its own `updateClient` callback (line 460), so on an early-failure path the cleanup detaches a sender that a prior turn (or unrelated code path) installed on the same conversation. Subsequent events/turns then stop reaching the interactive client until it explicitly rebinds.

## Fix

Track whether this turn actually installed the client callback with a local `clientCallbackInstalled` flag. The cleanup only resets `updateClient` when this turn installed it; otherwise the prior sender remains attached.

## Test

Adds a regression test that throws from `persistUserMessage` (before the bridge reaches its `updateClient` install site) and asserts `updateClient` is never called during the resulting cleanup.

Closes #30602 follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->