### PR TITLE
fix(app-control): preserve lock when late-running confirmation races a newer failed start

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -776,6 +776,56 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
+    test("late running confirmation from older overlapping start is preserved", async () => {
+      // Same-conversation overlapping starts where the older one's `running`
+      // response arrives AFTER a newer optimistic start has superseded it,
+      // and the newer one then fails. The host has actually confirmed A as
+      // running, so the lock must remain held for A rather than going
+      // undefined and desyncing from the host.
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // A is dispatched; do not resolve yet.
+      const pA = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.a" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdA = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+
+      // C is dispatched, overwriting the optimistic active pointer to C.
+      sentMessages.length = 0;
+      const pC = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.c" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdC = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // A finally returns running — by object identity active is no longer A,
+      // but the host has confirmed A so we must still record it as confirmed.
+      proxy.resolve(reqIdA, payload({ pngBase64: PNG_A }));
+      await pA;
+      // Active is still the newer optimistic C; nothing has rolled it back.
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // C fails — rollback must restore active to A (the current confirmed),
+      // not to undefined (the snapshot prior at C's dispatch time).
+      proxy.resolve(reqIdC, payload({ state: "missing" }));
+      await pC;
+
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.a");
+
+      proxy.dispose();
+    });
+
     test("first-start failure releases the lock (no prior session to restore)", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -18,12 +18,14 @@
  * resource. It is acquired optimistically when `app_control_start` is
  * dispatched (storing `(conversationId, app)`) so that the synchronous
  * guard and the asynchronous host round-trip cannot race. A separate
- * `confirmedAppControlSession` tracks the last successfully-started
- * session; the rollback path on a failed `start` restores from confirmed
- * (not from a sibling optimistic write), so two overlapping starts that
- * both fail cannot leave a phantom lock pointing at a never-confirmed
- * optimistic value. The lock is released outright when the owning
- * proxy's `dispose()` fires.
+ * `confirmedAppControlSession` tracks the last session the host reported
+ * `running`; the rollback path on a failed `start` restores from the
+ * current confirmed pointer (not from a per-call snapshot of a sibling
+ * optimistic write), so two overlapping starts that both fail cannot
+ * leave a phantom lock — and a late-arriving `running` for an older
+ * overlapping start still updates the confirmed pointer so the lock
+ * survives a subsequent rollback of the newer start. The lock is
+ * released outright when the owning proxy's `dispose()` fires.
  *
  * `app_control_start` is the only tool that can acquire the lock — the
  * user's medium-risk approval at start time is the consent boundary. All
@@ -253,7 +255,6 @@ export class HostAppControlProxy extends HostProxyBase<
     // belong to the active session and target the same `app`. Without this
     // gate, prompt-injected calls would bypass the start-time approval and
     // send raw input to arbitrary apps.
-    let priorSession: ActiveAppControlSession | undefined;
     let attemptedSession: ActiveAppControlSession | undefined;
     if (input.tool === "start") {
       if (
@@ -268,9 +269,6 @@ export class HostAppControlProxy extends HostProxyBase<
           isError: true,
         };
       }
-      // Snapshot the last confirmed session — see the module header for
-      // why we use confirmed, not the live optimistic value.
-      priorSession = confirmedAppControlSession;
       // Acquire optimistically to close the TOCTOU window between this
       // synchronous guard and the asynchronous `dispatchRequest` below. Two
       // concurrent starts from different conversations would otherwise both
@@ -307,13 +305,13 @@ export class HostAppControlProxy extends HostProxyBase<
         if (payload.state === "running") {
           this.promoteStartIfCurrent(attemptedSession);
         } else {
-          this.rollbackStartIfCurrent(attemptedSession, priorSession);
+          this.rollbackStartIfCurrent(attemptedSession);
         }
       }
       return this.handleSuccess(payload);
     } catch (err) {
       if (input.tool === "start") {
-        this.rollbackStartIfCurrent(attemptedSession, priorSession);
+        this.rollbackStartIfCurrent(attemptedSession);
       }
       if (err instanceof HostProxyRequestError) {
         if (err.reason === "timeout") {
@@ -341,27 +339,41 @@ export class HostAppControlProxy extends HostProxyBase<
    * already replaced our write — e.g. start A → start B (pending) →
    * start C (success); when B later fails, the live session is C and the
    * identity check makes our rollback a no-op rather than restoring A.
+   *
+   * Restores from the *current* `confirmedAppControlSession`, not a
+   * per-call snapshot of it. This matters when a late-arriving `running`
+   * for an older overlapping start has updated `confirmedAppControlSession`
+   * in the meantime: if A is dispatched, then C is dispatched (overwriting
+   * active), then A returns `running` (confirming A), then C returns
+   * non-running, the rollback must restore active to A — not undefined.
    */
   private rollbackStartIfCurrent(
     attempted: ActiveAppControlSession | undefined,
-    prior: ActiveAppControlSession | undefined,
   ): void {
     if (attempted != null && activeAppControlSession === attempted) {
-      activeAppControlSession = prior;
+      activeAppControlSession = confirmedAppControlSession;
     }
   }
 
   /**
    * Promote this start's optimistic write to the confirmed pointer when
-   * the host returns `running`. Identity-keyed so a late success from an
-   * older overlapping start does not overwrite a newer confirmed session.
+   * the host returns `running`. Gated on conversation ownership rather
+   * than object identity: a newer overlapping start in the same
+   * conversation may have superseded our optimistic write while we were
+   * waiting on the host, but the host's `running` response for our
+   * `attempted` is still ground-truth that the lock should be held.
+   * The conversation-ownership check ensures we don't resurrect a session
+   * after `dispose()` cleared the lock or after another conversation
+   * acquired it.
    */
   private promoteStartIfCurrent(
     attempted: ActiveAppControlSession | undefined,
   ): void {
-    if (attempted != null && activeAppControlSession === attempted) {
-      confirmedAppControlSession = attempted;
+    if (attempted == null) return;
+    if (activeAppControlSession?.conversationId !== attempted.conversationId) {
+      return;
     }
+    confirmedAppControlSession = attempted;
   }
 
   /**


### PR DESCRIPTION
## Summary

Codex flagged a race in #30782's fix where overlapping same-conversation \`app_control_start\` calls could desync from the host:

1. A dispatched: \`activeAppControlSession = A_opt\`, \`prior_A = confirmed = undefined\`
2. C dispatched: \`activeAppControlSession = C_opt\`, \`prior_C = confirmed = undefined\`
3. A returns \`running\` late: \`promoteStartIfCurrent(A_opt)\` checked identity \`active === A_opt\` — but it had already been overwritten by C_opt, so promotion was skipped and \`confirmed\` stayed \`undefined\`.
4. C returns non-running: rollback restored \`active\` to \`prior_C = undefined\`.

Result: both pointers \`undefined\` while A was actually \`running\` on the host. Another conversation could then acquire control unexpectedly.

## Fix

- \`promoteStartIfCurrent\` now gates on conversation ownership of \`activeAppControlSession\` rather than object identity. The host's \`running\` for A is still ground-truth even if a newer overlapping start has replaced our optimistic write — the conversation-ownership gate still blocks resurrecting a session after \`dispose()\` or after another conversation acquired the lock.
- \`rollbackStartIfCurrent\` now restores from the *current* \`confirmedAppControlSession\` instead of a per-call \`prior\` snapshot. In the scenario above, C's rollback now falls back to A (which got promoted to confirmed in step 3) rather than to \`undefined\`.
- Removed the now-unused \`priorSession\` plumbing in \`request()\`.

## Test plan

- [x] Added regression test covering the exact scenario.
- [x] Existing overlapping-start tests continue to pass with the new restore-from-confirmed semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->