### PR TITLE
fix(macos): isolate table copy-button hover to prevent full surface re-render

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -456,6 +456,8 @@ private struct TableCopyButtonOverlay: View {
             .contentShape(Rectangle())
             .onHover { isHovered = $0 }
             .opacity(isHovered ? 1 : 0)
+            .allowsHitTesting(isHovered)
+            .accessibilityHidden(!isHovered)
             .animation(VAnimation.fast, value: isHovered)
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -15,7 +15,6 @@ public struct InlineSurfaceRouter: View {
 
     @State private var selectionPayload: [String: AnyCodable]?
     @State private var clickedActionLabel: String?
-    @State private var isCardHovered = false
 
     public init(
         surface: InlineSurfaceData,
@@ -152,10 +151,7 @@ public struct InlineSurfaceRouter: View {
                 .padding(VSpacing.sm)
             } else if isTableSurface, case .table(let tableData) = surface.data {
                 #if os(macOS)
-                VCopyButton(text: Self.tableAsMarkdown(tableData), size: .compact)
-                    .opacity(isCardHovered ? 1 : 0)
-                    .animation(VAnimation.fast, value: isCardHovered)
-                    .padding(VSpacing.sm)
+                TableCopyButtonOverlay(tableData: tableData)
                 #endif
             } else if isDocumentPreview {
                 if case .documentPreview(let data) = surface.data {
@@ -179,9 +175,6 @@ public struct InlineSurfaceRouter: View {
                 }
             }
         }
-        #if os(macOS)
-        .onHover { isCardHovered = $0 }
-        #endif
         // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
         .widthCap(isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth))
         }
@@ -429,7 +422,7 @@ public struct InlineSurfaceRouter: View {
     }
 
     /// Builds a markdown table string from TableSurfaceData for clipboard copy.
-    static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
+    public static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
         func escapeCell(_ text: String) -> String {
             text.replacingOccurrences(of: "|", with: "\\|")
                 .replacingOccurrences(of: "\n", with: " ")
@@ -445,3 +438,25 @@ public struct InlineSurfaceRouter: View {
         return ([headerLine, separatorLine] + rowLines).joined(separator: "\n")
     }
 }
+
+// MARK: - TableCopyButtonOverlay
+
+#if os(macOS)
+/// Self-contained hover overlay for the table copy button. Owns its own
+/// `@State` so hover changes only re-render this small view — not the
+/// parent `InlineSurfaceRouter` and its expensive `InlineTableWidget`.
+private struct TableCopyButtonOverlay: View {
+    let tableData: TableSurfaceData
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VCopyButton(text: InlineSurfaceRouter.tableAsMarkdown(tableData), size: .compact)
+            .padding(VSpacing.sm)
+            .contentShape(Rectangle())
+            .onHover { isHovered = $0 }
+            .opacity(isHovered ? 1 : 0)
+            .animation(VAnimation.fast, value: isHovered)
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -452,12 +452,12 @@ private struct TableCopyButtonOverlay: View {
 
     var body: some View {
         VCopyButton(text: InlineSurfaceRouter.tableAsMarkdown(tableData), size: .compact)
+            .allowsHitTesting(isHovered)
+            .accessibilityHidden(!isHovered)
             .padding(VSpacing.sm)
             .contentShape(Rectangle())
             .onHover { isHovered = $0 }
             .opacity(isHovered ? 1 : 0)
-            .allowsHitTesting(isHovered)
-            .accessibilityHidden(!isHovered)
             .animation(VAnimation.fast, value: isHovered)
     }
 }


### PR DESCRIPTION
## Summary

- Extract `TableCopyButtonOverlay` from `InlineSurfaceRouter` so hover-driven `@State` changes only re-render the small copy-button overlay — not the parent router and its expensive `InlineTableWidget`
- Remove the card-level `.onHover { isCardHovered = $0 }` that previously wrapped the entire surface card VStack, since `isCardHovered` was only consumed by the table copy button's opacity
- Copy button now appears on hover of the button area (top-right corner) rather than the entire card

## Context

`InlineSurfaceRouter` had `.onHover` on the entire card VStack. For large table surfaces (e.g., Gmail declutter tables with 75+ rows), hovering anywhere on the card triggered a `@State` mutation on the parent view, which re-evaluated `InlineSurfaceRouter.body` — including `InlineTableWidget` and its `TableColumnLayout.sizeThatFits()` across all rows. If the re-measurement produced even subpixel height differences from floating-point width proposal variance, the LazyVStack content height shifted, causing visible scroll jitter. This is the primary remaining cause of Issue #30787 for table surfaces.

The new `TableCopyButtonOverlay` struct owns its own `@State isHovered`, so SwiftUI only invalidates the overlay's body on hover — the parent and table widget are untouched.

## Test plan

- [ ] Hover over a large inline table (e.g., Gmail declutter results) — no scroll jitter
- [ ] Copy button appears when hovering the top-right corner of the table
- [ ] Copy button copies table as markdown to clipboard
- [ ] Other surface types (dynamic pages, documents) still show their overlay buttons correctly
- [ ] No regression in table selection, column resize, or action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->