### PR TITLE
fix(macos): flush partial output before clearing turn tracking

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -854,9 +854,8 @@ final class ChatActionHandler {
                 }
             }
         }
-        vm.clearCurrentTurnTracking()
-        vm.discardStreamingBuffer()
         vm.flushPartialOutputBuffer()
+        vm.clearCurrentTurnTracking()
         vm.dispatchPendingSendDirect()
     }
 
@@ -1369,8 +1368,8 @@ final class ChatActionHandler {
                 }
             }
         }
-        vm.clearCurrentTurnTracking()
         vm.flushPartialOutputBuffer()
+        vm.clearCurrentTurnTracking()
         // When the user intentionally cancelled, suppress the error.
         // Otherwise, set error state so the UI shows the error banner.
         if !wasCancelling {

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -42,11 +42,11 @@ extension ChatViewModel {
                 messages[index].thinkingSegments.append(text)
                 messages[index].contentOrder.append(.thinking(segIdx))
             }
-        } else if currentAssistantMessageId != nil {
-            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(text.count) buffered thinking chars")
-            currentAssistantMessageId = nil
-            return
         } else {
+            if let staleId = currentAssistantMessageId {
+                log.warning("Stale currentAssistantMessageId \(staleId.uuidString) — promoting buffered \(text.count) thinking chars to new message")
+                currentAssistantMessageId = nil
+            }
             var msg = ChatMessage(role: .assistant, text: "", isStreaming: true)
             msg.thinkingSegments = [text]
             msg.contentOrder = [.thinking(0)]


### PR DESCRIPTION
Followup to #30825.

## Problem

#30825 moved \`discardStreamingBuffer()\` and \`discardPartialOutputBuffer()\` into \`clearCurrentTurnTracking()\` to prevent stale flushes from creating orphan messages. But two callers in \`ChatActionHandler\` intentionally call \`flushPartialOutputBuffer()\` AFTER \`clearCurrentTurnTracking()\` to preserve tool-call output through cancel/error. With the new code, that flush became a no-op — accumulated tool output (e.g. partial bash stdout) was silently dropped.

## Fix

- \`handleGenerationCancelled\`: flush partial output BEFORE clearing turn tracking. Drop the now-redundant \`discardStreamingBuffer()\` (clearCurrentTurnTracking already discards it).
- \`handleConversationError\`: same — flush before clear.

## Secondary: thinking stale-ID symmetry

Devin also flagged asymmetry in \`ChatViewModel+StreamingHelpers\`: \`appendTextToCurrentMessage\` promotes buffered text to a new message on stale ID, but \`appendThinkingToCurrentMessage\` discarded thinking text. Since \`flushStreamingBuffer()\` calls \`flushThinkingBuffer()\` first, a stale flush could lose thinking content before the text flush salvaged itself. Made thinking symmetric — promote to a new message instead of discarding.

Addresses review comments from Codex and Devin on #30825.