### PR TITLE
fix(macos): extract scroll observer init to unblock Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -129,7 +129,25 @@ extension MessageListView {
         }
     }
 
+    // MARK: - Scroll observer
+
+    var scrollObserver: MessageListScrollObserver {
+        MessageListScrollObserver(
+            onGeometryChange: enqueueScrollGeometryUpdate,
+            shouldPreserveScrollAnchor: shouldPreserveScrollAnchor,
+            onAnchorShift: handleDebugAnchorShift,
+            onAnchorDecision: handleDebugAnchorDecision,
+            onContentHeightSourceDiagnostic: isScrollDebugOverlayEnabled
+                ? MessageListView.logContentHeightSource
+                : nil
+        )
+    }
+
     // MARK: - Scroll debug callbacks
+
+    private func shouldPreserveScrollAnchor() -> Bool {
+        !scrollState.isPaginationInFlight && scrollState.isStreamingActive
+    }
 
     func handleDebugAnchorShift() {
         guard isScrollDebugOverlayEnabled else { return }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -182,37 +182,7 @@ struct MessageListView: View {
                     Spacer(minLength: 0)
                     scrollViewContent
                         .fixedWidth(widths.chatColumnWidth)
-                        .background(
-                            MessageListScrollObserver(
-                                onGeometryChange: { newState in
-                                    enqueueScrollGeometryUpdate(newState)
-                                },
-                                shouldPreserveScrollAnchor: { [scrollState] in
-                                    // Anchor preservation absorbs streaming
-                                    // growth at the latest end so users
-                                    // scrolled up don't see their reading
-                                    // position shift. It must NOT fire while
-                                    // idle: idle content-height changes come
-                                    // from `LazyVStack` lazy-cell estimate
-                                    // corrections and media-embed late loads,
-                                    // which are progressive and self-correcting.
-                                    // Compensating them produces large jerky
-                                    // offset shifts that read as scroll jitter.
-                                    //
-                                    // Also skip during pagination — the explicit
-                                    // scroll-to-anchor in `handlePaginationSentinel`
-                                    // owns that flow, and shifting the offset to
-                                    // absorb the older page's height would race
-                                    // the snap.
-                                    !scrollState.isPaginationInFlight && scrollState.isStreamingActive
-                                },
-                                onAnchorShift: handleDebugAnchorShift,
-                                onAnchorDecision: handleDebugAnchorDecision,
-                                onContentHeightSourceDiagnostic: isScrollDebugOverlayEnabled
-                                    ? MessageListView.logContentHeightSource
-                                    : nil
-                            )
-                        )
+                        .background(scrollObserver)
                     Spacer(minLength: 0)
                 }
                 .fixedWidth(widths.scrollSurfaceWidth)


### PR DESCRIPTION
## Summary
- Extract the full `MessageListScrollObserver(...)` initializer from the view body into a `scrollObserver` computed property in `MessageListView+ScrollHandling.swift`
- Extract the `shouldPreserveScrollAnchor` inline closure into a private method
- Simplify `onGeometryChange` to a direct method reference
- Reduces `MessageListView.body` by ~30 lines, breaking up the expression that was causing the Swift type-checker to time out

## Original prompt
After extracting the debug closures in #30820, the Swift compiler still couldn't type-check `MessageListView.body` in reasonable time (error now on line 183 at `scrollViewContent`). The remaining `MessageListScrollObserver` initializer with its closure arguments was still too complex within the deeply nested view builder. This PR moves the entire observer construction out of the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->