### PR TITLE
feat(skills): add quality model preflight to app-builder skill

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -56,6 +56,45 @@ All new apps use `formatVersion: 2`: source files live under `src/` and compiled
 
 ## Workflow
 
+### 0. Preflight — Pin to a high-quality model
+
+App building is design-heavy judgment work — color palettes, layout decisions, component architecture, micro-interactions. A stronger model produces meaningfully better apps: more creative visual directions, cleaner component boundaries, fewer generic patterns. Before building, check whether the conversation is already pinned to the quality profile:
+
+```
+assistant inference session list
+```
+
+If no session is active, check the current default profile:
+
+```
+assistant config get llm.default.profile
+```
+
+If the active profile is `balanced` or `cost-optimized` (or any non-quality profile), prompt the user:
+
+```
+assistant ui confirm "App building works best with a high-quality model — it makes better design decisions, writes cleaner components, and produces more visually polished results. Switch to the quality profile for this build? (You can switch back after.)"
+```
+
+If the user confirms (or if `assistant ui confirm` isn't available, ask in conversation), open an inference session:
+
+```
+assistant inference session open quality-optimized --ttl 1h
+```
+
+If `quality-optimized` isn't a profile name on this workspace, list the available profiles and open against the highest-quality one:
+
+```
+assistant config get llm.profiles
+assistant inference session open <profile-name> --ttl 1h
+```
+
+The `--ttl 1h` gives comfortable headroom for a typical app build without leaving a forever-pinned session if the close in Step 6 is skipped.
+
+If the user declines, proceed anyway — the build still works, the model just won't be pinned. Skip the close in Step 6 too.
+
+If `assistant inference session` isn't available on this binary, proceed without it.
+
 ### 1. Gather Requirements
 
 **Default: just build.** When a user says "build me a habit tracker," don't ask what colors they want or how many fields to include. Immediately:
@@ -350,6 +389,16 @@ When the user requests changes, prefer **`file_edit`** over rewriting the entire
 After making all file changes, call `app_refresh(app_id)` once to compile and refresh the UI. Do NOT call it after every individual file edit — batch your changes first.
 
 Apps should have multiple source files under `src/` (`styles.css`, components, helpers, etc.). Import CSS and modules from TSX so esbuild includes them in the compiled output.
+
+### 6. Close the inference session
+
+If you opened an inference session in Step 0, close it now:
+
+```
+assistant inference session close
+```
+
+If you skipped the open in Step 0 (because the user declined, the CLI didn't have the command, or the profile was already quality), skip this step too.
 
 ## Interaction Standards
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -73,7 +73,7 @@ assistant config get llm.default.profile
 If the active profile is `balanced` or `cost-optimized` (or any non-quality profile), prompt the user:
 
 ```
-assistant ui confirm "App building works best with a high-quality model — it makes better design decisions, writes cleaner components, and produces more visually polished results. Switch to the quality profile for this build? (You can switch back after.)"
+assistant ui confirm --message "App building works best with a high-quality model — it makes better design decisions, writes cleaner components, and produces more visually polished results. Switch to the quality profile for this build? (You can switch back after.)"
 ```
 
 If the user confirms (or if `assistant ui confirm` isn't available, ask in conversation), open an inference session:

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -70,13 +70,17 @@ If no session is active, check the current default profile:
 assistant config get llm.default.profile
 ```
 
-If the active profile is `balanced` or `cost-optimized` (or any non-quality profile), prompt the user:
+If the profile is already `quality-optimized`, skip the rest of this step and proceed to Step 1.
+
+**If the active profile is `balanced`, `cost-optimized`, or any non-quality profile, you MUST ask the user for permission before switching. Do NOT open an inference session without explicit user confirmation.** Use `assistant ui confirm`:
 
 ```
 assistant ui confirm --message "App building works best with a high-quality model — it makes better design decisions, writes cleaner components, and produces more visually polished results. Switch to the quality profile for this build? (You can switch back after.)"
 ```
 
-If the user confirms (or if `assistant ui confirm` isn't available, ask in conversation), open an inference session:
+If `assistant ui confirm` isn't available on this binary, ask the user directly in conversation instead. **Either way, wait for the user's answer before proceeding.**
+
+**Only if the user confirms**, open an inference session:
 
 ```
 assistant inference session open quality-optimized --ttl 1h
@@ -91,7 +95,7 @@ assistant inference session open <profile-name> --ttl 1h
 
 The `--ttl 1h` gives comfortable headroom for a typical app build without leaving a forever-pinned session if the close in Step 6 is skipped.
 
-If the user declines, proceed anyway — the build still works, the model just won't be pinned. Skip the close in Step 6 too.
+**If the user declines, do not switch profiles.** Proceed with the current profile — the build still works, the model just won't be pinned. Skip the close in Step 6 too.
 
 If `assistant inference session` isn't available on this binary, proceed without it.
 


### PR DESCRIPTION
## Summary
- Adds a **Step 0 (Preflight)** to the app-builder skill that checks the active model profile and prompts the user to switch to `quality-optimized` before building, mirroring the pattern from the memory v2 migration skill
- Adds a symmetric **Step 6 (Close)** to close the inference session after the build completes
- Uses `--ttl 1h` (shorter than the migration's 2h) since app builds are quicker

## Test plan
- [ ] Activate app-builder skill on a workspace with `balanced` profile — verify the preflight prompt appears
- [ ] Confirm the inference session opens on user approval and closes after Step 5
- [ ] Verify declining the prompt still allows the build to proceed without pinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)