### PR TITLE
fix(providers): enable DeepSeek reasoning + tool use for complex tasks

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -21,6 +21,7 @@ interface FakeChunk {
   choices: Array<{
     delta: {
       content?: string | null;
+      reasoning_content?: string | null;
       tool_calls?: Array<{
         index: number;
         id?: string;
@@ -94,6 +95,7 @@ mock.module("openai", () => ({
 }));
 
 // Import after mocking
+import { DeepSeekProvider } from "../providers/deepseek/client.js";
 import { FireworksProvider } from "../providers/fireworks/client.js";
 import { OllamaProvider } from "../providers/ollama/client.js";
 import { OpenAIChatCompletionsProvider } from "../providers/openai/chat-completions-provider.js";
@@ -103,6 +105,17 @@ import { OpenRouterProvider } from "../providers/openrouter/client.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function reasoningChunk(
+  reasoning_content: string,
+  finish: string | null = null,
+): FakeChunk {
+  return {
+    choices: [{ delta: { reasoning_content }, finish_reason: finish }],
+    usage: null,
+    model: "gpt-5.2",
+  };
+}
 
 function textChunk(content: string, finish: string | null = null): FakeChunk {
   return {
@@ -1068,6 +1081,139 @@ describe("OpenAIProvider", () => {
       ],
     });
   });
+
+  // -----------------------------------------------------------------------
+  // reasoning_content (DeepSeek-style thinking) streaming & round-trip
+  // -----------------------------------------------------------------------
+  test("captures reasoning_content from stream as thinking block", async () => {
+    fakeChunks = [
+      reasoningChunk("Let me think"),
+      reasoningChunk(" about this."),
+      textChunk("Hello!"),
+      usageChunk(10, 5),
+    ];
+
+    const events: Array<{ type: string }> = [];
+    const result = await provider.sendMessage(
+      [userMsg("Hi")],
+      undefined,
+      undefined,
+      {
+        onEvent: (e) => events.push(e),
+      },
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: "thinking",
+      thinking: "Let me think about this.",
+    });
+    expect(result.content[1]).toEqual({ type: "text", text: "Hello!" });
+
+    const thinkingDeltas = events.filter((e) => e.type === "thinking_delta");
+    expect(thinkingDeltas).toHaveLength(2);
+  });
+
+  test("reasoning + tool calls orders correctly (thinking -> tool_use)", async () => {
+    fakeChunks = [
+      reasoningChunk("Planning..."),
+      ...toolCallChunks([
+        { id: "call_1", name: "file_read", args: '{"path":"/a"}' },
+      ]),
+      usageChunk(10, 30),
+    ];
+
+    const result = await provider.sendMessage([userMsg("Read /a")]);
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe("thinking");
+    expect(result.content[1].type).toBe("tool_use");
+  });
+
+  test("no thinking block when reasoning_content is absent", async () => {
+    fakeChunks = [textChunk("Just text"), usageChunk(10, 5)];
+
+    const result = await provider.sendMessage([userMsg("Hi")]);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+  });
+
+  test("includes reasoning_content on assistant messages in conversation history", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "User said hello." },
+          { type: "text", text: "Hi there!" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+      reasoning_content: "User said hello.",
+    });
+  });
+
+  test("omits reasoning_content when no thinking blocks exist", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hi there!" }],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+    });
+    expect(sent[1]).not.toHaveProperty("reasoning_content");
+  });
+
+  test("skips thinking blocks with signatures (Anthropic-originated) in reasoning_content", async () => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Anthropic thinking with signature",
+            signature: "abc123",
+          },
+          { type: "text", text: "Hi there!" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "How are you?" }] },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    expect(sent[1]).toEqual({
+      role: "assistant",
+      content: "Hi there!",
+    });
+    expect(sent[1]).not.toHaveProperty("reasoning_content");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1528,5 +1674,123 @@ describe("OpenAIProvider reasoning_effort", () => {
       config: { effort: "medium" },
     });
     expect(lastCreateParams!.reasoning_effort).toBe("medium");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DeepSeekProvider thinking config
+// ---------------------------------------------------------------------------
+
+describe("DeepSeekProvider thinking config", () => {
+  let deepseek: DeepSeekProvider;
+
+  beforeEach(() => {
+    fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
+    lastCreateParams = null;
+    deepseek = new DeepSeekProvider("test-key", "deepseek-v4-pro");
+  });
+
+  test("sends thinking.type=enabled when thinking config is enabled", async () => {
+    await deepseek.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "adaptive" } },
+    });
+    expect(lastCreateParams!.thinking).toEqual({ type: "enabled" });
+  });
+
+  test("sends thinking.type=disabled when thinking config is disabled", async () => {
+    await deepseek.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "disabled" } },
+    });
+    expect(lastCreateParams!.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("omits thinking param when thinking config is absent", async () => {
+    await deepseek.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: {},
+    });
+    expect(lastCreateParams!.thinking).toBeUndefined();
+  });
+
+  test("translates { enabled: true } to { type: enabled }", async () => {
+    await deepseek.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { enabled: true } },
+    });
+    expect(lastCreateParams!.thinking).toEqual({ type: "enabled" });
+  });
+
+  test("translates { enabled: false } to { type: disabled }", async () => {
+    await deepseek.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { enabled: false } },
+    });
+    expect(lastCreateParams!.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("provider name is deepseek", () => {
+    expect(deepseek.name).toBe("deepseek");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// effort config passthrough — DeepSeek
+// ---------------------------------------------------------------------------
+
+describe("effort config passthrough — DeepSeek", () => {
+  function makeProvider(
+    providerName: string,
+    captureOptions: (opts: SendMessageOptions) => void,
+  ): Provider {
+    return {
+      name: providerName,
+      sendMessage: async (
+        _msgs: Message[],
+        _tools?: ToolDefinition[],
+        _sys?: string,
+        opts?: SendMessageOptions,
+      ): Promise<ProviderResponse> => {
+        if (opts) captureOptions(opts);
+        return {
+          content: [],
+          model: "test",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "stop",
+        };
+      },
+    };
+  }
+
+  test("effort is preserved for deepseek provider", async () => {
+    let capturedOptions: SendMessageOptions | undefined;
+    const inner = makeProvider("deepseek", (opts) => {
+      capturedOptions = opts;
+    });
+    const retry = new RetryProvider(inner);
+
+    await retry.sendMessage(
+      [userMsg("hi")],
+      undefined,
+      undefined,
+      { config: { effort: "high" } },
+    );
+
+    const config = capturedOptions?.config as Record<string, unknown>;
+    expect(config.effort).toBe("high");
+  });
+
+  test("thinking is preserved for deepseek provider", async () => {
+    let capturedOptions: SendMessageOptions | undefined;
+    const inner = makeProvider("deepseek", (opts) => {
+      capturedOptions = opts;
+    });
+    const retry = new RetryProvider(inner);
+
+    await retry.sendMessage(
+      [userMsg("hi")],
+      undefined,
+      undefined,
+      { config: { thinking: { enabled: true } } },
+    );
+
+    const config = capturedOptions?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({ type: "adaptive" });
   });
 });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1544,6 +1544,7 @@ export class AnthropicProvider implements Provider {
       case "text":
         return { type: "text", text: block.text };
       case "thinking":
+        if (!block.signature) return null;
         return {
           type: "thinking",
           thinking: block.thinking,

--- a/assistant/src/providers/deepseek/client.ts
+++ b/assistant/src/providers/deepseek/client.ts
@@ -1,0 +1,46 @@
+import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+import {
+  isThinkingConfigDisabled,
+  isThinkingConfigEnabled,
+} from "../thinking-config.js";
+import type { SendMessageOptions } from "../types.js";
+
+export interface DeepSeekProviderOptions {
+  baseURL?: string;
+  streamTimeoutMs?: number;
+}
+
+const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+
+export class DeepSeekProvider extends OpenAIChatCompletionsProvider {
+  constructor(
+    apiKey: string,
+    model: string,
+    options: DeepSeekProviderOptions = {},
+  ) {
+    super(apiKey, model, {
+      baseURL: options.baseURL?.trim() || DEFAULT_DEEPSEEK_BASE_URL,
+      providerName: "deepseek",
+      providerLabel: "DeepSeek",
+      streamTimeoutMs: options.streamTimeoutMs,
+    });
+  }
+
+  protected override buildExtraCreateParams(
+    options?: SendMessageOptions,
+  ): Record<string, unknown> {
+    const config = options?.config as Record<string, unknown> | undefined;
+    const thinking = config?.thinking;
+
+    if (thinking === undefined) return {};
+
+    if (isThinkingConfigDisabled(thinking)) {
+      return { thinking: { type: "disabled" } };
+    }
+    if (isThinkingConfigEnabled(thinking)) {
+      return { thinking: { type: "enabled" } };
+    }
+
+    return {};
+  }
+}

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -19,6 +19,7 @@
  */
 
 import { AnthropicProvider } from "../anthropic/client.js";
+import { DeepSeekProvider } from "../deepseek/client.js";
 import { FireworksProvider } from "../fireworks/client.js";
 import { GeminiProvider } from "../gemini/client.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
@@ -98,12 +99,10 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       baseURL: "https://api.z.ai/api/paas/v4/",
       streamTimeoutMs,
     }),
-  deepseek: ({ apiKey, model, streamTimeoutMs }) =>
-    new OpenAIChatCompletionsProvider(apiKey, model, {
-      providerName: "deepseek",
-      providerLabel: "DeepSeek",
-      baseURL: "https://api.deepseek.com",
+  deepseek: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new DeepSeekProvider(apiKey, model, {
       streamTimeoutMs,
+      ...(baseURL ? { baseURL } : {}),
     }),
   minimax: ({ apiKey, model, streamTimeoutMs }) =>
     new OpenAIChatCompletionsProvider(apiKey, model, {

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -189,6 +189,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       // Accumulate the response from chunks
       let contentText = "";
+      let reasoningText = "";
       const toolCallMap = new Map<
         number,
         { id: string; name: string; args: string }
@@ -215,6 +216,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
         for await (const chunk of stream) {
           const choice = chunk.choices[0];
           if (choice) {
+            const reasoningDelta = (
+              choice.delta as { reasoning_content?: string }
+            ).reasoning_content;
+            if (reasoningDelta) {
+              reasoningText += reasoningDelta;
+              onEvent?.({ type: "thinking_delta", thinking: reasoningDelta });
+            }
+
             if (choice.delta.content) {
               contentText += choice.delta.content;
               onEvent?.({ type: "text_delta", text: choice.delta.content });
@@ -262,6 +271,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       // Build content blocks
       const content: ContentBlock[] = [];
+      if (reasoningText) {
+        content.push({ type: "thinking", thinking: reasoningText });
+      }
       if (contentText) {
         content.push({ type: "text", text: contentText });
       }
@@ -468,6 +480,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     msg: Message,
   ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
     const textParts: string[] = [];
+    const thinkingParts: string[] = [];
     const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] =
       [];
 
@@ -475,6 +488,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
       switch (block.type) {
         case "text":
           textParts.push(block.text);
+          break;
+        case "thinking":
+          if (!block.signature) thinkingParts.push(block.thinking);
           break;
         case "tool_use":
           toolCalls.push({
@@ -492,7 +508,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         case "web_search_tool_result":
           textParts.push("[Web search results]");
           break;
-        // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
+        // redacted_thinking, image — not applicable for OpenAI assistant messages
       }
     }
 
@@ -501,6 +517,12 @@ export class OpenAIChatCompletionsProvider implements Provider {
         role: "assistant",
         content: textParts.length > 0 ? textParts.join("") : null,
       };
+
+    if (thinkingParts.length > 0) {
+      Object.assign(result, {
+        reasoning_content: thinkingParts.join(""),
+      });
+    }
 
     if (toolCalls.length > 0) {
       result.tool_calls = toolCalls;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -42,6 +42,7 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "openai",
   "openrouter",
   "fireworks",
+  "deepseek",
 ]);
 
 /**
@@ -49,7 +50,7 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
  * the wire; OpenRouter either forwards it to its Anthropic-compatible path or
  * translates it into the unified `reasoning` parameter on OpenAI-compat calls.
  */
-const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter"]);
+const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter", "deepseek"]);
 
 /**
  * Providers that consume the `verbosity` config. Currently OpenAI (mapped to

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -44,7 +44,8 @@ export interface ToolUseContent {
 export interface ThinkingContent {
   type: "thinking";
   thinking: string;
-  signature: string;
+  /** Anthropic-specific cryptographic signature. Absent for non-Anthropic providers (e.g. DeepSeek). */
+  signature?: string;
 }
 
 export interface RedactedThinkingContent {


### PR DESCRIPTION
## Summary

- Fix DeepSeek V4 models failing on complex multi-step tasks that require reasoning + tool calling
- Parse `reasoning_content` from streaming deltas and round-trip it in conversation history so multi-turn tool calling works
- Create `DeepSeekProvider` subclass that forwards thinking config to DeepSeek's wire format (`thinking: { type: "enabled" | "disabled" }`)
- Add DeepSeek to `THINKING_AWARE_PROVIDERS` and `EFFORT_SUPPORTED_PROVIDERS`

## Root Cause

Three issues prevented DeepSeek from working with complex tasks:

1. **reasoning_content not passed back during tool calling** — DeepSeek V4 requires `reasoning_content` in the assistant message during multi-turn conversations. Without it, the API returns 400. The base `toOpenAIAssistantMessage()` was dropping thinking blocks entirely.

2. **Thinking config stripped** — DeepSeek was not in `THINKING_AWARE_PROVIDERS`, so the retry layer deleted the thinking config before it reached the provider.

3. **No thinking parameter forwarding** — DeepSeek expects `thinking: { type: "enabled" | "disabled" }` in the request body (similar to but distinct from Anthropic's format). Without a `buildExtraCreateParams()` override, this was never sent.

## Approach

- **Base class changes** (benefits MiniMax too): Parse `reasoning_content` from streaming deltas, emit `thinking_delta` events, and include `reasoning_content` in outgoing assistant messages when signature-less thinking blocks are present. The `!block.signature` guard distinguishes DeepSeek-style thinking (no signature) from Anthropic-style (has signature).

- **DeepSeek-specific subclass**: `DeepSeekProvider` extends `OpenAIChatCompletionsProvider` with a `buildExtraCreateParams()` override that translates the internal thinking config to DeepSeek's wire format. When thinking config is absent, it's omitted (DeepSeek defaults to thinking enabled).

- **Type change**: `ThinkingContent.signature` is now optional since non-Anthropic providers don't produce cryptographic signatures. A guard in `AnthropicProvider.toAnthropicBlockSafe()` skips signature-less thinking blocks.

## Coordination

- PR #30884 (JARVIS-867) overlaps on `reasoning_content` streaming and `EFFORT_SUPPORTED_PROVIDERS`. This PR is a superset — if #30884 merges first, the delta here shrinks to the DeepSeek-specific additions.
- Branch `do/deepseek-reasoning-content-roundtrip` also overlaps on the round-trip logic. Same coordination applies.

Closes JARVIS-866
Part of JARVIS-863

## Test plan

- [x] 14 new tests covering reasoning_content streaming, thinking_delta events, round-tripping in conversation history, Anthropic signature guard, DeepSeek thinking config forwarding, and effort/thinking preservation through RetryProvider
- [x] All 78 tests pass in `openai-provider.test.ts` (64 existing + 14 new)
- [x] All 76 Anthropic provider tests pass
- [x] All 21 retry-callsite tests pass
- [x] Clean `tsc --noEmit` typecheck
- [x] Clean `eslint` lint
- [ ] Manual verification with DeepSeek V4 Pro in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


Before:
<img width="990" height="766" alt="image" src="https://github.com/user-attachments/assets/ae77e8ba-c6de-4695-8a05-c1342983d462" />
