### PR TITLE
fix(ci): allow dispatch-ios-release when build-chrome-extension is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2641,7 +2641,7 @@ jobs:
         && needs.push-assistant-manifest.result == 'success'
         && needs.push-gateway-manifest.result == 'success'
         && needs.push-credential-executor-manifest.result == 'success'
-        && needs.build-chrome-extension.result == 'success'
+        && (needs.build-chrome-extension.result == 'success' || needs.build-chrome-extension.result == 'skipped')
         && (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
         && (needs.publish-meta.result == 'success' || needs.publish-meta.result == 'skipped')
         && (needs.push-dockerhub-image.result == 'success' || needs.push-dockerhub-image.result == 'skipped')


### PR DESCRIPTION
Closes LUM-1583

## Problem

The v0.8.2 production release had no iOS build. The `dispatch-ios-release` job was silently skipped because its `if` condition required `needs.build-chrome-extension.result == 'success'` — but `build-chrome-extension` is conditionally run only when the chrome extension has meaningful code changes. When skipped, GitHub Actions sets the result to `'skipped'`, not `'success'`, so the iOS dispatch never fires.

This is the first patch release where: (a) no chrome extension code changed between tags (only `manifest.json`/`package.json`, which are excluded from the diff check), and (b) the major.minor version didn't bump (0.8 → 0.8), so the force-build heuristic didn't trigger either.

A prior fix in `56703b5ccd` addressed the same class of bug for `ci-playwright` but missed `build-chrome-extension`.

## Fix

Accept `'skipped'` alongside `'success'` for `build-chrome-extension`, matching the pattern already used on the adjacent lines for `publish-npm`, `publish-meta`, and `push-dockerhub-image`.

## Root cause analysis

1. **How did the code get into this state?** The `dispatch-ios-release` job was added with `build-chrome-extension` as a hard `== 'success'` gate, likely copied from the `release` job's dependency list without considering that `build-chrome-extension` is conditional.
2. **What led to it?** The conditionally-skippable nature of `build-chrome-extension` wasn't accounted for when wiring dependencies. The inconsistency with the `|| 'skipped'` pattern on adjacent lines was a warning sign.
3. **Warning signs missed?** The fix for `ci-playwright` (`56703b5ccd`) was a near-identical issue — that fix should have prompted an audit of all other dependencies in the same condition block.
4. **Prevention:** When adding conditional jobs as dependencies, always use the `|| 'skipped'` pattern unless the downstream job genuinely cannot run without the upstream's artifacts.

## Test plan

- The fix is a single-line workflow condition change; no unit test is possible.
- Verified the `if` expression syntax matches the existing pattern on adjacent lines.
- Confirmed no other jobs in `release.yml` gate on `build-chrome-extension.result` without handling `'skipped'` (only the Slack notification job references it, for display only).

## Human review checklist

- [ ] Verify the `if` expression is syntactically valid (parentheses balanced, `||` operator correct)
- [ ] Confirm iOS release dispatch genuinely has no dependency on chrome extension build artifacts
- [ ] Consider whether any _other_ conditional jobs in the `needs` list (e.g. `build-macos-arm64`, `build-macos-x64`) could have the same latent issue — those are currently unconditional, so they're safe today, but worth noting

Link to Devin session: https://app.devin.ai/sessions/c8b8163a922d49f8b3e877d93e7214f9
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->