### PR TITLE
Revert "feat(providers): feature-flag new DeepSeek OpenRouter models behind `provider-deepseek-openrouter`"

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -707,7 +707,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: { inputPer1mTokens: 0.435, outputPer1mTokens: 0.87 },
-        featureFlag: "provider-deepseek-openrouter",
       },
       {
         id: "deepseek/deepseek-v4-flash",
@@ -719,7 +718,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: { inputPer1mTokens: 0.14, outputPer1mTokens: 0.28 },
-        featureFlag: "provider-deepseek-openrouter",
       },
       {
         id: "deepseek/deepseek-v3.2-speciale",
@@ -731,7 +729,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: false,
         pricing: { inputPer1mTokens: 0.287, outputPer1mTokens: 0.431 },
-        featureFlag: "provider-deepseek-openrouter",
       },
       // Qwen
       {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -336,14 +336,6 @@
       "label": "MiniMax Provider",
       "description": "Enable the MiniMax direct API provider and its models (M2.7, M2.5, M2.1, M2, and highspeed variants) in the provider picker and model selection UI",
       "defaultEnabled": false
-    },
-    {
-      "id": "provider-deepseek-openrouter",
-      "scope": "assistant",
-      "key": "provider-deepseek-openrouter",
-      "label": "DeepSeek Models on OpenRouter",
-      "description": "Enable DeepSeek V4 Pro, V4 Flash, and V3.2 Speciale models under the OpenRouter provider",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
Reverts vellum-ai/vellum-assistant#30875

these models were fine on openrouter, just not on deepseek as a provider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->