### PR TITLE
fix(memory-v2): narrow payload-index error swallowing to already-exists

### DIFF
--- a/assistant/src/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/qdrant.test.ts
@@ -121,6 +121,9 @@ const state = {
   // Throw queue for upsert: first call shifts and throws if non-null;
   // subsequent calls succeed once the queue is exhausted.
   upsertThrowQueue: [] as Array<Error | null>,
+  // Throw queue for createPayloadIndex: each entry maps to the next call,
+  // so tests can simulate index-creation failures (strict-mode, network).
+  createIndexThrowQueue: [] as Array<Error | null>,
 };
 
 class MockQdrantClient {
@@ -157,6 +160,10 @@ class MockQdrantClient {
     params: { field_name: string; field_schema: string },
   ) {
     state.createIndexCalls.push(params);
+    if (state.createIndexThrowQueue.length > 0) {
+      const next = state.createIndexThrowQueue.shift();
+      if (next) throw next;
+    }
     return {};
   }
   async upsert(_name: string, params: { wait: boolean; points: MockPoint[] }) {
@@ -228,6 +235,7 @@ function resetState(): void {
   state.countThrows = null;
   state.countCalls = 0;
   state.upsertThrowQueue.length = 0;
+  state.createIndexThrowQueue.length = 0;
   _resetMemoryV2QdrantForTests();
   // Drop any sentinel a prior test left behind so the no-drift default path
   // doesn't accidentally report `migrated: true`.
@@ -438,6 +446,54 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     expect(existsSync(REEMBED_SENTINEL_PATH)).toBe(false);
     await clearReembedSentinel();
     expect(existsSync(REEMBED_SENTINEL_PATH)).toBe(false);
+  });
+
+  test("swallows 'already exists' on createPayloadIndex but propagates other failures without latching readiness", async () => {
+    // Existing collection that already has the full schema — the ensure
+    // path goes through `ensurePayloadIndexes` to backfill long-lived
+    // installs. The first index call hits an "already exists" race
+    // (benign; swallow); the second hits a strict-mode rejection (must
+    // propagate so readiness is not latched).
+    state.collectionExistsBeforeCreate = true;
+    state.createIndexThrowQueue.push(
+      Object.assign(
+        new Error("Wrong input: Payload field 'slug' already exists"),
+        { status: 400 },
+      ),
+      Object.assign(
+        new Error(
+          "Strict mode prohibits creating payload indexes on this deployment",
+        ),
+        { status: 400 },
+      ),
+    );
+
+    let caught: unknown = null;
+    try {
+      await ensureConceptPageCollection();
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as Error | null)?.message).toMatch(/strict mode/i);
+
+    // Both attempts ran; the strict-mode failure was not swallowed.
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
+    ]);
+
+    // Readiness must NOT be latched after a non-benign failure — otherwise
+    // later slug/kind-filtered queries (e.g. skill backfill) would keep
+    // failing until a daemon restart. A follow-up ensure must retry.
+    const result = await ensureConceptPageCollection();
+    expect(result).toEqual({ migrated: false });
+    // Indexes attempted again on the retry (no throws queued this time).
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
+      { field_name: "slug", field_schema: "keyword" },
+      { field_name: "kind", field_schema: "keyword" },
+    ]);
   });
 
   test("concurrent ensure during a schema rebuild only deletes/creates once", async () => {

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -290,10 +290,13 @@ async function ensureConceptPageCollectionOnce(): Promise<{
  *     payload fields, so without this the backfill consistently fails and
  *     legacy skill points remain untagged.
  *
- * `createPayloadIndex` is idempotent in Qdrant; re-issuing on an existing
- * index is a no-op. We tolerate other failure shapes so that an upgrade of
- * a long-lived install — where the collection existed before this index
- * set — converges on the next ensure call without aborting the boot path.
+ * Same-schema `createPayloadIndex` calls are idempotent server-side in
+ * Qdrant (200 OK), so the only "already exists" failures we expect are
+ * narrow races where a concurrent caller created the same index a moment
+ * earlier. Those are benign and swallowed. Every other failure — strict-mode
+ * rejection, index-limit, transient network blip — must propagate so the
+ * caller does not latch readiness on a collection whose `slug`/`kind`
+ * filters will keep rejecting queries until the next daemon restart.
  */
 async function ensurePayloadIndexes(): Promise<void> {
   const client = getClient();
@@ -301,16 +304,30 @@ async function ensurePayloadIndexes(): Promise<void> {
     { field_name: "slug", field_schema: "keyword" as const },
     { field_name: "kind", field_schema: "keyword" as const },
   ];
-  for (const index of indexes) {
-    try {
-      await client.createPayloadIndex(MEMORY_V2_COLLECTION, index);
-    } catch (err) {
-      log.warn(
-        { err, collection: MEMORY_V2_COLLECTION, index },
-        "createPayloadIndex non-fatal — assuming index already present",
-      );
-    }
-  }
+  // Parallel so one "already exists" race on a single index doesn't stall
+  // the other create round-trip. v1's `qdrant-client.ts` uses the same
+  // Promise.all shape.
+  await Promise.all(
+    indexes.map(async (index) => {
+      try {
+        await client.createPayloadIndex(MEMORY_V2_COLLECTION, index);
+      } catch (err) {
+        if (isPayloadIndexAlreadyExists(err)) return;
+        throw err;
+      }
+    }),
+  );
+}
+
+/**
+ * True when a `createPayloadIndex` error indicates the index already
+ * exists with matching parameters — the only failure shape it is safe to
+ * swallow. Qdrant returns 4xx with messages like
+ * `"Wrong input: Payload field 'kind' already exists ..."`.
+ */
+function isPayloadIndexAlreadyExists(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /already exists/i.test(msg);
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #30606. Previously `ensurePayloadIndexes` caught every `createPayloadIndex` error and treated it as success, then latched collection readiness. That left transient or policy failures (strict-mode rejection, index-limit, network blip) silently unresolved — every subsequent `slug`/`kind`-filtered query kept failing until daemon restart even though startup reported success.

Now only the genuine "already exists" race is swallowed; every other failure propagates so readiness does not latch and the next ensure call retries.

- Added `isPayloadIndexAlreadyExists(err)` helper (regex on error message, mirrors `isCollectionMissing` shape).
- Parallelized the two index creates with `Promise.all` to match v1's `qdrant-client.ts` pattern.
- Regression test: a strict-mode failure surfaces to the caller, readiness is not latched, and a follow-up ensure retries both indexes.

## Test plan

- [x] `bun test src/memory/v2/__tests__/qdrant.test.ts` — 27 pass
- [x] `bunx tsc --noEmit`