### PR TITLE
fix(macos): extract diagnostic callback to computed property

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -132,18 +132,21 @@ extension MessageListView {
     // MARK: - Scroll observer
 
     var scrollObserver: MessageListScrollObserver {
-        let debugDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? =
-            isScrollDebugOverlayEnabled ? { event in MessageListView.logContentHeightSource(event) } : nil
-        return MessageListScrollObserver(
+        MessageListScrollObserver(
             onGeometryChange: { [self] state in enqueueScrollGeometryUpdate(state) },
             shouldPreserveScrollAnchor: { [self] in shouldPreserveScrollAnchor() },
             onAnchorShift: { [self] in handleDebugAnchorShift() },
             onAnchorDecision: { [self] event in handleDebugAnchorDecision(event) },
-            onContentHeightSourceDiagnostic: debugDiagnostic
+            onContentHeightSourceDiagnostic: debugContentHeightDiagnostic
         )
     }
 
     // MARK: - Scroll debug callbacks
+
+    private var debugContentHeightDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? {
+        guard isScrollDebugOverlayEnabled else { return nil }
+        return { event in MessageListView.logContentHeightSource(event) }
+    }
 
     private func shouldPreserveScrollAnchor() -> Bool {
         !scrollState.isPaginationInFlight && scrollState.isStreamingActive


### PR DESCRIPTION
## Summary
- Move the `debugDiagnostic` ternary from a local `let` in `scrollObserver` into its own `debugContentHeightDiagnostic` computed property
- Use `guard/return` pattern instead of ternary to avoid the closure-vs-nil ambiguity that triggers the Swift compiler bug
- Fixes "failed to produce diagnostic for expression" error that persisted through #30822 and #30823

## Original prompt
The Swift compiler was still failing on the ternary expression `isScrollDebugOverlayEnabled ? { event in ... } : nil` inside `scrollObserver`, even with an explicit type annotation on the `let` binding. This is a known Swift type checker limitation where ternary expressions containing closure literals and `nil` confuse the checker regardless of type context. Extracting to a separate computed property with `guard/return` eliminates the ternary entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->