### PR TITLE
feat(heartbeat): cap consecutive runs without guardian interaction

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -47,6 +47,15 @@ export const HeartbeatConfigSchema = z
       .describe(
         "Hour of the day (0-23) when heartbeat checks stop, or null to disable active hours restriction",
       ),
+    maxConsecutiveRuns: z
+      .number({ error: "heartbeat.maxConsecutiveRuns must be a number" })
+      .int("heartbeat.maxConsecutiveRuns must be an integer")
+      .positive("heartbeat.maxConsecutiveRuns must be a positive integer")
+      .nullable()
+      .default(3)
+      .describe(
+        "Maximum heartbeats that can run consecutively without a guardian message. Counter resets when the guardian sends a message. Set to null for unlimited.",
+      ),
   })
   .describe("Periodic heartbeat configuration for health monitoring")
   .superRefine((config, ctx) => {

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -47,12 +47,22 @@ mock.module("../../util/platform.js", () => ({
 
 // Stub config so heartbeat is enabled. Must export every symbol from
 // the real module because Bun's mock.module replaces the entire module.
-const stubConfig = {
+// Tests that need to flex maxConsecutiveRuns mutate this in-place.
+const stubConfig: {
+  heartbeat: {
+    enabled: boolean;
+    intervalMs: number;
+    activeHoursStart: number | null;
+    activeHoursEnd: number | null;
+    maxConsecutiveRuns: number | null;
+  };
+} = {
   heartbeat: {
     enabled: true,
     intervalMs: 60_000,
     activeHoursStart: null,
     activeHoursEnd: null,
+    maxConsecutiveRuns: null,
   },
 };
 mock.module("../../config/loader.js", () => ({
@@ -164,7 +174,6 @@ mock.module("../../runtime/pre-first-message-gate.js", () => ({
   hasReceivedUserMessage: () => preFirstMessageGateOpen,
 }));
 
-
 const { HeartbeatService } = await import("../heartbeat-service.js");
 
 let origWorkspaceDir: string | undefined;
@@ -177,6 +186,7 @@ beforeEach(() => {
   runBackgroundJobCalls.length = 0;
   skipHeartbeatRunCalls.length = 0;
   preFirstMessageGateOpen = true;
+  stubConfig.heartbeat.maxConsecutiveRuns = null;
   runBackgroundJobImpl = async () => ({
     conversationId: STUB_CONVERSATION_ID,
     ok: true,
@@ -350,9 +360,85 @@ describe("HeartbeatService", () => {
 
     expect(runBackgroundJobCalls).toHaveLength(1);
     expect(
-      skipHeartbeatRunCalls.some(
-        (c) => c.reason === "pre_first_user_message",
-      ),
+      skipHeartbeatRunCalls.some((c) => c.reason === "pre_first_user_message"),
     ).toBe(false);
+  });
+
+  describe("max consecutive runs cap", () => {
+    test("skips with reason 'max_consecutive_runs' after the cap is hit", async () => {
+      stubConfig.heartbeat.maxConsecutiveRuns = 2;
+      const service = new HeartbeatService({ alerter: () => {} });
+
+      expect(await service.runOnce({ force: false })).toBe(true);
+      expect(await service.runOnce({ force: false })).toBe(true);
+      expect(await service.runOnce({ force: false })).toBe(false);
+
+      expect(runBackgroundJobCalls).toHaveLength(2);
+      expect(
+        skipHeartbeatRunCalls.some((c) => c.reason === "max_consecutive_runs"),
+      ).toBe(true);
+    });
+
+    test("resetTimer() clears the counter so auto runs resume", async () => {
+      stubConfig.heartbeat.maxConsecutiveRuns = 1;
+      const service = new HeartbeatService({ alerter: () => {} });
+      service.start();
+      try {
+        await service.runOnce({ force: false });
+        expect(await service.runOnce({ force: false })).toBe(false);
+
+        service.resetTimer();
+        expect(await service.runOnce({ force: false })).toBe(true);
+        expect(runBackgroundJobCalls).toHaveLength(2);
+      } finally {
+        await service.stop();
+      }
+    });
+
+    test("null disables the cap entirely", async () => {
+      stubConfig.heartbeat.maxConsecutiveRuns = null;
+      const service = new HeartbeatService({ alerter: () => {} });
+
+      for (let i = 0; i < 5; i++) {
+        expect(await service.runOnce({ force: false })).toBe(true);
+      }
+      expect(runBackgroundJobCalls).toHaveLength(5);
+      expect(
+        skipHeartbeatRunCalls.some((c) => c.reason === "max_consecutive_runs"),
+      ).toBe(false);
+    });
+
+    test("force runs bypass the cap and do not increment the counter", async () => {
+      stubConfig.heartbeat.maxConsecutiveRuns = 2;
+      const service = new HeartbeatService({ alerter: () => {} });
+
+      // Five force runs would push us well past the cap if force counted.
+      for (let i = 0; i < 5; i++) {
+        expect(await service.runOnce({ force: true })).toBe(true);
+      }
+      // Two auto runs should still proceed because the counter is at zero.
+      expect(await service.runOnce({ force: false })).toBe(true);
+      expect(await service.runOnce({ force: false })).toBe(true);
+      // The third auto run trips the cap.
+      expect(await service.runOnce({ force: false })).toBe(false);
+      expect(
+        skipHeartbeatRunCalls.some((c) => c.reason === "max_consecutive_runs"),
+      ).toBe(true);
+    });
+
+    test("reconfigure() resets the counter", async () => {
+      stubConfig.heartbeat.maxConsecutiveRuns = 1;
+      const service = new HeartbeatService({ alerter: () => {} });
+      service.start();
+      try {
+        await service.runOnce({ force: false });
+        expect(await service.runOnce({ force: false })).toBe(false);
+
+        service.reconfigure();
+        expect(await service.runOnce({ force: false })).toBe(true);
+      } finally {
+        await service.stop();
+      }
+    });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -23,7 +23,8 @@ export type HeartbeatSkipReason =
   | "disabled"
   | "outside_active_hours"
   | "overlap"
-  | "pre_first_user_message";
+  | "pre_first_user_message"
+  | "max_consecutive_runs";
 
 export interface HeartbeatRunRecord {
   id: string;

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -198,6 +198,10 @@ export class HeartbeatService {
   private _startupMissedCount = 0;
   private _startupCrashedCount = 0;
   private _hasRunStartupRecovery = false;
+  // Counter of consecutive auto-heartbeats since the last guardian message.
+  // Reset by resetTimer (guardian message), reconfigure, and stop. Force runs
+  // bypass the cap and do not increment.
+  private _consecutiveRuns = 0;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -355,6 +359,7 @@ export class HeartbeatService {
 
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
+    this._consecutiveRuns = 0;
     this.configEpoch++;
     if (this._pendingRunId) {
       supersedePendingRun(this._pendingRunId);
@@ -376,6 +381,9 @@ export class HeartbeatService {
    * after an active conversation.
    */
   resetTimer(): void {
+    // Counter resets even when the timer is null so a guardian message during
+    // a stopped window still clears the count.
+    this._consecutiveRuns = 0;
     if (!this.timer) return;
     if (this.cronMode) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
@@ -395,6 +403,7 @@ export class HeartbeatService {
   }
 
   async stop(): Promise<void> {
+    this._consecutiveRuns = 0;
     this.stopped = true;
     if (this.timer) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
@@ -505,6 +514,28 @@ export class HeartbeatService {
       }
     }
 
+    // Cap consecutive auto-runs without a guardian message so the assistant
+    // stops burning LLM tokens when the user is away. Force runs (manual
+    // operator action) bypass the cap and do not increment the counter.
+    if (
+      !force &&
+      config.maxConsecutiveRuns != null &&
+      this._consecutiveRuns >= config.maxConsecutiveRuns
+    ) {
+      log.debug(
+        {
+          consecutiveRuns: this._consecutiveRuns,
+          maxConsecutiveRuns: config.maxConsecutiveRuns,
+        },
+        "Max consecutive runs reached, skipping",
+      );
+      if (runId) skipHeartbeatRun(runId, "max_consecutive_runs");
+      if (!this.cronMode) {
+        this.scheduleNextRun(config.intervalMs);
+      }
+      return false;
+    }
+
     // Overlap prevention
     if (this.activeRun) {
       log.debug("Previous heartbeat run still active, skipping");
@@ -530,6 +561,9 @@ export class HeartbeatService {
         this.activeRun = null;
       }
       this._lastRunAt = Date.now();
+      if (!force) {
+        this._consecutiveRuns++;
+      }
       if (!this.cronMode) {
         this.scheduleNextRun(getConfig().heartbeat.intervalMs);
       }


### PR DESCRIPTION
## Summary
- Add \`heartbeat.maxConsecutiveRuns\` config (default 3, \`null\` = unlimited) to bound consecutive auto-heartbeats between guardian messages.
- Counter lives in \`HeartbeatService\`, increments on auto runs, and resets on \`resetTimer()\` (guardian message), \`reconfigure()\`, and \`stop()\`. Force runs bypass the cap and don't increment, mirroring how \`force\` already bypasses the disabled / pre-first-message / active-hours gates.
- New skip reason \`max_consecutive_runs\` plumbed through \`HeartbeatSkipReason\`.

## Original prompt
Limit how many heartbeats the assistant can run without user interaction so it doesn't keep burning LLM tokens when the user is away. The counter should reset whenever the guardian sends a message, default to 3, be configurable in config.json, and accept \`null\` for unlimited.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->