### PR TITLE
feat(assistant): add tools.exclude config to hide tools from the LLM

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -53,6 +53,7 @@ import {
   RateLimitConfigSchema,
   TimeoutConfigSchema,
 } from "./schemas/timeouts.js";
+import { ToolsConfigSchema } from "./schemas/tools.js";
 import { UpdatesConfigSchema } from "./schemas/updates.js";
 import { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
@@ -117,6 +118,7 @@ export const AssistantConfigSchema = z
       NotificationsConfigSchema.parse({}),
     ),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
+    tools: ToolsConfigSchema.default(ToolsConfigSchema.parse({})),
     // Per-plugin config blocks keyed by plugin name. The schema is intentionally
     // permissive — each plugin's manifest supplies its own validator which the
     // plugin bootstrap (`external-plugins-bootstrap.ts`) runs against the raw

--- a/assistant/src/config/schemas/tools.ts
+++ b/assistant/src/config/schemas/tools.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const ToolsConfigSchema = z
+  .object({
+    exclude: z
+      .array(z.string(), { error: "tools.exclude must be an array of strings" })
+      .default([])
+      .describe(
+        "Tool names to suppress. Excluded tools are not sent to the LLM. Names match `ToolDefinition.name` exactly (e.g. `bash`, `mcp__server__tool`).",
+      ),
+  })
+  .describe("Tool visibility configuration");
+
+export type ToolsConfig = z.infer<typeof ToolsConfigSchema>;

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the `config.tools.exclude` filter applied inside
+ * `createResolveToolsCallback`. Excluded tool names must not appear in the
+ * tool list resolved per turn, nor in the executor's `allowedToolNames`.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as configLoader from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/schema.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import {
+  __clearRegistryForTesting,
+  registerMcpTools,
+} from "../../tools/registry.js";
+import type { Tool } from "../../tools/types.js";
+import { createResolveToolsCallback } from "../conversation-tool-setup.js";
+
+type SkillProjectionContext =
+  import("../conversation-tool-setup.js").SkillProjectionContext;
+type SkillProjectionCache =
+  import("../conversation-skill-tools.js").SkillProjectionCache;
+
+function def(name: string): ToolDefinition {
+  return { name, description: name, input_schema: { type: "object" } };
+}
+
+function mcpTool(name: string): Tool {
+  return {
+    name,
+    description: name,
+    origin: "mcp",
+    getDefinition: () => def(name),
+  } as unknown as Tool;
+}
+
+function makeCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
+    coreToolNames: new Set<string>(),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+function withExclude(exclude: string[]) {
+  const stub: Partial<AssistantConfig> = { tools: { exclude } };
+  return spyOn(configLoader, "getConfig").mockReturnValue(
+    stub as AssistantConfig,
+  );
+}
+
+let getConfigSpy: ReturnType<typeof withExclude> | undefined;
+
+beforeEach(() => {
+  __clearRegistryForTesting();
+});
+
+afterEach(() => {
+  getConfigSpy?.mockRestore();
+  getConfigSpy = undefined;
+  __clearRegistryForTesting();
+});
+
+describe("createResolveToolsCallback — config.tools.exclude", () => {
+  test("excluded core tool is omitted from the resolved tool list", () => {
+    getConfigSpy = withExclude(["bash"]);
+    const resolver = createResolveToolsCallback(
+      [def("bash"), def("file_read")],
+      makeCtx(),
+    );
+    const result = resolver!([]);
+    expect(result.map((d) => d.name)).toEqual(["file_read"]);
+  });
+
+  test("excluded core tool is removed from ctx.allowedToolNames", () => {
+    getConfigSpy = withExclude(["bash"]);
+    const ctx = makeCtx();
+    const resolver = createResolveToolsCallback(
+      [def("bash"), def("file_read")],
+      ctx,
+    );
+    resolver!([]);
+    expect(ctx.allowedToolNames?.has("bash")).toBe(false);
+    expect(ctx.allowedToolNames?.has("file_read")).toBe(true);
+  });
+
+  test("excluded MCP tool is omitted from the resolved tool list", () => {
+    registerMcpTools([
+      mcpTool("mcp__server__navigate"),
+      mcpTool("mcp__server__click"),
+    ]);
+    getConfigSpy = withExclude(["mcp__server__navigate"]);
+    const resolver = createResolveToolsCallback(
+      [def("mcp__server__navigate"), def("mcp__server__click")],
+      makeCtx(),
+    );
+    const result = resolver!([]);
+    expect(result.map((d) => d.name)).toEqual(["mcp__server__click"]);
+  });
+
+  test("unknown name in exclude list is silently ignored", () => {
+    getConfigSpy = withExclude(["does_not_exist"]);
+    const resolver = createResolveToolsCallback([def("file_read")], makeCtx());
+    expect(() => resolver!([])).not.toThrow();
+    expect(resolver!([]).map((d) => d.name)).toEqual(["file_read"]);
+  });
+
+  test("empty exclude list leaves the tool set unchanged", () => {
+    getConfigSpy = withExclude([]);
+    const resolver = createResolveToolsCallback(
+      [def("bash"), def("file_read")],
+      makeCtx(),
+    );
+    expect(
+      resolver!([])
+        .map((d) => d.name)
+        .sort(),
+    ).toEqual(["bash", "file_read"]);
+  });
+
+  test("excluded tool stays excluded under disk-pressure cleanup mode", () => {
+    // `bash` is a cleanup-safe tool and would normally survive cleanup mode;
+    // the exclude filter must still suppress it.
+    getConfigSpy = withExclude(["bash"]);
+    const ctx = makeCtx({ diskPressureCleanupModeActive: true });
+    const resolver = createResolveToolsCallback(
+      [def("bash"), def("file_read")],
+      ctx,
+    );
+    const result = resolver!([]);
+    expect(result.map((d) => d.name)).not.toContain("bash");
+    expect(ctx.allowedToolNames?.has("bash")).toBe(false);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -13,6 +13,7 @@ import {
 } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
+import { getConfig } from "../config/loader.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -571,7 +572,10 @@ export function createResolveToolsCallback(
     const scopedMcpDefs = ctx.subagentAllowedTools
       ? currentMcpDefs.filter((d) => ctx.subagentAllowedTools!.has(d.name))
       : currentMcpDefs;
-    const allBaseDefs = [...scopedCoreDefs, ...scopedMcpDefs];
+    const excluded = new Set(getConfig().tools.exclude);
+    const allBaseDefs = [...scopedCoreDefs, ...scopedMcpDefs].filter(
+      (d) => !excluded.has(d.name),
+    );
 
     const effectivePreactivated = [
       ...DEFAULT_PREACTIVATED_SKILL_IDS,
@@ -588,6 +592,7 @@ export function createResolveToolsCallback(
       if (ctx.subagentAllowedTools && !ctx.subagentAllowedTools.has(name)) {
         continue;
       }
+      if (excluded.has(name)) continue;
       turnAllowed.add(name);
     }
     if (ctx.diskPressureCleanupModeActive === true) {


### PR DESCRIPTION
## Summary
- Add `tools.exclude: string[]` to `config.json`. Names listed there are filtered out of the per-turn tool list `createResolveToolsCallback` returns to the agent loop, and stripped from `ctx.allowedToolNames` so the executor refuses them too.
- Filter runs at the per-turn chokepoint inside `createResolveToolsCallback`, so it covers core, MCP, host, and UI-surface tools uniformly. The disk-pressure cleanup branch inherits the filter through the already-filtered `allBaseDefs`/`turnAllowed`, regression-tested.
- New unit tests in `assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts` cover core, MCP, unknown-name (silent ignore), empty-list, and disk-pressure cleanup scenarios.

## Original prompt
The user wanted a way to mark specific tools as hidden from the LLM via `config.json` — phrased as "exclude from the system prompt," though in practice tools are sent in the structured Anthropic `tools` API field rather than embedded in the system prompt text. The plan filters that field (and the executor allowlist) by tool name, with live reload via the existing config file-signature cache so edits take effect on the next turn without restarting the conversation.

Closes #30817
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->