### PR TITLE
fix(macos): preserve streaming text when message ID goes stale

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -3344,7 +3344,7 @@ final class ChatViewModelTests: XCTestCase {
                        "No new messages should be created during history load")
     }
 
-    func testFlushDiscardsStaleBuffer() {
+    func testFlushPromotesStaleBufferToNewMessage() {
         // Set currentAssistantMessageId to a UUID that doesn't correspond to
         // any message in the messages array (stale reference after a history
         // replacement or reconnect).
@@ -3353,14 +3353,23 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.streamingDeltaBuffer = "orphaned buffer text"
         let initialMessageCount = viewModel.messages.count
 
-        // Flush should detect the stale ID and discard the buffer instead of
-        // creating an orphan assistant message.
+        // Flush should promote the buffered text into a new assistant message
+        // rather than silently discarding it. Dropping leading chunks of a
+        // streaming response corrupts inline markup (e.g. <thinking> tags) on
+        // the rendered side, which is worse than the orphan-message risk the
+        // discard branch originally guarded against — message_complete will
+        // backfill daemonMessageId on the new message.
         viewModel.flushStreamingBuffer()
 
-        XCTAssertEqual(viewModel.messages.count, initialMessageCount,
-                       "Stale flush should not create a new message")
-        XCTAssertNil(viewModel.currentAssistantMessageId,
-                     "Stale flush should reset currentAssistantMessageId to nil")
+        XCTAssertEqual(viewModel.messages.count, initialMessageCount + 1,
+                       "Stale flush should create a new assistant message from the buffered text")
+        XCTAssertEqual(viewModel.messages.last?.text, "orphaned buffer text",
+                       "Promoted message should contain the previously-stale buffer")
+        XCTAssertEqual(viewModel.messages.last?.role, .assistant)
+        XCTAssertEqual(viewModel.currentAssistantMessageId, viewModel.messages.last?.id,
+                       "currentAssistantMessageId should reference the new message")
+        XCTAssertNotEqual(viewModel.currentAssistantMessageId, staleId,
+                          "currentAssistantMessageId should no longer reference the stale UUID")
     }
 
     // MARK: - Buffered Text Before Finalize Invariant

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -108,11 +108,11 @@ extension ChatViewModel {
             } else {
                 messages[index].textSegments[messages[index].textSegments.count - 1] += text
             }
-        } else if currentAssistantMessageId != nil {
-            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(text.count) buffered chars")
-            currentAssistantMessageId = nil
-            return
         } else {
+            if let staleId = currentAssistantMessageId {
+                log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) chars to new message")
+                currentAssistantMessageId = nil
+            }
             var msg = ChatMessage(role: .assistant, text: text, isStreaming: true)
             if currentTurnUserText == "/models" {
                 msg.modelList = ModelListData()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -276,12 +276,20 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Cancel any pending idle fallback and clear per-message turn tracking state.
     /// Every code path that sets `currentAssistantMessageId = nil` should call this
     /// instead to ensure the idle fallback timer is always cancelled.
+    ///
+    /// Also discards any in-flight streaming/partial-output buffers tied to the
+    /// turn being cleared. A scheduled flush firing after this point would
+    /// otherwise try to append to a now-nil `currentAssistantMessageId`, creating
+    /// an orphan message — or worse, append to a freshly assigned ID from the
+    /// next turn, splicing dropped leading chunks of the next response.
     func clearCurrentTurnTracking() {
         idleFallbackTask?.cancel()
         idleFallbackTask = nil
         currentAssistantMessageId = nil
         currentTurnUserText = nil
         currentAssistantHasText = false
+        discardStreamingBuffer()
+        discardPartialOutputBuffer()
     }
 
     /// Whether the assistant is actively working on a response — covers sending,

--- a/clients/shared/Tests/ClearCurrentTurnTrackingTests.swift
+++ b/clients/shared/Tests/ClearCurrentTurnTrackingTests.swift
@@ -66,4 +66,26 @@ final class ClearCurrentTurnTrackingTests: XCTestCase {
         // isThinking uses a setter that may schedule/cancel watchdogs, so just verify
         // the method doesn't crash when other turn state is set.
     }
+
+    func testDiscardsStreamingBuffers() {
+        // A flush scheduled after the turn is cleared would otherwise either
+        // create an orphan message or splice dropped leading chunks into the
+        // next turn's response (corrupting inline <thinking> tags on render).
+        viewModel.currentAssistantMessageId = UUID()
+        viewModel.streamingDeltaBuffer = "buffered text from cancelled turn"
+        viewModel.streamingFlushTask = Task { @MainActor in }
+        viewModel.thinkingDeltaBuffer = "buffered thinking"
+        viewModel.thinkingFlushTask = Task { @MainActor in }
+
+        viewModel.clearCurrentTurnTracking()
+
+        XCTAssertTrue(viewModel.streamingDeltaBuffer.isEmpty,
+                      "streamingDeltaBuffer should be discarded")
+        XCTAssertNil(viewModel.streamingFlushTask,
+                     "streamingFlushTask should be cancelled and nil'd")
+        XCTAssertTrue(viewModel.thinkingDeltaBuffer.isEmpty,
+                      "thinkingDeltaBuffer should be discarded")
+        XCTAssertNil(viewModel.thinkingFlushTask,
+                     "thinkingFlushTask should be cancelled and nil'd")
+    }
 }


### PR DESCRIPTION
## Summary
- `appendTextToCurrentMessage` no longer silently discards buffered text when `currentAssistantMessageId` references a missing message — it promotes the buffer into a new assistant message instead. `message_complete` backfills `daemonMessageId` on the new message, so the orphan risk the discard branch originally guarded against is gone.
- `clearCurrentTurnTracking` now also calls `discardStreamingBuffer()` and `discardPartialOutputBuffer()`, making turn-clear a single atomic operation. Defends every call site instead of relying on each one to remember the discard sequence.
- Tests updated: the test that locked in the old discard behavior now asserts the promote-not-drop contract, and a new test in `ClearCurrentTurnTrackingTests` locks in the buffer-discard side effect.

## Original prompt
Investigating why inline `<thinking>...</thinking>` blocks sometimes misrender in the macOS chat UI — either ending mid-sentence with leakage into the response area, or rendering as a plain text bubble ending with a literal `</thinking>`. Confirmed the raw Anthropic SSE response and stored conversation messages both have balanced tags, so the loss happens entirely client-side after the daemon emits the deltas. Comparing the stored assistant message to the rendered output showed ~56 leading characters missing — including the opening `<thinking>` tag — which is exactly the failure mode of `appendTextToCurrentMessage`'s stale-ID discard branch. Goal: stop silently dropping leading streaming chunks and harden `clearCurrentTurnTracking` so the next time the message array is mutated mid-stream nothing gets lost.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->