### PR TITLE
Rename clientJson to clientMetadata

### DIFF
--- a/assistant/src/__tests__/turn-events-store.test.ts
+++ b/assistant/src/__tests__/turn-events-store.test.ts
@@ -202,7 +202,7 @@ describe("queryUnreportedTurnEvents", () => {
     }
   });
 
-  test("extracts interfaceId, channelId, and clientJson from messages.metadata", async () => {
+  test("extracts interfaceId, channelId, and clientMetadata from messages.metadata", async () => {
     // Three user messages with different metadata shapes to cover the
     // realistic spectrum of attribution carried on messages.metadata:
     //  - Full interactive: macOS surface, vellum channel, with a client
@@ -232,11 +232,11 @@ describe("queryUnreportedTurnEvents", () => {
     expect(byId[macOsMsg.id]).toBeDefined();
     expect(byId[macOsMsg.id].interfaceId).toBe("macos");
     expect(byId[macOsMsg.id].channelId).toBe("vellum");
-    // clientJson is returned as raw JSON text -- the reporter parses it.
+    // clientMetadata is returned as raw JSON text -- the reporter parses it.
     // We verify it round-trips back to the input object.
-    expect(byId[macOsMsg.id].clientJson).not.toBeNull();
+    expect(byId[macOsMsg.id].clientMetadata).not.toBeNull();
     expect(
-      JSON.parse(byId[macOsMsg.id].clientJson as string),
+      JSON.parse(byId[macOsMsg.id].clientMetadata as string),
     ).toMatchObject({
       os: "darwin",
       interface_version: "0.8.2",
@@ -244,13 +244,13 @@ describe("queryUnreportedTurnEvents", () => {
 
     expect(byId[slackMsg.id].interfaceId).toBe("slack");
     expect(byId[slackMsg.id].channelId).toBe("slack");
-    expect(byId[slackMsg.id].clientJson).toBeNull();
+    expect(byId[slackMsg.id].clientMetadata).toBeNull();
 
     // Legacy rows (no metadata threading) return null for all three
     // attribution fields -- downstream analytics treats these as
     // "unknown" without breaking the batch.
     expect(byId[legacyMsg.id].interfaceId).toBeNull();
     expect(byId[legacyMsg.id].channelId).toBeNull();
-    expect(byId[legacyMsg.id].clientJson).toBeNull();
+    expect(byId[legacyMsg.id].clientMetadata).toBeNull();
   });
 });

--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -65,7 +65,7 @@ export interface TurnEvent {
    * Returned as raw JSON text — the reporter parses + re-shapes for the
    * wire format.
    */
-  clientJson: string | null;
+  clientMetadata: string | null;
 }
 
 /**
@@ -140,9 +140,9 @@ export function queryUnreportedTurnEvents(
       >`json_extract(${messages.metadata}, '$.userMessageChannel')`.as(
         "channel_id",
       ),
-      clientJson: sql<
+      clientMetadata: sql<
         string | null
-      >`json_extract(${messages.metadata}, '$.client')`.as("client_json"),
+      >`json_extract(${messages.metadata}, '$.client')`.as("client_metadata"),
     })
     .from(messages)
     .innerJoin(conversations, eq(messages.conversationId, conversations.id))

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -43,7 +43,7 @@ const mockQueryUnreportedTurnEvents = mock(
       turnIndex: number;
       interfaceId: string | null;
       channelId: string | null;
-      clientJson: string | null;
+      clientMetadata: string | null;
     }[],
 );
 
@@ -553,7 +553,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -601,7 +601,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-background",
@@ -611,7 +611,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-scheduled",
@@ -621,7 +621,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -666,7 +666,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "macos",
         channelId: "vellum",
-        clientJson: JSON.stringify({
+        clientMetadata: JSON.stringify({
           browser_family: null,
           os: "darwin",
           interface_version: "0.8.2",
@@ -680,7 +680,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "slack",
         channelId: "slack",
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-web-broken",
@@ -690,7 +690,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "web",
         channelId: "vellum",
-        clientJson: "{not valid json",
+        clientMetadata: "{not valid json",
       },
       {
         id: "evt-turn-legacy",
@@ -700,7 +700,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -248,9 +248,9 @@ export class UsageTelemetryReporter {
           // Parse defensively — a corrupted blob in the JSON column should
           // not block the whole batch flush.
           let client: TurnTelemetryClientInfo | null = null;
-          if (e.clientJson) {
+          if (e.clientMetadata) {
             try {
-              const parsed = JSON.parse(e.clientJson) as unknown;
+              const parsed = JSON.parse(e.clientMetadata) as unknown;
               if (
                 parsed &&
                 typeof parsed === "object" &&


### PR DESCRIPTION
## Summary
- Renames `clientJson` → `clientMetadata` across the `TurnEvent` interface, SQL query alias, usage telemetry reporter, and all associated tests.
- No backwards-compatibility shim — this is a hotfix rename before the field is widely consumed.

## Original prompt
Follow-up to PR #30849 which added client metadata threading on turn telemetry events. The user requested renaming the `clientJson` field to `clientMetadata` throughout the codebase as a hotfix, with no backwards compatibility needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)