### PR TITLE
Allow assistant targeting by display name

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -107,7 +107,7 @@ describe("assistant-config", () => {
     );
   });
 
-  test("findAssistantByName resolves a unique display name", () => {
+  test("findAssistantByName only resolves assistant IDs", () => {
     writeLockfile({
       assistants: [
         makeEntry("assistant-1", "http://localhost:7821", { name: "Alice" }),
@@ -115,10 +115,26 @@ describe("assistant-config", () => {
       ],
     });
 
-    expect(findAssistantByName("Alice")?.assistantId).toBe("assistant-1");
+    expect(findAssistantByName("Alice")).toBeNull();
+    expect(findAssistantByName("assistant-1")?.assistantId).toBe("assistant-1");
   });
 
-  test("findAssistantByName resolves a unique legacy assistantName", () => {
+  test("lookupAssistantByIdentifier resolves a unique display name", () => {
+    writeLockfile({
+      assistants: [
+        makeEntry("assistant-1", "http://localhost:7821", { name: "Alice" }),
+        makeEntry("assistant-2", "http://localhost:7822", { name: "Bob" }),
+      ],
+    });
+
+    const result = lookupAssistantByIdentifier("Alice");
+    expect(result.status).toBe("found");
+    expect(result.status === "found" ? result.entry.assistantId : null).toBe(
+      "assistant-1",
+    );
+  });
+
+  test("lookupAssistantByIdentifier resolves a unique legacy assistantName", () => {
     writeLockfile({
       assistants: [
         makeEntry("assistant-1", "http://localhost:7821", {
@@ -127,7 +143,9 @@ describe("assistant-config", () => {
       ],
     });
 
-    expect(findAssistantByName("Legacy Alice")?.assistantId).toBe(
+    const result = lookupAssistantByIdentifier("Legacy Alice");
+    expect(result.status).toBe("found");
+    expect(result.status === "found" ? result.entry.assistantId : null).toBe(
       "assistant-1",
     );
   });
@@ -140,7 +158,11 @@ describe("assistant-config", () => {
       ],
     });
 
-    expect(findAssistantByName("Alice")?.assistantId).toBe("Alice");
+    const result = lookupAssistantByIdentifier("Alice");
+    expect(result.status).toBe("found");
+    expect(result.status === "found" ? result.entry.assistantId : null).toBe(
+      "Alice",
+    );
   });
 
   test("ambiguous display name lookup is explicit", () => {

--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -10,6 +10,10 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 import {
   loadLatestAssistant,
   findAssistantByName,
+  formatAssistantLookupError,
+  formatAssistantReference,
+  getAssistantDisplayName,
+  lookupAssistantByIdentifier,
   removeAssistantEntry,
   loadAllAssistants,
   saveAssistantEntry,
@@ -85,6 +89,88 @@ describe("assistant-config", () => {
     const result = findAssistantByName("beta");
     expect(result).not.toBeNull();
     expect(result!.assistantId).toBe("beta");
+  });
+
+  test("getAssistantDisplayName prefers platform and legacy display names", () => {
+    expect(
+      getAssistantDisplayName(
+        makeEntry("assistant-1", undefined, { name: "Alice" }),
+      ),
+    ).toBe("Alice");
+    expect(
+      getAssistantDisplayName(
+        makeEntry("assistant-2", undefined, { assistantName: "Legacy Alice" }),
+      ),
+    ).toBe("Legacy Alice");
+    expect(getAssistantDisplayName(makeEntry("assistant-3"))).toBe(
+      "assistant-3",
+    );
+  });
+
+  test("findAssistantByName resolves a unique display name", () => {
+    writeLockfile({
+      assistants: [
+        makeEntry("assistant-1", "http://localhost:7821", { name: "Alice" }),
+        makeEntry("assistant-2", "http://localhost:7822", { name: "Bob" }),
+      ],
+    });
+
+    expect(findAssistantByName("Alice")?.assistantId).toBe("assistant-1");
+  });
+
+  test("findAssistantByName resolves a unique legacy assistantName", () => {
+    writeLockfile({
+      assistants: [
+        makeEntry("assistant-1", "http://localhost:7821", {
+          assistantName: "Legacy Alice",
+        }),
+      ],
+    });
+
+    expect(findAssistantByName("Legacy Alice")?.assistantId).toBe(
+      "assistant-1",
+    );
+  });
+
+  test("assistant ID lookup wins over a display name match", () => {
+    writeLockfile({
+      assistants: [
+        makeEntry("Alice", "http://localhost:7821", { name: "Primary" }),
+        makeEntry("assistant-2", "http://localhost:7822", { name: "Alice" }),
+      ],
+    });
+
+    expect(findAssistantByName("Alice")?.assistantId).toBe("Alice");
+  });
+
+  test("ambiguous display name lookup is explicit", () => {
+    writeLockfile({
+      assistants: [
+        makeEntry("assistant-1", "http://localhost:7821", { name: "Alice" }),
+        makeEntry("assistant-2", "http://localhost:7822", { name: "Alice" }),
+      ],
+    });
+
+    const result = lookupAssistantByIdentifier("Alice");
+    expect(result.status).toBe("ambiguous");
+    expect(findAssistantByName("Alice")).toBeNull();
+    expect(formatAssistantLookupError("Alice", result)).toContain(
+      "assistant-1",
+    );
+    expect(formatAssistantLookupError("Alice", result)).toContain(
+      "assistant-2",
+    );
+  });
+
+  test("formatAssistantReference includes distinct display name and id", () => {
+    expect(
+      formatAssistantReference(
+        makeEntry("assistant-1", undefined, { name: "Alice" }),
+      ),
+    ).toBe("Alice (assistant-1)");
+    expect(formatAssistantReference(makeEntry("assistant-2"))).toBe(
+      "assistant-2",
+    );
   });
 
   test("findAssistantByName returns null for non-existent name", () => {

--- a/cli/src/__tests__/assistant-target-args.test.ts
+++ b/cli/src/__tests__/assistant-target-args.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+
+describe("parseAssistantTargetArg", () => {
+  test("joins unquoted display-name words into one assistant target", () => {
+    expect(parseAssistantTargetArg(["Example", "Assistant"])).toBe(
+      "Example Assistant",
+    );
+  });
+
+  test("skips boolean flags", () => {
+    expect(parseAssistantTargetArg(["Example", "Assistant", "--verbose"])).toBe(
+      "Example Assistant",
+    );
+  });
+
+  test("skips configured flags and their values", () => {
+    expect(
+      parseAssistantTargetArg(
+        ["--url", "http://localhost:7830", "Example", "Assistant"],
+        ["--url"],
+      ),
+    ).toBe("Example Assistant");
+  });
+
+  test("returns undefined when no target is present", () => {
+    expect(parseAssistantTargetArg(["--verbose"])).toBeUndefined();
+  });
+});

--- a/cli/src/__tests__/ps-platform-status.test.ts
+++ b/cli/src/__tests__/ps-platform-status.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +24,7 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // ---------------------------------------------------------------------------
 
 import * as assistantConfig from "../lib/assistant-config.js";
+import * as healthCheck from "../lib/health-check.js";
 import * as orphanDetection from "../lib/orphan-detection.js";
 import * as platformClient from "../lib/platform-client.js";
 
@@ -57,6 +66,10 @@ const fetchPlatformAssistantsMock = spyOn(
   platformClient,
   "fetchPlatformAssistants",
 ).mockResolvedValue([]);
+const checkManagedHealthMock = spyOn(
+  healthCheck,
+  "checkManagedHealth",
+).mockResolvedValue({ status: "healthy", detail: null });
 
 // ---------------------------------------------------------------------------
 // stdout / stderr capture
@@ -66,23 +79,32 @@ let stdout: string[];
 let stderr: string[];
 let originalLog: typeof console.log;
 let originalError: typeof console.error;
+let originalStdoutWrite: typeof process.stdout.write;
 
 beforeEach(() => {
   stdout = [];
   stderr = [];
   originalLog = console.log;
   originalError = console.error;
+  originalStdoutWrite = process.stdout.write;
   console.log = ((...args: unknown[]) => {
     stdout.push(args.map((a) => String(a)).join(" "));
   }) as typeof console.log;
   console.error = ((...args: unknown[]) => {
     stderr.push(args.map((a) => String(a)).join(" "));
   }) as typeof console.error;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
 });
 
 afterEach(() => {
   console.log = originalLog;
   console.error = originalError;
+  process.stdout.write = originalStdoutWrite;
+  loadAllAssistantsMock.mockReturnValue([]);
+  getActiveAssistantMock.mockReturnValue(null);
   readPlatformTokenMock.mockReturnValue(null);
   fetchCurrentUserMock.mockReset();
   fetchCurrentUserMock.mockResolvedValue({
@@ -92,6 +114,8 @@ afterEach(() => {
   });
   fetchPlatformAssistantsMock.mockReset();
   fetchPlatformAssistantsMock.mockResolvedValue([]);
+  checkManagedHealthMock.mockReset();
+  checkManagedHealthMock.mockResolvedValue({ status: "healthy", detail: null });
 });
 
 afterAll(() => {
@@ -102,6 +126,7 @@ afterAll(() => {
   readPlatformTokenMock.mockRestore();
   fetchCurrentUserMock.mockRestore();
   fetchPlatformAssistantsMock.mockRestore();
+  checkManagedHealthMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -125,12 +150,12 @@ describe("vellum ps — platform status line", () => {
     expect(stdout.filter((l) => l.startsWith("Platform:"))).toEqual([
       "Platform: not logged in",
     ]);
-    expect(
-      stderr.some((l) => l.includes("Failed to fetch organization")),
-    ).toBe(false);
-    expect(
-      stdout.some((l) => l.includes("Failed to fetch organization")),
-    ).toBe(false);
+    expect(stderr.some((l) => l.includes("Failed to fetch organization"))).toBe(
+      false,
+    );
+    expect(stdout.some((l) => l.includes("Failed to fetch organization"))).toBe(
+      false,
+    );
 
     // Structural guarantee: we never even tried to talk to the platform.
     expect(fetchCurrentUserMock).not.toHaveBeenCalled();
@@ -152,31 +177,50 @@ describe("vellum ps — platform status line", () => {
     expect(stdout.filter((l) => l.startsWith("Platform:"))).toEqual([
       "Platform: not logged in",
     ]);
-    expect(
-      stderr.some((l) => l.includes("Failed to fetch organization")),
-    ).toBe(false);
-    expect(
-      stdout.some((l) => l.includes("Failed to fetch organization")),
-    ).toBe(false);
-    expect(
-      stderr.some((l) => l.includes("Unable to connect")),
-    ).toBe(false);
+    expect(stderr.some((l) => l.includes("Failed to fetch organization"))).toBe(
+      false,
+    );
+    expect(stdout.some((l) => l.includes("Failed to fetch organization"))).toBe(
+      false,
+    );
+    expect(stderr.some((l) => l.includes("Unable to connect"))).toBe(false);
   });
 
   test("local token present and platform reachable: prints 'Platform: logged in as <email>'", async () => {
     readPlatformTokenMock.mockReturnValue("session_abc123");
     fetchCurrentUserMock.mockResolvedValue({
       id: "u1",
-      email: "vargas@vellum.ai",
-      display: "Vargas",
+      email: "user@example.com",
+      display: "Example User",
     });
     fetchPlatformAssistantsMock.mockResolvedValue([]);
 
     await listAllAssistants(false);
 
-    expect(stdout).toContain("Platform: logged in as vargas@vellum.ai");
-    expect(
-      stderr.some((l) => l.includes("Failed to fetch organization")),
-    ).toBe(false);
+    expect(stdout).toContain("Platform: logged in as user@example.com");
+    expect(stderr.some((l) => l.includes("Failed to fetch organization"))).toBe(
+      false,
+    );
+  });
+
+  test("assistant rows use display name as primary label and keep id visible", async () => {
+    loadAllAssistantsMock.mockReturnValue([
+      {
+        assistantId: "assistant-123",
+        name: "Alice",
+        runtimeUrl: "https://platform.example",
+        cloud: "vellum",
+        species: "vellum",
+      },
+    ]);
+    getActiveAssistantMock.mockReturnValue("assistant-123");
+
+    await listAllAssistants(false);
+
+    const output = stdout.join("\n");
+    expect(output).toContain("* Alice");
+    expect(output).toContain("id: assistant-123");
+    expect(output).toContain("https://platform.example");
+    expect(output).not.toContain("* assistant-123");
   });
 });

--- a/cli/src/__tests__/ps-platform-status.test.ts
+++ b/cli/src/__tests__/ps-platform-status.test.ts
@@ -223,4 +223,38 @@ describe("vellum ps — platform status line", () => {
     expect(output).toContain("https://platform.example");
     expect(output).not.toContain("* assistant-123");
   });
+
+  test("assistant list renders one stable final row per assistant", async () => {
+    loadAllAssistantsMock.mockReturnValue([
+      {
+        assistantId: "assistant-123",
+        name: "Alice",
+        runtimeUrl: "https://platform.example/a",
+        cloud: "vellum",
+        species: "vellum",
+      },
+      {
+        assistantId: "assistant-456",
+        name: "Bob",
+        runtimeUrl: "https://platform.example/b",
+        cloud: "vellum",
+        species: "vellum",
+      },
+    ]);
+    getActiveAssistantMock.mockReturnValue("assistant-123");
+    checkManagedHealthMock.mockImplementation(async (_runtimeUrl, id) => ({
+      status: id === "assistant-123" ? "healthy" : "sleeping",
+      detail: null,
+    }));
+
+    await listAllAssistants(false);
+
+    const output = stdout.join("\n");
+    expect(output).not.toContain("\x1b[");
+    expect(output).not.toContain("checking...");
+    expect(output.match(/Alice/g)).toHaveLength(1);
+    expect(output.match(/Bob/g)).toHaveLength(1);
+    expect(output).toContain("healthy");
+    expect(output).toContain("sleeping");
+  });
 });

--- a/cli/src/__tests__/use.test.ts
+++ b/cli/src/__tests__/use.test.ts
@@ -1,0 +1,129 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getActiveAssistant,
+  type AssistantEntry,
+} from "../lib/assistant-config.js";
+import { use } from "../commands/use.js";
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-use-test-"));
+const originalArgv = [...process.argv];
+const originalExit = process.exit;
+const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+
+let consoleLogSpy: ReturnType<typeof spyOn>;
+let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+function makeEntry(
+  assistantId: string,
+  extra: Partial<AssistantEntry> = {},
+): AssistantEntry {
+  return {
+    assistantId,
+    runtimeUrl: `http://localhost:${7800 + assistantId.length}`,
+    cloud: "local",
+    ...extra,
+  };
+}
+
+function writeLockfile(
+  entries: AssistantEntry[],
+  activeAssistant?: string,
+): void {
+  mkdirSync(testDir, { recursive: true });
+  writeFileSync(
+    join(testDir, ".vellum.lock.json"),
+    JSON.stringify(
+      {
+        assistants: entries,
+        ...(activeAssistant ? { activeAssistant } : {}),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe("vellum use", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    rmSync(join(testDir, ".vellum.lock.json"), { force: true });
+    process.argv = ["bun", "vellum", "use"];
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as typeof process.exit;
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    if (originalLockfileDir === undefined) {
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = originalLockfileDir;
+    }
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("sets active assistant by unique display name", async () => {
+    writeLockfile([
+      makeEntry("assistant-1", { name: "Alice" }),
+      makeEntry("assistant-2", { name: "Bob" }),
+    ]);
+    process.argv = ["bun", "vellum", "use", "Alice"];
+
+    await use();
+
+    expect(getActiveAssistant()).toBe("assistant-1");
+    expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
+      "Active assistant set to Alice (assistant-1).",
+    );
+  });
+
+  test("prints active assistant with display name and id", async () => {
+    writeLockfile([makeEntry("assistant-1", { name: "Alice" })], "assistant-1");
+
+    await use();
+
+    expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
+      "Active assistant: Alice (assistant-1)",
+    );
+  });
+
+  test("rejects ambiguous display names without changing active assistant", async () => {
+    writeLockfile(
+      [
+        makeEntry("assistant-1", { name: "Alice" }),
+        makeEntry("assistant-2", { name: "Alice" }),
+      ],
+      "assistant-2",
+    );
+    process.argv = ["bun", "vellum", "use", "Alice"];
+
+    await expect(use()).rejects.toThrow("process.exit:1");
+
+    expect(getActiveAssistant()).toBe("assistant-2");
+    const output = consoleErrorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Multiple assistants match 'Alice'");
+    expect(output).toContain("assistant-1");
+    expect(output).toContain("assistant-2");
+  });
+});

--- a/cli/src/__tests__/use.test.ts
+++ b/cli/src/__tests__/use.test.ts
@@ -98,6 +98,21 @@ describe("vellum use", () => {
     );
   });
 
+  test("sets active assistant by unquoted multi-word display name", async () => {
+    writeLockfile([
+      makeEntry("assistant-1", { name: "Example Assistant" }),
+      makeEntry("assistant-2", { name: "Bob" }),
+    ]);
+    process.argv = ["bun", "vellum", "use", "Example", "Assistant"];
+
+    await use();
+
+    expect(getActiveAssistant()).toBe("assistant-1");
+    expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain(
+      "Active assistant set to Example Assistant (assistant-1).",
+    );
+  });
+
   test("prints active assistant with display name and id", async () => {
     writeLockfile([makeEntry("assistant-1", { name: "Alice" })], "assistant-1");
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -23,6 +23,7 @@ import {
   WEB_INTERFACE_ID,
   getClientRegistrationHeaders,
 } from "../lib/client-identity";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import {
   fetchOrganizationId,
   fetchPlatformAssistants,
@@ -68,7 +69,14 @@ function readAssistantName(entry: AssistantEntry | null): string | undefined {
 function parseArgs(): ParsedArgs {
   const args = process.argv.slice(3);
 
-  let positionalName: string | undefined;
+  const positionalName = parseAssistantTargetArg(args, [
+    "--url",
+    "-u",
+    "--assistant-id",
+    "-a",
+    "--interface",
+    "-i",
+  ]);
   const flagArgs: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -85,8 +93,6 @@ function parseArgs(): ParsedArgs {
       args[i + 1]
     ) {
       flagArgs.push(arg, args[++i]);
-    } else if (!arg.startsWith("-") && positionalName === undefined) {
-      positionalName = arg;
     }
   }
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -4,9 +4,12 @@ import path from "node:path";
 
 import {
   findAssistantByName,
+  formatAssistantLookupError,
   getActiveAssistant,
+  lookupAssistantByIdentifier,
   resolveAssistant,
   saveAssistantEntry,
+  type AssistantEntry,
 } from "../lib/assistant-config";
 import {
   DAEMON_INTERNAL_ASSISTANT_ID,
@@ -55,9 +58,7 @@ interface ParsedArgs {
   zone?: string;
 }
 
-function readAssistantName(
-  entry: ReturnType<typeof findAssistantByName>,
-): string | undefined {
+function readAssistantName(entry: AssistantEntry | null): string | undefined {
   const rawName = entry?.name ?? entry?.assistantName;
   return typeof rawName === "string" && rawName.trim()
     ? rawName.trim()
@@ -89,24 +90,26 @@ function parseArgs(): ParsedArgs {
     }
   }
 
-  let entry: ReturnType<typeof findAssistantByName> = null;
+  let entry: AssistantEntry | null = null;
   if (positionalName) {
-    entry = findAssistantByName(positionalName);
-    if (!entry) {
-      console.error(
-        `No assistant instance found with name '${positionalName}'.`,
-      );
+    const result = lookupAssistantByIdentifier(positionalName);
+    if (result.status !== "found") {
+      console.error(formatAssistantLookupError(positionalName, result));
       process.exit(1);
     }
+    entry = result.entry;
   } else {
     const hasExplicitUrl =
       flagArgs.includes("--url") || flagArgs.includes("-u");
     const active = getActiveAssistant();
     if (active) {
-      entry = findAssistantByName(active);
+      const result = lookupAssistantByIdentifier(active);
+      if (result.status === "found") {
+        entry = result.entry;
+      }
       if (!entry && !hasExplicitUrl) {
         console.error(
-          `Active assistant '${active}' not found in lockfile. Set an active assistant with 'vellum use <name>'.`,
+          `Active assistant '${active}' not found in lockfile. Set an active assistant with 'vellum use <name-or-id>'.`,
         );
         process.exit(1);
       }
@@ -116,7 +119,7 @@ function parseArgs(): ParsedArgs {
       entry = resolveAssistant();
     } else if (!entry) {
       console.error(
-        "No active assistant set. Set one with 'vellum use <name>' or specify a name: 'vellum client <name>'.",
+        "No active assistant set. Set one with 'vellum use <name-or-id>' or specify one: 'vellum client <name-or-id>'.",
       );
       process.exit(1);
     }
@@ -217,10 +220,10 @@ function printUsage(): void {
   console.log(`${ANSI.bold}vellum client${ANSI.reset} - Connect to a hatched assistant
 
 ${ANSI.bold}USAGE:${ANSI.reset}
-    vellum client [name] [options]
+    vellum client [name-or-id] [options]
 
 ${ANSI.bold}ARGUMENTS:${ANSI.reset}
-    [name]                     Instance name (default: active)
+    [name-or-id]               Assistant display name or ID (default: active)
 
 ${ANSI.bold}OPTIONS:${ANSI.reset}
     -u, --url <url>            Runtime URL

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -2,9 +2,13 @@ import { join } from "path";
 
 import {
   findAssistantByName,
+  formatAssistantLookupError,
+  formatAssistantReference,
   getActiveAssistant,
+  getAssistantDisplayName,
   getDaemonPidPath,
   loadAllAssistants,
+  lookupAssistantByIdentifier,
   type AssistantEntry,
 } from "../lib/assistant-config";
 import { resolveEnvironmentSource } from "../lib/environments/resolve";
@@ -377,7 +381,7 @@ async function getDockerProcesses(entry: AssistantEntry): Promise<TableRow[]> {
 async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
   const cloud = resolveCloud(entry);
 
-  console.log(`Processes for ${entry.assistantId} (${cloud}):\n`);
+  console.log(`Processes for ${formatAssistantReference(entry)} (${cloud}):\n`);
 
   if (cloud === "local") {
     const rows = await getLocalProcesses(entry);
@@ -519,6 +523,9 @@ export async function listAllAssistants(verbose: boolean): Promise<void> {
 
   const assistants = loadAllAssistants();
   const activeId = getActiveAssistant();
+  const activeAssistantId = activeId
+    ? (findAssistantByName(activeId)?.assistantId ?? activeId)
+    : null;
 
   if (assistants.length === 0) {
     console.log("No assistants found.");
@@ -542,13 +549,14 @@ export async function listAllAssistants(verbose: boolean): Promise<void> {
 
   const rows: TableRow[] = assistants.map((a) => {
     const infoParts: string[] = [];
+    infoParts.push(`id: ${a.assistantId}`);
     if (a.runtimeUrl) infoParts.push(a.runtimeUrl);
     if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
     if (a.species) infoParts.push(`species: ${a.species}`);
-    const prefix = a.assistantId === activeId ? "* " : "  ";
+    const prefix = a.assistantId === activeAssistantId ? "* " : "  ";
 
     return {
-      name: prefix + a.assistantId,
+      name: prefix + getAssistantDisplayName(a),
       status: withStatusEmoji("checking..."),
       info: infoParts.join(" | "),
     };
@@ -609,14 +617,15 @@ export async function listAllAssistants(verbose: boolean): Promise<void> {
       }
 
       const infoParts: string[] = [];
+      infoParts.push(`id: ${a.assistantId}`);
       if (a.runtimeUrl) infoParts.push(a.runtimeUrl);
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
       if (a.species) infoParts.push(`species: ${a.species}`);
       if (health.detail) infoParts.push(health.detail);
 
-      const prefix = a.assistantId === activeId ? "* " : "  ";
+      const prefix = a.assistantId === activeAssistantId ? "* " : "  ";
       const updatedRow: TableRow = {
-        name: prefix + a.assistantId,
+        name: prefix + getAssistantDisplayName(a),
         status: withStatusEmoji(health.status),
         info: infoParts.join(" | "),
       };
@@ -638,14 +647,16 @@ export async function listAllAssistants(verbose: boolean): Promise<void> {
 export async function ps(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum ps [<name>] [--verbose]");
+    console.log("Usage: vellum ps [<name-or-id>] [--verbose]");
     console.log("");
     console.log(
       "List all assistants, or show processes for a specific assistant.",
     );
     console.log("");
     console.log("Arguments:");
-    console.log("  <name>       Show processes for the named assistant");
+    console.log(
+      "  <name-or-id> Show processes for the assistant display name or ID",
+    );
     console.log("");
     console.log("Options:");
     console.log(
@@ -656,18 +667,18 @@ export async function ps(): Promise<void> {
 
   const verbose = args.includes("--verbose");
   const positional = args.filter((a) => !a.startsWith("--"));
-  const assistantId = positional[0];
+  const assistantIdentifier = positional[0];
 
-  if (!assistantId) {
+  if (!assistantIdentifier) {
     await listAllAssistants(verbose);
     return;
   }
 
-  const entry = findAssistantByName(assistantId);
-  if (!entry) {
-    console.error(`No assistant found with name '${assistantId}'.`);
+  const result = lookupAssistantByIdentifier(assistantIdentifier);
+  if (result.status !== "found") {
+    console.error(formatAssistantLookupError(assistantIdentifier, result));
     process.exit(1);
   }
 
-  await showAssistantProcesses(entry);
+  await showAssistantProcesses(result.entry);
 }

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -11,6 +11,7 @@ import {
   lookupAssistantByIdentifier,
   type AssistantEntry,
 } from "../lib/assistant-config";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { resolveEnvironmentSource } from "../lib/environments/resolve";
 import { loadGuardianToken } from "../lib/guardian-token";
 import {
@@ -657,8 +658,7 @@ export async function ps(): Promise<void> {
   }
 
   const verbose = args.includes("--verbose");
-  const positional = args.filter((a) => !a.startsWith("--"));
-  const assistantIdentifier = positional[0];
+  const assistantIdentifier = parseAssistantTargetArg(args);
 
   if (!assistantIdentifier) {
     await listAllAssistants(verbose);

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -56,8 +56,10 @@ function pad(s: string, w: number): string {
   return s + " ".repeat(Math.max(0, w - s.length));
 }
 
-function computeColWidths(rows: TableRow[]): ColWidths {
-  const headers: TableRow = { name: "NAME", status: "STATUS", info: "INFO" };
+function computeColWidths(
+  rows: TableRow[],
+  headers: TableRow = { name: "NAME", status: "STATUS", info: "INFO" },
+): ColWidths {
   const all = [headers, ...rows];
   return {
     name: Math.max(...all.map((r) => r.name.length)),
@@ -70,9 +72,11 @@ function formatRow(r: TableRow, colWidths: ColWidths): string {
   return `  ${pad(r.name, colWidths.name)}  ${pad(r.status, colWidths.status)}  ${r.info}`;
 }
 
-function printTable(rows: TableRow[]): void {
-  const colWidths = computeColWidths(rows);
-  const headers: TableRow = { name: "PROCESS", status: "STATUS", info: "INFO" };
+function printTable(
+  rows: TableRow[],
+  headers: TableRow = { name: "PROCESS", status: "STATUS", info: "INFO" },
+): void {
+  const colWidths = computeColWidths(rows, headers);
   console.log(formatRow(headers, colWidths));
   const sep = `  ${"-".repeat(colWidths.name)}  ${"-".repeat(colWidths.status)}  ${"-".repeat(colWidths.info)}`;
   console.log(sep);
@@ -477,6 +481,75 @@ async function showAssistantProcesses(entry: AssistantEntry): Promise<void> {
 
 // ── List all assistants (no arg) ────────────────────────────────
 
+type AssistantHealth = {
+  status: string;
+  detail: string | null;
+  version?: string;
+};
+
+async function getAssistantListHealth(
+  entry: AssistantEntry,
+): Promise<AssistantHealth> {
+  const resources = entry.resources;
+  if (entry.cloud === "local" && resources) {
+    // TODO(ATL-306): Remove readPidFile/getDaemonPidPath in favor of
+    // fetching daemon PIDs via the health API (Gateway Security Migration).
+    const pid = readPidFile(getDaemonPidPath(resources));
+    const alive = pid !== null && isProcessAlive(pid);
+    if (!alive) {
+      return { status: "sleeping", detail: null };
+    }
+    const token = loadGuardianToken(entry.assistantId)?.accessToken;
+    return checkHealth(entry.localUrl ?? entry.runtimeUrl, token);
+  }
+
+  if (entry.cloud === "docker") {
+    const res = dockerResourceNames(entry.assistantId);
+    const state = await getDockerContainerState(res.assistantContainer);
+    if (!state || state !== "running") {
+      return { status: "sleeping", detail: null };
+    }
+    const token = loadGuardianToken(entry.assistantId)?.accessToken;
+    return checkHealth(entry.localUrl ?? entry.runtimeUrl, token);
+  }
+
+  if (entry.cloud === "apple-container") {
+    // Apple containers are managed by the macOS app. Probe the gateway
+    // (runtimeUrl is always written to the lockfile during hatch).
+    const token = loadGuardianToken(entry.assistantId)?.accessToken;
+    return entry.runtimeUrl
+      ? checkHealth(entry.runtimeUrl, token)
+      : { status: "unknown", detail: "no runtime URL" };
+  }
+
+  if (entry.cloud === "vellum") {
+    return checkManagedHealth(entry.runtimeUrl, entry.assistantId);
+  }
+
+  const token = loadGuardianToken(entry.assistantId)?.accessToken;
+  return checkHealth(entry.localUrl ?? entry.runtimeUrl, token);
+}
+
+function formatAssistantListRow(
+  entry: AssistantEntry,
+  activeAssistantId: string | null,
+  health: AssistantHealth,
+): TableRow {
+  const infoParts: string[] = [];
+  infoParts.push(`id: ${entry.assistantId}`);
+  if (entry.runtimeUrl) infoParts.push(entry.runtimeUrl);
+  if (entry.cloud) infoParts.push(`cloud: ${entry.cloud}`);
+  if (entry.species) infoParts.push(`species: ${entry.species}`);
+  if (health.detail) infoParts.push(health.detail);
+
+  const prefix = entry.assistantId === activeAssistantId ? "* " : "  ";
+  return {
+    name: prefix + getAssistantDisplayName(entry),
+    status: withStatusEmoji(health.status),
+    info: infoParts.join(" | "),
+  };
+}
+
 export async function listAllAssistants(verbose: boolean): Promise<void> {
   const { name: envName, source: envSource } = resolveEnvironmentSource();
   const sourceLabels: Record<typeof envSource, string> = {
@@ -547,99 +620,17 @@ export async function listAllAssistants(verbose: boolean): Promise<void> {
     return;
   }
 
-  const rows: TableRow[] = assistants.map((a) => {
-    const infoParts: string[] = [];
-    infoParts.push(`id: ${a.assistantId}`);
-    if (a.runtimeUrl) infoParts.push(a.runtimeUrl);
-    if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
-    if (a.species) infoParts.push(`species: ${a.species}`);
-    const prefix = a.assistantId === activeAssistantId ? "* " : "  ";
-
-    return {
-      name: prefix + getAssistantDisplayName(a),
-      status: withStatusEmoji("checking..."),
-      info: infoParts.join(" | "),
-    };
-  });
-
-  const colWidths = computeColWidths(rows);
-
-  const headers: TableRow = { name: "NAME", status: "STATUS", info: "INFO" };
-  console.log(formatRow(headers, colWidths));
-  const sep = `  ${"-".repeat(colWidths.name)}  ${"-".repeat(colWidths.status)}  ${"-".repeat(colWidths.info)}`;
-  console.log(sep);
-  for (const row of rows) {
-    console.log(formatRow(row, colWidths));
-  }
-
-  const totalDataRows = rows.length;
-
-  await Promise.all(
-    assistants.map(async (a, rowIndex) => {
-      // For local assistants, check if the daemon process is alive before
-      // hitting the health endpoint. If the PID file is missing or the
-      // process isn't running, the assistant is sleeping — skip the
-      // network health check to avoid a misleading "unreachable" status.
-      let health: { status: string; detail: string | null; version?: string };
-      const resources = a.resources;
-      if (a.cloud === "local" && resources) {
-        // TODO(ATL-306): Remove readPidFile/getDaemonPidPath in favor of
-        // fetching daemon PIDs via the health API (Gateway Security Migration).
-        const pid = readPidFile(getDaemonPidPath(resources));
-        const alive = pid !== null && isProcessAlive(pid);
-        if (!alive) {
-          health = { status: "sleeping", detail: null };
-        } else {
-          const token = loadGuardianToken(a.assistantId)?.accessToken;
-          health = await checkHealth(a.localUrl ?? a.runtimeUrl, token);
-        }
-      } else if (a.cloud === "docker") {
-        const res = dockerResourceNames(a.assistantId);
-        const state = await getDockerContainerState(res.assistantContainer);
-        if (!state || state !== "running") {
-          health = { status: "sleeping", detail: null };
-        } else {
-          const token = loadGuardianToken(a.assistantId)?.accessToken;
-          health = await checkHealth(a.localUrl ?? a.runtimeUrl, token);
-        }
-      } else if (a.cloud === "apple-container") {
-        // Apple containers are managed by the macOS app. Probe the gateway
-        // (runtimeUrl is always written to the lockfile during hatch).
-        const token = loadGuardianToken(a.assistantId)?.accessToken;
-        health = a.runtimeUrl
-          ? await checkHealth(a.runtimeUrl, token)
-          : { status: "unknown" as const, detail: "no runtime URL" };
-      } else if (a.cloud === "vellum") {
-        health = await checkManagedHealth(a.runtimeUrl, a.assistantId);
-      } else {
-        const token = loadGuardianToken(a.assistantId)?.accessToken;
-        health = await checkHealth(a.localUrl ?? a.runtimeUrl, token);
-      }
-
-      const infoParts: string[] = [];
-      infoParts.push(`id: ${a.assistantId}`);
-      if (a.runtimeUrl) infoParts.push(a.runtimeUrl);
-      if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
-      if (a.species) infoParts.push(`species: ${a.species}`);
-      if (health.detail) infoParts.push(health.detail);
-
-      const prefix = a.assistantId === activeAssistantId ? "* " : "  ";
-      const updatedRow: TableRow = {
-        name: prefix + getAssistantDisplayName(a),
-        status: withStatusEmoji(health.status),
-        info: infoParts.join(" | "),
-      };
-
-      const linesUp = totalDataRows - rowIndex;
-      process.stdout.write(
-        `\x1b[${linesUp}A` +
-          `\r\x1b[K` +
-          formatRow(updatedRow, colWidths) +
-          `\n` +
-          (linesUp > 1 ? `\x1b[${linesUp - 1}B` : ""),
-      );
-    }),
+  const rows = await Promise.all(
+    assistants.map(async (entry) =>
+      formatAssistantListRow(
+        entry,
+        activeAssistantId,
+        await getAssistantListHealth(entry),
+      ),
+    ),
   );
+
+  printTable(rows, { name: "NAME", status: "STATUS", info: "INFO" });
 }
 
 // ── Entry point ─────────────────────────────────────────────────

--- a/cli/src/commands/use.ts
+++ b/cli/src/commands/use.ts
@@ -1,6 +1,8 @@
 import {
-  findAssistantByName,
+  formatAssistantLookupError,
+  formatAssistantReference,
   getActiveAssistant,
+  lookupAssistantByIdentifier,
   setActiveAssistant,
 } from "../lib/assistant-config.js";
 
@@ -8,12 +10,14 @@ export async function use(): Promise<void> {
   const args = process.argv.slice(3);
 
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum use [<name>]");
+    console.log("Usage: vellum use [<name-or-id>]");
     console.log("");
     console.log("Set the active assistant for commands.");
     console.log("");
     console.log("Arguments:");
-    console.log("  <name>    Name of the assistant to make active");
+    console.log(
+      "  <name-or-id>    Assistant display name or ID to make active",
+    );
     console.log("");
     console.log(
       "When called without a name, prints the current active assistant.",
@@ -26,19 +30,28 @@ export async function use(): Promise<void> {
   if (!name) {
     const active = getActiveAssistant();
     if (active) {
-      console.log(`Active assistant: ${active}`);
+      const result = lookupAssistantByIdentifier(active);
+      if (result.status === "found") {
+        console.log(
+          `Active assistant: ${formatAssistantReference(result.entry)}`,
+        );
+      } else {
+        console.log(`Active assistant: ${active} (not found in lockfile)`);
+      }
     } else {
       console.log("No active assistant set.");
     }
     return;
   }
 
-  const entry = findAssistantByName(name);
-  if (!entry) {
-    console.error(`No assistant found with name '${name}'.`);
+  const result = lookupAssistantByIdentifier(name);
+  if (result.status !== "found") {
+    console.error(formatAssistantLookupError(name, result));
     process.exit(1);
   }
 
-  setActiveAssistant(name);
-  console.log(`Active assistant set to '${name}'.`);
+  setActiveAssistant(result.entry.assistantId);
+  console.log(
+    `Active assistant set to ${formatAssistantReference(result.entry)}.`,
+  );
 }

--- a/cli/src/commands/use.ts
+++ b/cli/src/commands/use.ts
@@ -5,6 +5,7 @@ import {
   lookupAssistantByIdentifier,
   setActiveAssistant,
 } from "../lib/assistant-config.js";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 
 export async function use(): Promise<void> {
   const args = process.argv.slice(3);
@@ -25,7 +26,7 @@ export async function use(): Promise<void> {
     process.exit(0);
   }
 
-  const name = args.find((a) => !a.startsWith("-"));
+  const name = parseAssistantTargetArg(args);
 
   if (!name) {
     const active = getActiveAssistant();

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -314,8 +314,7 @@ export function loadLatestAssistant(): AssistantEntry | null {
 }
 
 export function findAssistantByName(name: string): AssistantEntry | null {
-  const result = lookupAssistantByIdentifier(name);
-  return result.status === "found" ? result.entry : null;
+  return readAssistants().find((entry) => entry.assistantId === name) ?? null;
 }
 
 export function getAssistantDisplayName(entry: AssistantEntry): string {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -109,6 +109,11 @@ export interface AssistantEntry {
   [key: string]: unknown;
 }
 
+export type AssistantLookupResult =
+  | { status: "found"; entry: AssistantEntry }
+  | { status: "not_found" }
+  | { status: "ambiguous"; matches: AssistantEntry[] };
+
 interface LockfileData {
   assistants?: Record<string, unknown>[];
   activeAssistant?: string;
@@ -309,8 +314,71 @@ export function loadLatestAssistant(): AssistantEntry | null {
 }
 
 export function findAssistantByName(name: string): AssistantEntry | null {
+  const result = lookupAssistantByIdentifier(name);
+  return result.status === "found" ? result.entry : null;
+}
+
+export function getAssistantDisplayName(entry: AssistantEntry): string {
+  const primary = entry.name?.trim();
+  if (primary) return primary;
+
+  const legacy = entry.assistantName?.trim();
+  if (legacy) return legacy;
+
+  return entry.assistantId;
+}
+
+export function formatAssistantReference(entry: AssistantEntry): string {
+  const displayName = getAssistantDisplayName(entry);
+  return displayName === entry.assistantId
+    ? entry.assistantId
+    : `${displayName} (${entry.assistantId})`;
+}
+
+function getAssistantDisplayNameCandidates(entry: AssistantEntry): string[] {
+  return Array.from(
+    new Set(
+      [entry.name?.trim(), entry.assistantName?.trim()].filter(
+        (value): value is string => typeof value === "string" && value !== "",
+      ),
+    ),
+  );
+}
+
+export function lookupAssistantByIdentifier(
+  identifier: string,
+): AssistantLookupResult {
   const entries = readAssistants();
-  return entries.find((e) => e.assistantId === name) ?? null;
+  const exactId = entries.find((entry) => entry.assistantId === identifier);
+  if (exactId) {
+    return { status: "found", entry: exactId };
+  }
+
+  const displayMatches = entries.filter((entry) =>
+    getAssistantDisplayNameCandidates(entry).includes(identifier),
+  );
+  if (displayMatches.length === 1) {
+    return { status: "found", entry: displayMatches[0] };
+  }
+  if (displayMatches.length > 1) {
+    return { status: "ambiguous", matches: displayMatches };
+  }
+
+  return { status: "not_found" };
+}
+
+export function formatAssistantLookupError(
+  identifier: string,
+  result: AssistantLookupResult = lookupAssistantByIdentifier(identifier),
+): string {
+  if (result.status === "ambiguous") {
+    const matches = result.matches
+      .map((entry) => formatAssistantReference(entry))
+      .join(", ");
+    return `Multiple assistants match '${identifier}': ${matches}. Use the assistant ID to disambiguate.`;
+  }
+
+  return `No assistant found with name or ID '${identifier}'.`;
 }
 
 export function removeAssistantEntry(assistantId: string): void {
@@ -446,13 +514,25 @@ export function resolveAssistant(nameArg?: string): AssistantEntry | null {
  * 3. Sole lockfile entry (any cloud)
  */
 export function resolveTargetAssistant(nameArg?: string): AssistantEntry {
-  const entry = resolveAssistant(nameArg);
-  if (entry) return entry;
-
   if (nameArg) {
-    console.error(`No assistant found with name '${nameArg}'.`);
+    const result = lookupAssistantByIdentifier(nameArg);
+    if (result.status === "found") return result.entry;
+    console.error(formatAssistantLookupError(nameArg, result));
   } else {
+    const active = getActiveAssistant();
+    if (active) {
+      const result = lookupAssistantByIdentifier(active);
+      if (result.status === "found") return result.entry;
+      if (result.status === "ambiguous") {
+        console.error(formatAssistantLookupError(active, result));
+        process.exit(1);
+      }
+      // Active assistant no longer exists in lockfile — fall through.
+    }
+
     const all = readAssistants();
+    if (all.length === 1) return all[0];
+
     if (all.length === 0) {
       console.error("No assistant found. Run 'vellum hatch' first.");
     } else {

--- a/cli/src/lib/assistant-target-args.ts
+++ b/cli/src/lib/assistant-target-args.ts
@@ -1,0 +1,21 @@
+export function parseAssistantTargetArg(
+  args: string[],
+  flagsWithValues: readonly string[] = [],
+): string | undefined {
+  const flagsWithValuesSet = new Set(flagsWithValues);
+  const parts: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (flagsWithValuesSet.has(arg)) {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    parts.push(arg);
+  }
+
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}


### PR DESCRIPTION
## Summary
- add display-name-aware assistant lookup with exact assistant ID precedence and explicit duplicate-name errors
- update `vellum use`, `vellum client`, and `vellum ps` to accept unique display names while storing/using canonical assistant IDs
- render `vellum ps` rows with display names as the primary label and assistant IDs visible in the info column

## Original prompt
This is PR 4 from the Vellum CLI M1 lifecycle trust plan. The goal is to make assistant targeting less confusing by allowing `vellum use <display-name>` and related CLI paths to resolve unique display names, while keeping active assistant state unambiguous and safe when duplicate names exist.