### PR TITLE
fix(macos): tighten stale-cancel budget against overcount and residual

### DIFF
--- a/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
+++ b/clients/macos/vellum-assistantTests/InteractiveTurnCompletionTickTests.swift
@@ -177,9 +177,11 @@ final class InteractiveTurnCompletionTickTests: XCTestCase {
         viewModel.sendMessage()
         // Simulate the daemon having queued 2 items behind the in-flight.
         // `pendingQueuedCount` reflects only still-queued entries (the
-        // in-flight already triggered `message_dequeued`), so the cancel
-        // batch emits 3 events total — 1 for the in-flight (handled by the
-        // first event) and 2 trailing echoes for the queued items.
+        // in-flight already triggered `message_dequeued`, which also
+        // populates `activeRequestIdToMessageId`). The cancel batch emits
+        // 3 events total — 1 for the in-flight (handled by the first
+        // event) and 2 trailing echoes for the queued items.
+        viewModel.activeRequestIdToMessageId["req-in-flight"] = UUID()
         viewModel.pendingQueuedCount = 2
 
         // User cancels; daemon emits 3 `generation_cancelled` events. The
@@ -210,5 +212,78 @@ final class InteractiveTurnCompletionTickTests: XCTestCase {
         viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
         XCTAssertEqual(viewModel.messageManager.interactiveTurnCompletionTick, beforeTick &+ 1,
                        "New send's completion must still bump the interactive tick")
+    }
+
+    func testCancelWhileNewestSendStillQueuedDoesNotOvercountBudget() {
+        // Codex P2: user sends, `message_queued` arrives, user cancels
+        // before `message_dequeued` is processed. There is no dequeued
+        // in-flight request — the cancel batch contains only the queued
+        // item. The daemon emits exactly one `generation_cancelled`
+        // (consumed by the `wasCancelling = true` branch); no trailing
+        // echoes follow. The stale-echo budget must therefore be 0, not
+        // `pendingQueuedCount` (which would leave 1 stuck and silently
+        // absorb the next legitimate per-message daemon cancel).
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        // Nothing has been dequeued: `activeRequestIdToMessageId` is empty
+        // and `pendingQueuedCount` includes the not-yet-dequeued send.
+        XCTAssertTrue(viewModel.activeRequestIdToMessageId.isEmpty)
+        viewModel.pendingQueuedCount = 1
+
+        viewModel.isCancelling = true
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 0,
+                       "No dequeued in-flight means no trailing echoes; budget must be 0 to avoid overcount")
+
+        // Confirm a subsequent legitimate per-message daemon cancel for a
+        // new send is not silently absorbed by leftover budget.
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1)
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0,
+                       "Per-message daemon cancel must decrement the new send's count, not drain stale budget")
+    }
+
+    func testMessageCompleteForNewSendDrainsResidualBudgetFromEchoLoss() {
+        // Devin: if the daemon emits fewer trailing `generation_cancelled`
+        // echoes than primed (echo loss without a full stream disconnect),
+        // `staleCancelEventsExpected` would otherwise remain positive
+        // until the watchdog timeout. During that window, any legitimate
+        // per-message daemon cancel would silently drain the stale budget
+        // instead of decrementing `pendingUserTurnCount`. The fix: a real
+        // `message_complete` for a new send clears the budget, since it
+        // implies the prior cancel batch is fully resolved.
+        viewModel.inputText = "First"
+        viewModel.sendMessage()
+        viewModel.activeRequestIdToMessageId["req-in-flight"] = UUID()
+        viewModel.pendingQueuedCount = 2
+
+        viewModel.isCancelling = true
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 2)
+
+        // User dispatches a new send; only one trailing echo arrives (the
+        // other was dropped). Without the drain, residual budget = 1.
+        viewModel.inputText = "Second"
+        viewModel.sendMessage()
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 1,
+                       "Echo loss left residual budget; setup confirms preconditions for the drain")
+
+        // `message_complete` for the new send must zero the residual.
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        XCTAssertEqual(viewModel.messageManager.staleCancelEventsExpected, 0,
+                       "message_complete for a new send must drain residual budget from echo loss")
+
+        // A subsequent per-message daemon cancel for a third send must
+        // now decrement `pendingUserTurnCount` instead of being absorbed.
+        viewModel.inputText = "Third"
+        viewModel.sendMessage()
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 1)
+        viewModel.handleServerMessage(.generationCancelled(GenerationCancelledMessage(conversationId: "test-conversation")))
+        XCTAssertEqual(viewModel.messageManager.pendingUserTurnCount, 0,
+                       "Without leftover budget, the daemon cancel decrements as intended")
     }
 }

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -755,6 +755,13 @@ final class ChatActionHandler {
                 vm.messageManager.pendingUserTurnCount -= 1
                 vm.messageManager.interactiveTurnCompletionTick &+= 1
             }
+            // A real turn end means any prior cancel batch is fully
+            // resolved, so any residual `staleCancelEventsExpected` is
+            // from echo loss (daemon emitted fewer trailing
+            // `generation_cancelled` events than primed) and would
+            // otherwise silently consume the next per-message daemon
+            // cancel's decrement. Bound the budget to the cancel batch.
+            vm.messageManager.staleCancelEventsExpected = 0
         }
     }
 
@@ -808,11 +815,21 @@ final class ChatActionHandler {
         if wasCancelling {
             vm.isSending = false
             // Prime the stale-echo budget before zeroing `pendingQueuedCount`.
-            // The in-flight cancel is the event we just handled; the daemon
-            // will emit one more for each still-queued entry, and a new
-            // send dispatched via `dispatchPendingSendDirect()` below must
-            // not have its turn count consumed by those trailing echoes.
-            vm.messageManager.staleCancelEventsExpected = vm.pendingQueuedCount
+            // The daemon emits one `generation_cancelled` per cancelled item
+            // (in-flight + still-queued). The event we just handled is one
+            // of those; the rest are trailing echoes that must not consume
+            // counts belonging to a send dispatched via
+            // `dispatchPendingSendDirect()` below.
+            //
+            // If a dequeued in-flight request exists, the first event is its
+            // cancel and the trailing echoes equal `pendingQueuedCount`.
+            // Otherwise (Codex P2 case: user cancelled after `message_queued`
+            // but before `message_dequeued`), the first event is itself one
+            // of the queued items so trailing echoes = pendingQueuedCount - 1.
+            let hadInFlight = !vm.activeRequestIdToMessageId.isEmpty
+            vm.messageManager.staleCancelEventsExpected = hadInFlight
+                ? vm.pendingQueuedCount
+                : max(0, vm.pendingQueuedCount - 1)
             vm.pendingQueuedCount = 0
             vm.pendingMessageIds = []
             vm.requestIdToMessageId = [:]


### PR DESCRIPTION
Follow-up on review feedback for #30607.

## Problems

1. **Codex P2 — budget overcount.** `staleCancelEventsExpected = pendingQueuedCount` assumes the first `generation_cancelled` always corresponds to a dequeued in-flight turn. If the user cancels after \`message_queued\` but before \`message_dequeued\`, no in-flight exists; the daemon emits exactly one event (for the queued item, consumed by the \`wasCancelling = true\` branch) and no trailing echoes follow. The current code leaves \`staleCancelEventsExpected = 1\` stuck, which silently absorbs the next legitimate per-message daemon cancel for a new send.

2. **Devin — residual budget from echo loss.** If the daemon emits fewer trailing echoes than primed (echo loss without a stream disconnect), \`staleCancelEventsExpected\` stays positive until the 60s/90s watchdog. During that window, any legitimate per-message daemon cancel for a new send silently drains the stale budget instead of decrementing \`pendingUserTurnCount\`, suppressing one chime.

## Fix

1. Use \`!activeRequestIdToMessageId.isEmpty\` as the signal for whether a dequeued in-flight exists. If yes: trailing echoes = \`pendingQueuedCount\`. If no: trailing echoes = \`max(0, pendingQueuedCount - 1)\` since the first event is itself for a queued item.

2. Zero \`staleCancelEventsExpected\` inside \`handleMessageComplete\`'s non-aux, non-cancelAck branch. A real turn end implies the prior cancel batch is fully resolved, so any leftover budget is stale.

## Tests

- \`testCancelWhileNewestSendStillQueuedDoesNotOvercountBudget\`: cancel with no \`message_dequeued\` yet primes budget = 0; subsequent per-message daemon cancel for a new send still decrements.
- \`testMessageCompleteForNewSendDrainsResidualBudgetFromEchoLoss\`: in-flight + 2 queued primes budget = 2; only 1 trailing echo arrives; \`message_complete\` for a new send zeroes residual; subsequent per-message daemon cancel for a third send decrements.
- Updated \`testStaleCancelEchoDoesNotConsumeNewSendTurnCount\` to faithfully simulate a dequeued in-flight by populating \`activeRequestIdToMessageId\`.

## Human Attention

Event-protocol bookkeeping with subtle interleavings — review the cancel/queue state transitions carefully. The \`hadInFlight\` signal hinges on \`activeRequestIdToMessageId\` being populated only between \`message_dequeued\` and \`message_complete\`/\`generation_cancelled\`. Risk: medium.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->