### PR TITLE
fix(home): persist 'have you tried' banner dismissal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -28,7 +28,7 @@ struct HomePageView: View {
     let onSuggestionSelected: (HomeSuggestion) -> Void
     var onDetailPanelSelected: (FeedItem) -> Void = { _ in }
 
-    @State private var suggestionsDismissed: Bool = false
+    @AppStorage("homeSuggestionsDismissed") private var suggestionsDismissed: Bool = false
     @State private var activeFilter: FeedItemCategory? = nil
 
     private let maxContentWidth: CGFloat = 960


### PR DESCRIPTION
## Summary

- Swap \`@State\` for \`@AppStorage(\"homeSuggestionsDismissed\")\` on the home page's suggestion pill bar dismissal flag so once the user clicks the X, the banner stays gone across app relaunches.
- Mirrors the existing precedent in \`clients/macos/vellum-assistant/Features/Settings/IntegrationsPanelContent.swift:23\` (\`@AppStorage(\"integrationsBannerDismissed\")\`) — no new convention introduced.
- One-line change; the existing read at line 76 and write at line 82 are unchanged because \`@AppStorage<Bool>\` is a drop-in replacement for \`@State<Bool>\` from the call-site's perspective.

## Original prompt

While viewing the home page, the user asked for the \"By the way, have you tried one of these:\" suggestion popup to stay dismissed forever once the X is clicked — today it only hides for the current view lifetime and reappears on relaunch. The fix is local UI preference state (not synced server-side), since the suggestions themselves are deterministically regenerated from connection state, so \`@AppStorage\` (UserDefaults-backed) is the right fit and matches an existing banner pattern already in the macOS app.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->