### PR TITLE
fix: only thread-link Slack replies

### DIFF
--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -259,6 +259,51 @@ describe("handleListMessages page=latest", () => {
     });
   });
 
+  test("top-level Slack messages with matching threadTs use plain permalinks", () => {
+    const conv = createConversation();
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "msg-slack-top-level",
+        conversationId: conv.id,
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Slack top-level" }]),
+        metadata: JSON.stringify({
+          slackMeta: writeSlackMetadata({
+            source: "slack",
+            channelId: "C123ABCDEF",
+            channelName: "engineering",
+            channelTs: "1710000000.000200",
+            threadTs: "1710000000.000200",
+            displayName: "Alice",
+            actorExternalUserId: "U_ALICE",
+            eventKind: "message",
+          }),
+        }),
+        createdAt: 1,
+      })
+      .run();
+
+    const body = callList({ conversationId: conv.id, page: "latest" });
+
+    expect(body.messages[0].slackMessage).toEqual({
+      channelId: "C123ABCDEF",
+      channelName: "engineering",
+      channelTs: "1710000000.000200",
+      threadTs: "1710000000.000200",
+      sender: {
+        displayName: "Alice",
+        externalUserId: "U_ALICE",
+      },
+      messageLink: {
+        appUrl:
+          "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000200",
+        webUrl:
+          "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
+      },
+    });
+  });
+
   test("page=latest on unresolved conversationKey returns null metadata contract", () => {
     const body = callList({
       conversationKey: "no-such-key",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -154,19 +154,23 @@ function buildSlackHistoryMessage(
   if (!slackMeta) return undefined;
 
   const slackConfig = getConfig().slack;
+  const replyThreadTs =
+    slackMeta.threadTs && slackMeta.threadTs !== slackMeta.channelTs
+      ? slackMeta.threadTs
+      : undefined;
   const messageLink = buildSlackMessageDeepLinks({
     teamId: slackConfig?.teamId,
     teamUrl: slackConfig?.teamUrl,
     channelId: slackMeta.channelId,
     messageTs: slackMeta.channelTs,
-    ...(slackMeta.threadTs ? { threadTs: slackMeta.threadTs } : {}),
+    ...(replyThreadTs ? { threadTs: replyThreadTs } : {}),
   });
-  const threadLink = slackMeta.threadTs
+  const threadLink = replyThreadTs
     ? buildSlackMessageDeepLinks({
         teamId: slackConfig?.teamId,
         teamUrl: slackConfig?.teamUrl,
         channelId: slackMeta.channelId,
-        messageTs: slackMeta.threadTs,
+        messageTs: replyThreadTs,
       })
     : undefined;
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for slack-channel-sender-ui.md.

**Gap:** Top-level Slack messages with threadTs equal to channelTs opened as thread links.
**Fix:** Only include thread query params for actual thread replies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->