### PR TITLE
fix(macos): gate chat scroll anchor preservation on active streaming

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -396,6 +396,7 @@ Three fixes outside the scroll subsystem prevent observation feedback loops that
 
 - **Route all scroll reactions through dedicated methods.** Do not add inline `onChange` handlers that call `scrollTo` directly in `MessageListView`. Instead, add a new method on the scroll state or behavior extension and call it from the view. This keeps scroll logic centralized and testable.
 - **Use an in-flight guard to prevent stacking concurrent pagination loads.** The `isPaginationInFlight` flag on `MessageListScrollState` gates the pagination sentinel. Without it, rapid scroll-to-top can enqueue multiple concurrent loads before `isLoadingMoreMessages` is set by the async response, duplicating content and corrupting the history cursor.
+- **Gate `ScrollAnchorPreserver` on active streaming.** `clipView.setBoundsOrigin` compensation must only fire while the assistant is producing a response (`isStreamingActive`). Compensating idle content-height changes — `LazyVStack` lazy-cell estimate corrections, media-embed late loads — produces large jerky offset shifts that read as scroll jitter on hover or mouse-move. Lazy-cell drift is progressive and self-correcting and is the intended trade-off of the `LazyVStack` transcript stack; do not "fight" it with offset shifts. When adding a new use case for anchor preservation, route it through an explicit state signal on `MessageListScrollState` rather than widening the `shouldPreserveScrollAnchor` predicate.
 <details>
 <summary><strong>Layout timing, scroll forwarding, and .scrollPosition caveats</strong></summary>
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -228,6 +228,15 @@ final class MessageListScrollState {
 
     @ObservationIgnored var lastHandledChatColumnWidth: CGFloat = 0
     @ObservationIgnored var isPaginationInFlight: Bool = false
+    /// Mirrors `MessageListView.isSending`. Gates `ScrollAnchorPreserver` so
+    /// `clipView.setBoundsOrigin` compensation only fires while the assistant
+    /// is actively producing a response — the case that compensation was
+    /// designed for. Idle content-height changes (lazy-cell materialization in
+    /// `LazyVStack`, media-embed late loads, etc.) are progressive and
+    /// self-correcting; compensating them produces large jerky offset shifts
+    /// that look like scroll jitter on hover or mouse-move. Mirrored from the
+    /// view layer in `handleAppear` and `handleSendingChanged`.
+    @ObservationIgnored var isStreamingActive: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -26,6 +26,12 @@ extension MessageListView {
         let isConversationSwitch = previousConversationId != nil
             && previousConversationId != conversationId
         scrollState.currentConversationId = conversationId
+        // Seed the anchor-preservation gate so it fires immediately when the
+        // view appears mid-stream (conversation switch into a still-streaming
+        // thread, or app launch with isSending=true). Otherwise it would only
+        // turn on at the next isSending transition, missing the growth that
+        // happens before that.
+        scrollState.isStreamingActive = isSending
         if isConversationSwitch {
             handleConversationSwitched()
         } else {
@@ -75,6 +81,10 @@ extension MessageListView {
     func handleSendingChanged() {
         // Guard against stale fires during a conversation switch.
         guard conversationId == scrollState.currentConversationId else { return }
+        // Mirror into the scroll state so the anchor-preservation gate flips
+        // synchronously with the send/stream lifecycle. See `isStreamingActive`
+        // on `MessageListScrollState` for the rationale.
+        scrollState.isStreamingActive = isSending
         if isSending {
             // Only pin on genuine user sends, not confirmation resumes.
             // When the assistant resumes from awaiting_confirmation,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -188,12 +188,23 @@ struct MessageListView: View {
                                     enqueueScrollGeometryUpdate(newState)
                                 },
                                 shouldPreserveScrollAnchor: { [scrollState] in
-                                    // Skip during pagination — the explicit
+                                    // Anchor preservation absorbs streaming
+                                    // growth at the latest end so users
+                                    // scrolled up don't see their reading
+                                    // position shift. It must NOT fire while
+                                    // idle: idle content-height changes come
+                                    // from `LazyVStack` lazy-cell estimate
+                                    // corrections and media-embed late loads,
+                                    // which are progressive and self-correcting.
+                                    // Compensating them produces large jerky
+                                    // offset shifts that read as scroll jitter.
+                                    //
+                                    // Also skip during pagination — the explicit
                                     // scroll-to-anchor in `handlePaginationSentinel`
-                                    // is the source of truth for that flow, and
-                                    // shifting the offset to absorb the older
-                                    // page's height would race the snap.
-                                    !scrollState.isPaginationInFlight
+                                    // owns that flow, and shifting the offset to
+                                    // absorb the older page's height would race
+                                    // the snap.
+                                    !scrollState.isPaginationInFlight && scrollState.isStreamingActive
                                 },
                                 onAnchorShift: { [scrollState, isScrollDebugOverlayEnabled] in
                                     // Debug-only counter for anchor-preserver

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -213,8 +213,7 @@ public struct SubagentGroupRow: View {
         .background(isHovered ? VColor.surfaceActive : Color.clear)
         .contentShape(Rectangle())
         .onTapGesture { onTap?() }
-        .onHover { isHovered = $0 }
-        .pointerCursor()
+        .pointerCursor { isHovered = $0 }
         .accessibilityLabel("Subagent: \(subagent.label), \(statusLabel)")
         .accessibilityHint("Opens subagent detail panel")
         .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
## Summary

`ScrollAnchorPreserver` compensates `clipView.setBoundsOrigin` for content-height changes so users scrolled up don't lose their reading position while the assistant streams. The predicate was always-on outside pagination, so compensation fired on **any** content-height change — including idle `LazyVStack` lazy-cell estimate corrections and media-embed late loads. Compensating those changes produces large jerky offset shifts that read as page jitter on hover and mouse-move.

This PR adds `MessageListScrollState.isStreamingActive` (mirrored from `MessageListView.isSending`) and tightens the predicate to `!isPaginationInFlight && isStreamingActive`. Idle drift now passes through naturally; streaming behavior is unchanged.

Also fixes a dual hover-registration on `SubagentGroupRow` (`.onHover` + bare `.pointerCursor()`) that violated `PointerCursorModifier`'s documented contract by installing two `NSTrackingArea`s at the same frame. Consolidated to `.pointerCursor(onHover:)`.

## Why

The transcript stack uses `LazyVStack` for performance — off-screen row heights are estimated from measured averages, so `documentView.frame.height` shifts by tens-to-hundreds of points as cells materialize. That drift is the explicit, documented trade-off of `LazyVStack`: progressive and self-correcting as rows are measured.

`ScrollAnchorPreserver` was built for streaming-response growth at the latest end and fires `setBoundsOrigin` to keep the user's reading position stable while content appends. It was never reconciled with the `LazyVStack` migration, so it now "compensates" lazy-cell drift — and the compensation itself is the visible jitter.

Confirmed with `scroll-debug-overlay` telemetry on an idle long-history conversation: `anchorTotal` climbed past 1600, with `lastAnchor applied +328pt` on a single mouse-move — roughly half a viewport of unwanted shift, with no streaming in progress.

## Benefits

- Eliminates the page jitter / scroll-shift reported on hover and mouse-move in any long conversation (subagent groups, inline tables, message history with images).
- Restores the documented `LazyVStack` trade-off (small progressive drift) instead of fighting it with large jerky compensation.
- Streaming compensation path is unchanged — the fix narrows when compensation fires, not what it does.

## Safety

- Predicate change is purely a narrowing of when compensation runs. Streaming + pagination paths behave identically.
- `isStreamingActive` is seeded in `handleAppear` so the gate is correct from the first geometry tick after mount (mid-stream re-entry, conversation switch into a still-streaming thread, app launch with `isSending=true`).
- `@ObservationIgnored` storage — no incremental SwiftUI invalidation cost.
- The dual-hover fix on `SubagentGroupRow` uses the existing `.pointerCursor(onHover:)` API already exercised throughout the design system.

## References

- [SwiftUI `LazyVStack`](https://developer.apple.com/documentation/swiftui/lazyvstack) — documents the cell-materialization model and estimate-based sizing.
- [`NSClipView.setBoundsOrigin(_:)`](https://developer.apple.com/documentation/appkit/nsclipview/setboundsorigin(_:)) — the AppKit primitive `ScrollAnchorPreserver` invokes.
- [`NSScrollView` willStart/didEndLiveScrollNotification](https://developer.apple.com/documentation/appkit/nsscrollview/willstartlivescrollnotification) — already gates compensation during user gestures; this PR adds the analogous gate for streaming vs. idle.
- [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/) — the rationale for `LazyVStack` over eager `VStack` in scrollable transcripts.
- [`SwiftUI.View.onHover(perform:)`](https://developer.apple.com/documentation/swiftui/view/onhover(perform:)) — `NSTrackingArea` semantics that motivate consolidating duplicate registrations.

## Alternatives considered and rejected

- **Increase `minCompensationDelta` from 1pt to ~5-10pt.** Masks the symptom for small drifts but still allows compensation for the +300pt single-shift cases. Doesn't address the cause and would also suppress legitimate streaming compensation for the same small-delta cases.
- **Suppress compensation in a sliding window after hover state changes.** Treats the symptom (visible during hover), not the cause (compensation firing in idle). Easy to game from other hover sites and creates a special case that future code can violate.
- **Pin every row to a fixed height (or stop using `LazyVStack`).** Reverts the performance fix that exists for documented reasons (`LazyVStack` migration eliminated >=2s hangs on conversation switch / window resize / typography change). Fixed heights also break message content with variable height (markdown blocks, code, embeds).
- **Pure debounce of `frameDidChangeNotification`.** Hides cause inside the observer rather than fixing the upstream predicate. Debounce windows also race with real streaming where rapid sub-second compensations are correct.

## Root cause analysis

**How did the code get into this state?** Two changes that were each correct in isolation interacted badly:

1. `ScrollAnchorPreserver` was built to absorb streaming growth at the latest end, gated only on `!isPaginationInFlight`. At the time, the transcript stack was an eager `VStack` — all cells were measured precisely, so the only source of meaningful `frame.height` change *was* streaming. The always-on predicate was effectively correct for that world.
2. The transcript stack migrated from `VStack` to `LazyVStack` to eliminate multi-second main-thread hangs. The migration log explicitly accepted small progressive drift from estimate corrections as a deliberate trade-off.

The migration didn't touch `ScrollAnchorPreserver`'s predicate. The preserver then started "fighting" the documented drift, producing the jitter users see.

**What mistakes or decisions led to it?**

- The anchor-preservation predicate was scoped to "is this not a pagination?" rather than "is content growth caused by streaming?" — i.e. it implicitly assumed eager measurement made every height change streaming-attributable.
- The `LazyVStack` migration's acceptance of drift didn't include a cross-check for downstream systems that compensated for content-height deltas under the prior assumption.

**Warning signs we missed.** None at the time the predicate was written (the assumption held). After the lazy migration, the warning sign was the `scroll-debug-overlay` HUD: `anchorTotal` climbing in idle conversations is by definition compensation firing without streaming. The HUD existed; nobody had cause to enable it on idle threads.

**Prevention.**

- A `clients/AGENTS.md` rule has been added: anchor preservation must be gated on active streaming, and new use cases route through an explicit state signal rather than widening the predicate.
- When a foundational rendering primitive changes its measurement model (lazy vs. eager, fixed vs. variable), any subsystem that *acts on* content-height deltas must be reviewed in the same PR. This is a class of bug worth checklisting in future similar migrations.

## Test plan

- [x] Hover subagent rows in a long conversation — no jitter (HUD: `ΔcontentH` returns to 0 cleanly; `anchorTotal` stable).
- [x] Move mouse around an inline-table conversation — no jitter (HUD: `anchorTotal` stable).
- [ ] Send a message; while scrolled up, verify anchor compensation still keeps reading position stable as the response streams.
- [ ] Trigger pagination by scrolling to top of history — pagination snap unchanged.
- [ ] Conversation switch into a still-streaming thread — `isStreamingActive` seeded correctly from `handleAppear`, no missed first-frame compensation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)