### PR TITLE
fix(macos/settings): only bump external-confirmation gen on actual value change

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -140,12 +140,14 @@ public final class SettingsStore: ObservableObject {
     private var lastConfirmedSetActiveProfileGen: Int = 0
 
     /// Monotonic counter incremented every time `loadInferenceProfiles`
-    /// updates `lastConfirmedActiveProfile` from a daemon-pushed config.
-    /// Each `setActiveProfile` call captures this at entry; if it advances
-    /// during the await, an external confirmation landed mid-flight and
-    /// the success branch must defer to it. Counting events rather than
-    /// comparing values catches no-op-looking drifts (e.g. X→Y→X) that a
-    /// value-equality check would miss.
+    /// lands an `activeProfile` value that *differs* from the previously
+    /// confirmed one. Each `setActiveProfile` call captures this at entry;
+    /// if it advances during the await, an external confirmation changed
+    /// the daemon-authoritative value mid-flight and the success branch
+    /// must defer to it. Counting transitions catches no-op-looking drifts
+    /// (e.g. X→Y→X) that a value-equality check on the entry snapshot
+    /// would miss, while ignoring slow refreshes that re-assert the same
+    /// value the store already had.
     private var externalActiveProfileConfirmationGen: Int = 0
 
     static let availableImageGenModels: [String] = [
@@ -3303,9 +3305,11 @@ public final class SettingsStore: ObservableObject {
         self.hasExplicitProfileOrder = rawOrder != nil
         self.profiles = orderedNames.compactMap { profilesByName[$0] }
         if let active = (llm?["activeProfile"] as? String).flatMap({ $0.isEmpty ? nil : $0 }) {
+            if active != lastConfirmedActiveProfile {
+                externalActiveProfileConfirmationGen += 1
+            }
             self.activeProfile = active
             self.lastConfirmedActiveProfile = active
-            externalActiveProfileConfirmationGen += 1
         }
     }
 
@@ -3356,13 +3360,15 @@ public final class SettingsStore: ObservableObject {
     ///    arrives, B is no longer in flight either. No newer pick is live,
     ///    so A applies fully — re-syncing `activeProfile` from the
     ///    post-revert "balanced" back to the daemon-confirmed "A".
-    /// 3. A in flight → external load confirms a daemon-pushed value → A
-    ///    late success: the push advances
-    ///    `externalActiveProfileConfirmationGen`. A's success branch
-    ///    detects the bump and skips, leaving the daemon-pushed value
-    ///    intact. The counter catches the drift even when the external
-    ///    push happens to land the same string twice (X→Y→X) where a
-    ///    value-equality check would miss it.
+    /// 3. A in flight → external load changes the daemon-confirmed value
+    ///    → A late success: the push advances
+    ///    `externalActiveProfileConfirmationGen` (it only bumps on a true
+    ///    transition, so a slow refresh that re-asserts the pre-existing
+    ///    value does not trip the guard). A's success branch detects the
+    ///    bump and skips, leaving the daemon-pushed value intact. The
+    ///    counter catches the drift even when the external push happens
+    ///    to land the same string twice (X→Y→X) where a value-equality
+    ///    check against the entry snapshot would miss it.
     @discardableResult
     func setActiveProfile(_ name: String) async -> Bool {
         setActiveProfileGenerationCounter += 1

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -409,6 +409,65 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertEqual(store.activeProfile, "A")
     }
 
+    /// A slow `refreshDaemonConfig()` GET that was already in flight when
+    /// the user picks "A" can return *during* A's PATCH, carrying the
+    /// pre-A active profile. That stale push must not look like a true
+    /// external write — counting it would force A's success branch into
+    /// the defer path and leave `lastConfirmedActiveProfile` stuck at the
+    /// pre-A value, so a subsequent failed pick would roll back to a
+    /// profile the assistant had already moved off of.
+    func testSetActiveProfileIgnoresStaleRefreshReassertingPreviousValue() async {
+        // Seed the store with a confirmed value so the "stale refresh"
+        // mid-flight can replay that same value.
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": ["balanced": ["model": "claude-sonnet-4-6"]],
+            ]
+        ])
+
+        var continuationA: CheckedContinuation<Bool, Never>?
+        let aSuspended = expectation(description: "A PATCH suspended")
+        mockSettingsClient.patchConfigHandler = { _ in
+            return await withCheckedContinuation { cont in
+                continuationA = cont
+                aSuspended.fulfill()
+            }
+        }
+
+        async let resultA: Bool = store.setActiveProfile("A")
+        await fulfillment(of: [aSuspended], timeout: 1.0)
+
+        // A slow GET started before the pick lands during the PATCH and
+        // re-asserts the pre-A value. Because the value matches what was
+        // already confirmed, it must not bump the external-confirmation
+        // counter.
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": ["balanced": ["model": "claude-sonnet-4-6"]],
+            ]
+        ])
+
+        continuationA?.resume(returning: true)
+        let aSucceeded = await resultA
+        XCTAssertTrue(aSucceeded)
+        XCTAssertEqual(
+            store.activeProfile,
+            "A",
+            "A's success must apply when the only external push re-asserts the prior value"
+        )
+
+        // A subsequent failed pick must revert to "A", proving
+        // `lastConfirmedActiveProfile` advanced — not to "balanced",
+        // which would indicate the success branch wrongly deferred.
+        mockSettingsClient.patchConfigHandler = nil
+        mockSettingsClient.patchConfigResponse = false
+        let bSucceeded = await store.setActiveProfile("B")
+        XCTAssertFalse(bSucceeded)
+        XCTAssertEqual(store.activeProfile, "A")
+    }
+
     // MARK: - setProfile
 
     func testSetProfileRoundTripsAndUpdatesPublishedState() async {


### PR DESCRIPTION
Addresses Codex feedback on #30946. A refresh that returns the same activeProfile no longer trips a concurrent setActiveProfile's success branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->