### PR TITLE
Fix macOS chat layout stall diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -30,6 +30,7 @@ final class MessageListScrollState {
     @ObservationIgnored var scrollContainerHeight: CGFloat = 0
     @ObservationIgnored var lastContentOffsetY: CGFloat = 0
     @ObservationIgnored var viewportHeight: CGFloat = .infinity
+    @ObservationIgnored var lastTranscriptDiagnosticsAt: Date = .distantPast
 
     // MARK: - State
 
@@ -178,6 +179,7 @@ final class MessageListScrollState {
         scrollContainerHeight = 0
         lastContentOffsetY = 0
         viewportHeight = .infinity
+        lastTranscriptDiagnosticsAt = .distantPast
         showScrollToLatest = false
         anchorSetTime = nil
         anchorTimeoutTask?.cancel()
@@ -219,6 +221,7 @@ final class MessageListScrollState {
         scrollContainerHeight = 0
         lastContentOffsetY = 0
         viewportHeight = .infinity
+        lastTranscriptDiagnosticsAt = .distantPast
         showScrollToLatest = false
         scrollIndicatorsHidden = false
         lastPaginationCompletedAt = .distantPast

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -52,6 +52,7 @@ extension MessageListView {
         if !isSending {
             scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
         }
+        recordTranscriptDiagnosticsSnapshot(reason: "appear", force: true)
         // Handle pending anchor if already set.
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
@@ -109,9 +110,12 @@ extension MessageListView {
                 UserDefaults.standard.set(true, forKey: "hasEverSentMessage")
             }
         }
+        recordTranscriptDiagnosticsSnapshot(reason: isSending ? "sending_started" : "sending_stopped", force: true)
     }
 
     func handleMessagesRevisionChanged() {
+        recordTranscriptDiagnosticsSnapshot(reason: "messages_revision")
+
         // Queued-turn handoff updates message status without changing count.
         // Re-check the pin anchor so it advances to the dequeued user message.
         guard conversationId == scrollState.currentConversationId,
@@ -124,6 +128,8 @@ extension MessageListView {
     func handleMessagesCountChanged() {
         // Guard against stale fires during a conversation switch.
         guard conversationId == scrollState.currentConversationId else { return }
+        recordTranscriptDiagnosticsSnapshot(reason: "messages_count", force: true)
+
         // --- Anchor message resolution ---
         if let id = anchorMessageId,
            let displayId = TranscriptItems.displayId(for: id, in: messages) {
@@ -214,6 +220,86 @@ extension MessageListView {
         // With inverted scroll, the latest messages appear at the visual
         // bottom naturally — no imperative scroll needed.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
+        recordTranscriptDiagnosticsSnapshot(reason: "conversation_switched", force: true)
+    }
+
+    // MARK: - Transcript Diagnostics
+
+    /// Updates the content-safe snapshot used by hang diagnostics and log
+    /// exports. This intentionally records only identifiers, counts, flags,
+    /// and geometry - never message text, tool bodies, or attachment content.
+    func recordTranscriptDiagnosticsSnapshot(
+        reason: String,
+        force: Bool = false,
+        isLiveScrolling: Bool? = nil
+    ) {
+        guard let conversationId else { return }
+        if let currentConversationId = scrollState.currentConversationId,
+           currentConversationId != conversationId {
+            return
+        }
+
+        let now = Date()
+        if !force && now.timeIntervalSince(scrollState.lastTranscriptDiagnosticsAt) < 1.0 {
+            return
+        }
+        scrollState.lastTranscriptDiagnosticsAt = now
+
+        var sanitizer = NumericSanitizer()
+        let offsetY = sanitizer.sanitize(scrollState.lastContentOffsetY, field: "scrollOffsetY")
+        let contentHeight = sanitizer.sanitize(scrollState.scrollContentHeight, field: "contentHeight")
+        let containerHeight = sanitizer.sanitize(scrollState.scrollContainerHeight, field: "viewportHeight")
+        let scrollViewportHeight = sanitizer.sanitize(viewportHeight, field: "scrollViewportHeight")
+        let currentContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
+        let distanceFromBottom = scrollState.distanceFromBottom
+        let isNearBottom = distanceFromBottom.isFinite
+            ? distanceFromBottom <= MessageListScrollState.hideScrollToLatestThreshold
+            : nil
+        let toolCallCount = messages.reduce(0) { total, message in
+            total + message.toolCalls.count
+        }
+
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: conversationId.uuidString,
+            capturedAt: now,
+            messageCount: messages.count,
+            toolCallCount: toolCallCount,
+            isPinnedToBottom: isNearBottom ?? false,
+            isUserScrolling: isLiveScrolling ?? false,
+            scrollOffsetY: offsetY,
+            contentHeight: contentHeight,
+            viewportHeight: containerHeight,
+            isNearBottom: isNearBottom,
+            hasBeenInteracted: scrollState.scrollContentHeight > 0 || scrollState.lastContentOffsetY > 0,
+            isPaginationInFlight: scrollState.isPaginationInFlight,
+            scrollMode: scrollState.isStreamingActive ? "streaming" : "idle",
+            anchorMessageId: scrollState.pinnedLatestTurnAnchorMessageId?.uuidString,
+            highlightedMessageId: highlightedMessageId?.uuidString,
+            scrollViewportHeight: scrollViewportHeight,
+            containerWidth: currentContainerWidth,
+            lastScrollToReason: reason,
+            source: .messageList,
+            scrollIntentSource: scrollState.isStreamingActive ? .followBottom : nil,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        )
+        ChatDiagnosticsStore.shared.updateSnapshot(snapshot)
+
+        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+            kind: .transcriptSnapshotCaptured,
+            conversationId: conversationId.uuidString,
+            reason: reason,
+            messageCount: messages.count,
+            toolCallCount: toolCallCount,
+            isPinnedToBottom: isNearBottom,
+            isUserScrolling: isLiveScrolling,
+            scrollOffsetY: offsetY,
+            contentHeight: contentHeight,
+            viewportHeight: containerHeight,
+            source: .messageList,
+            interaction: scrollState.isStreamingActive ? .stream : nil,
+            scrollIntentSource: scrollState.isStreamingActive ? .followBottom : nil,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        ))
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -59,6 +59,12 @@ extension MessageListView {
         // --- Distance-based scroll-to-latest CTA ---
         scrollState.updateScrollToLatest()
 
+        // --- Content-safe hang diagnostics ---
+        recordTranscriptDiagnosticsSnapshot(
+            reason: "scroll_geometry",
+            isLiveScrolling: newState.isLiveScrolling
+        )
+
         // --- Pagination ---
         // With inverted scroll the visual top (oldest messages) is where
         // distanceFromTop approaches 0. Negate so the sentinel's

--- a/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
@@ -19,25 +19,30 @@ public struct BottomAlignedMinHeightLayout: Layout {
         self.minHeight = minHeight
     }
 
-    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    public func makeCache(subviews: Subviews) -> SingleSubviewLayoutCache {
+        SingleSubviewLayoutCache()
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGSize {
         guard let child = subviews.first else {
             return CGSize(width: proposal.replacingUnspecifiedDimensions().width, height: minHeight)
         }
         let childSize = child.sizeThatFits(proposal)
+        cache.store(proposal: proposal, childSize: childSize)
         return CGSize(
             width: childSize.width,
             height: max(childSize.height, minHeight)
         )
     }
 
-    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) {
         guard let child = subviews.first else { return }
-        // Re-measure with the SAME proposal that sizeThatFits received.
-        // Using bounds.height would propose the expanded min-height to the
-        // child, which can return a different size than during measurement
-        // — causing SwiftUI to detect a layout inconsistency and
-        // re-evaluate the layout every frame.
-        let childSize = child.sizeThatFits(proposal)
+        // Reuse the measurement from sizeThatFits. Falling back to the same
+        // proposal preserves layout consistency without forcing a second
+        // transcript-wide measurement during placement.
+        let childSize = cache.childSize(for: proposal) {
+            child.sizeThatFits(proposal)
+        }
         // Pin child to bottom of bounds (same as alignment: .bottom).
         let y = bounds.maxY - childSize.height
         child.place(

--- a/clients/shared/DesignSystem/Modifiers/CenterAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/CenterAlignedMinHeightLayout.swift
@@ -18,25 +18,30 @@ public struct CenterAlignedMinHeightLayout: Layout {
         self.minHeight = minHeight
     }
 
-    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    public func makeCache(subviews: Subviews) -> SingleSubviewLayoutCache {
+        SingleSubviewLayoutCache()
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGSize {
         guard let child = subviews.first else {
             return CGSize(width: proposal.replacingUnspecifiedDimensions().width, height: minHeight)
         }
         let childSize = child.sizeThatFits(proposal)
+        cache.store(proposal: proposal, childSize: childSize)
         return CGSize(
             width: childSize.width,
             height: max(childSize.height, minHeight)
         )
     }
 
-    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) {
         guard let child = subviews.first else { return }
-        // Re-measure with the SAME proposal that sizeThatFits received.
-        // Using bounds.height would propose the expanded min-height to the
-        // child, which can return a different size than during measurement
-        // — causing SwiftUI to detect a layout inconsistency and
-        // re-evaluate the layout every frame.
-        let childSize = child.sizeThatFits(proposal)
+        // Reuse the measurement from sizeThatFits. Falling back to the same
+        // proposal preserves layout consistency without forcing a second
+        // subtree-wide measurement during placement.
+        let childSize = cache.childSize(for: proposal) {
+            child.sizeThatFits(proposal)
+        }
         // Vertically center child within bounds (same as default
         // `.frame(minHeight:)` alignment of `.center`).
         let y = bounds.midY - childSize.height / 2

--- a/clients/shared/DesignSystem/Modifiers/SingleSubviewLayoutCache.swift
+++ b/clients/shared/DesignSystem/Modifiers/SingleSubviewLayoutCache.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Caches the last child measurement for single-child `Layout` wrappers.
+///
+/// SwiftUI normally calls `sizeThatFits` before `placeSubviews` with the same
+/// proposal. Reusing that measurement avoids a second walk through expensive
+/// descendants such as chat transcript `LazyVStack`s.
+public struct SingleSubviewLayoutCache {
+    private var proposalWidth: CGFloat?
+    private var proposalHeight: CGFloat?
+    private var childSize: CGSize?
+
+    public init() {}
+
+    mutating func store(proposal: ProposedViewSize, childSize: CGSize) {
+        proposalWidth = proposal.width
+        proposalHeight = proposal.height
+        self.childSize = childSize
+    }
+
+    mutating func childSize(for proposal: ProposedViewSize, measuring measure: () -> CGSize) -> CGSize {
+        if proposalWidth == proposal.width,
+           proposalHeight == proposal.height,
+           let childSize {
+            return childSize
+        }
+
+        let measured = measure()
+        store(proposal: proposal, childSize: measured)
+        return measured
+    }
+}

--- a/clients/shared/DesignSystem/Modifiers/TopAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/TopAlignedMinHeightLayout.swift
@@ -19,25 +19,30 @@ public struct TopAlignedMinHeightLayout: Layout {
         self.minHeight = minHeight
     }
 
-    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    public func makeCache(subviews: Subviews) -> SingleSubviewLayoutCache {
+        SingleSubviewLayoutCache()
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGSize {
         guard let child = subviews.first else {
             return CGSize(width: proposal.replacingUnspecifiedDimensions().width, height: minHeight)
         }
         let childSize = child.sizeThatFits(proposal)
+        cache.store(proposal: proposal, childSize: childSize)
         return CGSize(
             width: childSize.width,
             height: max(childSize.height, minHeight)
         )
     }
 
-    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) {
         guard let child = subviews.first else { return }
-        // Re-measure with the SAME proposal that sizeThatFits received.
-        // Using bounds.height would propose the expanded min-height to the
-        // child, which can return a different size than during measurement
-        // — causing SwiftUI to detect a layout inconsistency and
-        // re-evaluate the layout every frame.
-        let childSize = child.sizeThatFits(proposal)
+        // Reuse the measurement from sizeThatFits. Falling back to the same
+        // proposal preserves layout consistency without forcing a second
+        // subtree-wide measurement during placement.
+        let childSize = cache.childSize(for: proposal) {
+            child.sizeThatFits(proposal)
+        }
         // Pin child to top of bounds (same as alignment: .top).
         child.place(
             at: bounds.origin,

--- a/clients/shared/Tests/SingleSubviewLayoutCacheTests.swift
+++ b/clients/shared/Tests/SingleSubviewLayoutCacheTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import XCTest
+@testable import VellumAssistantShared
+
+final class SingleSubviewLayoutCacheTests: XCTestCase {
+    func testReusesMeasurementForSameProposal() {
+        var cache = SingleSubviewLayoutCache()
+        let proposal = ProposedViewSize(width: 320, height: nil)
+        var measurementCount = 0
+
+        let first = cache.childSize(for: proposal) {
+            measurementCount += 1
+            return CGSize(width: 320, height: 120)
+        }
+        let second = cache.childSize(for: proposal) {
+            measurementCount += 1
+            return CGSize(width: 320, height: 999)
+        }
+
+        XCTAssertEqual(first, CGSize(width: 320, height: 120))
+        XCTAssertEqual(second, first)
+        XCTAssertEqual(measurementCount, 1)
+    }
+
+    func testRemeasuresWhenProposalChanges() {
+        var cache = SingleSubviewLayoutCache()
+        var measurementCount = 0
+
+        _ = cache.childSize(for: ProposedViewSize(width: 320, height: nil)) {
+            measurementCount += 1
+            return CGSize(width: 320, height: 120)
+        }
+        let changed = cache.childSize(for: ProposedViewSize(width: 480, height: nil)) {
+            measurementCount += 1
+            return CGSize(width: 480, height: 150)
+        }
+
+        XCTAssertEqual(changed, CGSize(width: 480, height: 150))
+        XCTAssertEqual(measurementCount, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- Cache single-child SwiftUI layout measurements for min-height wrappers so chat transcript placement does not remeasure the whole LazyVStack.
- Record content-safe transcript snapshots during chat lifecycle and scroll events so future hang-context captures include counts, geometry, and streaming state.
- Add focused cache regression tests.

## Investigation
- A live macOS sample of the frozen app showed the main thread at 100% CPU inside SwiftUI layout, with `BottomAlignedMinHeightLayout.placeSubviews` leading back through `FixedWidthLayout.sizeThatFits` and the chat `LazyVStack`.
- The existing hang context had stall events but no transcript snapshots, so future captures needed more UI-side state to make this diagnosable without another manual sample.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SingleSubviewLayoutCacheTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ChatDiagnosticsStoreTests`

Closes #30937

Apple refs checked (2026-05-16): https://developer.apple.com/documentation/swiftui/layout, https://developer.apple.com/documentation/swiftui/layout/cache, https://developer.apple.com/documentation/swiftui/composing-custom-layouts-with-swiftui
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->