### PR TITLE
fix(migrations): revert stale gemini profiles before call-sites

### DIFF
--- a/assistant/src/__tests__/workspace-migration-086-revert-stale-gemini-mis-rewrites.test.ts
+++ b/assistant/src/__tests__/workspace-migration-086-revert-stale-gemini-mis-rewrites.test.ts
@@ -162,6 +162,34 @@ describe("086-revert-stale-gemini-mis-rewrites migration", () => {
     expect(config.llm.profiles.custom.model).toBe("gemini-3-flash");
   });
 
+  test("reverts both profile and call-site when call-site references a candidate profile", () => {
+    // Regression for ordering bug: if profile reversion ran after call-site
+    // evaluation, the call-site would see the profile's pre-revert rewritten
+    // model and infer a Gemini context, masking its own need to revert.
+    writeConfig({
+      llm: {
+        default: { provider: "ollama", model: "llama3.2" },
+        profiles: {
+          custom: { model: "gemini-3-flash-preview" },
+        },
+        callSites: {
+          recall: { profile: "custom", model: "gemini-3-flash-preview" },
+        },
+      },
+    });
+
+    revertStaleGeminiMisRewritesMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        profiles: { custom: { model: string } };
+        callSites: { recall: { model: string; profile: string } };
+      };
+    };
+    expect(config.llm.profiles.custom.model).toBe("gemini-3-flash");
+    expect(config.llm.callSites.recall.model).toBe("gemini-3-flash");
+  });
+
   test("mainAgent revert uses activeProfile over call-site for context", () => {
     writeConfig({
       llm: {

--- a/assistant/src/workspace/migrations/086-revert-stale-gemini-mis-rewrites.ts
+++ b/assistant/src/workspace/migrations/086-revert-stale-gemini-mis-rewrites.ts
@@ -49,14 +49,36 @@ export const revertStaleGeminiMisRewritesMigration: WorkspaceMigration = {
     const profiles = readObject(llm.profiles);
     const activeProfileName =
       typeof llm.activeProfile === "string" ? llm.activeProfile : undefined;
+
+    let changed = false;
+
+    // Pass 1: revert profile candidates first so that pass 2's call-site
+    // evaluation sees the reverted profile state. A call-site that references
+    // a profile candidate would otherwise infer `siteProfileProvider = gemini`
+    // from the profile's pre-revert rewritten model, masking the call-site's
+    // own need to revert.
+    if (profiles !== null) {
+      for (const rawProfile of Object.values(profiles)) {
+        const profile = readObject(rawProfile);
+        if (profile === null) continue;
+        if (!isRevertCandidate(profile)) continue;
+        if (isExplicitlyNonGemini(defaultProvider)) {
+          profile.model = STALE_MODEL;
+          changed = true;
+        }
+      }
+    }
+
+    // Compute the active-profile provider after pass 1 so it reflects any
+    // reversion of the active profile itself.
     const activeProfileBlock =
       profiles !== null && activeProfileName !== undefined
         ? readObject(profiles[activeProfileName])
         : null;
     const activeProfileProvider = inferLayerProvider(activeProfileBlock);
 
-    let changed = false;
-
+    // Pass 2: call-site candidates. `inferLayerProvider` is re-read from
+    // `profiles` per call site, so it observes pass 1's reversions.
     const callSites = readObject(llm.callSites);
     if (callSites !== null) {
       for (const [site, rawConfig] of Object.entries(callSites)) {
@@ -81,18 +103,6 @@ export const revertStaleGeminiMisRewritesMigration: WorkspaceMigration = {
         });
         if (isExplicitlyNonGemini(effective)) {
           callSiteConfig.model = STALE_MODEL;
-          changed = true;
-        }
-      }
-    }
-
-    if (profiles !== null) {
-      for (const rawProfile of Object.values(profiles)) {
-        const profile = readObject(rawProfile);
-        if (profile === null) continue;
-        if (!isRevertCandidate(profile)) continue;
-        if (isExplicitlyNonGemini(defaultProvider)) {
-          profile.model = STALE_MODEL;
           changed = true;
         }
       }


### PR DESCRIPTION
Addresses Codex P1 feedback on #30784.

## Bug

In migration 086-revert-stale-gemini-mis-rewrites, call-site candidates were evaluated against profile candidates' **pre-revert** state. When a call-site referenced a profile candidate, \`siteProfileProvider\` was inferred from the profile's current rewritten model (\`gemini-3-flash-preview\`) via the catalog and returned \`gemini\`, so \`effectiveProviderExcludingSite\` resolved to Gemini and the call-site revert was incorrectly skipped. Profile reversion then ran afterward, leaving the profile reverted but the call-site still mis-rewritten.

## Fix

Reorder the migration to revert profile candidates **first**, then evaluate call-site candidates. After reversion, the profile's model is \`gemini-3-flash\` (not in the catalog), so \`inferLayerProvider\` returns \`undefined\` and the call-site falls through to the lower layers (active profile / default), correctly identifying the non-Gemini context.

\`activeProfileProvider\` is recomputed after pass 1 so it reflects any reversion of the active profile itself.

## Test

Adds a regression test for the exact scenario: workspace with \`llm.default.provider = "ollama"\`, \`profiles.custom.model = "gemini-3-flash-preview"\`, \`callSites.recall = { profile: "custom", model: "gemini-3-flash-preview" }\`. Verifies both the profile **and** the call-site are reverted to \`gemini-3-flash\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->