### PR TITLE
Cherry-pick fixes and features for v0.8.2

### DIFF
--- a/assistant/src/__tests__/config-set-route.test.ts
+++ b/assistant/src/__tests__/config-set-route.test.ts
@@ -27,6 +27,8 @@ mock.module("../config/loader.js", () => ({
   deepMergeOverwrite: () => {},
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
+  withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
+  withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
   // setNestedValue is also exported by loader; handleSetConfig imports the
   // real one from this module, so we re-export a thin implementation that
   // mutates in place (matches loader's behavior).
@@ -142,6 +144,84 @@ describe("config_set route - request validation", () => {
     const calls = (savedRaw as unknown as Record<string, unknown>)
       .calls as Record<string, unknown>;
     expect(calls.enabled).toBe(true);
+  });
+
+  test("preserves user profiles and custom settings when setting unrelated key", async () => {
+    rawConfig = {
+      llm: {
+        activeProfile: "my-custom-profile",
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+          "my-custom-profile": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            maxTokens: 32000,
+          },
+        },
+      },
+      memory: {
+        embeddings: { provider: "openai" },
+      },
+    };
+    savedRaw = null;
+    const result = await configSetRoute.handler({
+      body: {
+        path: "memory.cleanup.llmRequestLogRetentionMs",
+        value: 86400000,
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+
+    const saved = savedRaw as unknown as Record<string, unknown>;
+    const llm = saved.llm as Record<string, unknown>;
+    expect(llm.activeProfile).toBe("my-custom-profile");
+
+    const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+    expect(profiles["my-custom-profile"]).toEqual({
+      source: "user",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 32000,
+    });
+    expect(profiles.balanced).toEqual({
+      source: "managed",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    const memory = saved.memory as Record<string, unknown>;
+    expect((memory.embeddings as Record<string, unknown>).provider).toBe(
+      "openai",
+    );
+    expect(
+      (memory.cleanup as Record<string, unknown>).llmRequestLogRetentionMs,
+    ).toBe(86400000);
+  });
+
+  test("preserves all top-level keys when setting a nested path", async () => {
+    rawConfig = {
+      llm: { default: { provider: "anthropic" } },
+      calls: { enabled: true },
+      heartbeat: { activeHoursStart: "09:00", activeHoursEnd: "22:00" },
+    };
+    savedRaw = null;
+    await configSetRoute.handler({
+      body: { path: "memory.cleanup.conversationRetentionDays", value: 30 },
+    });
+    expect(savedRaw).not.toBeNull();
+    const saved = savedRaw as unknown as Record<string, unknown>;
+    expect(saved.llm).toEqual({ default: { provider: "anthropic" } });
+    expect(saved.calls).toEqual({ enabled: true });
+    expect(saved.heartbeat).toEqual({
+      activeHoursStart: "09:00",
+      activeHoursEnd: "22:00",
+    });
   });
 });
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -67,6 +67,8 @@ mock.module("../config/loader.js", () => ({
   },
   getConfig: () => rawConfig,
   invalidateConfigCache: () => {},
+  withSuppressedConfigDiskWrites: async (fn: () => unknown) => fn(),
+  withSuppressedConfigDiskWritesSync: (fn: () => unknown) => fn(),
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { getVisibleProviderCatalog } from "../providers/provider-catalog-visibility.js";
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+/** Minimal AssistantConfig stub for feature-flag resolution. */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+describe("getVisibleProviderCatalog", () => {
+  test("returns the full catalog when all feature flags are enabled", () => {
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting(allFlags);
+
+    const visible = getVisibleProviderCatalog(makeConfig());
+    expect(visible.length).toBe(PROVIDER_CATALOG.length);
+    expect(visible.map((p) => p.id)).toEqual(PROVIDER_CATALOG.map((p) => p.id));
+  });
+
+  test("hides a provider whose featureFlag is disabled", () => {
+    const allFlags: Record<string, boolean> = {};
+    for (const entry of PROVIDER_CATALOG) {
+      if (entry.featureFlag) allFlags[entry.featureFlag] = true;
+      for (const model of entry.models) {
+        if (model.featureFlag) allFlags[model.featureFlag] = true;
+      }
+    }
+    _setOverridesForTesting({ ...allFlags, "test-provider-flag": false });
+
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_flagged_provider__",
+      displayName: "Test Flagged Provider",
+      models: [
+        {
+          id: "test-model",
+          displayName: "Test Model",
+        },
+      ],
+      defaultModel: "test-model",
+      featureFlag: "test-provider-flag",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      expect(
+        visible.find((p) => p.id === "__test_flagged_provider__"),
+      ).toBeUndefined();
+      expect(visible.length).toBe(original.length);
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+
+  test("hides a model whose featureFlag is disabled but keeps the provider", () => {
+    _setOverridesForTesting({ "test-model-flag": false });
+
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_provider_with_flagged_model__",
+      displayName: "Test Provider",
+      models: [
+        {
+          id: "visible-model",
+          displayName: "Visible Model",
+        },
+        {
+          id: "flagged-model",
+          displayName: "Flagged Model",
+          featureFlag: "test-model-flag",
+        },
+      ],
+      defaultModel: "visible-model",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      const provider = visible.find(
+        (p) => p.id === "__test_provider_with_flagged_model__",
+      );
+      expect(provider).toBeDefined();
+      expect(provider!.models.map((m) => m.id)).toEqual(["visible-model"]);
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+
+  test("hides a provider entirely when all its models are flagged off", () => {
+    _setOverridesForTesting({
+      "flag-a": false,
+      "flag-b": false,
+    });
+
+    const original = [...PROVIDER_CATALOG];
+    PROVIDER_CATALOG.push({
+      id: "__test_all_models_flagged__",
+      displayName: "All Flagged",
+      models: [
+        {
+          id: "model-a",
+          displayName: "Model A",
+          featureFlag: "flag-a",
+        },
+        {
+          id: "model-b",
+          displayName: "Model B",
+          featureFlag: "flag-b",
+        },
+      ],
+      defaultModel: "model-a",
+    });
+
+    try {
+      const visible = getVisibleProviderCatalog(makeConfig());
+      expect(
+        visible.find((p) => p.id === "__test_all_models_flagged__"),
+      ).toBeUndefined();
+    } finally {
+      PROVIDER_CATALOG.length = 0;
+      PROVIDER_CATALOG.push(...original);
+    }
+  });
+});

--- a/assistant/src/__tests__/turn-events-store.test.ts
+++ b/assistant/src/__tests__/turn-events-store.test.ts
@@ -202,7 +202,7 @@ describe("queryUnreportedTurnEvents", () => {
     }
   });
 
-  test("extracts interfaceId, channelId, and clientJson from messages.metadata", async () => {
+  test("extracts interfaceId, channelId, and clientMetadata from messages.metadata", async () => {
     // Three user messages with different metadata shapes to cover the
     // realistic spectrum of attribution carried on messages.metadata:
     //  - Full interactive: macOS surface, vellum channel, with a client
@@ -232,11 +232,11 @@ describe("queryUnreportedTurnEvents", () => {
     expect(byId[macOsMsg.id]).toBeDefined();
     expect(byId[macOsMsg.id].interfaceId).toBe("macos");
     expect(byId[macOsMsg.id].channelId).toBe("vellum");
-    // clientJson is returned as raw JSON text -- the reporter parses it.
+    // clientMetadata is returned as raw JSON text -- the reporter parses it.
     // We verify it round-trips back to the input object.
-    expect(byId[macOsMsg.id].clientJson).not.toBeNull();
+    expect(byId[macOsMsg.id].clientMetadata).not.toBeNull();
     expect(
-      JSON.parse(byId[macOsMsg.id].clientJson as string),
+      JSON.parse(byId[macOsMsg.id].clientMetadata as string),
     ).toMatchObject({
       os: "darwin",
       interface_version: "0.8.2",
@@ -244,13 +244,13 @@ describe("queryUnreportedTurnEvents", () => {
 
     expect(byId[slackMsg.id].interfaceId).toBe("slack");
     expect(byId[slackMsg.id].channelId).toBe("slack");
-    expect(byId[slackMsg.id].clientJson).toBeNull();
+    expect(byId[slackMsg.id].clientMetadata).toBeNull();
 
     // Legacy rows (no metadata threading) return null for all three
     // attribution fields -- downstream analytics treats these as
     // "unknown" without breaking the batch.
     expect(byId[legacyMsg.id].interfaceId).toBeNull();
     expect(byId[legacyMsg.id].channelId).toBeNull();
-    expect(byId[legacyMsg.id].clientJson).toBeNull();
+    expect(byId[legacyMsg.id].clientMetadata).toBeNull();
   });
 });

--- a/assistant/src/__tests__/turn-events-store.test.ts
+++ b/assistant/src/__tests__/turn-events-store.test.ts
@@ -201,4 +201,56 @@ describe("queryUnreportedTurnEvents", () => {
       expect(e.conversationType).toBe("standard");
     }
   });
+
+  test("extracts interfaceId, channelId, and clientJson from messages.metadata", async () => {
+    // Three user messages with different metadata shapes to cover the
+    // realistic spectrum of attribution carried on messages.metadata:
+    //  - Full interactive: macOS surface, vellum channel, with a client
+    //    block stamped by the (forthcoming) HTTP header middleware.
+    //  - Channel inbound: Slack surface, no client headers (channel
+    //    inbound paths don't carry browser context).
+    //  - Legacy: a message persisted before metadata threading existed.
+    const conv = createConversation({ conversationType: "standard" });
+
+    const macOsMsg = await addMessage(conv.id, "user", "hi from desktop", {
+      userMessageInterface: "macos",
+      userMessageChannel: "vellum",
+      client: {
+        os: "darwin",
+        interface_version: "0.8.2",
+      },
+    });
+    const slackMsg = await addMessage(conv.id, "user", "hi from slack", {
+      userMessageInterface: "slack",
+      userMessageChannel: "slack",
+    });
+    const legacyMsg = await addMessage(conv.id, "user", "hi from the past");
+
+    const events = queryUnreportedTurnEvents(0, undefined, 100);
+    const byId = Object.fromEntries(events.map((e) => [e.id, e]));
+
+    expect(byId[macOsMsg.id]).toBeDefined();
+    expect(byId[macOsMsg.id].interfaceId).toBe("macos");
+    expect(byId[macOsMsg.id].channelId).toBe("vellum");
+    // clientJson is returned as raw JSON text -- the reporter parses it.
+    // We verify it round-trips back to the input object.
+    expect(byId[macOsMsg.id].clientJson).not.toBeNull();
+    expect(
+      JSON.parse(byId[macOsMsg.id].clientJson as string),
+    ).toMatchObject({
+      os: "darwin",
+      interface_version: "0.8.2",
+    });
+
+    expect(byId[slackMsg.id].interfaceId).toBe("slack");
+    expect(byId[slackMsg.id].channelId).toBe("slack");
+    expect(byId[slackMsg.id].clientJson).toBeNull();
+
+    // Legacy rows (no metadata threading) return null for all three
+    // attribution fields -- downstream analytics treats these as
+    // "unknown" without breaking the batch.
+    expect(byId[legacyMsg.id].interfaceId).toBeNull();
+    expect(byId[legacyMsg.id].channelId).toBeNull();
+    expect(byId[legacyMsg.id].clientJson).toBeNull();
+  });
 });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -25,6 +25,7 @@ const log = getLogger("config");
 let cached: AssistantConfig | null = null;
 let cachedFileSignature: ConfigFileSignature | null = null;
 let loading = false;
+let suppressConfigDiskWritesDepth = 0;
 
 type ConfigFileSignature =
   | {
@@ -683,49 +684,54 @@ export function loadConfig(): AssistantConfig {
       configFileExisted = false;
     }
 
-    // Warn about and strip deprecated config fields so users know their
-    // settings are no longer honored rather than silently dropping them.
-    warnAndStripDeprecatedFields(fileConfig, configPath);
+    if (suppressConfigDiskWritesDepth === 0) {
+      warnAndStripDeprecatedFields(fileConfig, configPath);
+    }
 
     // Validate and apply defaults via Zod schema
     let config = validateWithSchema(fileConfig);
 
-    // Managed Gemini embedding defaults migration.
-    // When on a managed platform (IS_PLATFORM=true) with the feature flag
-    // enabled and no explicit embedding provider chosen (provider=auto),
-    // persist Gemini embedding defaults into the raw config file.
-    // Idempotent: once provider=gemini is written, subsequent loads skip this.
-    if (config.memory.embeddings.provider === "auto") {
-      try {
-        if (
-          (process.env.IS_PLATFORM === "true" ||
-            process.env.IS_PLATFORM === "1") &&
-          isManagedGeminiFFEnabled(config)
-        ) {
-          setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
-          setNestedValue(
-            fileConfig,
-            "memory.embeddings.geminiModel",
-            "gemini-embedding-2",
+    if (suppressConfigDiskWritesDepth === 0) {
+      // Managed Gemini embedding defaults migration.
+      // When on a managed platform (IS_PLATFORM=true) with the feature flag
+      // enabled and no explicit embedding provider chosen (provider=auto),
+      // persist Gemini embedding defaults into the raw config file.
+      // Idempotent: once provider=gemini is written, subsequent loads skip this.
+      if (config.memory.embeddings.provider === "auto") {
+        try {
+          if (
+            (process.env.IS_PLATFORM === "true" ||
+              process.env.IS_PLATFORM === "1") &&
+            isManagedGeminiFFEnabled(config)
+          ) {
+            setNestedValue(fileConfig, "memory.embeddings.provider", "gemini");
+            setNestedValue(
+              fileConfig,
+              "memory.embeddings.geminiModel",
+              "gemini-embedding-2",
+            );
+            setNestedValue(
+              fileConfig,
+              "memory.embeddings.geminiDimensions",
+              3072,
+            );
+            setNestedValue(fileConfig, "memory.qdrant.vectorSize", 3072);
+            writeFileSync(
+              configPath,
+              JSON.stringify(fileConfig, null, 2) + "\n",
+            );
+            log.info(
+              "Applied managed Gemini embedding defaults (provider=gemini, model=gemini-embedding-2, dimensions=3072, vectorSize=3072)",
+            );
+            // Re-validate so the returned config reflects the migration.
+            config = validateWithSchema(fileConfig);
+          }
+        } catch (err) {
+          log.warn(
+            { err },
+            "Managed Gemini defaults migration failed — continuing with existing config",
           );
-          setNestedValue(
-            fileConfig,
-            "memory.embeddings.geminiDimensions",
-            3072,
-          );
-          setNestedValue(fileConfig, "memory.qdrant.vectorSize", 3072);
-          writeFileSync(configPath, JSON.stringify(fileConfig, null, 2) + "\n");
-          log.info(
-            "Applied managed Gemini embedding defaults (provider=gemini, model=gemini-embedding-2, dimensions=3072, vectorSize=3072)",
-          );
-          // Re-validate so the returned config reflects the migration.
-          config = validateWithSchema(fileConfig);
         }
-      } catch (err) {
-        log.warn(
-          { err },
-          "Managed Gemini defaults migration failed — continuing with existing config",
-        );
       }
     }
 
@@ -763,7 +769,7 @@ export function loadConfig(): AssistantConfig {
     // changes were inert because the merge only filled absent keys and never
     // reconciled existing values. Contract: disk = user intent, in-memory
     // cache = effective values.
-    if (!configFileExisted) {
+    if (!configFileExisted && suppressConfigDiskWritesDepth === 0) {
       try {
         const dir = dirname(configPath);
         if (!existsSync(dir)) {
@@ -840,6 +846,26 @@ export function invalidateConfigCache(): void {
   cached = null;
   cachedFileSignature = null;
   loading = false;
+}
+
+export async function withSuppressedConfigDiskWrites<T>(
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  suppressConfigDiskWritesDepth++;
+  try {
+    return await fn();
+  } finally {
+    suppressConfigDiskWritesDepth--;
+  }
+}
+
+export function withSuppressedConfigDiskWritesSync<T>(fn: () => T): T {
+  suppressConfigDiskWritesDepth++;
+  try {
+    return fn();
+  } finally {
+    suppressConfigDiskWritesDepth--;
+  }
 }
 
 /**

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -8,8 +8,8 @@ import {
   saveRawConfig,
 } from "../config/loader.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
+import { getVisibleProviderCatalog } from "../providers/provider-catalog-visibility.js";
 
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
@@ -132,7 +132,10 @@ function parseModelCommand(trimmed: string): ModelCommandParse | null {
 }
 
 function orderedProfileNames(
-  profiles: Record<string, { label?: string; description?: string; status?: "active" | "disabled" }>,
+  profiles: Record<
+    string,
+    { label?: string; description?: string; status?: "active" | "disabled" }
+  >,
   profileOrder: readonly string[] | undefined,
 ): string[] {
   const order = profileOrder ?? [];
@@ -177,8 +180,12 @@ async function resolveModelCommand(
       const isDisabled = profile.status === "disabled";
       const marker = isCurrent ? " **[current]**" : "";
       const disabled = isDisabled ? " *(disabled)*" : "";
-      const description = profile.description ? ` — ${profile.description}` : "";
-      lines.push(`  - \`${name}\` (${label})${marker}${disabled}${description}`);
+      const description = profile.description
+        ? ` — ${profile.description}`
+        : "";
+      lines.push(
+        `  - \`${name}\` (${label})${marker}${disabled}${description}`,
+      );
     }
     lines.push("\nSwitch with `/model <name>`.");
     return { kind: "unknown", message: lines.join("\n") };
@@ -240,7 +247,7 @@ async function resolveModelList(): Promise<SlashResolution> {
     id: provider,
     displayName: providerName,
     models,
-  } of PROVIDER_CATALOG) {
+  } of getVisibleProviderCatalog(config)) {
     const hasKey = configuredProviders.has(provider);
     const status = hasKey ? "✓" : "✗";
     lines.push(`**${providerName}** ${status}`);

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -7,8 +7,8 @@ import {
 import { setServiceField } from "../../config/raw-config-utils.js";
 import { providerForImageModelPrefix } from "../../media/types.js";
 import type { ProviderCatalogEntry } from "../../providers/model-catalog.js";
-import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { getConfiguredProviders } from "../../providers/provider-availability.js";
+import { getVisibleProviderCatalog } from "../../providers/provider-catalog-visibility.js";
 import { CONFIG_RELOAD_DEBOUNCE_MS, log } from "./shared.js";
 
 // ---------------------------------------------------------------------------
@@ -65,15 +65,16 @@ export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
   const resolved = resolveCallSiteConfig("mainAgent", config.llm);
   const provider = resolved.provider;
+  const visibleCatalog = getVisibleProviderCatalog(config);
 
   return {
     model: resolved.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
-    availableModels: PROVIDER_CATALOG.find(
-      (p) => p.id === provider,
-    )?.models?.map((m) => ({ id: m.id, displayName: m.displayName })),
-    allProviders: PROVIDER_CATALOG.map(projectProviderForWire),
+    availableModels: visibleCatalog
+      .find((p) => p.id === provider)
+      ?.models?.map((m) => ({ id: m.id, displayName: m.displayName })),
+    allProviders: visibleCatalog.map(projectProviderForWire),
   };
 }
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -96,6 +96,16 @@ export const messageMetadataSchema = z
     assistantMessageChannel: channelIdSchema.optional(),
     userMessageInterface: interfaceIdSchema.optional(),
     assistantMessageInterface: interfaceIdSchema.optional(),
+    /**
+     * Optional client-side metadata bag attached to user messages by HTTP
+     * header middleware (reads `x-vellum-browser-family`,
+     * `x-vellum-browser-version`, `x-vellum-client-os`,
+     * `x-vellum-interface-version`). Forwarded verbatim onto
+     * `TurnTelemetryEvent.client` for downstream analytics. Kept as a
+     * permissive `record` so adding a new client field doesn't require a
+     * migration -- dbt can unpack later via JSON_VALUE.
+     */
+    client: z.record(z.string(), z.unknown()).optional(),
     subagentNotification: subagentNotificationSchema.optional(),
     /**
      * Trust class of the actor at the time this message was persisted.

--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -65,7 +65,7 @@ export interface TurnEvent {
    * Returned as raw JSON text — the reporter parses + re-shapes for the
    * wire format.
    */
-  clientJson: string | null;
+  clientMetadata: string | null;
 }
 
 /**
@@ -140,9 +140,9 @@ export function queryUnreportedTurnEvents(
       >`json_extract(${messages.metadata}, '$.userMessageChannel')`.as(
         "channel_id",
       ),
-      clientJson: sql<
+      clientMetadata: sql<
         string | null
-      >`json_extract(${messages.metadata}, '$.client')`.as("client_json"),
+      >`json_extract(${messages.metadata}, '$.client')`.as("client_metadata"),
     })
     .from(messages)
     .innerJoin(conversations, eq(messages.conversationId, conversations.id))

--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -30,6 +30,42 @@ export interface TurnEvent {
    * partition lookup.
    */
   turnIndex: number;
+  /**
+   * Canonical `InterfaceId` enum value identifying the UI surface the user
+   * was interacting from at message-creation time (`"macos"`, `"ios"`,
+   * `"cli"`, `"web"`, `"chrome-extension"`, `"slack"`, `"telegram"`,
+   * `"whatsapp"`, `"email"`, `"phone"`). Sourced from
+   * `messages.metadata.userMessageInterface` (stamped on insert by every
+   * `persistUserMessage` path that flows through `TurnChannelContext`).
+   *
+   * Null when the metadata didn't carry the field — historical rows
+   * predating the threading, or system-initiated turns with no inbound
+   * client context. Downstream analytics should treat null as
+   * `"unknown"`.
+   */
+  interfaceId: string | null;
+  /**
+   * Canonical `ChannelId` enum value identifying the messaging fabric the
+   * user message arrived on (`"vellum"` for in-app messaging from
+   * macos/ios/web/cli; `"slack"`/`"telegram"`/`"whatsapp"`/`"email"`/
+   * `"phone"` for channel-based interfaces). Sourced from
+   * `messages.metadata.userMessageChannel`.
+   *
+   * The 7th `ChannelId` value (`"platform"`) is APNs-push outbound-only
+   * and should never appear on a user-message row.
+   */
+  channelId: string | null;
+  /**
+   * Flexible client metadata stashed under `messages.metadata.client` by
+   * the HTTP header middleware. Carries optional `browserFamily`,
+   * `browserVersion`, `os`, `interfaceVersion` (and is extensible without
+   * a migration since it lives inside the JSON column). Null when no
+   * client headers were attached.
+   *
+   * Returned as raw JSON text — the reporter parses + re-shapes for the
+   * wire format.
+   */
+  clientJson: string | null;
 }
 
 /**
@@ -87,6 +123,26 @@ export function queryUnreportedTurnEvents(
                OR (m2.created_at = ${messages.createdAt}
                    AND m2.id <= ${messages.id}))
       )`.as("turn_index"),
+      // Client attribution: extract from `messages.metadata` JSON.
+      // `userMessageInterface` and `userMessageChannel` are stamped on
+      // insert by every `persistUserMessage` path that flows through
+      // `TurnChannelContext`. `client` is the flexible namespace for
+      // browser/os/version metadata attached by HTTP header middleware.
+      // `json_extract` returns SQL NULL when the JSON path is absent —
+      // exactly the null semantics we want on the wire.
+      interfaceId: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.userMessageInterface')`.as(
+        "interface_id",
+      ),
+      channelId: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.userMessageChannel')`.as(
+        "channel_id",
+      ),
+      clientJson: sql<
+        string | null
+      >`json_extract(${messages.metadata}, '$.client')`.as("client_json"),
     })
     .from(messages)
     .innerJoin(conversations, eq(messages.conversationId, conversations.id))

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -45,6 +45,8 @@ export interface CatalogModel {
   supportsVision?: boolean;
   supportsToolUse?: boolean;
   pricing?: CatalogModelPricing;
+  /** When set, this model is only visible when the named feature flag is enabled. */
+  featureFlag?: string;
 }
 
 const DEFAULT_CONTEXT_WINDOW_TOKENS = 200000;
@@ -97,6 +99,8 @@ export interface ProviderCatalogEntry {
    * OpenRouter where managed keys are not available.
    */
   supportsPlatformAuth?: boolean;
+  /** When set, this provider is only visible when the named feature flag is enabled. */
+  featureFlag?: string;
 }
 
 /**
@@ -871,6 +875,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
     id: "zai",
     displayName: "z.ai",
+    featureFlag: "provider-zai",
     subtitle: "GLM models from z.ai (Zhipu AI). Requires a z.ai API key.",
     setupMode: "api-key",
     setupHint: "Enter your z.ai API key to enable GLM models.",
@@ -944,6 +949,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     setupMode: "api-key",
     setupHint: "Enter your DeepSeek API key to enable DeepSeek models.",
     envVar: "DEEPSEEK_API_KEY",
+    featureFlag: "provider-deepseek",
     credentialsGuide: {
       description:
         "Sign in to the DeepSeek platform, navigate to API Keys, and create a new key.",
@@ -987,6 +993,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "minimax",
     displayName: "MiniMax",
     subtitle: "MiniMax models. Requires a MiniMax API key.",
+    featureFlag: "provider-minimax",
     setupMode: "api-key",
     setupHint: "Enter your MiniMax API key to enable MiniMax models.",
     envVar: "MINIMAX_API_KEY",

--- a/assistant/src/providers/provider-availability.ts
+++ b/assistant/src/providers/provider-availability.ts
@@ -5,9 +5,11 @@
  * environment variable fallbacks, and managed proxy availability.
  */
 
-import { API_KEY_PROVIDERS } from "../config/loader.js";
+import { API_KEY_PROVIDERS, getConfig } from "../config/loader.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
+import { PROVIDER_CATALOG } from "./model-catalog.js";
 import { managedFallbackEnabledFor } from "./platform-proxy/context.js";
+import { getVisibleProviderCatalog } from "./provider-catalog-visibility.js";
 
 /**
  * Check whether a single provider is usable — via a user-provided key
@@ -25,11 +27,24 @@ export async function isProviderAvailable(provider: string): Promise<boolean> {
 /**
  * Build the list of providers that are usable — via a user-provided key
  * (secure storage or env var) or via the managed proxy fallback.
+ * Feature-flagged LLM providers that are currently disabled are excluded.
  * Ollama is always included because it does not require an API key.
  */
 export async function getConfiguredProviders(): Promise<string[]> {
+  // Build the set of LLM providers hidden by feature flags so we can
+  // exclude them while leaving non-LLM providers (search, STT, TTS)
+  // in API_KEY_PROVIDERS unchanged.
+  const allLlmIds = new Set(PROVIDER_CATALOG.map((p) => p.id));
+  const visibleLlmIds = new Set(
+    getVisibleProviderCatalog(getConfig()).map((p) => p.id),
+  );
+  const hiddenLlmIds = new Set(
+    [...allLlmIds].filter((id) => !visibleLlmIds.has(id)),
+  );
+
   const configured: string[] = [];
   for (const p of API_KEY_PROVIDERS) {
+    if (hiddenLlmIds.has(p)) continue;
     if (await isProviderAvailable(p)) {
       configured.push(p);
     }

--- a/assistant/src/providers/provider-catalog-visibility.ts
+++ b/assistant/src/providers/provider-catalog-visibility.ts
@@ -1,0 +1,36 @@
+/**
+ * Feature-flag-aware provider catalog filtering.
+ *
+ * User-facing catalog consumers (model info, slash commands, provider
+ * availability) use `getVisibleProviderCatalog()` to hide providers and
+ * models gated behind disabled feature flags. Internal consumers
+ * (adapter-factory, pricing, auth) continue using the unfiltered
+ * `PROVIDER_CATALOG` directly.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  PROVIDER_CATALOG,
+  type ProviderCatalogEntry,
+} from "./model-catalog.js";
+
+export function getVisibleProviderCatalog(
+  config: AssistantConfig,
+): ProviderCatalogEntry[] {
+  return PROVIDER_CATALOG.filter(
+    (entry) =>
+      !entry.featureFlag ||
+      isAssistantFeatureFlagEnabled(entry.featureFlag, config),
+  )
+    .map((entry) => {
+      const visibleModels = entry.models.filter(
+        (m) =>
+          !m.featureFlag ||
+          isAssistantFeatureFlagEnabled(m.featureFlag, config),
+      );
+      if (visibleModels.length === entry.models.length) return entry;
+      return { ...entry, models: visibleModels };
+    })
+    .filter((entry) => entry.models.length > 0);
+}

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -28,6 +28,8 @@ import {
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
+  withSuppressedConfigDiskWrites,
+  withSuppressedConfigDiskWritesSync,
 } from "../../config/loader.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
@@ -229,7 +231,7 @@ function getModelSetContext(): ModelSetContext {
       watcher.suppressConfigReload = value;
     },
     updateConfigFingerprint() {
-      watcher.updateFingerprint();
+      withSuppressedConfigDiskWritesSync(() => watcher.updateFingerprint());
     },
     debounceTimers: watcher.timers,
   };
@@ -471,15 +473,14 @@ async function commitConfigWrite(
 
   clearEmbeddingBackendCache();
   invalidateConfigCache();
-  // Reinitialize providers so the live registry reflects the new config
-  // (e.g. a mode flip between managed and your-own). Isolated try/catch so
-  // a provider reinit failure doesn't mask the successful config save.
-  // Only advance the config fingerprint on success - if reinit failed, leave
-  // it stale so the watcher can detect the saved config on the next event
-  // and retry provider initialization.
+  // Reinitialize providers so the live registry reflects the new config.
+  // Suppress disk writes inside loadConfig() — we just wrote the raw config
+  // and the first-launch seed path would overwrite it with full defaults.
   try {
-    await initializeProviders(getConfig());
-    configWatcher.updateFingerprint();
+    await withSuppressedConfigDiskWrites(async () => {
+      await initializeProviders(getConfig());
+      configWatcher.updateFingerprint();
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, `${opLabel} config: provider reinit failed: ${message}`);

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -46,6 +46,34 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
   cost: number | null;
 }
 
+/**
+ * Optional client metadata bag carried on `TurnTelemetryEvent.client`.
+ * Sourced from `messages.metadata.client`, which is populated by HTTP
+ * header middleware reading `x-vellum-browser-family`,
+ * `x-vellum-browser-version`, `x-vellum-client-os`,
+ * `x-vellum-interface-version`. Extensible without a schema change —
+ * lives entirely in the JSON metadata column.
+ */
+export interface TurnTelemetryClientInfo {
+  /** Browser family for `web`/`chrome-extension` interfaces: `"chrome"|"safari"|"firefox"|"edge"`. */
+  browser_family?: string;
+  /** Major browser version only (`"124"`, not the full UA string). */
+  browser_version?: string;
+  /**
+   * User's operating system at message time. For `web`/`chrome-extension`
+   * this comes from `navigator.userAgentData`; for `macos`/`ios` it's
+   * implicit from the interface, but clients may still send it explicitly.
+   */
+  os?: string;
+  /**
+   * Version of the surface app/client (`"0.8.2"` for the macOS app,
+   * web client SHA, etc.) — distinct from `assistant_version` on the
+   * batch envelope, which identifies the daemon. A user can be on an
+   * older surface than the daemon (or vice versa, on web).
+   */
+  interface_version?: string;
+}
+
 /** Turn event — one per user message. */
 export interface TurnTelemetryEvent extends TelemetryEventBase {
   type: "turn";
@@ -69,6 +97,36 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
    * predicate). The first user turn in a conversation is `1`.
    */
   turn_index: number;
+  /**
+   * Canonical `InterfaceId` enum value identifying the UI surface the
+   * user was interacting from when this turn was created (`"macos"`,
+   * `"ios"`, `"cli"`, `"web"`, `"chrome-extension"`, `"slack"`,
+   * `"telegram"`, `"whatsapp"`, `"email"`, `"phone"`). Sourced from the
+   * `userMessageInterface` field already stamped on `messages.metadata`
+   * by every `persistUserMessage` path that flows through
+   * `TurnChannelContext`.
+   *
+   * Null when the metadata didn't carry the field — historical rows or
+   * system-initiated turns with no inbound client context. Downstream
+   * consumers should treat null as `"unknown"`.
+   */
+  interface_id: string | null;
+  /**
+   * Canonical `ChannelId` enum value identifying the messaging fabric the
+   * user message arrived on (`"vellum"` for in-app from macos/ios/web/
+   * cli/chrome-extension; `"slack"`/`"telegram"`/`"whatsapp"`/`"email"`/
+   * `"phone"` for channel-based interfaces). The 7th `ChannelId` value
+   * (`"platform"`) is APNs-push outbound-only and should never appear
+   * here.
+   */
+  channel_id: string | null;
+  /**
+   * Optional client-side metadata bag. Null when no client headers were
+   * attached to the request that created the user message (most
+   * channel-inbound paths today, and any path the new HTTP header
+   * middleware hasn't been wired to yet).
+   */
+  client: TurnTelemetryClientInfo | null;
 }
 
 /** Lifecycle event — app_open, hatch, etc. */

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -41,6 +41,9 @@ const mockQueryUnreportedTurnEvents = mock(
       conversationId: string;
       conversationType: string;
       turnIndex: number;
+      interfaceId: string | null;
+      channelId: string | null;
+      clientJson: string | null;
     }[],
 );
 
@@ -548,6 +551,9 @@ describe("UsageTelemetryReporter", () => {
         conversationId: "conv-mixed",
         conversationType: "standard",
         turnIndex: 1,
+        interfaceId: null,
+        channelId: null,
+        clientJson: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -593,6 +599,9 @@ describe("UsageTelemetryReporter", () => {
         conversationId: "conv-std",
         conversationType: "standard",
         turnIndex: 1,
+        interfaceId: null,
+        channelId: null,
+        clientJson: null,
       },
       {
         id: "evt-turn-background",
@@ -600,6 +609,9 @@ describe("UsageTelemetryReporter", () => {
         conversationId: "conv-bg",
         conversationType: "background",
         turnIndex: 1,
+        interfaceId: null,
+        channelId: null,
+        clientJson: null,
       },
       {
         id: "evt-turn-scheduled",
@@ -607,6 +619,9 @@ describe("UsageTelemetryReporter", () => {
         conversationId: "conv-sched",
         conversationType: "scheduled",
         turnIndex: 1,
+        interfaceId: null,
+        channelId: null,
+        clientJson: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -632,6 +647,117 @@ describe("UsageTelemetryReporter", () => {
     expect(byId["evt-turn-standard"].conversation_type).toBe("standard");
     expect(byId["evt-turn-background"].conversation_type).toBe("background");
     expect(byId["evt-turn-scheduled"].conversation_type).toBe("scheduled");
+  });
+
+  test("turn events carry interface_id, channel_id, and parsed client metadata", async () => {
+    // Four turns spanning the relevant cases:
+    //  - macOS in-app turn with full client block (typical interactive user)
+    //  - slack inbound turn with no client block (channel-based, no headers)
+    //  - web turn with malformed client JSON (parsing guard: emit null,
+    //    do not break the batch)
+    //  - historical turn with no metadata at all (pre-rollout row)
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedTurnEvents.mockReturnValue([
+      {
+        id: "evt-turn-macos",
+        createdAt: 1700000400000,
+        conversationId: "conv-mac",
+        conversationType: "standard",
+        turnIndex: 1,
+        interfaceId: "macos",
+        channelId: "vellum",
+        clientJson: JSON.stringify({
+          browser_family: null,
+          os: "darwin",
+          interface_version: "0.8.2",
+        }),
+      },
+      {
+        id: "evt-turn-slack",
+        createdAt: 1700000500000,
+        conversationId: "conv-slack",
+        conversationType: "standard",
+        turnIndex: 1,
+        interfaceId: "slack",
+        channelId: "slack",
+        clientJson: null,
+      },
+      {
+        id: "evt-turn-web-broken",
+        createdAt: 1700000600000,
+        conversationId: "conv-web",
+        conversationType: "standard",
+        turnIndex: 1,
+        interfaceId: "web",
+        channelId: "vellum",
+        clientJson: "{not valid json",
+      },
+      {
+        id: "evt-turn-legacy",
+        createdAt: 1700000700000,
+        conversationId: "conv-legacy",
+        conversationType: "standard",
+        turnIndex: 1,
+        interfaceId: null,
+        channelId: null,
+        clientJson: null,
+      },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":4}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+
+    const byId: Record<
+      string,
+      {
+        interface_id: string | null;
+        channel_id: string | null;
+        client: Record<string, unknown> | null;
+      }
+    > = {};
+    for (const e of body.events as Array<{
+      daemon_event_id: string;
+      interface_id: string | null;
+      channel_id: string | null;
+      client: Record<string, unknown> | null;
+    }>) {
+      byId[e.daemon_event_id] = e;
+    }
+
+    expect(byId["evt-turn-macos"]).toMatchObject({
+      interface_id: "macos",
+      channel_id: "vellum",
+      client: {
+        os: "darwin",
+        interface_version: "0.8.2",
+      },
+    });
+    expect(byId["evt-turn-slack"]).toMatchObject({
+      interface_id: "slack",
+      channel_id: "slack",
+      client: null,
+    });
+    // Malformed client JSON is downgraded to null without failing the
+    // batch — the interface_id/channel_id from the typed columns still
+    // ride through cleanly.
+    expect(byId["evt-turn-web-broken"]).toMatchObject({
+      interface_id: "web",
+      channel_id: "vellum",
+      client: null,
+    });
+    expect(byId["evt-turn-legacy"]).toMatchObject({
+      interface_id: null,
+      channel_id: null,
+      client: null,
+    });
   });
 
   test("llm_usage events carry conversation_id, conversation_type, and turn_index", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -43,7 +43,7 @@ const mockQueryUnreportedTurnEvents = mock(
       turnIndex: number;
       interfaceId: string | null;
       channelId: string | null;
-      clientJson: string | null;
+      clientMetadata: string | null;
     }[],
 );
 
@@ -553,7 +553,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -601,7 +601,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-background",
@@ -611,7 +611,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-scheduled",
@@ -621,7 +621,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>
@@ -666,7 +666,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "macos",
         channelId: "vellum",
-        clientJson: JSON.stringify({
+        clientMetadata: JSON.stringify({
           browser_family: null,
           os: "darwin",
           interface_version: "0.8.2",
@@ -680,7 +680,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "slack",
         channelId: "slack",
-        clientJson: null,
+        clientMetadata: null,
       },
       {
         id: "evt-turn-web-broken",
@@ -690,7 +690,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: "web",
         channelId: "vellum",
-        clientJson: "{not valid json",
+        clientMetadata: "{not valid json",
       },
       {
         id: "evt-turn-legacy",
@@ -700,7 +700,7 @@ describe("UsageTelemetryReporter", () => {
         turnIndex: 1,
         interfaceId: null,
         channelId: null,
-        clientJson: null,
+        clientMetadata: null,
       },
     ]);
     mockFetch.mockImplementation(() =>

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -248,9 +248,9 @@ export class UsageTelemetryReporter {
           // Parse defensively — a corrupted blob in the JSON column should
           // not block the whole batch flush.
           let client: TurnTelemetryClientInfo | null = null;
-          if (e.clientJson) {
+          if (e.clientMetadata) {
             try {
-              const parsed = JSON.parse(e.clientJson) as unknown;
+              const parsed = JSON.parse(e.clientMetadata) as unknown;
               if (
                 parsed &&
                 typeof parsed === "object" &&

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -27,7 +27,7 @@ import { VellumPlatformClient } from "../platform/client.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
-import type { TelemetryEvent } from "./types.js";
+import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -242,16 +242,43 @@ export class UsageTelemetryReporter {
             recorded_at: e.createdAt,
           }),
         ),
-        ...turnEvents.map(
-          (e): TelemetryEvent => ({
+        ...turnEvents.map((e): TelemetryEvent => {
+          // `messages.metadata.client` is a nested JSON object extracted
+          // via `json_extract`; sqlite returns it as a text representation.
+          // Parse defensively — a corrupted blob in the JSON column should
+          // not block the whole batch flush.
+          let client: TurnTelemetryClientInfo | null = null;
+          if (e.clientJson) {
+            try {
+              const parsed = JSON.parse(e.clientJson) as unknown;
+              if (
+                parsed &&
+                typeof parsed === "object" &&
+                !Array.isArray(parsed)
+              ) {
+                client = parsed as TurnTelemetryClientInfo;
+              }
+            } catch {
+              // Malformed client JSON — emit null rather than fail the
+              // batch. Logged once below for visibility.
+              log.warn(
+                { turnId: e.id, conversationId: e.conversationId },
+                "Telemetry turn: failed to parse messages.metadata.client; emitting null",
+              );
+            }
+          }
+          return {
             type: "turn",
             daemon_event_id: e.id,
             recorded_at: e.createdAt,
             conversation_id: e.conversationId,
             conversation_type: e.conversationType,
             turn_index: e.turnIndex,
-          }),
-        ),
+            interface_id: e.interfaceId,
+            channel_id: e.channelId,
+            client,
+          };
+        }),
         ...lifecycleEvents.map(
           (e): TelemetryEvent => ({
             type: "lifecycle",

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -15,7 +15,6 @@ public struct InlineSurfaceRouter: View {
 
     @State private var selectionPayload: [String: AnyCodable]?
     @State private var clickedActionLabel: String?
-    @State private var isCardHovered = false
 
     public init(
         surface: InlineSurfaceData,
@@ -152,10 +151,7 @@ public struct InlineSurfaceRouter: View {
                 .padding(VSpacing.sm)
             } else if isTableSurface, case .table(let tableData) = surface.data {
                 #if os(macOS)
-                VCopyButton(text: Self.tableAsMarkdown(tableData), size: .compact)
-                    .opacity(isCardHovered ? 1 : 0)
-                    .animation(VAnimation.fast, value: isCardHovered)
-                    .padding(VSpacing.sm)
+                TableCopyButtonOverlay(tableData: tableData)
                 #endif
             } else if isDocumentPreview {
                 if case .documentPreview(let data) = surface.data {
@@ -179,9 +175,6 @@ public struct InlineSurfaceRouter: View {
                 }
             }
         }
-        #if os(macOS)
-        .onHover { isCardHovered = $0 }
-        #endif
         // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
         .widthCap(isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth))
         }
@@ -429,7 +422,7 @@ public struct InlineSurfaceRouter: View {
     }
 
     /// Builds a markdown table string from TableSurfaceData for clipboard copy.
-    static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
+    public static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
         func escapeCell(_ text: String) -> String {
             text.replacingOccurrences(of: "|", with: "\\|")
                 .replacingOccurrences(of: "\n", with: " ")
@@ -445,3 +438,27 @@ public struct InlineSurfaceRouter: View {
         return ([headerLine, separatorLine] + rowLines).joined(separator: "\n")
     }
 }
+
+// MARK: - TableCopyButtonOverlay
+
+#if os(macOS)
+/// Self-contained hover overlay for the table copy button. Owns its own
+/// `@State` so hover changes only re-render this small view — not the
+/// parent `InlineSurfaceRouter` and its expensive `InlineTableWidget`.
+private struct TableCopyButtonOverlay: View {
+    let tableData: TableSurfaceData
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VCopyButton(text: InlineSurfaceRouter.tableAsMarkdown(tableData), size: .compact)
+            .allowsHitTesting(isHovered)
+            .accessibilityHidden(!isHovered)
+            .padding(VSpacing.sm)
+            .contentShape(Rectangle())
+            .onHover { isHovered = $0 }
+            .opacity(isHovered ? 1 : 0)
+            .animation(VAnimation.fast, value: isHovered)
+    }
+}
+#endif

--- a/clients/shared/Network/TrustRuleClient.swift
+++ b/clients/shared/Network/TrustRuleClient.swift
@@ -53,14 +53,22 @@ private struct TrustRuleSuggestionResponse: Decodable {
 
 // MARK: - Errors
 
+private struct GatewayErrorResponse: Decodable {
+    let error: String?
+}
+
 public enum TrustRuleClientError: Error, LocalizedError {
-    case requestFailed(Int)
+    case requestFailed(Int, String?)
     case notFound
     case featureDisabled
 
     public var errorDescription: String? {
         switch self {
-        case .requestFailed(let code): return "Trust rule v3 request failed (HTTP \(code))"
+        case .requestFailed(let code, let serverMessage):
+            if let serverMessage, !serverMessage.isEmpty {
+                return serverMessage
+            }
+            return "Trust rule request failed (HTTP \(code))"
         case .notFound: return "Trust rule not found"
         case .featureDisabled: return "Feature not enabled"
         }
@@ -92,6 +100,10 @@ public protocol TrustRuleClientProtocol {
 public struct TrustRuleClient: TrustRuleClientProtocol {
     nonisolated public init() {}
 
+    private static func extractServerError(from data: Data) -> String? {
+        try? JSONDecoder().decode(GatewayErrorResponse.self, from: data).error
+    }
+
     public func listRules(origin: String? = nil, tool: String? = nil, includeDeleted: Bool? = nil) async throws -> [TrustRule] {
         var params: [String: String] = [:]
         if let origin { params["origin"] = origin }
@@ -103,7 +115,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         )
         guard response.isSuccess else {
             log.error("listRules failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleListResponse.self, from: response.data).rules
     }
@@ -124,7 +136,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("createRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -146,7 +158,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("updateRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -164,7 +176,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("deleteRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
     }
 
@@ -181,7 +193,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("resetRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSingleResponse.self, from: response.data).rule
     }
@@ -223,7 +235,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         }
         guard response.isSuccess else {
             log.error("suggestRule failed (HTTP \(response.statusCode))")
-            throw TrustRuleClientError.requestFailed(response.statusCode)
+            throw TrustRuleClientError.requestFailed(response.statusCode, Self.extractServerError(from: response.data))
         }
         return try JSONDecoder().decode(TrustRuleSuggestionResponse.self, from: response.data).suggestion
     }

--- a/gateway/src/__tests__/trust-rule-store.test.ts
+++ b/gateway/src/__tests__/trust-rule-store.test.ts
@@ -87,6 +87,55 @@ describe("create()", () => {
     expect(rule.createdAt <= after).toBe(true);
     expect(rule.updatedAt).toBe(rule.createdAt);
   });
+
+  test("upserts when a rule with the same tool+pattern already exists", () => {
+    const original = store.create({
+      tool: "bash",
+      pattern: "create-upsert-echo",
+      risk: "low",
+      description: "Original description",
+    });
+
+    const updated = store.create({
+      tool: "bash",
+      pattern: "create-upsert-echo",
+      risk: "high",
+      description: "Updated description",
+    });
+
+    expect(updated.id).toBe(original.id);
+    expect(updated.risk).toBe("high");
+    expect(updated.description).toBe("Updated description");
+    expect(updated.origin).toBe("user_defined");
+    expect(updated.createdAt).toBe(original.createdAt);
+    expect(updated.updatedAt >= original.updatedAt).toBe(true);
+  });
+
+  test("upsert un-deletes a soft-deleted rule with the same tool+pattern", () => {
+    store.upsertDefault({
+      id: "default:bash:create-upsert-undelete",
+      tool: "bash",
+      pattern: "create-upsert-undelete",
+      risk: "low",
+      description: "Default rule",
+    });
+    store.remove("default:bash:create-upsert-undelete");
+
+    const deleted = store.getById("default:bash:create-upsert-undelete")!;
+    expect(deleted.deleted).toBe(true);
+
+    const recreated = store.create({
+      tool: "bash",
+      pattern: "create-upsert-undelete",
+      risk: "medium",
+      description: "Re-created by user",
+    });
+
+    expect(recreated.deleted).toBe(false);
+    expect(recreated.risk).toBe("medium");
+    expect(recreated.description).toBe("Re-created by user");
+    expect(recreated.origin).toBe("user_defined");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/db/trust-rule-store.ts
+++ b/gateway/src/db/trust-rule-store.ts
@@ -159,7 +159,9 @@ export class TrustRuleStore {
   }
 
   /**
-   * Create a user-defined trust rule. Generates a UUIDv4 id.
+   * Create or update a user-defined trust rule. If a rule with the same
+   * (tool, pattern) already exists, updates its risk and description
+   * instead of failing on the UNIQUE constraint.
    */
   create(input: CreateInput): TrustRule {
     assertValidRisk(input.risk);
@@ -167,23 +169,26 @@ export class TrustRuleStore {
     const now = nowISO();
     const id = crypto.randomUUID();
 
-    this.db
-      .insert(trustRules)
-      .values({
-        id,
-        tool: input.tool,
-        pattern: input.pattern,
-        risk: input.risk,
-        description: input.description,
-        origin: "user_defined",
-        userModified: false,
-        deleted: false,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .run();
+    this.db.run(sql`
+      INSERT INTO trust_rules (id, tool, pattern, risk, description, origin, user_modified, deleted, created_at, updated_at)
+      VALUES (${id}, ${input.tool}, ${input.pattern}, ${input.risk}, ${input.description}, 'user_defined', 0, 0, ${now}, ${now})
+      ON CONFLICT (tool, pattern) DO UPDATE SET
+        risk = excluded.risk,
+        description = excluded.description,
+        origin = excluded.origin,
+        deleted = 0,
+        updated_at = excluded.updated_at
+    `);
 
-    return this.getById(id)!;
+    const row = this.db
+      .select()
+      .from(trustRules)
+      .where(
+        and(eq(trustRules.tool, input.tool), eq(trustRules.pattern, input.pattern)),
+      )
+      .get();
+
+    return toTrustRule(row!);
   }
 
   /**

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -206,9 +206,9 @@ export function createTrustRulesCreateHandler() {
       return Response.json({ rule }, { status: 201 });
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Internal server error";
+        err instanceof Error ? err.message : "Failed to create trust rule";
       log.error({ err }, "Failed to create trust rule");
-      return Response.json({ error: message }, { status: 400 });
+      return Response.json({ error: message }, { status: 500 });
     }
   };
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,30 @@
       "label": "External Plugins",
       "description": "Enable the external-plugin install path: the `assistant plugins` CLI subcommand and the declarative external-plugin loader convention (`<workspaceDir>/plugins/<name>/` directories containing `package.json` plus interface dirs). Gates an unstable surface that may change shape before stabilizing.",
       "defaultEnabled": false
+    },
+    {
+      "id": "provider-zai",
+      "scope": "assistant",
+      "key": "provider-zai",
+      "label": "z.ai Provider",
+      "description": "Enable the z.ai (Zhipu AI) provider and its GLM models in the provider picker and model selection UI",
+      "defaultEnabled": false
+    },
+    {
+      "id": "provider-deepseek",
+      "scope": "assistant",
+      "key": "provider-deepseek",
+      "label": "DeepSeek Provider",
+      "description": "Enable the DeepSeek direct API provider and its models (V4 Pro, V4 Flash) in the provider picker and model selection UI",
+      "defaultEnabled": false
+    },
+    {
+      "id": "provider-minimax",
+      "scope": "assistant",
+      "key": "provider-minimax",
+      "label": "MiniMax Provider",
+      "description": "Enable the MiniMax direct API provider and its models (M2.7, M2.5, M2.1, M2, and highspeed variants) in the provider picker and model selection UI",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- fix: upsert trust rules on duplicate tool+pattern instead of failing (#30847)
- feat(telemetry): emit interface_id, channel_id, and client metadata on turn events (#30849)
- rename clientJson to clientMetadata in turn events telemetry (#30853)
- fix(config): prevent config set from overwriting custom values (#30867)
- feat(providers): feature-flag new providers (z.ai, DeepSeek, MiniMax) (#30877)
- fix(macos): isolate table copy-button hover to prevent full surface re-render (#30863)

## Test plan
- [ ] Verify cherry-picked commits apply cleanly against release/v0.8.2
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->