### PR TITLE
Codify Slack content persistence contracts

### DIFF
--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -314,6 +314,30 @@ describe("processMessage displayContent", () => {
     ]);
   });
 
+  test("honors whitespace-only displayContent without falling back to model content", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="slack">\n  \t  \n</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      { displayContent: "  \t  " },
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([]);
+    expect(addMessageCalls[0]!.content).not.toContain("<external_content");
+    expect(conversation.getMessages()).toEqual([
+      { role: "user", content: [{ type: "text", text: modelContent }] },
+    ]);
+  });
+
   test("omitted displayContent persists model content", async () => {
     const conversation = makeTestConversation();
     activeConversation = conversation;
@@ -325,6 +349,28 @@ describe("processMessage displayContent", () => {
       modelContent,
       undefined,
       undefined,
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([
+      { type: "text", text: modelContent },
+    ]);
+  });
+
+  test("explicit undefined displayContent persists model content", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="webhook">wrapped content</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      { displayContent: undefined },
       "slack",
       "slack",
     );

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -2026,6 +2026,28 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(persisted[0].content).toBe(rawContent);
   });
 
+  test("live Slack raw content trims surrounding whitespace before persistence", async () => {
+    const rawContent = "  live Slack padded raw text\t ";
+    const trimmedContent = "live Slack padded raw text";
+    const captured = await handleAndCaptureLiveSlackProcessMessage(
+      buildSlackChannelRequest("1700000000.000325", {
+        content: rawContent,
+      }),
+    );
+
+    expect(captured.content.match(/<external_content/g)?.length).toBe(1);
+    expect(captured.content).toContain('<external_content source="slack"');
+    expect(captured.content).toContain(
+      `\n${trimmedContent}\n</external_content>`,
+    );
+    expect(captured.options?.displayContent).toBe(trimmedContent);
+
+    const persisted = readMessagesByConversation(captured.conversationId);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].content).toBe(trimmedContent);
+    expect(persisted[0].content).not.toContain("<external_content");
+  });
+
   test("live Slack attachment-only passes empty raw displayContent for persistence", async () => {
     seedAttachment("att-slack-file");
 


### PR DESCRIPTION
Adds focused regression coverage for Slack displayContent and raw content persistence edge cases.

Closes #30916
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->