### PR TITLE
fix(contacts): apply optimistic local updates for create and delete

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -122,7 +122,8 @@ struct ContactsContainerView: View {
                                 contact: contact,
                                 connectionManager: connectionManager,
                                 store: store,
-                                onDelete: {
+                                onDelete: { [contactId] in
+                                    viewModel.contactsStore?.contacts.removeAll { $0.id == contactId }
                                     selection = .assistant
                                     viewModel.loadContacts()
                                 },
@@ -344,10 +345,9 @@ struct ContactsContainerView: View {
                 channels: nil
             )
             if let contact {
-                viewModel.loadContacts()
-                // Small delay to let the contacts list refresh before selecting
-                try? await Task.sleep(nanoseconds: 200_000_000)
+                viewModel.contactsStore?.contacts.append(contact)
                 selection = .contact(contact.id)
+                viewModel.loadContacts()
             }
         } catch {
             createContactError = "Failed to create contact: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary
- **Create**: immediately append the new contact to the store's local contacts array and select it, instead of relying on a background fetch + 200ms sleep
- **Delete**: immediately remove the contact from the local array before switching selection and refreshing
- Both paths still call `loadContacts()` as a background consistency sync

## Original prompt
The "Add Contact" button in the Contacts tab appeared to do nothing — the contact was created via the API, but the UI didn't reflect the change until a manual tab switch/page refresh. The same issue affected contact deletion. The root cause was that the background `loadContacts()` refresh wasn't reliably propagating changes through the nested `@Observable` observation chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->