### PR TITLE
feat(providers): feature-flag z.ai provider behind `provider-zai`

### DIFF
--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,17 +19,31 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
-  test("returns the full catalog when no feature flags are set", () => {
+  test("returns the full catalog when all feature flags are enabled", () => {
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting(allFlags);
+
     const visible = getVisibleProviderCatalog(makeConfig());
     expect(visible.length).toBe(PROVIDER_CATALOG.length);
     expect(visible.map((p) => p.id)).toEqual(PROVIDER_CATALOG.map((p) => p.id));
   });
 
   test("hides a provider whose featureFlag is disabled", () => {
-    _setOverridesForTesting({ "test-provider-flag": false });
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting({ ...allFlags, "test-provider-flag": false });
 
-    // Temporarily patch the catalog to add a flagged provider — we test
-    // against the real catalog array so we mutate-and-restore.
     const original = [...PROVIDER_CATALOG];
     PROVIDER_CATALOG.push({
       id: "__test_flagged_provider__",
@@ -49,7 +63,6 @@ describe("getVisibleProviderCatalog", () => {
       expect(
         visible.find((p) => p.id === "__test_flagged_provider__"),
       ).toBeUndefined();
-      // All original providers should still be present
       expect(visible.length).toBe(original.length);
     } finally {
       PROVIDER_CATALOG.length = 0;

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -875,6 +875,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
     id: "zai",
     displayName: "z.ai",
+    featureFlag: "provider-zai",
     subtitle: "GLM models from z.ai (Zhipu AI). Requires a z.ai API key.",
     setupMode: "api-key",
     setupHint: "Enter your z.ai API key to enable GLM models.",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,14 @@
       "label": "External Plugins",
       "description": "Enable the external-plugin install path: the `assistant plugins` CLI subcommand and the declarative external-plugin loader convention (`<workspaceDir>/plugins/<name>/` directories containing `package.json` plus interface dirs). Gates an unstable surface that may change shape before stabilizing.",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-zai",
+      "scope": "assistant",
+      "key": "provider-zai",
+      "label": "z.ai Provider",
+      "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Declare `provider-zai` feature flag in the registry with `defaultEnabled: false`
- Add `featureFlag: "provider-zai"` to the z.ai catalog entry so it is hidden from the UI by default
- Companion PR needed in vellum-assistant-platform for LaunchDarkly Terraform

Part of plan: provider-feature-flags.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->