### PR TITLE
Fix min-height layout alignment cache signatures

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
@@ -66,11 +66,11 @@ public struct BottomAlignedMinHeightLayout: Layout {
     /// child via `placeSubviews`, not alignment guides.
     ///
     /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu)
-    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 
-    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 }

--- a/clients/shared/DesignSystem/Modifiers/CenterAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/CenterAlignedMinHeightLayout.swift
@@ -63,11 +63,11 @@ public struct CenterAlignedMinHeightLayout: Layout {
     /// child via `placeSubviews`, not alignment guides.
     ///
     /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu)
-    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 
-    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 }

--- a/clients/shared/DesignSystem/Modifiers/TopAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/TopAlignedMinHeightLayout.swift
@@ -65,11 +65,11 @@ public struct TopAlignedMinHeightLayout: Layout {
     /// child via `placeSubviews`, not alignment guides.
     ///
     /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu)
-    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 
-    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout SingleSubviewLayoutCache) -> CGFloat? {
         nil
     }
 }

--- a/clients/shared/Tests/MinHeightLayoutAlignmentSignatureTests.swift
+++ b/clients/shared/Tests/MinHeightLayoutAlignmentSignatureTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import XCTest
+
+final class MinHeightLayoutAlignmentSignatureTests: XCTestCase {
+    func testMinHeightExplicitAlignmentOverridesUseLayoutCacheType() throws {
+        let layoutFiles = [
+            "BottomAlignedMinHeightLayout.swift",
+            "CenterAlignedMinHeightLayout.swift",
+            "TopAlignedMinHeightLayout.swift",
+        ]
+        let modifiersDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("DesignSystem/Modifiers")
+
+        for fileName in layoutFiles {
+            let sourceURL = modifiersDirectory.appendingPathComponent(fileName)
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            let explicitAlignmentLines = source
+                .split(separator: "\n")
+                .filter { $0.contains("explicitAlignment(of guide:") }
+
+            XCTAssertEqual(explicitAlignmentLines.count, 2, "\(fileName) should override both explicitAlignment variants")
+
+            for line in explicitAlignmentLines {
+                XCTAssertTrue(
+                    line.contains("cache: inout SingleSubviewLayoutCache"),
+                    "\(fileName) explicitAlignment overload must use the layout cache type"
+                )
+                XCTAssertFalse(
+                    line.contains("cache: inout ()"),
+                    "\(fileName) explicitAlignment overload no longer matches Layout.Cache"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Update all three min-height layout `explicitAlignment` overrides to use `SingleSubviewLayoutCache`, keeping them active after the cache-type change from #30938.
- Add a focused source-level guard test so future cache changes do not silently turn those SwiftUI protocol overrides into inert overloads.

## Original prompt
Automated review comments on #30938 flagged that the SwiftUI `explicitAlignment` overrides still used `cache: inout ()` after the layouts switched to `SingleSubviewLayoutCache`. The goal was to verify the comments and ship a follow-up fix immediately so the layout-stall mitigation keeps its O(1) alignment behavior.

## Validation
- `git diff --check --cached`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter MinHeightLayoutAlignmentSignatureTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SingleSubviewLayoutCacheTests`

Closes #30939

Apple refs checked (2026-05-16): https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu, https://developer.apple.com/documentation/swiftui/layout/cache
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->