### PR TITLE
fix(macos): wrap static method ref in closure to fix Swift type-check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -133,7 +133,7 @@ extension MessageListView {
 
     var scrollObserver: MessageListScrollObserver {
         let debugDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? =
-            isScrollDebugOverlayEnabled ? MessageListView.logContentHeightSource : nil
+            isScrollDebugOverlayEnabled ? { event in MessageListView.logContentHeightSource(event) } : nil
         return MessageListScrollObserver(
             onGeometryChange: { [self] state in enqueueScrollGeometryUpdate(state) },
             shouldPreserveScrollAnchor: { [self] in shouldPreserveScrollAnchor() },


### PR DESCRIPTION
## Summary
- Replace `MessageListView.logContentHeightSource` bare static method reference with `{ event in MessageListView.logContentHeightSource(event) }` explicit closure
- Fixes "failed to produce diagnostic for expression" compiler error from #30822

## Original prompt
After #30822, the Swift compiler still hit a type-check failure on the ternary assigning the `debugDiagnostic` local — the bare static method reference `MessageListView.logContentHeightSource` in a ternary with `nil` triggers a Swift compiler bug. Wrapping it in an explicit closure resolves the ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->