### PR TITLE
fix(macos): extract onReceive flag handler to unblock Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -324,6 +324,12 @@ extension MessageListView {
         }
     }
 
+    func handleFeatureFlagDidChange(_ notification: Notification) {
+        guard let key = notification.userInfo?["key"] as? String, key == "scroll-debug-overlay" else { return }
+        let enabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
+        isScrollDebugOverlayEnabled = enabled
+    }
+
     /// Window-became-key counterpart to `handleConfirmationFocusIfNeeded`:
     /// when the app regains key window status while a pending confirmation
     /// is active, hand focus off the composer so the bubble's key monitor

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -283,9 +283,7 @@ struct MessageListView: View {
                 isScrollDebugOverlayEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
             }
             .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-                guard let key = notification.userInfo?["key"] as? String, key == "scroll-debug-overlay" else { return }
-                let enabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("scroll-debug-overlay")
-                isScrollDebugOverlayEnabled = enabled
+                handleFeatureFlagDidChange(notification)
             }
             .onDisappear {
                 scrollState.cancelAll()


### PR DESCRIPTION
## Summary
- Extracted the `.onReceive(.assistantFeatureFlagDidChange)` closure body into `handleFeatureFlagDidChange(_:)` in the `MessageListView+Lifecycle` extension
- Mirrors the existing `handleWindowDidBecomeKey(_:)` pattern from PR #30814
- The prior fix (typed local + assignment in #30815) was insufficient — the view builder chain is too complex for the compiler even with the split

## Original prompt
Fix Swift compiler error at `MessageListView.swift:288` where the compiler is unable to type-check the `isScrollDebugOverlayEnabled = enabled` assignment in reasonable time. The previous fix (splitting into a typed local) wasn't enough — the entire `.onReceive` closure body needs to be extracted into a helper method to reduce type-checker pressure on the view builder chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->