### PR TITLE
fix(macos): use explicit closures in scrollObserver to fix Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -132,14 +132,14 @@ extension MessageListView {
     // MARK: - Scroll observer
 
     var scrollObserver: MessageListScrollObserver {
-        MessageListScrollObserver(
-            onGeometryChange: enqueueScrollGeometryUpdate,
-            shouldPreserveScrollAnchor: shouldPreserveScrollAnchor,
-            onAnchorShift: handleDebugAnchorShift,
-            onAnchorDecision: handleDebugAnchorDecision,
-            onContentHeightSourceDiagnostic: isScrollDebugOverlayEnabled
-                ? MessageListView.logContentHeightSource
-                : nil
+        let debugDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? =
+            isScrollDebugOverlayEnabled ? MessageListView.logContentHeightSource : nil
+        return MessageListScrollObserver(
+            onGeometryChange: { [self] state in enqueueScrollGeometryUpdate(state) },
+            shouldPreserveScrollAnchor: { [self] in shouldPreserveScrollAnchor() },
+            onAnchorShift: { [self] in handleDebugAnchorShift() },
+            onAnchorDecision: { [self] event in handleDebugAnchorDecision(event) },
+            onContentHeightSourceDiagnostic: debugDiagnostic
         )
     }
 


### PR DESCRIPTION
## Summary
- Replace bare method references (`enqueueScrollGeometryUpdate`, `shouldPreserveScrollAnchor`, etc.) with explicit closure wrappers using `[self]` capture lists
- Pre-resolve the `isScrollDebugOverlayEnabled` ternary into a typed local variable to avoid inline optional-closure type inference
- Fixes "failed to produce diagnostic for expression" compiler error from #30821

## Original prompt
After #30821 extracted the `MessageListScrollObserver` init into a computed property, the Swift compiler hit a different error: "failed to produce diagnostic for expression" — a Swift bug triggered when the type checker can't resolve method references as closure arguments in certain generic contexts. The fix is to wrap each method reference in an explicit closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->