### PR TITLE
fix(migrations): revert 075 modification; add new gated re-embed migration

### DIFF
--- a/assistant/src/__tests__/workspace-migration-085-memory-v2-bm25-b-reembed-disabled-v2-pages.test.ts
+++ b/assistant/src/__tests__/workspace-migration-085-memory-v2-bm25-b-reembed-disabled-v2-pages.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for workspace migration `075-memory-v2-bm25-b-default-reembed`.
+ * Tests for workspace migration
+ * `085-memory-v2-bm25-b-reembed-disabled-v2-pages`.
  *
- * The migration enqueues a one-shot `memory_v2_reembed` job so existing
- * concept pages pick up the new `bm25_b` default. It is gated on whether
- * the workspace already has concept pages on disk so a workspace that
- * disabled v2 (but kept its pages) still gets the queued reembed when v2
- * is re-enabled later.
+ * Re-enqueues `memory_v2_reembed` for workspaces with v2 concept pages,
+ * gated on (a) concept pages existing on disk and (b) v2 not being
+ * explicitly disabled in config.json. Migration 075 already shipped
+ * un-gated, so this follow-up runs with the gating we want now.
  */
 
 import {
@@ -20,13 +20,13 @@ import { dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { memoryV2Bm25BDefaultReembedMigration } from "../workspace/migrations/075-memory-v2-bm25-b-default-reembed.js";
+import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "../workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 
 let workspaceDir: string;
 let dbPath: string;
 
 beforeEach(() => {
-  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-075-test-"));
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-085-test-"));
   const dbDir = join(workspaceDir, "data", "db");
   mkdirSync(dbDir, { recursive: true });
   dbPath = join(dbDir, "assistant.db");
@@ -61,6 +61,14 @@ function seedConceptPage(relativePath: string): void {
   writeFileSync(fullPath, "---\nedges: []\n---\nbody\n", "utf-8");
 }
 
+function writeConfig(content: object): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(content),
+    "utf-8",
+  );
+}
+
 function countReembedJobs(): number {
   const db = new Database(dbPath);
   try {
@@ -75,38 +83,48 @@ function countReembedJobs(): number {
   }
 }
 
-describe("075-memory-v2-bm25-b-default-reembed migration", () => {
+describe("085-memory-v2-bm25-b-reembed-disabled-v2-pages migration", () => {
   test("skips enqueue when memory/concepts/ does not exist", () => {
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(0);
   });
 
   test("skips enqueue when memory/concepts/ is empty", () => {
     mkdirSync(join(workspaceDir, "memory", "concepts"), { recursive: true });
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(0);
   });
 
   test("enqueues when a top-level concept page exists", () => {
     seedConceptPage("alice.md");
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 
   test("enqueues when only a nested concept page exists", () => {
     seedConceptPage("people/alice.md");
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 
-  test("enqueues even when memory.v2.enabled is explicitly false (pages may be reembedded once v2 is re-enabled)", () => {
+  test("skips enqueue when memory.v2.enabled is explicitly false", () => {
     seedConceptPage("alice.md");
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      JSON.stringify({ memory: { v2: { enabled: false } } }),
-      "utf-8",
-    );
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    writeConfig({ memory: { v2: { enabled: false } } });
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("enqueues when config.json exists but memory.v2.enabled is not set", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: {} });
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+  });
+
+  test("enqueues when memory.v2.enabled is explicitly true", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: { v2: { enabled: true } } });
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 
@@ -119,7 +137,7 @@ describe("075-memory-v2-bm25-b-default-reembed migration", () => {
        VALUES ('pre-existing', 'memory_v2_reembed', '{}', 'pending', 0, 0, 0, NULL, 0, 0)`,
     );
     db.close();
-    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });
 });

--- a/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
+++ b/assistant/src/workspace/migrations/075-memory-v2-bm25-b-default-reembed.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
@@ -12,12 +12,6 @@ import type { WorkspaceMigration } from "./types.js";
  * vectors at write time, so without this nudge workspaces that never pinned
  * the field would silently mix old and new length normalization until a
  * manual reembed.
- *
- * Gated on whether the workspace already has concept pages on disk, not on
- * `memory.v2.enabled`. A workspace that has v2 disabled today may still
- * carry pages from a prior session; if v2 is re-enabled later, the queued
- * job is what brings those pages onto the new default. Workspaces that
- * have never written a v2 page have nothing to reembed.
  */
 export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
   id: "075-memory-v2-bm25-b-default-reembed",
@@ -25,8 +19,6 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
     "Enqueue memory_v2_reembed so existing concept pages pick up the new bm25_b=0.4 default",
 
   run(workspaceDir: string): void {
-    if (!hasConceptPages(workspaceDir)) return;
-
     const dbPath = join(workspaceDir, "data", "db", "assistant.db");
     if (!existsSync(dbPath)) return; // Fresh install — pages will embed at the new default.
 
@@ -67,29 +59,3 @@ export const memoryV2Bm25BDefaultReembedMigration: WorkspaceMigration = {
     // Forward-only: the reembed is a one-shot data refresh.
   },
 };
-
-/**
- * Returns true when `memory/concepts/` contains any `.md` file. Walks the
- * tree iteratively so we bail on the first hit — pages can be nested in
- * subdirectories (e.g. `memory/concepts/people/alice.md`).
- */
-function hasConceptPages(workspaceDir: string): boolean {
-  const stack = [join(workspaceDir, "memory", "concepts")];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        stack.push(join(dir, entry.name));
-      } else if (entry.isFile() && entry.name.endsWith(".md")) {
-        return true;
-      }
-    }
-  }
-  return false;
-}

--- a/assistant/src/workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts
+++ b/assistant/src/workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Follow-up to `075-memory-v2-bm25-b-default-reembed`. Migration 075 shipped
+ * in v0.8.1 with no gating beyond "db exists", so workspaces with no v2
+ * pages still recorded a checkpoint entry and a queued reembed job. We
+ * cannot edit 075 to add gating retroactively — the runner skips any
+ * already-checkpointed id — so this migration re-runs the enqueue with the
+ * gating we want now.
+ *
+ * Two gates:
+ *
+ * 1. `hasConceptPages` — only enqueue if `memory/concepts/` actually has a
+ *    `.md` page. Workspaces that never wrote a v2 page have nothing to
+ *    reembed.
+ * 2. `isMemoryV2Disabled` — skip when `memory.v2.enabled` is explicitly
+ *    `false`. The worker does not currently gate `memory_v2_reembed`
+ *    dispatch on the config flag, so enqueueing for a workspace that
+ *    intentionally disabled v2 would immediately re-embed pages and hit
+ *    the embedding backend against the user's intent.
+ */
+export const memoryV2Bm25BReembedDisabledV2PagesMigration: WorkspaceMigration =
+  {
+    id: "085-memory-v2-bm25-b-reembed-disabled-v2-pages",
+    description:
+      "Re-enqueue memory_v2_reembed for workspaces with v2 pages, gated on v2 not being explicitly disabled",
+
+    run(workspaceDir: string): void {
+      if (isMemoryV2Disabled(workspaceDir)) return;
+      if (!hasConceptPages(workspaceDir)) return;
+
+      const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+      if (!existsSync(dbPath)) return;
+
+      let db: Database;
+      try {
+        db = new Database(dbPath);
+      } catch {
+        return;
+      }
+
+      try {
+        const tableRow = db
+          .query(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_jobs'`,
+          )
+          .get();
+        if (!tableRow) return;
+
+        const existing = db
+          .query(
+            `SELECT id FROM memory_jobs WHERE type='memory_v2_reembed' AND status IN ('pending','running') LIMIT 1`,
+          )
+          .get();
+        if (existing) return;
+
+        const now = Date.now();
+        db.query(
+          `INSERT INTO memory_jobs
+             (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+           VALUES (?, 'memory_v2_reembed', '{}', 'pending', 0, 0, ?, NULL, ?, ?)`,
+        ).run(randomUUID(), now, now, now);
+      } finally {
+        db.close();
+      }
+    },
+
+    down(_workspaceDir: string): void {
+      // Forward-only: the reembed is a one-shot data refresh.
+    },
+  };
+
+/**
+ * Returns true only when `memory.v2.enabled` is explicitly set to `false`
+ * in the workspace `config.json`. Missing/unparseable config falls through
+ * to the schema default (enabled), matching `MemoryV2ConfigSchema`.
+ */
+function isMemoryV2Disabled(workspaceDir: string): boolean {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const memory = (raw as { memory?: { v2?: { enabled?: unknown } } })?.memory;
+    return memory?.v2?.enabled === false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when `memory/concepts/` contains any `.md` file. Walks the
+ * tree iteratively so we bail on the first hit — pages can be nested in
+ * subdirectories (e.g. `memory/concepts/people/alice.md`).
+ */
+function hasConceptPages(workspaceDir: string): boolean {
+  const stack = [join(workspaceDir, "memory", "concepts")];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        stack.push(join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -82,6 +82,7 @@ import { backfillBashAllowedToolsForInjectionCredentialsMigration } from "./081-
 import { backfillManagedProfileLabelsMigration } from "./082-backfill-managed-profile-labels.js";
 import { systemPromptPrefixToFileMigration } from "./083-system-prompt-prefix-to-file.js";
 import { removeLegacySkillsIndexMigration } from "./084-remove-legacy-skills-index.js";
+import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "./085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -175,4 +176,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillManagedProfileLabelsMigration,
   systemPromptPrefixToFileMigration,
   removeLegacySkillsIndexMigration,
+  memoryV2Bm25BReembedDisabledV2PagesMigration,
 ];


### PR DESCRIPTION
Addresses post-merge feedback on #30600.

## Why

**Devin P0**: Migration 075 was already released in v0.8.1. The workspace migration runner skips any id already in the checkpoint, so the new \`hasConceptPages\` gating added in #30600 would never execute on workspaces that already ran 075 — including the v2-disabled workspaces the PR aimed to fix. AGENTS.md is explicit: migrations are write-once after release; duplication is preferable to coupling.

**Codex P1**: The #30600 version enqueued \`memory_v2_reembed\` whenever pages exist, even when \`memory.v2.enabled\` is explicitly false. The worker does not gate dispatch on the v2 flag, so this would immediately re-embed/hit the embedding backend in workspaces that intentionally disabled v2.

## What

- Revert \`075-memory-v2-bm25-b-default-reembed.ts\` to the v0.8.1 released state (commit \`9ad946cc91\`, verified via \`git tag --contains\`).
- Delete the test file added in #30565/#30600 — original 075 had no test at that path.
- New migration \`085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts\`:
  - \`hasConceptPages\` iterative walk from #30600.
  - \`isMemoryV2Disabled\` gate from #30565 (Codex's concern).
- Register \`085\` at the end of \`WORKSPACE_MIGRATIONS\` (append-only).
- New test file covers both gates and dedupe.

Closes the regression introduced by #30600.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->