### PR TITLE
Fix macOS test fake subagent conformance

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -3885,4 +3885,5 @@ private struct FakeSubagentClient: SubagentClientProtocol {
     func abort(subagentId: String, conversationId: String?) async -> SubagentAbortResult { abortResult }
     func fetchDetail(subagentId: String, conversationId: String) async -> SubagentDetailResponse? { nil }
     func sendMessage(subagentId: String, content: String, conversationId: String?) async -> Bool { true }
+    func reconcile(parentConversationId: String) async -> SubagentReconcileResponse? { nil }
 }


### PR DESCRIPTION
## Summary
- Added the missing `reconcile(parentConversationId:)` stub to `FakeSubagentClient`.
- Restores `SubagentClientProtocol` conformance so the macOS test target compiles.
- Closes #30923

## Original prompt
The main-branch CD workflow was failing on the macOS Tests job for run https://github.com/vellum-ai/vellum-assistant/actions/runs/25947697630/job/76279132967. The request was to use the `/do` flow to diagnose the job failure, fix the main-branch breakage, and ship a review PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->