### PR TITLE
fix: upsert trust rules on duplicate tool+pattern instead of failing

### DIFF
--- a/clients/shared/Network/TrustRuleClient.swift
+++ b/clients/shared/Network/TrustRuleClient.swift
@@ -53,14 +53,22 @@ private struct TrustRuleSuggestionResponse: Decodable {
 
 // MARK: - Errors
 
+private struct GatewayErrorResponse: Decodable {
+    let error: String?
+}
+
 public enum TrustRuleClientError: Error, LocalizedError {
-    case requestFailed(Int)
+    case requestFailed(Int, String?)
     case notFound
     case featureDisabled
 
     public var errorDescription: String? {
         switch self {
-        case .requestFailed(let code): return "Trust rule v3 request failed (HTTP \(code))"
+        case .requestFailed(let code, let serverMessage):
+            if let serverMessage, !serverMessage.isEmpty {
+                return serverMessage
+            }
+            return "Trust rule request failed (HTTP \(code))"
         case .notFound: return "Trust rule not found"
         case .featureDisabled: return "Feature not enabled"
         }
@@ -92,6 +100,10 @@ public protocol TrustRuleClientProtocol {
 public struct TrustRuleClient: TrustRuleClientProtocol {
     nonisolated public init() {}
 
+    private static func extractServerError(from data: Data) -> String? {
+        try? JSONDecoder().decode(GatewayErrorResponse.self, from: data).error
+    }
+
     public func listRules(origin: String? = nil, tool: String? = nil, includeDeleted: Bool? = nil) async throws -> [TrustRule] {
         var params: [String: String] = [:]
         if let origin { params["origin"] = origin }
@@ -103,7 +115,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         )
         guard response.isSuccess else {
             log.error("listRules failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleListResponse.self, from: response.data).rules
     }
@@ -124,7 +136,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("createRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -146,7 +158,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("updateRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -164,7 +176,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("deleteRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
     }
 
@@ -181,7 +193,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("resetRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -223,7 +235,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("suggestRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSuggestionResponse.self, from: response.data).suggestion
     }

--- a/gateway/src/__tests__/trust-rule-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-store.test.ts
@@ -87,6 +87,54 @@ describe("create()", () => {
     expect(rule.createdAt <= after).toBe(true);
     expect(rule.updatedAt).toBe(rule.createdAt);
   });
+
+  test("upserts when a rule with the same tool+pattern already exists", () => {
+    const original = store.create({
+      tool: "bash",
+      pattern: "create-upsert-echo",
+      risk: "low",
+      description: "Original description",
+    });
+
+    const updated = store.create({
+      tool: "bash",
+      pattern: "create-upsert-echo",
+      risk: "high",
+      description: "Updated description",
+    });
+
+    expect(updated.id).toBe(original.id);
+    expect(updated.risk).toBe("high");
+    expect(updated.description).toBe("Updated description");
+    expect(updated.origin).toBe("user_defined");
+    expect(updated.createdAt).toBe(original.createdAt);
+    expect(updated.updatedAt >= original.updatedAt).toBe(true);
+  });
+
+  test("upsert un-deletes a soft-deleted rule with the same tool+pattern", () => {
+    store.upsertDefault({
+      id: "default:bash:create-upsert-undelete",
+      tool: "bash",
+      pattern: "create-upsert-undelete",
+      risk: "low",
+      description: "Default rule",
+    });
+    store.remove("default:bash:create-upsert-undelete");
+
+    const deleted = store.getById("default:bash:create-upsert-undelete")!;
+    expect(deleted.deleted).toBe(true);
+
+    const recreated = store.create({
+      tool: "bash",
+      pattern: "create-upsert-undelete",
+      risk: "medium",
+      description: "Re-created by user",
+    });
+
+    expect(recreated.deleted).toBe(false);
+    expect(recreated.risk).toBe("medium");
+    expect(recreated.description).toBe("Re-created by user");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/__tests__/trust-rule-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-store.test.ts
@@ -134,6 +134,7 @@ describe("create()", () => {
     expect(recreated.deleted).toBe(false);
     expect(recreated.risk).toBe("medium");
     expect(recreated.description).toBe("Re-created by user");
+    expect(recreated.origin).toBe("user_defined");
   });
 });
 

--- a/gateway/src/db/trust-rule-store.ts
+++ b/gateway/src/db/trust-rule-store.ts
@@ -175,6 +175,7 @@ export class TrustRuleStore {
       ON CONFLICT (tool, pattern) DO UPDATE SET
         risk = excluded.risk,
         description = excluded.description,
+        origin = excluded.origin,
         deleted = 0,
         updated_at = excluded.updated_at
     `);

--- a/gateway/src/db/trust-rule-store.ts
+++ b/gateway/src/db/trust-rule-store.ts
@@ -159,7 +159,9 @@ export class TrustRuleStore {
   }
 
   /**
-   * Create a user-defined trust rule. Generates a UUIDv4 id.
+   * Create or update a user-defined trust rule. If a rule with the same
+   * (tool, pattern) already exists, updates its risk and description
+   * instead of failing on the UNIQUE constraint.
    */
   create(input: CreateInput): TrustRule {
     assertValidRisk(input.risk);
@@ -167,23 +169,25 @@ export class TrustRuleStore {
     const now = nowISO();
     const id = crypto.randomUUID();
 
-    this.db
-      .insert(trustRules)
-      .values({
-        id,
-        tool: input.tool,
-        pattern: input.pattern,
-        risk: input.risk,
-        description: input.description,
-        origin: "user_defined",
-        userModified: false,
-        deleted: false,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .run();
+    this.db.run(sql`
+      INSERT INTO trust_rules (id, tool, pattern, risk, description, origin, user_modified, deleted, created_at, updated_at)
+      VALUES (${id}, ${input.tool}, ${input.pattern}, ${input.risk}, ${input.description}, 'user_defined', 0, 0, ${now}, ${now})
+      ON CONFLICT (tool, pattern) DO UPDATE SET
+        risk = excluded.risk,
+        description = excluded.description,
+        deleted = 0,
+        updated_at = excluded.updated_at
+    `);
 
-    return this.getById(id)!;
+    const row = this.db
+      .select()
+      .from(trustRules)
+      .where(
+        and(eq(trustRules.tool, input.tool), eq(trustRules.pattern, input.pattern)),
+      )
+      .get();
+
+    return toTrustRule(row!);
   }
 
   /**

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -206,9 +206,9 @@ export function createTrustRulesCreateHandler() {
       return Response.json({ rule }, { status: 201 });
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Internal server error";
+        err instanceof Error ? err.message : "Failed to create trust rule";
       log.error({ err }, "Failed to create trust rule");
-      return Response.json({ error: message }, { status: 400 });
+      return Response.json({ error: message }, { status: 500 });
     }
   };
 }


### PR DESCRIPTION
## Summary
- **Gateway store**: Changed `TrustRuleStore.create()` to use `INSERT ... ON CONFLICT (tool, pattern) DO UPDATE` so duplicate rules are upserted (risk, description, deleted flag updated) instead of throwing a SQLite UNIQUE constraint error.
- **Gateway route**: Changed the catch-all error response from HTTP 400 to 500 (since validation errors are already handled above) and improved the fallback message.
- **Swift client**: `TrustRuleClientError.requestFailed` now extracts and surfaces the server's `{ error }` message in the UI dialog, instead of showing the generic "Trust rule v3 request failed (HTTP 400)" string.
- **Tests**: Added two new tests covering the upsert-on-duplicate and un-delete-on-upsert behaviors.

## Original prompt
User reported a bug where saving a trust rule that already existed (same tool + pattern) showed a cryptic "Failed to Save Rule — Trust rule v3 request failed (HTTP 400)" dialog. The root cause was a raw SQLite UNIQUE constraint violation surfaced as a generic error. The fix upserts on conflict instead of failing, and also improves error message propagation from the gateway to the macOS UI for any remaining failure cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->