### PR TITLE
Soften 'the user' in LLM-visible tool descriptions

### DIFF
--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -192,7 +192,7 @@ render(<App />, document.getElementById('app')!);
   const nextStepsField = mainTsxScaffolded
     ? {
         next_steps:
-          "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves the user with an empty Hello-world placeholder.",
+          "Scaffold created with a placeholder src/main.tsx only. The app is NOT built yet. You MUST now (1) write the real src/main.tsx, components under src/components/, and src/styles.css with file_write, then (2) call app_refresh once. Stopping here leaves an empty Hello-world placeholder as the only result.",
       }
     : {};
 

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -74,7 +74,7 @@ export type AskQuestionInput = z.infer<typeof InputSchema>;
 // ── Tool description ────────────────────────────────────────────────
 
 const DESCRIPTION = [
-  "Use this tool whenever the user's request is ambiguous and can be resolved",
+  "Use this tool whenever a request is ambiguous and can be resolved",
   "by 2–4 plausible interpretations or discrete choices. Prefer it over",
   "plain-text clarification — structured options are faster to answer and",
   "remove guessing.",
@@ -82,7 +82,7 @@ const DESCRIPTION = [
   "When in doubt between (a) asking inline and (b) calling ask_question with",
   "structured options: call ask_question. The structured choices are better UX.",
   "",
-  'Example: if the user says "schedule lunch with Alice next week" and there',
+  'Example: given a request like "schedule lunch with Alice next week" where there',
   "are two plausible Alice contacts, ask which Alice with options like",
   '`{id: "alice_work", label: "Alice (work)"}` and',
   '`{id: "alice_personal", label: "Alice (personal)"}`.',
@@ -97,8 +97,8 @@ const DESCRIPTION = [
   "- You're about to take a low-stakes reversible action and can adjust based",
   "  on feedback.",
   "",
-  "If the user skips a question, proceed with reasonable defaults for that",
-  "question; if they skip every question in the batch, stop interrupting them",
+  "If a question is skipped, proceed with reasonable defaults for that",
+  "question; if every question in the batch is skipped, stop interrupting",
   "and use defaults across the board.",
   "",
   "Provide 2–4 options. A free-text fallback is always added by the UI — do not",
@@ -169,7 +169,7 @@ export class AskQuestionTool implements Tool {
               properties: {
                 question: {
                   type: "string",
-                  description: "The clarifying question shown to the user.",
+                  description: "The clarifying question to display.",
                 },
                 description: {
                   type: "string",

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -90,7 +90,7 @@ const MODE_TRADEOFFS: Record<StatusCheckMode, string[]> = {
   [BROWSER_STATUS_MODE.EXTENSION]: [
     "This is the preferred approach for all things browser-use.",
     "On macOS, the host browser proxy is provisioned automatically via the desktop client's SSE bridge — no extension install required.",
-    "When the Chrome extension is also installed, it takes priority for direct WebSocket routing to the user's Chrome session.",
+    "When the Chrome extension is also installed, it takes priority for direct WebSocket routing to the active Chrome session.",
     "More secure than relying on Chrome's native remote debugging functionality.",
   ],
   [BROWSER_STATUS_MODE.CDP_INSPECT]: [
@@ -101,8 +101,8 @@ const MODE_TRADEOFFS: Record<StatusCheckMode, string[]> = {
   ],
   [BROWSER_STATUS_MODE.LOCAL]: [
     "The least-preferred approach for all things browser-use.",
-    "Considered a last-resort fallback if the user has not installed the Chrome Extension or enabled remote debugging in Chrome, and has indicated that they do not want to.",
-    "Does not use the user's existing browser profile, so sessions/cookies may differ.",
+    "Considered a last-resort fallback when the Chrome Extension is not installed, remote debugging in Chrome is not enabled, and neither will be enabled.",
+    "Does not use the existing browser profile, so sessions/cookies may differ.",
     "Requires that Playwright and Chromium are installed on the host machine,",
   ],
 };
@@ -392,8 +392,8 @@ function acquireCdpClientWithMode(
     targetClientId != null
       ? "extension"
       : browserMode === "auto" && rememberedKind !== null
-      ? rememberedKind
-      : browserMode;
+        ? rememberedKind
+        : browserMode;
 
   try {
     const raw = getCdpClient(context, { mode: effectiveMode, targetClientId });
@@ -406,7 +406,11 @@ function acquireCdpClientWithMode(
     // sticky preference doesn't surface as a hard failure.
     // Do not apply this fallback when target_client_id is set — a targeting
     // failure must surface as an error, not silently route elsewhere.
-    if (browserMode === "auto" && effectiveMode !== "auto" && targetClientId == null) {
+    if (
+      browserMode === "auto" &&
+      effectiveMode !== "auto" &&
+      targetClientId == null
+    ) {
       browserManager.clearPreferredBackendKind(context.conversationId);
       try {
         const raw = getCdpClient(context, { mode: "auto", targetClientId });
@@ -952,10 +956,10 @@ export async function executeBrowserNavigate(
                 "2. Use credential fill to enter email/password from credential_store",
               );
               lines.push(
-                "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
+                "3. For email verification codes, use ui_show with a form to request the code mid-turn",
               );
               lines.push(
-                "4. Do NOT give up or tell the user to sign in manually - handle the login flow yourself",
+                "4. Do NOT give up or suggest manual sign-in - handle the login flow yourself",
               );
             }
           } else {
@@ -964,7 +968,7 @@ export async function executeBrowserNavigate(
               "⚠️ CAPTCHA/Cloudflare verification detected on this page.",
             );
             lines.push(
-              "The user needs to solve this challenge manually. Please inform the user that the page requires human verification before the content can be accessed.",
+              "This challenge requires human verification. Surface this clearly: the page cannot be accessed until the verification is solved manually.",
             );
           }
         } else {
@@ -979,10 +983,10 @@ export async function executeBrowserNavigate(
             "2. Use credential fill to enter email/password from credential_store",
           );
           lines.push(
-            "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
+            "3. For email verification codes, use ui_show with a form to request the code mid-turn",
           );
           lines.push(
-            "4. Do NOT give up or tell the user to sign in manually - handle the login flow yourself",
+            "4. Do NOT give up or suggest manual sign-in - handle the login flow yourself",
           );
         }
       }

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -374,7 +374,7 @@ export const computerUseOpenAppTool: Tool = {
 export const computerUseRunAppleScriptTool: Tool = {
   name: "computer_use_run_applescript",
   description:
-    "Run an AppleScript command. Prefer this over click/type when possible - it doesn't move the cursor or interrupt the user. Never use 'do shell script' inside AppleScript (blocked for security).",
+    "Run an AppleScript command. Prefer this over click/type when possible - it doesn't move the cursor or interrupt foreground activity. Never use 'do shell script' inside AppleScript (blocked for security).",
   category: "computer-use",
   defaultRiskLevel: RiskLevel.Low,
   executionMode: "proxy",
@@ -448,7 +448,7 @@ export const computerUseDoneTool: Tool = {
 export const computerUseRespondTool: Tool = {
   name: "computer_use_respond",
   description:
-    "Respond to the user with a text answer instead of performing computer actions. Use this when you can answer directly without interacting with the screen.",
+    "Reply with a text answer instead of performing computer actions. Use this when you can answer directly without interacting with the screen.",
   category: "computer-use",
   defaultRiskLevel: RiskLevel.Low,
   executionMode: "proxy",
@@ -462,7 +462,7 @@ export const computerUseRespondTool: Tool = {
         properties: {
           answer: {
             type: "string",
-            description: "The text answer to display to the user",
+            description: "The text answer to display",
           },
           reasoning: {
             type: "string",

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -88,7 +88,7 @@ class CredentialStoreTool implements Tool {
             type: "string",
             enum: ["store", "list", "delete", "prompt"],
             description:
-              'The operation to perform. Use "prompt" to ask the user for a secret via secure UI - the value never enters the conversation.',
+              'The operation to perform. Use "prompt" to request a secret via secure UI - the value never enters the conversation.',
           },
           service: {
             type: "string",

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -41,7 +41,7 @@ class FileEditTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a status update.",
           },
         },
         required: ["path", "old_string", "new_string", "activity"],

--- a/assistant/src/tools/filesystem/list.ts
+++ b/assistant/src/tools/filesystem/list.ts
@@ -30,7 +30,7 @@ class FileListTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a status update.",
           },
         },
         required: ["path", "activity"],

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -41,7 +41,7 @@ class FileReadTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a status update.",
           },
         },
         required: ["path", "activity"],

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -56,7 +56,7 @@ class FileWriteTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a status update.",
           },
         },
         required: ["path", "content", "activity"],
@@ -121,7 +121,10 @@ class FileWriteTool implements Tool {
       // Indexing `pkb/*.json` (or any other extension) here would produce
       // chunks the reconciler can't see, leading to orphaned vectors and
       // pointless embedding work.
-      if (filePath.toLowerCase().endsWith(".md") && isInsidePkbRoot(filePath, pkbRoot)) {
+      if (
+        filePath.toLowerCase().endsWith(".md") &&
+        isInsidePkbRoot(filePath, pkbRoot)
+      ) {
         enqueuePkbIndexJob({
           pkbRoot,
           absPath: filePath,

--- a/assistant/src/tools/host-filesystem/transfer.ts
+++ b/assistant/src/tools/host-filesystem/transfer.ts
@@ -13,7 +13,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 class HostFileTransferTool implements Tool {
   name = "host_file_transfer";
   description =
-    "Copy a file between the assistant's workspace and the user's host machine. Set direction to 'to_host' to send a workspace file to the host, or 'to_sandbox' to pull a host file into the workspace. When multiple clients support host_file, specify which one to use with target_client_id.";
+    "Copy a file between the assistant's workspace and the host machine. Set direction to 'to_host' to send a workspace file to the host, or 'to_sandbox' to pull a host file into the workspace. When multiple clients support host_file, specify which one to use with target_client_id.";
   category = "host-filesystem";
   defaultRiskLevel = RiskLevel.Medium;
 

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -95,7 +95,7 @@ function buildHostBashProxyEnv(
 class HostShellTool implements Tool {
   name = "host_bash";
   description =
-    "LAST RESORT — Execute a shell command directly on the user's host machine. You MUST strongly prefer the regular `bash` tool for all commands. Only use `host_bash` when you are absolutely certain the command MUST run on the user's host machine and CANNOT run in the workspace (e.g., managing host-level system services, accessing host-only peripherals, or interacting with host paths outside the workspace). If in doubt, use `bash` instead. Approval-gated: your user must allow each invocation. Do not use for commands that require injected credentials or secrets.";
+    "LAST RESORT — Execute a shell command directly on the host machine. You MUST strongly prefer the regular `bash` tool for all commands. Only use `host_bash` when you are absolutely certain the command MUST run on the host machine and CANNOT run in the workspace (e.g., managing host-level system services, accessing host-only peripherals, or interacting with host paths outside the workspace). If in doubt, use `bash` instead. Approval-gated: each invocation must be explicitly approved. Do not use for commands that require injected credentials or secrets.";
   category = "host-terminal";
   // host_bash is a weaker-tier escape hatch under CES lockdown. It remains
   // Medium risk by default but persistent approvals are disabled for

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -402,7 +402,7 @@ export class PermissionChecker {
           const denialMessage =
             contextualDenial.length > 0
               ? contextualDenial
-              : `Permission denied by user. The user chose not to allow the "${name}" tool. Do NOT retry this tool call immediately. Instead, tell the user that the action was not performed because they denied permission, and ask if they would like you to try again or take a different approach. Wait for the user to explicitly respond before retrying.`;
+              : `Permission denied. The "${name}" tool was not allowed. Do NOT retry this tool call immediately. Instead, explain that the action was not performed because permission was denied, and ask whether to try again or take a different approach. Wait for an explicit response before retrying.`;
           const denialReason =
             contextualDenial.length > 0
               ? `Permission denied (${name}): contextual policy`

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -150,7 +150,7 @@ export async function executeScheduleCreate(
           `  Status: ${job.status}`,
           ``,
           `Integrations: ${integrations}`,
-          `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn the user about any missing capabilities before confirming the schedule is ready.`,
+          `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn about any missing capabilities before confirming the schedule is ready.`,
         ].join("\n"),
         isError: false,
       };
@@ -239,7 +239,7 @@ export async function executeScheduleCreate(
         `  Next run: ${nextRunDate}`,
         ``,
         `Integrations: ${integrations}`,
-        `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn the user about any missing capabilities before confirming the schedule is ready.`,
+        `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn about any missing capabilities before confirming the schedule is ready.`,
       ].join("\n"),
       isError: false,
     };

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -30,7 +30,7 @@ class SkillExecuteTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a progress update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a progress update.",
           },
         },
         required: ["tool", "input", "activity"],

--- a/assistant/src/tools/subagent/notify-parent.ts
+++ b/assistant/src/tools/subagent/notify-parent.ts
@@ -59,7 +59,7 @@ class NotifyParentTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+              "Brief non-technical explanation of what you are doing and why, shown as a status update.",
           },
         },
         required: ["message", "activity"],

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -53,7 +53,7 @@ const FRIENDLY_NAMES: Record<PermissionType, string> = {
 class RequestSystemPermissionTool implements Tool {
   name = "request_system_permission";
   description =
-    "Ask the user to grant a macOS system permission via System Settings. " +
+    "Request a macOS system permission via System Settings. " +
     "Use when a tool fails with a permission/access error (e.g. 'Operation not permitted', 'EACCES', sandbox denial). " +
     "Do not explain how to open System Settings manually - this tool handles it with a clickable button.";
   category = "system";
@@ -74,7 +74,7 @@ class RequestSystemPermissionTool implements Tool {
           activity: {
             type: "string",
             description:
-              "Short explanation of why this permission is needed (shown to the user)",
+              "Short explanation of why this permission is needed (shown in the prompt)",
           },
         },
         required: ["permission_type", "activity"],

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -28,7 +28,7 @@ function proxyExecute(): Promise<ToolExecutionResult> {
 export const uiShowTool: Tool = {
   name: "ui_show",
   description:
-    "Show structured data or UI to the user. For long-form writing use the document skill; for interactive apps use the app-builder skill.\n\n" +
+    "Surface structured data or UI in the conversation. For long-form writing use the document skill; for interactive apps use the app-builder skill.\n\n" +
     "Surface types (data shapes):\n" +
     '- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "weather_forecast" (native weather widget), "task_progress" (live step tracker - update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] })\n' +
     '- table: { columns: [{ id, label }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +
@@ -92,17 +92,17 @@ export const uiShowTool: Tool = {
             type: "string",
             enum: ["inline", "panel"],
             description:
-              'Where to render the surface. "inline" embeds it in the chat message. "panel" shows a floating window. Defaults to "inline". Prefer inline — only use panel when the user explicitly asks for a separate window.',
+              'Where to render the surface. "inline" embeds it in the chat message. "panel" shows a floating window. Defaults to "inline". Prefer inline — only use panel when a separate window is explicitly requested.',
           },
           await_action: {
             type: "boolean",
             description:
-              "Whether to block until the user interacts with an action. Defaults to true when actions are provided.",
+              "Whether to block until an action is selected. Defaults to true when actions are provided.",
           },
           persistent: {
             type: "boolean",
             description:
-              "When true, clicking an action does not dismiss the surface — the card stays visible and only the clicked action is marked as spent. Use for launcher or menu-style cards where the user may click multiple buttons. Defaults to false.",
+              "When true, clicking an action does not dismiss the surface — the card stays visible and only the clicked action is marked as spent. Use for launcher or menu-style cards where multiple buttons may be clicked. Defaults to false.",
           },
         },
         required: ["surface_type", "data"],


### PR DESCRIPTION
## Summary

- Reworks ~34 occurrences of "the user" across 14 tool files in `assistant/src/tools/` — tool descriptions, parameter schemas, and tool-result content strings.
- The phrase casts the human as an abstract third party and reads as impersonal in prompts the LLM sees on every turn. Rewrites either drop the referent (passive/imperative voice) or substitute a more natural alternative ("the host machine", "the active Chrome session", "shown as a status update", etc.).
- Scoped to LLM-visible strings only: code comments, JSDoc on shared types, test files, and skill SKILL.md content were left alone.

## Original prompt

Sweep the Vellum assistant's tool descriptions for occurrences of "the user" — the phrasing casts the human as an abstract third party and comes across as impersonal to the model. Find every case in tool description/parameter strings and rework each to read naturally, ideally without a third-party referent.