### PR TITLE
fix(openrouter): request reasoning summary so Kimi K2.6 emits visible thinking

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -22,6 +22,7 @@ interface FakeChunk {
     delta: {
       content?: string | null;
       reasoning_content?: string | null;
+      reasoning?: string | null;
       tool_calls?: Array<{
         index: number;
         id?: string;
@@ -215,7 +216,21 @@ function reasoningChunk(
   finish: string | null = null,
 ): FakeChunk {
   return {
-    choices: [{ delta: { reasoning_content: reasoning }, finish_reason: finish }],
+    choices: [
+      { delta: { reasoning_content: reasoning }, finish_reason: finish },
+    ],
+    usage: null,
+    model: "gpt-5.2",
+  };
+}
+
+// OpenRouter spec uses `delta.reasoning` rather than `delta.reasoning_content`.
+function openRouterReasoningChunk(
+  reasoning: string,
+  finish: string | null = null,
+): FakeChunk {
+  return {
+    choices: [{ delta: { reasoning }, finish_reason: finish }],
     usage: null,
     model: "gpt-5.2",
   };
@@ -393,7 +408,10 @@ describe("OpenAIProvider", () => {
       type: "thinking_delta",
       thinking: "Let me think...",
     });
-    expect(events[1]).toEqual({ type: "text_delta", text: "The answer is 42." });
+    expect(events[1]).toEqual({
+      type: "text_delta",
+      text: "The answer is 42.",
+    });
   });
 
   test("reasoning + tool calls orders correctly (thinking → tool_use)", async () => {
@@ -419,6 +437,36 @@ describe("OpenAIProvider", () => {
 
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe("text");
+  });
+
+  test("parses OpenRouter's `delta.reasoning` field into thinking block", async () => {
+    fakeChunks = [
+      openRouterReasoningChunk("Hmm, let me think..."),
+      textChunk("Final answer."),
+      usageChunk(10, 8),
+    ];
+
+    const events: ProviderEvent[] = [];
+    const result = await provider.sendMessage(
+      [userMsg("Hi")],
+      undefined,
+      undefined,
+      {
+        onEvent: (e) => events.push(e),
+      },
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: "thinking",
+      thinking: "Hmm, let me think...",
+      signature: "",
+    });
+    expect(result.content[1]).toEqual({ type: "text", text: "Final answer." });
+    expect(events).toContainEqual({
+      type: "thinking_delta",
+      thinking: "Hmm, let me think...",
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -1388,14 +1436,17 @@ describe("OpenRouterProvider reasoning", () => {
     shouldThrow = null;
   });
 
-  test("sends reasoning.enabled=true when thinking config is present", async () => {
+  test("sends reasoning.enabled=true with default detailed summary when thinking config is present", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
       config: { thinking: { type: "adaptive" } },
     });
 
     expect(lastCreateParams).toBeTruthy();
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: true });
+    expect(lastCreateParams!.reasoning).toEqual({
+      enabled: true,
+      summary: "detailed",
+    });
   });
 
   test("sends reasoning.enabled=false when thinking is explicitly disabled", async () => {
@@ -1458,7 +1509,10 @@ describe("OpenRouterProvider reasoning", () => {
     await retry.sendMessage([userMsg("hi")], undefined, undefined, {
       config: { thinking: { type: "adaptive" } },
     });
-    expect(lastCreateParams!.reasoning).toEqual({ enabled: true });
+    expect(lastCreateParams!.reasoning).toEqual({
+      enabled: true,
+      summary: "detailed",
+    });
   });
 
   test("RetryProvider + OpenRouterProvider disables thinking end-to-end", async () => {

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -116,7 +116,7 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extras.provider).toBe(undefined);
     });
 
-    test("still carries reasoning flag alongside provider.only", () => {
+    test("enables thinking with default detailed summary alongside provider.only", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",
         "x-ai/grok-4.20-beta",
@@ -128,12 +128,12 @@ describe("OpenRouter provider.only plumbing", () => {
         },
       });
       expect(extras).toEqual({
-        reasoning: { enabled: true },
+        reasoning: { enabled: true, summary: "detailed" },
         provider: { only: ["xAI"] },
       });
     });
 
-    test("disabled thinking keeps reasoning disabled alongside provider.only", () => {
+    test("disabled thinking keeps reasoning disabled and omits summary", () => {
       const provider = new ProbeOpenRouterProvider(
         "fake-key",
         "x-ai/grok-4.20-beta",
@@ -147,6 +147,54 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extras).toEqual({
         reasoning: { enabled: false },
         provider: { only: ["xAI"] },
+      });
+    });
+
+    test("nests effort under reasoning and maps `max` to xhigh", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "moonshotai/kimi-k2.6",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { enabled: true },
+          effort: "max",
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "xhigh", summary: "detailed" },
+      });
+    });
+
+    test("honors a per-call summary override", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "moonshotai/kimi-k2.6",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { enabled: true },
+          openrouter: { reasoning: { summary: "concise" } },
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, summary: "concise" },
+      });
+    });
+
+    test("ignores an invalid summary override and falls back to detailed", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "moonshotai/kimi-k2.6",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { enabled: true },
+          openrouter: { reasoning: { summary: "verbose" } },
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, summary: "detailed" },
       });
     });
   });

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -80,7 +80,7 @@ export interface OpenAIChatCompletionsProviderOptions {
  *  passed through explicitly because OpenAI defaults `reasoning_effort` to
  *  "medium" when the field is omitted — the user's opt-out is only honored
  *  when we send it on the wire. */
-const EFFORT_TO_REASONING_EFFORT: Record<
+export const EFFORT_TO_REASONING_EFFORT: Record<
   string,
   NonNullable<
     OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"]
@@ -217,16 +217,21 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 onEvent?.({ type: "thinking_delta", thinking });
               }
               insideThinkBlock = false;
-              pendingContent = pendingContent.substring(closeIdx + "</think>".length);
+              pendingContent = pendingContent.substring(
+                closeIdx + "</think>".length,
+              );
             } else {
-              const partial = final ? 0 : partialTagSuffix(pendingContent, "</think>");
+              const partial = final
+                ? 0
+                : partialTagSuffix(pendingContent, "</think>");
               const safeLen = pendingContent.length - partial;
               if (safeLen > 0) {
                 const thinking = pendingContent.substring(0, safeLen);
                 reasoningText += thinking;
                 onEvent?.({ type: "thinking_delta", thinking });
               }
-              pendingContent = partial > 0 ? pendingContent.substring(safeLen) : "";
+              pendingContent =
+                partial > 0 ? pendingContent.substring(safeLen) : "";
               break;
             }
           } else {
@@ -238,16 +243,21 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 onEvent?.({ type: "text_delta", text });
               }
               insideThinkBlock = true;
-              pendingContent = pendingContent.substring(openIdx + "<think>".length);
+              pendingContent = pendingContent.substring(
+                openIdx + "<think>".length,
+              );
             } else {
-              const partial = final ? 0 : partialTagSuffix(pendingContent, "<think>");
+              const partial = final
+                ? 0
+                : partialTagSuffix(pendingContent, "<think>");
               const safeLen = pendingContent.length - partial;
               if (safeLen > 0) {
                 const t = pendingContent.substring(0, safeLen);
                 contentText += t;
                 onEvent?.({ type: "text_delta", text: t });
               }
-              pendingContent = partial > 0 ? pendingContent.substring(safeLen) : "";
+              pendingContent =
+                partial > 0 ? pendingContent.substring(safeLen) : "";
               break;
             }
           }
@@ -290,9 +300,17 @@ export class OpenAIChatCompletionsProvider implements Provider {
               }
             }
 
-            const reasoningContent = (
-              choice.delta as { reasoning_content?: string | null }
-            ).reasoning_content;
+            // Compatibility providers disagree on the field name: Fireworks /
+            // DeepSeek / Together / Groq stream `reasoning_content`; OpenRouter
+            // (per its ChatAssistantMessage spec) streams `reasoning`. Accept
+            // both so we don't silently drop thinking from either family.
+            const deltaWithReasoning = choice.delta as {
+              reasoning?: string | null;
+              reasoning_content?: string | null;
+            };
+            const reasoningContent =
+              deltaWithReasoning.reasoning_content ??
+              deltaWithReasoning.reasoning;
             if (reasoningContent) {
               reasoningText += reasoningContent;
               onEvent?.({ type: "thinking_delta", thinking: reasoningContent });
@@ -343,11 +361,19 @@ export class OpenAIChatCompletionsProvider implements Provider {
       }
 
       // Build content blocks
-      const finalReasoning = this.parseThinkTags ? reasoningText.trim() : reasoningText;
-      const finalContent = this.parseThinkTags ? contentText.trim() : contentText;
+      const finalReasoning = this.parseThinkTags
+        ? reasoningText.trim()
+        : reasoningText;
+      const finalContent = this.parseThinkTags
+        ? contentText.trim()
+        : contentText;
       const content: ContentBlock[] = [];
       if (finalReasoning) {
-        content.push({ type: "thinking", thinking: finalReasoning, signature: "" });
+        content.push({
+          type: "thinking",
+          thinking: finalReasoning,
+          signature: "",
+        });
       }
       if (finalContent) {
         content.push({ type: "text", text: finalContent });

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,6 +1,9 @@
 import { ProviderError } from "../../util/errors.js";
 import { AnthropicProvider } from "../anthropic/client.js";
-import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+import {
+  EFFORT_TO_REASONING_EFFORT,
+  OpenAIChatCompletionsProvider,
+} from "../openai/chat-completions-provider.js";
 import { isThinkingConfigEnabled } from "../thinking-config.js";
 import type {
   Message,
@@ -51,6 +54,25 @@ export function extractOnlyList(config: unknown): string[] {
   const only = cfg?.openrouter?.only;
   if (!Array.isArray(only)) return [];
   return only.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+// OpenRouter's `reasoning.summary` field controls whether reasoning models emit
+// a human-readable summary alongside (or instead of) encrypted reasoning blocks.
+// Models like Kimi K2.6 return only encrypted `reasoning_details` unless a
+// summary level is requested, so the stream carries no visible thinking content.
+// Default to "detailed" so users see thinking by default; allow per-call
+// override via `config.openrouter.reasoning.summary`. Per OpenRouter's
+// ChatRequestReasoning schema, valid values are "auto" | "concise" | "detailed".
+const VALID_REASONING_SUMMARIES = new Set(["auto", "concise", "detailed"]);
+
+function extractReasoningSummaryOverride(config: unknown): string | undefined {
+  const cfg = config as
+    | { openrouter?: { reasoning?: { summary?: unknown } } }
+    | undefined;
+  const summary = cfg?.openrouter?.reasoning?.summary;
+  return typeof summary === "string" && VALID_REASONING_SUMMARIES.has(summary)
+    ? summary
+    : undefined;
 }
 
 /**
@@ -160,14 +182,30 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   // OpenRouter's unified `reasoning` parameter controls extended thinking on
   // its OpenAI-compatible endpoint. Anthropic models skip this path entirely and
   // go through AnthropicProvider, which receives the native `thinking` object.
+  //
+  // `effort` nests under `reasoning` here (rather than flat `reasoning_effort`)
+  // because OpenRouter's documented `ChatRequestReasoning` shape is the union of
+  // { effort, summary }. `summary` is required for models like Kimi K2.6 that
+  // would otherwise return only encrypted reasoning blocks; we default to
+  // "detailed" and let callers override via `config.openrouter.reasoning.summary`.
   protected override buildExtraCreateParams(
     options?: SendMessageOptions,
   ): Record<string, unknown> {
     const config = options?.config as Record<string, unknown> | undefined;
     const thinkingEnabled = isThinkingConfigEnabled(config?.thinking);
-    const extras: Record<string, unknown> = {
-      reasoning: { enabled: thinkingEnabled },
-    };
+    const effort = config?.effort as string | undefined;
+    const mappedEffort = effort
+      ? EFFORT_TO_REASONING_EFFORT[effort]
+      : undefined;
+    const summaryOverride = extractReasoningSummaryOverride(config);
+    const reasoning: Record<string, unknown> = { enabled: thinkingEnabled };
+    if (mappedEffort) {
+      reasoning.effort = mappedEffort;
+    }
+    if (thinkingEnabled) {
+      reasoning.summary = summaryOverride ?? "detailed";
+    }
+    const extras: Record<string, unknown> = { reasoning };
     const only = extractOnlyList(config);
     if (only.length > 0) {
       const existingProvider = (config?.provider ?? {}) as Record<


### PR DESCRIPTION
## Summary

- OpenRouter requests now send `reasoning.summary: "detailed"` by default (overridable via `config.openrouter.reasoning.summary`), and nest `effort` under `reasoning` to match OpenRouter's documented `ChatRequestReasoning` shape. Without `summary`, reasoning-only models like `moonshotai/kimi-k2.6` return only encrypted `reasoning_details` and no visible thinking ever reaches the UI.
- The chat-completions streaming parser now reads either `delta.reasoning` (OpenRouter's spec) or `delta.reasoning_content` (Fireworks/DeepSeek/Together/Groq convention). Previously OpenRouter-streamed reasoning was silently dropped even when correctly requested.
- **Cost-shape note**: defaulting `summary` to `"detailed"` means OpenRouter will bill for reasoning summary tokens by default when thinking is enabled. This matches user intent (they enabled thinking — they want to see it) and can be downgraded per-call to `"concise"` or `"auto"` via the override.

## Original prompt

The user noticed that reasoning content wasn't coming back from OpenRouter when using Kimi K2.6 and asked whether we needed to set `reasoning.summary: "detailed"`. Investigation confirmed yes — and surfaced a second bug where the streaming parser was reading `delta.reasoning_content` (a Fireworks/DeepSeek field name) instead of OpenRouter's `delta.reasoning`. Both fixes ship together since either alone would still result in no visible thinking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->