### PR TITLE
fix(macos): consolidate redundant hover tracking areas to reduce scroll flickering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -42,10 +42,9 @@ struct RunningIndicator: View {
                 indicatorContent
             }
             .buttonStyle(.plain)
-            .pointerCursor()
-            .onHover { hovering in
-                isHovered = hovering
-            }
+            .pointerCursor(onHover: { hovering in
+                if isHovered != hovering { isHovered = hovering }
+            })
         } else {
             indicatorContent
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatWidgetViews.swift
@@ -42,9 +42,7 @@ struct RunningIndicator: View {
                 indicatorContent
             }
             .buttonStyle(.plain)
-            .pointerCursor(onHover: { hovering in
-                if isHovered != hovering { isHovered = hovering }
-            })
+            .pointerCursor(onHover: { isHovered = $0 })
         } else {
             indicatorContent
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -115,8 +115,9 @@ private struct AttachmentRemoveButton: View {
                 .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentTertiary)
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -115,9 +115,7 @@ private struct AttachmentRemoveButton: View {
                 .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentTertiary)
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -71,8 +71,9 @@ struct EmojiPickerRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in isHovered = hovering }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
     }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -71,9 +71,7 @@ struct EmojiPickerRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
     }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -134,7 +134,8 @@ struct SlashCommandRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in isHovered = hovering }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -134,8 +134,6 @@ struct SlashCommandRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
@@ -98,8 +98,9 @@ struct HomeRecapGroupRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor()
-        .onHover { isParentHovering = $0 }
+        .pointerCursor(onHover: { hovering in
+            if isParentHovering != hovering { isParentHovering = hovering }
+        })
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(parentTitle))
         .accessibilityAddTraits(.isButton)
@@ -186,8 +187,9 @@ private struct ChildRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor()
-        .onHover { isHovering = $0 }
+        .pointerCursor(onHover: { hovering in
+            if isHovering != hovering { isHovering = hovering }
+        })
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(child.title))
         .accessibilityAddTraits(.isButton)

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapGroupRow.swift
@@ -98,9 +98,7 @@ struct HomeRecapGroupRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isParentHovering != hovering { isParentHovering = hovering }
-        })
+        .pointerCursor(onHover: { isParentHovering = $0 })
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(parentTitle))
         .accessibilityAddTraits(.isButton)
@@ -187,9 +185,7 @@ private struct ChildRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovering != hovering { isHovering = hovering }
-        })
+        .pointerCursor(onHover: { isHovering = $0 })
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(child.title))
         .accessibilityAddTraits(.isButton)

--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -299,10 +299,9 @@ private struct PublishedButton: View {
                         copied = false
                     }
                 }
-                .onHover { hovering in
-                    isCopyHovered = hovering
-                }
-                .pointerCursor()
+                .pointerCursor(onHover: { hovering in
+                    if isCopyHovered != hovering { isCopyHovered = hovering }
+                })
                 .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
         }
         .foregroundStyle(VColor.primaryBase)

--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -299,9 +299,7 @@ private struct PublishedButton: View {
                         copied = false
                     }
                 }
-                .pointerCursor(onHover: { hovering in
-                    if isCopyHovered != hovering { isCopyHovered = hovering }
-                })
+                .pointerCursor(onHover: { isCopyHovered = $0 })
                 .accessibilityLabel(copied ? "URL copied" : "Copy published URL")
         }
         .foregroundStyle(VColor.primaryBase)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -319,10 +319,7 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            let newValue = hovering ? app.id : nil
-            if hoveredAppId != newValue { hoveredAppId = newValue }
-        })
+        .pointerCursor(onHover: { hoveredAppId = $0 ? app.id : nil })
         .vContextMenu(width: 200) {
             VMenuItem(icon: (app.isPinned ? VIcon.pinOff : .pin).rawValue, label: app.isPinned ? "Unpin" : "Pin") {
                 if app.isPinned {
@@ -406,10 +403,7 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            let newValue = hovering ? "shared-\(app.uuid)" : nil
-            if hoveredAppId != newValue { hoveredAppId = newValue }
-        })
+        .pointerCursor(onHover: { hoveredAppId = $0 ? "shared-\(app.uuid)" : nil })
     }
 
     // MARK: - Document Card
@@ -454,10 +448,7 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            let newValue = hovering ? document.surfaceId : nil
-            if hoveredAppId != newValue { hoveredAppId = newValue }
-        })
+        .pointerCursor(onHover: { hoveredAppId = $0 ? document.surfaceId : nil })
         .accessibilityLabel(document.title)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -319,10 +319,10 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in
-            hoveredAppId = hovering ? app.id : nil
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = hovering ? app.id : nil
+            if hoveredAppId != newValue { hoveredAppId = newValue }
+        })
         .vContextMenu(width: 200) {
             VMenuItem(icon: (app.isPinned ? VIcon.pinOff : .pin).rawValue, label: app.isPinned ? "Unpin" : "Pin") {
                 if app.isPinned {
@@ -406,10 +406,10 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in
-            hoveredAppId = hovering ? "shared-\(app.uuid)" : nil
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = hovering ? "shared-\(app.uuid)" : nil
+            if hoveredAppId != newValue { hoveredAppId = newValue }
+        })
     }
 
     // MARK: - Document Card
@@ -454,10 +454,10 @@ struct AppsGridView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in
-            hoveredAppId = hovering ? document.surfaceId : nil
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = hovering ? document.surfaceId : nil
+            if hoveredAppId != newValue { hoveredAppId = newValue }
+        })
         .accessibilityLabel(document.title)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -1044,7 +1044,8 @@ private struct TimezoneResultRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -1044,8 +1044,6 @@ private struct TimezoneResultRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -170,10 +170,7 @@ struct AppSharePanelView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            let newValue = hovering ? index : nil
-            if hoveredServiceIndex != newValue { hoveredServiceIndex = newValue }
-        })
+        .pointerCursor(onHover: { hoveredServiceIndex = $0 ? index : nil })
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -170,10 +170,10 @@ struct AppSharePanelView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { hovering in
-            hoveredServiceIndex = hovering ? index : nil
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = hovering ? index : nil
+            if hoveredServiceIndex != newValue { hoveredServiceIndex = newValue }
+        })
     }
 
     // MARK: - Helpers

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -573,9 +573,7 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
         .animation(VAnimation.fast, value: isHovered)
         .accessibilityLabel(node.name)
         .accessibilityHint(directoryAccessibilityHint)

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -573,8 +573,9 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor()
-        .onHover { isHovered = $0 }
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
         .animation(VAnimation.fast, value: isHovered)
         .accessibilityLabel(node.name)
         .accessibilityHint(directoryAccessibilityHint)

--- a/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
@@ -67,10 +67,9 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
         .contentShape(Rectangle())
         .animation(VAnimation.fast, value: isDividerHovered)
         .animation(VAnimation.fast, value: isDragging)
-        .onHover { hovering in
-            isDividerHovered = hovering
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isDividerHovered != hovering { isDividerHovered = hovering }
+        })
         .gesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
                 .onChanged { value in

--- a/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VAppWorkspaceDockLayout.swift
@@ -67,9 +67,7 @@ public struct VAppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
         .contentShape(Rectangle())
         .animation(VAnimation.fast, value: isDividerHovered)
         .animation(VAnimation.fast, value: isDragging)
-        .pointerCursor(onHover: { hovering in
-            if isDividerHovered != hovering { isDividerHovered = hovering }
-        })
+        .pointerCursor(onHover: { isDividerHovered = $0 })
         .gesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
                 .onChanged { value in

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -75,9 +75,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
         .contentShape(Rectangle())
         .animation(VAnimation.fast, value: isDividerHovered)
         .animation(VAnimation.fast, value: isDragging)
-        .pointerCursor(onHover: { hovering in
-            if isDividerHovered != hovering { isDividerHovered = hovering }
-        })
+        .pointerCursor(onHover: { isDividerHovered = $0 })
         .gesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
                 .onChanged { value in

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -75,10 +75,9 @@ public struct VSplitView<Main: View, Panel: View>: View {
         .contentShape(Rectangle())
         .animation(VAnimation.fast, value: isDividerHovered)
         .animation(VAnimation.fast, value: isDragging)
-        .onHover { hovering in
-            isDividerHovered = hovering
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isDividerHovered != hovering { isDividerHovered = hovering }
+        })
         .gesture(
             DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
                 .onChanged { value in

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -471,8 +471,9 @@ public struct VMenuItem<Trailing: View>: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
             .onTapGesture { guard isEnabled else { return }; dismissMenu?(); action() }
-            .onHover { isHovered = $0 }
-            .pointerCursor()
+            .pointerCursor(onHover: { hovering in
+                if isHovered != hovering { isHovered = hovering }
+            })
             .accessibilityElement(children: .combine)
             .accessibilityLabel(label)
             .accessibilityAddTraits(.isButton)

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -471,9 +471,7 @@ public struct VMenuItem<Trailing: View>: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
             .onTapGesture { guard isEnabled else { return }; dismissMenu?(); action() }
-            .pointerCursor(onHover: { hovering in
-                if isHovered != hovering { isHovered = hovering }
-            })
+            .pointerCursor(onHover: { isHovered = $0 })
             .accessibilityElement(children: .combine)
             .accessibilityLabel(label)
             .accessibilityAddTraits(.isButton)

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -98,10 +98,7 @@ public struct VButton: View {
             tintColor: tintColor,
             buttonShape: buttonShape
         ))
-        .pointerCursor(onHover: { hovering in
-            let newValue = effectivelyDisabled ? false : hovering
-            if isHovered != newValue { isHovered = newValue }
-        })
+        .pointerCursor(onHover: { isHovered = effectivelyDisabled ? false : $0 })
         .disabled(isDisabled)
         .accessibilityLabel(label)
         .accessibilityHint(effectivelyDisabled ? "Button is currently disabled" : "")

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -98,10 +98,10 @@ public struct VButton: View {
             tintColor: tintColor,
             buttonShape: buttonShape
         ))
-        .onHover { hovering in
-            isHovered = effectivelyDisabled ? false : hovering
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = effectivelyDisabled ? false : hovering
+            if isHovered != newValue { isHovered = newValue }
+        })
         .disabled(isDisabled)
         .accessibilityLabel(label)
         .accessibilityHint(effectivelyDisabled ? "Button is currently disabled" : "")

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -102,10 +102,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 .background(zoneBackgroundColor(isHovered: isPrimaryHovered))
             }
             .buttonStyle(.plain)
-            .pointerCursor(onHover: { hovering in
-                let newValue = isDisabled ? false : hovering
-                if isPrimaryHovered != newValue { isPrimaryHovered = newValue }
-            })
+            .pointerCursor(onHover: { isPrimaryHovered = isDisabled ? false : $0 })
 
             // Divider
             divider
@@ -164,10 +161,7 @@ public struct VSplitButton<MenuContent: View>: View {
             .accessibilityLabel("\(label) options")
         }
         .frame(width: dropdownWidth, height: zoneHeight)
-        .pointerCursor(onHover: { hovering in
-            let newValue = isDisabled ? false : hovering
-            if isDropdownHovered != newValue { isDropdownHovered = newValue }
-        })
+        .pointerCursor(onHover: { isDropdownHovered = isDisabled ? false : $0 })
     }
     #endif
 
@@ -200,10 +194,7 @@ public struct VSplitButton<MenuContent: View>: View {
             .accessibilityLabel("\(label) options")
         }
         .frame(width: dropdownWidth, height: zoneHeight)
-        .pointerCursor(onHover: { hovering in
-            let newValue = isDisabled ? false : hovering
-            if isDropdownHovered != newValue { isDropdownHovered = newValue }
-        })
+        .pointerCursor(onHover: { isDropdownHovered = isDisabled ? false : $0 })
         .overlay {
             GeometryReader { geo in
                 Color.clear

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -102,10 +102,10 @@ public struct VSplitButton<MenuContent: View>: View {
                 .background(zoneBackgroundColor(isHovered: isPrimaryHovered))
             }
             .buttonStyle(.plain)
-            .onHover { hovering in
-                isPrimaryHovered = isDisabled ? false : hovering
-            }
-            .pointerCursor()
+            .pointerCursor(onHover: { hovering in
+                let newValue = isDisabled ? false : hovering
+                if isPrimaryHovered != newValue { isPrimaryHovered = newValue }
+            })
 
             // Divider
             divider
@@ -164,10 +164,10 @@ public struct VSplitButton<MenuContent: View>: View {
             .accessibilityLabel("\(label) options")
         }
         .frame(width: dropdownWidth, height: zoneHeight)
-        .onHover { hovering in
-            isDropdownHovered = isDisabled ? false : hovering
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = isDisabled ? false : hovering
+            if isDropdownHovered != newValue { isDropdownHovered = newValue }
+        })
     }
     #endif
 
@@ -200,10 +200,10 @@ public struct VSplitButton<MenuContent: View>: View {
             .accessibilityLabel("\(label) options")
         }
         .frame(width: dropdownWidth, height: zoneHeight)
-        .onHover { hovering in
-            isDropdownHovered = isDisabled ? false : hovering
-        }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            let newValue = isDisabled ? false : hovering
+            if isDropdownHovered != newValue { isDropdownHovered = newValue }
+        })
         .overlay {
             GeometryReader { geo in
                 Color.clear

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -40,10 +40,9 @@ public struct VShortcutTag: View {
                 tagContent
             }
             .buttonStyle(.plain)
-            .onHover { hovering in
-                isHovered = hovering
-            }
-            .pointerCursor()
+            .pointerCursor(onHover: { hovering in
+                if isHovered != hovering { isHovered = hovering }
+            })
             .accessibilityLabel(text)
         } else {
             tagContent

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -40,9 +40,7 @@ public struct VShortcutTag: View {
                 tagContent
             }
             .buttonStyle(.plain)
-            .pointerCursor(onHover: { hovering in
-                if isHovered != hovering { isHovered = hovering }
-            })
+            .pointerCursor(onHover: { isHovered = $0 })
             .accessibilityLabel(text)
         } else {
             tagContent

--- a/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
@@ -81,9 +81,7 @@ private struct Segment: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSegmentControl.swift
@@ -81,8 +81,9 @@ private struct Segment: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -79,9 +79,7 @@ public struct VTab: View {
                 .opacity(isSelected ? 1 : 0)
         )
         .animation(VAnimation.fast, value: isHovered)
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -79,8 +79,9 @@ public struct VTab: View {
                 .opacity(isSelected ? 1 : 0)
         )
         .animation(VAnimation.fast, value: isHovered)
-        .onHover { hovering in isHovered = hovering }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
     }
 }
 

--- a/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
@@ -14,18 +14,24 @@ struct PointerCursorModifier: ViewModifier {
     var enabled: Bool = true
     var onHover: ((Bool) -> Void)?
 
+    @ViewBuilder
     func body(content: Content) -> some View {
         #if os(macOS)
-        content
-            .pointerStyle(enabled && isEnabled ? .link : nil)
-            .onHover { hovering in
-                onHover?(hovering)
-            }
+        if let onHover {
+            content
+                .pointerStyle(enabled && isEnabled ? .link : nil)
+                .onHover { hovering in onHover(hovering) }
+        } else {
+            content
+                .pointerStyle(enabled && isEnabled ? .link : nil)
+        }
         #else
-        content
-            .onHover { hovering in
-                onHover?(hovering)
-            }
+        if let onHover {
+            content
+                .onHover { hovering in onHover(hovering) }
+        } else {
+            content
+        }
         #endif
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -180,7 +180,9 @@ public struct InlineSurfaceRouter: View {
             }
         }
         #if os(macOS)
-        .onHover { isCardHovered = $0 }
+        .onHover { hovering in
+            if isCardHovered != hovering { isCardHovered = hovering }
+        }
         #endif
         // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
         .widthCap(isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth))

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -180,9 +180,7 @@ public struct InlineSurfaceRouter: View {
             }
         }
         #if os(macOS)
-        .onHover { hovering in
-            if isCardHovered != hovering { isCardHovered = hovering }
-        }
+        .onHover { isCardHovered = $0 }
         #endif
         // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
         .widthCap(isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth))

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -213,9 +213,7 @@ public struct SubagentGroupRow: View {
         .background(isHovered ? VColor.surfaceActive : Color.clear)
         .contentShape(Rectangle())
         .onTapGesture { onTap?() }
-        .pointerCursor(onHover: { hovering in
-            if isHovered != hovering { isHovered = hovering }
-        })
+        .pointerCursor(onHover: { isHovered = $0 })
         .accessibilityLabel("Subagent: \(subagent.label), \(statusLabel)")
         .accessibilityHint("Opens subagent detail panel")
         .accessibilityAddTraits(.isButton)

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -213,8 +213,9 @@ public struct SubagentGroupRow: View {
         .background(isHovered ? VColor.surfaceActive : Color.clear)
         .contentShape(Rectangle())
         .onTapGesture { onTap?() }
-        .onHover { isHovered = $0 }
-        .pointerCursor()
+        .pointerCursor(onHover: { hovering in
+            if isHovered != hovering { isHovered = hovering }
+        })
         .accessibilityLabel("Subagent: \(subagent.label), \(statusLabel)")
         .accessibilityHint("Opens subagent detail panel")
         .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
Consolidates dual `.onHover` + `.pointerCursor()` into single `.pointerCursor(onHover:)` calls across 20 files, and fixes `PointerCursorModifier` to skip dead `.onHover` registration when no callback is provided — eliminating redundant `NSTrackingArea` registrations that contribute to hover-triggered scroll flickering in the inverted transcript.

---

### Problem

Multiple views register **two `NSTrackingArea`s** per hoverable element:
1. An explicit `.onHover { isHovered = $0 }` for state mutation
2. `.pointerCursor()` → `PointerCursorModifier` internally applies another `.onHover { onHover?(hovering) }` that is a no-op (nil callback)

### Fix

- **`PointerCursorModifier`**: `@ViewBuilder` with `if let onHover` skips `.onHover` registration when no callback provided. Bare `.pointerCursor()` now only applies `.pointerStyle(.link)`.
- **20 call sites**: Consolidated to `.pointerCursor(onHover: { isHovered = $0 })` (1 tracking area instead of 2).
- **No equality guards**: SwiftUI's `@State` checks equality for `Equatable` types before invalidation on macOS 14+. Direct `isHovered = $0` is correct and idiomatic.

### `@ViewBuilder` view identity

The `if let onHover` creates `_ConditionalContent<A, B>`, safe because each call site has a **static** `onHover` parameter (always nil or always non-nil → stable branch per call site). Ref: [SwiftUI View Identity (WWDC21)](https://developer.apple.com/videos/play/wwdc2021/10022/)

### Root cause analysis

1. **How?** `PointerCursorModifier.body` always registered `.onHover` even when callback was nil. Call sites used separate `.onHover` + bare `.pointerCursor()` without realizing the modifier installed its own.
2. **Warning signs?** The `.pointerCursor(onHover:)` overload existed but was unused — all callers used the two-modifier pattern.
3. **Prevention?** The modifier fix ensures the nil case no longer registers a dead tracking area, so even the two-modifier pattern is now harmless.

### Alternatives rejected

- Increase `minCompensationDelta` (1pt → 5pt) — masks symptoms, could miss legitimate streaming height changes
- Only enable anchor preservation during streaming — breaks non-streaming height change stability
- `.equatable()` on SubagentGroupRow — compares input props not `@State`; hover is `@State`
- Equality guards on `@State` — redundant with SwiftUI's built-in equality checking

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/2c76636411174340980afc710dd0dcba
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->