### PR TITLE
ci(release): fix Chrome extension zip find glob (asset never attaching to GitHub releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2477,7 +2477,7 @@ jobs:
 
           # Add Chrome extension zip if available
           if [ -d "chrome-extension-artifacts" ]; then
-            CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay-*.zip" -type f | sort | head -1)
+            CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay.zip" -type f | head -1)
             [ -n "$CRX_ZIP" ] && ASSETS+=("$CRX_ZIP#vellum-browser-relay-${VERSION}.zip")
           fi
 


### PR DESCRIPTION
## Prompt / plan

Restore the original intent of [`cc20d6472d`](https://github.com/vellum-ai/vellum-assistant/commit/cc20d6472d4c99d70644e0e90e9d00c63f0005d5) ([PR #24838](https://github.com/vellum-ai/vellum-assistant/pull/24838), April 2026) — which wired up the Chrome extension's build zip to be attached to each GitHub release alongside the macOS DMG/zip artifacts. The wiring regressed silently when `clients/chrome-extension/build.sh` was later changed to emit `vellum-browser-relay.zip` (no version suffix) while `release.yml`'s find-glob still required the original `vellum-browser-relay-*.zip` pattern.

## Root cause

`release.yml`'s "Create GitHub Releases" step uses:

```bash
CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay-*.zip" -type f | sort | head -1)
[ -n "$CRX_ZIP" ] && ASSETS+=("$CRX_ZIP#vellum-browser-relay-${VERSION}.zip")
```

The `find -name "vellum-browser-relay-*.zip"` glob requires a literal hyphen followed by one or more characters before `.zip`. The actual emitted filename is `vellum-browser-relay.zip` (no hyphen-suffix), so the glob never matches, `$CRX_ZIP` is always empty, and the `ASSETS+=` line is silently skipped. The release proceeds without the Chrome extension attached.

## Observed impact

Spot-checked the asset lists of the last 9 GitHub releases (v0.6.0 through v0.8.1, May 2026 latest):

| Release | macOS DMG | macOS ZIP | install.sh | appcast.xml | Chrome ext zip |
|---|---|---|---|---|---|
| v0.8.1 | yes | yes | yes | yes | **no** |
| v0.8.0 | yes | yes | yes | yes | **no** |
| v0.7.3 | yes | yes | yes | yes | **no** |
| v0.7.2 | yes | yes | yes | yes | **no** |
| v0.7.1 | yes | yes | yes | yes | **no** |
| v0.7.0 | yes | yes | yes | yes | **no** |
| v0.6.5 | yes | yes | yes | yes | **no** |
| v0.6.4 | yes | yes | yes | yes | **no** |
| v0.6.0 | yes | yes | yes | yes | **no** |

User-visible impact is effectively zero — the extension is distributed via the [Chrome Web Store](https://chrome.google.com/webstore) (`publish-chrome-extension` job in the same workflow, uses `chrome-webstore-upload-cli`), which is unaffected by this bug. The GitHub-release attachment was intended as a transparency / developer artifact alongside the macOS builds.

## Fix

```diff
- CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay-*.zip" -type f | sort | head -1)
+ CRX_ZIP=$(find chrome-extension-artifacts -name "vellum-browser-relay.zip" -type f | head -1)
```

The find now uses the literal filename `build.sh` actually emits. Dropped `| sort` since the new pattern matches a single fixed name (no ordering question across multiple matches). Kept `| head -1` as defensive belt-and-suspenders so any future duplicate (e.g. nested artifact layout) still resolves to one path.

The next line — `ASSETS+=("$CRX_ZIP#vellum-browser-relay-${VERSION}.zip")` — uses `gh release create`'s [`#displayName`](https://cli.github.com/manual/gh_release_create) suffix to rename the asset on attachment. So the public-facing artifact name on the release page is still `vellum-browser-relay-${VERSION}.zip` (versioned). Only the internal lookup gets corrected.

## Why this is safe

- **No other consumer touched.** `build.sh` is unchanged; `clients/chrome-extension/README.md` still references `vellum-browser-relay.zip` for Chrome Web Store dashboard uploads; the CWS `publish-chrome-extension` job uses `ls /tmp/chrome-extension/*.zip` (glob-agnostic to filename) and is unaffected; the `upload-artifact` and `download-artifact` steps reference the unversioned filename and remain consistent.
- **Worst case is the original state.** If the artifact directory doesn't exist or the file isn't there for any reason, the `if [ -d "chrome-extension-artifacts" ]` and `[ -n "$CRX_ZIP" ]` guards both skip the attach — same behavior as today.
- **The CWS distribution path is unchanged.** `publish-chrome-extension` runs independently of `release` and continues to upload to the Web Store as it does today.
- **Visible behavior change is purely additive**: the Chrome ext zip starts appearing as an asset on future releases. Existing release pages (which never had it) are not modified.

## Alternatives considered

- **Re-version the build output in `build.sh`** (emit `vellum-browser-relay-${VERSION}.zip` again). Rejected: it touches more files (the CWS-dashboard upload docs in `README.md`, the `extension-environments.json` lookup conventions, the `dev-release.yaml` upload paths), and the `#displayName` rename suffix already gives users the versioned name on the release page. Smaller, lower-risk change wins.
- **Drop the GitHub-release attach block entirely.** Rejected: the original PR ([#24838](https://github.com/vellum-ai/vellum-assistant/pull/24838)) explicitly intended for the zip to appear alongside the macOS artifacts; we shouldn't drop a documented release surface because of a regression we can fix in one line.

## Test plan

- Static: ran `yamllint` / `actionlint` mentally — the change is a single string literal in a `run:` script step, no syntax impact.
- Diff-only verification: confirmed only the single line in `release.yml` changes; no other workflows reference the same find pattern.
- Repo-wide grep for `vellum-browser-relay-` (with trailing hyphen) confirms this is the only consumer that expected the legacy versioned format.
- Verification of the fix will land on the next release dispatch — the Chrome ext zip should appear as `vellum-browser-relay-${VERSION}.zip` on the release page.

## Out of scope

- Renaming `vellum-browser-relay` → `vellum-chrome-extension` in code and docs (separate naming decision, deferred to [LUM-1548](https://linear.app/vellum/issue/LUM-1548/) if pursued).
- Reorganizing the Chrome extension release path or moving the extension to `apps/` (deferred to [LUM-1548](https://linear.app/vellum/issue/LUM-1548/) when the move is unparked).

Closes LUM-1574

Link to Devin session: https://app.devin.ai/sessions/b248fca817384acf800388c7e8d82e3c
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->