### PR TITLE
fix(macos): extract didBecomeKey handler to unblock Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -323,5 +323,21 @@ extension MessageListView {
             scrollState.lastAutoFocusedRequestId = nil
         }
     }
+
+    /// Window-became-key counterpart to `handleConfirmationFocusIfNeeded`:
+    /// when the app regains key window status while a pending confirmation
+    /// is active, hand focus off the composer so the bubble's key monitor
+    /// receives the next keystroke.
+    func handleWindowDidBecomeKey(_ notification: Notification) {
+        guard let requestId = activePendingRequestId,
+              scrollState.lastAutoFocusedRequestId != requestId,
+              let window = notification.object as? NSWindow,
+              window === NSApp.keyWindow,
+              let responder = window.firstResponder as? NSTextView,
+              responder.isEditable
+        else { return }
+        window.makeFirstResponder(nil)
+        scrollState.lastAutoFocusedRequestId = requestId
+    }
     #endif
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -324,14 +324,7 @@ struct MessageListView: View {
                 await handleAnchorDaemonMessageIdTask()
             }
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
-                if let requestId = activePendingRequestId, scrollState.lastAutoFocusedRequestId != requestId,
-                   let window = notification.object as? NSWindow,
-                   window === NSApp.keyWindow,
-                   let responder = window.firstResponder as? NSTextView,
-                   responder.isEditable {
-                    window.makeFirstResponder(nil)
-                    scrollState.lastAutoFocusedRequestId = requestId
-                }
+                handleWindowDidBecomeKey(notification)
             }
     }
 }


### PR DESCRIPTION
## Summary
- \`MessageListView.swift:333\` failed to compile (\"the compiler is unable to type-check this expression in reasonable time\") because the \`.onReceive\` closure for \`NSWindow.didBecomeKeyNotification\` had a six-clause \`if let\` chain mixing optional bindings with an identity comparison.
- Extract the closure body into \`handleWindowDidBecomeKey(_:)\` on the Lifecycle extension, alongside the sibling \`handleConfirmationFocusIfNeeded()\` helper. Behavior is identical.

## Original prompt
Fix the Swift compile error in \`clients/macos/vellum-assistant/Features/Chat/MessageListView.swift:333\` reported during \`Compiling VellumAssistantLib\`: \"the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions.\" The offending expression is the multi-clause \`if let\` inside the \`.onReceive(NSWindow.didBecomeKeyNotification)\` closure that resigns first responder when a pending confirmation is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->