### PR TITLE
Remove 'things the user asks you to hold onto' from relaxed PKB reminder

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -14,7 +14,7 @@ const BASE_REMINDER_DEFAULT =
 // `memory-retrospective` feature flag is on.
 const BASE_REMINDER_RELAXED =
   "<system_reminder>" +
-  "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments, things the user asks you to hold onto. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
+  "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
   "\n</system_reminder>";
 

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -3,7 +3,7 @@ const BODY_DEFAULT =
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing.";
 
 const BODY_RELAXED =
-  "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments, things the user asks you to hold onto. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
+  "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing.";
 
 /**


### PR DESCRIPTION
## Summary
- Drop the trailing \`, things the user asks you to hold onto\` phrase from the relaxed PKB system_reminder body in \`pkb-reminder-builder.ts\`
- Update the byte-for-byte test fixture in \`pkb-reminder-builder.test.ts\` to match

## Original prompt
Remove \`, things the user asks you to hold onto\` from the system_reminder injection to the user message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->