### PR TITLE
fix(memory): clear v2 everInjected unconditionally on compaction

### DIFF
--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -177,7 +177,7 @@ const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
 const schema = await import("../../schema.js");
 const { _resetMemoryV2QdrantForTests } = await import("../../v2/qdrant.js");
-const { hydrate: hydrateActivationState } =
+const { hydrate: hydrateActivationState, save: saveActivationState } =
   await import("../../v2/activation-store.js");
 
 // The wiring layer calls `getDb()` to fetch the SQLite handle. We mock
@@ -604,5 +604,37 @@ describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () =>
     expect(next.injectedBlockText).toContain(
       "# memory/concepts/alice-vscode.md",
     );
+  });
+
+  test("clears everInjected entries whose turn exceeds the tracker's currentTurn (zombie drift)", async () => {
+    // Regression: under the prior turn-bounded eviction, entries with `turn >
+    // tracker.currentTurn` survived `onCompacted` forever. This can happen
+    // after a non-graceful shutdown: `everInjected` is persisted every turn
+    // while the tracker snapshot is only persisted on graceful dispose, so a
+    // SIGKILL'd session followed by a reload restores the tracker from an
+    // older snapshot with a lower currentTurn while keeping the high-turn
+    // entries on disk.
+    const conversationId = "conv-test-zombie-drift";
+    const memory = new ConversationGraphMemory(conversationId);
+
+    // Seed the simulated post-crash state directly: tracker stays at
+    // currentTurn=0 (default for a fresh ConversationGraphMemory), while the
+    // persisted row carries everInjected entries from turns 10 and 20 (left
+    // over from a prior session that never disposed cleanly).
+    await saveActivationState(testDbHandle!, conversationId, {
+      messageId: "msg-zombie",
+      state: {},
+      everInjected: [
+        { slug: "alice-vscode", turn: 10 },
+        { slug: "bob-pkg-mgr", turn: 20 },
+      ],
+      currentTurn: 0,
+      updatedAt: 1,
+    });
+
+    await memory.onCompacted(0);
+
+    const after = await hydrateActivationState(testDbHandle!, conversationId);
+    expect(after?.everInjected).toEqual([]);
   });
 });

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -26,7 +26,7 @@ import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
 import {
-  evictCompactedTurns as evictCompactedTurnsV2,
+  clearEverInjected as clearV2EverInjected,
   hydrate as hydrateV2State,
   save as saveV2State,
 } from "../v2/activation-store.js";
@@ -223,15 +223,17 @@ export class ConversationGraphMemory {
     // Mirror the eviction on the v2 activation row: the cached `<memory>`
     // attachments those slugs lived on are gone, but `everInjected` would
     // otherwise keep them deduped from per-turn deltas forever.
+    //
+    // Cleared unconditionally rather than filtered by `upToTurn`: the
+    // tracker's `currentTurn` is only persisted on graceful dispose while
+    // `everInjected` is persisted every turn, so a SIGKILL'd session can
+    // leave entries with `turn > tracker.currentTurn` that a turn-bounded
+    // filter would skip.
     try {
       const db = getDb();
       const state = await hydrateV2State(db, this.conversationId);
       if (state) {
-        await saveV2State(
-          db,
-          this.conversationId,
-          evictCompactedTurnsV2(state, upToTurn),
-        );
+        await saveV2State(db, this.conversationId, clearV2EverInjected(state));
       }
     } catch (err) {
       log.warn(

--- a/assistant/src/memory/v2/__tests__/activation-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation-store.test.ts
@@ -7,7 +7,7 @@ import { type DrizzleDb, getSqliteFrom } from "../../db-connection.js";
 import { migrateActivationState } from "../../migrations/232-activation-state.js";
 import * as schema from "../../schema.js";
 import {
-  evictCompactedTurns,
+  clearEverInjected,
   forkActivationState,
   hydrate,
   save,
@@ -146,23 +146,37 @@ describe("activation-store", () => {
     });
   });
 
-  describe("evictCompactedTurns", () => {
-    test("drops entries with turn <= upToTurn and preserves the rest", () => {
+  describe("clearEverInjected", () => {
+    test("empties the everInjected list", () => {
       const state = buildState({
         everInjected: [
           { slug: "slug-a", turn: 1 },
           { slug: "slug-b", turn: 2 },
           { slug: "slug-c", turn: 3 },
-          { slug: "slug-d", turn: 5 },
         ],
       });
 
-      const result = evictCompactedTurns(state, 2);
+      const result = clearEverInjected(state);
 
-      expect(result.everInjected).toEqual([
-        { slug: "slug-c", turn: 3 },
-        { slug: "slug-d", turn: 5 },
-      ]);
+      expect(result.everInjected).toEqual([]);
+    });
+
+    test("clears entries even when their turn exceeds currentTurn — the SIGKILL drift case", () => {
+      // Regression: under turn-bounded eviction, entries with turn >
+      // currentTurn survived forever. A non-graceful shutdown can persist
+      // everInjected entries with high turn values, then a restart restores
+      // the tracker from an older snapshot with a lower currentTurn.
+      const state = buildState({
+        currentTurn: 5,
+        everInjected: [
+          { slug: "slug-a", turn: 10 },
+          { slug: "slug-b", turn: 20 },
+        ],
+      });
+
+      const result = clearEverInjected(state);
+
+      expect(result.everInjected).toEqual([]);
     });
 
     test("returns a new object — does not mutate the input", () => {
@@ -170,7 +184,7 @@ describe("activation-store", () => {
         everInjected: [{ slug: "slug-a", turn: 1 }],
       });
 
-      const result = evictCompactedTurns(state, 1);
+      const result = clearEverInjected(state);
 
       expect(result.everInjected).toEqual([]);
       expect(state.everInjected).toEqual([{ slug: "slug-a", turn: 1 }]);
@@ -179,24 +193,12 @@ describe("activation-store", () => {
 
     test("preserves every other field on the state", () => {
       const state = buildState();
-      const result = evictCompactedTurns(state, 0);
+      const result = clearEverInjected(state);
 
       expect(result.messageId).toBe(state.messageId);
       expect(result.state).toEqual(state.state);
       expect(result.currentTurn).toBe(state.currentTurn);
       expect(result.updatedAt).toBe(state.updatedAt);
-    });
-
-    test("evicts everything when upToTurn covers the entire list", () => {
-      const state = buildState({
-        everInjected: [
-          { slug: "slug-a", turn: 1 },
-          { slug: "slug-b", turn: 2 },
-        ],
-      });
-
-      const result = evictCompactedTurns(state, 5);
-      expect(result.everInjected).toEqual([]);
     });
   });
 });

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -357,7 +357,7 @@ const { getSqliteFrom } = await import("../../db-connection.js");
 const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
 const schema = await import("../../schema.js");
-const { evictCompactedTurns, hydrate, save } =
+const { clearEverInjected, hydrate, save } =
   await import("../activation-store.js");
 const { injectMemoryV2Block } = await import("../injection.js");
 const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
@@ -653,10 +653,10 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    // Simulate compaction: drop all everInjected entries with turn <= 1.
+    // Simulate compaction: clear the entire everInjected list.
     const beforeEvict = await hydrate(db, "conv-1");
     expect(beforeEvict).not.toBeNull();
-    const afterEvict = evictCompactedTurns(beforeEvict!, 1);
+    const afterEvict = clearEverInjected(beforeEvict!);
     expect(afterEvict.everInjected).toEqual([]);
     await save(db, "conv-1", afterEvict);
 

--- a/assistant/src/memory/v2/activation-store.ts
+++ b/assistant/src/memory/v2/activation-store.ts
@@ -11,11 +11,7 @@ import { eq } from "drizzle-orm";
 
 import type { DrizzleDb } from "../db-connection.js";
 import { activationState } from "../schema.js";
-import {
-  type ActivationState,
-  ActivationStateSchema,
-  type EverInjectedEntry,
-} from "./types.js";
+import { type ActivationState, ActivationStateSchema } from "./types.js";
 
 /**
  * Load the activation state for a conversation, or `null` if no row exists.
@@ -123,16 +119,18 @@ export function forkActivationState(
 }
 
 /**
- * Drop `everInjected` entries whose `turn` is at or below `upToTurn`.
- * Used after compaction evicts older turns — slugs that lived only on those
- * turns become eligible for re-injection on the next turn.
+ * Clear all `everInjected` entries. Used after compaction: the cached
+ * `<memory>` attachments those slugs lived on are gone, so future turns
+ * should be free to re-inject them.
+ *
+ * Unconditionally empties the list rather than filtering by turn number.
+ * `everInjected` is persisted on every turn while the in-memory tracker's
+ * `currentTurn` is only snapshotted on graceful conversation dispose, so a
+ * non-graceful shutdown (SIGKILL, crash) followed by a reload can leave
+ * `everInjected` entries with `turn` values above the restored tracker's
+ * `currentTurn`. A turn-bounded filter misses those stale entries and they
+ * dedupe forever; a full clear is robust to that drift.
  */
-export function evictCompactedTurns(
-  state: ActivationState,
-  upToTurn: number,
-): ActivationState {
-  const everInjected: EverInjectedEntry[] = state.everInjected.filter(
-    (entry) => entry.turn > upToTurn,
-  );
-  return { ...state, everInjected };
+export function clearEverInjected(state: ActivationState): ActivationState {
+  return { ...state, everInjected: [] };
 }


### PR DESCRIPTION
## Summary
- Memory v2 `onCompacted` now unconditionally clears `everInjected` instead of filtering by turn number, so stale entries can no longer dedupe against future per-turn deltas forever.
- The activation_state row's `everInjected` is persisted every turn while the tracker snapshot persists only on graceful dispose. A non-graceful shutdown (SIGKILL, crash) followed by a reload can leave entries with `turn > tracker.currentTurn`; the previous `evictCompactedTurns(state, upToTurn)` filter would skip those entries and they'd survive every subsequent compaction.
- Added a regression test that seeds the persisted row with high-turn entries against a tracker at `currentTurn=0` and asserts `onCompacted` clears them.

## Original prompt
Investigation triggered by a report that memory v2 injected concepts weren't being reset on compaction. A real activation_state row was observed with `everInjected` entries whose `turn` values were well above the row's `current_turn` — entries the turn-bounded eviction filter in `onCompacted` would never reach. Root cause: `everInjected` is persisted every turn while the tracker snapshot is only persisted on graceful dispose, so the in-memory tracker's `currentTurn` can drift below entries' persisted `turn` after any non-graceful daemon exit. The fix replaces the filter with an unconditional clear, matching the documented intent of "evict everything" in `onCompacted`.