### PR TITLE
fix: preserve Slack channel binding names

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -61,6 +61,7 @@ function resetTables() {
   db.run("DELETE FROM channel_inbound_events");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM external_conversation_bindings");
   db.run("DELETE FROM conversations");
 }
 
@@ -487,6 +488,57 @@ describe("channel-delivery-store", () => {
         },
       },
     });
+  });
+
+  test("binding upsert preserves existing chat name when incoming name is missing", () => {
+    const result = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalChatName: "engineering",
+      externalThreadId: "1710000000.000100",
+    });
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+    });
+
+    expect(
+      getBindingByChannelChatThread("slack", "C0123ABCDEF", "1710000000.000100")
+        ?.externalChatName,
+    ).toBe("engineering");
+  });
+
+  test("binding upsert preserves existing chat name when incoming name is blank", () => {
+    const result = recordInbound("slack", "C0123ABCDEF", "msg-1", {
+      sourceThreadId: "1710000000.000100",
+    });
+
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalChatName: "engineering",
+      externalThreadId: "1710000000.000100",
+    });
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalChatName: "   ",
+      externalThreadId: "1710000000.000100",
+    });
+
+    expect(
+      getBindingByChannelChatThread("slack", "C0123ABCDEF", "1710000000.000100")
+        ?.externalChatName,
+    ).toBe("engineering");
   });
 
   // ── Deduplication ─────────────────────────────────────────────────

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -7,7 +7,7 @@
  * list APIs.
  */
 
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
 import { externalConversationBindings } from "./schema.js";
@@ -99,7 +99,9 @@ export function upsertBinding(input: UpsertBindingInput): void {
       set: {
         sourceChannel: input.sourceChannel,
         externalChatId: input.externalChatId,
-        externalChatName,
+        externalChatName:
+          externalChatName ??
+          sql`${externalConversationBindings.externalChatName}`,
         externalThreadId,
         externalUserId: input.externalUserId ?? null,
         displayName: input.displayName ?? null,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -168,6 +168,10 @@ export async function handleChannelInbound({
   }
 
   const sourceChannel = body.sourceChannel;
+  const slackChannelName =
+    sourceChannel === "slack" && typeof sourceMetadata?.channelName === "string"
+      ? sourceMetadata.channelName.trim() || null
+      : null;
 
   if (!body.interface || typeof body.interface !== "string") {
     throw new BadRequestError("interface is required");
@@ -543,12 +547,6 @@ export async function handleChannelInbound({
   // self so assistant-scoped legacy routes do not overwrite each other's
   // channel binding metadata for the same chat.
   if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    const slackChannelName =
-      sourceChannel === "slack" &&
-      typeof sourceMetadata?.channelName === "string"
-        ? sourceMetadata.channelName
-        : null;
-
     upsertBinding({
       conversationId: result.conversationId,
       sourceChannel,
@@ -1054,10 +1052,7 @@ export async function handleChannelInbound({
         sourceChannel === "slack"
           ? {
               channelId: conversationExternalId,
-              ...(typeof sourceMetadata?.channelName === "string" &&
-              sourceMetadata.channelName.trim().length > 0
-                ? { channelName: sourceMetadata.channelName.trim() }
-                : {}),
+              ...(slackChannelName ? { channelName: slackChannelName } : {}),
               channelTs: sourceMessageId ?? externalMessageId,
               ...(slackThreadTs ? { threadTs: slackThreadTs } : {}),
               ...((body.actorDisplayName ?? body.actorUsername)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for slack-channel-sender-ui.md.

**Gap:** Missing channelName metadata could clear an existing persisted Slack channel name.
**Fix:** Normalize channelName once and preserve existing binding names when incoming names are missing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->