### PR TITLE
Expose Slack sender and exact message links from history

### DIFF
--- a/assistant/src/__tests__/inbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/inbound-slack-persistence.test.ts
@@ -148,6 +148,7 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
       {
         slackInbound: {
           channelId: "C0123CHANNEL",
+          channelName: "engineering",
           channelTs: "1700000001.111111",
           threadTs: "1700000000.000001",
           displayName: "Alice",
@@ -162,6 +163,7 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
     expect(slackMeta!.source).toBe("slack");
     expect(slackMeta!.eventKind).toBe("message");
     expect(slackMeta!.channelId).toBe("C0123CHANNEL");
+    expect(slackMeta!.channelName).toBe("engineering");
     expect(slackMeta!.channelTs).toBe("1700000001.111111");
     expect(slackMeta!.threadTs).toBe("1700000000.000001");
     expect(slackMeta!.displayName).toBe("Alice");
@@ -194,6 +196,7 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
     expect(slackMeta!.channelTs).toBe("1700000010.222222");
     expect(slackMeta!.threadTs).toBeUndefined();
     expect(slackMeta!.displayName).toBe("Bob");
+    expect(slackMeta!.channelName).toBeUndefined();
   });
 
   test("Slack normalized content is persisted with raw channelTs in slackMeta", async () => {

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -89,8 +89,10 @@ interface MessagePayload {
   timestamp: string;
   slackMessage?: {
     channelId: string;
+    channelName?: string;
     channelTs: string;
     threadTs?: string;
+    sender?: { displayName?: string; externalUserId?: string };
     messageLink?: { appUrl?: string; webUrl?: string };
     threadLink?: { appUrl?: string; webUrl?: string };
   };
@@ -219,8 +221,11 @@ describe("handleListMessages page=latest", () => {
           slackMeta: writeSlackMetadata({
             source: "slack",
             channelId: "C123ABCDEF",
+            channelName: "engineering",
             channelTs: "1710000000.000200",
             threadTs: "1710000000.000100",
+            displayName: "Alice",
+            actorExternalUserId: "U_ALICE",
             eventKind: "message",
           }),
         }),
@@ -232,13 +237,18 @@ describe("handleListMessages page=latest", () => {
 
     expect(body.messages[0].slackMessage).toEqual({
       channelId: "C123ABCDEF",
+      channelName: "engineering",
       channelTs: "1710000000.000200",
       threadTs: "1710000000.000100",
+      sender: {
+        displayName: "Alice",
+        externalUserId: "U_ALICE",
+      },
       messageLink: {
         appUrl:
           "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000200",
         webUrl:
-          "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
+          "https://example.slack.com/archives/C123ABCDEF/p1710000000000200?thread_ts=1710000000.000100&cid=C123ABCDEF",
       },
       threadLink: {
         appUrl:

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -270,6 +270,7 @@ export function buildSlackMetaForPersistence(params: {
   const slackMeta: SlackMessageMetadata = {
     source: "slack",
     channelId: candidate.channelId,
+    ...(candidate.channelName ? { channelName: candidate.channelName } : {}),
     channelTs: candidate.channelTs,
     eventKind: "message",
     ...(candidate.threadTs ? { threadTs: candidate.threadTs } : {}),

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -115,6 +115,8 @@ export interface RenderedHistoryContent {
 export interface SlackInboundMessageMetadata {
   /** Slack channel id (conversation external id) — recorded as `channelId`. */
   channelId: string;
+  /** Human-readable Slack channel name, when the gateway supplied it. */
+  channelName?: string;
   /** Slack `ts` for this message — required so persistence can record `channelTs`. */
   channelTs: string;
   /** Parent `thread_ts` when the message lives inside a thread; absent for top-level. */

--- a/assistant/src/messaging/providers/slack/deep-link.ts
+++ b/assistant/src/messaging/providers/slack/deep-link.ts
@@ -40,13 +40,21 @@ export function buildSlackWebMessageUrl(params: {
   teamUrl?: string | null;
   channelId: string;
   messageTs: string;
+  threadTs?: string;
 }): string | undefined {
   const teamUrl = normalizeSlackTeamUrl(params.teamUrl);
   if (!teamUrl) return undefined;
 
-  return `${teamUrl}/archives/${encodeURIComponent(
+  const baseUrl = `${teamUrl}/archives/${encodeURIComponent(
     params.channelId,
   )}/p${formatSlackPermalinkTimestamp(params.messageTs)}`;
+  if (!params.threadTs) return baseUrl;
+
+  const search = new URLSearchParams({
+    thread_ts: params.threadTs,
+    cid: params.channelId,
+  });
+  return `${baseUrl}?${search.toString()}`;
 }
 
 export function buildSlackMessageDeepLinks(params: {
@@ -54,6 +62,7 @@ export function buildSlackMessageDeepLinks(params: {
   teamUrl?: string | null;
   channelId: string;
   messageTs: string;
+  threadTs?: string;
 }): SlackMessageDeepLinks | undefined {
   const appUrl = buildSlackAppMessageUrl(params);
   const webUrl = buildSlackWebMessageUrl(params);

--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -62,9 +62,17 @@ describe("readSlackMetadata", () => {
       eventKind: "message",
       editedAt: "not-a-number",
     });
+    const badChannelName = JSON.stringify({
+      source: "slack",
+      channelId: "C123",
+      channelName: 42,
+      channelTs: "1700000000.000100",
+      eventKind: "message",
+    });
     expect(readSlackMetadata(badThreadTs)).toBeNull();
     expect(readSlackMetadata(badReactionOp)).toBeNull();
     expect(readSlackMetadata(badEditedAt)).toBeNull();
+    expect(readSlackMetadata(badChannelName)).toBeNull();
   });
 
   test("strips unknown top-level keys from the returned object", () => {
@@ -111,6 +119,7 @@ describe("readSlackMetadata", () => {
     const meta: SlackMessageMetadata = {
       source: "slack",
       channelId: "C123",
+      channelName: "engineering",
       channelTs: "1700000000.000100",
       threadTs: "1699999999.000000",
       displayName: "Alice",
@@ -174,6 +183,7 @@ describe("writeSlackMetadata", () => {
     const meta: SlackMessageMetadata = {
       source: "slack",
       channelId: "C123",
+      channelName: "engineering",
       channelTs: "1700000000.000100",
       threadTs: "1699999999.000000",
       displayName: "Alice",

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -35,6 +35,7 @@ const slackFileMetadataSchema = z.object({
 export const slackMessageMetadataSchema = z.object({
   source: z.literal("slack"),
   channelId: z.string(),
+  channelName: z.string().optional(),
   channelTs: z.string(),
   threadTs: z.string().optional(),
   displayName: z.string().optional(),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -236,8 +236,13 @@ export interface RuntimeMessagePayload {
   };
   slackMessage?: {
     channelId: string;
+    channelName?: string;
     channelTs: string;
     threadTs?: string;
+    sender?: {
+      displayName?: string;
+      externalUserId?: string;
+    };
     messageLink?: {
       appUrl?: string;
       webUrl?: string;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -159,6 +159,7 @@ function buildSlackHistoryMessage(
     teamUrl: slackConfig?.teamUrl,
     channelId: slackMeta.channelId,
     messageTs: slackMeta.channelTs,
+    ...(slackMeta.threadTs ? { threadTs: slackMeta.threadTs } : {}),
   });
   const threadLink = slackMeta.threadTs
     ? buildSlackMessageDeepLinks({
@@ -171,8 +172,21 @@ function buildSlackHistoryMessage(
 
   return {
     channelId: slackMeta.channelId,
+    ...(slackMeta.channelName ? { channelName: slackMeta.channelName } : {}),
     channelTs: slackMeta.channelTs,
     ...(slackMeta.threadTs ? { threadTs: slackMeta.threadTs } : {}),
+    ...(slackMeta.displayName || slackMeta.actorExternalUserId
+      ? {
+          sender: {
+            ...(slackMeta.displayName
+              ? { displayName: slackMeta.displayName }
+              : {}),
+            ...(slackMeta.actorExternalUserId
+              ? { externalUserId: slackMeta.actorExternalUserId }
+              : {}),
+          },
+        }
+      : {}),
     ...(messageLink ? { messageLink } : {}),
     ...(threadLink ? { threadLink } : {}),
   };

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1047,6 +1047,10 @@ export async function handleChannelInbound({
         sourceChannel === "slack"
           ? {
               channelId: conversationExternalId,
+              ...(typeof sourceMetadata?.channelName === "string" &&
+              sourceMetadata.channelName.trim().length > 0
+                ? { channelName: sourceMetadata.channelName.trim() }
+                : {}),
               channelTs: sourceMessageId ?? externalMessageId,
               ...(slackThreadTs ? { threadTs: slackThreadTs } : {}),
               ...((body.actorDisplayName ?? body.actorUsername)


### PR DESCRIPTION
## Summary
- Persist Slack channel names and sender fields into Slack message metadata.
- Emit sender/channel metadata and exact threaded Slack links from message history.

Part of plan: slack-channel-sender-ui.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->