### PR TITLE
fix(memory): clear cached graph injection when memory is disabled

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -363,7 +363,14 @@ export class ConversationGraphMemory {
       metrics: null as RetrievalMetrics | null,
     };
 
-    if (!config.memory.enabled) return noopResult;
+    if (!config.memory.enabled) {
+      // Clear any cached injection so a later overflow-reduction
+      // re-injection via `reinjectCachedMemory()` cannot reintroduce a
+      // stale <memory> block after the user disables memory.
+      this.lastInjectedBlock = null;
+      this.lastInjectedNodeIds = [];
+      return noopResult;
+    }
 
     // Gate: skip for empty/tool-result-only messages — unless we need to
     // reload after compaction (needsReload) or haven't initialized yet.


### PR DESCRIPTION
Followup to #30861.

Codex flagged that the early-return on `!config.memory.enabled` in `ConversationGraphMemory.prepareMemory` left `lastInjectedBlock` / `lastInjectedNodeIds` untouched. If memory had already been injected earlier in a conversation and the user then flipped `memory.enabled` off, a later overflow-reduction cycle in `conversation-agent-loop.ts` could call `reinjectCachedMemory()` and reintroduce the stale `<memory>` block — violating the disable-memory contract added in #30861.

Fix: clear the cached block and node IDs at the gate point before returning. `reinjectCachedMemory()` already short-circuits when `lastInjectedBlock` is null, so the trusted-actor reinjection path now correctly returns the messages unchanged once memory is off.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->