### PR TITLE
fix(macos): preserve scroll delta when anchor reference exits viewport

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift
@@ -455,12 +455,17 @@ struct MessageListScrollObserver: NSViewRepresentable {
         ///
         /// Reference identity is stored as an *index path* from
         /// `documentView` (e.g. `"0/2"`). On each emit we re-resolve the
-        /// path to whatever `NSView` is currently there. If it still
-        /// intersects the viewport and has non-zero height, we diff its
-        /// `minY` against the cached value. If the path no longer
-        /// resolves (LazyVStack removed a slot, structure shifted) or the
-        /// view at the path no longer intersects the viewport, we pick a
-        /// new path and return `0` — no compensation on the pick-frame.
+        /// path to whatever `NSView` is currently there. While the
+        /// resolved view still has non-zero height we diff its `minY`
+        /// against the cached value — even if it has been pushed outside
+        /// the viewport by a large upstream reflow, since that final
+        /// delta is exactly the shift we need to compensate for. When the
+        /// reference no longer intersects the viewport we still report
+        /// the delta, then pick a fresh in-viewport reference so the
+        /// next emit can keep tracking. If the path no longer resolves
+        /// (LazyVStack removed a slot, structure shifted) or the view
+        /// collapsed to zero height, we have no reliable previous-Y to
+        /// diff against, so we pick a new path and return `0`.
         ///
         /// Returning `0` is also what's expected on the first emit after
         /// attach: `anchorReferencePath` is `nil`, we pick one, and the
@@ -478,18 +483,32 @@ struct MessageListScrollObserver: NSViewRepresentable {
             )
             if let path = anchorReferencePath,
                let view = resolvePath(path, from: documentView),
-               isViewUsable(view, in: documentView, viewport: viewport) {
+               view.frame.height > 0 {
                 let currentY = view.convert(.zero, to: documentView).y
                 let delta = currentY - lastReferenceY
-                lastReferenceY = currentY
+                let frameInDoc = view.convert(view.bounds, to: documentView)
+                if frameInDoc.intersects(viewport) {
+                    lastReferenceY = currentY
+                    return delta
+                }
+                // Reference was pushed outside the viewport on this emit
+                // (large upstream reflow — image load, thinking-block
+                // expansion, history correction). Apply its final delta
+                // as compensation, then pick a new in-viewport reference
+                // so subsequent emits keep tracking visible content.
+                pickAndStoreReference(in: documentView, viewport: viewport)
                 return delta
             }
             // Path invalid — pick a new one. No delta on this emit since
             // there's no previous-Y to diff against.
+            pickAndStoreReference(in: documentView, viewport: viewport)
+            return 0
+        }
+
+        private func pickAndStoreReference(in documentView: NSView, viewport: CGRect) {
             let pick = pickAnchorReferencePath(in: documentView, viewport: viewport)
             anchorReferencePath = pick?.path
             lastReferenceY = pick?.view.convert(.zero, to: documentView).y ?? 0
-            return 0
         }
 
         /// Walks `path` (e.g. `"0/2"`) from `root`, returning the resolved
@@ -505,16 +524,6 @@ struct MessageListScrollObserver: NSViewRepresentable {
                 current = current.subviews[index]
             }
             return current === root ? nil : current
-        }
-
-        /// A view at the resolved path is still usable when it has a
-        /// non-zero height and still intersects the viewport. Anything
-        /// else means the LazyVStack pushed it offscreen — pick a new
-        /// reference rather than tracking a stale position.
-        private func isViewUsable(_ view: NSView, in documentView: NSView, viewport: CGRect) -> Bool {
-            guard view.frame.height > 0 else { return false }
-            let frameInDoc = view.convert(view.bounds, to: documentView)
-            return frameInDoc.intersects(viewport)
         }
 
         /// Picks an anchor reference path from the materialized subtree of

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift
@@ -266,9 +266,20 @@ struct ScrollDebugOverlayView: View {
 
     /// A skip that accompanied a real content-height change is a compensation
     /// we missed — this is the class of event the telemetry is meant to flag.
+    ///
+    /// `.noVisibleShift` skips are explicitly excluded: under the
+    /// reference-based compensation model, streaming tokens grow
+    /// `contentHDelta` without moving any visible row, and the preserver
+    /// correctly skips those frames. Flagging them red would make the HUD
+    /// flash on every streaming token — i.e. precisely during the scenario
+    /// the reference-based formulation is designed to handle correctly.
     static func isMissedCompensation(_ event: ScrollAnchorDecisionEvent?) -> Bool {
         guard let event else { return false }
-        if case .skipped = event.outcome, event.contentHDelta != 0 { return true }
+        if case .skipped(let reason) = event.outcome,
+           reason != .noVisibleShift,
+           event.contentHDelta != 0 {
+            return true
+        }
         return false
     }
 }


### PR DESCRIPTION
Followup to #30833 addressing review comments.

## Changes

**Codex P1** — `MessageListScrollObserver.swift`: When a large reflow above the viewport pushes the tracked anchor reference completely outside the viewport between emits, the previous code returned \`0\` (no compensation) and repicked a fresh reference, reintroducing a visible jump for image loads / thinking-block expansion / history correction. Now we still compute and return the delta from the old reference's prior position before invalidating it, then pick a new in-viewport reference for subsequent emits. The path-resolves-but-collapsed-to-zero-height case still returns \`0\` since the position is unreliable.

**Devin** — \`ScrollDebugOverlayView.swift\`: \`isMissedCompensation\` was flagging every \`.noVisibleShift\` skip with a non-zero \`contentHDelta\` as a missed compensation, which is the canonical *correct* behavior under the reference-based compensation model (streaming tokens grow content height without moving any visible row). Exclude \`.noVisibleShift\` from the red-flash check so the debug HUD doesn't flash on every streamed token.

Also factored the duplicated reference-repick block into a small helper.

## Files
- \`clients/macos/vellum-assistant/Features/Chat/MessageListScrollObserver.swift\`
- \`clients/macos/vellum-assistant/Features/Chat/ScrollDebugOverlayView.swift\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->