### PR TITLE
fix(macos/settings): preserve external activeProfile updates during in-flight setActiveProfile

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3331,20 +3331,29 @@ public final class SettingsStore: ObservableObject {
     /// Each call captures a monotonic generation at entry. After the await,
     /// post-PATCH mutation is gated on whether a *newer* pick is still
     /// "live" — i.e. either still in flight or already successfully
-    /// confirmed. This distinguishes two race scenarios:
+    /// confirmed — and on whether the daemon-confirmed value was updated
+    /// out-of-band (e.g. by a `loadInferenceProfiles` push from another
+    /// client/session). This distinguishes three race scenarios:
     ///
     /// 1. A→B both succeed, A late: B's success advances
     ///    `lastConfirmedSetActiveProfileGen` past A. A's late success sees
     ///    that and skips entirely, so it does not stomp B.
     /// 2. A→B-fails-and-reverts→A late success: B never confirms, so
-    ///    `lastConfirmedSetActiveProfileGen` is unchanged. By the time A's
-    ///    success arrives, B is no longer in flight either. No newer pick
-    ///    is live, so A applies fully — re-syncing `activeProfile` from
-    ///    the post-revert "balanced" back to the daemon-confirmed "A".
+    ///    `lastConfirmedSetActiveProfileGen` is unchanged and
+    ///    `lastConfirmedActiveProfile` was never touched during A's call.
+    ///    By the time A's success arrives, B is no longer in flight
+    ///    either. No newer pick is live, so A applies fully — re-syncing
+    ///    `activeProfile` from the post-revert "balanced" back to the
+    ///    daemon-confirmed "A".
+    /// 3. A in flight → external load pushes "C" → A late success: the
+    ///    push updates `lastConfirmedActiveProfile` to "C". A's success
+    ///    branch detects the snapshot drift and skips, leaving the
+    ///    daemon-pushed value intact instead of stomping it back to "A".
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
         setActiveProfileGenerationCounter += 1
         let myGen = setActiveProfileGenerationCounter
+        let confirmedAtEntry = lastConfirmedActiveProfile
         inFlightSetActiveProfileGens.insert(myGen)
         self.activeProfile = name
         let success = await settingsClient.patchConfig([
@@ -3354,9 +3363,10 @@ public final class SettingsStore: ObservableObject {
 
         let newerPickLive = lastConfirmedSetActiveProfileGen > myGen
             || inFlightSetActiveProfileGens.contains(where: { $0 > myGen })
+        let confirmedChangedExternally = lastConfirmedActiveProfile != confirmedAtEntry
 
         if success {
-            if !newerPickLive {
+            if !newerPickLive, !confirmedChangedExternally {
                 lastConfirmedActiveProfile = name
                 self.activeProfile = name
                 lastConfirmedSetActiveProfileGen = myGen

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -302,6 +302,61 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertEqual(store.activeProfile, "A")
     }
 
+    /// When `loadInferenceProfiles` pushes a remote-confirmed value (e.g.
+    /// from another client/session) while a `setActiveProfile` PATCH is in
+    /// flight, the older local PATCH must not stomp the newer daemon-pushed
+    /// value once it finally succeeds. The user picks "A"; while the PATCH
+    /// is suspended, a config push updates the authoritative value to "C";
+    /// "A"'s late success must observe the snapshot drift on
+    /// `lastConfirmedActiveProfile` and leave both `activeProfile` and
+    /// `lastConfirmedActiveProfile` set to "C".
+    func testSetActiveProfileDoesNotStompExternalConfirmedUpdate() async {
+        var continuationA: CheckedContinuation<Bool, Never>?
+        let aSuspended = expectation(description: "A PATCH suspended")
+        mockSettingsClient.patchConfigHandler = { _ in
+            return await withCheckedContinuation { cont in
+                continuationA = cont
+                aSuspended.fulfill()
+            }
+        }
+
+        async let resultA: Bool = store.setActiveProfile("A")
+
+        await fulfillment(of: [aSuspended], timeout: 1.0)
+        XCTAssertEqual(store.activeProfile, "A")
+
+        // External config push (another client/session) advances the
+        // daemon-authoritative value to "C" while A is still in flight.
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "C",
+                "profiles": ["C": ["model": "claude-sonnet-4-6"]],
+            ]
+        ])
+        XCTAssertEqual(store.activeProfile, "C")
+
+        // A's late success arrives. Even though no newer local pick is
+        // live, the snapshot of `lastConfirmedActiveProfile` taken at
+        // entry no longer matches — so the success branch must skip its
+        // writes and leave the daemon-pushed value intact.
+        continuationA?.resume(returning: true)
+        let aSucceeded = await resultA
+        XCTAssertTrue(aSucceeded)
+        XCTAssertEqual(
+            store.activeProfile,
+            "C",
+            "Late local success must not stomp a newer remote-confirmed value"
+        )
+
+        // A subsequent failed pick must revert to "C", not "A",
+        // confirming `lastConfirmedActiveProfile` was preserved.
+        mockSettingsClient.patchConfigHandler = nil
+        mockSettingsClient.patchConfigResponse = false
+        let dSucceeded = await store.setActiveProfile("D")
+        XCTAssertFalse(dSucceeded)
+        XCTAssertEqual(store.activeProfile, "C")
+    }
+
     // MARK: - setProfile
 
     func testSetProfileRoundTripsAndUpdatesPublishedState() async {


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #30781: an older local setActiveProfile PATCH can stomp a newer daemon-pushed value that arrived via loadInferenceProfiles while the PATCH was in flight.

The fix snapshots lastConfirmedActiveProfile at the entry of setActiveProfile and skips the success branch's writes when the snapshot drifts during the await. This distinguishes scenario 2 (legitimate revert by failed sibling — confirmed value unchanged) from scenario 3 (external load updated authoritative value — confirmed value changed).

Closes the loop on #30781 review feedback.

## Test plan

- [x] Added testSetActiveProfileDoesNotStompExternalConfirmedUpdate regression test
- [x] Existing testSetActiveProfileIgnoresStaleSuccessFromOlderInflightCall remains valid (newerPickLive still gates scenario 1)
- [x] Existing testSetActiveProfileAppliesLateSuccessWhenNewerPickFailed remains valid (scenario 2 leaves lastConfirmedActiveProfile unchanged so snapshot still matches)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->