### PR TITLE
fix(config): prevent config set from overwriting custom values

### DIFF
--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -28,6 +28,7 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
+  withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
   // setNestedValue is also exported by loader; handleSetConfig imports the
   // real one from this module, so we re-export a thin implementation that
   // mutates in place (matches loader's behavior).

--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -177,7 +177,7 @@ describe("config_set route - request validation", () => {
     expect(result).toEqual({ ok: true });
     expect(savedRaw).not.toBeNull();
 
-    const saved = savedRaw as Record<string, unknown>;
+    const saved = savedRaw as unknown as Record<string, unknown>;
     const llm = saved.llm as Record<string, unknown>;
     expect(llm.activeProfile).toBe("my-custom-profile");
 
@@ -214,7 +214,7 @@ describe("config_set route - request validation", () => {
       body: { path: "memory.cleanup.conversationRetentionDays", value: 30 },
     });
     expect(savedRaw).not.toBeNull();
-    const saved = savedRaw as Record<string, unknown>;
+    const saved = savedRaw as unknown as Record<string, unknown>;
     expect(saved.llm).toEqual({ default: { provider: "anthropic" } });
     expect(saved.calls).toEqual({ enabled: true });
     expect(saved.heartbeat).toEqual({

--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -27,6 +27,7 @@ mock.module("../config/loader.js", () => ({
   deepMergeOverwrite: () => {},
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
+  withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
   // setNestedValue is also exported by loader; handleSetConfig imports the
   // real one from this module, so we re-export a thin implementation that
   // mutates in place (matches loader's behavior).
@@ -142,6 +143,84 @@ describe("config_set route - request validation", () => {
     const calls = (savedRaw as unknown as Record<string, unknown>)
       .calls as Record<string, unknown>;
     expect(calls.enabled).toBe(true);
+  });
+
+  test("preserves user profiles and custom settings when setting unrelated key", async () => {
+    rawConfig = {
+      llm: {
+        activeProfile: "my-custom-profile",
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+          "my-custom-profile": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            maxTokens: 32000,
+          },
+        },
+      },
+      memory: {
+        embeddings: { provider: "openai" },
+      },
+    };
+    savedRaw = null;
+    const result = await configSetRoute.handler({
+      body: {
+        path: "memory.cleanup.llmRequestLogRetentionMs",
+        value: 86400000,
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+
+    const saved = savedRaw as Record<string, unknown>;
+    const llm = saved.llm as Record<string, unknown>;
+    expect(llm.activeProfile).toBe("my-custom-profile");
+
+    const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+    expect(profiles["my-custom-profile"]).toEqual({
+      source: "user",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 32000,
+    });
+    expect(profiles.balanced).toEqual({
+      source: "managed",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    const memory = saved.memory as Record<string, unknown>;
+    expect((memory.embeddings as Record<string, unknown>).provider).toBe(
+      "openai",
+    );
+    expect(
+      (memory.cleanup as Record<string, unknown>).llmRequestLogRetentionMs,
+    ).toBe(86400000);
+  });
+
+  test("preserves all top-level keys when setting a nested path", async () => {
+    rawConfig = {
+      llm: { default: { provider: "anthropic" } },
+      calls: { enabled: true },
+      heartbeat: { activeHoursStart: "09:00", activeHoursEnd: "22:00" },
+    };
+    savedRaw = null;
+    await configSetRoute.handler({
+      body: { path: "memory.cleanup.conversationRetentionDays", value: 30 },
+    });
+    expect(savedRaw).not.toBeNull();
+    const saved = savedRaw as Record<string, unknown>;
+    expect(saved.llm).toEqual({ default: { provider: "anthropic" } });
+    expect(saved.calls).toEqual({ enabled: true });
+    expect(saved.heartbeat).toEqual({
+      activeHoursStart: "09:00",
+      activeHoursEnd: "22:00",
+    });
   });
 });
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -68,6 +68,7 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
   withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
+  withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -67,6 +67,7 @@ mock.module("../config/loader.js", () => ({
   },
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
+  withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -859,6 +859,15 @@ export async function withSuppressedConfigDiskWrites<T>(
   }
 }
 
+export function withSuppressedConfigDiskWritesSync<T>(fn: () => T): T {
+  suppressConfigDiskWritesDepth++;
+  try {
+    return fn();
+  } finally {
+    suppressConfigDiskWritesDepth--;
+  }
+}
+
 /**
  * Load the raw config from disk without any secure-storage merging.
  * Used by CLI config commands to read/write the file directly.

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -25,6 +25,7 @@ const log = getLogger("config");
 let cached: AssistantConfig | null = null;
 let cachedFileSignature: ConfigFileSignature | null = null;
 let loading = false;
+let suppressConfigDiskWritesDepth = 0;
 
 type ConfigFileSignature =
   | {
@@ -683,49 +684,54 @@ export function loadConfig(): AssistantConfig {
       configFileExisted = false;
     }
 
-    // Warn about and strip deprecated config fields so users know their
-    // settings are no longer honored rather than silently dropping them.
-    warnAndStripDeprecatedFields(fileConfig, configPath);
+    if (suppressConfigDiskWritesDepth === 0) {
+      warnAndStripDeprecatedFields(fileConfig, configPath);
+    }
 
     // Validate and apply defaults via Zod schema
     let config = validateWithSchema(fileConfig);
 
-    // Managed Gemini embedding defaults migration.
-    // When on a managed platform (IS_PLATFORM=true) with the feature flag
-    // enabled and no explicit embedding provider chosen (provider=auto),
-    // persist Gemini embedding defaults into the raw config file.
-    // Idempotent: once provider=gemini is written, subsequent loads skip this.
-    if (config.memory.embeddings.provider === "auto") {
-      try {
-        if (
-          (process.env.IS_PLATFORM === "true" ||
-            process.env.IS_PLATFORM === "1") &&
-          isManagedGeminiFFEnabled(config)
-        ) {
-          setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
-          setNestedValue(
-            fileConfig,
-            "memory.embeddings.geminiModel",
-            "gemini-embedding-2",
+    if (suppressConfigDiskWritesDepth === 0) {
+      // Managed Gemini embedding defaults migration.
+      // When on a managed platform (IS_PLATFORM=true) with the feature flag
+      // enabled and no explicit embedding provider chosen (provider=auto),
+      // persist Gemini embedding defaults into the raw config file.
+      // Idempotent: once provider=gemini is written, subsequent loads skip this.
+      if (config.memory.embeddings.provider === "auto") {
+        try {
+          if (
+            (process.env.IS_PLATFORM === "true" ||
+              process.env.IS_PLATFORM === "1") &&
+            isManagedGeminiFFEnabled(config)
+          ) {
+            setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
+            setNestedValue(
+              fileConfig,
+              "memory.embeddings.geminiModel",
+              "gemini-embedding-2",
+            );
+            setNestedValue(
+              fileConfig,
+              "memory.embeddings.geminiDimensions",
+              3072,
+            );
+            setNestedValue(fileConfig, "memory.qdrant.vectorSize", 3072);
+            writeFileSync(
+              configPath,
+              JSON.stringify(fileConfig, null, 2) + "\n",
+            );
+            log.info(
+              "Applied managed Gemini embedding defaults (provider=gemini, model=gemini-embedding-2, dimensions=3072, vectorSize=3072)",
+            );
+            // Re-validate so the returned config reflects the migration.
+            config = validateWithSchema(fileConfig);
+          }
+        } catch (err) {
+          log.warn(
+            { err },
+            "Managed Gemini defaults migration failed — continuing with existing config",
           );
-          setNestedValue(
-            fileConfig,
-            "memory.embeddings.geminiDimensions",
-            3072,
-          );
-          setNestedValue(fileConfig, "memory.qdrant.vectorSize", 3072);
-          writeFileSync(configPath, JSON.stringify(fileConfig, null, 2) + "\n");
-          log.info(
-            "Applied managed Gemini embedding defaults (provider=gemini, model=gemini-embedding-2, dimensions=3072, vectorSize=3072)",
-          );
-          // Re-validate so the returned config reflects the migration.
-          config = validateWithSchema(fileConfig);
         }
-      } catch (err) {
-        log.warn(
-          { err },
-          "Managed Gemini defaults migration failed — continuing with existing config",
-        );
       }
     }
 
@@ -763,7 +769,7 @@ export function loadConfig(): AssistantConfig {
     // changes were inert because the merge only filled absent keys and never
     // reconciled existing values. Contract: disk = user intent, in-memory
     // cache = effective values.
-    if (!configFileExisted) {
+    if (!configFileExisted && suppressConfigDiskWritesDepth === 0) {
       try {
         const dir = dirname(configPath);
         if (!existsSync(dir)) {
@@ -840,6 +846,17 @@ export function invalidateConfigCache(): void {
   cached = null;
   cachedFileSignature = null;
   loading = false;
+}
+
+export async function withSuppressedConfigDiskWrites<T>(
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  suppressConfigDiskWritesDepth++;
+  try {
+    return await fn();
+  } finally {
+    suppressConfigDiskWritesDepth--;
+  }
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -28,6 +28,7 @@ import {
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
+  withSuppressedConfigDiskWrites,
 } from "../../config/loader.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
@@ -229,7 +230,7 @@ function getModelSetContext(): ModelSetContext {
       watcher.suppressConfigReload = value;
     },
     updateConfigFingerprint() {
-      watcher.updateFingerprint();
+      void withSuppressedConfigDiskWrites(() => watcher.updateFingerprint());
     },
     debounceTimers: watcher.timers,
   };
@@ -471,15 +472,14 @@ async function commitConfigWrite(
 
   clearEmbeddingBackendCache();
   invalidateConfigCache();
-  // Reinitialize providers so the live registry reflects the new config
-  // (e.g. a mode flip between managed and your-own). Isolated try/catch so
-  // a provider reinit failure doesn't mask the successful config save.
-  // Only advance the config fingerprint on success - if reinit failed, leave
-  // it stale so the watcher can detect the saved config on the next event
-  // and retry provider initialization.
+  // Reinitialize providers so the live registry reflects the new config.
+  // Suppress disk writes inside loadConfig() — we just wrote the raw config
+  // and the first-launch seed path would overwrite it with full defaults.
   try {
-    await initializeProviders(getConfig());
-    configWatcher.updateFingerprint();
+    await withSuppressedConfigDiskWrites(async () => {
+      await initializeProviders(getConfig());
+      configWatcher.updateFingerprint();
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, `${opLabel} config: provider reinit failed: ${message}`);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -29,6 +29,7 @@ import {
   saveRawConfig,
   setNestedValue,
   withSuppressedConfigDiskWrites,
+  withSuppressedConfigDiskWritesSync,
 } from "../../config/loader.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
@@ -230,7 +231,7 @@ function getModelSetContext(): ModelSetContext {
       watcher.suppressConfigReload = value;
     },
     updateConfigFingerprint() {
-      void withSuppressedConfigDiskWrites(() => watcher.updateFingerprint());
+      withSuppressedConfigDiskWritesSync(() => watcher.updateFingerprint());
     },
     debounceTimers: watcher.timers,
   };


### PR DESCRIPTION
## Summary
- Add `withSuppressedConfigDiskWrites()` helper in config loader that uses a depth counter to safely suppress `loadConfig()`'s disk-write side effects (deprecated-field stripping, Gemini migration, first-launch seed)
- Wrap `commitConfigWrite`'s post-save `getConfig()` + `updateFingerprint()` calls so `loadConfig()` never overwrites the config that was just saved
- Add regression tests verifying `config set` preserves existing user profiles, custom settings, and all top-level keys

## Original prompt
The user reported that running `assistant config set <key> <value>` rewrites the entire config.json, resetting custom config values and dropping user-created model profiles. The root cause is that `commitConfigWrite` calls `getConfig()` → `loadConfig()` after saving, and `loadConfig()` has disk-write side effects (especially the first-launch seed that writes full schema defaults) that can overwrite the file just saved by `saveRawConfig`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->