### PR TITLE
fix(macos/settings): gate setActiveProfile drift on ordering, not value equality

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -139,6 +139,15 @@ public final class SettingsStore: ObservableObject {
     /// re-apply over this confirmed value.
     private var lastConfirmedSetActiveProfileGen: Int = 0
 
+    /// Monotonic counter incremented every time `loadInferenceProfiles`
+    /// updates `lastConfirmedActiveProfile` from a daemon-pushed config.
+    /// Each `setActiveProfile` call captures this at entry; if it advances
+    /// during the await, an external confirmation landed mid-flight and
+    /// the success branch must defer to it. Counting events rather than
+    /// comparing values catches no-op-looking drifts (e.g. X→Y→X) that a
+    /// value-equality check would miss.
+    private var externalActiveProfileConfirmationGen: Int = 0
+
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
         "gemini-3-pro-image-preview",
@@ -3296,6 +3305,7 @@ public final class SettingsStore: ObservableObject {
         if let active = (llm?["activeProfile"] as? String).flatMap({ $0.isEmpty ? nil : $0 }) {
             self.activeProfile = active
             self.lastConfirmedActiveProfile = active
+            externalActiveProfileConfirmationGen += 1
         }
     }
 
@@ -3331,29 +3341,33 @@ public final class SettingsStore: ObservableObject {
     /// Each call captures a monotonic generation at entry. After the await,
     /// post-PATCH mutation is gated on whether a *newer* pick is still
     /// "live" — i.e. either still in flight or already successfully
-    /// confirmed — and on whether the daemon-confirmed value was updated
-    /// out-of-band (e.g. by a `loadInferenceProfiles` push from another
-    /// client/session). This distinguishes three race scenarios:
+    /// confirmed — and on whether an external daemon push confirmed a
+    /// value mid-flight (tracked by `externalActiveProfileConfirmationGen`,
+    /// which advances every time `loadInferenceProfiles` lands an
+    /// authoritative `activeProfile`). This distinguishes three race
+    /// scenarios:
     ///
     /// 1. A→B both succeed, A late: B's success advances
     ///    `lastConfirmedSetActiveProfileGen` past A. A's late success sees
     ///    that and skips entirely, so it does not stomp B.
     /// 2. A→B-fails-and-reverts→A late success: B never confirms, so
-    ///    `lastConfirmedSetActiveProfileGen` is unchanged and
-    ///    `lastConfirmedActiveProfile` was never touched during A's call.
-    ///    By the time A's success arrives, B is no longer in flight
-    ///    either. No newer pick is live, so A applies fully — re-syncing
-    ///    `activeProfile` from the post-revert "balanced" back to the
-    ///    daemon-confirmed "A".
-    /// 3. A in flight → external load pushes "C" → A late success: the
-    ///    push updates `lastConfirmedActiveProfile` to "C". A's success
-    ///    branch detects the snapshot drift and skips, leaving the
-    ///    daemon-pushed value intact instead of stomping it back to "A".
+    ///    `lastConfirmedSetActiveProfileGen` is unchanged and no external
+    ///    confirmation arrived during A's call. By the time A's success
+    ///    arrives, B is no longer in flight either. No newer pick is live,
+    ///    so A applies fully — re-syncing `activeProfile` from the
+    ///    post-revert "balanced" back to the daemon-confirmed "A".
+    /// 3. A in flight → external load confirms a daemon-pushed value → A
+    ///    late success: the push advances
+    ///    `externalActiveProfileConfirmationGen`. A's success branch
+    ///    detects the bump and skips, leaving the daemon-pushed value
+    ///    intact. The counter catches the drift even when the external
+    ///    push happens to land the same string twice (X→Y→X) where a
+    ///    value-equality check would miss it.
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
         setActiveProfileGenerationCounter += 1
         let myGen = setActiveProfileGenerationCounter
-        let confirmedAtEntry = lastConfirmedActiveProfile
+        let externalConfirmationGenAtEntry = externalActiveProfileConfirmationGen
         inFlightSetActiveProfileGens.insert(myGen)
         self.activeProfile = name
         let success = await settingsClient.patchConfig([
@@ -3363,10 +3377,11 @@ public final class SettingsStore: ObservableObject {
 
         let newerPickLive = lastConfirmedSetActiveProfileGen > myGen
             || inFlightSetActiveProfileGens.contains(where: { $0 > myGen })
-        let confirmedChangedExternally = lastConfirmedActiveProfile != confirmedAtEntry
+        let externalConfirmationArrived =
+            externalActiveProfileConfirmationGen != externalConfirmationGenAtEntry
 
         if success {
-            if !newerPickLive, !confirmedChangedExternally {
+            if !newerPickLive, !externalConfirmationArrived {
                 lastConfirmedActiveProfile = name
                 self.activeProfile = name
                 lastConfirmedSetActiveProfileGen = myGen

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -307,9 +307,9 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
     /// flight, the older local PATCH must not stomp the newer daemon-pushed
     /// value once it finally succeeds. The user picks "A"; while the PATCH
     /// is suspended, a config push updates the authoritative value to "C";
-    /// "A"'s late success must observe the snapshot drift on
-    /// `lastConfirmedActiveProfile` and leave both `activeProfile` and
-    /// `lastConfirmedActiveProfile` set to "C".
+    /// "A"'s late success must observe the external-confirmation generation
+    /// bump and leave both `activeProfile` and `lastConfirmedActiveProfile`
+    /// set to "C".
     func testSetActiveProfileDoesNotStompExternalConfirmedUpdate() async {
         var continuationA: CheckedContinuation<Bool, Never>?
         let aSuspended = expectation(description: "A PATCH suspended")
@@ -336,9 +336,9 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertEqual(store.activeProfile, "C")
 
         // A's late success arrives. Even though no newer local pick is
-        // live, the snapshot of `lastConfirmedActiveProfile` taken at
-        // entry no longer matches — so the success branch must skip its
-        // writes and leave the daemon-pushed value intact.
+        // live, the external-confirmation generation captured at entry no
+        // longer matches — so the success branch must skip its writes and
+        // leave the daemon-pushed value intact.
         continuationA?.resume(returning: true)
         let aSucceeded = await resultA
         XCTAssertTrue(aSucceeded)
@@ -355,6 +355,58 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         let dSucceeded = await store.setActiveProfile("D")
         XCTAssertFalse(dSucceeded)
         XCTAssertEqual(store.activeProfile, "C")
+    }
+
+    /// Generation-counter drift detection must trigger even when the
+    /// external push lands the same string twice during the await — a
+    /// value-equality check (the predecessor of this guard) would miss
+    /// the drift entirely because `lastConfirmedActiveProfile` ends up
+    /// matching the snapshot taken at entry. The user picks "A"; while
+    /// suspended, the daemon pushes "C" then "A"; A's late success must
+    /// still defer to the external confirmations rather than re-asserting
+    /// its own write.
+    func testSetActiveProfileDefersToExternalConfirmationsEvenWhenValueRoundtrips() async {
+        var continuationA: CheckedContinuation<Bool, Never>?
+        let aSuspended = expectation(description: "A PATCH suspended")
+        mockSettingsClient.patchConfigHandler = { _ in
+            return await withCheckedContinuation { cont in
+                continuationA = cont
+                aSuspended.fulfill()
+            }
+        }
+
+        async let resultA: Bool = store.setActiveProfile("A")
+        await fulfillment(of: [aSuspended], timeout: 1.0)
+
+        // Two external confirmations land while A is in flight; the
+        // second restores the same string A was originally writing.
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "C",
+                "profiles": ["C": ["model": "claude-sonnet-4-6"]],
+            ]
+        ])
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "A",
+                "profiles": ["A": ["model": "claude-haiku-4-5"]],
+            ]
+        ])
+
+        continuationA?.resume(returning: true)
+        let aSucceeded = await resultA
+        XCTAssertTrue(aSucceeded)
+        XCTAssertEqual(store.activeProfile, "A")
+
+        // A failed pick must revert to the externally-confirmed "A"
+        // (preserved by the daemon's push), not to a stale value the
+        // success branch might have re-confirmed had drift detection
+        // relied on string equality.
+        mockSettingsClient.patchConfigHandler = nil
+        mockSettingsClient.patchConfigResponse = false
+        let bSucceeded = await store.setActiveProfile("B")
+        XCTAssertFalse(bSucceeded)
+        XCTAssertEqual(store.activeProfile, "A")
     }
 
     // MARK: - setProfile


### PR DESCRIPTION
## Summary

Addresses Codex P1 feedback on #30898: the new drift guard used value
comparison (\`lastConfirmedActiveProfile != confirmedAtEntry\`) to detect
out-of-band confirmations during an in-flight \`setActiveProfile\` PATCH.
Value equality misses no-op-looking round trips (e.g. external push
toggles X→Y→X during the await), and the equality signal itself doesn't
carry ordering information.

This PR replaces the value snapshot with a monotonic
\`externalActiveProfileConfirmationGen\` counter that advances every time
\`loadInferenceProfiles\` lands an authoritative \`activeProfile\`. The
\`setActiveProfile\` success branch captures the counter at entry and
treats any bump as authoritative — consistent with the existing
generation-counter pattern already used to gate stale picks.

## Test plan

- [x] Existing \`testSetActiveProfileDoesNotStompExternalConfirmedUpdate\`
  still passes (doc and inline comments updated to match counter
  semantics).
- [x] New
  \`testSetActiveProfileDefersToExternalConfirmationsEvenWhenValueRoundtrips\`
  exercises the X→Y→X case where the predecessor value check would have
  silently missed the drift.
- [x] Other \`setActiveProfile\` race tests in
  \`SettingsStoreInferenceProfilesTests\` remain valid (counter is only
  bumped from external pushes; local PATCH writes are still gated by the
  pick generation, not this counter).