### PR TITLE
feat(memory): use participant display names in retrospective transcript

### DIFF
--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -64,18 +64,36 @@ function extractAnalysisText(blocks: ContentBlock[]): string {
   return parts.join("\n");
 }
 
-function formatRole(role: string): string {
-  return role === "user" ? "User" : "Assistant";
+export interface TranscriptFormatOptions {
+  timeZone?: string;
+  assistantName?: string | null;
+  userName?: string | null;
+}
+
+function resolveName(
+  name: string | null | undefined,
+  fallback: string,
+): string {
+  return name && name.length > 0 ? name : fallback;
+}
+
+function formatRole(
+  role: string,
+  options: TranscriptFormatOptions = {},
+): string {
+  return role === "user"
+    ? resolveName(options.userName, "User")
+    : resolveName(options.assistantName, "Assistant");
 }
 
 function formatSubagentMessages(
   msgs: ReturnType<typeof getMessages>,
-  timeZone?: string,
+  options: TranscriptFormatOptions = {},
 ): string {
   const lines: string[] = [];
   for (const msg of msgs) {
-    const role = formatRole(msg.role);
-    const time = formatLocalTimestamp(msg.createdAt, timeZone);
+    const role = formatRole(msg.role, options);
+    const time = formatLocalTimestamp(msg.createdAt, options.timeZone);
     const content = parseContent(msg.content);
     const text = extractAnalysisText(content);
     if (text) {
@@ -110,11 +128,11 @@ type TranscriptMessage = ReturnType<typeof getMessages>[number];
  */
 export function formatMessageSliceForTranscript(
   messages: TranscriptMessage[],
-  options: { timeZone?: string } = {},
+  options: TranscriptFormatOptions = {},
 ): string {
   const lines: string[] = [];
   for (const msg of messages) {
-    appendMessageBlock(lines, msg, options.timeZone);
+    appendMessageBlock(lines, msg, options);
   }
   return lines.join("\n");
 }
@@ -122,10 +140,10 @@ export function formatMessageSliceForTranscript(
 function appendMessageBlock(
   lines: string[],
   msg: TranscriptMessage,
-  timeZone?: string,
+  options: TranscriptFormatOptions = {},
 ): void {
-  const role = formatRole(msg.role);
-  const time = formatLocalTimestamp(msg.createdAt, timeZone);
+  const role = formatRole(msg.role, options);
+  const time = formatLocalTimestamp(msg.createdAt, options.timeZone);
   const content = parseContent(msg.content);
   const text = extractAnalysisText(content);
 
@@ -147,7 +165,7 @@ function appendMessageBlock(
           const subMessages = getMessages(notif.conversationId);
           lines.push(`### Subagent: ${notif.label} (${notif.status})`);
           lines.push("");
-          lines.push(formatSubagentMessages(subMessages, timeZone));
+          lines.push(formatSubagentMessages(subMessages, options));
           lines.push("");
         }
       }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -68,19 +68,39 @@ mock.module("../conversation-crud.js", () => ({
 let transcriptFormatterCalls: Array<{
   messageIds: string[];
   timeZone?: string;
+  assistantName?: string | null;
+  userName?: string | null;
 }> = [];
 
 mock.module("../../export/transcript-formatter.js", () => ({
   formatMessageSliceForTranscript: (
     messages: Array<{ id: string; createdAt: number }>,
-    options: { timeZone?: string } = {},
+    options: {
+      timeZone?: string;
+      assistantName?: string | null;
+      userName?: string | null;
+    } = {},
   ) => {
     transcriptFormatterCalls.push({
       messageIds: messages.map((m) => m.id),
       timeZone: options.timeZone,
+      assistantName: options.assistantName,
+      userName: options.userName,
     });
     return messages.map((m) => `[msg ${m.id}]`).join("\n");
   },
+}));
+
+let mockAssistantName: string | null = "Bob";
+let mockUserName: string | null = "Alice";
+
+mock.module("../../daemon/identity-helpers.js", () => ({
+  getAssistantName: () => mockAssistantName,
+  resolveUserName: (_workspaceDir: string) => mockUserName,
+}));
+
+mock.module("../../util/platform.js", () => ({
+  getWorkspaceDir: () => "/tmp/test-workspace",
 }));
 
 mock.module("../conversation-bootstrap.js", () => ({
@@ -178,6 +198,8 @@ describe("memoryRetrospectiveJob", () => {
     bootstrapCalls = [];
     deletedConversationIds = [];
     transcriptFormatterCalls = [];
+    mockAssistantName = "Bob";
+    mockUserName = "Alice";
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -316,6 +338,23 @@ describe("memoryRetrospectiveJob", () => {
 
     const hint = wakeCalls[0]!.hint;
     expect(hint).toContain("Timestamps are in Europe/Berlin.");
+  });
+
+  test("resolved assistant and user display names are passed to the transcript formatter", async () => {
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(transcriptFormatterCalls).toHaveLength(1);
+    expect(transcriptFormatterCalls[0]!.assistantName).toBe("Bob");
+    expect(transcriptFormatterCalls[0]!.userName).toBe("Alice");
+  });
+
+  test("formatter receives null names when identity files are missing — formatter handles fallback", async () => {
+    mockAssistantName = null;
+    mockUserName = null;
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(transcriptFormatterCalls[0]!.assistantName).toBeNull();
+    expect(transcriptFormatterCalls[0]!.userName).toBeNull();
   });
 
   test("non-remember tool_use blocks in the prior retro are ignored", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -34,10 +34,15 @@
 
 import type { AssistantConfig } from "../config/types.js";
 import { resolveTurnTimezoneContext } from "../daemon/date-context.js";
+import {
+  getAssistantName,
+  resolveUserName,
+} from "../daemon/identity-helpers.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { formatMessageSliceForTranscript } from "../export/transcript-formatter.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { bootstrapConversation } from "./conversation-bootstrap.js";
 import {
   deleteConversation,
@@ -126,13 +131,16 @@ export async function memoryRetrospectiveJob(
   // 4. Build prompt. Render message timestamps in the user's clock, not UTC,
   // so the assistant's reasoning about relative times in the slice
   // ("yesterday afternoon", "around dinnertime") matches what the user
-  // actually experienced.
+  // actually experienced. Resolve the assistant and user display names so the
+  // transcript reads as the conversation it was, not as generic role labels.
   const timezoneContext = resolveTurnTimezoneContext({
     configuredUserTimeZone: config.ui.userTimezone ?? null,
     detectedTimezone: config.ui.detectedTimezone ?? null,
   });
   const transcript = formatMessageSliceForTranscript(newMessages, {
     timeZone: timezoneContext.effectiveTimezone,
+    assistantName: getAssistantName(),
+    userName: resolveUserName(getWorkspaceDir()),
   });
   const prompt = buildPrompt({
     transcript,


### PR DESCRIPTION
## Summary
- Thread an optional `{ assistantName, userName }` pair into `formatMessageSliceForTranscript` via the existing `TranscriptFormatOptions` bag (alongside the existing `timeZone`).
- Resolve the names once per retrospective run in `memory-retrospective-job.ts` using the existing `getAssistantName()` / `resolveUserName(getWorkspaceDir())` helpers — same pattern as `memory/v2/router.ts` and `memory/v2/sweep-job.ts`.
- Falls back to `"User"` / `"Assistant"` when a name is missing or empty. `buildAnalysisTranscript` and its callers (`analyze-conversation`) keep the generic labels — they pass no names and hit the defaults.

## Original prompt
The memory retrospective job re-reads a slice of conversation messages and asks the assistant to call `remember` on anything worth saving. The transcript currently labels each block with `## User (...)` / `## Assistant (...)`, which loses identity context the model has everywhere else (system prompt, memory). Switching the labels to the resolved display names lets the retrospective read like the conversation it actually was. The change is scoped narrowly to the retrospective code path — the analyze-conversation export path is intentionally left alone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->