### PR TITLE
fix: ensure reply suggestion ghost text always uses user perspective

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2073,14 +2073,25 @@ async function generateLlmSuggestion(
         ? escapeXmlContent(priorUserText)
         : priorUserText;
 
-  const systemPrompt =
-    "You generate short, casual reply suggestions a user might type next in a chat. Match the tone and register of the preceding conversation. Output only the reply text inside the requested tags — no preamble, no commentary.";
+  const systemPrompt = [
+    "You generate short, casual reply suggestions a user might type next in a chat.",
+    "Match the tone and register of the preceding conversation.",
+    "",
+    "CRITICAL — write from the USER'S perspective only, NEVER from the assistant's:",
+    "- The suggestion is what the USER will type into the chat input",
+    "- Use first-person \"I\" only if the user has used it in their prior messages",
+    "- NEVER start with phrases like \"I can help\", \"Here's what\", \"Let me\", \"I'd suggest\" — those are assistant-voice",
+    "- Think: if you were the user reading the assistant's reply, what question or follow-up would you ask next?",
+    "",
+    "Output only the reply text inside the requested tags — no preamble, no commentary.",
+  ].join("\n");
 
   const userPrompt =
     `Here is the end of a conversation:\n\n` +
     `<user_message>${truncatedUser ?? "(no prior user message)"}</user_message>\n` +
     `<assistant_message>${truncatedAssistant}</assistant_message>\n\n` +
-    `Write the user's next reply, focusing on the LAST question or call-to-action in the assistant message. Keep it short (under 15 words), casual, and in the user's voice. Respond in this exact format:\n\n` +
+    `Write the USER'S next reply — what the user would type. Focus on the LAST question or call-to-action in the assistant message. Keep it short (under 15 words), casual, and in the user's voice. ` +
+    `The reply must read as something typed BY the user, not something the assistant would say. Respond in this exact format:\n\n` +
     `<reply>YOUR_REPLY_HERE</reply>`;
 
   // Single user message only — no assistant-role prefill. Anthropic
@@ -2139,7 +2150,44 @@ async function generateLlmSuggestion(
     );
     return null;
   }
+
+  // Reject suggestions written from the assistant's perspective
+  if (isAssistantVoiceSuggestion(firstLine)) {
+    log.debug(
+      { suggestion: firstLine },
+      "Suggestion rejected: reads as assistant-voice, not user-voice",
+    );
+    return null;
+  }
+
   return firstLine;
+}
+
+// ── Assistant-voice detection helpers ────────────────────────────────
+
+const ASSISTANT_VOICE_PATTERNS = [
+  /^I can help/i,
+  /^I('ll| will) (help|explain|show|walk|guide|break|summarize|suggest)/i,
+  /^Here('s| is) (what|how|a|the|my|some)/i,
+  /^Let me (explain|help|show|check|look|see|know|find|get|try|think|clarify)/i,
+  /^I('d| would) (suggest|recommend|say|start|check|look)/i,
+  /^That('s| is) (a |an )?(great|good|interesting|excellent|valid) (question|point)/i,
+  /^Sure,? (I|let|here)/i,
+  /^Of course,? (I|let|here)/i,
+  /^(Yes|Yeah|Absolutely),? (I|let|here)/i,
+  /^To (answer|help|clarify|address|summarize|explain) (your|the|that)/i,
+  /^(Based on|According to|Looking at|From what) (the|your|what|my)/i,
+  /^(I understand|I see|I noticed|I found|I think|I believe|I know)/i,
+];
+
+/**
+ * Detect whether a reply suggestion reads as the assistant speaking
+ * rather than the user. Patterns catch the most common LLM tendency
+ * to answer from the assistant's perspective, which is the opposite of
+ * what a tab-complete ghost-text chip should predict.
+ */
+function isAssistantVoiceSuggestion(text: string): boolean {
+  return ASSISTANT_VOICE_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 export async function handleGetSuggestion(


### PR DESCRIPTION
## Summary
Fixes #29946 by ensuring the chat input ghost text always predicts what the **user** would type next, never what the assistant would say.

## Problem
The reply suggestion ghost text (tab-to-accept) occasionally generated suggestions from the assistant's perspective — e.g. "I can help you with that. Here's what I'd suggest..." — instead of predicting the user's next message. This was confusing and broke the mental model of the input field as the user's space.

## Changes
1. **Strengthened system prompt** with explicit "CRITICAL" section:
   - Write from USER'S perspective only, NEVER from assistant's
   - Anti-pattern list: "I can help", "Here's what", "Let me", "I'd suggest"
   - Guidance: "if you were the user reading the assistant's reply, what would you ask next?"

2. **Added `isAssistantVoiceSuggestion()` post-processing filter** that rejects suggestions matching these assistant-voice patterns:
   - `I can help / I'll help / Let me help`
   - `Here's what / Here's how`
   - `I'd suggest / I would recommend`
   - `That's a great question`
   - `To answer your question`
   - `Based on / According to`
   - And 8 other commonly detected patterns

## Type of Change
- [x] Bug fix

## Checklist
- [x] Changes limited to the issue scope (single file, ~50 lines)
- [x] No new dependencies
- [x] Backward compatible — non-assistant-voice suggestions pass through unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->