### PR TITLE
test(ci): align manifest and assertions with softened tool descriptions

### DIFF
--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -242,7 +242,7 @@ describe("ToolExecutor lifecycle events", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("Permission denied by user");
+    expect(result.content).toContain("Permission denied");
     expect(events.map((event) => event.type)).toEqual([
       "start",
       "permission_prompt",

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -24,11 +24,7 @@
         "properties": {
           "click_type": {
             "type": "string",
-            "enum": [
-              "single",
-              "double",
-              "right"
-            ],
+            "enum": ["single", "double", "right"],
             "description": "Type of click to perform (default: \"single\")"
           },
           "element_id": {
@@ -52,9 +48,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "reasoning"
-        ]
+        "required": ["reasoning"]
       },
       "executor": "tools/computer-use-click.ts",
       "execution_target": "host"
@@ -80,10 +74,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "text",
-          "reasoning"
-        ]
+        "required": ["text", "reasoning"]
       },
       "executor": "tools/computer-use-type-text.ts",
       "execution_target": "host"
@@ -109,10 +100,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "key",
-          "reasoning"
-        ]
+        "required": ["key", "reasoning"]
       },
       "executor": "tools/computer-use-key.ts",
       "execution_target": "host"
@@ -139,12 +127,7 @@
           },
           "direction": {
             "type": "string",
-            "enum": [
-              "up",
-              "down",
-              "left",
-              "right"
-            ],
+            "enum": ["up", "down", "left", "right"],
             "description": "Scroll direction"
           },
           "amount": {
@@ -160,11 +143,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "direction",
-          "amount",
-          "reasoning"
-        ]
+        "required": ["direction", "amount", "reasoning"]
       },
       "executor": "tools/computer-use-scroll.ts",
       "execution_target": "host"
@@ -210,9 +189,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "reasoning"
-        ]
+        "required": ["reasoning"]
       },
       "executor": "tools/computer-use-drag.ts",
       "execution_target": "host"
@@ -238,10 +215,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "duration_ms",
-          "reasoning"
-        ]
+        "required": ["duration_ms", "reasoning"]
       },
       "executor": "tools/computer-use-wait.ts",
       "execution_target": "host"
@@ -267,17 +241,14 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "app_name",
-          "reasoning"
-        ]
+        "required": ["app_name", "reasoning"]
       },
       "executor": "tools/computer-use-open-app.ts",
       "execution_target": "host"
     },
     {
       "name": "computer_use_run_applescript",
-      "description": "Run an AppleScript command. Prefer this over click/type when possible - it doesn't move the cursor or interrupt the user. Never use 'do shell script' inside AppleScript (blocked for security).",
+      "description": "Run an AppleScript command. Prefer this over click/type when possible - it doesn't move the cursor or interrupt foreground activity. Never use 'do shell script' inside AppleScript (blocked for security).",
       "category": "computer-use",
       "risk": "medium",
       "input_schema": {
@@ -296,10 +267,7 @@
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."
           }
         },
-        "required": [
-          "script",
-          "reasoning"
-        ]
+        "required": ["script", "reasoning"]
       },
       "executor": "tools/computer-use-run-applescript.ts",
       "execution_target": "host"
@@ -317,16 +285,14 @@
             "description": "Human-readable summary of what was accomplished"
           }
         },
-        "required": [
-          "summary"
-        ]
+        "required": ["summary"]
       },
       "executor": "tools/computer-use-done.ts",
       "execution_target": "host"
     },
     {
       "name": "computer_use_respond",
-      "description": "Respond to the user with a text answer instead of performing computer actions. Use this when you can answer directly without interacting with the screen.",
+      "description": "Reply with a text answer instead of performing computer actions. Use this when you can answer directly without interacting with the screen.",
       "category": "computer-use",
       "risk": "low",
       "input_schema": {
@@ -334,17 +300,14 @@
         "properties": {
           "answer": {
             "type": "string",
-            "description": "The text answer to display to the user"
+            "description": "The text answer to display"
           },
           "reasoning": {
             "type": "string",
             "description": "Explanation of how you determined the answer"
           }
         },
-        "required": [
-          "answer",
-          "reasoning"
-        ]
+        "required": ["answer", "reasoning"]
       },
       "executor": "tools/computer-use-respond.ts",
       "execution_target": "host"

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -62,8 +62,8 @@ describe("AskQuestionTool definition", () => {
     expect(def.description).toContain("When in doubt");
     expect(def.description).toContain("plausible interpretations");
     expect(def.description).toContain("remove guessing");
-    expect(def.description).toContain("skips a question");
-    expect(def.description).toContain("skip every question in the batch");
+    expect(def.description).toContain("a question is skipped");
+    expect(def.description).toContain("every question in the batch is skipped");
     // Batching language is back now that the prompter handles batches.
     expect(def.description).toContain("Batch related clarifications");
     expect(def.description).toContain("up to 5");


### PR DESCRIPTION
## Summary
- Update computer-use TOOLS.json manifest to match the new softened descriptions for `computer_use_run_applescript`, `computer_use_respond`, and its `answer` parameter.
- Update `ask-question-tool.test.ts` substring assertions to match the new "is skipped" wording.
- Update `tool-executor-lifecycle-events.test.ts` permission-denied assertion to match the new message (drops "by user").

(Prettier also collapsed pre-existing multi-line JSON arrays in TOOLS.json into single lines — incidental reformat triggered by the pre-commit hook on the staged file.)

## Original prompt
Fix the specific CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/25906459681/job/76141259490. Three tests broke after commit `664d889094` softened "the user" wording in LLM-visible tool descriptions but didn't update the static TOOLS.json manifest or two test assertions that compared against the prior strings.