### PR TITLE
feat(a2a): add a2a_tasks table for tracking request/response lifecycle

### DIFF
--- a/assistant/src/a2a/__tests__/task-store.test.ts
+++ b/assistant/src/a2a/__tests__/task-store.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+import { getDb, getSqliteFrom } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import type { A2AMessage, Artifact } from "../protocol-types.js";
+import {
+  completeWithArtifacts,
+  createTask,
+  getPushUrl,
+  getTask,
+  linkConversation,
+  updateState,
+} from "../task-store.js";
+
+initializeDb();
+
+function makeRequestMessage(overrides?: Partial<A2AMessage>): A2AMessage {
+  return {
+    message_id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ kind: "text", text: "Hello from sender" }],
+    ...overrides,
+  };
+}
+
+describe("a2a-task-store", () => {
+  beforeEach(() => {
+    const raw = getSqliteFrom(getDb());
+    raw.run("DELETE FROM a2a_tasks");
+  });
+
+  // ── State transitions ───────────────────────────────────────────
+
+  test("createTask returns a task in submitted state", () => {
+    const msg = makeRequestMessage();
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: msg,
+    });
+
+    expect(task.id).toBeTruthy();
+    expect(task.status.state).toBe("submitted");
+    expect(task.artifacts).toBeUndefined();
+  });
+
+  test("submitted -> working -> completed lifecycle", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    const working = updateState(task.id, "working", "Processing...");
+    expect(working.status.state).toBe("working");
+    expect(working.status.message).toBeDefined();
+
+    const completed = updateState(task.id, "completed");
+    expect(completed.status.state).toBe("completed");
+  });
+
+  test("cannot transition from terminal state (completed -> working)", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "completed");
+
+    expect(() => updateState(task.id, "working")).toThrow(/terminal state/);
+  });
+
+  test("cannot transition from failed state", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "failed");
+
+    expect(() => updateState(task.id, "working")).toThrow(/terminal state/);
+  });
+
+  test("cannot transition from canceled state", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "canceled");
+
+    expect(() => updateState(task.id, "submitted")).toThrow(/terminal state/);
+  });
+
+  test("cannot transition from rejected state", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "rejected");
+
+    expect(() => updateState(task.id, "working")).toThrow(/terminal state/);
+  });
+
+  // ── Artifact serialization round-trip ─────────────────────────
+
+  test("completeWithArtifacts stores and retrieves artifacts via JSON round-trip", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "working");
+
+    const artifacts: Artifact[] = [
+      {
+        artifact_id: "art-1",
+        parts: [{ kind: "text", text: "Result data" }],
+        metadata: { score: 0.95 },
+      },
+      {
+        artifact_id: "art-2",
+        parts: [
+          { kind: "data", data: { key: "value" } },
+          {
+            kind: "file",
+            url: "https://example.com/file.txt",
+            filename: "file.txt",
+          },
+        ],
+      },
+    ];
+
+    const completed = completeWithArtifacts(task.id, artifacts);
+    expect(completed.status.state).toBe("completed");
+    expect(completed.artifacts).toHaveLength(2);
+    expect(completed.artifacts![0].artifact_id).toBe("art-1");
+    expect(completed.artifacts![0].metadata).toEqual({ score: 0.95 });
+    expect(completed.artifacts![1].parts).toHaveLength(2);
+
+    // Verify round-trip via fresh getTask
+    const fetched = getTask(task.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.artifacts).toEqual(completed.artifacts);
+  });
+
+  test("completeWithArtifacts rejects terminal task", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    updateState(task.id, "completed");
+
+    expect(() =>
+      completeWithArtifacts(task.id, [
+        { artifact_id: "art-1", parts: [{ kind: "text", text: "late" }] },
+      ]),
+    ).toThrow(/terminal state/);
+  });
+
+  // ── Push URL storage and retrieval ────────────────────────────
+
+  test("push URL is stored and retrieved", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+      pushUrl: "https://example.com/push",
+    });
+
+    const url = getPushUrl(task.id);
+    expect(url).toBe("https://example.com/push");
+  });
+
+  test("getPushUrl returns null when no push URL set", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    const url = getPushUrl(task.id);
+    expect(url).toBeNull();
+  });
+
+  test("getPushUrl returns null for unknown task ID", () => {
+    const url = getPushUrl("nonexistent-id");
+    expect(url).toBeNull();
+  });
+
+  // ── getTask ───────────────────────────────────────────────────
+
+  test("getTask returns null for unknown ID", () => {
+    const result = getTask("nonexistent-id");
+    expect(result).toBeNull();
+  });
+
+  test("getTask returns task with context_id when provided", () => {
+    const task = createTask({
+      contextId: "ctx-456",
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    const fetched = getTask(task.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.context_id).toBe("ctx-456");
+  });
+
+  // ── linkConversation ──────────────────────────────────────────
+
+  test("linkConversation associates a conversation ID", () => {
+    const task = createTask({
+      senderAssistantId: "assistant-123",
+      requestMessage: makeRequestMessage(),
+    });
+
+    linkConversation(task.id, "conv-789");
+
+    // Verify via raw DB since getTask doesn't expose conversationId
+    const raw = getSqliteFrom(getDb());
+    const row = raw
+      .prepare("SELECT conversation_id FROM a2a_tasks WHERE id = ?")
+      .get(task.id) as { conversation_id: string };
+    expect(row.conversation_id).toBe("conv-789");
+  });
+
+  test("linkConversation throws for unknown task ID", () => {
+    expect(() => linkConversation("nonexistent-id", "conv-123")).toThrow(
+      /not found/,
+    );
+  });
+
+  // ── updateState error cases ───────────────────────────────────
+
+  test("updateState throws for unknown task ID", () => {
+    expect(() => updateState("nonexistent-id", "working")).toThrow(/not found/);
+  });
+});

--- a/assistant/src/a2a/task-store.ts
+++ b/assistant/src/a2a/task-store.ts
@@ -1,0 +1,167 @@
+import { eq } from "drizzle-orm";
+
+import type { DrizzleDb } from "../memory/db-connection.js";
+import { getDb } from "../memory/db-connection.js";
+import { rawChanges } from "../memory/raw-query.js";
+import { a2aTasks } from "../memory/schema.js";
+import { TERMINAL_TASK_STATES } from "./protocol-constants.js";
+import type {
+  A2AMessage,
+  A2ATask,
+  Artifact,
+  TaskState,
+} from "./protocol-types.js";
+
+// ── Internal types ──────────────────────────────────────────────────
+
+/** Raw database row shape for a2a_tasks. */
+type A2ATaskRow = typeof a2aTasks.$inferSelect;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Throw if the task doesn't exist or is in a terminal state. */
+function assertNonTerminal(
+  db: DrizzleDb,
+  taskId: string,
+  targetState: TaskState,
+): void {
+  const current = db
+    .select({ state: a2aTasks.state })
+    .from(a2aTasks)
+    .where(eq(a2aTasks.id, taskId))
+    .get();
+
+  if (!current) {
+    throw new Error(`A2A task not found: ${taskId}`);
+  }
+
+  if (TERMINAL_TASK_STATES.has(current.state as TaskState)) {
+    throw new Error(
+      `Cannot transition task ${taskId} from terminal state "${current.state}" to "${targetState}"`,
+    );
+  }
+}
+
+function rowToTask(row: A2ATaskRow): A2ATask {
+  return {
+    id: row.id,
+    context_id: row.contextId ?? undefined,
+    status: {
+      state: row.state as TaskState,
+      message: row.statusMessage
+        ? {
+            message_id: "",
+            role: "agent",
+            parts: [{ kind: "text", text: row.statusMessage }],
+          }
+        : undefined,
+      timestamp: new Date(row.updatedAt).toISOString(),
+    },
+    artifacts: row.artifactsJson
+      ? (JSON.parse(row.artifactsJson) as Artifact[])
+      : undefined,
+  };
+}
+
+// ── Store functions ─────────────────────────────────────────────────
+
+export function createTask(params: {
+  contextId?: string;
+  senderAssistantId: string;
+  requestMessage: A2AMessage;
+  pushUrl?: string;
+}): A2ATask {
+  const db = getDb();
+  const now = Date.now();
+
+  const row: A2ATaskRow = {
+    id: crypto.randomUUID(),
+    contextId: params.contextId ?? null,
+    conversationId: null,
+    state: "submitted",
+    statusMessage: null,
+    requestMessageJson: JSON.stringify(params.requestMessage),
+    artifactsJson: null,
+    pushUrl: params.pushUrl ?? null,
+    senderAssistantId: params.senderAssistantId,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.insert(a2aTasks).values(row).run();
+
+  return rowToTask(row);
+}
+
+export function getTask(taskId: string): A2ATask | null {
+  const db = getDb();
+  const row = db.select().from(a2aTasks).where(eq(a2aTasks.id, taskId)).get();
+  return row ? rowToTask(row) : null;
+}
+
+export function updateState(
+  taskId: string,
+  state: TaskState,
+  statusMessage?: string,
+): A2ATask {
+  const db = getDb();
+  assertNonTerminal(db, taskId, state);
+
+  db.update(a2aTasks)
+    .set({
+      state,
+      statusMessage: statusMessage ?? null,
+      updatedAt: Date.now(),
+    })
+    .where(eq(a2aTasks.id, taskId))
+    .run();
+
+  return rowToTask(
+    db.select().from(a2aTasks).where(eq(a2aTasks.id, taskId)).get()!,
+  );
+}
+
+export function completeWithArtifacts(
+  taskId: string,
+  artifacts: Artifact[],
+): A2ATask {
+  const db = getDb();
+  assertNonTerminal(db, taskId, "completed");
+
+  db.update(a2aTasks)
+    .set({
+      state: "completed",
+      artifactsJson: JSON.stringify(artifacts),
+      updatedAt: Date.now(),
+    })
+    .where(eq(a2aTasks.id, taskId))
+    .run();
+
+  return rowToTask(
+    db.select().from(a2aTasks).where(eq(a2aTasks.id, taskId)).get()!,
+  );
+}
+
+export function linkConversation(taskId: string, conversationId: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.update(a2aTasks)
+    .set({ conversationId, updatedAt: now })
+    .where(eq(a2aTasks.id, taskId))
+    .run();
+
+  if (rawChanges() === 0) {
+    throw new Error(`A2A task not found: ${taskId}`);
+  }
+}
+
+export function getPushUrl(taskId: string): string | null {
+  const db = getDb();
+  const row = db
+    .select({ pushUrl: a2aTasks.pushUrl })
+    .from(a2aTasks)
+    .where(eq(a2aTasks.id, taskId))
+    .get();
+  return row?.pushUrl ?? null;
+}

--- a/assistant/src/a2a/task-store.ts
+++ b/assistant/src/a2a/task-store.ts
@@ -131,6 +131,7 @@ export function completeWithArtifacts(
   db.update(a2aTasks)
     .set({
       state: "completed",
+      statusMessage: null,
       artifactsJson: JSON.stringify(artifacts),
       updatedAt: Date.now(),
     })

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -39,6 +39,7 @@ import {
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
   migrate231RepairMemoryGraphEventDates,
+  migrateA2ATasks,
   migrateActivationState,
   migrateActivationStateFkCascade,
   migrateAddConversationInferenceProfile,
@@ -430,6 +431,7 @@ export function initializeDb(): void {
     migrateExternalConversationBindingThreadId,
     createOnboardingEventsTable,
     migrateNormalizeSlackExternalContent,
+    migrateA2ATasks,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/250-a2a-tasks.ts
+++ b/assistant/src/memory/migrations/250-a2a-tasks.ts
@@ -1,0 +1,49 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_a2a_tasks_v1";
+
+/**
+ * Create the a2a_tasks table for tracking A2A request/response lifecycle.
+ *
+ * Each row represents one inbound A2A task, tracking its state machine
+ * progression through submitted -> working -> completed/failed/canceled/rejected.
+ */
+export function migrateA2ATasks(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    if (tableHasColumn(database, "a2a_tasks", "id")) {
+      return;
+    }
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS a2a_tasks (
+        id TEXT PRIMARY KEY,
+        context_id TEXT,
+        conversation_id TEXT,
+        state TEXT NOT NULL DEFAULT 'submitted',
+        status_message TEXT,
+        request_message_json TEXT NOT NULL,
+        artifacts_json TEXT,
+        push_url TEXT,
+        sender_assistant_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context
+        ON a2a_tasks (context_id)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_a2a_tasks_conversation
+        ON a2a_tasks (conversation_id)
+    `);
+  });
+}
+
+export function downA2ATasks(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS a2a_tasks`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -214,6 +214,7 @@ export {
   downNormalizeSlackExternalContent,
   migrateNormalizeSlackExternalContent,
 } from "./249-normalize-slack-external-content.js";
+export { downA2ATasks, migrateA2ATasks } from "./250-a2a-tasks.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -49,6 +49,7 @@ import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.j
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
 import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
 import { downNormalizeSlackExternalContent } from "./249-normalize-slack-external-content.js";
+import { downA2ATasks } from "./250-a2a-tasks.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -419,6 +420,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Normalize legacy persisted Slack external_content wrappers back to raw message content",
     down: downNormalizeSlackExternalContent,
+  },
+  {
+    key: "migration_a2a_tasks_v1",
+    version: 49,
+    description:
+      "Create a2a_tasks table for tracking A2A request/response lifecycle",
+    down: downA2ATasks,
   },
 ];
 

--- a/assistant/src/memory/schema/a2a.ts
+++ b/assistant/src/memory/schema/a2a.ts
@@ -1,0 +1,15 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const a2aTasks = sqliteTable("a2a_tasks", {
+  id: text("id").primaryKey(),
+  contextId: text("context_id"),
+  conversationId: text("conversation_id"),
+  state: text("state").notNull().default("submitted"),
+  statusMessage: text("status_message"),
+  requestMessageJson: text("request_message_json").notNull(),
+  artifactsJson: text("artifacts_json"),
+  pushUrl: text("push_url"),
+  senderAssistantId: text("sender_assistant_id").notNull(),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./a2a.js";
 export * from "./acp.js";
 export * from "./bookmarks.js";
 export * from "./calls.js";


### PR DESCRIPTION
## Summary
- Add a2a_tasks migration with state, request/response JSON, and push URL fields
- Add task store module with state machine enforcement and artifact management
- Add tests for task lifecycle, serialization round-trips, and error cases

Part of plan: a2a-channel.md (PR 3 of 8)