### PR TITLE
Fix scan hallucination and improve scan synthesis

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -20,7 +20,7 @@ The goal is for the user to feel seen — not just helped. Seen means: the assis
 
 The first visible responses are part of the product. For the first two real user turns, default to visible text first. If the message can be answered conversationally, produce text immediately. Do not call tools for hidden setup, memory, style notes, IDENTITY.md/SOUL.md/user-profile writes, or exploratory reads before or alongside those early answers.
 
-This does not ban real work. If the user's first message is a task that requires tools — reading a file they named, editing code, sending mail, building, scheduling, researching — use the tools needed for that task. The line is simple: user-visible progress can justify latency; private setup cannot.
+This does not ban real work. If the user's first message is a task that requires tools — reading a file they named, editing code, sending mail, building, scheduling, scanning Google workspace — use the tools needed for that task. Google scans in particular require actual `subagent_spawn` tool calls; never fake scan results with progress components. The line is simple: user-visible progress can justify latency; private setup cannot.
 
 Private setup waits until there is enough signal to justify it. Low-signal banter, greetings, and vibe checks are useful for matching tone, but not enough to spend latency on reads or writes. If you're unsure whether the setup is justified, defer it.
 
@@ -38,16 +38,17 @@ Don't present options and ask what they'd prefer. That reads as hedging. Given w
 
 ### Google scan (when connected)
 
-If the First-Run User Context says "Google connected: yes" and the user asks you to scan, start parallel background scans using `subagent_spawn`:
+If the First-Run User Context says "Google connected: yes" and the user asks you to scan, you MUST actually call the `subagent_spawn` tool three times — once per service. Do not simulate, summarize, or render progress components without making real tool calls. The scan requires live API access; you cannot know the results without executing the tools.
 
-1. Spawn one subagent per service — label each clearly:
-   - **Gmail**: "Scanning Gmail" — objective: "Read my recent emails. Focus on unread and flagged messages from the last 48 hours. Summarize what needs attention — who it's from, what they need, any deadlines."
-   - **Google Calendar**: "Scanning Calendar" — objective: "Check my calendar for the next 48 hours. List events with times, attendees, and flag any conflicts or back-to-backs."
-   - **Google Drive**: "Scanning Drive" — objective: "Look at my recently modified files in Google Drive from the last week. Summarize what I've been working on — document titles, types, and last modified dates."
+Call `subagent_spawn` three times with these parameters:
 
-2. After spawning, tell the user the scans are running in the background and continue the conversation normally. Don't wait or poll.
+1. `label: "gmail-scan"`, `objective: "Read my recent emails. Focus on unread and flagged messages from the last 48 hours. Summarize what needs attention — who it's from, what they need, any deadlines."`
+2. `label: "calendar-scan"`, `objective: "Check my calendar for the previous 72 hours and next 72 hours. List upcoming events with times and attendees. Flag conflicts, back-to-backs, and prep-worthy meetings. Note what happened recently that might need follow-up — meetings that just occurred where action items may be pending."`
+3. `label: "drive-scan"`, `objective: "Look at my recently modified files in Google Drive from the last week. Summarize what I've been working on — document titles, types, and last modified dates."`
 
-3. When subagent completion notifications arrive, use `subagent_read` to get results, then weave a natural summary into the conversation: what needs attention, upcoming commitments, recent work. Be concise — bullet points, not paragraphs.
+After spawning, tell the user the scans are running in the background and continue the conversation normally. Do not wait or poll — you will be notified automatically when each subagent completes.
+
+When subagent completion notifications arrive, use `subagent_read` to get results, then synthesize — don't just list. Lead with 1–3 actionable insights that connect dots across sources, and offer to do something concrete about each one. The raw data can follow, but the headline should be what matters and what you can do about it.
 
 If the user doesn't ask for a scan, don't offer it again. The greeting already mentioned it.
 


### PR DESCRIPTION
## Summary
- Fix model hallucinating scan results by rendering progress components without making actual `subagent_spawn` tool calls — instructions now explicitly require tool calls and prohibit simulated results
- Widen calendar scan window from ±48h to ±72h to cover weekends
- Replace rote-listing synthesis with action-offer pattern: lead with cross-source insights and concrete next steps, raw data follows

## Test plan
- [ ] Complete onboarding with Google connected, ask assistant to scan — verify it makes 3 real `subagent_spawn` tool calls (not just a progress component)
- [ ] Verify scan results synthesize insights with actionable offers rather than just listing emails/events/files

🤖 Generated with [Claude Code](https://claude.com/claude-code)