### PR TITLE
fix(providers): filter feature-flagged providers from native client catalog seed

### DIFF
--- a/assistant/scripts/sync-llm-catalog.ts
+++ b/assistant/scripts/sync-llm-catalog.ts
@@ -81,6 +81,8 @@ function projectModel(model: CatalogModel): Record<string, unknown> {
   if (model.supportsToolUse !== undefined)
     projected.supportsToolUse = model.supportsToolUse;
   if (model.pricing !== undefined) projected.pricing = model.pricing;
+  if (model.featureFlag !== undefined)
+    projected.featureFlag = model.featureFlag;
   return projected;
 }
 
@@ -99,6 +101,8 @@ function projectProvider(entry: ProviderCatalogEntry): Record<string, unknown> {
     projected.credentialsGuide = entry.credentialsGuide;
   if (entry.supportsPlatformAuth !== undefined)
     projected.supportsPlatformAuth = entry.supportsPlatformAuth;
+  if (entry.featureFlag !== undefined)
+    projected.featureFlag = entry.featureFlag;
   projected.defaultModel = entry.defaultModel;
   projected.models = entry.models.map(projectModel);
   // NOTE: `apiKeyUrl` intentionally omitted — clients use

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -69,6 +69,7 @@ interface ClientCatalogModel {
       cacheWritePer1mTokens?: number;
     }>;
   };
+  featureFlag?: string;
 }
 
 interface ClientCatalogEntry {
@@ -81,6 +82,7 @@ interface ClientCatalogEntry {
   apiKeyPlaceholder?: string;
   credentialsGuide?: ClientCatalogCredentialsGuide;
   supportsPlatformAuth?: boolean;
+  featureFlag?: string;
   defaultModel: string;
   models: ClientCatalogModel[];
 }
@@ -138,6 +140,7 @@ describe("LLM catalog parity: daemon vs client", () => {
       expect(clientEntry.credentialsGuide).toEqual(
         daemonEntry.credentialsGuide,
       );
+      expect(clientEntry.featureFlag).toBe(daemonEntry.featureFlag);
       expect(clientEntry.defaultModel).toBe(daemonEntry.defaultModel);
     }
   });
@@ -198,6 +201,7 @@ describe("LLM catalog parity: daemon vs client", () => {
         expect(clientModel.supportsVision).toBe(daemonModel.supportsVision);
         expect(clientModel.supportsToolUse).toBe(daemonModel.supportsToolUse);
         expect(clientModel.pricing).toEqual(daemonModel.pricing);
+        expect(clientModel.featureFlag).toBe(daemonModel.featureFlag);
       }
     }
   });

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -888,6 +888,7 @@
         "linkLabel": "Open z.ai Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-zai",
       "defaultModel": "glm-5.1",
       "models": [
         {
@@ -966,6 +967,7 @@
         "linkLabel": "Open DeepSeek Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-deepseek",
       "defaultModel": "deepseek-v4-pro",
       "models": [
         {
@@ -1016,6 +1018,7 @@
         "linkLabel": "Open MiniMax Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-minimax",
       "defaultModel": "MiniMax-M2.7",
       "models": [
         {

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -91,6 +91,9 @@ public struct LLMModelEntry: Decodable {
     public let supportsToolUse: Bool?
     /// Per-1M-token pricing, if known.
     public let pricing: LLMPricing?
+    /// Feature flag key gating this model. When non-nil, the model is hidden
+    /// from the client-side seed until the daemon confirms it is enabled.
+    public let featureFlag: String?
 
     public init(
         id: String,
@@ -104,7 +107,8 @@ public struct LLMModelEntry: Decodable {
         supportsCaching: Bool? = nil,
         supportsVision: Bool? = nil,
         supportsToolUse: Bool? = nil,
-        pricing: LLMPricing? = nil
+        pricing: LLMPricing? = nil,
+        featureFlag: String? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -118,6 +122,7 @@ public struct LLMModelEntry: Decodable {
         self.supportsVision = supportsVision
         self.supportsToolUse = supportsToolUse
         self.pricing = pricing
+        self.featureFlag = featureFlag
     }
 }
 
@@ -157,6 +162,9 @@ public struct LLMProviderEntry: Decodable {
     /// Vellum)" option for this provider — selecting it would have no
     /// effect since there's no managed proxy route for the provider.
     public let supportsPlatformAuth: Bool?
+    /// Feature flag key gating this provider. When non-nil, the provider is
+    /// hidden from the client-side seed until the daemon confirms it is enabled.
+    public let featureFlag: String?
     /// The default model ID (must be present in `models`).
     public let defaultModel: String
     /// All models offered by this provider.
@@ -172,6 +180,7 @@ public struct LLMProviderEntry: Decodable {
         apiKeyPlaceholder: String?,
         credentialsGuide: LLMCredentialsGuide?,
         supportsPlatformAuth: Bool? = nil,
+        featureFlag: String? = nil,
         defaultModel: String,
         models: [LLMModelEntry]
     ) {
@@ -184,6 +193,7 @@ public struct LLMProviderEntry: Decodable {
         self.apiKeyPlaceholder = apiKeyPlaceholder
         self.credentialsGuide = credentialsGuide
         self.supportsPlatformAuth = supportsPlatformAuth
+        self.featureFlag = featureFlag
         self.defaultModel = defaultModel
         self.models = models
     }
@@ -213,9 +223,14 @@ public struct LLMProviderCatalog: Decodable {
 
 /// Public read accessors for the cached LLM provider catalog.
 public enum LLMProviderRegistry {
-    /// All providers in catalog order.
+    /// All providers in catalog order, excluding feature-flagged entries.
+    ///
+    /// Providers with a non-nil `featureFlag` are hidden from the client-side
+    /// seed because the client cannot resolve feature flag state. The daemon's
+    /// `model_info` response replaces this seed with the correctly filtered
+    /// list once it arrives.
     public static var providers: [LLMProviderEntry] {
-        shared.providers
+        shared.providers.filter { $0.featureFlag == nil }
     }
 
     /// The default provider (first entry).

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -888,6 +888,7 @@
         "linkLabel": "Open z.ai Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-zai",
       "defaultModel": "glm-5.1",
       "models": [
         {
@@ -966,6 +967,7 @@
         "linkLabel": "Open DeepSeek Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-deepseek",
       "defaultModel": "deepseek-v4-pro",
       "models": [
         {
@@ -1016,6 +1018,7 @@
         "linkLabel": "Open MiniMax Platform"
       },
       "supportsPlatformAuth": false,
+      "featureFlag": "provider-minimax",
       "defaultModel": "MiniMax-M2.7",
       "models": [
         {


### PR DESCRIPTION
## Summary
- Include `featureFlag` field in the generated client catalog JSON via the sync script
- Add `featureFlag: String?` to Swift `LLMProviderEntry` and `LLMModelEntry` types
- Filter out providers with a non-nil `featureFlag` from `LLMProviderRegistry.providers` so the native client seed does not show feature-flagged providers before the daemon model_info response arrives
- Add `featureFlag` parity assertions to `llm-catalog-parity.test.ts`

## Original prompt
A Devin review on #30877 flagged that the native macOS client seeds its provider catalog from the bundled LLMProviderRegistry JSON before the daemon filtered model_info response arrives. Feature-flagged providers (z.ai, DeepSeek, MiniMax) were visible in that seed window because the client catalog did not carry the featureFlag field. This fix propagates the field and filters flagged providers client-side.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->