### PR TITLE
fix(app-control): preserve confirmed session when older overlapping start arrives last

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -42,6 +42,7 @@ mock.module("../runtime/pending-interactions.js", () => ({
 const {
   HostAppControlProxy,
   _getActiveAppControlSession,
+  _getConfirmedAppControlSession,
   _resetActiveAppControlSession,
   _setActiveAppControlSession,
 } = await import("../daemon/host-app-control-proxy.js");
@@ -822,6 +823,71 @@ describe("HostAppControlProxy", () => {
       const session = _getActiveAppControlSession();
       expect(session?.conversationId).toBe("conv-1");
       expect(session?.app).toBe("com.example.a");
+
+      proxy.dispose();
+    });
+
+    test("both-succeed older-arrives-last does not overwrite newer confirmed session", async () => {
+      // Two same-conversation starts both succeed, but the older one's
+      // `running` response arrives AFTER the newer one's. With a
+      // conversation-only ownership guard, the older response would
+      // overwrite the newer confirmed session — a latent bug that surfaces
+      // on a subsequent rollback. Verify the confirmed pointer stays on the
+      // newer session (C), and that a later rollback restores to C, not A.
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      const pA = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.a" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdA = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+
+      sentMessages.length = 0;
+      const pC = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.c" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdC = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // C succeeds first → active = C, confirmed = C.
+      proxy.resolve(reqIdC, payload({ pngBase64: PNG_A }));
+      await pC;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+      expect(_getConfirmedAppControlSession()?.app).toBe("com.example.c");
+
+      // A succeeds second (older arrives last). The conversation-ownership
+      // check passes for A, but A is no longer the live optimistic write
+      // and a session is already confirmed — must NOT overwrite confirmed.
+      proxy.resolve(reqIdA, payload({ pngBase64: PNG_B }));
+      await pA;
+      expect(_getConfirmedAppControlSession()?.app).toBe("com.example.c");
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // A later restart D that fails must roll back to C (the true
+      // confirmed), not to A — guards against the latent-bug case.
+      sentMessages.length = 0;
+      const pD = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.d" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdD = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(reqIdD, payload({ state: "missing" }));
+      await pD;
+
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.c");
 
       proxy.dispose();
     });

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -112,6 +112,13 @@ export function _getActiveAppControlSession():
   return activeAppControlSession;
 }
 
+/** Test-only helper: read the last host-confirmed session. */
+export function _getConfirmedAppControlSession():
+  | ActiveAppControlSession
+  | undefined {
+  return confirmedAppControlSession;
+}
+
 /** Test-only helper: clear both session pointers between test cases. */
 export function _resetActiveAppControlSession(): void {
   activeAppControlSession = undefined;
@@ -373,7 +380,19 @@ export class HostAppControlProxy extends HostProxyBase<
     if (activeAppControlSession?.conversationId !== attempted.conversationId) {
       return;
     }
-    confirmedAppControlSession = attempted;
+    // Promote when this start is still the live optimistic write (normal
+    // path) OR when no session has been confirmed yet — the latter covers
+    // a late-arriving `running` for an older overlapping start whose
+    // optimistic write was superseded but whose host confirmation is
+    // still ground-truth. Without the `confirmedAppControlSession == null`
+    // branch, two overlapping starts that both succeed would let the
+    // later-arriving older response overwrite the newer confirmed session.
+    if (
+      activeAppControlSession === attempted ||
+      confirmedAppControlSession == null
+    ) {
+      confirmedAppControlSession = attempted;
+    }
   }
 
   /**


### PR DESCRIPTION
Followup to #30799 addressing Codex P2 + Devin BUG-0001 feedback.

Both reviewers found a race in promoteStartIfCurrent: if two same-conversation starts both succeed but the older response arrives last, the conversation-ownership guard lets the stale older confirmation overwrite the newer confirmed session. A subsequent rollback then restores from the stale pointer.

Fix: only overwrite confirmedAppControlSession when the attempt is still the live optimistic write OR no session has been confirmed yet. The second branch preserves #30799's intent (late-arriving running for an older overlapping start whose optimistic write was superseded but host confirmation is ground-truth) while preventing the regression.

Added test for the both-succeed-older-arrives-last scenario.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->