### PR TITLE
Reduce Codex agent setup friction

### DIFF
--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -314,6 +314,30 @@ describe("processMessage displayContent", () => {
     ]);
   });
 
+  test("honors whitespace-only displayContent without falling back to model content", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="slack">\n  \t  \n</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      { displayContent: "  \t  " },
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([]);
+    expect(addMessageCalls[0]!.content).not.toContain("<external_content");
+    expect(conversation.getMessages()).toEqual([
+      { role: "user", content: [{ type: "text", text: modelContent }] },
+    ]);
+  });
+
   test("omitted displayContent persists model content", async () => {
     const conversation = makeTestConversation();
     activeConversation = conversation;
@@ -325,6 +349,28 @@ describe("processMessage displayContent", () => {
       modelContent,
       undefined,
       undefined,
+      "slack",
+      "slack",
+    );
+
+    expect(result.messageId).toBe("persisted-1");
+    expect(addMessageCalls).toHaveLength(1);
+    expect(JSON.parse(addMessageCalls[0]!.content)).toEqual([
+      { type: "text", text: modelContent },
+    ]);
+  });
+
+  test("explicit undefined displayContent persists model content", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+    const modelContent =
+      '<external_content source="webhook">wrapped content</external_content>';
+
+    const result = await processMessage(
+      "conv-display-content",
+      modelContent,
+      undefined,
+      { displayContent: undefined },
       "slack",
       "slack",
     );

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -2026,6 +2026,28 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(persisted[0].content).toBe(rawContent);
   });
 
+  test("live Slack raw content trims surrounding whitespace before persistence", async () => {
+    const rawContent = "  live Slack padded raw text\t ";
+    const trimmedContent = "live Slack padded raw text";
+    const captured = await handleAndCaptureLiveSlackProcessMessage(
+      buildSlackChannelRequest("1700000000.000325", {
+        content: rawContent,
+      }),
+    );
+
+    expect(captured.content.match(/<external_content/g)?.length).toBe(1);
+    expect(captured.content).toContain('<external_content source="slack"');
+    expect(captured.content).toContain(
+      `\n${trimmedContent}\n</external_content>`,
+    );
+    expect(captured.options?.displayContent).toBe(trimmedContent);
+
+    const persisted = readMessagesByConversation(captured.conversationId);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].content).toBe(trimmedContent);
+    expect(persisted[0].content).not.toContain("<external_content");
+  });
+
   test("live Slack attachment-only passes empty raw displayContent for persistence", async () => {
     seedAttachment("att-slack-file");
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,15 @@
 # Scripts
 
 This directory contains highly unstable scripts intended for internal use by Vellum contributors only. They may change or break at any time without notice and should not be relied upon by non-Vellum contributors.
+
+## Agent preflight
+
+Run `node scripts/agent-preflight.mjs` from the repo root at the start of a
+Codex session or fresh worktree. It performs read-only checks for Bun/PATH
+readiness, GitHub CLI authentication, Python availability, required `.claude`
+helper scripts, optional project-board config, and the optional sibling platform
+repo.
+
+The script exits non-zero only when hard requirements fail. Warnings call out
+optional setup gaps or degraded helper availability without mutating the
+checkout.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,3 +13,16 @@ repo.
 The script exits non-zero only when hard requirements fail. Warnings call out
 optional setup gaps or degraded helper availability without mutating the
 checkout.
+
+## PR check summary
+
+Run `node scripts/pr-check-summary.mjs <pr-number-or-url>` from the repo root
+when inspecting review state or CI on a pull request. It uses stable `gh pr view`
+and `gh pr checks` JSON fields, then prints concise `PR`, `Checks`, `Review`,
+and `Next steps` sections.
+
+The helper exits 0 when inspection succeeds, even if checks are failing. It exits
+non-zero only when it cannot inspect the PR. Pending or in-progress checks are
+called out because logs may not be available yet. For fresh worktrees, run
+`node scripts/agent-preflight.mjs` first to catch missing GitHub CLI auth or
+helper setup.

--- a/scripts/agent-preflight.mjs
+++ b/scripts/agent-preflight.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { accessSync, constants, existsSync, lstatSync, readlinkSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const requiredClaudeHelpers = [
+  "worktree",
+  "ship",
+  "review-runtime",
+  "gh-review",
+  "wait-ci",
+];
+
+const failures = [];
+const warnings = [];
+const ok = [];
+const info = [];
+
+function commandPath(command) {
+  for (const pathEntry of (process.env.PATH ?? "").split(":")) {
+    if (!pathEntry) {
+      continue;
+    }
+
+    const candidate = join(pathEntry, command);
+    if (existsSync(candidate) && isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function commandVersion(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  return (result.stdout || result.stderr).trim().split("\n")[0] || null;
+}
+
+function isExecutable(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function checkBun() {
+  const bun = commandPath("bun");
+  if (!bun) {
+    failures.push("Bun is not on PATH. Run: export PATH=\"$HOME/.bun/bin:$PATH\"");
+    return;
+  }
+
+  const version = commandVersion("bun", ["--version"]);
+  ok.push(`Bun available at ${bun}${version ? ` (${version})` : ""}`);
+
+  const expectedPath = join(process.env.HOME ?? "", ".bun", "bin");
+  const pathEntries = (process.env.PATH ?? "").split(":");
+  if (expectedPath && !pathEntries.includes(expectedPath)) {
+    warnings.push(`$HOME/.bun/bin is not on PATH; Bun is resolving from ${bun}`);
+  }
+}
+
+function checkGitHubCli() {
+  const gh = commandPath("gh");
+  if (!gh) {
+    failures.push("GitHub CLI is not on PATH.");
+    return;
+  }
+
+  const auth = spawnSync("gh", ["auth", "status", "--hostname", "github.com"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+
+  if (auth.status !== 0) {
+    failures.push("GitHub CLI is installed but not authenticated for github.com. Run: gh auth login");
+    return;
+  }
+
+  ok.push(`GitHub CLI authenticated at ${gh}`);
+}
+
+function checkPython() {
+  const python3 = commandPath("python3");
+  if (python3) {
+    ok.push(`python3 available at ${python3}`);
+    return;
+  }
+
+  const python = commandPath("python");
+  if (python) {
+    warnings.push(`python3 is not on PATH; only python was found at ${python}`);
+    return;
+  }
+
+  warnings.push("No Python executable found on PATH; install python3 before running Python-based helpers.");
+}
+
+function checkClaudeHelpers() {
+  const claudeDir = join(repoRoot, ".claude");
+  if (!existsSync(claudeDir)) {
+    failures.push(".claude directory is missing; this looks like a bare worktree without helper scripts.");
+    warnings.push(
+      "Bootstrap guidance: restore .claude from the repo checkout and ensure the shared claude-skills scripts are present.",
+    );
+    return;
+  }
+
+  const missing = [];
+  const notExecutable = [];
+  const brokenSymlinks = [];
+
+  for (const helper of requiredClaudeHelpers) {
+    const helperPath = join(claudeDir, helper);
+    if (!existsSync(helperPath)) {
+      missing.push(`.claude/${helper}`);
+
+      try {
+        const stat = lstatSync(helperPath);
+        if (stat.isSymbolicLink()) {
+          brokenSymlinks.push(`.claude/${helper} -> ${readlinkSync(helperPath)}`);
+        }
+      } catch {
+        // Missing path; the concise failure above is enough.
+      }
+
+      continue;
+    }
+
+    if (!isExecutable(helperPath)) {
+      notExecutable.push(`.claude/${helper}`);
+    }
+  }
+
+  if (missing.length > 0) {
+    failures.push(`Missing .claude helpers: ${missing.join(", ")}`);
+  }
+
+  if (notExecutable.length > 0) {
+    failures.push(`.claude helpers are present but not executable: ${notExecutable.join(", ")}`);
+  }
+
+  if (brokenSymlinks.length > 0) {
+    warnings.push(`Broken .claude helper symlinks: ${brokenSymlinks.join(", ")}`);
+  }
+
+  if (missing.length > 0 || brokenSymlinks.length > 0) {
+    warnings.push(
+      "Bootstrap guidance: restore .claude helper symlinks and make sure ../claude-skills exists before using worktree/ship/review helpers.",
+    );
+  }
+
+  if (missing.length === 0 && notExecutable.length === 0) {
+    const helperList = requiredClaudeHelpers
+      .map((helper) => `.claude/${helper}`)
+      .join(", ");
+    ok.push(`.claude helpers available: ${helperList}`);
+  }
+}
+
+function checkOptionalFiles() {
+  const projectConfig = join(repoRoot, ".private", "project-config.env");
+  if (existsSync(projectConfig)) {
+    ok.push(".private/project-config.env present");
+  } else {
+    warnings.push(".private/project-config.env is absent; project-board automation may need explicit flags.");
+  }
+
+  const platformRepo = resolve(repoRoot, "..", "vellum-assistant-platform");
+  if (existsSync(platformRepo)) {
+    ok.push("../vellum-assistant-platform present");
+  } else {
+    info.push("../vellum-assistant-platform not found; only needed for cross-repo platform tasks.");
+  }
+}
+
+function printSection(label, items) {
+  if (items.length === 0) {
+    return;
+  }
+
+  console.log(`\n${label}`);
+  for (const item of items) {
+    console.log(`- ${item}`);
+  }
+}
+
+checkBun();
+checkGitHubCli();
+checkPython();
+checkClaudeHelpers();
+checkOptionalFiles();
+
+console.log("Agent preflight");
+console.log(`Repo: ${repoRoot}`);
+printSection("OK", ok);
+printSection("Warnings", warnings);
+printSection("Failures", failures);
+printSection("Info", info);
+
+if (failures.length > 0) {
+  console.log("\nResult: failed");
+  process.exit(1);
+}
+
+console.log("\nResult: passed");

--- a/scripts/pr-check-summary.mjs
+++ b/scripts/pr-check-summary.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const prRef = process.argv[2];
+
+const prViewFieldSets = [
+  ["state", "mergedAt", "title", "url", "headRefName", "baseRefName", "reviewDecision", "mergeStateStatus"],
+  ["state", "mergedAt", "title", "url", "headRefName", "baseRefName", "reviewDecision"],
+  ["state", "mergedAt", "title", "url", "headRefName", "baseRefName"],
+];
+const checkFields = [
+  "name",
+  "state",
+  "link",
+  "workflow",
+  "startedAt",
+  "completedAt",
+  "description",
+  "bucket",
+  "event",
+];
+
+if (!prRef) {
+  console.error("Usage: node scripts/pr-check-summary.mjs <pr-number-or-url>");
+  process.exit(1);
+}
+
+function runGh(args) {
+  return spawnSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function resultMessage(result, fallback) {
+  if (result.error) {
+    return result.error.message;
+  }
+
+  return result.stderr?.trim() || result.stdout?.trim() || fallback;
+}
+
+function parseJson(stdout, context) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Could not parse ${context} JSON: ${error.message}`);
+  }
+}
+
+function getPr() {
+  const errors = [];
+
+  for (const fields of prViewFieldSets) {
+    const result = runGh(["pr", "view", prRef, "--json", fields.join(",")]);
+    if (result.status === 0) {
+      return parseJson(result.stdout, "PR");
+    }
+
+    errors.push(resultMessage(result, `gh pr view exited ${result.status}`));
+  }
+
+  throw new Error(`Could not inspect PR ${prRef}:\n${errors.join("\n")}`);
+}
+
+function getChecks() {
+  const result = runGh(["pr", "checks", prRef, "--json", checkFields.join(",")]);
+  if (result.status === 0 || result.stdout?.trim()) {
+    try {
+      const checks = parseJson(result.stdout, "checks");
+      if (!Array.isArray(checks)) {
+        throw new Error("Could not inspect checks: gh returned non-array JSON.");
+      }
+      return checks;
+    } catch (error) {
+      if (result.status === 0) {
+        throw error;
+      }
+    }
+  }
+
+  const message = resultMessage(result, `gh pr checks exited ${result.status}`);
+  return { error: message };
+}
+
+function isFailed(check) {
+  const values = [check.state, check.bucket].filter(Boolean).map((value) => String(value).toLowerCase());
+  return values.some((value) => (
+    value.includes("fail") ||
+    value.includes("error") ||
+    value.includes("cancel") ||
+    value.includes("timed_out") ||
+    value.includes("action_required")
+  ));
+}
+
+function isPending(check) {
+  const values = [check.state, check.bucket].filter(Boolean).map((value) => String(value).toLowerCase());
+  return values.some((value) => (
+    value.includes("pending") ||
+    value.includes("queued") ||
+    value.includes("in_progress") ||
+    value.includes("running") ||
+    value.includes("waiting") ||
+    value.includes("requested")
+  ));
+}
+
+function isPassing(check) {
+  const values = [check.state, check.bucket].filter(Boolean).map((value) => String(value).toLowerCase());
+  return values.some((value) => value.includes("pass") || value.includes("success"));
+}
+
+function isSkipped(check) {
+  const values = [check.state, check.bucket].filter(Boolean).map((value) => String(value).toLowerCase());
+  return values.some((value) => value.includes("skip"));
+}
+
+function formatCheck(check) {
+  const parts = [check.name || "(unnamed check)"];
+  if (check.workflow) {
+    parts.push(`workflow: ${check.workflow}`);
+  }
+  if (check.state) {
+    parts.push(`state: ${check.state}`);
+  }
+  if (check.bucket) {
+    parts.push(`bucket: ${check.bucket}`);
+  }
+  if (check.link) {
+    parts.push(`link: ${check.link}`);
+  }
+  if (check.description) {
+    parts.push(`description: ${check.description}`);
+  }
+  return parts.join(" | ");
+}
+
+function printSection(label, lines) {
+  console.log(`\n${label}`);
+  if (lines.length === 0) {
+    console.log("- None");
+    return;
+  }
+
+  for (const line of lines) {
+    console.log(`- ${line}`);
+  }
+}
+
+function prLines(pr) {
+  const lines = [
+    `${pr.title ?? "(untitled)"}`,
+    `${pr.url ?? prRef}`,
+    `State: ${pr.state ?? "unknown"}${pr.mergedAt ? `, merged at ${pr.mergedAt}` : ""}`,
+  ];
+
+  if (pr.headRefName || pr.baseRefName) {
+    lines.push(`Branch: ${pr.headRefName ?? "unknown"} -> ${pr.baseRefName ?? "unknown"}`);
+  }
+  if (pr.mergeStateStatus) {
+    lines.push(`Merge state: ${pr.mergeStateStatus}`);
+  }
+
+  return lines;
+}
+
+function reviewLines(pr) {
+  if (!pr.reviewDecision) {
+    return ["Review decision unavailable or not required."];
+  }
+
+  return [`Review decision: ${pr.reviewDecision}`];
+}
+
+function checkSummary(checksResult) {
+  if (checksResult.error) {
+    return {
+      lines: [`Could not inspect checks: ${checksResult.error}`],
+      nextSteps: ["Open the PR in GitHub or rerun this helper after confirming gh authentication and repository access."],
+    };
+  }
+
+  if (checksResult.length === 0) {
+    return {
+      lines: ["No checks reported for this PR."],
+      nextSteps: ["No CI inspection target found."],
+    };
+  }
+
+  const failed = checksResult.filter(isFailed);
+  const pending = checksResult.filter((check) => !isFailed(check) && isPending(check));
+  const passing = checksResult.filter((check) => !isFailed(check) && !isPending(check) && isPassing(check));
+  const skipped = checksResult.filter((check) => !isFailed(check) && !isPending(check) && !isPassing(check) && isSkipped(check));
+  const other = checksResult.filter((check) => (
+    !failed.includes(check) &&
+    !pending.includes(check) &&
+    !passing.includes(check) &&
+    !skipped.includes(check)
+  ));
+
+  const lines = [
+    `${checksResult.length} total: ${passing.length} passing, ${failed.length} failing, ${pending.length} in progress or pending, ${skipped.length} skipped, ${other.length} other.`,
+  ];
+
+  for (const check of failed) {
+    lines.push(`Failed: ${formatCheck(check)}`);
+  }
+  for (const check of pending) {
+    lines.push(`Pending: ${formatCheck(check)}. Logs may not be available yet.`);
+  }
+  for (const check of other) {
+    lines.push(`Other: ${formatCheck(check)}`);
+  }
+  if (failed.length === 0 && pending.length === 0 && skipped.length === 0 && other.length === 0) {
+    lines.push("All reported checks are passing.");
+  } else if (failed.length === 0 && pending.length === 0 && other.length === 0) {
+    lines.push("No failed or running checks reported; skipped checks are not CI-log targets.");
+  }
+
+  const nextSteps = [];
+  if (failed.length > 0) {
+    nextSteps.push("Inspect failed check links above, then fetch logs for the specific run/job if needed.");
+  }
+  if (pending.length > 0) {
+    nextSteps.push("Wait for pending checks to finish before trying to fetch logs; GitHub may not expose logs while a job is queued or running.");
+  }
+  if (failed.length === 0 && pending.length === 0) {
+    nextSteps.push("No failed or running checks need CI-log inspection.");
+  }
+
+  return { lines, nextSteps };
+}
+
+try {
+  const pr = getPr();
+  const checksResult = getChecks();
+  const checks = checkSummary(checksResult);
+
+  printSection("PR", prLines(pr));
+  printSection("Checks", checks.lines);
+  printSection("Review", reviewLines(pr));
+  printSection("Next steps", checks.nextSteps);
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -12,8 +12,9 @@
  *   6. `description` constraints: 1-1024 chars, non-empty.
  *   7. Optional `compatibility`: 1-500 chars if present.
  *   8. Required `metadata.emoji` (Vellum extension).
- *   9. Frontmatter is followed by Markdown body content.
- *  10. Non-standard top-level fields emit migration guidance:
+ *   9. Hyphenated skill names require `metadata.vellum.display-name`.
+ *  10. Frontmatter is followed by Markdown body content.
+ *  11. Non-standard top-level fields emit migration guidance:
  *      - Vellum-specific fields → move to `metadata.vellum`
  *      - Environment requirements → move to `compatibility`
  *
@@ -158,40 +159,57 @@ function validateCompatibility(compatibility) {
   return errors;
 }
 
-function validateMetadataEmoji(metadata) {
-  const errors = [];
-
-  // Handle JSON string metadata (used by bundled skills)
+function parseMetadata(metadata) {
   if (typeof metadata === "string") {
     try {
-      const parsed = JSON.parse(metadata);
-      // Check for top-level emoji or emoji nested in vellum namespace
-      if (
-        (typeof parsed.emoji === "string" && parsed.emoji.length > 0) ||
-        (typeof parsed.vellum?.emoji === "string" && parsed.vellum.emoji.length > 0)
-      ) {
-        return errors; // emoji found
-      }
+      return JSON.parse(metadata);
     } catch {
-      // JSON parsing failed — fall through to report missing emoji
+      return null;
     }
-    errors.push(
-      'Required field "metadata.emoji" is missing. Skills must have an emoji in metadata.',
-    );
-    return errors;
   }
 
   if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  return metadata;
+}
+
+function validateMetadataEmoji(metadata) {
+  const errors = [];
+  const parsed = parseMetadata(metadata);
+
+  if (!parsed) {
     errors.push(
       'Required field "metadata.emoji" is missing. Skills must have an emoji in metadata.',
     );
     return errors;
   }
 
-  const emoji = metadata.emoji;
-  if (typeof emoji !== "string" || emoji.length === 0) {
+  const hasEmoji =
+    (typeof parsed.emoji === "string" && parsed.emoji.length > 0) ||
+    (typeof parsed.vellum?.emoji === "string" && parsed.vellum.emoji.length > 0);
+  if (!hasEmoji) {
     errors.push(
       'Required field "metadata.emoji" is missing or empty. Skills must have an emoji in metadata.',
+    );
+  }
+
+  return errors;
+}
+
+function validateMetadataDisplayName(name, metadata) {
+  const errors = [];
+
+  if (typeof name !== "string" || !name.includes("-")) {
+    return errors;
+  }
+
+  const parsed = parseMetadata(metadata);
+  const displayName = parsed?.vellum?.["display-name"];
+  if (typeof displayName !== "string" || displayName.length === 0) {
+    errors.push(
+      'Hyphenated skill names must define metadata.vellum.display-name with a human-readable catalog label.',
     );
   }
 
@@ -306,7 +324,14 @@ function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
     );
   }
 
-  // 6. Check for non-standard fields and recommend migration
+  // 6. Validate metadata.vellum.display-name for hyphenated first-party slugs
+  errors.push(
+    ...validateMetadataDisplayName(frontmatter.name, frontmatter.metadata).map(
+      (e) => `${prefix}: ${e}`,
+    ),
+  );
+
+  // 7. Check for non-standard fields and recommend migration
   errors.push(
     ...validateNonStandardFields(frontmatter).map(
       (e) => `${prefix}: ${e}`,

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -12,8 +12,10 @@
 - **Follow the [Agent Skills specification](https://agentskills.io/specification)**
   - All skills must conform to the spec's SKILL.md format: required YAML frontmatter (`name`, `description`), optional fields (`license`, `compatibility`, `metadata`, `allowed-tools`), and Markdown body
   - The `name` field must match the parent directory name, use only lowercase alphanumeric characters and hyphens (1-64 chars), and must not start/end with a hyphen or contain consecutive hyphens
+  - Hyphenated skill names must include `metadata.vellum.display-name` with a human-readable catalog label
   - Use the spec's directory structure: `SKILL.md` at root, `scripts/` for executable code, `references/` for supplementary docs, `assets/` for static resources
   - Follow progressive disclosure: keep `description` keyword-rich for discovery (~100 tokens), keep `SKILL.md` body under 500 lines (< 5000 tokens recommended), and move detailed reference material to `references/`
+  - After editing skills, run `node scripts/skills/generate-catalog.mjs`, `node scripts/skills/lint-skill-spec.mjs`, and `node scripts/skills/check-catalog.mjs`
 
 - **API interactions use Vellum's outbound proxy**
   - Outbound network traffic from the bash tool is automatically intercepted by an outbound proxy in a manner that's transparent to the assistant

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -468,7 +468,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-14T12:47:52-05:00"
+      "updatedAt": "2026-05-14T19:52:02-05:00"
     },
     {
       "id": "outlook",


### PR DESCRIPTION
## Summary
Reduce recurring Codex setup and review friction with repo-owned preflight, skill metadata validation, PR/CI inspection tooling, and focused Slack content persistence contracts.

## Changes
- Add `scripts/agent-preflight.mjs` and documentation for quick agent environment checks.
- Require display names for hyphenated first-party skills and refresh the skill catalog.
- Add `scripts/pr-check-summary.mjs` for stable GitHub PR check inspection.
- Add focused Slack `displayContent` and raw content persistence regression tests.

## Milestone PRs (merged into feature branch)
- #30917: Add agent preflight checks
- #30918: Require display names for hyphenated skills
- #30919: Add PR check summary helper
- #30926: Codify Slack content persistence contracts

## Project issue
Closes #30912

## Test plan
- [x] `node scripts/agent-preflight.mjs`
- [x] `node --check scripts/agent-preflight.mjs`
- [x] `node scripts/skills/lint-skill-spec.mjs`
- [x] `node scripts/skills/check-catalog.mjs`
- [x] `node --check scripts/pr-check-summary.mjs`
- [x] `node scripts/pr-check-summary.mjs 30918`
- [x] `cd assistant && bun test src/__tests__/process-message-display-content.test.ts`
- [x] `cd assistant && bun test src/__tests__/thread-backfill.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->