### PR TITLE
feat(a2a): register a2a channel type, interface ID, and notification policy

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -94,6 +94,15 @@ const CHANNEL_POLICIES = {
       codeRedemptionEnabled: false,
     },
   },
+  a2a: {
+    notification: {
+      deliveryEnabled: false,
+      conversationStrategy: "continue_existing_conversation",
+    },
+    invite: {
+      codeRedemptionEnabled: false,
+    },
+  },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
 
 export type ChannelPolicies = typeof CHANNEL_POLICIES;

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -6,6 +6,7 @@ export const CHANNEL_IDS = [
   "slack",
   "email",
   "platform",
+  "a2a",
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
@@ -133,6 +134,17 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
         "I'd like to verify a contact's WhatsApp identity. Can you walk me through it?",
     },
   },
+  a2a: {
+    id: "a2a",
+    label: "A2A",
+    subtitle: "Agent-to-Agent protocol",
+    icon: "bot",
+    supportsVerification: false,
+    setupMessages: {
+      guardian: "Connect with other Vellum assistants via the A2A protocol.",
+      contact: "",
+    },
+  },
 };
 
 export const INTERFACE_IDS = [
@@ -146,6 +158,7 @@ export const INTERFACE_IDS = [
   "slack",
   "email",
   "chrome-extension",
+  "a2a",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -20,6 +20,7 @@ import { AnalysisConfigSchema } from "./schemas/analysis.js";
 import { BackupConfigSchema } from "./schemas/backup.js";
 import { CallsConfigSchema } from "./schemas/calls.js";
 import {
+  A2AConfigSchema,
   SlackConfigSchema,
   TelegramConfigSchema,
   TwilioConfigSchema,
@@ -111,6 +112,7 @@ export const AssistantConfigSchema = z
     whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
     telegram: TelegramConfigSchema.default(TelegramConfigSchema.parse({})),
     slack: SlackConfigSchema.default(SlackConfigSchema.parse({})),
+    a2a: A2AConfigSchema.default(A2AConfigSchema.parse({})),
     ingress: IngressConfigSchema,
     platform: PlatformConfigSchema.default(PlatformConfigSchema.parse({})),
     daemon: DaemonConfigSchema.default(DaemonConfigSchema.parse({})),

--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -99,6 +99,15 @@ export const TelegramConfigSchema = z
   })
   .describe("Telegram bot channel configuration");
 
+export const A2AConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "a2a.enabled must be a boolean" })
+      .default(false)
+      .describe("Whether the A2A channel is enabled"),
+  })
+  .describe("Agent-to-Agent protocol channel configuration");
+
 export const SlackConfigSchema = z
   .object({
     deliverAuthBypass: z


### PR DESCRIPTION
## Summary
- Add "a2a" to CHANNEL_IDS and INTERFACE_IDS arrays
- Add a2a channel metadata, notification policy, and config schema
- Wire A2AConfigSchema into the parent channel config

Part of plan: a2a-channel.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->