### PR TITLE
fix(migrations): cancel pending memory_v2_reembed when 085 gates fail

### DIFF
--- a/assistant/src/__tests__/workspace-migration-085-memory-v2-bm25-b-reembed-disabled-v2-pages.test.ts
+++ b/assistant/src/__tests__/workspace-migration-085-memory-v2-bm25-b-reembed-disabled-v2-pages.test.ts
@@ -20,6 +20,7 @@ import { dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { memoryV2Bm25BDefaultReembedMigration } from "../workspace/migrations/075-memory-v2-bm25-b-default-reembed.js";
 import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "../workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 
 let workspaceDir: string;
@@ -83,6 +84,34 @@ function countReembedJobs(): number {
   }
 }
 
+function insertReembedJob(id: string, status: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.run(
+      `INSERT INTO memory_jobs
+         (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+       VALUES (?, 'memory_v2_reembed', '{}', ?, 0, 0, 0, NULL, 0, 0)`,
+      [id, status],
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function jobIdsByStatus(status: string): string[] {
+  const db = new Database(dbPath);
+  try {
+    const rows = db
+      .query(
+        `SELECT id FROM memory_jobs WHERE type='memory_v2_reembed' AND status=? ORDER BY id`,
+      )
+      .all(status) as { id: string }[];
+    return rows.map((r) => r.id);
+  } finally {
+    db.close();
+  }
+}
+
 describe("085-memory-v2-bm25-b-reembed-disabled-v2-pages migration", () => {
   test("skips enqueue when memory/concepts/ does not exist", () => {
     memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
@@ -130,13 +159,61 @@ describe("085-memory-v2-bm25-b-reembed-disabled-v2-pages migration", () => {
 
   test("does not duplicate when a pending reembed job already exists", () => {
     seedConceptPage("alice.md");
-    const db = new Database(dbPath);
-    db.run(
-      `INSERT INTO memory_jobs
-         (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
-       VALUES ('pre-existing', 'memory_v2_reembed', '{}', 'pending', 0, 0, 0, NULL, 0, 0)`,
-    );
-    db.close();
+    insertReembedJob("pre-existing", "pending");
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+  });
+
+  test("cancels pending reembed job when memory.v2.enabled is false", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: { v2: { enabled: false } } });
+    insertReembedJob("from-075", "pending");
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("cancels pending reembed job when no concept pages exist", () => {
+    insertReembedJob("from-075", "pending");
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("leaves running reembed job alone when v2 is disabled", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: { v2: { enabled: false } } });
+    insertReembedJob("in-flight", "running");
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(jobIdsByStatus("running")).toEqual(["in-flight"]);
+    expect(jobIdsByStatus("pending")).toEqual([]);
+  });
+
+  test("is idempotent when re-run with v2 disabled and no pending jobs", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: { v2: { enabled: false } } });
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("end-to-end: 075 enqueues, 085 cancels when v2 disabled with concept pages", () => {
+    seedConceptPage("alice.md");
+    writeConfig({ memory: { v2: { enabled: false } } });
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("end-to-end: 075 enqueues, 085 cancels when no concept pages exist", () => {
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(1);
+    memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
+    expect(countReembedJobs()).toBe(0);
+  });
+
+  test("end-to-end: 075 enqueues, 085 keeps single job when gates pass", () => {
+    seedConceptPage("alice.md");
+    memoryV2Bm25BDefaultReembedMigration.run(workspaceDir);
     memoryV2Bm25BReembedDisabledV2PagesMigration.run(workspaceDir);
     expect(countReembedJobs()).toBe(1);
   });

--- a/assistant/src/workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts
+++ b/assistant/src/workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts
@@ -23,6 +23,13 @@ import type { WorkspaceMigration } from "./types.js";
  *    dispatch on the config flag, so enqueueing for a workspace that
  *    intentionally disabled v2 would immediately re-embed pages and hit
  *    the embedding backend against the user's intent.
+ *
+ * When either gate fails, we also DELETE any pending `memory_v2_reembed`
+ * job that 075 may have enqueued in the same startup sweep. For workspaces
+ * that never checkpointed 075 (upgrades from pre-v0.8.1, first-boot sweeps),
+ * 075 runs first and unconditionally enqueues a job; without the explicit
+ * cancellation here, 075's job would survive 085's gate and execute against
+ * the user's intent.
  */
 export const memoryV2Bm25BReembedDisabledV2PagesMigration: WorkspaceMigration =
   {
@@ -31,9 +38,6 @@ export const memoryV2Bm25BReembedDisabledV2PagesMigration: WorkspaceMigration =
       "Re-enqueue memory_v2_reembed for workspaces with v2 pages, gated on v2 not being explicitly disabled",
 
     run(workspaceDir: string): void {
-      if (isMemoryV2Disabled(workspaceDir)) return;
-      if (!hasConceptPages(workspaceDir)) return;
-
       const dbPath = join(workspaceDir, "data", "db", "assistant.db");
       if (!existsSync(dbPath)) return;
 
@@ -51,6 +55,20 @@ export const memoryV2Bm25BReembedDisabledV2PagesMigration: WorkspaceMigration =
           )
           .get();
         if (!tableRow) return;
+
+        // If either gate fails, cancel any pending reembed job that 075 may
+        // have enqueued in this same startup sweep. Leave 'running' jobs
+        // alone — the worker is already mid-flight and canceling would orphan
+        // its state. Only 'pending' jobs are safe to delete here.
+        if (
+          isMemoryV2Disabled(workspaceDir) ||
+          !hasConceptPages(workspaceDir)
+        ) {
+          db.query(
+            `DELETE FROM memory_jobs WHERE type='memory_v2_reembed' AND status='pending'`,
+          ).run();
+          return;
+        }
 
         const existing = db
           .query(


### PR DESCRIPTION
## Summary

Follow-up to #30780. Migration 085 added gating for the unconditional `memory_v2_reembed` enqueue that 075 had shipped in v0.8.1. But for workspaces that have never checkpointed 075 (upgrades from pre-v0.8.1, first-boot sweeps), 075 and 085 both run in the same startup session: 075 enqueues unconditionally, then 085 sees the pending job at its existing-job check and short-circuits — so the disabled-v2 / no-concept-pages gates never actually cancel 075's job.

Per Devin's recommendation, 085 now DELETEs any pending `memory_v2_reembed` job when its gates indicate the reembed should not happen. \`running\` jobs are left alone (the worker is mid-flight; canceling would orphan its state).

## Changes

- \`assistant/src/workspace/migrations/085-memory-v2-bm25-b-reembed-disabled-v2-pages.ts\`: open DB first, then check gates; if gates fail, DELETE pending jobs and return.
- \`assistant/src/__tests__/workspace-migration-085-memory-v2-bm25-b-reembed-disabled-v2-pages.test.ts\`: add cancellation tests (gate-fail with pending job seeded), running-job-preserved test, idempotency test, and three end-to-end tests that run 075 then 085 together.

Addresses Codex (P2) and Devin (P0) feedback on #30780.

## Test plan

- [x] New unit tests pass in isolation
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->