### PR TITLE
feat(providers): feature-flag MiniMax direct provider behind `provider-minimax`

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -993,6 +993,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "minimax",
     displayName: "MiniMax",
     subtitle: "MiniMax models. Requires a MiniMax API key.",
+    featureFlag: "provider-minimax",
     setupMode: "api-key",
     setupHint: "Enter your MiniMax API key to enable MiniMax models.",
     envVar: "MINIMAX_API_KEY",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -328,6 +328,14 @@
       "label": "DeepSeek Provider",
       "description": "Enable the DeepSeek direct API provider and its models (V4 Pro, V4 Flash) in the provider picker and model selection UI",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-minimax",
+      "scope": "assistant",
+      "key": "provider-minimax",
+      "label": "MiniMax Provider",
+      "description": "Enable the MiniMax direct API provider and its models (M2.7, M2.5, M2.1, M2, and highspeed variants) in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Declare `provider-minimax` feature flag in the registry with `defaultEnabled: false`
- Add `featureFlag: "provider-minimax"` to the MiniMax catalog entry so it is hidden from the UI by default
- Companion PR needed in vellum-assistant-platform for LaunchDarkly Terraform

Part of plan: provider-feature-flags.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->