### PR TITLE
feat(providers): feature-flag new providers (z.ai, DeepSeek, MiniMax)

### DIFF
--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,17 +19,31 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
-  test("returns the full catalog when no feature flags are set", () => {
+  test("returns the full catalog when all feature flags are enabled", () => {
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting(allFlags);
+
     const visible = getVisibleProviderCatalog(makeConfig());
     expect(visible.length).toBe(PROVIDER_CATALOG.length);
     expect(visible.map((p) => p.id)).toEqual(PROVIDER_CATALOG.map((p) => p.id));
   });
 
   test("hides a provider whose featureFlag is disabled", () => {
-    _setOverridesForTesting({ "test-provider-flag": false });
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting({ ...allFlags, "test-provider-flag": false });
 
-    // Temporarily patch the catalog to add a flagged provider — we test
-    // against the real catalog array so we mutate-and-restore.
     const original = [...PROVIDER_CATALOG];
     PROVIDER_CATALOG.push({
       id: "__test_flagged_provider__",
@@ -49,7 +63,6 @@ describe("getVisibleProviderCatalog", () => {
       expect(
         visible.find((p) => p.id === "__test_flagged_provider__"),
       ).toBeUndefined();
-      // All original providers should still be present
       expect(visible.length).toBe(original.length);
     } finally {
       PROVIDER_CATALOG.length = 0;

--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { getVisibleProviderCatalog } from "../providers/provider-catalog-visibility.js";
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+/** Minimal AssistantConfig stub for feature-flag resolution. */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+describe("getVisibleProviderCatalog", () => {
+  test("returns the full catalog when no feature flags are set", () => {
+    const visible = getVisibleProviderCatalog(makeConfig());
+    expect(visible.length).toBe(PROVIDER_CATALOG.length);
+    expect(visible.map((p) => p.id)).toEqual(PROVIDER_CATALOG.map((p) => p.id));
+  });
+
+  test("hides a provider whose featureFlag is disabled", () => {
+    _setOverridesForTesting({ "test-provider-flag": false });
+
+    // Temporarily patch the catalog to add a flagged provider — we test
+    // against the real catalog array so we mutate-and-restore.
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_flagged_provider__",
+      displayName: "Test Flagged Provider",
+      models: [
+        {
+          id: "test-model",
+          displayName: "Test Model",
+        },
+      ],
+      defaultModel: "test-model",
+      featureFlag: "test-provider-flag",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      expect(
+        visible.find((p) => p.id === "__test_flagged_provider__"),
+      ).toBeUndefined();
+      // All original providers should still be present
+      expect(visible.length).toBe(original.length);
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+
+  test("hides a model whose featureFlag is disabled but keeps the provider", () => {
+    _setOverridesForTesting({ "test-model-flag": false });
+
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_provider_with_flagged_model__",
+      displayName: "Test Provider",
+      models: [
+        {
+          id: "visible-model",
+          displayName: "Visible Model",
+        },
+        {
+          id: "flagged-model",
+          displayName: "Flagged Model",
+          featureFlag: "test-model-flag",
+        },
+      ],
+      defaultModel: "visible-model",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      const provider = visible.find(
+        (p) => p.id === "__test_provider_with_flagged_model__",
+      );
+      expect(provider).toBeDefined();
+      expect(provider!.models.map((m) => m.id)).toEqual(["visible-model"]);
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+
+  test("hides a provider entirely when all its models are flagged off", () => {
+    _setOverridesForTesting({
+      "flag-a": false,
+      "flag-b": false,
+    });
+
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_all_models_flagged__",
+      displayName: "All Flagged",
+      models: [
+        {
+          id: "model-a",
+          displayName: "Model A",
+          featureFlag: "flag-a",
+        },
+        {
+          id: "model-b",
+          displayName: "Model B",
+          featureFlag: "flag-b",
+        },
+      ],
+      defaultModel: "model-a",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      expect(
+        visible.find((p) => p.id === "__test_all_models_flagged__"),
+      ).toBeUndefined();
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+});

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -8,8 +8,8 @@ import {
   saveRawConfig,
 } from "../config/loader.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
+import { getVisibleProviderCatalog } from "../providers/provider-catalog-visibility.js";
 
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
@@ -132,7 +132,10 @@ function parseModelCommand(trimmed: string): ModelCommandParse | null {
 }
 
 function orderedProfileNames(
-  profiles: Record<string, { label?: string; description?: string; status?: "active" | "disabled" }>,
+  profiles: Record<
+    string,
+    { label?: string; description?: string; status?: "active" | "disabled" }
+  >,
   profileOrder: readonly string[] | undefined,
 ): string[] {
   const order = profileOrder ?? [];
@@ -177,8 +180,12 @@ async function resolveModelCommand(
       const isDisabled = profile.status === "disabled";
       const marker = isCurrent ? " **[current]**" : "";
       const disabled = isDisabled ? " *(disabled)*" : "";
-      const description = profile.description ? ` — ${profile.description}` : "";
-      lines.push(`  - \`${name}\` (${label})${marker}${disabled}${description}`);
+      const description = profile.description
+        ? ` — ${profile.description}`
+        : "";
+      lines.push(
+        `  - \`${name}\` (${label})${marker}${disabled}${description}`,
+      );
     }
     lines.push("\nSwitch with `/model <name>`.");
     return { kind: "unknown", message: lines.join("\n") };
@@ -240,7 +247,7 @@ async function resolveModelList(): Promise<SlashResolution> {
     id: provider,
     displayName: providerName,
     models,
-  } of PROVIDER_CATALOG) {
+  } of getVisibleProviderCatalog(config)) {
     const hasKey = configuredProviders.has(provider);
     const status = hasKey ? "✓" : "✗";
     lines.push(`**${providerName}** ${status}`);

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -7,8 +7,8 @@ import {
 import { setServiceField } from "../../config/raw-config-utils.js";
 import { providerForImageModelPrefix } from "../../media/types.js";
 import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
-import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { getConfiguredProviders } from "../../providers/provider-availability.js";
+import { getVisibleProviderCatalog } from "../../providers/provider-catalog-visibility.js";
 import { CONFIG_RELOAD_DEBOUNCE_MS, log } from "./shared.js";
 
 // ---------------------------------------------------------------------------
@@ -65,15 +65,16 @@ export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
   const resolved = resolveCallSiteConfig("mainAgent", config.llm);
   const provider = resolved.provider;
+  const visibleCatalog = getVisibleProviderCatalog(config);
 
   return {
     model: resolved.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
-    availableModels: PROVIDER_CATALOG.find(
-      (p) => p.id === provider,
-    )?.models?.map((m) => ({ id: m.id, displayName: m.displayName })),
-    allProviders: PROVIDER_CATALOG.map(projectProviderForWire),
+    availableModels: visibleCatalog
+      .find((p) => p.id === provider)
+      ?.models?.map((m) => ({ id: m.id, displayName: m.displayName })),
+    allProviders: visibleCatalog.map(projectProviderForWire),
   };
 }
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -993,6 +993,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "minimax",
     displayName: "MiniMax",
     subtitle: "MiniMax models. Requires a MiniMax API key.",
+    featureFlag: "provider-minimax",
     setupMode: "api-key",
     setupHint: "Enter your MiniMax API key to enable MiniMax models.",
     envVar: "MINIMAX_API_KEY",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -949,6 +949,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     setupMode: "api-key",
     setupHint: "Enter your DeepSeek API key to enable DeepSeek models.",
     envVar: "DEEPSEEK_API_KEY",
+    featureFlag: "provider-deepseek",
     credentialsGuide: {
       description:
         "Sign in to the DeepSeek platform, navigate to API Keys, and create a new key.",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -45,6 +45,8 @@ export interface CatalogModel {
   supportsVision?: boolean;
   supportsToolUse?: boolean;
   pricing?: CatalogModelPricing;
+  /** When set, this model is only visible when the named feature flag is enabled. */
+  featureFlag?: string;
 }
 
 const DEFAULT_CONTEXT_WINDOW_TOKENS = 200000;
@@ -97,6 +99,8 @@ export interface ProviderCatalogEntry {
    * OpenRouter where managed keys are not available.
    */
   supportsPlatformAuth?: boolean;
+  /** When set, this provider is only visible when the named feature flag is enabled. */
+  featureFlag?: string;
 }
 
 /**

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -875,6 +875,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
     id: "zai",
     displayName: "z.ai",
+    featureFlag: "provider-zai",
     subtitle: "GLM models from z.ai (Zhipu AI). Requires a z.ai API key.",
     setupMode: "api-key",
     setupHint: "Enter your z.ai API key to enable GLM models.",

--- a/assistant/src/providers/provider-availability.ts
+++ b/assistant/src/providers/provider-availability.ts
@@ -5,9 +5,11 @@
  * environment variable fallbacks, and managed proxy availability.
  */
 
-import { API_KEY_PROVIDERS } from "../config/loader.js";
+import { API_KEY_PROVIDERS, getConfig } from "../config/loader.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
+import { PROVIDER_CATALOG } from "./model-catalog.js";
 import { managedFallbackEnabledFor } from "./platform-proxy/context.js";
+import { getVisibleProviderCatalog } from "./provider-catalog-visibility.js";
 
 /**
  * Check whether a single provider is usable — via a user-provided key
@@ -25,11 +27,24 @@ export async function isProviderAvailable(provider: string): Promise<boolean> {
 /**
  * Build the list of providers that are usable — via a user-provided key
  * (secure storage or env var) or via the managed proxy fallback.
+ * Feature-flagged LLM providers that are currently disabled are excluded.
  * Ollama is always included because it does not require an API key.
  */
 export async function getConfiguredProviders(): Promise<string[]> {
+  // Build the set of LLM providers hidden by feature flags so we can
+  // exclude them while leaving non-LLM providers (search, STT, TTS)
+  // in API_KEY_PROVIDERS unchanged.
+  const allLlmIds = new Set(PROVIDER_CATALOG.map((p) => p.id));
+  const visibleLlmIds = new Set(
+    getVisibleProviderCatalog(getConfig()).map((p) => p.id),
+  );
+  const hiddenLlmIds = new Set(
+    [...allLlmIds].filter((id) => !visibleLlmIds.has(id)),
+  );
+
   const configured: string[] = [];
   for (const p of API_KEY_PROVIDERS) {
+    if (hiddenLlmIds.has(p)) continue;
     if (await isProviderAvailable(p)) {
       configured.push(p);
     }

--- a/assistant/src/providers/provider-catalog-visibility.ts
+++ b/assistant/src/providers/provider-catalog-visibility.ts
@@ -1,0 +1,36 @@
+/**
+ * Feature-flag-aware provider catalog filtering.
+ *
+ * User-facing catalog consumers (model info, slash commands, provider
+ * availability) use `getVisibleProviderCatalog()` to hide providers and
+ * models gated behind disabled feature flags. Internal consumers
+ * (adapter-factory, pricing, auth) continue using the unfiltered
+ * `PROVIDER_CATALOG` directly.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  PROVIDER_CATALOG,
+  type ProviderCatalogEntry,
+} from "./model-catalog.js";
+
+export function getVisibleProviderCatalog(
+  config: AssistantConfig,
+): ProviderCatalogEntry[] {
+  return PROVIDER_CATALOG.filter(
+    (entry) =>
+      !entry.featureFlag ||
+      isAssistantFeatureFlagEnabled(entry.featureFlag, config),
+  )
+    .map((entry) => {
+      const visibleModels = entry.models.filter(
+        (m) =>
+          !m.featureFlag ||
+          isAssistantFeatureFlagEnabled(m.featureFlag, config),
+      );
+      if (visibleModels.length === entry.models.length) return entry;
+      return { ...entry, models: visibleModels };
+    })
+    .filter((entry) => entry.models.length > 0);
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,14 @@
       "label": "External Plugins",
       "description": "Enable the external-plugin install path: the `assistant plugins` CLI subcommand and the declarative external-plugin loader convention (`<workspaceDir>/plugins/<name>/` directories containing `package.json` plus interface dirs). Gates an unstable surface that may change shape before stabilizing.",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-zai",
+      "scope": "assistant",
+      "key": "provider-zai",
+      "label": "z.ai Provider",
+      "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -320,6 +320,14 @@
       "label": "z.ai Provider",
       "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-deepseek",
+      "scope": "assistant",
+      "key": "provider-deepseek",
+      "label": "DeepSeek Provider",
+      "description": "Enable the DeepSeek direct API provider and its models (V4 Pro, V4 Flash) in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -328,6 +328,14 @@
       "label": "DeepSeek Provider",
       "description": "Enable the DeepSeek direct API provider and its models (V4 Pro, V4 Flash) in the provider picker and model selection UI",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-minimax",
+      "scope": "assistant",
+      "key": "provider-minimax",
+      "label": "MiniMax Provider",
+      "description": "Enable the MiniMax direct API provider and its models (M2.7, M2.5, M2.1, M2, and highspeed variants) in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add optional `featureFlag` field to `ProviderCatalogEntry` and `CatalogModel` interfaces
- Create `getVisibleProviderCatalog()` that filters providers/models by feature flag state at runtime
- Update user-facing consumers (`getModelInfo`, conversation slash commands, `getConfiguredProviders`) to use filtered catalog
- Declare `provider-zai`, `provider-deepseek`, `provider-minimax` flags (all `defaultEnabled: false`)
- Internal consumers (adapter-factory, pricing, auth) continue using unfiltered `PROVIDER_CATALOG`

## Test plan
- [x] `provider-catalog-visibility.test.ts` covers provider hiding, model hiding, and full-catalog-visible scenarios
- [x] Existing `llm-catalog-parity.test.ts` passes
- [x] Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->