### PR TITLE
Make Twilio setup automation-first for webhooks

### DIFF
--- a/assistant/src/__tests__/twilio-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/twilio-setup-skill-regression.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dirname ?? __dirname, "..", "..", "..");
+const SKILL_PATH = resolve(REPO_ROOT, "skills", "twilio-setup", "SKILL.md");
+
+const skillContent = readFileSync(SKILL_PATH, "utf-8");
+
+describe("twilio-setup skill regression", () => {
+  test("keeps setup and webhook repair automation-first", () => {
+    expect(skillContent).toContain("## Automation-First Rule");
+    expect(skillContent).toContain(
+      "Do not tell the user to paste webhook URLs into the Twilio Console on the first try",
+    );
+    expect(skillContent).toContain(
+      "Manual Twilio Console instructions are fallback-only",
+    );
+    expect(skillContent).toContain(
+      "Do not send the user to the Twilio Console for this repair until this update command has been attempted and failed.",
+    );
+  });
+
+  test("continues to provide the automated Twilio webhook update command", () => {
+    expect(skillContent).toContain("IncomingPhoneNumbers/$PHONE_SID.json");
+    expect(skillContent).toContain(
+      '-d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice"',
+    );
+    expect(skillContent).toContain(
+      '-d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"',
+    );
+  });
+
+  test("does not preserve the known manual-first phrasing", () => {
+    expect(skillContent).not.toContain("Here's what to plug into");
+    expect(skillContent).not.toContain(
+      "plug into your Twilio phone number config",
+    );
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -65,8 +65,8 @@ import { getLlmRequestLogSource } from "../../memory/llm-request-log-source.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../memory/memory-v2-activation-log-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
-import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { listConnections } from "../../providers/inference/connections.js";
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { validateAllowlistFile } from "../../security/secret-allowlist.js";
 import { resolvePricingForUsage } from "../../util/pricing.js";
@@ -670,17 +670,9 @@ async function handleReplaceInferenceProfile({
     // here would wipe the UI-owned seed fields (provider, model, advanced
     // params) because that function assumes the body carries the full UI
     // surface.
-    patchManagedProfileFields(
-      raw,
-      name,
-      fragment,
-    );
+    patchManagedProfileFields(raw, name, fragment);
   } else {
-    replaceInferenceProfileConfig(
-      raw,
-      name,
-      fragment,
-    );
+    replaceInferenceProfileConfig(raw, name, fragment);
   }
   // Route through `commitConfigWrite` so profile edits flow through the
   // post-write side effects shared with `handlePatchConfig` /

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -468,7 +468,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T12:47:52-05:00"
+      "updatedAt": "2026-05-14T19:52:02-05:00"
     },
     {
       "id": "outlook",
@@ -746,7 +746,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-05T17:21:43-06:00"
+      "updatedAt": "2026-05-15T15:10:58-06:00"
     },
     {
       "id": "typescript-eval",

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -11,6 +11,12 @@ metadata:
 
 You are helping your user configure Twilio for voice calls. Walk through each step below.
 
+## Automation-First Rule
+
+On the first setup or repair attempt, configure Twilio yourself using the CLI and API commands in this skill. Do not tell the user to paste webhook URLs into the Twilio Console on the first try, and do not stop after printing values for the user to copy into their phone number settings.
+
+Manual Twilio Console instructions are fallback-only. Use them only after you have attempted the automated API path and it failed or was unavailable. When falling back, briefly say what automated step you tried and what blocked it.
+
 ## Value Classification
 
 Before you begin, understand how each Twilio value is stored:
@@ -158,6 +164,8 @@ For local/self-hosted assistants without Velay, load the `public-ingress` skill 
 
 Set webhook URLs on the phone number so Twilio routes traffic to the assistant.
 
+This is an action for you to perform, not an instruction for the user. Do not respond with copy/paste webhook values for the user to enter in Twilio unless the automated update below failed or Twilio API access is unavailable.
+
 Retrieve credentials and config values:
 
 ```bash
@@ -182,6 +190,8 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
   -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
+
+If the update succeeds, tell the user Twilio is configured. If it fails, explain the API error and either retry with corrected values or then offer Twilio Console fallback instructions.
 
 ## Clearing Credentials
 
@@ -241,3 +251,5 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
   -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
+
+Do not send the user to the Twilio Console for this repair until this update command has been attempted and failed.


### PR DESCRIPTION
## Summary
- Add an automation-first rule to the Twilio setup skill so webhook setup and repair are attempted via CLI/API before manual console fallback.
- Clarify that webhook URLs should not be handed to users for first-try manual Twilio configuration.
- Add a regression test covering the automation-first contract and the automated webhook update command.

Closes #30890

## Original prompt
The Twilio setup skill recently led the assistant to tell the user what to paste into the Twilio phone number configuration instead of configuring it directly. The requested change is to make the skill avoid asking users to do first-try Twilio configuration themselves, especially for webhook setup, and only fall back to manual instructions after an automated attempt fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->