### PR TITLE
fix(macos): apply late setActiveProfile success when newer pick reverted

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -123,6 +123,22 @@ public final class SettingsStore: ObservableObject {
     /// optimistic value that itself never landed on the daemon.
     private var lastConfirmedActiveProfile: String = "balanced"
 
+    /// Monotonic counter incremented on each `setActiveProfile` call.
+    /// Each call captures its generation at entry and uses it to detect
+    /// out-of-order completions when picks race.
+    private var setActiveProfileGenerationCounter: Int = 0
+
+    /// Generations of `setActiveProfile` calls currently awaiting their
+    /// PATCH response. A newer pick in this set means the user has moved
+    /// on; an older completion must not stomp it.
+    private var inFlightSetActiveProfileGens: Set<Int> = []
+
+    /// Generation of the most recent `setActiveProfile` call whose success
+    /// was applied to `activeProfile` / `lastConfirmedActiveProfile`. A
+    /// later out-of-order success with a smaller generation must not
+    /// re-apply over this confirmed value.
+    private var lastConfirmedSetActiveProfileGen: Int = 0
+
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
@@ -3312,26 +3328,44 @@ public final class SettingsStore: ObservableObject {
     /// `self.activeProfile` synchronously so SwiftUI bindings render the new
     /// value without waiting for the round-trip.
     ///
-    /// Both branches gate post-PATCH state mutation on `self.activeProfile
-    /// == name` — i.e. apply only if the published state still reflects
-    /// this call's pick. Guards against stale async completions when picks
-    /// resolve out of order: e.g. user picks A then B; B succeeds first; A's
-    /// delayed success then arrives and would otherwise stomp the newer
-    /// confirmed value.
+    /// Each call captures a monotonic generation at entry. After the await,
+    /// post-PATCH mutation is gated on whether a *newer* pick is still
+    /// "live" — i.e. either still in flight or already successfully
+    /// confirmed. This distinguishes two race scenarios:
+    ///
+    /// 1. A→B both succeed, A late: B's success advances
+    ///    `lastConfirmedSetActiveProfileGen` past A. A's late success sees
+    ///    that and skips entirely, so it does not stomp B.
+    /// 2. A→B-fails-and-reverts→A late success: B never confirms, so
+    ///    `lastConfirmedSetActiveProfileGen` is unchanged. By the time A's
+    ///    success arrives, B is no longer in flight either. No newer pick
+    ///    is live, so A applies fully — re-syncing `activeProfile` from
+    ///    the post-revert "balanced" back to the daemon-confirmed "A".
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
+        setActiveProfileGenerationCounter += 1
+        let myGen = setActiveProfileGenerationCounter
+        inFlightSetActiveProfileGens.insert(myGen)
         self.activeProfile = name
         let success = await settingsClient.patchConfig([
             "llm": ["activeProfile": name]
         ])
-        if !success {
-            log.error("Failed to patch config for llm.activeProfile")
-        }
-        guard self.activeProfile == name else { return success }
+        inFlightSetActiveProfileGens.remove(myGen)
+
+        let newerPickLive = lastConfirmedSetActiveProfileGen > myGen
+            || inFlightSetActiveProfileGens.contains(where: { $0 > myGen })
+
         if success {
-            lastConfirmedActiveProfile = name
+            if !newerPickLive {
+                lastConfirmedActiveProfile = name
+                self.activeProfile = name
+                lastConfirmedSetActiveProfileGen = myGen
+            }
         } else {
-            self.activeProfile = lastConfirmedActiveProfile
+            log.error("Failed to patch config for llm.activeProfile")
+            if !newerPickLive, self.activeProfile == name {
+                self.activeProfile = lastConfirmedActiveProfile
+            }
         }
         return success
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -236,6 +236,72 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         )
     }
 
+    /// When the newer in-flight pick fails and reverts before the older
+    /// pick's success arrives, the older success must still apply — the
+    /// daemon has it and no live newer intent remains. The user picks A
+    /// then B; B's PATCH fails first (UI reverts to "balanced"); A's
+    /// delayed success then arrives. Because B is no longer in flight and
+    /// never confirmed, A is the only "live" intent and must drive both
+    /// `activeProfile` and `lastConfirmedActiveProfile` back to "A".
+    ///
+    /// Regression test for the previous guard (`self.activeProfile ==
+    /// name` only) which would early-return here and leave the UI stuck
+    /// on "balanced" while the daemon held "A".
+    func testSetActiveProfileAppliesLateSuccessWhenNewerPickFailed() async {
+        var continuationA: CheckedContinuation<Bool, Never>?
+        var continuationB: CheckedContinuation<Bool, Never>?
+        let bothSuspended = expectation(description: "both PATCH calls suspended")
+        bothSuspended.expectedFulfillmentCount = 2
+        mockSettingsClient.patchConfigHandler = { partial in
+            let name = (partial["llm"] as? [String: Any])?["activeProfile"] as? String
+            return await withCheckedContinuation { cont in
+                if name == "A" {
+                    continuationA = cont
+                } else {
+                    continuationB = cont
+                }
+                bothSuspended.fulfill()
+            }
+        }
+
+        async let resultA: Bool = store.setActiveProfile("A")
+        async let resultB: Bool = store.setActiveProfile("B")
+
+        await fulfillment(of: [bothSuspended], timeout: 1.0)
+
+        // Optimistic writes ran synchronously; the later pick (B) is current.
+        XCTAssertEqual(store.activeProfile, "B")
+
+        // Resolve B first as a failure — UI must revert to the last
+        // daemon-confirmed value ("balanced") since A's PATCH has not
+        // returned yet and B was the only newer-than-A in flight.
+        continuationB?.resume(returning: false)
+        let bSucceeded = await resultB
+        XCTAssertFalse(bSucceeded)
+        XCTAssertEqual(store.activeProfile, "balanced")
+
+        // Resolve A's late success. No newer pick is live (B failed and
+        // reverted; nothing newer in flight). Both `activeProfile` and
+        // `lastConfirmedActiveProfile` must advance to "A" so the UI
+        // matches the daemon-persisted value.
+        continuationA?.resume(returning: true)
+        let aSucceeded = await resultA
+        XCTAssertTrue(aSucceeded)
+        XCTAssertEqual(
+            store.activeProfile,
+            "A",
+            "Late success must apply when the newer pick failed and reverted"
+        )
+
+        // A subsequent failed pick must revert to "A", not "balanced",
+        // confirming `lastConfirmedActiveProfile` was also updated.
+        mockSettingsClient.patchConfigHandler = nil
+        mockSettingsClient.patchConfigResponse = false
+        let cSucceeded = await store.setActiveProfile("C")
+        XCTAssertFalse(cSucceeded)
+        XCTAssertEqual(store.activeProfile, "A")
+    }
+
     // MARK: - setProfile
 
     func testSetProfileRoundTripsAndUpdatesPublishedState() async {


### PR DESCRIPTION
## Summary

Follow-up to #30605. Codex P1 and Devin P0 flagged a new regression
introduced by the previous fix: guarding *all* post-await mutations
with \`self.activeProfile == name\` drops a valid success when two
requests race and the newer one fails first.

Scenario: user picks A then B; B fails (reverts \`activeProfile\` to
\`lastConfirmedActiveProfile\`, e.g. "balanced"); A's PATCH then
succeeds. The current-value guard fails (activeProfile is "balanced"),
so neither \`lastConfirmedActiveProfile\` nor \`self.activeProfile\` is
updated — daemon has "A" but UI shows "balanced".

The PR's original intent (block A→B-confirmed→A-late-success from
stomping B) is still desired. We need to distinguish "newer pick is
currently confirmed/optimistic" from "newer pick failed and reverted".

## Fix

Each \`setActiveProfile\` call captures a monotonic generation at entry.
After the await, we check whether any *newer* pick is still **live**:
- Newer pick in flight (\`inFlightSetActiveProfileGens\` contains a
  larger gen), OR
- Newer pick already successfully confirmed
  (\`lastConfirmedSetActiveProfileGen > myGen\`).

If no newer pick is live, the success/failure applies fully (success
re-syncs \`activeProfile\`/\`lastConfirmedActiveProfile\` to \`name\`; failure
reverts if \`activeProfile == name\`). If a newer pick is live, the
older completion is dropped — no state mutation.

This distinguishes:
- **A→B both succeed, A late**: B's success advances
  \`lastConfirmedSetActiveProfileGen\` past A. A's late success sees that
  and skips entirely — B is preserved.
- **A→B-fail-reverted→A late success**: B never confirms and is no
  longer in flight when A's success arrives. No newer pick is live, so
  A applies fully — UI re-syncs from the post-revert "balanced" back to
  the daemon-confirmed "A".

## Test plan
- [x] Existing \`testSetActiveProfileIgnoresStaleSuccessFromOlderInflightCall\`
  still passes (A→B-confirmed→A-late-success: A is dropped).
- [x] New \`testSetActiveProfileAppliesLateSuccessWhenNewerPickFailed\`
  (A→B-fail-reverted→A-late-success: A is applied; also verifies
  subsequent failed pick reverts to "A", confirming
  \`lastConfirmedActiveProfile\` was also updated).
- [x] Existing single-call round-trip / failure tests still cover the
  non-racing paths.