### PR TITLE
fix: wrap raw Slack recall evidence

### DIFF
--- a/assistant/src/__tests__/context-search-conversations-source.test.ts
+++ b/assistant/src/__tests__/context-search-conversations-source.test.ts
@@ -5,6 +5,7 @@ import type { RecallSearchContext } from "../memory/context-search/types.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { rawRun } from "../memory/raw-query.js";
+import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 initializeDb();
 
 let seedId = 0;
@@ -246,6 +247,53 @@ describe("searchConversationSource", () => {
     });
   });
 
+  test("wraps raw non-guardian Slack recall evidence from metadata", async () => {
+    const { conversation, message } = await seedConversation({
+      title: "Raw Slack recall",
+      role: "user",
+      content: "The rawrecalltoken decision came from Slack.",
+      metadata: slackMetadata("1700000100.000000", {
+        provenanceTrustClass: "unknown",
+      }),
+    });
+
+    const result = await searchConversationSource(
+      "rawrecalltoken",
+      makeContext(),
+      1,
+    );
+
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0]).toMatchObject({
+      locator: `${conversation.id}#${message.id}`,
+      excerpt:
+        '<external_content source="slack" origin="@alice">\nThe rawrecalltoken decision came from Slack.\n</external_content>',
+    });
+  });
+
+  test("does not wrap guardian Slack recall evidence", async () => {
+    const { conversation, message } = await seedConversation({
+      title: "Guardian Slack recall",
+      role: "user",
+      content: "The guardianrecalltoken decision came from Slack.",
+      metadata: slackMetadata("1700000101.000000", {
+        provenanceTrustClass: "guardian",
+      }),
+    });
+
+    const result = await searchConversationSource(
+      "guardianrecalltoken",
+      makeContext(),
+      1,
+    );
+
+    expect(result.evidence).toHaveLength(1);
+    expect(result.evidence[0]).toMatchObject({
+      locator: `${conversation.id}#${message.id}`,
+      excerpt: "The guardianrecalltoken decision came from Slack.",
+    });
+  });
+
   test("broadens overconstrained recall queries to salient terms", async () => {
     const specific = await seedConversation({
       title: "Birthday cake plan",
@@ -279,6 +327,7 @@ function seedConversation(opts: {
   memoryScopeId?: string;
   role?: string;
   content: string;
+  metadata?: string;
 }) {
   const id = ++seedId;
   const now = Date.now() + id;
@@ -318,17 +367,37 @@ function seedConversation(opts: {
       conversation_id,
       role,
       content,
-      created_at
-    ) VALUES (?, ?, ?, ?, ?)
+      created_at,
+      metadata
+    ) VALUES (?, ?, ?, ?, ?, ?)
     `,
     message.id,
     conversation.id,
     opts.role ?? "assistant",
     opts.content,
     now,
+    opts.metadata ?? null,
   );
 
   return { conversation, message };
+}
+
+function slackMetadata(
+  channelTs: string,
+  extra: Record<string, unknown>,
+): string {
+  return JSON.stringify({
+    userMessageChannel: "slack",
+    assistantMessageChannel: "slack",
+    slackMeta: writeSlackMetadata({
+      source: "slack",
+      channelId: "C0123",
+      channelTs,
+      eventKind: "message",
+      displayName: "@alice",
+    }),
+    ...extra,
+  });
 }
 
 function makeContext(

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -633,7 +633,11 @@ async function drainSingleMessage(
       await addMessage(
         conversation.conversationId,
         "user",
-        JSON.stringify(cleanUserMsg.content),
+        serializePersistedUserMessageContent(
+          next.content,
+          next.attachments,
+          next.displayContent,
+        ),
         drainChannelMeta,
       );
       persistedCompactMessage = true;
@@ -1319,7 +1323,11 @@ export async function processMessage(
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        JSON.stringify(cleanUserMsg.content),
+        serializePersistedUserMessageContent(
+          content,
+          attachments,
+          displayContent,
+        ),
         routerChannelMeta,
       );
       conversation.messages.push(llmUserMsg);
@@ -1495,7 +1503,11 @@ export async function processMessage(
       const persisted = await addMessage(
         conversation.conversationId,
         "user",
-        JSON.stringify(cleanUserMsg.content),
+        serializePersistedUserMessageContent(
+          content,
+          attachments,
+          displayContent,
+        ),
         pmChannelMeta,
       );
       persistedCompactMessage = true;

--- a/assistant/src/memory/context-search/sources/conversations.ts
+++ b/assistant/src/memory/context-search/sources/conversations.ts
@@ -1,3 +1,5 @@
+import { readSlackMetadata } from "../../../messaging/providers/slack/message-metadata.js";
+import { wrapUntrustedContent } from "../../../security/untrusted-content.js";
 import { AUTO_ANALYSIS_SOURCE } from "../../auto-analysis-guard.js";
 import {
   buildFtsMatchQuery,
@@ -15,6 +17,7 @@ interface ConversationEvidenceRow {
   role: string;
   content: string;
   created_at: number;
+  metadata: string | null;
   title: string | null;
 }
 
@@ -118,7 +121,7 @@ export async function searchConversationSource(
       source: "conversations",
       title: row.title?.trim() || "Untitled conversation",
       locator: `${row.conversation_id}#${row.message_id}`,
-      excerpt: buildRecallEvidenceExcerpt(row.content, trimmedQuery),
+      excerpt: buildRecallExcerpt(row, trimmedQuery),
       timestampMs: row.created_at,
       score,
       metadata: {
@@ -142,6 +145,7 @@ function searchWithFts(
       m.role,
       m.content,
       m.created_at,
+      m.metadata,
       c.title
     FROM messages_fts
     JOIN messages m ON m.id = messages_fts.message_id
@@ -175,6 +179,7 @@ function searchWithLike(
       m.role,
       m.content,
       m.created_at,
+      m.metadata,
       c.title
     FROM messages m
     JOIN conversations c ON c.id = m.conversation_id
@@ -192,6 +197,58 @@ function searchWithLike(
     excludedConversationId,
     limit,
   );
+}
+
+function buildRecallExcerpt(
+  row: ConversationEvidenceRow,
+  query: string,
+): string {
+  const excerpt = buildRecallEvidenceExcerpt(row.content, query);
+  const slackMeta = parseSlackRecallMetadata(row.metadata);
+  if (
+    row.role !== "user" ||
+    !slackMeta ||
+    slackMeta.provenanceTrustClass === "guardian" ||
+    excerpt.length === 0 ||
+    excerpt.includes("<external_content")
+  ) {
+    return excerpt;
+  }
+
+  return wrapUntrustedContent(excerpt, {
+    source: "slack",
+    ...(slackMeta.displayName ? { sourceDetail: slackMeta.displayName } : {}),
+  });
+}
+
+function parseSlackRecallMetadata(rawMetadata: string | null): {
+  displayName?: string;
+  provenanceTrustClass?: string;
+} | null {
+  if (!rawMetadata) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawMetadata);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const metadata = parsed as Record<string, unknown>;
+  if (typeof metadata.slackMeta !== "string") return null;
+  const slackMeta = readSlackMetadata(metadata.slackMeta);
+  if (!slackMeta) return null;
+
+  return {
+    ...(slackMeta.displayName ? { displayName: slackMeta.displayName } : {}),
+    ...(typeof metadata.provenanceTrustClass === "string"
+      ? { provenanceTrustClass: metadata.provenanceTrustClass }
+      : {}),
+  };
 }
 
 function buildRecallFtsMatchQueries(query: string): string[] {


### PR DESCRIPTION
## Summary
- Wraps raw non-guardian Slack conversation recall excerpts using persisted Slack metadata.
- Uses display-content-aware persistence in remaining Conversation.processMessage branches.

Fixes final self-review gaps for slack-runtime-content-wrapping.md.