### PR TITLE
fix(macos): extract scroll debug closures to unblock Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -129,4 +129,16 @@ extension MessageListView {
         }
     }
 
+    // MARK: - Scroll debug callbacks
+
+    func handleDebugAnchorShift() {
+        guard isScrollDebugOverlayEnabled else { return }
+        scrollState.recordDebugAnchorShift()
+    }
+
+    func handleDebugAnchorDecision(_ event: ScrollAnchorDecisionEvent) {
+        guard isScrollDebugOverlayEnabled else { return }
+        scrollState.recordAnchorDecision(event)
+    }
+
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -206,31 +206,10 @@ struct MessageListView: View {
                                     // the snap.
                                     !scrollState.isPaginationInFlight && scrollState.isStreamingActive
                                 },
-                                onAnchorShift: { [scrollState, isScrollDebugOverlayEnabled] in
-                                    // Debug-only counter for anchor-preserver
-                                    // activations. Gated on the cached flag
-                                    // so the hot path doesn't take the flag
-                                    // manager's `NSLock` per shift.
-                                    guard isScrollDebugOverlayEnabled else { return }
-                                    scrollState.recordDebugAnchorShift()
-                                },
-                                onAnchorDecision: { [scrollState, isScrollDebugOverlayEnabled] event in
-                                    // Debug-only full-decision log. Captures
-                                    // skips (shrinks, live-scroll gate, etc.)
-                                    // plus applies, with pre/post offsets.
-                                    guard isScrollDebugOverlayEnabled else { return }
-                                    scrollState.recordAnchorDecision(event)
-                                },
+                                onAnchorShift: handleDebugAnchorShift,
+                                onAnchorDecision: handleDebugAnchorDecision,
                                 onContentHeightSourceDiagnostic: isScrollDebugOverlayEnabled
-                                    ? { event in
-                                        // Debug-only attribution of which subview
-                                        // grew/shrank when contentH ticked by a
-                                        // small amount. Passing the callback as
-                                        // `nil` when the flag is off short-circuits
-                                        // the coordinator's tree walk entirely,
-                                        // so we pay nothing in production.
-                                        MessageListView.logContentHeightSource(event)
-                                      }
+                                    ? MessageListView.logContentHeightSource
                                     : nil
                             )
                         )


### PR DESCRIPTION
## Summary
- Extract `onAnchorShift` and `onAnchorDecision` inline closures into `handleDebugAnchorShift()` and `handleDebugAnchorDecision()` methods in the `ScrollHandling` extension
- Replace `onContentHeightSourceDiagnostic` wrapping closure with a direct static-method reference (`MessageListView.logContentHeightSource`)
- Reduces expression complexity in the `MessageListScrollObserver` initializer to unblock the Swift type-checker

## Original prompt
The Swift compiler was unable to type-check the `MessageListScrollObserver` initializer expression in `MessageListView.swift` within reasonable time (error at line 215). This is a continuation of the pattern from recent PRs (#30819, #30815, #30814) that extract complex closures from the view body to help the type-checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->