### PR TITLE
fix(migrations): add 085 to revert 057 stale-Gemini mis-rewrites

### DIFF
--- a/assistant/src/__tests__/workspace-migration-085-revert-stale-gemini-mis-rewrites.test.ts
+++ b/assistant/src/__tests__/workspace-migration-085-revert-stale-gemini-mis-rewrites.test.ts
@@ -1,0 +1,241 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { revertStaleGeminiMisRewritesMigration } from "../workspace/migrations/085-revert-stale-gemini-mis-rewrites.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-085-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("085-revert-stale-gemini-mis-rewrites migration", () => {
+  test("registered in WORKSPACE_MIGRATIONS", () => {
+    expect(WORKSPACE_MIGRATIONS).toContain(
+      revertStaleGeminiMisRewritesMigration,
+    );
+  });
+
+  test("reverts call-site model when 057 rewrote on non-Gemini default", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        callSites: {
+          recall: { model: "gemini-3-flash-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { recall: { model: string } } };
+    };
+    expect(config.llm.callSites.recall.model).toBe("gemini-3-flash");
+  });
+
+  test("reverts latency call-site model when default is openrouter", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openrouter", model: "x-ai/grok-4" },
+        callSites: {
+          memoryRetrieval: { model: "gemini-3.1-flash-lite-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { memoryRetrieval: { model: string } } };
+    };
+    expect(config.llm.callSites.memoryRetrieval.model).toBe("gemini-3-flash");
+  });
+
+  test("does not revert when default provider is Gemini", () => {
+    const before = {
+      llm: {
+        default: { provider: "gemini", model: "gemini-3-flash-preview" },
+        callSites: {
+          recall: { model: "gemini-3-flash-preview" },
+        },
+      },
+    };
+    writeConfig(before);
+    const beforeRaw = readFileSync(configPath(), "utf-8");
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(beforeRaw);
+  });
+
+  test("does not revert when fragment has an explicit provider", () => {
+    const before = {
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        callSites: {
+          recall: { provider: "gemini", model: "gemini-3-flash-preview" },
+        },
+      },
+    };
+    writeConfig(before);
+    const beforeRaw = readFileSync(configPath(), "utf-8");
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(beforeRaw);
+  });
+
+  test("does not revert when site profile carries Gemini context via catalog", () => {
+    const before = {
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        profiles: {
+          custom: { model: "gemini-2.5-pro" },
+        },
+        callSites: {
+          recall: { profile: "custom", model: "gemini-3-flash-preview" },
+        },
+      },
+    };
+    writeConfig(before);
+    const beforeRaw = readFileSync(configPath(), "utf-8");
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(beforeRaw);
+  });
+
+  test("reverts profile fragment when default provider is non-Gemini", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openrouter", model: "x-ai/grok-4" },
+        profiles: {
+          custom: { model: "gemini-3-flash-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { profiles: { custom: { model: string } } };
+    };
+    expect(config.llm.profiles.custom.model).toBe("gemini-3-flash");
+  });
+
+  test("mainAgent revert uses activeProfile over call-site for context", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-3-flash-preview" },
+        activeProfile: "ollamaActive",
+        profiles: {
+          ollamaActive: { provider: "ollama", model: "llama3.2" },
+        },
+        callSites: {
+          mainAgent: { model: "gemini-3-flash-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: { mainAgent: { model: string } } };
+    };
+    // For mainAgent the active profile sits above the call-site, so an
+    // Ollama active profile dominates the Gemini default and the rewrite
+    // must be reverted.
+    expect(config.llm.callSites.mainAgent.model).toBe("gemini-3-flash");
+  });
+
+  test("non-mainAgent ignores activeProfile when site.profile is Gemini", () => {
+    const before = {
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        activeProfile: "alsoOllama",
+        profiles: {
+          alsoOllama: { provider: "ollama", model: "llama3.2" },
+          geminiProfile: {
+            provider: "gemini",
+            model: "gemini-3-flash-preview",
+          },
+        },
+        callSites: {
+          recall: { profile: "geminiProfile", model: "gemini-3-flash-preview" },
+        },
+      },
+    };
+    writeConfig(before);
+    const beforeRaw = readFileSync(configPath(), "utf-8");
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    expect(readFileSync(configPath(), "utf-8")).toBe(beforeRaw);
+  });
+
+  test("no-op when config.json is missing", () => {
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+    expect(existsSync(configPath())).toBe(false);
+  });
+
+  test("no-op on malformed config", () => {
+    writeFileSync(configPath(), "{not json");
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe("{not json");
+  });
+
+  test("idempotent: re-running after revert is a no-op", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        callSites: {
+          recall: { model: "gemini-3-flash-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+    expect(readFileSync(configPath(), "utf-8")).toBe(afterFirst);
+  });
+});

--- a/assistant/src/workspace/migrations/085-revert-stale-gemini-mis-rewrites.ts
+++ b/assistant/src/workspace/migrations/085-revert-stale-gemini-mis-rewrites.ts
@@ -1,0 +1,188 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Revert mis-rewrites by migration 057 where a non-Gemini fragment was
+ * incorrectly treated as Gemini.
+ *
+ * Migration 057's `inferProvider` helper hardcodes `model === "gemini-3-flash"`
+ * as Gemini even when no `provider` is set, but `resolveCallSiteConfig` only
+ * infers providers via the catalog and `gemini-3-flash` is not a catalog
+ * entry. The runtime resolver therefore leaves such fragments inheriting from
+ * lower layers, so a workspace like `llm.default = {provider: "ollama"}` with
+ * `llm.callSites.recall = {model: "gemini-3-flash"}` (a user-named local
+ * model) resolves as Ollama at runtime — but 057 rewrites that recall model
+ * to `gemini-3-flash-preview`, flipping the catalog-based provider inference
+ * to Gemini and corrupting the user's intent.
+ *
+ * For each call-site or profile fragment that currently looks like a 057
+ * rewrite output (model in the replacement set, no explicit `provider`), this
+ * migration recomputes the effective provider via proper catalog-based
+ * inference using only the other layers. If that effective provider is
+ * explicitly non-Gemini, the fragment's model is reverted to
+ * `gemini-3-flash`, restoring the user's pre-057 state.
+ */
+export const revertStaleGeminiMisRewritesMigration: WorkspaceMigration = {
+  id: "085-revert-stale-gemini-mis-rewrites",
+  description:
+    "Revert 057 mis-rewrites of gemini-3-flash in non-Gemini fragment contexts",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const defaultBlock = readObject(llm.default);
+    const defaultProvider = inferLayerProvider(defaultBlock);
+    const profiles = readObject(llm.profiles);
+    const activeProfileName =
+      typeof llm.activeProfile === "string" ? llm.activeProfile : undefined;
+    const activeProfileBlock =
+      profiles !== null && activeProfileName !== undefined
+        ? readObject(profiles[activeProfileName])
+        : null;
+    const activeProfileProvider = inferLayerProvider(activeProfileBlock);
+
+    let changed = false;
+
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const [site, rawConfig] of Object.entries(callSites)) {
+        const callSiteConfig = readObject(rawConfig);
+        if (callSiteConfig === null) continue;
+        if (!isRevertCandidate(callSiteConfig)) continue;
+        const siteProfileName =
+          typeof callSiteConfig.profile === "string"
+            ? callSiteConfig.profile
+            : undefined;
+        const siteProfileBlock =
+          profiles !== null && siteProfileName !== undefined
+            ? readObject(profiles[siteProfileName])
+            : null;
+        const siteProfileProvider = inferLayerProvider(siteProfileBlock);
+
+        const effective = effectiveProviderExcludingSite({
+          callSite: site,
+          siteProfileProvider,
+          activeProfileProvider,
+          defaultProvider,
+        });
+        if (isExplicitlyNonGemini(effective)) {
+          callSiteConfig.model = STALE_MODEL;
+          changed = true;
+        }
+      }
+    }
+
+    if (profiles !== null) {
+      for (const rawProfile of Object.values(profiles)) {
+        const profile = readObject(rawProfile);
+        if (profile === null) continue;
+        if (!isRevertCandidate(profile)) continue;
+        if (isExplicitlyNonGemini(defaultProvider)) {
+          profile.model = STALE_MODEL;
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) return;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: re-applying the broken rewrite would reintroduce the bug.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const STALE_MODEL = "gemini-3-flash";
+
+// Models 057 writes when rewriting. Any fragment now holding one of these
+// values without an explicit provider is a potential mis-rewrite candidate.
+const REPLACEMENT_MODELS = new Set<string>([
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+]);
+
+// Subset of the Gemini provider catalog used for per-layer catalog inference.
+// Mirrors `getCatalogProviderForModel` for Gemini entries only — for other
+// providers we treat a bare model as "provider unknown" and fall through to
+// lower layers, which is safe because the revert only fires when at least one
+// layer below carries an explicit non-Gemini provider.
+const GEMINI_CATALOG_MODELS = new Set<string>([
+  "gemini-3.1-pro-preview",
+  "gemini-3.1-pro-preview-customtools",
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+  "gemini-2.5-pro",
+]);
+
+function isRevertCandidate(block: Record<string, unknown>): boolean {
+  if (typeof block.provider === "string") return false;
+  return typeof block.model === "string" && REPLACEMENT_MODELS.has(block.model);
+}
+
+function inferLayerProvider(
+  block: Record<string, unknown> | null,
+): string | undefined {
+  if (block === null) return undefined;
+  if (typeof block.provider === "string") return block.provider;
+  if (
+    typeof block.model === "string" &&
+    GEMINI_CATALOG_MODELS.has(block.model)
+  ) {
+    return "gemini";
+  }
+  return undefined;
+}
+
+function isExplicitlyNonGemini(provider: string | undefined): boolean {
+  return provider !== undefined && provider !== "gemini";
+}
+
+// Mirrors `resolveCallSiteConfig`'s layered provider resolution, omitting the
+// candidate call-site fragment itself (its provider is undefined and its
+// model is the replacement value, so including it would always say "gemini"
+// via catalog inference — defeating the revert check).
+function effectiveProviderExcludingSite(args: {
+  callSite: string;
+  siteProfileProvider: string | undefined;
+  activeProfileProvider: string | undefined;
+  defaultProvider: string | undefined;
+}): string | undefined {
+  const {
+    callSite,
+    siteProfileProvider,
+    activeProfileProvider,
+    defaultProvider,
+  } = args;
+  if (callSite === "mainAgent") {
+    return activeProfileProvider ?? siteProfileProvider ?? defaultProvider;
+  }
+  return siteProfileProvider ?? activeProfileProvider ?? defaultProvider;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -82,6 +82,7 @@ import { backfillBashAllowedToolsForInjectionCredentialsMigration } from "./081-
 import { backfillManagedProfileLabelsMigration } from "./082-backfill-managed-profile-labels.js";
 import { systemPromptPrefixToFileMigration } from "./083-system-prompt-prefix-to-file.js";
 import { removeLegacySkillsIndexMigration } from "./084-remove-legacy-skills-index.js";
+import { revertStaleGeminiMisRewritesMigration } from "./085-revert-stale-gemini-mis-rewrites.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -175,4 +176,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillManagedProfileLabelsMigration,
   systemPromptPrefixToFileMigration,
   removeLegacySkillsIndexMigration,
+  revertStaleGeminiMisRewritesMigration,
 ];


### PR DESCRIPTION
Addresses Codex P1 feedback on #30604.

Migration 057's `inferProvider` helper hardcodes `model === "gemini-3-flash"` as Gemini even when no `provider` is set, but `resolveCallSiteConfig` only infers providers via the catalog and `gemini-3-flash` is not a catalog entry. The runtime resolver therefore leaves such fragments inheriting from lower layers, so a workspace like `llm.default = {provider: "ollama"}` with `llm.callSites.recall = {model: "gemini-3-flash"}` resolves as Ollama at runtime — but 057 rewrites that recall model to `gemini-3-flash-preview`, flipping the catalog-based inference to Gemini and corrupting the user's intent.

## Released vs unreleased decision

The original migration 057 was released in v0.7.0 and has been modified twice since (#29998 in v0.8.1, then #30535 and #30604 — neither tagged yet). Because 057 is in a released tag, the write-once rule applies and modifying it again would compound the existing violations. This PR adds a new migration 085 instead.

## What 085 does

For each call-site or profile fragment that currently looks like a 057 rewrite output (model in `{gemini-3-flash-preview, gemini-3.1-flash-lite-preview}`, no explicit provider), it recomputes the effective provider via proper catalog-based inference using only the *other* layers. If that effective provider is explicitly non-Gemini, the fragment's model is reverted to `gemini-3-flash`, restoring the user's pre-057 state.

The mainAgent vs non-mainAgent layer precedence mirrors `resolveCallSiteConfig`. A minimal inline Gemini-catalog model set lets us detect Gemini context in lower layers without importing from outside `./types.js`, per workspace-migration self-containment.

## Test plan

- [x] `bun test src/__tests__/workspace-migration-085-revert-stale-gemini-mis-rewrites.test.ts` — 12 cases covering revert, no-revert (gemini default, explicit provider, gemini site profile, gemini catalog model in lower layer), mainAgent precedence, profile fragments, idempotence, no-op on missing/malformed config
- [x] 057 tests still pass
- [x] `bunx tsc --noEmit` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->