### PR TITLE
fix(subagents): resolve stuck Running state after app crash/restart

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14488,6 +14488,45 @@ paths:
                 - conversationId
                 - content
               additionalProperties: false
+  /v1/subagents/reconcile:
+    get:
+      operationId: subagents_reconcile_get
+      summary: Reconcile subagent live status
+      description:
+        Returns the live in-memory status of all subagents known to the daemon for a given parent conversation.
+        Subagents not in the response are orphaned.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagents:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                      required:
+                        - status
+                      additionalProperties: false
+                required:
+                  - subagents
+                additionalProperties: false
+      parameters:
+        - name: parentConversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent conversation ID
   /v1/suggestion:
     get:
       operationId: suggestion_get

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -141,6 +141,7 @@ export async function regenerateResponse(
   const conversation = await getOrCreateConversation(conversationId);
   touchConversation(conversationId);
   conversation.updateClient(broadcastMessage, false);
+  getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   const requestId = uuid();
   conversation.traceEmitter.emit("request_received", "Regenerate requested", {
     requestId,

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -31,6 +31,7 @@ import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
+import { getSubagentManager } from "../subagent/index.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import {
@@ -455,6 +456,7 @@ export async function processMessage(
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);
+    getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   }
 
   try {
@@ -521,6 +523,7 @@ export async function processMessageInBackground(
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);
+    getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   }
 
   conversation.setSlackRuntimeContextNotice(options?.slackRuntimeContextNotice);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -101,6 +101,7 @@ import { writeOnboardingSection } from "../../prompts/persona-resolver.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
+import { getSubagentManager } from "../../subagent/index.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getInterfacesDir,
@@ -1492,6 +1493,12 @@ export async function handleSendMessage(
   // that can service host_browser_request events; we restore that single
   // proxy explicitly below without relaxing `hasNoClient`.
   conversation.updateClient(broadcastMessage, !isInteractive);
+  if (isInteractive) {
+    getSubagentManager().updateParentSender(
+      mapping.conversationId,
+      broadcastMessage,
+    );
+  }
 
   // ── Canned first-greeting fast path ──
   // On a completely fresh workspace, skip LLM inference for the macOS

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -189,6 +189,47 @@ function getSubagentDetail(
 
 export const ROUTES: RouteDefinition[] = [
   {
+    operationId: "reconcileSubagents",
+    endpoint: "subagents/reconcile",
+    method: "GET",
+    policyKey: "subagents",
+    summary: "Reconcile subagent live status",
+    description:
+      "Returns the live in-memory status of all subagents known to the daemon for a given parent conversation. Subagents not in the response are orphaned.",
+    tags: ["subagents"],
+    queryParams: [
+      {
+        name: "parentConversationId",
+        schema: { type: "string" },
+        description: "Parent conversation ID",
+      },
+    ],
+    responseBody: z.object({
+      subagents: z.record(
+        z.string(),
+        z.object({
+          status: z.string(),
+        }),
+      ),
+    }),
+    handler: ({ queryParams }) => {
+      const parentConversationId = queryParams?.parentConversationId;
+      if (!parentConversationId) {
+        throw new BadRequestError(
+          "parentConversationId query parameter is required",
+        );
+      }
+      const manager = getSubagentManager();
+      const children = manager.getChildrenOf(parentConversationId);
+      const subagents: Record<string, { status: string }> = {};
+      for (const child of children) {
+        subagents[child.config.id] = { status: child.status };
+      }
+      return { subagents };
+    },
+  },
+
+  {
     operationId: "getSubagentDetail",
     endpoint: "subagents/:id",
     method: "GET",

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -403,6 +403,14 @@ export class SubagentManager {
     this.setStatus(subagentId, "running", getSender());
     managed.state.startedAt = Date.now();
 
+    // Periodically snapshot usage stats and broadcast to the client so the
+    // detail panel shows live-updating input/output/cost values during execution.
+    const usageBroadcastInterval = setInterval(() => {
+      if (TERMINAL_STATUSES.has(managed.state.status)) return;
+      managed.state.usage = { ...conversation.usageStats };
+      this.setStatus(subagentId, managed.state.status, getSender());
+    }, 5_000);
+
     try {
       // For forks, inject the parent's message history before the first message.
       // This prepends the inherited context so the fork has full conversational
@@ -472,6 +480,7 @@ export class SubagentManager {
 
       log.error({ subagentId, err }, "Subagent failed");
     } finally {
+      clearInterval(usageBroadcastInterval);
       // Release the heavyweight Conversation — output is already persisted in DB.
       // drainQueue is async: it awaits buildPassthroughBatch (which awaits
       // resolveSlash) before shifting anything, and runAgentLoop fires it
@@ -523,6 +532,10 @@ export class SubagentManager {
       return false;
     }
 
+    // Snapshot usage before aborting so the terminal event carries accurate stats.
+    if (managed.conversation) {
+      managed.state.usage = { ...managed.conversation.usageStats };
+    }
     managed.conversation?.abort(
       createAbortReason(
         "subagent_aborted",

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -403,14 +403,6 @@ export class SubagentManager {
     this.setStatus(subagentId, "running", getSender());
     managed.state.startedAt = Date.now();
 
-    // Periodically snapshot usage stats and broadcast to the client so the
-    // detail panel shows live-updating input/output/cost values during execution.
-    const usageBroadcastInterval = setInterval(() => {
-      if (TERMINAL_STATUSES.has(managed.state.status)) return;
-      managed.state.usage = { ...conversation.usageStats };
-      this.setStatus(subagentId, managed.state.status, getSender());
-    }, 5_000);
-
     try {
       // For forks, inject the parent's message history before the first message.
       // This prepends the inherited context so the fork has full conversational
@@ -480,7 +472,6 @@ export class SubagentManager {
 
       log.error({ subagentId, err }, "Subagent failed");
     } finally {
-      clearInterval(usageBroadcastInterval);
       // Release the heavyweight Conversation — output is already persisted in DB.
       // drainQueue is async: it awaits buildPassthroughBatch (which awaits
       // resolveSlash) before shifting anything, and runAgentLoop fires it
@@ -532,10 +523,6 @@ export class SubagentManager {
       return false;
     }
 
-    // Snapshot usage before aborting so the terminal event carries accurate stats.
-    if (managed.conversation) {
-      managed.state.usage = { ...managed.conversation.usageStats };
-    }
     managed.conversation?.abort(
       createAbortReason(
         "subagent_aborted",

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -903,6 +903,8 @@ export class SubagentManager {
           subagentId: info.subagentId,
           label: info.label,
           status: "running" as const,
+          conversationId: managed.state.conversationId,
+          objective: managed.state.config.objective,
         },
       },
     );

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -436,6 +436,8 @@ struct SubagentDetailPanel: View {
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .contentTransition(.numericText())
+                    .animation(.easeInOut(duration: 0.6), value: value)
                 Text(label)
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -436,8 +436,6 @@ struct SubagentDetailPanel: View {
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .contentTransition(.numericText())
-                    .animation(.easeInOut(duration: 0.6), value: value)
                 Text(label)
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2209,7 +2209,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // Reconcile non-terminal subagents with the daemon to detect orphans.
         // After a daemon restart the SubagentManager is empty, so subagents
         // reconstructed from the DB as "running" are actually dead.
-        let nonTerminalSubagentIds = activeSubagents.filter { !$0.isTerminal }.map(\.id)
+        let nonTerminalSubagentIds = Set(activeSubagents.filter { !$0.isTerminal }.map(\.id))
         if !nonTerminalSubagentIds.isEmpty, let parentConvId = conversationId {
             Task { @MainActor [weak self] in
                 guard let self else { return }
@@ -2217,9 +2217,9 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 guard let response = await client.reconcile(parentConversationId: parentConvId) else { return }
                 for i in self.activeSubagents.indices {
                     let info = self.activeSubagents[i]
+                    guard nonTerminalSubagentIds.contains(info.id) else { continue }
                     guard !info.isTerminal else { continue }
                     if response.subagents[info.id] == nil {
-                        // Daemon has no knowledge of this subagent — it's orphaned
                         self.activeSubagents[i].status = .failed
                         self.activeSubagents[i].error = "Connection interrupted during restart"
                     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2206,6 +2206,27 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             }
         }
 
+        // Reconcile non-terminal subagents with the daemon to detect orphans.
+        // After a daemon restart the SubagentManager is empty, so subagents
+        // reconstructed from the DB as "running" are actually dead.
+        let nonTerminalSubagentIds = activeSubagents.filter { !$0.isTerminal }.map(\.id)
+        if !nonTerminalSubagentIds.isEmpty, let parentConvId = conversationId {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let client = SubagentClient()
+                guard let response = await client.reconcile(parentConversationId: parentConvId) else { return }
+                for i in self.activeSubagents.indices {
+                    let info = self.activeSubagents[i]
+                    guard !info.isTerminal else { continue }
+                    if response.subagents[info.id] == nil {
+                        // Daemon has no knowledge of this subagent — it's orphaned
+                        self.activeSubagents[i].status = .failed
+                        self.activeSubagents[i].error = "Connection interrupted during restart"
+                    }
+                }
+            }
+        }
+
         // Update daemon pagination cursor from the response metadata.
         self.hasMoreHistory = hasMore
         self.historyCursor = oldestTimestamp

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2219,7 +2219,12 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     let info = self.activeSubagents[i]
                     guard nonTerminalSubagentIds.contains(info.id) else { continue }
                     guard !info.isTerminal else { continue }
-                    if response.subagents[info.id] == nil {
+                    if let liveStatus = response.subagents[info.id] {
+                        let status = SubagentStatus(wire: liveStatus.status)
+                        if status.isTerminal {
+                            self.activeSubagents[i].status = status
+                        }
+                    } else {
                         self.activeSubagents[i].status = .failed
                         self.activeSubagents[i].error = "Connection interrupted during restart"
                     }

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -253,7 +253,7 @@ public final class SubagentDetailStore {
             subagentStates[subagentId] = SubagentState()
         }
         stagedObjectives[subagentId] = objective
-        if stagedEvents[subagentId] == nil {
+        if stagedEvents[subagentId] == nil && currentEvents(for: subagentId).isEmpty {
             stagedEvents[subagentId] = []
         }
         scheduleFlush()

--- a/clients/shared/Network/SubagentClient.swift
+++ b/clients/shared/Network/SubagentClient.swift
@@ -23,11 +23,21 @@ public enum SubagentAbortResult: Equatable, Sendable {
     case failed
 }
 
+/// Response from the subagent reconciliation endpoint.
+public struct SubagentReconcileResponse: Codable, Sendable {
+    public let subagents: [String: SubagentLiveStatus]
+
+    public struct SubagentLiveStatus: Codable, Sendable {
+        public let status: String
+    }
+}
+
 /// Focused client for subagent operations routed through the gateway.
 public protocol SubagentClientProtocol {
     func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult
     func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse?
     func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool
+    func reconcile(parentConversationId: String) async -> SubagentReconcileResponse?
 }
 
 /// Gateway-backed implementation of ``SubagentClientProtocol``.
@@ -103,6 +113,25 @@ public struct SubagentClient: SubagentClientProtocol {
         } catch {
             log.error("sendMessage error: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    public func reconcile(parentConversationId: String) async -> SubagentReconcileResponse? {
+        do {
+            let params: [String: String] = ["parentConversationId": parentConversationId]
+            let response = try await GatewayHTTPClient.get(
+                path: "subagents/reconcile",
+                params: params,
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("reconcile failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return try JSONDecoder().decode(SubagentReconcileResponse.self, from: response.data)
+        } catch {
+            log.error("reconcile error: \(error.localizedDescription)")
+            return nil
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes subagents showing as "Running" indefinitely after the macOS app crashes, rebuilds, or the daemon restarts — when the subagent is actually dead or unreachable.

**Two root causes identified and fixed:**

- **Stale `parentSendToClient` on reconnect**: `SubagentManager.updateParentSender()` existed but was never called from production code. After app reconnect, all `subagent_status_changed` SSE events were sent to the dead old connection. Now wired at all 4 `conversation.updateClient()` call sites.
- **No reconciliation for orphaned subagents**: After daemon restart, `SubagentManager` is empty but non-terminal `subagentNotification` records in the DB are reconstructed as "Running" with no way to detect they're orphaned. Added a `GET /subagents/reconcile` endpoint and client-side reconciliation in `populateFromHistory` that marks daemon-unknown subagents as failed.

## Test plan

- [ ] Spawn a subagent, force-quit the app mid-run, relaunch — subagent should either continue running (if daemon alive) or show as failed
- [ ] Spawn a subagent, restart the daemon while it's running, relaunch app — subagent should show as failed with "Connection interrupted during restart"
- [ ] Spawn a subagent, rebuild the app in Xcode while subagent is running — after rebuild, subagent events should continue flowing
- [ ] Normal subagent lifecycle (spawn → complete) still works end-to-end
- [ ] Verify TypeScript typecheck passes
- [ ] Verify Swift build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->