### PR TITLE
Persist and serialize Slack conversation channel binding

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -7,6 +7,15 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    slack: {
+      teamId: "T123",
+      teamUrl: "https://example.slack.com/",
+    },
+  }),
+}));
+
 import { eq } from "drizzle-orm";
 
 import {
@@ -421,6 +430,7 @@ describe("channel-delivery-store", () => {
       conversationId: result.conversationId,
       sourceChannel: "slack",
       externalChatId: "C0123ABCDEF",
+      externalChatName: "engineering",
       externalThreadId: "1710000000.000100",
     });
 
@@ -429,10 +439,52 @@ describe("channel-delivery-store", () => {
     expect(detail?.conversation.channelBinding).toMatchObject({
       sourceChannel: "slack",
       externalChatId: "C0123ABCDEF",
+      externalChatName: "engineering",
       externalThreadId: "1710000000.000100",
       slackThread: {
         channelId: "C0123ABCDEF",
         threadTs: "1710000000.000100",
+        link: {
+          appUrl:
+            "slack://channel?team=T123&id=C0123ABCDEF&message=1710000000.000100",
+          webUrl:
+            "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+        },
+      },
+      slackChannel: {
+        channelId: "C0123ABCDEF",
+        name: "engineering",
+        link: {
+          webUrl: "https://example.slack.com/archives/C0123ABCDEF",
+        },
+      },
+    });
+  });
+
+  test("conversation detail exposes Slack channel id fallback without stored channel name", () => {
+    const result = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+    });
+
+    const detail = buildConversationDetailResponse(result.conversationId);
+
+    expect(detail?.conversation.channelBinding).toMatchObject({
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalChatName: "C0123ABCDEF",
+      slackChannel: {
+        channelId: "C0123ABCDEF",
+        name: "C0123ABCDEF",
+        link: {
+          webUrl: "https://example.slack.com/archives/C0123ABCDEF",
+        },
       },
     });
   });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -95,6 +95,7 @@ import {
   migrateDropSetupSkillIdColumn,
   migrateDropSimplifiedMemory,
   migrateDropUsageCompositeIndexes,
+  migrateExternalConversationBindingChatName,
   migrateExternalConversationBindingThreadId,
   migrateFkCascadeRebuilds,
   migrateGuardianActionFollowup,
@@ -430,6 +431,7 @@ export function initializeDb(): void {
     migrateExternalConversationBindingThreadId,
     createOnboardingEventsTable,
     migrateNormalizeSlackExternalContent,
+    migrateExternalConversationBindingChatName,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -16,6 +16,7 @@ export interface ExternalConversationBinding {
   conversationId: string;
   sourceChannel: string;
   externalChatId: string;
+  externalChatName?: string | null;
   externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
@@ -30,6 +31,7 @@ export interface UpsertBindingInput {
   conversationId: string;
   sourceChannel: string;
   externalChatId: string;
+  externalChatName?: string | null;
   externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
@@ -43,6 +45,13 @@ function normalizeExternalThreadId(
   return trimmed ? trimmed : null;
 }
 
+function normalizeExternalChatName(
+  externalChatName?: string | null,
+): string | null {
+  const trimmed = externalChatName?.trim();
+  return trimmed ? trimmed : null;
+}
+
 /**
  * Insert or update an external conversation binding on conflict (conversationId).
  * On conflict, updates channel metadata and timestamps.
@@ -51,6 +60,7 @@ export function upsertBinding(input: UpsertBindingInput): void {
   const db = getDb();
   const now = Date.now();
   const externalThreadId = normalizeExternalThreadId(input.externalThreadId);
+  const externalChatName = normalizeExternalChatName(input.externalChatName);
 
   // If a stale binding exists for this channel/chat/thread tuple under a
   // different conversationId, remove it first so the unique index is not violated.
@@ -75,6 +85,7 @@ export function upsertBinding(input: UpsertBindingInput): void {
       conversationId: input.conversationId,
       sourceChannel: input.sourceChannel,
       externalChatId: input.externalChatId,
+      externalChatName,
       externalThreadId,
       externalUserId: input.externalUserId ?? null,
       displayName: input.displayName ?? null,
@@ -88,6 +99,7 @@ export function upsertBinding(input: UpsertBindingInput): void {
       set: {
         sourceChannel: input.sourceChannel,
         externalChatId: input.externalChatId,
+        externalChatName,
         externalThreadId,
         externalUserId: input.externalUserId ?? null,
         displayName: input.displayName ?? null,

--- a/assistant/src/memory/migrations/109-external-conversation-bindings.ts
+++ b/assistant/src/memory/migrations/109-external-conversation-bindings.ts
@@ -11,6 +11,7 @@ export function createExternalConversationBindingsTables(
       conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
       source_channel TEXT NOT NULL,
       external_chat_id TEXT NOT NULL,
+      external_chat_name TEXT,
       external_thread_id TEXT,
       external_user_id TEXT,
       display_name TEXT,

--- a/assistant/src/memory/migrations/250-external-conversation-binding-chat-name.ts
+++ b/assistant/src/memory/migrations/250-external-conversation-binding-chat-name.ts
@@ -1,0 +1,43 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_external_conversation_binding_chat_name_v1";
+
+export function migrateExternalConversationBindingChatName(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    if (
+      tableHasColumn(
+        database,
+        "external_conversation_bindings",
+        "external_chat_name",
+      )
+    ) {
+      return;
+    }
+
+    database.run(
+      `ALTER TABLE external_conversation_bindings ADD COLUMN external_chat_name TEXT`,
+    );
+  });
+}
+
+export function downExternalConversationBindingChatName(
+  database: DrizzleDb,
+): void {
+  if (
+    !tableHasColumn(
+      database,
+      "external_conversation_bindings",
+      "external_chat_name",
+    )
+  ) {
+    return;
+  }
+
+  database.run(
+    `ALTER TABLE external_conversation_bindings DROP COLUMN external_chat_name`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -215,6 +215,10 @@ export {
   migrateNormalizeSlackExternalContent,
 } from "./249-normalize-slack-external-content.js";
 export {
+  downExternalConversationBindingChatName,
+  migrateExternalConversationBindingChatName,
+} from "./250-external-conversation-binding-chat-name.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -49,6 +49,7 @@ import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.j
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
 import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
 import { downNormalizeSlackExternalContent } from "./249-normalize-slack-external-content.js";
+import { downExternalConversationBindingChatName } from "./250-external-conversation-binding-chat-name.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -419,6 +420,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Normalize legacy persisted Slack external_content wrappers back to raw message content",
     down: downNormalizeSlackExternalContent,
+  },
+  {
+    key: "migration_external_conversation_binding_chat_name_v1",
+    version: 49,
+    description:
+      "Add external_chat_name to external conversation bindings for channel footer metadata",
+    down: downExternalConversationBindingChatName,
   },
 ];
 

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -78,6 +78,7 @@ export const externalConversationBindings = sqliteTable(
       .references(() => conversations.id, { onDelete: "cascade" }),
     sourceChannel: text("source_channel").notNull(),
     externalChatId: text("external_chat_id").notNull(),
+    externalChatName: text("external_chat_name"),
     externalThreadId: text("external_thread_id"),
     externalUserId: text("external_user_id"),
     displayName: text("display_name"),

--- a/assistant/src/messaging/providers/slack/deep-link.ts
+++ b/assistant/src/messaging/providers/slack/deep-link.ts
@@ -57,6 +57,16 @@ export function buildSlackWebMessageUrl(params: {
   return `${baseUrl}?${search.toString()}`;
 }
 
+export function buildSlackWebChannelUrl(params: {
+  teamUrl?: string | null;
+  channelId: string;
+}): string | undefined {
+  const teamUrl = normalizeSlackTeamUrl(params.teamUrl);
+  if (!teamUrl) return undefined;
+
+  return `${teamUrl}/archives/${encodeURIComponent(params.channelId)}`;
+}
+
 export function buildSlackMessageDeepLinks(params: {
   teamId?: string | null;
   teamUrl?: string | null;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -543,10 +543,17 @@ export async function handleChannelInbound({
   // self so assistant-scoped legacy routes do not overwrite each other's
   // channel binding metadata for the same chat.
   if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
+    const slackChannelName =
+      sourceChannel === "slack" &&
+      typeof sourceMetadata?.channelName === "string"
+        ? sourceMetadata.channelName
+        : null;
+
     upsertBinding({
       conversationId: result.conversationId,
       sourceChannel,
       externalChatId: conversationExternalId,
+      externalChatName: slackChannelName,
       externalThreadId: slackThreadTs ?? null,
       externalUserId: canonicalSenderId ?? rawSenderId ?? null,
       displayName: body.actorDisplayName ?? null,

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -23,7 +23,10 @@ import {
 } from "../../memory/conversation-crud.js";
 import type { ExternalConversationBinding } from "../../memory/external-conversation-store.js";
 import { getBindingsForConversations } from "../../memory/external-conversation-store.js";
-import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
+import {
+  buildSlackMessageDeepLinks,
+  buildSlackWebChannelUrl,
+} from "../../messaging/providers/slack/deep-link.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,10 +94,11 @@ function buildForkParent(
 }
 
 function buildChannelBinding(binding: ExternalConversationBinding) {
+  const externalChatName =
+    binding.externalChatName?.trim() ||
+    (binding.sourceChannel === "slack" ? binding.externalChatId : undefined);
   const slackConfig =
-    binding.sourceChannel === "slack" && binding.externalThreadId
-      ? getConfig().slack
-      : undefined;
+    binding.sourceChannel === "slack" ? getConfig().slack : undefined;
   const slackThreadLink =
     slackConfig && binding.externalThreadId
       ? buildSlackMessageDeepLinks({
@@ -112,10 +116,31 @@ function buildChannelBinding(binding: ExternalConversationBinding) {
           ...(slackThreadLink ? { link: slackThreadLink } : {}),
         }
       : undefined;
+  const slackChannelWebUrl = slackConfig
+    ? buildSlackWebChannelUrl({
+        teamUrl: slackConfig.teamUrl,
+        channelId: binding.externalChatId,
+      })
+    : undefined;
+  const slackChannel =
+    binding.sourceChannel === "slack"
+      ? {
+          channelId: binding.externalChatId,
+          name: externalChatName,
+          ...(slackChannelWebUrl
+            ? {
+                link: {
+                  webUrl: slackChannelWebUrl,
+                },
+              }
+            : {}),
+        }
+      : undefined;
 
   return {
     sourceChannel: binding.sourceChannel,
     externalChatId: binding.externalChatId,
+    ...(externalChatName ? { externalChatName } : {}),
     ...(binding.externalThreadId
       ? { externalThreadId: binding.externalThreadId }
       : {}),
@@ -123,6 +148,7 @@ function buildChannelBinding(binding: ExternalConversationBinding) {
     displayName: binding.displayName,
     username: binding.username,
     ...(slackThread ? { slackThread } : {}),
+    ...(slackChannel ? { slackChannel } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Persist Slack channel names on external conversation bindings.
- Serialize Slack channel id, name, and link data for conversation summaries.

Part of plan: slack-channel-sender-ui.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->