### PR TITLE
feat(macos): persist scroll-anchor diagnostic next to CSV in ~/Downloads/

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -239,6 +239,14 @@ final class MessageListScrollState {
     @ObservationIgnored var isStreamingActive: Bool = false
     @ObservationIgnored var paginationTask: Task<Void, Never>?
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
+    /// Receiver for `ContentHeightSourceDiagnosticEvent`s — set by the
+    /// scroll-debug overlay when the user starts a recording session,
+    /// cleared on stop. `MessageListView`'s
+    /// `onContentHeightSourceDiagnostic` callback dispatches through this
+    /// optional so the overlay can capture per-event subview attribution
+    /// to a sidecar file paired with the CSV. `nil` whenever the user
+    /// isn't actively recording.
+    @ObservationIgnored weak var anchorDiagSink: ScrollAnchorDiagSink?
 
     // MARK: - Debug metrics (populated only when scroll-debug-overlay is on)
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -302,7 +302,13 @@ extension MessageListView {
         let truncated = event.changedSubviews.count > maxEntries
             ? " …+\(event.changedSubviews.count - maxEntries)"
             : ""
-        scrollDiagLog.debug("contentHΔ=\(event.contentHDelta) changed=\(event.changedSubviews.count): \(summary)\(truncated)")
+        // `.info` rather than `.debug` so the entries land in the in-memory
+        // log buffer reachable by `log show --info` and `log stream`.
+        // `.debug` would only be retrievable after `log config --mode
+        // "level:debug" --subsystem ...`, which is too much setup for a
+        // dev-only diagnostic — the sidecar file is the durable path; this
+        // emission exists for live tailing.
+        scrollDiagLog.info("contentHΔ=\(event.contentHDelta) changed=\(event.changedSubviews.count): \(summary)\(truncated)")
     }
 
     // MARK: - Confirmation focus

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -145,7 +145,17 @@ extension MessageListView {
 
     private var debugContentHeightDiagnostic: (@MainActor (ContentHeightSourceDiagnosticEvent) -> Void)? {
         guard isScrollDebugOverlayEnabled else { return nil }
-        return { event in MessageListView.logContentHeightSource(event) }
+        // Two paths, both fed by every event so investigators can pick the
+        // capture method that matches their workflow:
+        //   • `scrollState.anchorDiagSink` is set while the HUD's "rec" button
+        //     is active, capturing events to a sidecar file paired with the
+        //     CSV in `~/Downloads/` for offline analysis.
+        //   • `logContentHeightSource` emits to `os.Logger` at `.info` for
+        //     live `log stream` users who'd rather watch it interactively.
+        return { [self] event in
+            scrollState.anchorDiagSink?.record(event)
+            MessageListView.logContentHeightSource(event)
+        }
     }
 
     private func shouldPreserveScrollAnchor() -> Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -204,11 +204,17 @@ struct ScrollDebugOverlayView: View {
 
     private func toggleRecording() {
         if recorder.isRecording {
+            scrollState.anchorDiagSink = nil
             if let url = recorder.stop() {
                 NSWorkspace.shared.activateFileViewerSelecting([url])
             }
         } else {
             recorder.start()
+            // Route diag events into the recorder for the duration of the
+            // recording session. Cleared on stop so the callback can stay
+            // wired on `MessageListView` without leaking events into a
+            // recorder that's no longer collecting.
+            scrollState.anchorDiagSink = recorder
         }
     }
 
@@ -267,14 +273,33 @@ struct ScrollDebugOverlayView: View {
     }
 }
 
+// MARK: - ScrollAnchorDiagSink
+
+/// Receiver for `ContentHeightSourceDiagnosticEvent`s emitted by
+/// `MessageListScrollObserver`'s coordinator. Lets `MessageListView` route
+/// events to whichever sink is interested without taking a direct dependency
+/// on `ScrollDebugRecorder` — the recorder lives on `ScrollDebugOverlayView`
+/// and is reached via `MessageListScrollState.anchorDiagSink`, which is set
+/// when recording starts and cleared on stop.
+@MainActor
+protocol ScrollAnchorDiagSink: AnyObject {
+    func record(_ event: ContentHeightSourceDiagnosticEvent)
+}
+
 // MARK: - ScrollDebugRecorder
 
 /// Captures per-frame snapshots of the scroll metrics displayed in the HUD
 /// and writes them as CSV to `~/Downloads` on stop. Only exists when the
 /// scroll-debug overlay is mounted — all work happens on the main actor.
+///
+/// Also accumulates `ContentHeightSourceDiagnosticEvent`s when wired up as
+/// the `MessageListScrollState.anchorDiagSink`, and writes them to a
+/// sidecar text file paired with the CSV on stop. The sidecar uses the
+/// same `<timestamp>` suffix as the CSV so the two always line up when
+/// shipped to whoever's debugging.
 @Observable
 @MainActor
-final class ScrollDebugRecorder {
+final class ScrollDebugRecorder: ScrollAnchorDiagSink {
     /// Observed so the record button's label/indicator update when recording
     /// toggles. The frame buffer and session start are `@ObservationIgnored` —
     /// appending to them inside the HUD's body would otherwise invalidate
@@ -285,6 +310,26 @@ final class ScrollDebugRecorder {
     /// time, which is computed off the first frame's timestamp.
     @ObservationIgnored var sessionStartTime: Date?
     @ObservationIgnored var frames: [Frame] = []
+    /// `ContentHeightSourceDiagnosticEvent`s collected via `record(_:)`
+    /// while recording. Written to a sidecar text file paired with the CSV
+    /// on `stop()`. Cleared by `clear()` alongside `frames`.
+    @ObservationIgnored var diagEvents: [DiagEvent] = []
+
+    /// Compact in-memory copy of a `ContentHeightSourceDiagnosticEvent` —
+    /// stored separately from the live struct so we can keep the recorder's
+    /// buffer growth bounded (`maxDiagSubviewsPerEvent` truncates the
+    /// per-event subview list at capture time, not write time).
+    struct DiagEvent {
+        let timestamp: Date
+        let contentHDelta: CGFloat
+        let totalChangedCount: Int
+        let subviews: [ContentHeightSourceDiagnosticEvent.ChangedSubview]
+    }
+
+    /// Cap on per-event subview entries kept in memory and written to disk.
+    /// A single layout storm under the 8pt `contentHDelta` threshold can
+    /// emit hundreds of changes; this keeps the diag file size bounded.
+    static let maxDiagSubviewsPerEvent: Int = 32
 
     struct Frame {
         let timestamp: Date
@@ -338,22 +383,46 @@ final class ScrollDebugRecorder {
         frames.append(frame)
     }
 
+    /// `ScrollAnchorDiagSink` conformance. Called by `MessageListView`'s
+    /// `onContentHeightSourceDiagnostic` callback once per small `contentH`
+    /// delta while the overlay flag is on. No-op when not recording so the
+    /// callback can stay wired to `scrollState` for the whole session
+    /// without leaking events into a stopped recorder.
+    func record(_ event: ContentHeightSourceDiagnosticEvent) {
+        guard isRecording else { return }
+        let trimmed = event.changedSubviews.prefix(Self.maxDiagSubviewsPerEvent)
+        diagEvents.append(DiagEvent(
+            timestamp: event.at,
+            contentHDelta: event.contentHDelta,
+            totalChangedCount: event.changedSubviews.count,
+            subviews: Array(trimmed)
+        ))
+    }
+
     /// Stop recording and write the accumulated buffer to
-    /// `~/Downloads/vellum-scroll-debug-<timestamp>.csv`. Frames are kept so
-    /// a subsequent `start()` appends to the same buffer; call `clear()` to
-    /// reset. Returns the written URL, or `nil` if the buffer was empty or
-    /// the write failed.
+    /// `~/Downloads/vellum-scroll-debug-<timestamp>.csv`. If any diagnostic
+    /// events were collected (via `record(_:)`), also write a paired
+    /// `vellum-scroll-anchor-diag-<timestamp>.txt` using the same anchor
+    /// timestamp so the two files line up when shipped. Frames and diag
+    /// events are kept so a subsequent `start()` appends to the same
+    /// buffers; call `clear()` to reset. Returns the CSV URL, or `nil` if
+    /// the frame buffer was empty or the write failed.
     func stop() -> URL? {
         isRecording = false
         sessionStartTime = nil
-        guard !frames.isEmpty else { return nil }
-        return writeCSV(frames: frames)
+        guard let firstFrame = frames.first else { return nil }
+        let csvURL = writeCSV(frames: frames)
+        if !diagEvents.isEmpty {
+            _ = writeDiagFile(events: diagEvents, anchor: firstFrame.timestamp)
+        }
+        return csvURL
     }
 
     /// Discard the buffer. Safe to call while recording — the next captured
     /// frame becomes the new anchor, and the HUD's elapsed readout restarts.
     func clear() {
         frames.removeAll(keepingCapacity: true)
+        diagEvents.removeAll(keepingCapacity: true)
         if isRecording {
             sessionStartTime = Date()
         } else {
@@ -413,6 +482,55 @@ final class ScrollDebugRecorder {
 
         do {
             try csv.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        } catch {
+            NSLog("ScrollDebugRecorder: failed to write \(url.path): \(error)")
+            return nil
+        }
+    }
+
+    /// Writes the accumulated diagnostic events to a sidecar text file at
+    /// `~/Downloads/vellum-scroll-anchor-diag-<timestamp>.txt`. `anchor`
+    /// matches the CSV's first-frame timestamp so the two files share the
+    /// same suffix and `elapsedSec` baseline. Each line is a flat record:
+    ///
+    /// ```
+    /// <elapsedSec>,<contentHDelta>,<changedCount>,<typeName@path@minY:prev->curr>|...
+    /// ```
+    ///
+    /// Subview entries are pipe-separated inside a single CSV field so each
+    /// line stays parseable. `changedCount` is the untrimmed total — the
+    /// `subviews` list is capped at `maxDiagSubviewsPerEvent`, so the two
+    /// can differ.
+    private func writeDiagFile(events: [DiagEvent], anchor: Date) -> URL? {
+        var out = "elapsedSec,contentHDelta,changedCount,subviews\n"
+        out.reserveCapacity(events.count * 160)
+        for event in events {
+            let elapsed = event.timestamp.timeIntervalSince(anchor)
+            let subviews = event.subviews.map { s in
+                "\(s.typeName)@\(s.path)@\(Int(s.minY)):\(s.previousHeight)->\(s.currentHeight)"
+            }.joined(separator: "|")
+            out.append(String(format: "%.4f", elapsed))
+            out.append(",")
+            out.append(String(format: "%.2f", event.contentHDelta))
+            out.append(",")
+            out.append(String(event.totalChangedCount))
+            out.append(",")
+            out.append(subviews)
+            out.append("\n")
+        }
+
+        let nameFormatter = DateFormatter()
+        nameFormatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        nameFormatter.locale = Locale(identifier: "en_US_POSIX")
+        let filename = "vellum-scroll-anchor-diag-\(nameFormatter.string(from: anchor)).txt"
+
+        let directory = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        let url = directory.appendingPathComponent(filename)
+
+        do {
+            try out.write(to: url, atomically: true, encoding: .utf8)
             return url
         } catch {
             NSLog("ScrollDebugRecorder: failed to write \(url.path): \(error)")


### PR DESCRIPTION
## Summary

- Extend `ScrollDebugRecorder` (the existing CSV recorder behind `scroll-debug-overlay`) to also collect `ContentHeightSourceDiagnosticEvent`s into a buffer while recording, and write them to `~/Downloads/vellum-scroll-anchor-diag-<timestamp>.txt` on stop — same `<timestamp>` suffix as the paired CSV, same `elapsedSec` baseline. One line per event: `elapsedSec,contentHDelta,changedCount,<typeName@path@minY:prev->curr>|…`. Per-event subview list capped at 32 entries so a layout-storm event under the 8pt threshold can't blow up the file.
- Add `ScrollAnchorDiagSink` protocol and a weak `MessageListScrollState.anchorDiagSink` field. `ScrollDebugOverlayView.toggleRecording()` assigns the recorder as the sink on start and clears it on stop. The `MessageListView+ScrollHandling.debugContentHeightDiagnostic` callback now dispatches every event to both `scrollState.anchorDiagSink?.record(…)` (sidecar capture) and `os.Logger` (live tailers).
- Upgrade the `ScrollAnchorDiag` `os.Logger` call from `.debug` to `.info`. On macOS, `.debug` entries sit in a tiny in-memory ring buffer that `log show` cannot read back retroactively — `.info` lands in the in-memory buffer reachable by `log show --info` and `log stream`, which is enough for live tailing while still avoiding disk pressure from a 100+/sec emit rate.

## Original prompt

PR #30813 added subview-attribution instrumentation that emits via `scrollDiagLog.debug(…)`. The user has captured four scroll-debug CSVs in `~/Downloads/` over the last two hours but the paired diagnostic logs never land — `log show --info --debug --last 30m --predicate 'category == "ScrollAnchorDiag"'` returns zero rows because `.debug`-level entries in macOS unified logging are ephemeral and not persisted to disk. The user's working capture path is "press the HUD's rec button, send the CSV from `~/Downloads/`"; the diagnostic needs to ride that same path. This PR routes the events into the existing recorder so the next session produces a CSV *and* a sidecar diag file in `~/Downloads/` automatically — no `log stream` setup, no log buffer dependence.

The diag file's per-event lines line up with the CSV's `elapsedSec` so we can locate the exact moment of any anomaly (e.g. the `±7` oscillation in `vellum-scroll-debug-2026-05-15-041346.csv`) and read off which `NSView` (by path / type / minY) changed height at that tick. That tells us whether the next anchor fix should be the reference-element approach or the tighter offset gate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->