### PR TITLE
fix: expose Slack channel binding fields in typed contracts

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -224,6 +224,7 @@ export interface ConversationTitleUpdated {
 interface ChannelBinding {
   sourceChannel: ChannelId;
   externalChatId: string;
+  externalChatName?: string | null;
   externalThreadId?: string | null;
   externalUserId?: string | null;
   displayName?: string | null;
@@ -233,6 +234,13 @@ interface ChannelBinding {
     threadTs: string;
     link?: {
       appUrl?: string;
+      webUrl?: string;
+    };
+  };
+  slackChannel?: {
+    channelId: string;
+    name?: string;
+    link?: {
       webUrl?: string;
     };
   };

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -576,19 +576,69 @@ public struct CancelRequest: Codable, Sendable {
 }
 
 /// Channel binding metadata exposed in conversation list APIs.
+public struct ChannelBindingSlackThreadLink: Codable, Sendable {
+    public let appUrl: String?
+    public let webUrl: String?
+
+    public init(appUrl: String? = nil, webUrl: String? = nil) {
+        self.appUrl = appUrl
+        self.webUrl = webUrl
+    }
+}
+
+public struct ChannelBindingSlackThread: Codable, Sendable {
+    public let channelId: String
+    public let threadTs: String
+    public let link: ChannelBindingSlackThreadLink?
+
+    public init(channelId: String, threadTs: String, link: ChannelBindingSlackThreadLink? = nil) {
+        self.channelId = channelId
+        self.threadTs = threadTs
+        self.link = link
+    }
+}
+
+public struct ChannelBindingSlackChannelLink: Codable, Sendable {
+    public let webUrl: String?
+
+    public init(webUrl: String? = nil) {
+        self.webUrl = webUrl
+    }
+}
+
+public struct ChannelBindingSlackChannel: Codable, Sendable {
+    public let channelId: String
+    public let name: String?
+    public let link: ChannelBindingSlackChannelLink?
+
+    public init(channelId: String, name: String? = nil, link: ChannelBindingSlackChannelLink? = nil) {
+        self.channelId = channelId
+        self.name = name
+        self.link = link
+    }
+}
+
 public struct ChannelBinding: Codable, Sendable {
     public let sourceChannel: String
     public let externalChatId: String
+    public let externalChatName: String?
+    public let externalThreadId: String?
     public let externalUserId: String?
     public let displayName: String?
     public let username: String?
+    public let slackThread: ChannelBindingSlackThread?
+    public let slackChannel: ChannelBindingSlackChannel?
 
-    public init(sourceChannel: String, externalChatId: String, externalUserId: String? = nil, displayName: String? = nil, username: String? = nil) {
+    public init(sourceChannel: String, externalChatId: String, externalChatName: String? = nil, externalThreadId: String? = nil, externalUserId: String? = nil, displayName: String? = nil, username: String? = nil, slackThread: ChannelBindingSlackThread? = nil, slackChannel: ChannelBindingSlackChannel? = nil) {
         self.sourceChannel = sourceChannel
         self.externalChatId = externalChatId
+        self.externalChatName = externalChatName
+        self.externalThreadId = externalThreadId
         self.externalUserId = externalUserId
         self.displayName = displayName
         self.username = username
+        self.slackThread = slackThread
+        self.slackChannel = slackChannel
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for slack-channel-sender-ui.md.

**Gap:** Serialized Slack channel binding fields were missing from public typed contracts.
**Fix:** Add optional channel name/link fields to ChannelBinding contracts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->