### PR TITLE
fix(tools): guard against undefined input_schema in tool resolver

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -157,6 +157,26 @@ describe("injectActivityField", () => {
     expect(Object.is(result[0], defs[0])).toBe(true);
   });
 
+  test("passes through undefined/null input_schema unchanged (no crash)", () => {
+    // Repro for the crash where an MCP server returned a tool with missing
+    // inputSchema and `injectActivityField` threw on `schema.type` access.
+    const defs: ToolDefinition[] = [
+      {
+        name: "missing",
+        description: "x",
+        input_schema: undefined as unknown as object,
+      },
+      {
+        name: "nullish",
+        description: "x",
+        input_schema: null as unknown as object,
+      },
+    ];
+    const result = injectActivityField(defs);
+    expect(Object.is(result[0], defs[0])).toBe(true);
+    expect(Object.is(result[1], defs[1])).toBe(true);
+  });
+
   test("does NOT add activity to top-level required when only in oneOf branch", () => {
     const defs = [
       makeDef("my_tool", {

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -14,6 +14,24 @@ const log = getLogger("mcp-client");
 
 const CONNECT_TIMEOUT_MS = 30_000;
 
+// MCP servers occasionally return tools with a missing or non-object
+// `inputSchema` (spec violation, but seen in the wild). Coerce to a valid
+// empty object schema so downstream code that assumes `input_schema: object`
+// (e.g. `injectActivityField`) doesn't crash.
+function normalizeInputSchema(
+  raw: unknown,
+  toolName: string,
+): Record<string, unknown> {
+  if (raw != null && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  log.warn(
+    { toolName, received: typeof raw },
+    "MCP tool returned non-object inputSchema; defaulting to empty object schema",
+  );
+  return { type: "object", properties: {} };
+}
+
 export interface McpToolInfo {
   name: string;
   description: string;
@@ -80,9 +98,7 @@ export class McpClient {
         `mcp:${this.serverId}:tokens`,
       );
       if (cachedTokens) {
-        const callbackTransport = getIsPlatform()
-          ? "gateway"
-          : "loopback";
+        const callbackTransport = getIsPlatform() ? "gateway" : "loopback";
         this.oauthProvider = new McpOAuthProvider(
           this.serverId,
           transportConfig.url,
@@ -164,7 +180,7 @@ export class McpClient {
     return result.tools.map((tool) => ({
       name: tool.name,
       description: tool.description ?? "",
-      inputSchema: tool.inputSchema as Record<string, unknown>,
+      inputSchema: normalizeInputSchema(tool.inputSchema, tool.name),
     }));
   }
 

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -23,8 +23,13 @@ export function injectActivityField(
       return def;
     }
 
-    const schema = def.input_schema as Record<string, unknown>;
-    if (schema.type !== "object" || !schema.properties) {
+    const schema = def.input_schema as Record<string, unknown> | undefined;
+    if (
+      schema == null ||
+      typeof schema !== "object" ||
+      schema.type !== "object" ||
+      !schema.properties
+    ) {
       return def;
     }
 


### PR DESCRIPTION
## Summary

- Normalize `inputSchema` at the MCP client boundary — coerce missing/non-object schemas to `{type:"object", properties:{}}` with a warn log so spec-violating servers (e.g. parameterless tools that omit `inputSchema`) can't crash the agent loop.
- Extend the existing non-conforming-schema guard in `injectActivityField` to also cover `null`/`undefined`, consistent with its existing skip-on-non-conforming policy.
- Regression test for `null`/`undefined` `input_schema`.

Closes #30804

## Original prompt

User hit `TypeError: undefined is not an object (evaluating 'schema3.type')` in `getToolTokenBudget` → `injectActivityField` while sending a message. Investigation traced this to two latent paths that can produce a `ToolDefinition` with undefined `input_schema`: (1) the MCP `listTools` boundary cast, and (2) a misshapen workspace plugin where the registry destructure pulled `undefined` from the top level. The workspace plugin was fixed locally; this PR addresses the mainline gaps so the daemon stays up if any tool source ever emits a malformed schema.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->