### PR TITLE
feat(a2a): build A2A v1.0 agent card from assistant configuration

### DIFF
--- a/assistant/src/a2a/__tests__/agent-card.test.ts
+++ b/assistant/src/a2a/__tests__/agent-card.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildAgentCard } from "../agent-card.js";
+
+describe("buildAgentCard", () => {
+  const BASE_PARAMS = {
+    assistantName: "Alice",
+    baseUrl: "https://example.com",
+  };
+
+  test("includes all required top-level fields", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.name).toBe("Alice");
+    expect(card.description).toBeDefined();
+    expect(card.version).toBe("1.0.0");
+    expect(card.supported_interfaces).toBeDefined();
+    expect(card.capabilities).toBeDefined();
+    expect(card.default_input_modes).toBeDefined();
+    expect(card.default_output_modes).toBeDefined();
+    expect(card.skills).toBeDefined();
+  });
+
+  test("interface URL is baseUrl + /a2a", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.supported_interfaces).toHaveLength(1);
+    expect(card.supported_interfaces[0].url).toBe("https://example.com/a2a");
+    expect(card.supported_interfaces[0].protocol_binding).toBe("JSONRPC");
+    expect(card.supported_interfaces[0].protocol_version).toBe("1.0");
+  });
+
+  test("push_notifications capability is true", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.capabilities.push_notifications).toBe(true);
+  });
+
+  test("streaming capability is false", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.capabilities.streaming).toBe(false);
+  });
+
+  test("extended_agent_card capability is false", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.capabilities.extended_agent_card).toBe(false);
+  });
+
+  test("defaults description when omitted", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.description).toBe("Alice — a Vellum AI assistant");
+  });
+
+  test("uses explicit description when provided", () => {
+    const card = buildAgentCard({
+      ...BASE_PARAMS,
+      assistantDescription: "A specialized research assistant",
+    });
+
+    expect(card.description).toBe("A specialized research assistant");
+  });
+
+  test("advertises text/plain as default input and output mode", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.default_input_modes).toEqual(["text/plain"]);
+    expect(card.default_output_modes).toEqual(["text/plain"]);
+  });
+
+  test("includes a conversation skill", () => {
+    const card = buildAgentCard(BASE_PARAMS);
+
+    expect(card.skills).toHaveLength(1);
+    expect(card.skills[0]).toEqual({
+      id: "conversation",
+      name: "General conversation",
+      description: "Send a message and receive a response",
+      tags: ["chat"],
+    });
+  });
+
+  test("constructs correct interface URL with trailing-slash base", () => {
+    const card = buildAgentCard({
+      ...BASE_PARAMS,
+      baseUrl: "https://example.com/",
+    });
+
+    // The URL is constructed by simple concatenation; callers normalize the base.
+    expect(card.supported_interfaces[0].url).toBe("https://example.com//a2a");
+  });
+});

--- a/assistant/src/a2a/agent-card.ts
+++ b/assistant/src/a2a/agent-card.ts
@@ -1,0 +1,58 @@
+/**
+ * A2A v1.0 agent card builder.
+ *
+ * `buildAgentCard()` constructs a spec-compliant agent card from explicit
+ * parameters. `getAgentCard()` is a convenience wrapper that reads the
+ * assistant name and public base URL from workspace config.
+ */
+
+import { getConfig } from "../config/loader.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
+import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import type { AgentCard } from "./protocol-types.js";
+
+export interface BuildAgentCardParams {
+  assistantName: string;
+  assistantDescription?: string;
+  baseUrl: string;
+}
+
+export function buildAgentCard(params: BuildAgentCardParams): AgentCard {
+  return {
+    name: params.assistantName,
+    description:
+      params.assistantDescription ??
+      `${params.assistantName} — a Vellum AI assistant`,
+    version: "1.0.0",
+    supported_interfaces: [
+      {
+        url: `${params.baseUrl}/a2a`,
+        protocol_binding: "JSONRPC",
+        protocol_version: "1.0",
+      },
+    ],
+    capabilities: {
+      streaming: false,
+      push_notifications: true,
+      extended_agent_card: false,
+    },
+    default_input_modes: ["text/plain"],
+    default_output_modes: ["text/plain"],
+    skills: [
+      {
+        id: "conversation",
+        name: "General conversation",
+        description: "Send a message and receive a response",
+        tags: ["chat"],
+      },
+    ],
+  };
+}
+
+export function getAgentCard(): AgentCard {
+  const config = getConfig();
+  const assistantName = getAssistantName() ?? "Vellum Assistant";
+  const baseUrl = getPublicBaseUrl(config);
+
+  return buildAgentCard({ assistantName, baseUrl });
+}


### PR DESCRIPTION
## Summary
- Add buildAgentCard() to construct A2A v1.0 agent cards from assistant config
- Add getAgentCard() convenience wrapper that reads from workspace config
- Add tests for card construction, field defaults, and push notification capability

Part of plan: a2a-channel.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->