### PR TITLE
fix(macos): anchor chat scroll to a visible reference, not contentH delta

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -107,11 +107,33 @@ struct MessageListScrollObserver: NSViewRepresentable {
         /// instrumentation targets the steady ~1pt drift seen during
         /// streaming.
         private static let diagnosticContentHDeltaThreshold: CGFloat = 8
-        /// Last observed `documentView.frame.height`. Used to compute the
-        /// growth delta for anchor preservation. Reset to 0 on attach/detach
-        /// so a stale baseline from a previous conversation cannot apply
-        /// a phantom delta on the first emit of a new ScrollView.
+        /// Last observed `documentView.frame.height`. Kept for telemetry
+        /// (`ScrollAnchorDecisionEvent.contentHDelta`) only — the anchor
+        /// preserver no longer compensates against this value, because
+        /// `contentH` changes can come from sources that don't shift the
+        /// visible rows (LazyVStack height estimates, off-viewport growth
+        /// that doesn't propagate up the materialized subtree). Use
+        /// `lastReferenceY` for the actual compensation baseline.
         private var lastContentHeight: CGFloat = 0
+        /// Weak reference to a stable visible `NSView` whose movement we
+        /// compensate against. Picked on each emit when the previous
+        /// reference is invalidated (removed from the tree, scrolled out
+        /// of the viewport, or zero-height). Re-used otherwise.
+        ///
+        /// Compensating against this view's `minY` in `documentView` coords
+        /// — instead of the global `contentHDelta` — eliminates the failure
+        /// mode where `contentH` grows without visible rows shifting. The
+        /// recorded scroll-debug CSVs show this regularly: streaming
+        /// response below the viewport grows by 1 pt/token, `contentH`
+        /// follows, but the materialized rows in the viewport hold their
+        /// `minY` constant. The old anchor would still apply `+1` per
+        /// token, walking the user away from latest at ~120 pt/sec.
+        private weak var anchorReferenceView: NSView?
+        /// Cached `convert(.zero, to: documentView).y` of `anchorReferenceView`
+        /// from the last emit. The next emit's `Δref` is `currentY -
+        /// lastReferenceY`, which is what we pass to
+        /// `ScrollAnchorPreserver.decide`.
+        private var lastReferenceY: CGFloat = 0
         /// Tracks whether an AppKit live scroll (trackpad/wheel gesture plus
         /// momentum decay) is currently in progress. Bracketed by
         /// `willStartLiveScrollNotification` / `didEndLiveScrollNotification`
@@ -180,6 +202,12 @@ struct MessageListScrollObserver: NSViewRepresentable {
             // conversation switch destroys the old view tree, so stale paths
             // would no longer correspond to anything.
             self.lastSubviewHeights = [:]
+            // Re-attach destroys the old view tree, so any prior reference
+            // is now dangling (weak ref will be nil shortly). Reset
+            // explicitly so the first emit picks a fresh reference from
+            // the new tree without computing a delta against a stale Y.
+            self.anchorReferenceView = nil
+            self.lastReferenceY = 0
             installObservers()
         }
 
@@ -193,6 +221,8 @@ struct MessageListScrollObserver: NSViewRepresentable {
             lastContentHeight = 0
             isLiveScrolling = false
             lastSubviewHeights = [:]
+            anchorReferenceView = nil
+            lastReferenceY = 0
         }
 
         func emitCurrentSnapshotIfPossible() {
@@ -207,20 +237,28 @@ struct MessageListScrollObserver: NSViewRepresentable {
             let clipView = scrollView.contentView
             let currentContentHeight = documentView.frame.height
             let preOffsetY = clipView.bounds.origin.y
+            let containerHeight = clipView.bounds.height
             let contentHDelta = currentContentHeight - lastContentHeight
 
-            // Anchor preservation: when the streaming assistant response
-            // grows and the user is reading older content above the visual
-            // bottom, leaving the offset alone lets the new content push
-            // the visible region upward off the top of the viewport (the
-            // streaming message lives at doc Y=0; growing it shifts every
-            // higher-Y item further from the visual bottom). Shift the
-            // clip view by the height delta so the visible content stays
-            // put. The decision lives in `ScrollAnchorPreserver` so the
-            // logic is unit-testable without an NSScrollView.
+            // Anchor preservation: when content above the visible region
+            // shifts (because a message expanded, a thinking block opened,
+            // an old image loaded), compensate `clipView.bounds.origin.y`
+            // by the same amount so the visible rows hold their visual
+            // position. The compensation amount is the movement of a
+            // *concrete visible reference NSView* — not the global
+            // `contentH` delta. Captured recordings show the streaming
+            // response below the viewport grows by 1 pt/token while no
+            // visible row's `minY` changes, so compensating by
+            // `contentHDelta` would walk the user away from latest with
+            // no corresponding visual cause. Tracking a reference view
+            // instead skips that case cleanly.
+            let referenceDelta = updateAndReadReferenceDelta(
+                documentView: documentView,
+                viewportY: preOffsetY,
+                viewportHeight: containerHeight
+            )
             let decision = ScrollAnchorPreserver.decide(
-                currentContentHeight: currentContentHeight,
-                lastContentHeight: lastContentHeight,
+                compensationDelta: referenceDelta,
                 contentOffsetY: preOffsetY,
                 shouldPreserveAnchor: shouldPreserveScrollAnchor(),
                 isUserLiveScrolling: isLiveScrolling,
@@ -375,8 +413,15 @@ struct MessageListScrollObserver: NSViewRepresentable {
                     // that accumulated during the gesture has already
                     // been absorbed into the user's new scroll position,
                     // so we must not retroactively compensate for it on
-                    // the next passive emit.
+                    // the next passive emit. Both the content-height
+                    // baseline (for telemetry) and the reference baseline
+                    // (for the actual compensation) get reset. Drop the
+                    // reference view entirely: the user likely scrolled
+                    // it out of the viewport, so the next emit will pick
+                    // a fresh one from the post-gesture viewport.
                     self.lastContentHeight = self.documentView?.frame.height ?? 0
+                    self.anchorReferenceView = nil
+                    self.lastReferenceY = 0
                     self.emitCurrentSnapshotIfPossible()
                 }
             })
@@ -390,6 +435,114 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 center.removeObserver(observer)
             }
             observers.removeAll()
+        }
+
+        /// Resolves the anchor reference view for this emit and returns the
+        /// signed delta (in points) that the visible reference has moved
+        /// since the previous emit. The Coordinator passes this delta to
+        /// `ScrollAnchorPreserver.decide` as `compensationDelta`.
+        ///
+        /// If the previous reference is still in the tree and intersects
+        /// the viewport, it's reused and the delta is its `minY` movement
+        /// in `documentView` coords. If invalidated (removed, scrolled out,
+        /// shrunk to zero height), a new reference is picked from the
+        /// current viewport and `0` is returned — no compensation on the
+        /// pick-frame, because there's no previous-Y to diff against.
+        ///
+        /// Returning `0` is also what's expected on the first emit after
+        /// attach: `anchorReferenceView` is `nil`, we pick one, and the
+        /// decide function skips with `.noVisibleShift`.
+        private func updateAndReadReferenceDelta(
+            documentView: NSView,
+            viewportY: CGFloat,
+            viewportHeight: CGFloat
+        ) -> CGFloat {
+            let viewport = CGRect(
+                x: 0,
+                y: viewportY,
+                width: documentView.bounds.width,
+                height: viewportHeight
+            )
+            if let reference = anchorReferenceView, isReferenceStillUsable(reference, in: documentView, viewport: viewport) {
+                let currentY = reference.convert(.zero, to: documentView).y
+                let delta = currentY - lastReferenceY
+                lastReferenceY = currentY
+                return delta
+            }
+            // Reference invalid — pick a new one. No delta on this emit
+            // since there's no previous-Y to diff against.
+            let newReference = pickAnchorReference(in: documentView, viewport: viewport)
+            anchorReferenceView = newReference
+            lastReferenceY = newReference?.convert(.zero, to: documentView).y ?? 0
+            return 0
+        }
+
+        /// A reference is still usable when it's still in the document
+        /// view's subtree, still has a non-zero frame, and still intersects
+        /// the viewport. Anything else means it was recycled, hidden, or
+        /// scrolled fully out — pick a new one rather than tracking a stale
+        /// position that could spike the delta when the view is finally
+        /// destroyed.
+        private func isReferenceStillUsable(_ view: NSView, in documentView: NSView, viewport: CGRect) -> Bool {
+            guard view.isDescendant(of: documentView) else { return false }
+            guard view.frame.height > 0 else { return false }
+            let frameInDoc = view.convert(view.bounds, to: documentView)
+            return frameInDoc.intersects(viewport)
+        }
+
+        /// Picks an anchor reference from the materialized subtree of
+        /// `documentView`. Walks depth-first and returns the deepest
+        /// descendant whose frame intersects the viewport and has non-zero
+        /// height. We prefer the deepest match so we land on a concrete
+        /// row/leaf instead of the outer LazyVStack wrappers (which
+        /// themselves grow as content streams).
+        ///
+        /// Intersection — rather than full containment — is required
+        /// because real-world rows are often taller than the viewport in
+        /// long-running conversations; a strict containment test would
+        /// reject those and leave us with no reference. The deepest-match
+        /// preference still bypasses the wrapper chain even when the
+        /// outer rows are tall.
+        private func pickAnchorReference(in documentView: NSView, viewport: CGRect) -> NSView? {
+            var best: NSView?
+            var bestDepth = -1
+            walkForReference(
+                in: documentView,
+                depth: 0,
+                documentView: documentView,
+                viewport: viewport,
+                best: &best,
+                bestDepth: &bestDepth
+            )
+            return best
+        }
+
+        private func walkForReference(
+            in parent: NSView,
+            depth: Int,
+            documentView: NSView,
+            viewport: CGRect,
+            best: inout NSView?,
+            bestDepth: inout Int
+        ) {
+            guard depth < Self.diagnosticWalkMaxDepth else { return }
+            for child in parent.subviews {
+                guard child.frame.height > 0 else { continue }
+                let frameInDoc = child.convert(child.bounds, to: documentView)
+                guard frameInDoc.intersects(viewport) else { continue }
+                if depth > bestDepth {
+                    best = child
+                    bestDepth = depth
+                }
+                walkForReference(
+                    in: child,
+                    depth: depth + 1,
+                    documentView: documentView,
+                    viewport: viewport,
+                    best: &best,
+                    bestDepth: &bestDepth
+                )
+            }
         }
 
         /// Walks `root`'s descendant tree depth-first by index path, skipping
@@ -454,8 +607,7 @@ enum ScrollAnchorPreserver {
     enum SkipReason: String {
         case anchorPreservationDisabled
         case userLiveScrolling
-        case firstLayout
-        case contentHUnchanged
+        case noVisibleShift
         case jitterBelowThreshold
         case pinnedToLatest
     }
@@ -476,20 +628,20 @@ enum ScrollAnchorPreserver {
 
     /// Rich decision for a single layout-change notification. `offsetDelta`
     /// is a thin convenience over this, kept for tests and simple callers
-    /// that only need the CGFloat?.
+    /// that only need the `CGFloat?`.
     ///
-    /// In the inverted scroll, `contentOffsetY = 0` is the visual bottom
-    /// (latest messages). The streaming assistant response lives at the
-    /// low end of the document (doc Y near 0), so its growth pushes every
-    /// higher-Y item further from the visual bottom — and symmetrically,
-    /// when the streaming edge shrinks (pin spacer release, thinking-block
-    /// collapse during streaming, height-estimate correction) every
-    /// higher-Y item is pulled back toward the visual bottom. Either
-    /// direction moves the user's visible region off the current doc-Y
-    /// window unless the offset is shifted by the same signed delta.
+    /// `compensationDelta` is the signed movement of the *anchor reference
+    /// view* in `documentView` coords since the previous emit. Compensating
+    /// against the reference's movement — instead of the global
+    /// `contentHDelta` — handles the case where `contentH` grows without
+    /// visible rows shifting (streaming response below the viewport, lazy
+    /// height-estimate corrections in off-viewport rows). Recorded CSVs
+    /// caught the old `contentHDelta` formulation walking the user away
+    /// from latest at ~120 pt/sec while no row's `minY` changed; the
+    /// reference-based formulation skips those frames cleanly with
+    /// `.noVisibleShift`.
     static func decide(
-        currentContentHeight: CGFloat,
-        lastContentHeight: CGFloat,
+        compensationDelta: CGFloat,
         contentOffsetY: CGFloat,
         shouldPreserveAnchor: Bool,
         isUserLiveScrolling: Bool,
@@ -497,30 +649,27 @@ enum ScrollAnchorPreserver {
     ) -> Decision {
         if !shouldPreserveAnchor { return .skipped(.anchorPreservationDisabled) }
         if isUserLiveScrolling { return .skipped(.userLiveScrolling) }
-        if lastContentHeight <= 0 { return .skipped(.firstLayout) }
-        if currentContentHeight == lastContentHeight { return .skipped(.contentHUnchanged) }
-        if abs(currentContentHeight - lastContentHeight) < Self.minCompensationDelta {
+        if compensationDelta == 0 { return .skipped(.noVisibleShift) }
+        if abs(compensationDelta) < Self.minCompensationDelta {
             return .skipped(.jitterBelowThreshold)
         }
         if contentOffsetY <= pinnedToLatestEpsilon { return .skipped(.pinnedToLatest) }
-        return .applied(delta: currentContentHeight - lastContentHeight)
+        return .applied(delta: compensationDelta)
     }
 
     /// Returns the offset delta to add to `contentOffsetY` so the visible
-    /// content stays anchored when the document height changes (either
-    /// direction), or `nil` if no adjustment is needed. Kept for tests and
-    /// simple callers — see `decide(...)` for the richer outcome.
+    /// content stays anchored when the reference view's position changes,
+    /// or `nil` if no adjustment is needed. Kept for tests and simple
+    /// callers — see `decide(...)` for the richer outcome.
     static func offsetDelta(
-        currentContentHeight: CGFloat,
-        lastContentHeight: CGFloat,
+        compensationDelta: CGFloat,
         contentOffsetY: CGFloat,
         shouldPreserveAnchor: Bool,
         isUserLiveScrolling: Bool,
         pinnedToLatestEpsilon: CGFloat
     ) -> CGFloat? {
         switch decide(
-            currentContentHeight: currentContentHeight,
-            lastContentHeight: lastContentHeight,
+            compensationDelta: compensationDelta,
             contentOffsetY: contentOffsetY,
             shouldPreserveAnchor: shouldPreserveAnchor,
             isUserLiveScrolling: isUserLiveScrolling,

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -351,7 +351,7 @@ final class ScrollDebugRecorder: ScrollAnchorDiagSink {
         let anchorsPerSecond: Int
         let anchorTotal: Int
         /// Outcome string of the most recent anchor decision: `"applied"` or
-        /// the skip reason (`"contentHUnchanged"`, `"pinnedToLatest"`, etc.).
+        /// the skip reason (`"noVisibleShift"`, `"pinnedToLatest"`, etc.).
         /// Empty before the first decision fires.
         let anchorOutcome: String
         /// Delta applied by the anchor preserver on the most recent decision.

--- a/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollAnchorPreserverTests.swift
@@ -6,17 +6,16 @@ final class ScrollAnchorPreserverTests: XCTestCase {
 
     private static let epsilon: CGFloat = 8
 
-    // MARK: - The streaming bug case
+    // MARK: - Reference-shift compensation
 
-    func testStreamingGrowthShiftsOffsetByDelta() {
-        // User is reading older content 200pt above the visual bottom while
-        // a streaming assistant response (lives at doc Y=0 in the inverted
-        // scroll) grows by 50pt. Without compensation, the user's visible
-        // content scrolls upward off the viewport. Compensation must add
-        // 50pt to the offset so the same content stays in view.
+    func testCompensatesByReferenceShift() {
+        // A row above the visible region expanded by 50pt while the user is
+        // 200pt above the visual bottom. The coordinator observed the
+        // anchor reference's `minY` move 50pt; the preserver must shift
+        // `clipView.bounds.origin.y` by the same 50pt so the same content
+        // stays visible.
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1050,
-            lastContentHeight: 1000,
+            compensationDelta: 50,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -25,12 +24,13 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         XCTAssertEqual(delta, 50)
     }
 
-    func testStreamingGrowthCompensatesByExactDeltaForLargeJump() {
-        // A multi-token batch can land in a single layout pass. The delta
-        // must equal the actual height growth, not be capped or rounded.
+    func testCompensatesByExactReferenceShiftForLargeJump() {
+        // A multi-batch layout (e.g. paginated history finished resolving
+        // height estimates) can move the reference by thousands of points
+        // in a single emit. The delta must equal the actual reference
+        // shift, not be capped or rounded.
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 5000,
-            lastContentHeight: 1000,
+            compensationDelta: 4000,
             contentOffsetY: 800,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -39,44 +39,14 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         XCTAssertEqual(delta, 4000)
     }
 
-    // MARK: - Skip cases
-
-    func testSkipsOnFirstMeasurement() {
-        // Initial attach has lastContentHeight == 0. Compensating against
-        // 0 would treat the entire first emit as a delta and shove the
-        // user far off the visual bottom on first paint.
-        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1000,
-            lastContentHeight: 0,
-            contentOffsetY: 200,
-            shouldPreserveAnchor: true,
-            isUserLiveScrolling: false,
-            pinnedToLatestEpsilon: Self.epsilon
-        ))
-    }
-
-    func testSkipsWhenContentDidNotGrow() {
-        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1000,
-            lastContentHeight: 1000,
-            contentOffsetY: 200,
-            shouldPreserveAnchor: true,
-            isUserLiveScrolling: false,
-            pinnedToLatestEpsilon: Self.epsilon
-        ))
-    }
-
-    func testCompensatesOnContentShrink() {
-        // Symmetric case to the streaming-growth bug: when the streaming
-        // edge collapses (pin-latest-turn spacer release at end-of-stream,
-        // thinking-block dismissal during streaming, height-estimate
-        // correction), existing items at higher doc Y are pulled back
-        // toward the visual bottom by the same amount. Without a negative
-        // offset shift, the user's visible content drifts off the viewport
-        // in the opposite direction from the growth case.
+    func testCompensatesOnNegativeReferenceShift() {
+        // Symmetric case to the growth direction: when a row above the
+        // viewport collapses (thinking-block dismissal, height-estimate
+        // correction), the reference's `minY` decreases. The preserver
+        // must shift by the same negative delta so the viewport doesn't
+        // jump downward.
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 900,
-            lastContentHeight: 1000,
+            compensationDelta: -100,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -88,11 +58,11 @@ final class ScrollAnchorPreserverTests: XCTestCase {
     func testCompensatesOnSmallShrinkFromRecordedRegression() {
         // A per-frame HUD recording captured a 34pt shrink at the tail of
         // a streaming response with no compensation, producing a visible
-        // 34pt viewport jump. With shrink compensation enabled the offset
-        // shifts by -34 and the viewport stays put.
+        // 34pt viewport jump. Translated to the reference-based formulation:
+        // the reference's `minY` decreased by 34pt, the preserver must
+        // shift by -34 to hold the viewport.
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 9741,
-            lastContentHeight: 9775,
+            compensationDelta: -34,
             contentOffsetY: 1798.5,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -101,14 +71,46 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         XCTAssertEqual(delta, -34)
     }
 
-    func testSkipsShrinkWhenPinnedToVisualBottom() {
-        // Symmetric to the growth case: when the user is pinned to the
-        // visual bottom, shrink doesn't apply a negative shift either —
-        // NSScrollView auto-clamps at offset 0 and pulling "past" that
-        // would violate the pinned state the user chose.
+    // MARK: - Skip cases
+
+    func testSkipsWhenReferenceDidNotMove() {
+        // The headline regression: streaming response below the viewport
+        // grows by 1pt/token, `documentView.frame.height` grows in
+        // lockstep, but no row in the materialized subtree changes
+        // position. The coordinator passes `compensationDelta=0` and the
+        // preserver skips. This is the case the old `contentHDelta`
+        // formulation got wrong — applying `+1` per token walked the user
+        // away from latest at the token rate.
         XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 900,
-            lastContentHeight: 1000,
+            compensationDelta: 0,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsOnSubPixelJitter() {
+        // Layout passes occasionally produce sub-pt reference shifts from
+        // font-metric rounding or off-screen relayouts that don't
+        // correspond to a visible shift. Skipping these prevents accumulated
+        // drift from oscillating around a stable layout.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            compensationDelta: 0.3,
+            contentOffsetY: 200,
+            shouldPreserveAnchor: true,
+            isUserLiveScrolling: false,
+            pinnedToLatestEpsilon: Self.epsilon
+        ))
+    }
+
+    func testSkipsShrinkWhenPinnedToVisualBottom() {
+        // When the user is pinned to the visual bottom, shrinks don't
+        // apply a negative shift either — NSScrollView auto-clamps at
+        // offset 0 and pulling "past" that would violate the pinned state
+        // the user chose.
+        XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
+            compensationDelta: -100,
             contentOffsetY: 5,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -121,8 +123,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         // already auto-follows new content there — adding a delta would
         // push them off the bottom they intentionally stayed at.
         XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1100,
-            lastContentHeight: 1000,
+            compensationDelta: 100,
             contentOffsetY: 5,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -133,8 +134,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
     func testSkipsWhenAtExactlyEpsilon() {
         // Boundary: offset == epsilon counts as pinned (strict > check).
         XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1100,
-            lastContentHeight: 1000,
+            compensationDelta: 100,
             contentOffsetY: 8,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -144,8 +144,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
 
     func testCompensatesJustAboveEpsilon() {
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1100,
-            lastContentHeight: 1000,
+            compensationDelta: 100,
             contentOffsetY: 9,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,
@@ -159,8 +158,7 @@ final class ScrollAnchorPreserverTests: XCTestCase {
         // `handlePaginationSentinel` is the source of truth and shifting
         // the offset to absorb the older page would race the snap.
         XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1100,
-            lastContentHeight: 1000,
+            compensationDelta: 100,
             contentOffsetY: 200,
             shouldPreserveAnchor: false,
             isUserLiveScrolling: false,
@@ -172,15 +170,11 @@ final class ScrollAnchorPreserverTests: XCTestCase {
 
     func testSkipsWhenUserIsLiveScrolling() {
         // The user is actively scrolling (trackpad, wheel, or momentum
-        // decay). Any content-height growth during the gesture — most
-        // often LazyVStack lazy cell materialization — must not trigger
-        // a clipView origin shift, because calling setBoundsOrigin
-        // mid-gesture cancels the user's scroll input and traps them in
-        // the current region. The original streaming-bug inputs would
-        // otherwise compensate; the live-scroll gate must override.
+        // decay). Any content shift mid-gesture must not trigger a clip
+        // origin shift, because `setBoundsOrigin` mid-gesture cancels the
+        // user's scroll input and traps them in the current region.
         XCTAssertNil(ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1050,
-            lastContentHeight: 1000,
+            compensationDelta: 50,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: true,
@@ -189,12 +183,11 @@ final class ScrollAnchorPreserverTests: XCTestCase {
     }
 
     func testCompensatesOnceLiveScrollEnds() {
-        // After didEndLiveScrollNotification fires, isUserLiveScrolling
-        // flips back to false and subsequent passive growth (e.g., a
-        // streaming response continuing to arrive) compensates normally.
+        // After `didEndLiveScrollNotification` fires, isUserLiveScrolling
+        // flips back to false and subsequent passive shifts (e.g. a
+        // thinking block expanding above the viewport) compensate normally.
         let delta = ScrollAnchorPreserver.offsetDelta(
-            currentContentHeight: 1050,
-            lastContentHeight: 1000,
+            compensationDelta: 50,
             contentOffsetY: 200,
             shouldPreserveAnchor: true,
             isUserLiveScrolling: false,


### PR DESCRIPTION
## Summary

- Replace `ScrollAnchorPreserver.decide`'s `currentContentHeight`/`lastContentHeight` inputs with a single `compensationDelta` representing the signed movement of a concrete visible reference `NSView` since the previous emit. The Coordinator picks the deepest descendant of `documentView` whose frame intersects the viewport, tracks its `convert(.zero, to: documentView).y` across emits, and feeds the delta in.
- Rename the `.contentHUnchanged` skip reason to `.noVisibleShift` and drop `.firstLayout` (subsumed: the Coordinator now returns delta `0` on first emit / reference re-pick / live-scroll reset, which already routes to `.noVisibleShift`).
- Rewrite `ScrollAnchorPreserverTests` against the new API — same gate semantics (pinned, live-scrolling, sub-pt jitter, preservation disabled), now expressed as direct `compensationDelta` inputs.

## Original prompt

Across four scroll-debug CSVs the user shipped this morning, `documentView.frame.height` ticks `+1` per streaming token while no row in the materialized subtree shifts position — confirmed by the sidecar diagnostic file from PR #30829, which showed `_NSGraphicsView@0/0` holding `minY=903` for the full 5s capture while `contentH` rose 31700 → 31751. The old anchor compensated against `contentHDelta`, so `clipView.bounds.origin.y` walked away from latest at the token rate (~120 pt/sec on a fast model) even though no visible content had moved — that's the "chat keeps scrolling upward slowly" the user reported. Anchoring to the visible reference's `minY` instead skips those frames cleanly while still firing when content above the viewport actually shifts (thinking-block expansion, history height-estimate correction, etc.).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->