### PR TITLE
fix(oura-setup): use cloud.ouraring.com for account portal and authorize

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -637,7 +637,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T18:18:13-06:00"
+      "updatedAt": "2026-05-14T18:21:04-06:00"
     },
     {
       "id": "start-the-day",

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -16,7 +16,7 @@ Connect the user's Oura Ring to pull sleep, heart rate, readiness, activity, and
 
 - An Oura Ring (Gen 3 or Ring 4) with an active Oura Membership ($6/mo required for API access)
 - The Oura app installed and paired with the ring
-- An Oura Cloud account at https://api.ouraring.com
+- An Oura Cloud account at https://cloud.ouraring.com
 
 ## Setup
 
@@ -59,7 +59,7 @@ class Handler(BaseHTTPRequestHandler):
                 'redirect_uri': REDIRECT_URI, 'scope': SCOPES, 'state': 'assistant'
             })
             self.send_response(302)
-            self.send_header('Location', f'https://api.ouraring.com/oauth/authorize?{params}')
+            self.send_header('Location', f'https://cloud.ouraring.com/oauth/authorize?{params}')
             self.end_headers()
         elif parsed.path == '/callback':
             code = parse_qs(parsed.query).get('code', [''])[0]


### PR DESCRIPTION
## Summary

Revert the account-portal URL and OAuth authorize URL changes from #30689 back to `cloud.ouraring.com`. Both reviewers (Codex P1 and Devin) flagged that `api.ouraring.com` is the API host, not the user-facing portal — using it for OAuth authorize causes the consent flow to fail before a code is issued.

- Line 19: `cloud.ouraring.com` is Oura's account portal.
- Line 62: `cloud.ouraring.com/oauth/authorize` is the documented authorize URL.
- Line 73 (`api.ouraring.com/oauth/token`) remains unchanged — that's the correct token-exchange host.

Follow-up to #30689.

## Test plan
- [ ] OAuth helper script redirects to `cloud.ouraring.com/oauth/authorize` and completes the consent flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->