### PR TITLE
fix(apps): suppress auto-open on scaffold, add source_files to app_create

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -22,15 +22,18 @@ function makeApp(overrides: Partial<AppDefinition> = {}): AppDefinition {
 }
 
 function makeMockStore(overrides: Partial<AppStore> = {}): AppStore {
+  const files = new Set<string>();
   return {
     getApp: () => makeApp(),
     listApps: () => [makeApp()],
-    appFileExists: () => false,
+    appFileExists: (_appId: string, path: string) => files.has(path),
     createApp: (params) =>
       makeApp({ name: params.name, description: params.description }),
     updateApp: (id, updates) => makeApp({ id, ...updates }),
     deleteApp: () => {},
-    writeAppFile: () => {},
+    writeAppFile: (_appId: string, path: string) => {
+      files.add(path);
+    },
     ...overrides,
   };
 }
@@ -107,7 +110,10 @@ describe("app-builder skill tool scripts", () => {
         isError: false,
       });
       const result = await appCreateScript.run(
-        { name: "Auto App" },
+        {
+          name: "Auto App",
+          source_files: { "src/main.tsx": "// real code" },
+        },
         makeContext({ proxyToolResolver: proxy }),
       );
       expect(result.isError).toBe(false);

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -127,65 +127,17 @@ describe("executeAppCreate", () => {
     expect(parsed.next_steps).toContain("app_refresh");
   });
 
-  test("includes next_steps when auto_open succeeds", async () => {
+  test("skips auto_open on scaffold even when proxy resolver is available", async () => {
     const files: Record<string, string> = {};
     const app = makeMultifileApp({ name: "New App" });
     const store: AppStore = {
       ...mockStore(app, files),
       createApp: () => app,
     };
-    const proxyResolver = async () => ({
-      content: JSON.stringify({ opened: true }),
-      isError: false,
-    });
-
-    const result = await executeAppCreate(
-      { name: "New App" },
-      store,
-      proxyResolver,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = JSON.parse(result.content);
-    expect(parsed.auto_opened).toBe(true);
-    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
-    expect(parsed.next_steps).toContain("app_refresh");
-  });
-
-  test("includes next_steps when auto_open returns error", async () => {
-    const files: Record<string, string> = {};
-    const app = makeMultifileApp({ name: "New App" });
-    const store: AppStore = {
-      ...mockStore(app, files),
-      createApp: () => app,
-    };
-    const proxyResolver = async () => ({
-      content: "open failed",
-      isError: true,
-    });
-
-    const result = await executeAppCreate(
-      { name: "New App" },
-      store,
-      proxyResolver,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = JSON.parse(result.content);
-    expect(parsed.auto_opened).toBe(false);
-    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
-    expect(parsed.next_steps).toContain("app_refresh");
-  });
-
-  test("includes next_steps when auto_open proxy throws", async () => {
-    const files: Record<string, string> = {};
-    const app = makeMultifileApp({ name: "New App" });
-    const store: AppStore = {
-      ...mockStore(app, files),
-      createApp: () => app,
-    };
+    let proxyCalled = false;
     const proxyResolver = async () => {
-      throw new Error("proxy unavailable");
+      proxyCalled = true;
+      return { content: JSON.stringify({ opened: true }), isError: false };
     };
 
     const result = await executeAppCreate(
@@ -195,8 +147,9 @@ describe("executeAppCreate", () => {
     );
 
     expect(result.isError).toBe(false);
+    expect(proxyCalled).toBe(false);
     const parsed = JSON.parse(result.content);
-    expect(parsed.auto_opened).toBe(false);
+    expect(parsed.auto_opened).toBeUndefined();
     expect(parsed.next_steps).toContain("placeholder src/main.tsx");
     expect(parsed.next_steps).toContain("app_refresh");
   });
@@ -270,6 +223,100 @@ describe("executeAppCreate", () => {
     expect(result.isError).toBe(false);
     const parsed = JSON.parse(result.content);
     expect(parsed.compile_errors).toEqual(["unexpected token"]);
+    expect(parsed.next_steps).toBeUndefined();
+  });
+
+  test("suppresses auto_open when only scaffold exists", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+    let proxyCalledWith: Record<string, unknown> | undefined;
+    const proxyResolver = async (
+      toolName: string,
+      input: Record<string, unknown>,
+    ) => {
+      proxyCalledWith = { toolName, input };
+      return { content: JSON.stringify({ opened: true }), isError: false };
+    };
+
+    const result = await executeAppCreate(
+      { name: "New App" },
+      store,
+      proxyResolver,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(proxyCalledWith).toBeUndefined();
+    expect(parsed.auto_opened).toBeUndefined();
+    expect(parsed.next_steps).toContain("placeholder src/main.tsx");
+  });
+
+  test("fires auto_open when source_files includes main.tsx", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "Real App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+    let proxyCalledWith: Record<string, unknown> | undefined;
+    const proxyResolver = async (
+      toolName: string,
+      input: Record<string, unknown>,
+    ) => {
+      proxyCalledWith = { toolName, input };
+      return { content: JSON.stringify({ opened: true }), isError: false };
+    };
+
+    const result = await executeAppCreate(
+      {
+        name: "Real App",
+        source_files: {
+          "src/main.tsx":
+            "import { render } from 'preact';\nrender(<div>Real</div>, document.getElementById('app')!);",
+          "src/styles.css": "body { margin: 0; }",
+        },
+      },
+      store,
+      proxyResolver,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(proxyCalledWith).toBeDefined();
+    expect(parsed.auto_opened).toBe(true);
+    expect(parsed.next_steps).toBeUndefined();
+    expect(files["src/main.tsx"]).toContain("Real");
+    expect(files["src/styles.css"]).toContain("margin");
+  });
+
+  test("source_files are written and prevent scaffold", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "Inline App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+
+    const result = await executeAppCreate(
+      {
+        name: "Inline App",
+        source_files: {
+          "src/main.tsx": "// custom app code",
+          "src/components/App.tsx": "// App component",
+        },
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(files["src/main.tsx"]).toBe("// custom app code");
+    expect(files["src/components/App.tsx"]).toBe("// App component");
+    expect(files["src/index.html"]).toBeDefined();
+    const parsed = JSON.parse(result.content);
     expect(parsed.next_steps).toBeUndefined();
   });
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -177,27 +177,31 @@ useEffect(() => {
 }, []);
 ```
 
-**File workflow:** Call `app_create` first to create the app record and scaffold, use `file_write` for each source file under `src/`, then call `app_refresh` once to compile and refresh the UI.
+**File workflow:** Pass all source files inline via the `source_files` parameter of `app_create`. This writes and compiles the real app in a single call — no scaffold placeholder, no separate `file_write` or `app_refresh` needed for initial creation. For subsequent edits, use `file_edit`/`file_write` then call `app_refresh` once.
 
 **Allowed third-party packages:** `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`, `lucide`. Import them directly - esbuild resolves them at build time. No CDN imports. Note: `lucide` is the vanilla JS icon library (not `lucide-react`). Use its `createElement` or `createIcons` API, or manually inline SVG - do not import JSX icon components.
 
-**Example - creating a multi-file project** (assuming app slug is `project-tracker`):
+**Example - creating a multi-file project:**
 
 ```
-file_write("{workspaceDir}/data/apps/project-tracker/src/index.html", `<!DOCTYPE html>
+app_create({
+  name: "Project Tracker",
+  description: "Track projects with status and priority",
+  schema_json: '{"type":"object","properties":{"title":{"type":"string"},"status":{"type":"string"}},"required":["title"]}',
+  preview: { title: "Project Tracker", icon: "📋" },
+  source_files: {
+    "src/index.html": `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Project Tracker</title></head>
 <body><div id="app"></div></body>
-</html>`)
-
-file_write("{workspaceDir}/data/apps/project-tracker/src/main.tsx", `import { render } from 'preact';
+</html>`,
+    "src/main.tsx": `import { render } from 'preact';
 import { App } from './components/App';
 import './styles.css';
 
-render(<App />, document.getElementById('app')!);`)
-
-file_write("{workspaceDir}/data/apps/project-tracker/src/components/App.tsx", `import { FunctionComponent } from 'preact';
+render(<App />, document.getElementById('app')!);`,
+    "src/components/App.tsx": `import { FunctionComponent } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { Header } from './Header';
 
@@ -217,9 +221,8 @@ export const App: FunctionComponent = () => {
       {/* ... */}
     </div>
   );
-};`)
-
-file_write("{workspaceDir}/data/apps/project-tracker/src/components/Header.tsx", `import { FunctionComponent } from 'preact';
+};`,
+    "src/components/Header.tsx": `import { FunctionComponent } from 'preact';
 
 interface HeaderProps {
   title: string;
@@ -231,14 +234,12 @@ export const Header: FunctionComponent<HeaderProps> = ({ title, count }) => (
     <h1>{title}</h1>
     <span className="badge">{count} items</span>
   </header>
-);`)
-
-file_write("{workspaceDir}/data/apps/project-tracker/src/styles.css", `.app { padding: var(--v-spacing-lg); }
+);`,
+    "src/styles.css": `.app { padding: var(--v-spacing-lg); }
 .header { display: flex; justify-content: space-between; align-items: center; }
-.badge { background: var(--v-accent); color: var(--v-aux-white); padding: var(--v-spacing-xs) var(--v-spacing-sm); border-radius: var(--v-radius-pill); }`)
-
-# After all files are written, compile and refresh:
-app_refresh(app_id)
+.badge { background: var(--v-accent); color: var(--v-aux-white); padding: var(--v-spacing-xs) var(--v-spacing-sm); border-radius: var(--v-radius-pill); }`
+  }
+})
 ```
 
 **Technical constraints (multi-file):**
@@ -329,10 +330,11 @@ Call `app_create` with:
 - `name`: Short descriptive name
 - `description`: One-sentence summary
 - `schema_json`: JSON schema as string
-- `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat
+- `source_files`: Map of relative file paths to contents (e.g. `{"src/main.tsx": "...", "src/styles.css": "..."}`). **Always include this** with the complete app source — it writes, compiles, and opens the real app in a single call.
+- `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat after the app is built. Only fires when real source files are provided (not for scaffold-only apps).
 - `preview`: Always include - `title` (required), `subtitle`, `description`, `icon` (image URL preferred, emoji fallback), `metrics` (up to 3 key-value pills)
 
-Do not pass `html` or `pages` to `app_create`; those single-file shortcuts are retired. After `app_create` returns the app ID, write the real app source under `src/` and call `app_refresh`.
+Do not pass `html` or `pages` to `app_create`; those single-file shortcuts are retired.
 
 The app is NOT opened in a workspace panel automatically - users open it via the 'Open App' button on the inline card.
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -64,6 +64,13 @@
             },
             "required": ["title"]
           },
+          "source_files": {
+            "type": "object",
+            "description": "Map of file paths to file contents to write under the app directory. Supply the real app source here instead of making separate file_write calls. Paths are relative to the app directory (e.g. 'src/main.tsx', 'src/components/App.tsx', 'src/styles.css'). When src/main.tsx is included, no scaffold placeholder is created and the app compiles immediately with real content.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "change_summary": {
             "type": "string",
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add coin flip app', 'fix: correct button alignment'). Used as the version history entry."

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -130,6 +130,31 @@ export async function executeAppCreate(
     };
   }
 
+  if (input.source_files != null) {
+    if (
+      typeof input.source_files !== "object" ||
+      Array.isArray(input.source_files)
+    ) {
+      return {
+        content: JSON.stringify({
+          error:
+            "source_files must be an object mapping relative file paths to string contents",
+        }),
+        isError: true,
+      };
+    }
+    for (const [key, val] of Object.entries(input.source_files)) {
+      if (typeof val !== "string") {
+        return {
+          content: JSON.stringify({
+            error: `source_files["${key}"] must be a string, got ${typeof val}`,
+          }),
+          isError: true,
+        };
+      }
+    }
+  }
+
   // Extract icon from preview if provided - only persist emoji-like values,
   // not URLs which would render as raw strings in UI and bundle manifests.
   const rawIcon = preview?.icon as string | undefined;

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -86,6 +86,7 @@ export interface AppCreateInput {
   pages?: unknown;
   auto_open?: boolean;
   preview?: Record<string, unknown>;
+  source_files?: Record<string, string>;
 }
 
 export async function executeAppCreate(
@@ -172,10 +173,12 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-  // Only write scaffold files when they don't already exist on disk.
-  // The LLM may have written custom source files via file_write before
-  // calling app_create, and overwriting them would destroy the real app
-  // content, leaving only the scaffold placeholder.
+  if (input.source_files) {
+    for (const [filePath, content] of Object.entries(input.source_files)) {
+      store.writeAppFile(app.id, filePath, content);
+    }
+  }
+
   const mainTsxScaffolded = !store.appFileExists(app.id, "src/main.tsx");
   if (!store.appFileExists(app.id, "src/index.html")) {
     store.writeAppFile(app.id, "src/index.html", indexHtml);
@@ -214,7 +217,7 @@ render(<App />, document.getElementById('app')!);
 
   // Emit the inline preview card via the proxy without opening a workspace panel.
   // open_mode: "preview" signals to the client that this should be shown inline only.
-  if (autoOpen && proxyToolResolver) {
+  if (autoOpen && !mainTsxScaffolded && proxyToolResolver) {
     const createPreview = {
       ...(preview ?? {}),
       context: "app_create" as const,


### PR DESCRIPTION
## Summary

- **Short-term fix**: Gate auto-open on `!mainTsxScaffolded` — scaffold-only apps no longer emit the AppCard preview that makes the model interpret the result as task completion
- **Medium-term fix**: Add `source_files` parameter to `app_create` so the model can supply all real source code in a single tool call, eliminating the scaffold placeholder and collapsing the 3-tool sequence (`app_create` → `file_write` × N → `app_refresh`) into one call
- Updated SKILL.md workflow docs and example to recommend `source_files`

## Test plan

- [x] All 13 existing + new tests pass (`bun test app-executors`)
- [x] TypeScript type check passes
- [x] Prettier + ESLint pass
- [ ] Verify with Sonnet 4.6: scaffold-only `app_create` returns no `auto_opened` field and no AppCard
- [ ] Verify with Sonnet 4.6: `app_create` with `source_files` shows the real app inline and model doesn't need follow-up `file_write`/`app_refresh`

Closes JARVIS-833

🤖 Generated with [Claude Code](https://claude.com/claude-code)