### PR TITLE
fix(lint): sort providers imports in conversation-query-routes

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -65,8 +65,8 @@ import { getLlmRequestLogSource } from "../../memory/llm-request-log-source.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../memory/memory-v2-activation-log-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
-import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { listConnections } from "../../providers/inference/connections.js";
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { validateAllowlistFile } from "../../security/secret-allowlist.js";
 import { resolvePricingForUsage } from "../../util/pricing.js";
@@ -670,17 +670,9 @@ async function handleReplaceInferenceProfile({
     // here would wipe the UI-owned seed fields (provider, model, advanced
     // params) because that function assumes the body carries the full UI
     // surface.
-    patchManagedProfileFields(
-      raw,
-      name,
-      fragment,
-    );
+    patchManagedProfileFields(raw, name, fragment);
   } else {
-    replaceInferenceProfileConfig(
-      raw,
-      name,
-      fragment,
-    );
+    replaceInferenceProfileConfig(raw, name, fragment);
   }
   // Route through `commitConfigWrite` so profile edits flow through the
   // post-write side effects shared with `handlePatchConfig` /


### PR DESCRIPTION
## Summary
- `inference/connections.js` sorts before `model-catalog.js` lexicographically; eslint autofix reorders them.
- Prettier autofix also collapsed two over-wrapped function calls in `handleReplaceInferenceProfile`.
- Restores green lint on main (CI Main Assistant Checks).

## Original prompt
Fix the specific CI failure on https://github.com/vellum-ai/vellum-assistant/actions/runs/25943450067/job/76266261952 — the Lint job failed on main with a `simple-import-sort/imports` error in `assistant/src/runtime/routes/conversation-query-routes.ts`. Run autofix only; no other changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->