### PR TITLE
feat(providers): feature-flag DeepSeek direct provider behind `provider-deepseek`

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -949,6 +949,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     setupMode: "api-key",
     setupHint: "Enter your DeepSeek API key to enable DeepSeek models.",
     envVar: "DEEPSEEK_API_KEY",
+    featureFlag: "provider-deepseek",
     credentialsGuide: {
       description:
         "Sign in to the DeepSeek platform, navigate to API Keys, and create a new key.",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -320,6 +320,14 @@
       "label": "z.ai Provider",
       "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-deepseek",
+      "scope": "assistant",
+      "key": "provider-deepseek",
+      "label": "DeepSeek Provider",
+      "description": "Enable the DeepSeek direct API provider and its models (V4 Pro, V4 Flash) in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Declare `provider-deepseek` feature flag in the registry with `defaultEnabled: false`
- Add `featureFlag: "provider-deepseek"` to the DeepSeek catalog entry so it is hidden from the UI by default
- Companion PR needed in vellum-assistant-platform for LaunchDarkly Terraform

Part of plan: provider-feature-flags.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->