### PR TITLE
fix(heartbeat): prevent in-flight run from undoing resetTimer reset

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -395,6 +395,48 @@ describe("HeartbeatService", () => {
       }
     });
 
+    test("resetTimer() during an in-flight run is not undone by that run's increment", async () => {
+      // Regression: if a guardian message arrives mid-run, `resetTimer()`
+      // zeroes the counter but the in-flight run's `finally` block used to
+      // unconditionally `_consecutiveRuns++`, leaving the counter at 1 and
+      // tripping the cap-at-1 path one auto run too early.
+      stubConfig.heartbeat.maxConsecutiveRuns = 1;
+
+      let releaseInflight: () => void = () => {};
+      const inflight = new Promise<void>((resolve) => {
+        releaseInflight = resolve;
+      });
+      runBackgroundJobImpl = async () => {
+        await inflight;
+        return { conversationId: STUB_CONVERSATION_ID, ok: true };
+      };
+
+      const service = new HeartbeatService({ alerter: () => {} });
+      service.start();
+      try {
+        const runPromise = service.runOnce({ force: false });
+        // Guardian message arrives while the run is still executing.
+        service.resetTimer();
+        releaseInflight();
+        expect(await runPromise).toBe(true);
+
+        // The reset during the in-flight run must survive: the next auto run
+        // should proceed because the counter is still 0, not 1.
+        runBackgroundJobImpl = async () => ({
+          conversationId: STUB_CONVERSATION_ID,
+          ok: true,
+        });
+        expect(await service.runOnce({ force: false })).toBe(true);
+        expect(
+          skipHeartbeatRunCalls.some(
+            (c) => c.reason === "max_consecutive_runs",
+          ),
+        ).toBe(false);
+      } finally {
+        await service.stop();
+      }
+    });
+
     test("null disables the cap entirely", async () => {
       stubConfig.heartbeat.maxConsecutiveRuns = null;
       const service = new HeartbeatService({ alerter: () => {} });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -202,6 +202,9 @@ export class HeartbeatService {
   // Reset by resetTimer (guardian message), reconfigure, and stop. Force runs
   // bypass the cap and do not increment.
   private _consecutiveRuns = 0;
+  // Bumped every time the counter is reset so an in-flight run that finishes
+  // after a guardian message can detect the reset and skip its increment.
+  private _resetGeneration = 0;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -360,6 +363,7 @@ export class HeartbeatService {
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
     this._consecutiveRuns = 0;
+    this._resetGeneration++;
     this.configEpoch++;
     if (this._pendingRunId) {
       supersedePendingRun(this._pendingRunId);
@@ -384,6 +388,7 @@ export class HeartbeatService {
     // Counter resets even when the timer is null so a guardian message during
     // a stopped window still clears the count.
     this._consecutiveRuns = 0;
+    this._resetGeneration++;
     if (!this.timer) return;
     if (this.cronMode) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
@@ -404,6 +409,7 @@ export class HeartbeatService {
 
   async stop(): Promise<void> {
     this._consecutiveRuns = 0;
+    this._resetGeneration++;
     this.stopped = true;
     if (this.timer) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
@@ -552,6 +558,11 @@ export class HeartbeatService {
     }
     const run = this.executeRun(runId, scheduledFor);
     this.activeRun = run;
+    // Snapshot the reset generation so we can detect whether a reset (guardian
+    // message, reconfigure, stop) happened while this run was in flight. If it
+    // did, the counter was already zeroed and we must not undo that reset by
+    // incrementing in `finally`.
+    const startGeneration = this._resetGeneration;
     try {
       await run;
     } catch (err) {
@@ -561,7 +572,7 @@ export class HeartbeatService {
         this.activeRun = null;
       }
       this._lastRunAt = Date.now();
-      if (!force) {
+      if (!force && this._resetGeneration === startGeneration) {
         this._consecutiveRuns++;
       }
       if (!this.cronMode) {


### PR DESCRIPTION
Addresses Codex P1 feedback on #30792.

## Problem

If a guardian message arrives while a heartbeat run is still executing, \`resetTimer()\` zeroes \`_consecutiveRuns\`, but the in-flight run's \`finally\` block then unconditionally increments it. With \`maxConsecutiveRuns=1\`, the very next auto run gets skipped even though the user just interacted — violating the intended "reset on guardian message" behavior.

## Fix

Add a \`_resetGeneration\` counter that is bumped inside \`resetTimer()\`, \`reconfigure()\`, and \`stop()\`. Each \`runOnce\` snapshots the generation at start; the \`finally\` block only increments \`_consecutiveRuns\` if the snapshot still matches — if it changed, a reset happened during the run and the increment is skipped.

## Test

Added a regression test that holds an in-flight run open via a deferred promise, calls \`resetTimer()\` mid-run, releases the run, and asserts the next auto run is not skipped by the cap-at-1 path.

Related: #30792