### PR TITLE
Fix Twilio websocket URLs for platform callbacks

### DIFF
--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -826,6 +826,53 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     });
   });
 
+  test("uses platform callback assistant ID for Twilio websocket URL", async () => {
+    const assistantId = "019e2d0d-f355-744c-a12c-d7e7dcefcf1e";
+    fetchMock = mock(
+      async () =>
+        new Response(
+          '<?xml version="1.0" encoding="UTF-8"?><Response><Connect>' +
+            '<ConversationRelay url="wss://__VELLUM_PUBLIC_BASE_URL__/webhooks/twilio/relay?token=__VELLUM_RELAY_TOKEN__"/>' +
+            "</Connect></Response>",
+          {
+            status: 200,
+            headers: { "Content-Type": "text/xml" },
+          },
+        ),
+    );
+
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig({ velayBaseUrl: "https://velay-staging.vellum.ai" }),
+      makeCaches(),
+    );
+
+    const platformCallbackUrl =
+      `https://staging-platform.vellum.ai/v1/gateway/callbacks/${assistantId}` +
+      "/webhooks/twilio/voice?callSessionId=platform-wss-test";
+    const localUrl =
+      "http://localhost:7830/webhooks/twilio/voice?callSessionId=platform-wss-test";
+    const params = { CallSid: "CA-platform-wss" };
+    const signature = computeSignature(platformCallbackUrl, params, AUTH_TOKEN);
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+        "X-Vellum-Ingress-URL": platformCallbackUrl,
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(
+      `url="wss://velay-staging.vellum.ai/${assistantId}/webhooks/twilio/relay?`,
+    );
+    expect(body).not.toContain("__VELLUM_PUBLIC_BASE_URL__");
+    expect(body).not.toContain("staging-platform.vellum.ai");
+  });
+
   test("platform proxy URL takes priority over configured ingress", async () => {
     fetchMock = mock(
       async () =>

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -78,14 +78,17 @@ export function createTwilioVoiceVerifyCallbackHandler(
         { callSid, fromNumber },
         "No pending verification session found on callback — forwarding to assistant",
       );
-      return forwardToAssistant(config, params, req.url, caches);
+      return forwardToAssistant(
+        config,
+        params,
+        req.url,
+        validation.validatedCandidateUrl,
+        caches,
+      );
     }
 
     if (!digits) {
-      log.info(
-        { callSid, fromNumber },
-        "No digits entered — re-prompting",
-      );
+      log.info({ callSid, fromNumber }, "No digits entered — re-prompting");
       const actionUrl = buildActionUrl(url, attempt);
       return twimlResponse(
         gatherVerificationTwiml(actionUrl, attempt, session.codeDigits ?? 6),
@@ -113,7 +116,11 @@ export function createTwilioVoiceVerifyCallbackHandler(
       const nextAttempt = attempt + 1;
       const actionUrl = buildActionUrl(url, nextAttempt);
       return twimlResponse(
-        gatherVerificationTwiml(actionUrl, nextAttempt, session.codeDigits ?? 6),
+        gatherVerificationTwiml(
+          actionUrl,
+          nextAttempt,
+          session.codeDigits ?? 6,
+        ),
       );
     }
 
@@ -147,7 +154,10 @@ export function createTwilioVoiceVerifyCallbackHandler(
         );
 
         const existingGuardian = existingPhoneGuardians[0];
-        if (existingGuardian && existingGuardian.externalUserId !== fromNumber) {
+        if (
+          existingGuardian &&
+          existingGuardian.externalUserId !== fromNumber
+        ) {
           log.warn(
             {
               callSid,
@@ -209,7 +219,13 @@ export function createTwilioVoiceVerifyCallbackHandler(
       { callSid, fromNumber },
       "Voice verification complete — forwarding to assistant for call setup",
     );
-    return forwardToAssistant(config, params, req.url, caches);
+    return forwardToAssistant(
+      config,
+      params,
+      req.url,
+      validation.validatedCandidateUrl,
+      caches,
+    );
   };
 }
 
@@ -248,13 +264,17 @@ async function revokeExistingPhoneGuardian(): Promise<void> {
   try {
     const gwDb = getGatewayDb();
     for (const id of ids) {
-      gwDb.update(gwContactChannels)
+      gwDb
+        .update(gwContactChannels)
         .set({ status: "revoked", policy: "deny", updatedAt: now })
         .where(eq(gwContactChannels.id, id))
         .run();
     }
   } catch (gwErr) {
-    log.warn({ err: gwErr }, "Gateway DB revoke dual-write failed (best-effort)");
+    log.warn(
+      { err: gwErr },
+      "Gateway DB revoke dual-write failed (best-effort)",
+    );
   }
 }
 
@@ -276,6 +296,7 @@ async function forwardToAssistant(
   config: GatewayConfig,
   params: Record<string, string>,
   originalUrl: string,
+  validatedPublicUrl?: string,
   caches?: TwilioValidationCaches,
 ): Promise<Response> {
   try {
@@ -288,7 +309,12 @@ async function forwardToAssistant(
       config,
       params,
       originalUrl,
-      resolvePublicBaseWssUrl(config, caches?.configFile, platformAssistantId),
+      resolvePublicBaseWssUrl(
+        config,
+        caches?.configFile,
+        platformAssistantId,
+        validatedPublicUrl,
+      ),
     );
     return new Response(runtimeResponse.body, {
       status: runtimeResponse.status,
@@ -304,7 +330,10 @@ async function forwardToAssistant(
         },
       );
     }
-    log.error({ err }, "Failed to forward voice webhook to runtime after verification");
+    log.error(
+      { err },
+      "Failed to forward voice webhook to runtime after verification",
+    );
     return Response.json({ error: "Internal server error" }, { status: 502 });
   }
 }

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -352,6 +352,61 @@ describe("resolvePublicBaseWssUrl", () => {
     );
   });
 
+  test("uses assistant ID from validated platform callback URL with Velay", () => {
+    const config = {
+      ...baseConfig,
+      velayBaseUrl: "https://velay-staging.vellum.ai",
+    };
+    const result = resolvePublicBaseWssUrl(
+      config,
+      undefined,
+      undefined,
+      "https://staging-platform.vellum.ai/v1/gateway/callbacks/019e2d0d-f355-744c-a12c-d7e7dcefcf1e/webhooks/twilio/voice/?callSessionId=37b47ade-2eaf-469a-bede-6f2454875e6e",
+    );
+    expect(result).toBe(
+      "wss://velay-staging.vellum.ai/019e2d0d-f355-744c-a12c-d7e7dcefcf1e",
+    );
+  });
+
+  test("prefers validated platform callback URL over stale configFile publicBaseUrl", () => {
+    const config = {
+      ...baseConfig,
+      velayBaseUrl: "https://velay-staging.vellum.ai",
+    };
+    const mockConfigFile = {
+      getString: (section: string, key: string) =>
+        section === "ingress" && key === "publicBaseUrl"
+          ? "https://stale-tunnel.example.test"
+          : undefined,
+    } as Parameters<typeof resolvePublicBaseWssUrl>[1];
+    const result = resolvePublicBaseWssUrl(
+      config,
+      mockConfigFile,
+      undefined,
+      "https://staging-platform.vellum.ai/v1/gateway/callbacks/019e2d0d-f355-744c-a12c-d7e7dcefcf1e/webhooks/twilio/voice?callSessionId=sess-1",
+    );
+    expect(result).toBe(
+      "wss://velay-staging.vellum.ai/019e2d0d-f355-744c-a12c-d7e7dcefcf1e",
+    );
+  });
+
+  test("does not use a platform callback URL as the websocket base", () => {
+    const config = {
+      ...baseConfig,
+      velayBaseUrl: "https://velay-staging.vellum.ai",
+    };
+    const mockConfigFile = {
+      getString: (section: string, key: string) =>
+        section === "ingress" && key === "publicBaseUrl"
+          ? "https://staging-platform.vellum.ai/v1/gateway/callbacks/019e2d0d-f355-744c-a12c-d7e7dcefcf1e"
+          : undefined,
+    } as Parameters<typeof resolvePublicBaseWssUrl>[1];
+    const result = resolvePublicBaseWssUrl(config, mockConfigFile, undefined);
+    expect(result).toBe(
+      "wss://velay-staging.vellum.ai/019e2d0d-f355-744c-a12c-d7e7dcefcf1e",
+    );
+  });
+
   test("strips trailing slash from velayBaseUrl before joining assistant ID", () => {
     const config = {
       ...baseConfig,

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -151,7 +151,10 @@ export function createTwilioVoiceWebhookHandler(
           // The display name is intentionally included: the caller registered
           // this number themselves, so disclosing their own name is expected.
           const unverifiedStatuses = new Set(["unverified", "pending"]);
-          if (callerRecord && unverifiedStatuses.has(callerRecord.channel.status)) {
+          if (
+            callerRecord &&
+            unverifiedStatuses.has(callerRecord.channel.status)
+          ) {
             const isGuardian = callerRecord.contact.role === "guardian";
             log.info(
               {
@@ -197,7 +200,12 @@ export function createTwilioVoiceWebhookHandler(
         config,
         params,
         req.url,
-        resolvePublicBaseWssUrl(config, caches?.configFile, platformAssistantId),
+        resolvePublicBaseWssUrl(
+          config,
+          caches?.configFile,
+          platformAssistantId,
+          validation.validatedCandidateUrl,
+        ),
       );
       return new Response(runtimeResponse.body, {
         status: runtimeResponse.status,

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -503,15 +503,58 @@ export type TwilioForwardResponse = {
  * to Twilio, keeping the signing key out of the daemon for this flow.
  */
 const TWILIO_RELAY_TOKEN_PLACEHOLDER = "__VELLUM_RELAY_TOKEN__";
+const PLATFORM_CALLBACK_MARKER = "/gateway/callbacks/";
+
+function toWebSocketBaseUrl(url: string): string {
+  return url.replace(/^http(s?)/, "ws$1");
+}
+
+function extractPlatformCallbackAssistantId(
+  value: unknown,
+): string | undefined {
+  const normalized = normalizePublicBaseUrl(value);
+  if (!normalized) return undefined;
+
+  let pathname: string;
+  try {
+    pathname = new URL(normalized).pathname;
+  } catch {
+    return undefined;
+  }
+
+  const markerIndex = pathname.indexOf(PLATFORM_CALLBACK_MARKER);
+  if (markerIndex === -1) return undefined;
+
+  const assistantIdStart = markerIndex + PLATFORM_CALLBACK_MARKER.length;
+  const assistantId = pathname.slice(assistantIdStart).split("/")[0]?.trim();
+  return assistantId || undefined;
+}
+
+function resolveVelayBaseWssUrl(
+  config: GatewayConfig,
+  platformAssistantId?: string,
+): string | undefined {
+  if (!config.velayBaseUrl || !platformAssistantId) return undefined;
+
+  const withPath =
+    config.velayBaseUrl.replace(/\/+$/, "") + "/" + platformAssistantId;
+  const normalizedVelayUrl = normalizePublicBaseUrl(withPath);
+  return normalizedVelayUrl
+    ? toWebSocketBaseUrl(normalizedVelayUrl)
+    : undefined;
+}
 
 /**
  * Resolve the public base URL as a WebSocket URL (`wss://…`).
  *
  * Sources (in priority order):
- * 1. `ingress.publicBaseUrl` from the config file — written by Velay
- *    after tunnel registration, or set manually for self-hosted.
- * 2. `VELAY_BASE_URL` + platform assistant ID — fallback for platform
- *    sidecars before the config cache has observed the registered URL.
+ * 1. `VELAY_BASE_URL` + the assistant ID from the signed platform callback
+ *    URL.
+ * 2. `ingress.publicBaseUrl` from the config file when it is a real public
+ *    gateway base URL — written by Velay after tunnel registration, or set
+ *    manually for self-hosted.
+ * 3. `VELAY_BASE_URL` + the platform assistant ID from a configured callback
+ *    URL or credential cache.
  *
  * Returns `undefined` when no source provides a value — the placeholder
  * will remain in TwiML and Twilio will fail to connect, which is the
@@ -521,20 +564,29 @@ export function resolvePublicBaseWssUrl(
   config: GatewayConfig,
   configFile?: ConfigFileCache,
   platformAssistantId?: string,
+  validatedPublicUrl?: string,
 ): string | undefined {
   const raw = configFile?.getString("ingress", "publicBaseUrl");
   const normalized = normalizePublicBaseUrl(raw);
-  if (normalized) return normalized.replace(/^http(s?)/, "ws$1");
 
-  if (config.velayBaseUrl && platformAssistantId) {
-    const withPath =
-      config.velayBaseUrl.replace(/\/+$/, "") + "/" + platformAssistantId;
-    const normalizedVelayUrl = normalizePublicBaseUrl(withPath);
-    if (normalizedVelayUrl) {
-      return normalizedVelayUrl.replace(/^http(s?)/, "ws$1");
-    }
+  const validatedCallbackAssistantId =
+    extractPlatformCallbackAssistantId(validatedPublicUrl);
+  const validatedCallbackWssUrl = resolveVelayBaseWssUrl(
+    config,
+    validatedCallbackAssistantId,
+  );
+  if (validatedCallbackWssUrl) return validatedCallbackWssUrl;
+
+  const configuredCallbackAssistantId = extractPlatformCallbackAssistantId(raw);
+
+  if (normalized && !configuredCallbackAssistantId) {
+    return toWebSocketBaseUrl(normalized);
   }
-  return undefined;
+
+  return resolveVelayBaseWssUrl(
+    config,
+    configuredCallbackAssistantId ?? platformAssistantId,
+  );
 }
 
 /**

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -182,6 +182,8 @@ export type TwilioValidationSuccess = {
   rawBody: string;
   /** Parsed key-value pairs from the form body. */
   params: Record<string, string>;
+  /** Candidate URL that matched X-Twilio-Signature. */
+  validatedCandidateUrl?: string;
 };
 
 /** Options bag for optional cache injection into Twilio webhook validation. */
@@ -411,5 +413,9 @@ export async function validateTwilioWebhookRequest(
     log.info(successLogContext, "Twilio webhook signature validated");
   }
 
-  return { rawBody, params };
+  return {
+    rawBody,
+    params,
+    validatedCandidateUrl: validatingCandidate.url,
+  };
 }


### PR DESCRIPTION
## Summary
- Resolve Twilio websocket bases from signed platform callback URLs when Velay is configured.
- Avoid treating platform callback HTTP routes as websocket-upgradeable ingress URLs.
- Add coverage for staging-shaped callback URLs producing Velay websocket URLs in returned TwiML.

## Original prompt
A user was unable to set up Twilio in the staging cluster because Twilio reported error 64102, unable to connect to the websocket URL, while calling a staging platform callback route. Investigation showed the HTTP webhook URL was valid, but the TwiML websocket URL could be derived from the platform callback route instead of the Velay websocket endpoint. This PR moves the fix into an isolated `/do` worktree and prepares it for review.