### PR TITLE
feat(a2a): add A2A delivery adapter that completes tasks and pushes responses

### DIFF
--- a/assistant/src/messaging/providers/a2a/__tests__/deliver.test.ts
+++ b/assistant/src/messaging/providers/a2a/__tests__/deliver.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ChannelReplyPayload } from "@vellumai/gateway-client";
+
+import type { A2ATask, Artifact } from "../../../../a2a/protocol-types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let completedTask: A2ATask | null = null;
+let completeWithArtifactsCalls: Array<{
+  taskId: string;
+  artifacts: Artifact[];
+}> = [];
+let pushUrlByTaskId: Record<string, string | null> = {};
+let completeError: Error | null = null;
+
+const fetchCalls: Array<{
+  url: string;
+  init: RequestInit;
+}> = [];
+let fetchResponses: Array<{ ok: boolean; status: number; body: string }> = [];
+let fetchCallIndex = 0;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const defaultTask: A2ATask = {
+  id: "task-123",
+  status: { state: "completed", timestamp: new Date().toISOString() },
+  artifacts: [
+    {
+      artifact_id: "art-1",
+      parts: [{ kind: "text", text: "Hello from assistant" }],
+    },
+  ],
+};
+
+mock.module("../../../../a2a/task-store.js", () => ({
+  completeWithArtifacts: (taskId: string, artifacts: Artifact[]): A2ATask => {
+    completeWithArtifactsCalls.push({ taskId, artifacts });
+    if (completeError) throw completeError;
+    return completedTask ?? defaultTask;
+  },
+  getPushUrl: (taskId: string): string | null => {
+    return pushUrlByTaskId[taskId] ?? null;
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Intercept global fetch for push notification testing
+const originalFetch = globalThis.fetch;
+
+// Import the module under test AFTER mocks are set up
+const { deliverA2AReply } = await import("../deliver.js");
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  completedTask = null;
+  completeWithArtifactsCalls = [];
+  pushUrlByTaskId = {};
+  completeError = null;
+  fetchCalls.length = 0;
+  fetchResponses = [];
+  fetchCallIndex = 0;
+
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchCalls.push({ url, init: init ?? {} });
+    const responseSpec = fetchResponses[fetchCallIndex++] ?? {
+      ok: true,
+      status: 200,
+      body: "{}",
+    };
+    return new Response(responseSpec.body, {
+      status: responseSpec.status,
+      statusText: responseSpec.ok ? "OK" : "Error",
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deliverA2AReply", () => {
+  const baseCallbackUrl = "https://example.com/deliver/a2a?taskId=task-123";
+
+  test("completes task with text artifact", async () => {
+    const payload: ChannelReplyPayload = {
+      chatId: "chat-1",
+      text: "Hello from the assistant",
+    };
+
+    const result = await deliverA2AReply(baseCallbackUrl, payload);
+
+    expect(result.ok).toBe(true);
+    expect(completeWithArtifactsCalls).toHaveLength(1);
+    expect(completeWithArtifactsCalls[0].taskId).toBe("task-123");
+    expect(completeWithArtifactsCalls[0].artifacts).toHaveLength(1);
+    expect(completeWithArtifactsCalls[0].artifacts[0].parts).toEqual([
+      { kind: "text", text: "Hello from the assistant" },
+    ]);
+  });
+
+  test("completes task with file attachments", async () => {
+    const payload: ChannelReplyPayload = {
+      chatId: "chat-1",
+      text: "Here is a file",
+      attachments: [
+        {
+          id: "att-1",
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1024,
+          kind: "file",
+          data: "data:application/pdf;base64,abc123",
+        },
+      ],
+    };
+
+    const result = await deliverA2AReply(baseCallbackUrl, payload);
+
+    expect(result.ok).toBe(true);
+    expect(completeWithArtifactsCalls).toHaveLength(1);
+    const parts = completeWithArtifactsCalls[0].artifacts[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({
+      kind: "text",
+      text: "Here is a file",
+    });
+    expect(parts[1]).toEqual({
+      kind: "file",
+      filename: "report.pdf",
+      media_type: "application/pdf",
+      url: "data:application/pdf;base64,abc123",
+    });
+  });
+
+  test("returns ok: false when taskId is missing from URL", async () => {
+    const result = await deliverA2AReply("https://example.com/deliver/a2a", {
+      chatId: "chat-1",
+      text: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(completeWithArtifactsCalls).toHaveLength(0);
+  });
+
+  test("returns ok: true when payload has no content", async () => {
+    const result = await deliverA2AReply(baseCallbackUrl, {
+      chatId: "chat-1",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(completeWithArtifactsCalls).toHaveLength(0);
+  });
+
+  test("returns ok: false when task completion throws", async () => {
+    completeError = new Error("A2A task not found: task-123");
+
+    const result = await deliverA2AReply(baseCallbackUrl, {
+      chatId: "chat-1",
+      text: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns ok: false when task is already terminal", async () => {
+    completeError = new Error(
+      'Cannot transition task task-123 from terminal state "completed" to "completed"',
+    );
+
+    const result = await deliverA2AReply(baseCallbackUrl, {
+      chatId: "chat-1",
+      text: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  describe("push notifications", () => {
+    test("POSTs completed task to push URL", async () => {
+      pushUrlByTaskId["task-123"] = "https://requester.example.com/push";
+      fetchResponses = [{ ok: true, status: 200, body: "{}" }];
+
+      const result = await deliverA2AReply(baseCallbackUrl, {
+        chatId: "chat-1",
+        text: "Done",
+      });
+
+      expect(result.ok).toBe(true);
+
+      // Wait for the fire-and-forget push to complete
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0].url).toBe("https://requester.example.com/push");
+      expect(fetchCalls[0].init.method).toBe("POST");
+
+      const headers = fetchCalls[0].init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/a2a+json");
+      expect(headers["A2A-Version"]).toBe("1.0");
+    });
+
+    test("does not push when no push URL configured", async () => {
+      const result = await deliverA2AReply(baseCallbackUrl, {
+        chatId: "chat-1",
+        text: "Done",
+      });
+
+      expect(result.ok).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fetchCalls).toHaveLength(0);
+    });
+
+    test("push failure does not affect delivery result", async () => {
+      pushUrlByTaskId["task-123"] = "https://requester.example.com/push";
+      // All retries fail with 500
+      fetchResponses = Array(4).fill({
+        ok: false,
+        status: 500,
+        body: "Internal Server Error",
+      });
+
+      const result = await deliverA2AReply(baseCallbackUrl, {
+        chatId: "chat-1",
+        text: "Done",
+      });
+
+      // Delivery still succeeds even though push will fail
+      expect(result.ok).toBe(true);
+    });
+
+    test("stops retrying on non-retryable client error", async () => {
+      pushUrlByTaskId["task-123"] = "https://requester.example.com/push";
+      fetchResponses = [{ ok: false, status: 404, body: "Not Found" }];
+
+      await deliverA2AReply(baseCallbackUrl, {
+        chatId: "chat-1",
+        text: "Done",
+      });
+
+      // Wait for the fire-and-forget push to settle
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should only attempt once on a 4xx (non-429) error
+      expect(fetchCalls).toHaveLength(1);
+    });
+  });
+});

--- a/assistant/src/messaging/providers/a2a/deliver.ts
+++ b/assistant/src/messaging/providers/a2a/deliver.ts
@@ -1,0 +1,156 @@
+/**
+ * A2A direct delivery adapter.
+ *
+ * Completes an A2A task with response artifacts and optionally POSTs the
+ * completed task to the requester's push notification URL.
+ */
+
+import type {
+  ChannelDeliveryResult,
+  ChannelReplyPayload,
+} from "@vellumai/gateway-client";
+
+import {
+  A2A_CONTENT_TYPE,
+  A2A_VERSION,
+  A2A_VERSION_HEADER,
+} from "../../../a2a/protocol-constants.js";
+import type { Part } from "../../../a2a/protocol-types.js";
+import * as taskStore from "../../../a2a/task-store.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  computeRetryDelay,
+  isRetryableStatus,
+  sleep,
+} from "../../../util/retry.js";
+
+const log = getLogger("a2a-deliver");
+
+const MAX_RETRIES = 3;
+const PUSH_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the `taskId` query parameter from a callback URL. */
+function parseTaskId(callbackUrl: string): string | null {
+  try {
+    return new URL(callbackUrl).searchParams.get("taskId");
+  } catch {
+    return null;
+  }
+}
+
+/** Build A2A parts from a channel reply payload. */
+function buildParts(payload: ChannelReplyPayload): Part[] {
+  const parts: Part[] = [];
+
+  if (payload.text) {
+    parts.push({ kind: "text", text: payload.text });
+  }
+
+  if (payload.attachments) {
+    for (const att of payload.attachments) {
+      parts.push({
+        kind: "file",
+        filename: att.filename,
+        media_type: att.mimeType,
+        url: att.data,
+      });
+    }
+  }
+
+  return parts;
+}
+
+/** POST the completed task to the requester's push URL with retry. */
+async function pushNotification(
+  pushUrl: string,
+  taskJson: unknown,
+): Promise<void> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await sleep(computeRetryDelay(attempt - 1));
+    }
+
+    try {
+      const response = await fetch(pushUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": A2A_CONTENT_TYPE,
+          [A2A_VERSION_HEADER]: A2A_VERSION,
+        },
+        body: JSON.stringify(taskJson),
+        signal: AbortSignal.timeout(PUSH_TIMEOUT_MS),
+      });
+
+      if (response.ok) return;
+
+      const body = await response.text().catch(() => "");
+      lastError = new Error(
+        `Push notification failed with status ${response.status}: ${body}`,
+      );
+
+      if (!isRetryableStatus(response.status)) {
+        break;
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  // Push failure is logged but doesn't propagate
+  log.warn(
+    { pushUrl, error: lastError?.message },
+    "A2A push notification failed after retries",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Deliver an assistant reply as an A2A task completion. */
+export async function deliverA2AReply(
+  callbackUrl: string,
+  payload: ChannelReplyPayload,
+): Promise<ChannelDeliveryResult> {
+  const taskId = parseTaskId(callbackUrl);
+  if (!taskId) {
+    return { ok: false };
+  }
+
+  const parts = buildParts(payload);
+  if (parts.length === 0) {
+    log.debug({ taskId }, "No content to deliver; skipping A2A completion");
+    return { ok: true };
+  }
+
+  let completedTask;
+  try {
+    completedTask = taskStore.completeWithArtifacts(taskId, [
+      { artifact_id: crypto.randomUUID(), parts },
+    ]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ taskId, error: message }, "Failed to complete A2A task");
+    return { ok: false };
+  }
+
+  // Push notification — fire-and-forget
+  const pushUrl = taskStore.getPushUrl(taskId);
+  if (pushUrl) {
+    pushNotification(pushUrl, completedTask).catch((err) => {
+      log.error(
+        { taskId, pushUrl, error: String(err) },
+        "Unexpected push notification error",
+      );
+    });
+  }
+
+  log.info({ taskId }, "A2A reply delivered");
+  return { ok: true };
+}

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -5,7 +5,7 @@
  * matcher and send logic here.  The gateway-client consults
  * `isDirectDelivery()` before falling back to the HTTP proxy path.
  *
- * Currently supported: WhatsApp, Telegram, Slack.
+ * Currently supported: WhatsApp, Telegram, Slack, A2A.
  */
 
 import type {
@@ -15,6 +15,7 @@ import type {
 import { ChannelDeliveryError } from "@vellumai/gateway-client/http-delivery";
 
 import { getLogger } from "../../util/logger.js";
+import { deliverA2AReply } from "./a2a/deliver.js";
 import {
   sendSlackAssistantThreadStatus,
   sendSlackAttachments,
@@ -57,6 +58,10 @@ function isSlackCallback(callbackUrl: string): boolean {
   } catch {
     return callbackUrl.endsWith("/deliver/slack");
   }
+}
+
+function isA2ACallback(callbackUrl: string): boolean {
+  return matchesPathname(callbackUrl, "/deliver/a2a");
 }
 
 function parseSlackCallbackParams(callbackUrl: string): {
@@ -233,7 +238,8 @@ export function isDirectDelivery(callbackUrl: string): boolean {
   return (
     isWhatsAppCallback(callbackUrl) ||
     isTelegramCallback(callbackUrl) ||
-    isSlackCallback(callbackUrl)
+    isSlackCallback(callbackUrl) ||
+    isA2ACallback(callbackUrl)
   );
 }
 
@@ -253,6 +259,9 @@ export async function deliverDirect(
   }
   if (isSlackCallback(callbackUrl)) {
     return deliverSlack(callbackUrl, payload);
+  }
+  if (isA2ACallback(callbackUrl)) {
+    return deliverA2AReply(callbackUrl, payload);
   }
 
   // Defensive — isDirectDelivery should have returned false.


### PR DESCRIPTION
## Summary
- Add A2A delivery adapter that completes tasks with response artifacts
- POST completed tasks to requester's push notification URL with retry logic
- Register A2A callback URL in the direct delivery router

Part of plan: a2a-channel.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->