### PR TITLE
feat(macos): log subview height deltas when scroll anchor fires

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -28,13 +28,22 @@ struct MessageListScrollObserver: NSViewRepresentable {
     /// compensations (content shrinks, live-scroll gates, first-layout).
     /// `nil` when no observer cares.
     var onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)? = nil
+    /// Fired when `contentH` changes by a small amount (< 8pt) — used by the
+    /// scroll-debug overlay to localise which descendant of the document view
+    /// actually grew or shrank. Reports only views whose frame height changed
+    /// vs. the previous emit, so the log line lists candidate sources of the
+    /// phantom 1pt-per-frame drift that the anchor preserver is compensating
+    /// for. `nil` (and the diagnostic walk is skipped entirely) when no
+    /// observer cares, so the cost is paid only with the debug overlay on.
+    var onContentHeightSourceDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             onGeometryChange: onGeometryChange,
             shouldPreserveScrollAnchor: shouldPreserveScrollAnchor,
             onAnchorShift: onAnchorShift,
-            onAnchorDecision: onAnchorDecision
+            onAnchorDecision: onAnchorDecision,
+            onContentHeightSourceDiagnostic: onContentHeightSourceDiagnostic
         )
     }
 
@@ -53,6 +62,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
         context.coordinator.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
         context.coordinator.onAnchorShift = onAnchorShift
         context.coordinator.onAnchorDecision = onAnchorDecision
+        context.coordinator.onContentHeightSourceDiagnostic = onContentHeightSourceDiagnostic
         DispatchQueue.main.async { [weak nsView] in
             guard let nsView else { return }
             context.coordinator.attachIfNeeded(to: nsView)
@@ -74,8 +84,29 @@ struct MessageListScrollObserver: NSViewRepresentable {
         var shouldPreserveScrollAnchor: @MainActor () -> Bool
         var onAnchorShift: (@MainActor () -> Void)?
         var onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)?
+        var onContentHeightSourceDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)?
         private var observers: [NSObjectProtocol] = []
         private var lastSnapshot: ScrollGeometrySnapshot?
+        /// Per-subtree height snapshot, keyed by the descendant's index path
+        /// from the document view (e.g. `"0/3/1"`). Populated only when an
+        /// `onContentHeightSourceDiagnostic` observer is wired up; cleared on
+        /// detach so a scroll-view swap can't carry stale heights across
+        /// conversations. Walking depth-first by index path gives a stable
+        /// identity across SwiftUI's view re-evaluations, where the underlying
+        /// `NSView` object identifiers shift even when the layout doesn't.
+        private var lastSubviewHeights: [String: CGFloat] = [:]
+        /// Cap on diagnostic walk depth — SwiftUI hosting hierarchies are deep
+        /// and the walk runs on every small contentH delta, so we trim the
+        /// tail to keep the per-emit cost bounded. 12 is enough to reach the
+        /// LazyVStack row level in practice.
+        private static let diagnosticWalkMaxDepth: Int = 12
+        /// Upper bound on the magnitude of a `contentHDelta` worth walking for.
+        /// Large deltas come from layout-level events (pagination snap, height
+        /// estimate corrections after a column-width change, conversation
+        /// switches) — those don't need per-frame attribution. The
+        /// instrumentation targets the steady ~1pt drift seen during
+        /// streaming.
+        private static let diagnosticContentHDeltaThreshold: CGFloat = 8
         /// Last observed `documentView.frame.height`. Used to compute the
         /// growth delta for anchor preservation. Reset to 0 on attach/detach
         /// so a stale baseline from a previous conversation cannot apply
@@ -108,12 +139,14 @@ struct MessageListScrollObserver: NSViewRepresentable {
             onGeometryChange: @escaping @MainActor (ScrollGeometrySnapshot) -> Void,
             shouldPreserveScrollAnchor: @escaping @MainActor () -> Bool,
             onAnchorShift: (@MainActor () -> Void)? = nil,
-            onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)? = nil
+            onAnchorDecision: (@MainActor (ScrollAnchorDecisionEvent) -> Void)? = nil,
+            onContentHeightSourceDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? = nil
         ) {
             self.onGeometryChange = onGeometryChange
             self.shouldPreserveScrollAnchor = shouldPreserveScrollAnchor
             self.onAnchorShift = onAnchorShift
             self.onAnchorDecision = onAnchorDecision
+            self.onContentHeightSourceDiagnostic = onContentHeightSourceDiagnostic
         }
 
         func attachIfNeeded(to hostView: NSView) {
@@ -143,6 +176,10 @@ struct MessageListScrollObserver: NSViewRepresentable {
             // fresh full scroll cycle.
             self.isLiveScrolling = false
             self.lastSnapshot = nil
+            // Same baseline reset for the diagnostic walk's snapshot — a
+            // conversation switch destroys the old view tree, so stale paths
+            // would no longer correspond to anything.
+            self.lastSubviewHeights = [:]
             installObservers()
         }
 
@@ -155,6 +192,7 @@ struct MessageListScrollObserver: NSViewRepresentable {
             lastSnapshot = nil
             lastContentHeight = 0
             isLiveScrolling = false
+            lastSubviewHeights = [:]
         }
 
         func emitCurrentSnapshotIfPossible() {
@@ -208,6 +246,23 @@ struct MessageListScrollObserver: NSViewRepresentable {
                     postOffsetY: clipView.bounds.origin.y,
                     at: Date()
                 ))
+            }
+            // Diagnostic walk: when contentH changes and an observer is wired
+            // up, walk the documentView's descendant tree to identify which
+            // view(s) actually grew or shrank. Gated on the callback being
+            // non-nil so the deep walk's cost is only paid with the
+            // scroll-debug overlay on. Large deltas (pagination snap,
+            // conversation switch) refresh the snapshot but skip the report —
+            // those events don't need per-frame attribution.
+            if contentHDelta != 0, let onContentHeightSourceDiagnostic {
+                let changed = diffSubviewHeights(root: documentView)
+                if abs(contentHDelta) < Self.diagnosticContentHDeltaThreshold {
+                    onContentHeightSourceDiagnostic(ContentHeightSourceDiagnosticEvent(
+                        contentHDelta: contentHDelta,
+                        changedSubviews: changed,
+                        at: Date()
+                    ))
+                }
             }
             // Advance the baseline on every emit, including jitter-skipped
             // frames. Leaving the baseline stale on a sub-threshold skip lets
@@ -336,6 +391,56 @@ struct MessageListScrollObserver: NSViewRepresentable {
             }
             observers.removeAll()
         }
+
+        /// Walks `root`'s descendant tree depth-first by index path, skipping
+        /// `root` itself. For each descendant whose `frame.height` differs
+        /// from the value captured on the previous walk, records a
+        /// `ChangedSubview` describing where the change happened. Stores the
+        /// new heights back into `lastSubviewHeights` so the next walk diffs
+        /// against fresh state.
+        ///
+        /// `root` (the document view) is excluded from the report because its
+        /// height delta is already conveyed by `contentHDelta` — including it
+        /// would just duplicate that signal at every emit.
+        ///
+        /// The index path (`"0/3/1"`) is intentionally used as the identity
+        /// key — `NSView` object identifiers drift across SwiftUI view
+        /// re-evaluations even when the underlying layout is identical, but
+        /// the position of a subview in its parent's `subviews` array is
+        /// stable enough for short-window diagnostic comparison.
+        private func diffSubviewHeights(root: NSView) -> [ContentHeightSourceDiagnosticEvent.ChangedSubview] {
+            var current: [String: CGFloat] = [:]
+            var changed: [ContentHeightSourceDiagnosticEvent.ChangedSubview] = []
+            for (index, child) in root.subviews.enumerated() {
+                captureHeights(view: child, path: "\(index)", depth: 1, into: &current, changed: &changed)
+            }
+            lastSubviewHeights = current
+            return changed
+        }
+
+        private func captureHeights(
+            view: NSView,
+            path: String,
+            depth: Int,
+            into current: inout [String: CGFloat],
+            changed: inout [ContentHeightSourceDiagnosticEvent.ChangedSubview]
+        ) {
+            let height = view.frame.height
+            current[path] = height
+            if let previous = lastSubviewHeights[path], previous != height {
+                changed.append(ContentHeightSourceDiagnosticEvent.ChangedSubview(
+                    path: path,
+                    typeName: String(describing: type(of: view)),
+                    previousHeight: previous,
+                    currentHeight: height,
+                    minY: view.frame.minY
+                ))
+            }
+            guard depth < Self.diagnosticWalkMaxDepth else { return }
+            for (index, child) in view.subviews.enumerated() {
+                captureHeights(view: child, path: "\(path)/\(index)", depth: depth + 1, into: &current, changed: &changed)
+            }
+        }
     }
 }
 
@@ -437,4 +542,31 @@ struct ScrollAnchorDecisionEvent {
     let preOffsetY: CGFloat
     let postOffsetY: CGFloat
     let at: Date
+}
+
+/// Per-emit attribution payload describing which subviews of the document
+/// view actually changed height when `contentH` ticked by a small amount.
+/// Emitted only when the scroll-debug overlay is on (the view layer wires
+/// up `onContentHeightSourceDiagnostic` only in that case). The view layer
+/// is responsible for logging — keeping the observer free of `os.Logger`
+/// dependencies preserves its unit-testability.
+struct ContentHeightSourceDiagnosticEvent {
+    let contentHDelta: CGFloat
+    let changedSubviews: [ChangedSubview]
+    let at: Date
+
+    struct ChangedSubview {
+        /// Index path from the document view (`"0/3/1"`) — stable across
+        /// SwiftUI view re-evaluations within a single conversation.
+        let path: String
+        /// Swift type name (often a SwiftUI hosting wrapper like
+        /// `_TtGC7SwiftUI...`, occasionally a plain `NSView` subclass).
+        let typeName: String
+        let previousHeight: CGFloat
+        let currentHeight: CGFloat
+        /// Frame `minY` in the parent's coordinate space — useful for
+        /// locating the change in the inverted layout (small `minY` is near
+        /// the visual bottom / streaming end).
+        let minY: CGFloat
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -6,6 +6,12 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MessageListView")
 
+/// Separate category for the scroll-anchor source diagnostic so its high-rate
+/// output (one line per small contentH tick when the overlay is on) doesn't
+/// drown out other `MessageListView` logs. Filter with
+/// `log stream --predicate 'category == "ScrollAnchorDiag"'`.
+private let scrollDiagLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "ScrollAnchorDiag")
+
 /// Compound `task(id:)` key so the daemon-message-ID resolver re-fires both
 /// when the requested daemon ID changes and when the messages list grows
 /// (the matching row may not exist yet at the time the binding is set).
@@ -268,6 +274,35 @@ extension MessageListView {
         guard message.role == .user else { return false }
         if case .queued = message.status { return false }
         return true
+    }
+
+    // MARK: - Scroll-anchor source diagnostic
+
+    /// Formats a single content-height-source diagnostic event for the
+    /// `ScrollAnchorDiag` log category. The coordinator only fires this
+    /// callback when the scroll-debug overlay is on AND `contentH` ticked by
+    /// less than 8pt — the suspect range for the drift this instrumentation
+    /// targets. Output shape (one line per emit):
+    ///
+    /// ```
+    /// contentHΔ=1.0 changed=3: NSStackView(path=0/0/2 minY=2160 h=200→201) ...
+    /// ```
+    ///
+    /// `path` is the index path from the document view; the leftmost segment
+    /// is the document view's direct subview index, so two paths with a
+    /// common prefix sit in the same subtree.
+    static func logContentHeightSource(_ event: ContentHeightSourceDiagnosticEvent) {
+        // Cap the per-line output so a single emit can't blow up the log when
+        // a layout-storm event sneaks under the 8pt threshold.
+        let maxEntries = 12
+        let displayed = event.changedSubviews.prefix(maxEntries)
+        let summary = displayed.map { c in
+            "\(c.typeName)(path=\(c.path) minY=\(Int(c.minY)) h=\(c.previousHeight)→\(c.currentHeight))"
+        }.joined(separator: " ")
+        let truncated = event.changedSubviews.count > maxEntries
+            ? " …+\(event.changedSubviews.count - maxEntries)"
+            : ""
+        scrollDiagLog.debug("contentHΔ=\(event.contentHDelta) changed=\(event.changedSubviews.count): \(summary)\(truncated)")
     }
 
     // MARK: - Confirmation focus

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -220,7 +220,18 @@ struct MessageListView: View {
                                     // plus applies, with pre/post offsets.
                                     guard isScrollDebugOverlayEnabled else { return }
                                     scrollState.recordAnchorDecision(event)
-                                }
+                                },
+                                onContentHeightSourceDiagnostic: isScrollDebugOverlayEnabled
+                                    ? { event in
+                                        // Debug-only attribution of which subview
+                                        // grew/shrank when contentH ticked by a
+                                        // small amount. Passing the callback as
+                                        // `nil` when the flag is off short-circuits
+                                        // the coordinator's tree walk entirely,
+                                        // so we pay nothing in production.
+                                        MessageListView.logContentHeightSource(event)
+                                      }
+                                    : nil
                             )
                         )
                     Spacer(minLength: 0)


### PR DESCRIPTION
## Summary

- Add `onContentHeightSourceDiagnostic` callback to `MessageListScrollObserver`. When the scroll-debug overlay is on, the coordinator walks the document view's descendant tree on every `contentH` delta < 8pt and reports which subview(s) actually grew or shrank.
- Wire the callback in `MessageListView` to log a one-line summary to a dedicated `ScrollAnchorDiag` `os.Logger` category. Each line includes the index path, type name, frame `minY`, and previous→current heights of each changed descendant — enough to localise the source of the phantom 1pt drift the anchor is compensating for.
- No production cost. The callback is `nil` (and the recursive walk is skipped entirely) when the `scroll-debug-overlay` flag is off.

## Original prompt

The user reported the chat slowly scrolling upward during streaming and shared `vellum-scroll-debug-2026-05-15-025550.csv`, which shows `contentH` ticking by exactly +1pt every ~125ms with the anchor preserver applying a matching +1pt offset shift in lockstep for 14 seconds straight. Before changing anchor logic (the plan in `.claude/plans/the-chat-keeps-scrolling-streamed-unicorn.md` proposes a reference-element-based compensation), we need to pinpoint *which* subview is producing the phantom 1pt growth — streaming msg, lazy-cell estimate drift, pinned-section spacer math, or some animated indicator. This PR adds the targeted instrumentation so we can reproduce, capture the log, and pick the right fix.

To use: enable the `scroll-debug-overlay` flag, repro the bug, then `log stream --predicate 'category == "ScrollAnchorDiag"' --info` while the assistant streams.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->