### PR TITLE
Gate `<memory>` block injection on `memory.enabled` config

### DIFF
--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -23,7 +23,9 @@ export const MemoryConfigSchema = z
     enabled: z
       .boolean({ error: "memory.enabled must be a boolean" })
       .default(true)
-      .describe("Whether the long-term memory system is enabled"),
+      .describe(
+        "Whether the long-term memory system is enabled — gates background memory jobs, embedding generation, and `<memory>` block injection into user messages",
+      ),
     embeddings: MemoryEmbeddingsConfigSchema.default(
       MemoryEmbeddingsConfigSchema.parse({}),
     ),

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -215,9 +215,9 @@ function createTestDb(): DrizzleDb {
   return db;
 }
 
-function makeConfig(v2Enabled: boolean): AssistantConfig {
+function makeConfig(v2Enabled: boolean, memoryEnabled = true): AssistantConfig {
   return applyNestedDefaults({
-    memory: { v2: { enabled: v2Enabled } },
+    memory: { enabled: memoryEnabled, v2: { enabled: v2Enabled } },
   }) as AssistantConfig;
 }
 
@@ -515,6 +515,50 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
 
     expect(result.mode).toBe("context-load");
     expect(result.injectedBlockText).toBeNull();
+  });
+});
+
+describe("ConversationGraphMemory.prepareMemory — memory.enabled gate", () => {
+  test("memory.enabled=false short-circuits per-turn path: mode=none, no injection, v2/v1 not called", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true, false);
+    const messages = makeMessages();
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("none");
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+    expect(retrieveForTurnMock).not.toHaveBeenCalled();
+    expect(loadContextMemoryMock).not.toHaveBeenCalled();
+  });
+
+  test("memory.enabled=false short-circuits context-load path: mode=none, no injection, v2/v1 not called", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = new ConversationGraphMemory("conv-test-master-off");
+    const config = makeConfig(true, false);
+    const messages = makeMessages("first message of the conversation here");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("none");
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+    expect(loadContextMemoryMock).not.toHaveBeenCalled();
+    expect(retrieveForTurnMock).not.toHaveBeenCalled();
   });
 });
 

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -363,6 +363,8 @@ export class ConversationGraphMemory {
       metrics: null as RetrievalMetrics | null,
     };
 
+    if (!config.memory.enabled) return noopResult;
+
     // Gate: skip for empty/tool-result-only messages — unless we need to
     // reload after compaction (needsReload) or haven't initialized yet.
     const lastMessage = messages[messages.length - 1];

--- a/assistant/src/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/memory/v2/__tests__/static-context.test.ts
@@ -32,11 +32,15 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 let configMemoryV2Enabled = true;
+let configMemoryEnabled = true;
 
 mock.module("../../../config/loader.js", () => ({
   getConfig: () => ({}),
   loadConfig: () => ({
-    memory: { v2: { enabled: configMemoryV2Enabled } },
+    memory: {
+      enabled: configMemoryEnabled,
+      v2: { enabled: configMemoryV2Enabled },
+    },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
@@ -71,6 +75,7 @@ describe("readMemoryV2StaticContent", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
     configMemoryV2Enabled = true;
+    configMemoryEnabled = true;
   });
 
   afterEach(() => {
@@ -79,6 +84,12 @@ describe("readMemoryV2StaticContent", () => {
 
   test("returns null when config.memory.v2.enabled is off", () => {
     configMemoryV2Enabled = false;
+    for (const file of MEMORY_FILES) writeMemoryFile(file, `Content ${file}`);
+    expect(readMemoryV2StaticContent()).toBeNull();
+  });
+
+  test("returns null when config.memory.enabled is off even with v2 on", () => {
+    configMemoryEnabled = false;
     for (const file of MEMORY_FILES) writeMemoryFile(file, `Content ${file}`);
     expect(readMemoryV2StaticContent()).toBeNull();
   });

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -35,9 +35,9 @@ const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
 ];
 
 /**
- * Build the v2 static memory block, gated on `config.memory.v2.enabled`.
- * Empty/missing files are skipped; returns `null` when the gate is off or
- * every file is empty.
+ * Build the v2 static memory block, gated on `config.memory.enabled` and
+ * `config.memory.v2.enabled`. Empty/missing files are skipped; returns `null`
+ * when either gate is off or every file is empty.
  */
 export function readMemoryV2StaticContent(): string | null {
   let config;
@@ -46,7 +46,7 @@ export function readMemoryV2StaticContent(): string | null {
   } catch {
     return null;
   }
-  if (!config.memory.v2.enabled) {
+  if (!config.memory.enabled || !config.memory.v2.enabled) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- The `memory.enabled` config flag described itself as gating the long-term memory system but was only checked in background jobs and embedding-backend status — the daemon kept injecting `<memory>...</memory>` blocks into user messages even with `memory.enabled: false`.
- Adds early-return gates in `ConversationGraphMemory.prepareMemory()` and `readMemoryV2StaticContent()` so a single `memory.enabled: false` setting now fully suppresses both the dynamic activation block and the static essentials/threads/recent/buffer block (covering both v2 and the v1 fallback path).
- Tightens the schema description to mention `<memory>` block injection and adds three tests covering per-turn, context-load, and static-block paths.

## Original prompt

User asked whether a single config value could disable memory injections in the daemon. Investigation found `memory.enabled` already existed in the schema with a matching description but wasn't actually wired into the injection path — setting it to `false` halted writes but the daemon still injected `<memory>` blocks from existing data. User confirmed they wanted all `<memory>` block injection disabled, so this PR closes that gap by wiring `memory.enabled` into the two injection-path entry points. NOW.md and PKB context use separate wrappers and remain governed by their own (or absent) flags.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->