### PR TITLE
feat(a2a): add gateway A2A agent card, message:send, and push webhook endpoints

### DIFF
--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -10,7 +10,7 @@ import type { ChannelId } from "./types.js";
 
 export type InboundChannelId = Extract<
   ChannelId,
-  "telegram" | "whatsapp" | "slack" | "email"
+  "telegram" | "whatsapp" | "slack" | "email" | "a2a"
 >;
 
 interface InboundEventBase<C extends InboundChannelId> {
@@ -59,9 +59,11 @@ export type TelegramInboundEvent = InboundEventBase<"telegram">;
 export type WhatsAppInboundEvent = InboundEventBase<"whatsapp">;
 export type SlackInboundEvent = InboundEventBase<"slack">;
 export type EmailInboundEvent = InboundEventBase<"email">;
+export type A2aInboundEvent = InboundEventBase<"a2a">;
 
 export type GatewayInboundEvent =
   | TelegramInboundEvent
   | WhatsAppInboundEvent
   | SlackInboundEvent
-  | EmailInboundEvent;
+  | EmailInboundEvent
+  | A2aInboundEvent;

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -5,6 +5,7 @@ export const CHANNEL_IDS = [
   "whatsapp",
   "slack",
   "email",
+  "a2a",
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];
@@ -30,6 +31,7 @@ export const INTERFACE_IDS = [
   "whatsapp",
   "slack",
   "email",
+  "a2a",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];

--- a/gateway/src/handlers/normalize-a2a.ts
+++ b/gateway/src/handlers/normalize-a2a.ts
@@ -1,0 +1,165 @@
+/**
+ * A2A message normalization — converts A2A protocol messages and push
+ * notification responses into the gateway's standard GatewayInboundEvent
+ * shape so they flow through the same inbound pipeline as every other channel.
+ *
+ * Type definitions for A2A protocol objects are duplicated here from
+ * assistant/src/a2a/protocol-types.ts to respect the cross-package import
+ * boundary (AGENTS.md: gateway must not import from assistant via relative
+ * paths). Only the subset needed for normalization is defined.
+ */
+
+import type { A2aInboundEvent } from "../channels/inbound-event.js";
+
+// ── A2A protocol types (subset for normalization) ──────────────────
+
+interface TextPart {
+  kind: "text";
+  text: string;
+}
+
+interface DataPart {
+  kind: "data";
+  data: Record<string, unknown>;
+}
+
+interface FilePart {
+  kind: "file";
+  url?: string;
+  raw?: string;
+  filename?: string;
+}
+
+export type A2APart = TextPart | DataPart | FilePart;
+
+export interface A2AMessage {
+  message_id: string;
+  context_id?: string;
+  task_id?: string;
+  role: "user" | "agent";
+  parts: A2APart[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface A2ATaskStatus {
+  state: string;
+  message?: A2AMessage;
+  timestamp: string;
+}
+
+export interface A2AArtifact {
+  artifact_id: string;
+  parts: A2APart[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface A2ATask {
+  id: string;
+  context_id?: string;
+  status: A2ATaskStatus;
+  artifacts?: A2AArtifact[];
+  metadata?: Record<string, unknown>;
+}
+
+// ── Extraction / normalization ─────────────────────────────────────
+
+/**
+ * Extract displayable text from A2A message parts.
+ *
+ * - TextPart: joined as-is
+ * - DataPart: JSON-stringified
+ * - FilePart: skipped for MVP (file handling deferred)
+ */
+export function extractTextContent(parts: A2APart[]): string {
+  const segments: string[] = [];
+  for (const part of parts) {
+    switch (part.kind) {
+      case "text":
+        segments.push(part.text);
+        break;
+      case "data":
+        segments.push(JSON.stringify(part.data));
+        break;
+      case "file":
+        // File parts skipped for MVP
+        break;
+    }
+  }
+  return segments.join("\n");
+}
+
+/**
+ * Normalize an inbound A2A message (from `message:send`) into a
+ * GatewayInboundEvent that can be forwarded through the standard pipeline.
+ */
+export function normalizeA2AToInbound(
+  message: A2AMessage,
+  taskId: string,
+  senderAssistantId: string,
+  senderName?: string,
+): A2aInboundEvent {
+  const content = extractTextContent(message.parts);
+  const now = new Date().toISOString();
+
+  return {
+    version: "v1",
+    sourceChannel: "a2a",
+    receivedAt: now,
+    message: {
+      content,
+      conversationExternalId: message.context_id ?? taskId,
+      externalMessageId: message.message_id,
+    },
+    actor: {
+      actorExternalId: senderAssistantId,
+      displayName: senderName,
+    },
+    source: {
+      updateId: message.message_id,
+    },
+    raw: { message, taskId },
+  };
+}
+
+/**
+ * Normalize an A2A push notification (completed task from a peer) into a
+ * GatewayInboundEvent routed via the task's context_id.
+ */
+export function normalizeA2APushToInbound(task: A2ATask): A2aInboundEvent {
+  const now = new Date().toISOString();
+
+  // Build content from the status message or artifacts
+  let content = "";
+  if (task.status.message) {
+    content = extractTextContent(task.status.message.parts);
+  } else if (task.artifacts && task.artifacts.length > 0) {
+    const segments: string[] = [];
+    for (const artifact of task.artifacts) {
+      segments.push(extractTextContent(artifact.parts));
+    }
+    content = segments.join("\n");
+  }
+
+  // The sender is the remote assistant that processed the task.
+  // Metadata may carry the sender identity from the original request.
+  const senderAssistantId =
+    (task.metadata?.senderAssistantId as string) ?? "unknown";
+
+  return {
+    version: "v1",
+    sourceChannel: "a2a",
+    receivedAt: now,
+    message: {
+      content,
+      conversationExternalId: task.context_id ?? task.id,
+      externalMessageId: `push-${task.id}-${task.status.timestamp}`,
+    },
+    actor: {
+      actorExternalId: senderAssistantId,
+    },
+    source: {
+      updateId: `push-${task.id}`,
+    },
+    raw: { task },
+  };
+}

--- a/gateway/src/http/routes/a2a-routes.test.ts
+++ b/gateway/src/http/routes/a2a-routes.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+
+// --- Mocks ----------------------------------------------------------------
+
+const handleInboundMock = mock(
+  (_config: GatewayConfig, _normalized: unknown, _options?: unknown) =>
+    Promise.resolve({ forwarded: true, rejected: false }),
+);
+
+const assistantDbRunMock = mock((_sql: string, _bind?: unknown[]) =>
+  Promise.resolve({ changes: 1, lastInsertRowid: 0 }),
+);
+
+const assistantDbQueryMock = mock((_sql: string, _bind?: unknown[]) =>
+  Promise.resolve([]),
+);
+
+mock.module("../../handlers/handle-inbound.js", () => ({
+  handleInbound: handleInboundMock,
+}));
+
+mock.module("../../db/assistant-db-proxy.js", () => ({
+  assistantDbRun: assistantDbRunMock,
+  assistantDbQuery: assistantDbQueryMock,
+}));
+
+mock.module("../../runtime/client.js", () => ({
+  CircuitBreakerOpenError: class extends Error {},
+}));
+
+// Import after mocks are registered
+const {
+  createAgentCardHandler,
+  createSendMessageHandler,
+  createPushWebhookHandler,
+} = await import("./a2a-routes.js");
+
+// --- Helpers ---------------------------------------------------------------
+
+const baseConfig: GatewayConfig = {
+  assistantRuntimeBaseUrl: "http://localhost:7821",
+  defaultAssistantId: "ast-default",
+  gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+  logFile: { dir: undefined, retentionDays: 30 },
+  maxAttachmentBytes: {
+    telegram: 50 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    default: 50 * 1024 * 1024,
+  },
+  maxAttachmentConcurrency: 3,
+  maxWebhookPayloadBytes: 1024 * 1024,
+  port: 7830,
+  routingEntries: [],
+  runtimeInitialBackoffMs: 500,
+  runtimeMaxRetries: 2,
+  runtimeProxyRequireAuth: true,
+  runtimeTimeoutMs: 30000,
+  shutdownDrainMs: 5000,
+  unmappedPolicy: "default",
+  trustProxy: false,
+};
+
+function makeConfigFileCache(overrides?: {
+  a2aEnabled?: boolean;
+  publicBaseUrl?: string;
+}) {
+  const data: Record<string, Record<string, unknown>> = {
+    a2a: { enabled: overrides?.a2aEnabled ?? false },
+    ingress: {
+      publicBaseUrl: overrides?.publicBaseUrl ?? "https://example.com",
+    },
+  };
+
+  return {
+    getBoolean: (section: string, field: string) => {
+      const val = data[section]?.[field];
+      return typeof val === "boolean" ? val : undefined;
+    },
+    getString: (section: string, field: string) => {
+      const val = data[section]?.[field];
+      return typeof val === "string" ? val : undefined;
+    },
+  } as import("../../config-file-cache.js").ConfigFileCache;
+}
+
+function makeSendMessageRequest(
+  overrides?: Partial<{
+    message: Record<string, unknown>;
+    configuration: Record<string, unknown>;
+    senderAssistantId: string;
+    senderName: string;
+  }>,
+): Request {
+  const body = {
+    message: overrides?.message ?? {
+      message_id: "msg-1",
+      role: "user",
+      parts: [{ kind: "text", text: "Hello from peer" }],
+    },
+    ...(overrides?.configuration
+      ? { configuration: overrides.configuration }
+      : {}),
+  };
+
+  return new Request("http://localhost:7830/a2a/message:send", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(overrides?.senderAssistantId
+        ? { "x-sender-assistant-id": overrides.senderAssistantId }
+        : {}),
+      ...(overrides?.senderName
+        ? { "x-sender-name": overrides.senderName }
+        : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// --- Tests -----------------------------------------------------------------
+
+describe("Agent Card", () => {
+  it("returns 404 when A2A is not enabled", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: false });
+    const handler = createAgentCardHandler(configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/.well-known/agent-card.json"),
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("not enabled");
+  });
+
+  it("serves agent card when enabled", async () => {
+    const configFile = makeConfigFileCache({
+      a2aEnabled: true,
+      publicBaseUrl: "https://my-assistant.example.com",
+    });
+    const handler = createAgentCardHandler(configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/.well-known/agent-card.json"),
+    );
+
+    expect(res.status).toBe(200);
+    const card = (await res.json()) as {
+      name: string;
+      supported_interfaces: Array<{ url: string }>;
+      capabilities: { push_notifications: boolean };
+    };
+    expect(card.name).toBe("Vellum Assistant");
+    expect(card.supported_interfaces[0].url).toBe(
+      "https://my-assistant.example.com/a2a",
+    );
+    expect(card.capabilities.push_notifications).toBe(true);
+  });
+
+  it("returns 503 when no public base URL is configured", async () => {
+    const configFile = makeConfigFileCache({
+      a2aEnabled: true,
+      publicBaseUrl: "",
+    });
+    const handler = createAgentCardHandler(configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/.well-known/agent-card.json"),
+    );
+
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("message:send", () => {
+  beforeEach(() => {
+    handleInboundMock.mockClear();
+    assistantDbRunMock.mockClear();
+    assistantDbQueryMock.mockClear();
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: true, rejected: false }),
+    );
+  });
+
+  it("returns 404 when A2A is not enabled", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: false });
+    const handler = createSendMessageHandler(baseConfig, configFile);
+
+    const res = await handler(makeSendMessageRequest());
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid message payload", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createSendMessageHandler(baseConfig, configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/a2a/message:send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: { bad: true } }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates task and forwards message through inbound pipeline", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createSendMessageHandler(baseConfig, configFile);
+
+    const res = await handler(
+      makeSendMessageRequest({ senderAssistantId: "peer-ast-1" }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      task: { id: string; status: { state: string } };
+    };
+    expect(body.task.id).toBeTruthy();
+    expect(body.task.status.state).toBe("submitted");
+
+    // Verify task was created in DB
+    expect(assistantDbRunMock).toHaveBeenCalledTimes(1);
+    const dbCall = assistantDbRunMock.mock.calls[0];
+    expect(dbCall[0]).toContain("INSERT INTO a2a_tasks");
+
+    // Verify handleInbound was called with normalized event
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [_config, event] = handleInboundMock.mock.calls[0];
+    expect((event as { sourceChannel: string }).sourceChannel).toBe("a2a");
+    expect(
+      (event as { actor: { actorExternalId: string } }).actor.actorExternalId,
+    ).toBe("peer-ast-1");
+  });
+
+  it("returns rejected task when routing rejects the message", async () => {
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({
+        forwarded: false,
+        rejected: true,
+        rejectionReason: "Untrusted sender",
+      }),
+    );
+
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createSendMessageHandler(baseConfig, configFile);
+
+    const res = await handler(makeSendMessageRequest());
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      task: { status: { state: string } };
+    };
+    expect(body.task.status.state).toBe("rejected");
+  });
+
+  it("extracts push notification URL from configuration", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createSendMessageHandler(baseConfig, configFile);
+
+    const res = await handler(
+      makeSendMessageRequest({
+        configuration: {
+          task_push_notification_config: {
+            url: "https://peer.example.com/a2a/push",
+          },
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // Verify push URL was stored in DB
+    const dbCall = assistantDbRunMock.mock.calls[0];
+    const bindParams = dbCall[1] as (string | null)[];
+    // push_url is the 4th bind parameter
+    expect(bindParams[3]).toBe("https://peer.example.com/a2a/push");
+  });
+});
+
+describe("push webhook", () => {
+  beforeEach(() => {
+    handleInboundMock.mockClear();
+    assistantDbQueryMock.mockClear();
+    handleInboundMock.mockImplementation(() =>
+      Promise.resolve({ forwarded: true, rejected: false }),
+    );
+  });
+
+  it("returns 404 when A2A is not enabled", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: false });
+    const handler = createPushWebhookHandler(baseConfig, configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/a2a/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: {
+            id: "task-1",
+            status: { state: "completed", timestamp: new Date().toISOString() },
+          },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid push payload", async () => {
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createPushWebhookHandler(baseConfig, configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/a2a/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invalid: true }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts push and forwards through inbound pipeline", async () => {
+    assistantDbQueryMock.mockImplementation(() =>
+      Promise.resolve([
+        {
+          id: "task-1",
+          context_id: "ctx-1",
+          state: "working",
+          status_message: null,
+          artifacts_json: null,
+          updated_at: Date.now(),
+          sender_assistant_id: "peer-ast-1",
+        },
+      ]),
+    );
+
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createPushWebhookHandler(baseConfig, configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/a2a/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: {
+            id: "task-1",
+            status: {
+              state: "completed",
+              message: {
+                message_id: "resp-1",
+                role: "agent",
+                parts: [{ kind: "text", text: "Here is my response" }],
+              },
+              timestamp: new Date().toISOString(),
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    const [_config, event] = handleInboundMock.mock.calls[0];
+    expect((event as { sourceChannel: string }).sourceChannel).toBe("a2a");
+    // context_id from stored task is used for conversation routing
+    expect(
+      (event as { message: { conversationExternalId: string } }).message
+        .conversationExternalId,
+    ).toBe("ctx-1");
+  });
+
+  it("handles push for unknown task gracefully", async () => {
+    assistantDbQueryMock.mockImplementation(() => Promise.resolve([]));
+
+    const configFile = makeConfigFileCache({ a2aEnabled: true });
+    const handler = createPushWebhookHandler(baseConfig, configFile);
+
+    const res = await handler(
+      new Request("http://localhost:7830/a2a/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: {
+            id: "unknown-task",
+            context_id: "ctx-fallback",
+            status: {
+              state: "completed",
+              timestamp: new Date().toISOString(),
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/gateway/src/http/routes/a2a-routes.ts
+++ b/gateway/src/http/routes/a2a-routes.ts
@@ -1,0 +1,482 @@
+/**
+ * A2A v1.0 gateway routes:
+ * - GET  /.well-known/agent-card.json — agent card discovery
+ * - POST /a2a/message:send            — inbound message from a peer
+ * - POST /a2a/push                    — push notification from a peer
+ */
+
+import type { ConfigFileCache } from "../../config-file-cache.js";
+import type { GatewayConfig } from "../../config.js";
+import {
+  assistantDbQuery,
+  assistantDbRun,
+} from "../../db/assistant-db-proxy.js";
+import { handleInbound } from "../../handlers/handle-inbound.js";
+import { CircuitBreakerOpenError } from "../../runtime/client.js";
+import {
+  normalizeA2AToInbound,
+  normalizeA2APushToInbound,
+  type A2AMessage,
+  type A2APart,
+  type A2ATask,
+  type A2ATaskStatus,
+  type A2AArtifact,
+} from "../../handlers/normalize-a2a.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("a2a-routes");
+
+// ── A2A protocol constants (duplicated to avoid cross-package import) ──
+
+const A2A_AGENT_CARD_PATH = "/.well-known/agent-card.json";
+
+// ── Agent card builder ──────────────────────────────────────────────
+
+interface AgentCard {
+  name: string;
+  description: string;
+  version: string;
+  supported_interfaces: Array<{
+    url: string;
+    protocol_binding: string;
+    protocol_version: string;
+  }>;
+  capabilities: {
+    streaming: boolean;
+    push_notifications: boolean;
+    extended_agent_card: boolean;
+  };
+  default_input_modes: string[];
+  default_output_modes: string[];
+  skills: Array<{
+    id: string;
+    name: string;
+    description: string;
+    tags: string[];
+  }>;
+}
+
+function buildAgentCard(baseUrl: string, assistantName: string): AgentCard {
+  return {
+    name: assistantName,
+    description: `${assistantName} — a Vellum AI assistant`,
+    version: "1.0.0",
+    supported_interfaces: [
+      {
+        url: `${baseUrl}/a2a/message:send`,
+        protocol_binding: "JSONRPC",
+        protocol_version: "1.0",
+      },
+    ],
+    capabilities: {
+      streaming: false,
+      push_notifications: true,
+      extended_agent_card: false,
+    },
+    default_input_modes: ["text/plain"],
+    default_output_modes: ["text/plain"],
+    skills: [
+      {
+        id: "conversation",
+        name: "General conversation",
+        description: "Send a message and receive a response",
+        tags: ["chat"],
+      },
+    ],
+  };
+}
+
+// ── Task store helpers (raw SQL via assistant DB proxy) ──────────────
+
+async function createTaskViaDb(params: {
+  contextId?: string;
+  senderAssistantId: string;
+  requestMessage: A2AMessage;
+  pushUrl?: string;
+}): Promise<{
+  id: string;
+  context_id?: string;
+  status: A2ATaskStatus;
+}> {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+
+  await assistantDbRun(
+    `INSERT INTO a2a_tasks (id, context_id, state, request_message_json, push_url, sender_assistant_id, created_at, updated_at)
+     VALUES (?, ?, 'submitted', ?, ?, ?, ?, ?)`,
+    [
+      id,
+      params.contextId ?? null,
+      JSON.stringify(params.requestMessage),
+      params.pushUrl ?? null,
+      params.senderAssistantId,
+      now,
+      now,
+    ],
+  );
+
+  return {
+    id,
+    context_id: params.contextId ?? undefined,
+    status: {
+      state: "submitted",
+      timestamp: new Date(now).toISOString(),
+    },
+  };
+}
+
+async function getTaskFromDb(taskId: string): Promise<A2ATask | null> {
+  const rows = await assistantDbQuery<{
+    id: string;
+    context_id: string | null;
+    state: string;
+    status_message: string | null;
+    artifacts_json: string | null;
+    updated_at: number;
+    sender_assistant_id: string;
+  }>(
+    "SELECT id, context_id, state, status_message, artifacts_json, updated_at, sender_assistant_id FROM a2a_tasks WHERE id = ? LIMIT 1",
+    [taskId],
+  );
+
+  if (rows.length === 0) return null;
+
+  const row = rows[0];
+  return {
+    id: row.id,
+    context_id: row.context_id ?? undefined,
+    status: {
+      state: row.state,
+      message: row.status_message
+        ? {
+            message_id: "",
+            role: "agent",
+            parts: [{ kind: "text", text: row.status_message }],
+          }
+        : undefined,
+      timestamp: new Date(row.updated_at).toISOString(),
+    },
+    artifacts: row.artifacts_json
+      ? (JSON.parse(row.artifacts_json) as A2AArtifact[])
+      : undefined,
+    metadata: { senderAssistantId: row.sender_assistant_id },
+  };
+}
+
+// ── Validation helpers ──────────────────────────────────────────────
+
+function isValidA2AMessage(msg: unknown): msg is A2AMessage {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as Record<string, unknown>;
+  if (typeof m.message_id !== "string" || !m.message_id) return false;
+  if (m.role !== "user" && m.role !== "agent") return false;
+  if (!Array.isArray(m.parts)) return false;
+  return m.parts.every(isValidPart);
+}
+
+function isValidPart(part: unknown): part is A2APart {
+  if (!part || typeof part !== "object") return false;
+  const p = part as Record<string, unknown>;
+  if (p.kind === "text") return typeof p.text === "string";
+  if (p.kind === "data") return !!p.data && typeof p.data === "object";
+  if (p.kind === "file") return true;
+  return false;
+}
+
+function isValidTaskForPush(task: unknown): task is A2ATask {
+  if (!task || typeof task !== "object") return false;
+  const t = task as Record<string, unknown>;
+  if (typeof t.id !== "string" || !t.id) return false;
+  if (!t.status || typeof t.status !== "object") return false;
+  const s = t.status as Record<string, unknown>;
+  if (typeof s.state !== "string") return false;
+  if (typeof s.timestamp !== "string") return false;
+  return true;
+}
+
+// ── Route handler factories ─────────────────────────────────────────
+
+export function createAgentCardHandler(configFile: ConfigFileCache) {
+  return async (_req: Request): Promise<Response> => {
+    const enabled = configFile.getBoolean("a2a", "enabled") ?? false;
+    if (!enabled) {
+      return Response.json(
+        { error: "A2A channel is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    const publicBaseUrl =
+      configFile.getString("ingress", "publicBaseUrl") ?? "";
+    if (!publicBaseUrl) {
+      log.warn("Agent card requested but no public base URL configured");
+      return Response.json(
+        { error: "Public ingress URL not configured" },
+        { status: 503 },
+      );
+    }
+
+    const assistantName = "Vellum Assistant";
+    const card = buildAgentCard(publicBaseUrl, assistantName);
+
+    return Response.json(card, {
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+export function createSendMessageHandler(
+  config: GatewayConfig,
+  configFile: ConfigFileCache,
+) {
+  return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    const enabled = configFile.getBoolean("a2a", "enabled") ?? false;
+    if (!enabled) {
+      return Response.json(
+        { error: "A2A channel is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await req.json()) as Record<string, unknown>;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const message = body.message;
+    if (!isValidA2AMessage(message)) {
+      return Response.json(
+        { error: "Invalid A2A message: requires message_id, role, and parts" },
+        { status: 400 },
+      );
+    }
+
+    const senderAssistantId =
+      req.headers.get("x-sender-assistant-id") ?? "unknown";
+    const senderName = req.headers.get("x-sender-name") ?? undefined;
+
+    // Extract push notification config if provided
+    const configuration = body.configuration as
+      | Record<string, unknown>
+      | undefined;
+    const pushConfig = configuration?.task_push_notification_config as
+      | { url?: string }
+      | undefined;
+    const pushUrl =
+      typeof pushConfig?.url === "string" ? pushConfig.url : undefined;
+
+    // Create task in the assistant DB to track the request lifecycle
+    let task: {
+      id: string;
+      context_id?: string;
+      status: A2ATaskStatus;
+    };
+    try {
+      task = await createTaskViaDb({
+        contextId: message.context_id,
+        senderAssistantId,
+        requestMessage: message,
+        pushUrl,
+      });
+    } catch (err) {
+      tlog.error({ err }, "Failed to create A2A task");
+      return Response.json({ error: "Failed to create task" }, { status: 500 });
+    }
+
+    tlog.info(
+      { taskId: task.id, senderAssistantId },
+      "A2A message:send — task created",
+    );
+
+    // Normalize to GatewayInboundEvent and forward through the standard pipeline
+    const inboundEvent = normalizeA2AToInbound(
+      message,
+      task.id,
+      senderAssistantId,
+      senderName,
+    );
+
+    try {
+      const result = await handleInbound(config, inboundEvent, {
+        traceId,
+        sourceMetadata: {
+          a2aTaskId: task.id,
+          ...(pushUrl ? { a2aPushUrl: pushUrl } : {}),
+        },
+      });
+
+      if (result.rejected) {
+        tlog.warn(
+          { taskId: task.id, reason: result.rejectionReason },
+          "A2A message:send rejected by routing",
+        );
+        return Response.json(
+          {
+            task: {
+              id: task.id,
+              context_id: task.context_id,
+              status: {
+                state: "rejected",
+                message: {
+                  message_id: crypto.randomUUID(),
+                  role: "agent" as const,
+                  parts: [
+                    {
+                      kind: "text" as const,
+                      text:
+                        result.rejectionReason ?? "Message rejected by policy",
+                    },
+                  ],
+                },
+                timestamp: new Date().toISOString(),
+              },
+            },
+          },
+          { status: 200 },
+        );
+      }
+
+      // Return the task in submitted state — the runtime will process
+      // asynchronously and push the result if a push URL was provided.
+      return Response.json(
+        {
+          task: {
+            id: task.id,
+            context_id: task.context_id,
+            status: task.status,
+          },
+        },
+        { status: 200 },
+      );
+    } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        return Response.json(
+          { error: "Service temporarily unavailable" },
+          {
+            status: 503,
+            headers: { "Retry-After": String(err.retryAfterSecs) },
+          },
+        );
+      }
+      tlog.error({ err, taskId: task.id }, "Failed to forward A2A message");
+      return Response.json(
+        { error: "Failed to process message" },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+export function createPushWebhookHandler(
+  config: GatewayConfig,
+  configFile: ConfigFileCache,
+) {
+  return async (req: Request): Promise<Response> => {
+    const traceId = req.headers.get("x-trace-id") ?? undefined;
+    const tlog = traceId ? log.child({ traceId }) : log;
+
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    const enabled = configFile.getBoolean("a2a", "enabled") ?? false;
+    if (!enabled) {
+      return Response.json(
+        { error: "A2A channel is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await req.json()) as Record<string, unknown>;
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // The push payload can be a task status update or a full task
+    const task = body.task ?? body;
+    if (!isValidTaskForPush(task)) {
+      return Response.json(
+        { error: "Invalid push payload: requires task with id and status" },
+        { status: 400 },
+      );
+    }
+
+    tlog.info(
+      { taskId: task.id, state: task.status.state },
+      "A2A push received",
+    );
+
+    // Look up the original task to get the context_id for routing
+    let fullTask: A2ATask;
+    try {
+      const stored = await getTaskFromDb(task.id);
+      if (stored) {
+        // Merge the push status onto the stored task
+        fullTask = {
+          ...stored,
+          status: task.status as A2ATaskStatus,
+          artifacts: (task as A2ATask).artifacts ?? stored.artifacts,
+        };
+      } else {
+        // Unknown task — use what we have from the push payload
+        fullTask = task as A2ATask;
+      }
+    } catch (err) {
+      tlog.warn(
+        { err, taskId: task.id },
+        "Failed to look up stored task, using push payload",
+      );
+      fullTask = task as A2ATask;
+    }
+
+    // Normalize and forward
+    const inboundEvent = normalizeA2APushToInbound(fullTask);
+
+    try {
+      const result = await handleInbound(config, inboundEvent, {
+        traceId,
+        sourceMetadata: {
+          a2aTaskId: fullTask.id,
+          a2aPushState: fullTask.status.state,
+        },
+      });
+
+      if (result.rejected) {
+        tlog.warn(
+          { taskId: fullTask.id, reason: result.rejectionReason },
+          "A2A push rejected by routing",
+        );
+      }
+
+      return Response.json({ ok: true }, { status: 200 });
+    } catch (err) {
+      if (err instanceof CircuitBreakerOpenError) {
+        return Response.json(
+          { error: "Service temporarily unavailable" },
+          {
+            status: 503,
+            headers: { "Retry-After": String(err.retryAfterSecs) },
+          },
+        );
+      }
+      tlog.error({ err, taskId: fullTask.id }, "Failed to forward A2A push");
+      return Response.json(
+        { error: "Failed to process push" },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+export { A2A_AGENT_CARD_PATH };

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -119,6 +119,12 @@ import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js
 import { createLogExportHandler } from "./http/routes/log-export.js";
 import { createLogTailHandler } from "./http/routes/log-tail.js";
 import {
+  createAgentCardHandler,
+  createSendMessageHandler,
+  createPushWebhookHandler,
+  A2A_AGENT_CARD_PATH,
+} from "./http/routes/a2a-routes.js";
+import {
   createTrustRulesListHandler,
   createTrustRulesCreateHandler,
   createTrustRulesUpdateHandler,
@@ -467,6 +473,13 @@ async function main() {
   const handleTrustRulesReset = createTrustRulesResetHandler();
   const handleTrustRulesSuggest = createTrustRulesSuggestHandler();
 
+  const handleAgentCard = createAgentCardHandler(configFileCache);
+  const handleA2ASendMessage = createSendMessageHandler(
+    config,
+    configFileCache,
+  );
+  const handleA2APush = createPushWebhookHandler(config, configFileCache);
+
   const audioProxy = createAudioProxyHandler(config);
 
   const backupDeps = {
@@ -505,6 +518,23 @@ async function main() {
   // Auth middleware is applied declaratively per route — no manual
   // requireEdgeAuth/wrapWithAuthFailureTracking calls needed.
   const routes: RouteDefinition[] = [
+    // ── A2A protocol endpoints (unauthenticated — peer-to-peer discovery and messaging) ──
+    {
+      path: A2A_AGENT_CARD_PATH,
+      method: "GET",
+      handler: (req) => handleAgentCard(req),
+    },
+    {
+      path: "/a2a/message:send",
+      method: "POST",
+      handler: (req) => handleA2ASendMessage(req),
+    },
+    {
+      path: "/a2a/push",
+      method: "POST",
+      handler: (req) => handleA2APush(req),
+    },
+
     // ── Webhooks (unauthenticated, validated by provider-specific mechanisms) ──
     {
       path: "/webhooks/telegram",

--- a/gateway/src/types.ts
+++ b/gateway/src/types.ts
@@ -6,4 +6,5 @@ export type {
   WhatsAppInboundEvent,
   SlackInboundEvent,
   EmailInboundEvent,
+  A2aInboundEvent,
 } from "./channels/inbound-event.js";


### PR DESCRIPTION
## Summary
- Add gateway A2A routes: agent card discovery, message:send inbound, push notification webhook
- Add A2A-to-GatewayInboundEvent normalization for both inbound messages and push responses
- Route A2A messages through the standard inbound pipeline (ACL enforcement handles trust)

Part of plan: a2a-channel.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->