### PR TITLE
fix(macos): split onReceive assignment to unblock Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -284,7 +284,8 @@ struct MessageListView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
                 guard let key = notification.userInfo?["key"] as? String, key == "scroll-debug-overlay" else { return }
-                isScrollDebugOverlayEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+                let enabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+                isScrollDebugOverlayEnabled = enabled
             }
             .onDisappear {
                 scrollState.cancelAll()


### PR DESCRIPTION
## Summary
- Split `isScrollDebugOverlayEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(...)` inside the `.onReceive` closure into a typed `let enabled: Bool` intermediate, resolving the "unable to type-check this expression in reasonable time" compiler error.

## Original prompt
The macOS build was failing at `MessageListView.swift:287` with a Swift compiler error: "unable to type-check this expression in reasonable time." The fix extracts the feature-flag read into an explicitly typed local variable so the type-checker doesn't have to infer through the deeply nested SwiftUI closure chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->