### PR TITLE
chore(cli): bump upgrade readiness timeout from 3 to 5 minutes

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -40,10 +40,13 @@ export const DOCKERHUB_IMAGES: Record<ServiceName, string> = {
 };
 
 /** Internal ports exposed by each service's Dockerfile. Re-exported from environments/paths.ts. */
-export { ASSISTANT_INTERNAL_PORT, GATEWAY_INTERNAL_PORT } from "./environments/paths.js";
+export {
+  ASSISTANT_INTERNAL_PORT,
+  GATEWAY_INTERNAL_PORT,
+} from "./environments/paths.js";
 
 /** Max time to wait for the assistant container to emit the readiness sentinel. */
-export const DOCKER_READY_TIMEOUT_MS = 3 * 60 * 1000;
+export const DOCKER_READY_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Default virtual-camera device path. Overridable via `VELLUM_AVATAR_DEVICE`. */
 const DEFAULT_AVATAR_DEVICE_PATH = "/dev/video10";
@@ -612,7 +615,10 @@ export async function startContainers(
   },
   log: (msg: string) => void,
 ): Promise<void> {
-  const runArgs = buildServiceRunArgs({ ...opts, avatarDevicePath: resolveAvatarDevicePath() });
+  const runArgs = buildServiceRunArgs({
+    ...opts,
+    avatarDevicePath: resolveAvatarDevicePath(),
+  });
   for (const service of SERVICE_START_ORDER) {
     log(`🚀 Starting ${service} container...`);
     await exec("docker", runArgs[service]());


### PR DESCRIPTION
## Summary
- Bump `DOCKER_READY_TIMEOUT_MS` from `3 * 60 * 1000` to `5 * 60 * 1000` in `cli/src/lib/docker.ts`. This is the deadline the upgrade flow gives the new containers to pass `/readyz` before triggering `READINESS_TIMEOUT` and auto-rollback.
- Picked up an unrelated prettier reformat of the adjacent re-export block in the same file.

## Original prompt
While discussing the upgrade timeout, the user asked to bump the readiness deadline from 3 minutes to 5 minutes. Only the single shared constant in `cli/src/lib/docker.ts` (consumed by `upgrade-lifecycle.ts` and `commands/upgrade.ts`) needed to change; the unrelated 180_000ms timeout in `statefulset.ts` was intentionally left alone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->