### PR TITLE
[codex] Refresh CLI assistant display name sync

### DIFF
--- a/cli/src/__tests__/default-main-screen.test.ts
+++ b/cli/src/__tests__/default-main-screen.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  fetchAssistantDisplayName,
+  shouldRefreshAssistantIdentity,
+} from "../components/DefaultMainScreen";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("DefaultMainScreen identity helpers", () => {
+  test("fetchAssistantDisplayName reads and trims the runtime identity name", async () => {
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      expect(String(url)).toBe(
+        "http://127.0.0.1:7833/v1/assistants/assistant-1/identity",
+      );
+      return new Response(JSON.stringify({ name: "  Hatch  " }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    await expect(
+      fetchAssistantDisplayName("http://127.0.0.1:7833", "assistant-1"),
+    ).resolves.toBe("Hatch");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fetchAssistantDisplayName treats blank identity names as absent", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({ name: "   " }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      fetchAssistantDisplayName("http://127.0.0.1:7833", "assistant-1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("shouldRefreshAssistantIdentity recognizes identity events", () => {
+    expect(
+      shouldRefreshAssistantIdentity({
+        type: "sync_changed",
+        tags: ["assistant:self:identity"],
+      }),
+    ).toBe(true);
+
+    expect(shouldRefreshAssistantIdentity({ type: "identity_changed" })).toBe(
+      true,
+    );
+
+    expect(
+      shouldRefreshAssistantIdentity({
+        type: "sync_changed",
+        tags: ["conversations:list"],
+      }),
+    ).toBe(false);
+  });
+});

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -67,7 +67,7 @@ const TIPS = [
   "Send a message to start chatting",
   "Use /help to see available commands",
 ];
-const RIGHT_PANEL_INFO_SECTIONS = 3; // Assistant ID, Species, Status — each with heading + value
+const RIGHT_PANEL_INFO_SECTIONS = 3; // Instance ID, Species, Status — each with heading + value
 const RIGHT_PANEL_SPACERS = 2; // top spacer + spacer between tips and info
 const RIGHT_PANEL_TIPS_HEADING = 1;
 const RIGHT_PANEL_LINE_COUNT =
@@ -149,6 +149,10 @@ interface HealthResponse {
   message?: string;
 }
 
+interface IdentityResponse {
+  name?: string;
+}
+
 /** Extract human-readable message from a daemon JSON error response. */
 function friendlyErrorMessage(status: number, body: string): string {
   try {
@@ -223,6 +227,28 @@ async function pollMessages(
     undefined,
     auth,
   );
+}
+
+function normalizeAssistantDisplayName(
+  value: string | null | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function fetchAssistantDisplayName(
+  baseUrl: string,
+  assistantId: string,
+  auth?: Record<string, string>,
+): Promise<string | undefined> {
+  const identity = await runtimeRequest<IdentityResponse>(
+    baseUrl,
+    assistantId,
+    "/identity",
+    undefined,
+    auth,
+  );
+  return normalizeAssistantDisplayName(identity.name);
 }
 
 async function sendMessage(
@@ -333,6 +359,19 @@ interface SseEvent {
   // sync_changed fields
   tags?: string[];
   [key: string]: unknown;
+}
+
+const ASSISTANT_IDENTITY_SYNC_TAG = "assistant:self:identity";
+
+export function shouldRefreshAssistantIdentity(event: SseEvent): boolean {
+  if (event.type === "identity_changed") {
+    return true;
+  }
+  return (
+    event.type === "sync_changed" &&
+    Array.isArray(event.tags) &&
+    event.tags.includes(ASSISTANT_IDENTITY_SYNC_TAG)
+  );
 }
 
 /**
@@ -969,7 +1008,7 @@ function DefaultMainScreen({
     { text: "Tips for getting started", style: "heading" },
     ...TIPS.map((t) => ({ text: t, style: "normal" as const })),
     { text: " ", style: "normal" },
-    { text: "Assistant ID", style: "heading" },
+    { text: "Instance ID", style: "heading" },
     { text: assistantId, style: "dim" },
     { text: "Species", style: "heading" },
     {
@@ -1428,6 +1467,9 @@ function ChatApp({
   const [connectionError, setConnectionError] = useState<string | undefined>(
     undefined,
   );
+  const [displayAssistantName, setDisplayAssistantName] = useState<
+    string | undefined
+  >(() => normalizeAssistantDisplayName(assistantName));
   const prevFeedLengthRef = useRef(0);
   const busyRef = useRef(false);
   const connectedRef = useRef(false);
@@ -1442,6 +1484,10 @@ function ChatApp({
   const terminalRows = stdout.rows || DEFAULT_TERMINAL_ROWS;
   const terminalColumns = stdout.columns || DEFAULT_TERMINAL_COLUMNS;
   const headerHeight = calculateHeaderHeight(species, terminalColumns);
+
+  useEffect(() => {
+    setDisplayAssistantName(normalizeAssistantDisplayName(assistantName));
+  }, [assistantName]);
 
   const isCompact = terminalColumns < COMPACT_THRESHOLD;
   const compactInputAreaHeight = 1; // input row only, no separators
@@ -1661,6 +1707,23 @@ function ChatApp({
     setHealthStatus(status);
   }, []);
 
+  const refreshAssistantName = useCallback(async () => {
+    try {
+      const name = await fetchAssistantDisplayName(
+        runtimeUrl,
+        assistantId,
+        auth,
+      );
+      if (name) {
+        setDisplayAssistantName(name);
+      }
+    } catch (err) {
+      tuiLog.warn("failed to refresh assistant identity", {
+        error: String(err),
+      });
+    }
+  }, [runtimeUrl, assistantId, auth]);
+
   const cleanup = useCallback(() => {
     if (sseAbortRef.current) {
       sseAbortRef.current.abort();
@@ -1706,6 +1769,8 @@ function ChatApp({
           "yellow",
         );
       }
+
+      await refreshAssistantName();
 
       h.showSpinner("Loading conversation history...");
 
@@ -1881,8 +1946,13 @@ function ChatApp({
                 break;
 
               case "sync_changed":
-                // The interactive CLI does not currently keep any sync-tagged
-                // caches, so generic invalidations are intentionally ignored.
+                if (shouldRefreshAssistantIdentity(event)) {
+                  void refreshAssistantName();
+                }
+                break;
+
+              case "identity_changed":
+                void refreshAssistantName();
                 break;
 
               default:
@@ -1925,7 +1995,7 @@ function ChatApp({
       );
       return false;
     }
-  }, [runtimeUrl, assistantId, auth]);
+  }, [runtimeUrl, assistantId, auth, refreshAssistantName]);
 
   const handleInput = useCallback(
     async (input: string): Promise<void> => {
@@ -2408,7 +2478,7 @@ function ChatApp({
       <DefaultMainScreen
         runtimeUrl={runtimeUrl}
         assistantId={assistantId}
-        assistantName={assistantName}
+        assistantName={displayAssistantName}
         species={species}
         healthStatus={healthStatus}
       />


### PR DESCRIPTION
## Summary
- fetch the CLI header display name from the assistant `/identity` endpoint on connect
- refresh the displayed name when assistant identity sync events arrive
- relabel the stable slug from `Assistant ID` to `Instance ID`
- add focused tests for identity fetching and sync-event routing

## Why
The CLI header previously read the assistant display name once from lockfile/platform metadata and ignored identity invalidations. When the assistant chose a name during chat, the open CLI could keep showing the default onboarding title while also labeling the stable instance slug as `Assistant ID`, which made the two name concepts hard to distinguish.

## Validation
- `cd cli && bun test src/__tests__/default-main-screen.test.ts`
- `cd cli && bunx tsc --noEmit`
- `cd cli && bunx prettier --check src/components/DefaultMainScreen.tsx src/__tests__/default-main-screen.test.ts`
- commit hook: generic examples, formatting, and CLI lint for touched files
- pre-push hook: CLI lint for touched files

Closes #30896