### PR TITLE
[LUM-1533] fix(macos): skip dead .onHover registration in PointerCursorModifier

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
@@ -14,18 +14,24 @@ struct PointerCursorModifier: ViewModifier {
     var enabled: Bool = true
     var onHover: ((Bool) -> Void)?
 
+    @ViewBuilder
     func body(content: Content) -> some View {
         #if os(macOS)
-        content
-            .pointerStyle(enabled && isEnabled ? .link : nil)
-            .onHover { hovering in
-                onHover?(hovering)
-            }
+        if let onHover {
+            content
+                .pointerStyle(enabled && isEnabled ? .link : nil)
+                .onHover { hovering in onHover(hovering) }
+        } else {
+            content
+                .pointerStyle(enabled && isEnabled ? .link : nil)
+        }
         #else
-        content
-            .onHover { hovering in
-                onHover?(hovering)
-            }
+        if let onHover {
+            content
+                .onHover { hovering in onHover(hovering) }
+        } else {
+            content
+        }
         #endif
     }
 }


### PR DESCRIPTION
When no `onHover` callback is provided (bare `.pointerCursor()`), the modifier registered a no-op `.onHover { onHover?(hovering) }` that created an unnecessary `NSTrackingArea`. This uses `@ViewBuilder` with `if let onHover` to skip `.onHover` registration entirely when no callback exists — defense-in-depth alongside #30806's streaming gate fix.

---

Each call site has a static `onHover` parameter (always nil or always non-nil), so the `@ViewBuilder` conditional branch is stable per call site — no view identity thrashing. Ref: [SwiftUI View Identity (WWDC21)](https://developer.apple.com/videos/play/wwdc2021/10022/)

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/2c76636411174340980afc710dd0dcba