### PR TITLE
fix(token-estimator): handle undefined text in estimateTextTokens

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -33,6 +33,7 @@ function makePngBase64(width: number, height: number): string {
 describe("token estimator", () => {
   test("estimates text tokens from character length", () => {
     expect(estimateTextTokens("")).toBe(0);
+    expect(estimateTextTokens(undefined)).toBe(0);
     expect(estimateTextTokens("abcd")).toBe(1);
     expect(estimateTextTokens("abcde")).toBe(2);
   });

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -65,8 +65,8 @@ export interface TokenEstimatorOptions {
   toolTokenBudget?: number;
 }
 
-export function estimateTextTokens(text: string): number {
-  if (text.length === 0) return 0;
+export function estimateTextTokens(text: string | undefined): number {
+  if (!text) return 0;
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 


### PR DESCRIPTION
## Summary

- `estimateTextTokens` now accepts `string | undefined` and returns `0` for falsy input, instead of throwing `TypeError: undefined is not an object (evaluating 'text.length')` when called with `undefined`.
- Unblocks `POST /v1/messages/` for conversations whose tool set includes any tool with an undefined `description`. The bad tool registration is a separate issue — this just makes the estimator defensive so a single misbehaving tool no longer crashes every send.
- Adds one assertion to the existing `estimates text tokens from character length` test covering the `undefined` input.

Closes #30802

## Original prompt

User got "Failed to send" in the macOS app trying to message Velissa. Logs showed `POST /v1/messages/` failing with a `TypeError` in `estimateTextTokens` (called via `estimateToolDefinitionTokens` -> `tool.description`). The `ToolDefinition` type declares `description: string` as required, but the type isn't enforced at runtime and some tool is being registered without one. User asked for the minimal defensive fix in the estimator — widen the parameter type to `string | undefined` rather than scattering `?? ""` across 16+ call sites — and to track the misbehaving tool as a follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->