### PR TITLE
fix(providers): round-trip reasoning_content for DeepSeek multi-turn conversations

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1159,6 +1159,35 @@ describe("OpenAIProvider", () => {
     });
     expect(sent[1]).not.toHaveProperty("reasoning_content");
   });
+
+  test("skips thinking blocks with signatures (Anthropic-originated) in reasoning_content", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Anthropic thinking with signature",
+            signature: "abc123",
+          },
+          { type: "text", text: "Hi there!" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+    });
+    expect(sent[1]).not.toHaveProperty("reasoning_content");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -21,6 +21,7 @@ interface FakeChunk {
   choices: Array<{
     delta: {
       content?: string | null;
+      reasoning_content?: string | null;
       tool_calls?: Array<{
         index: number;
         id?: string;
@@ -103,6 +104,17 @@ import { OpenRouterProvider } from "../providers/openrouter/client.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function reasoningChunk(
+  reasoning_content: string,
+  finish: string | null = null,
+): FakeChunk {
+  return {
+    choices: [{ delta: { reasoning_content }, finish_reason: finish }],
+    usage: null,
+    model: "gpt-5.2",
+  };
+}
 
 function textChunk(content: string, finish: string | null = null): FakeChunk {
   return {
@@ -1067,6 +1079,85 @@ describe("OpenAIProvider", () => {
         },
       ],
     });
+  });
+
+  // -----------------------------------------------------------------------
+  // reasoning_content (DeepSeek-style thinking) round-trip
+  // -----------------------------------------------------------------------
+  test("captures reasoning_content from stream as thinking block", async () => {
+    fakeChunks = [
+      reasoningChunk("Let me think"),
+      reasoningChunk(" about this."),
+      textChunk("Hello!"),
+      usageChunk(10, 5),
+    ];
+
+    const events: Array<{ type: string }> = [];
+    const result = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      undefined,
+      undefined,
+      {
+        onEvent: (e) => events.push(e),
+      },
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: "thinking",
+      thinking: "Let me think about this.",
+    });
+    expect(result.content[1]).toEqual({ type: "text", text: "Hello!" });
+
+    const thinkingDeltas = events.filter((e) => e.type === "thinking_delta");
+    expect(thinkingDeltas).toHaveLength(2);
+  });
+
+  test("includes reasoning_content on assistant messages in conversation history", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "User said hello." },
+          { type: "text", text: "Hi there!" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+      reasoning_content: "User said hello.",
+    });
+  });
+
+  test("omits reasoning_content when no thinking blocks exist", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hi there!" }],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+    });
+    expect(sent[1]).not.toHaveProperty("reasoning_content");
   });
 });
 

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1544,6 +1544,7 @@ export class AnthropicProvider implements Provider {
       case "text":
         return { type: "text", text: block.text };
       case "thinking":
+        if (!block.signature) return null;
         return {
           type: "thinking",
           thinking: block.thinking,

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -189,6 +189,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       // Accumulate the response from chunks
       let contentText = "";
+      let reasoningText = "";
       const toolCallMap = new Map<
         number,
         { id: string; name: string; args: string }
@@ -215,6 +216,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
         for await (const chunk of stream) {
           const choice = chunk.choices[0];
           if (choice) {
+            // DeepSeek (and other OpenAI-compatible reasoning models) stream
+            // thinking output via `reasoning_content` on the delta.
+            const reasoningDelta = (
+              choice.delta as { reasoning_content?: string }
+            ).reasoning_content;
+            if (reasoningDelta) {
+              reasoningText += reasoningDelta;
+              onEvent?.({ type: "thinking_delta", thinking: reasoningDelta });
+            }
+
             if (choice.delta.content) {
               contentText += choice.delta.content;
               onEvent?.({ type: "text_delta", text: choice.delta.content });
@@ -262,6 +273,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       // Build content blocks
       const content: ContentBlock[] = [];
+      if (reasoningText) {
+        content.push({ type: "thinking", thinking: reasoningText });
+      }
       if (contentText) {
         content.push({ type: "text", text: contentText });
       }
@@ -468,6 +482,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     msg: Message,
   ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
     const textParts: string[] = [];
+    const thinkingParts: string[] = [];
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] =
       [];
 
@@ -475,6 +490,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
       switch (block.type) {
         case "text":
           textParts.push(block.text);
+          break;
+        case "thinking":
+          thinkingParts.push(block.thinking);
           break;
         case "tool_use":
           toolCalls.push({
@@ -492,7 +510,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         case "web_search_tool_result":
           textParts.push("[Web search results]");
           break;
-        // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
+        // redacted_thinking, image — not applicable for OpenAI assistant messages
       }
     }
 
@@ -501,6 +519,12 @@ export class OpenAIChatCompletionsProvider implements Provider {
         role: "assistant",
         content: textParts.length > 0 ? textParts.join("") : null,
       };
+
+    if (thinkingParts.length > 0) {
+      Object.assign(result, {
+        reasoning_content: thinkingParts.join(""),
+      });
+    }
 
     if (toolCalls.length > 0) {
       result.tool_calls = toolCalls;

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -492,7 +492,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
           textParts.push(block.text);
           break;
         case "thinking":
-          thinkingParts.push(block.thinking);
+          if (!block.signature) thinkingParts.push(block.thinking);
           break;
         case "tool_use":
           toolCalls.push({

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -44,7 +44,8 @@ export interface ToolUseContent {
 export interface ThinkingContent {
   type: "thinking";
   thinking: string;
-  signature: string;
+  /** Anthropic-specific cryptographic signature. Absent for non-Anthropic providers (e.g. DeepSeek). */
+  signature?: string;
 }
 
 export interface RedactedThinkingContent {


### PR DESCRIPTION
## Summary

- Capture `reasoning_content` from OpenAI-compatible streaming deltas and store as `thinking` ContentBlocks, enabling DeepSeek's reasoning output to be preserved and streamed to the UI
- Pass `reasoning_content` back on assistant messages in conversation history so DeepSeek's API accepts multi-turn requests
- Make `ThinkingContent.signature` optional (Anthropic-specific) so non-Anthropic reasoning providers can use the same thinking content type

Closes #30878

## Original prompt

A teammate reported that DeepSeek V4 Pro fails on any multi-turn conversation with `400 The 'reasoning_content' in the thinking mode must be passed back to the API`. Investigation of the feedback logs showed that the `OpenAIChatCompletionsProvider` silently discards `reasoning_content` from streaming responses and drops thinking blocks when constructing conversation history. The fix makes the reasoning content round-trip generic for any OpenAI-compatible provider with reasoning support.

## Test plan

- [ ] Existing OpenAI provider tests pass (67 tests, 3 new)
- [ ] New test: streaming `reasoning_content` chunks are captured as `thinking` ContentBlocks
- [ ] New test: assistant messages with thinking blocks include `reasoning_content` in API requests
- [ ] New test: `reasoning_content` is omitted when no thinking blocks exist
- [ ] Manual: DeepSeek V4 Pro multi-turn conversation completes without 400 errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->