### PR TITLE
feat(a2a): add A2A config handler and connection initiation by guardian handle

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for A2A config handler.
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import { findContactByAddress } from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { clearA2AConfig, getA2AConfig, setA2AConfig } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfigEnabled(enabled: boolean): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "a2a.enabled", enabled);
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+describe("getA2AConfig", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfigEnabled(false);
+  });
+
+  test("returns enabled: false when a2a is disabled", () => {
+    const result = getA2AConfig();
+    expect(result.success).toBe(true);
+    expect(result.enabled).toBe(false);
+    expect(result.activeConnections).toBe(0);
+  });
+
+  test("returns enabled: true when a2a is enabled", () => {
+    setConfigEnabled(true);
+    const result = getA2AConfig();
+    expect(result.success).toBe(true);
+    expect(result.enabled).toBe(true);
+  });
+});
+
+describe("setA2AConfig", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfigEnabled(false);
+  });
+
+  test("enables a2a in config", () => {
+    const result = setA2AConfig();
+    expect(result.success).toBe(true);
+    expect(result.enabled).toBe(true);
+  });
+
+  test("is idempotent", () => {
+    setA2AConfig();
+    const result = setA2AConfig();
+    expect(result.success).toBe(true);
+    expect(result.enabled).toBe(true);
+  });
+});
+
+describe("clearA2AConfig", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfigEnabled(true);
+  });
+
+  test("disables a2a in config", () => {
+    const result = clearA2AConfig();
+    expect(result.success).toBe(true);
+    expect(result.enabled).toBe(false);
+  });
+});
+
+describe("connectToAssistant", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("returns error when gatewayUrl is not provided and handle cannot be resolved", async () => {
+    const { connectToAssistant } = await import("../config-a2a.js");
+    const result = await connectToAssistant({
+      guardianHandle: "peer-assistant",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("gatewayUrl");
+  });
+
+  test("detects duplicate connection and returns alreadyConnected", async () => {
+    // Manually create a contact with an a2a channel to simulate existing connection
+    const { upsertContact } =
+      await import("../../../contacts/contact-store.js");
+    upsertContact({
+      displayName: "Peer Bot",
+      contactType: "assistant",
+      role: "contact",
+      channels: [
+        {
+          type: "a2a",
+          address: "peer-handle",
+          externalUserId: "peer-handle",
+          status: "active",
+          policy: "allow",
+        },
+      ],
+    });
+
+    // Verify the contact exists
+    const existing = findContactByAddress("a2a", "peer-handle");
+    expect(existing).not.toBeNull();
+
+    // Mock resolveGuardianHandle to return matching data
+    const { connectToAssistant } = await import("../config-a2a.js");
+
+    // We need to mock the fetch for the agent card
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.includes("agent-card.json")) {
+        return new Response(JSON.stringify({ name: "Peer Bot" }), {
+          status: 200,
+        });
+      }
+      // Return success for message:send
+      return new Response(JSON.stringify({ task: { id: "t1" } }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await connectToAssistant({
+        guardianHandle: "peer-handle",
+        gatewayUrl: "https://peer.example.com",
+      });
+      expect(result.success).toBe(true);
+      expect(result.alreadyConnected).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -1,0 +1,277 @@
+/**
+ * A2A channel configuration handler.
+ *
+ * Follows the same pattern as config-telegram.ts:
+ * - getA2AConfig()       — read a2a.enabled, count active a2a contact_channels
+ * - setA2AConfig()       — set a2a.enabled = true, register callback routes
+ * - clearA2AConfig()     — set a2a.enabled = false
+ * - connectToAssistant() — resolve handle, create contact + channel, send initial message
+ */
+
+import { v4 as uuid } from "uuid";
+
+import { buildAgentCard } from "../../a2a/agent-card.js";
+import { AGENT_CARD_PATH } from "../../a2a/protocol-constants.js";
+import type { SendMessageRequest } from "../../a2a/protocol-types.js";
+import {
+  getConfig,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import {
+  findContactByAddress,
+  searchContacts,
+  upsertContact,
+} from "../../contacts/contact-store.js";
+import type { VellumAssistantMetadata } from "../../contacts/types.js";
+import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import { getDb } from "../../memory/db-connection.js";
+import { assistantContactMetadata } from "../../memory/schema.js";
+import { getLogger } from "../../util/logger.js";
+import { getAssistantName } from "../identity-helpers.js";
+
+const log = getLogger("config-a2a");
+
+// ── Result types ────────────────────────────────────────────────────
+
+export interface A2AConfigResult {
+  success: boolean;
+  enabled: boolean;
+  activeConnections: number;
+  error?: string;
+}
+
+export interface ConnectToAssistantResult {
+  success: boolean;
+  contactId?: string;
+  error?: string;
+  alreadyConnected?: boolean;
+}
+
+// ── Config operations ───────────────────────────────────────────────
+
+export function getA2AConfig(): A2AConfigResult {
+  const config = getConfig();
+  const enabled = config.a2a?.enabled ?? false;
+
+  const contacts = searchContacts({ channelType: "a2a" });
+  const activeConnections = contacts.reduce((count, c) => {
+    return (
+      count +
+      c.channels.filter((ch) => ch.type === "a2a" && ch.status === "active")
+        .length
+    );
+  }, 0);
+
+  return { success: true, enabled, activeConnections };
+}
+
+export function setA2AConfig(): A2AConfigResult {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "a2a.enabled", true);
+  saveRawConfig(raw);
+  invalidateConfigCache();
+
+  const result = getA2AConfig();
+  return { ...result, success: true };
+}
+
+export function clearA2AConfig(): A2AConfigResult {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "a2a.enabled", false);
+  saveRawConfig(raw);
+  invalidateConfigCache();
+
+  return { success: true, enabled: false, activeConnections: 0 };
+}
+
+// ── Handle resolution (stubbable) ───────────────────────────────────
+
+export interface ResolvedAssistant {
+  assistantId: string;
+  gatewayUrl: string;
+  displayName: string;
+}
+
+/**
+ * Resolve a guardian handle to an assistant's gateway URL and identity.
+ *
+ * For MVP, this fetches the peer's agent card from the gateway URL.
+ * When the platform API for handle resolution is available, this function
+ * will be updated to use it.
+ */
+export async function resolveGuardianHandle(
+  guardianHandle: string,
+  gatewayUrl?: string,
+): Promise<ResolvedAssistant> {
+  if (!gatewayUrl) {
+    throw new Error(
+      `Platform handle resolution is not yet available. ` +
+        `Please provide the gatewayUrl directly for handle "${guardianHandle}".`,
+    );
+  }
+
+  const cardUrl = `${gatewayUrl}${AGENT_CARD_PATH}`;
+  try {
+    const res = await fetch(cardUrl);
+    if (!res.ok) {
+      throw new Error(
+        `Agent card fetch failed (${res.status}): ${await res.text()}`,
+      );
+    }
+    const card = (await res.json()) as { name?: string };
+    return {
+      assistantId: guardianHandle,
+      gatewayUrl,
+      displayName: card.name ?? guardianHandle,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Agent card fetch")) {
+      throw err;
+    }
+    throw new Error(
+      `Failed to reach peer assistant at ${cardUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// ── Connection initiation ───────────────────────────────────────────
+
+export async function connectToAssistant(params: {
+  guardianHandle: string;
+  gatewayUrl?: string;
+}): Promise<ConnectToAssistantResult> {
+  const { guardianHandle, gatewayUrl } = params;
+
+  // 1. Resolve the peer assistant's identity
+  let resolved: ResolvedAssistant;
+  try {
+    resolved = await resolveGuardianHandle(guardianHandle, gatewayUrl);
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // 2. Check for existing connection (idempotent)
+  const existing = findContactByAddress("a2a", resolved.assistantId);
+  if (existing) {
+    const activeChannel = existing.channels.find(
+      (ch) => ch.type === "a2a" && ch.status === "active",
+    );
+    if (activeChannel) {
+      return {
+        success: true,
+        contactId: existing.id,
+        alreadyConnected: true,
+      };
+    }
+  }
+
+  // 3. Create local contact + channel + assistant_contact_metadata
+  const contact = upsertContact({
+    displayName: resolved.displayName,
+    contactType: "assistant",
+    role: "contact",
+    channels: [
+      {
+        type: "a2a",
+        address: resolved.assistantId,
+        externalUserId: resolved.assistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  const db = getDb();
+  const metadataJson = JSON.stringify({
+    assistantId: resolved.assistantId,
+    gatewayUrl: resolved.gatewayUrl,
+  } satisfies VellumAssistantMetadata);
+
+  db.insert(assistantContactMetadata)
+    .values({
+      contactId: contact.id,
+      species: "vellum",
+      metadata: metadataJson,
+    })
+    .onConflictDoUpdate({
+      target: assistantContactMetadata.contactId,
+      set: {
+        species: "vellum",
+        metadata: metadataJson,
+      },
+    })
+    .run();
+
+  // 4. Send initial A2A message to the peer
+  try {
+    await sendInitialA2AMessage(resolved);
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to send initial A2A message (contact created, peer may not be notified)",
+    );
+  }
+
+  return { success: true, contactId: contact.id };
+}
+
+// ── Initial message sending ─────────────────────────────────────────
+
+async function sendInitialA2AMessage(peer: ResolvedAssistant): Promise<void> {
+  const config = getConfig();
+  const assistantName = getAssistantName() ?? "Vellum Assistant";
+
+  let senderBaseUrl: string;
+  try {
+    senderBaseUrl = getPublicBaseUrl(config);
+  } catch {
+    log.warn("No public base URL configured; skipping initial A2A message");
+    return;
+  }
+
+  const senderCard = buildAgentCard({
+    assistantName,
+    baseUrl: senderBaseUrl,
+  });
+
+  const messageId = uuid();
+  const body: SendMessageRequest = {
+    message: {
+      message_id: messageId,
+      role: "user",
+      parts: [
+        {
+          kind: "text",
+          text: `Hello! I'm ${assistantName}. I'd like to connect with you via A2A.`,
+        },
+      ],
+      metadata: {
+        sender_agent_card: senderCard,
+      },
+    },
+    configuration: {
+      return_immediately: true,
+    },
+  };
+
+  const url = `${peer.gatewayUrl}/a2a/message:send`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Sender-Assistant-Id": assistantName,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`A2A message:send failed (${res.status}): ${text}`);
+  }
+}

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -72,6 +72,7 @@ import { ROUTES as IMAGE_GENERATION_ROUTES } from "./image-generation-routes.js"
 import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-session-routes.js";
 import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-provider-connection-routes.js";
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
+import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
 import { ROUTES as SLACK_CHANNEL_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
@@ -223,6 +224,7 @@ export const ROUTES: RouteDefinition[] = [
   ...SECRET_ROUTES,
   ...SETTINGS_ROUTES,
   ...SKILL_ROUTES,
+  ...A2A_ROUTES,
   ...SLACK_CHANNEL_ROUTES,
   ...SLACK_SHARE_ROUTES,
   ...STT_ROUTES,

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -1,0 +1,100 @@
+/**
+ * Route handlers for A2A integration config endpoints.
+ *
+ * GET    /v1/integrations/a2a/config    — get current A2A config status
+ * POST   /v1/integrations/a2a/config    — enable A2A channel
+ * DELETE /v1/integrations/a2a/config    — disable A2A channel
+ * POST   /v1/integrations/a2a/connect   — initiate connection to a peer assistant
+ */
+
+import {
+  clearA2AConfig,
+  connectToAssistant,
+  getA2AConfig,
+  setA2AConfig,
+} from "../../../daemon/handlers/config-a2a.js";
+import { BadRequestError } from "../errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleGetA2AConfig() {
+  return getA2AConfig();
+}
+
+function handleSetA2AConfig() {
+  const result = setA2AConfig();
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to enable A2A");
+  }
+  return result;
+}
+
+function handleClearA2AConfig() {
+  return clearA2AConfig();
+}
+
+async function handleConnectToAssistant({ body = {} }: RouteHandlerArgs) {
+  const { guardianHandle, gatewayUrl } = body as {
+    guardianHandle?: string;
+    gatewayUrl?: string;
+  };
+  if (!guardianHandle) {
+    throw new BadRequestError("guardianHandle is required");
+  }
+  const result = await connectToAssistant({ guardianHandle, gatewayUrl });
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to connect to assistant");
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "integrations_a2a_config_get",
+    endpoint: "integrations/a2a/config",
+    method: "GET",
+    summary: "Get A2A config",
+    description: "Check current A2A channel configuration status.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: () => handleGetA2AConfig(),
+  },
+  {
+    operationId: "integrations_a2a_config_post",
+    endpoint: "integrations/a2a/config",
+    method: "POST",
+    summary: "Enable A2A channel",
+    description: "Enable the A2A channel for inter-assistant communication.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: () => handleSetA2AConfig(),
+  },
+  {
+    operationId: "integrations_a2a_config_delete",
+    endpoint: "integrations/a2a/config",
+    method: "DELETE",
+    summary: "Disable A2A channel",
+    description: "Disable the A2A channel.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: () => handleClearA2AConfig(),
+  },
+  {
+    operationId: "integrations_a2a_connect_post",
+    endpoint: "integrations/a2a/connect",
+    method: "POST",
+    summary: "Connect to assistant",
+    description:
+      "Initiate an A2A connection to a peer assistant by guardian handle.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleConnectToAssistant,
+  },
+];


### PR DESCRIPTION
## Summary
- Add A2A config handler (get/set/clear) following the Telegram handler pattern
- Add connectToAssistant() for guardian-initiated A2A connections by handle
- Add integration routes and register in the main routes index

Part of plan: a2a-channel.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->