### PR TITLE
fix(memory): gate build_conversation_summary on !memory.v2.enabled

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -585,3 +585,38 @@ describe("indexer v1/v2 mutual exclusion for graph_extract", () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// Indexer v1/v2 mutual exclusion: build_conversation_summary feeds
+// v1-only readers (fetchRecentSummaries, semantic search). When
+// memory.v2.enabled is on, the summary writes are unread, so the
+// indexer must not enqueue them.
+// ─────────────────────────────────────────────────────────────────
+
+describe("indexer v1/v2 mutual exclusion for build_conversation_summary", () => {
+  const originalV2Enabled = TEST_CONFIG.memory.v2.enabled;
+
+  afterEach(() => {
+    TEST_CONFIG.memory.v2.enabled = originalV2Enabled;
+  });
+
+  test("v2 active (config on) → build_conversation_summary not enqueued", async () => {
+    TEST_CONFIG.memory.v2.enabled = true;
+
+    const source = createConversation("summary-v2-active");
+    await indexMessages(source.id, 2);
+
+    expect(countJobsOfType("build_conversation_summary", source.id)).toBe(0);
+  });
+
+  test("config gate off → build_conversation_summary enqueued", async () => {
+    TEST_CONFIG.memory.v2.enabled = false;
+
+    const source = createConversation("summary-v2-config-off");
+    await indexMessages(source.id, 2);
+
+    expect(
+      countJobsOfType("build_conversation_summary", source.id),
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -169,32 +169,30 @@ export async function indexMessageNow(
     const batchSize = config.extraction.batchSize ?? 10;
     const idleTimeoutMs = config.extraction.idleTimeoutMs ?? 300_000;
 
+    // Reading config here is best-effort: when it fails we treat v2 as
+    // inactive (failing-open to v1) so a config error never silently
+    // drops the extraction or summarization paths.
+    let triggerConfig: ReturnType<typeof getConfig> | null = null;
+    try {
+      triggerConfig = getConfig();
+    } catch (err) {
+      log.debug(
+        { err, conversationId: input.conversationId },
+        "Skipping feature-gated extraction triggers: failed to load config",
+      );
+    }
+
+    const v2Config =
+      triggerConfig != null && triggerConfig.memory.v2.enabled
+        ? triggerConfig
+        : null;
+
     // Recursion guard: skip graph extraction + auto-analysis enqueues
     // when the source conversation is itself an auto-analysis
     // conversation. The analysis agent writes memory directly via tools,
     // so extracting from its reflective musings would double-count and
     // analyzing its own output would loop indefinitely.
-    // Summaries still run — they feed the graph retrieval pipeline and
-    // are not recursion-prone.
     if (!isAutoAnalysisSource) {
-      // Reading config here is best-effort: when it fails we treat v2 as
-      // inactive (failing-open to v1) so a config error never silently
-      // drops both extraction paths.
-      let triggerConfig: ReturnType<typeof getConfig> | null = null;
-      try {
-        triggerConfig = getConfig();
-      } catch (err) {
-        log.debug(
-          { err, conversationId: input.conversationId },
-          "Skipping feature-gated extraction triggers: failed to load config",
-        );
-      }
-
-      const v2Config =
-        triggerConfig != null && triggerConfig.memory.v2.enabled
-          ? triggerConfig
-          : null;
-
       // ── Graph extraction (v1) ───────────────────────────────────────
       // Suppressed when v2 is active — v2 reads memory from buffer.md
       // and concept pages, so the v1 graph would be stale data nobody
@@ -302,15 +300,22 @@ export async function indexMessageNow(
       }
     }
 
-    // ── Conversation summarization (independent of extraction) ────────
-    // Summaries feed the graph retrieval pipeline via fetchRecentSummaries().
-    // Debounced on the same idle timeout — no threshold trigger needed since
-    // summaries compress the whole conversation, not incremental batches.
-    upsertDebouncedJob(
-      "build_conversation_summary",
-      { conversationId: input.conversationId },
-      Date.now() + idleTimeoutMs,
-    );
+    // ── Conversation summarization (v1) ───────────────────────────────
+    // Summaries feed the v1 graph retrieval pipeline (fetchRecentSummaries,
+    // semantic search). Suppressed when v2 is active — v2 readers (concept
+    // pages, activation pipeline) do not consume `memorySummaries`, so the
+    // summarization LLM call would produce rows nothing reads. Stale rows
+    // from before v2 was enabled are short-circuited at dispatch in
+    // jobs-worker.ts. Debounced on the same idle timeout — no threshold
+    // trigger needed since summaries compress the whole conversation, not
+    // incremental batches.
+    if (v2Config == null) {
+      upsertDebouncedJob(
+        "build_conversation_summary",
+        { conversationId: input.conversationId },
+        Date.now() + idleTimeoutMs,
+      );
+    }
   }
 
   if (skippedShortSegments > 0) {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -524,6 +524,12 @@ async function processJob(
       pruneOldTraceEventsJob(job, config);
       return;
     case "build_conversation_summary":
+      // Stale rows enqueued before v2 was enabled must not consume the
+      // `conversationSummarization` LLM budget — v2 readers do not consume
+      // `memorySummaries`, mirroring the `graph_extract` gate below.
+      if (config.memory.v2.enabled) {
+        return;
+      }
       await buildConversationSummaryJob(job, config);
       return;
     case "backfill":


### PR DESCRIPTION
## Summary

- Stop calling the `conversationSummarization` LLM (`build_conversation_summary` memory job) when `memory.v2.enabled` is true — every v2 reader of `memorySummaries` was already bypassed (`embed_summary` is in `V1_QDRANT_JOB_TYPES`; `semantic.ts:62` returns early; `conversation-graph-memory` routes to the v2 injection block before the v1 retrieval that uses `fetchRecentSummaries` is reachable).
- Mirror the `graph_extract` two-site pattern: indexer skips enqueue (`indexer.ts`), worker short-circuits stale rows at dispatch (`jobs-worker.ts:processJob`).
- The other consumer of the `conversationSummarization` callsite — `assistant/src/context/window-manager.ts` for in-conversation context-window compaction — is independent of memory v2 and unchanged.

Closes #30793

## Original prompt

Investigation started from a question about which LLM callsite the `conversationSummarization` profile drives. Tracing the consumers showed two callers: `context/window-manager.ts` (context compaction, orthogonal to memory v2) and `memory/job-handlers/summarization.ts` (the `build_conversation_summary` memory job). Under `memory.v2.enabled`, every downstream reader of the resulting `memorySummaries` rows is already bypassed, so the LLM call is paid per conversation for output nothing consumes. The fix is to gate the job on `!memory.v2.enabled` the same way `graph_extract` is gated.