### PR TITLE
feat(a2a): add A2A v1.0 protocol type definitions and helpers

### DIFF
--- a/assistant/src/a2a/__tests__/protocol-helpers.test.ts
+++ b/assistant/src/a2a/__tests__/protocol-helpers.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import { TERMINAL_TASK_STATES } from "../protocol-constants.js";
+import {
+  INTERNAL_ERROR,
+  INVALID_PARAMS,
+  INVALID_REQUEST,
+  makeJsonRpcError,
+  makeJsonRpcSuccess,
+  METHOD_NOT_FOUND,
+  PARSE_ERROR,
+  TASK_NOT_CANCELABLE,
+  TASK_NOT_FOUND,
+  UNSUPPORTED_OPERATION,
+} from "../protocol-errors.js";
+
+describe("makeJsonRpcError", () => {
+  test("produces a valid JSON-RPC 2.0 error response", () => {
+    const response = makeJsonRpcError(1, PARSE_ERROR, "Parse error");
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32700,
+        message: "Parse error",
+      },
+    });
+  });
+
+  test("includes data field when provided", () => {
+    const response = makeJsonRpcError(
+      "req-1",
+      INVALID_PARAMS,
+      "Invalid params",
+      { field: "message" },
+    );
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: "req-1",
+      error: {
+        code: -32602,
+        message: "Invalid params",
+        data: { field: "message" },
+      },
+    });
+  });
+
+  test("omits data field when not provided", () => {
+    const response = makeJsonRpcError(null, INTERNAL_ERROR, "Internal error");
+
+    expect(response.error).toBeDefined();
+    expect("data" in response.error!).toBe(false);
+  });
+
+  test("accepts null id", () => {
+    const response = makeJsonRpcError(null, PARSE_ERROR, "Parse error");
+
+    expect(response.id).toBeNull();
+  });
+});
+
+describe("makeJsonRpcSuccess", () => {
+  test("produces a valid JSON-RPC 2.0 success response", () => {
+    const response = makeJsonRpcSuccess(1, { status: "ok" });
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { status: "ok" },
+    });
+  });
+
+  test("does not include an error field", () => {
+    const response = makeJsonRpcSuccess("req-2", null);
+
+    expect("error" in response).toBe(false);
+    expect(response.result).toBeNull();
+  });
+});
+
+describe("error code constants", () => {
+  test("standard JSON-RPC codes", () => {
+    expect(PARSE_ERROR).toBe(-32700);
+    expect(INVALID_REQUEST).toBe(-32600);
+    expect(METHOD_NOT_FOUND).toBe(-32601);
+    expect(INVALID_PARAMS).toBe(-32602);
+    expect(INTERNAL_ERROR).toBe(-32603);
+  });
+
+  test("A2A-specific codes", () => {
+    expect(TASK_NOT_FOUND).toBe(-32001);
+    expect(TASK_NOT_CANCELABLE).toBe(-32002);
+    expect(UNSUPPORTED_OPERATION).toBe(-32004);
+  });
+});
+
+describe("TERMINAL_TASK_STATES", () => {
+  test("contains exactly the four terminal states", () => {
+    expect(TERMINAL_TASK_STATES.size).toBe(4);
+    expect(TERMINAL_TASK_STATES.has("completed")).toBe(true);
+    expect(TERMINAL_TASK_STATES.has("failed")).toBe(true);
+    expect(TERMINAL_TASK_STATES.has("canceled")).toBe(true);
+    expect(TERMINAL_TASK_STATES.has("rejected")).toBe(true);
+  });
+
+  test("does not contain non-terminal states", () => {
+    expect(TERMINAL_TASK_STATES.has("submitted")).toBe(false);
+    expect(TERMINAL_TASK_STATES.has("working")).toBe(false);
+    expect(TERMINAL_TASK_STATES.has("input_required")).toBe(false);
+  });
+});

--- a/assistant/src/a2a/protocol-constants.ts
+++ b/assistant/src/a2a/protocol-constants.ts
@@ -1,0 +1,21 @@
+/**
+ * A2A v1.0 protocol constants.
+ */
+
+import type { TaskState } from "./protocol-types.js";
+
+export const A2A_VERSION = "1.0";
+export const A2A_CONTENT_TYPE = "application/a2a+json";
+export const A2A_VERSION_HEADER = "A2A-Version";
+export const AGENT_CARD_PATH = "/.well-known/agent-card.json";
+
+/**
+ * Task states that represent a terminal (final) condition.
+ * Once a task reaches one of these states it will not transition further.
+ */
+export const TERMINAL_TASK_STATES: ReadonlySet<TaskState> = new Set([
+  "completed",
+  "failed",
+  "canceled",
+  "rejected",
+]);

--- a/assistant/src/a2a/protocol-errors.ts
+++ b/assistant/src/a2a/protocol-errors.ts
@@ -16,6 +16,7 @@ export const INTERNAL_ERROR = -32603;
 
 export const TASK_NOT_FOUND = -32001;
 export const TASK_NOT_CANCELABLE = -32002;
+export const PUSH_NOTIFICATION_NOT_SUPPORTED = -32003;
 export const UNSUPPORTED_OPERATION = -32004;
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/assistant/src/a2a/protocol-errors.ts
+++ b/assistant/src/a2a/protocol-errors.ts
@@ -1,0 +1,49 @@
+/**
+ * A2A JSON-RPC error codes and helper functions.
+ */
+
+import type { JsonRpcResponse } from "./protocol-types.js";
+
+// ── Standard JSON-RPC error codes ───────────────────────────────────
+
+export const PARSE_ERROR = -32700;
+export const INVALID_REQUEST = -32600;
+export const METHOD_NOT_FOUND = -32601;
+export const INVALID_PARAMS = -32602;
+export const INTERNAL_ERROR = -32603;
+
+// ── A2A-specific error codes ────────────────────────────────────────
+
+export const TASK_NOT_FOUND = -32001;
+export const TASK_NOT_CANCELABLE = -32002;
+export const UNSUPPORTED_OPERATION = -32004;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+export function makeJsonRpcError(
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code,
+      message,
+      ...(data !== undefined && { data }),
+    },
+  };
+}
+
+export function makeJsonRpcSuccess(
+  id: string | number | null,
+  result: unknown,
+): JsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result,
+  };
+}

--- a/assistant/src/a2a/protocol-types.ts
+++ b/assistant/src/a2a/protocol-types.ts
@@ -1,0 +1,162 @@
+/**
+ * A2A v1.0 protocol type definitions.
+ *
+ * Implemented directly from the A2A spec — no SDK dependency.
+ * See https://google.github.io/A2A/
+ */
+
+// ── Agent Card ──────────────────────────────────────────────────────
+
+export interface AgentCard {
+  name: string;
+  description: string;
+  version: string;
+  supported_interfaces: AgentInterface[];
+  capabilities: AgentCapabilities;
+  default_input_modes: string[];
+  default_output_modes: string[];
+  skills: AgentSkill[];
+  security_schemes?: Record<string, unknown>;
+  security_requirements?: Record<string, string[]>[];
+}
+
+export interface AgentInterface {
+  url: string;
+  protocol_binding: string;
+  protocol_version: string;
+}
+
+export interface AgentSkill {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+export interface AgentCapabilities {
+  streaming: boolean;
+  push_notifications: boolean;
+  extended_agent_card: boolean;
+}
+
+// ── Messages ────────────────────────────────────────────────────────
+
+export interface A2AMessage {
+  message_id: string;
+  context_id?: string;
+  task_id?: string;
+  role: "user" | "agent";
+  parts: Part[];
+  metadata?: Record<string, unknown>;
+}
+
+export type Part = TextPart | DataPart | FilePart;
+
+export interface TextPart {
+  kind: "text";
+  text: string;
+}
+
+export interface DataPart {
+  kind: "data";
+  data: Record<string, unknown>;
+  media_type?: string;
+}
+
+export interface FilePart {
+  kind: "file";
+  url?: string;
+  raw?: string;
+  filename?: string;
+  media_type?: string;
+}
+
+// ── Tasks ───────────────────────────────────────────────────────────
+
+export type TaskState =
+  | "submitted"
+  | "working"
+  | "completed"
+  | "failed"
+  | "canceled"
+  | "input_required"
+  | "rejected";
+
+export interface TaskStatus {
+  state: TaskState;
+  message?: A2AMessage;
+  timestamp: string;
+}
+
+export interface A2ATask {
+  id: string;
+  context_id?: string;
+  status: TaskStatus;
+  artifacts?: Artifact[];
+  history?: A2AMessage[];
+  metadata?: Record<string, unknown>;
+}
+
+// ── Artifacts ───────────────────────────────────────────────────────
+
+export interface Artifact {
+  artifact_id: string;
+  parts: Part[];
+  metadata?: Record<string, unknown>;
+}
+
+// ── Requests / Responses ────────────────────────────────────────────
+
+export interface TaskPushNotificationConfig {
+  url: string;
+  authentication?: Record<string, unknown>;
+}
+
+export interface SendMessageConfiguration {
+  accepted_output_modes?: string[];
+  history_length?: number;
+  return_immediately?: boolean;
+  task_push_notification_config?: TaskPushNotificationConfig;
+}
+
+export interface SendMessageRequest {
+  message: A2AMessage;
+  configuration?: SendMessageConfiguration;
+}
+
+export type SendMessageResponse = { task: A2ATask } | { message: A2AMessage };
+
+// ── Push Events ─────────────────────────────────────────────────────
+
+export interface TaskStatusUpdateEvent {
+  task_id: string;
+  status: TaskStatus;
+  final: boolean;
+}
+
+export interface TaskArtifactUpdateEvent {
+  task_id: string;
+  artifact: Artifact;
+}
+
+// ── JSON-RPC ────────────────────────────────────────────────────────
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: JsonRpcError;
+}


### PR DESCRIPTION
## Summary
- Add TypeScript types for the full A2A v1.0 protocol (AgentCard, Message, Task, Artifact, JSON-RPC)
- Add JSON-RPC helper functions (makeJsonRpcError, makeJsonRpcSuccess) and protocol constants
- Add tests for JSON-RPC helpers and terminal state set

Part of plan: a2a-channel.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->