### PR TITLE
fix(openrouter): avoid duplicate effort field and parse reasoning_details

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -23,6 +23,11 @@ interface FakeChunk {
       content?: string | null;
       reasoning_content?: string | null;
       reasoning?: string | null;
+      reasoning_details?: Array<{
+        type?: string;
+        summary?: string | null;
+        text?: string | null;
+      }> | null;
       tool_calls?: Array<{
         index: number;
         id?: string;
@@ -231,6 +236,19 @@ function openRouterReasoningChunk(
 ): FakeChunk {
   return {
     choices: [{ delta: { reasoning }, finish_reason: finish }],
+    usage: null,
+    model: "gpt-5.2",
+  };
+}
+
+// OpenRouter's documented reasoning-summary shape: a `reasoning_details` array
+// with entries tagged `reasoning.summary` / `reasoning.text` / `reasoning.encrypted`.
+function reasoningDetailsChunk(
+  details: Array<{ type?: string; summary?: string; text?: string }>,
+  finish: string | null = null,
+): FakeChunk {
+  return {
+    choices: [{ delta: { reasoning_details: details }, finish_reason: finish }],
     usage: null,
     model: "gpt-5.2",
   };
@@ -467,6 +485,50 @@ describe("OpenAIProvider", () => {
       type: "thinking_delta",
       thinking: "Hmm, let me think...",
     });
+  });
+
+  test("parses OpenRouter `delta.reasoning_details` summary/text entries and skips encrypted", async () => {
+    fakeChunks = [
+      reasoningDetailsChunk([
+        { type: "reasoning.summary", summary: "Plan step one. " },
+        { type: "reasoning.encrypted", text: "ENCRYPTED_BLOB" },
+        { type: "reasoning.text", text: "Detailed thought." },
+      ]),
+      textChunk("Done."),
+      usageChunk(10, 8),
+    ];
+
+    const events: ProviderEvent[] = [];
+    const result = await provider.sendMessage(
+      [userMsg("Hi")],
+      undefined,
+      undefined,
+      {
+        onEvent: (e) => events.push(e),
+      },
+    );
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toEqual({
+      type: "thinking",
+      thinking: "Plan step one. Detailed thought.",
+      signature: "",
+    });
+    expect(result.content[1]).toEqual({ type: "text", text: "Done." });
+    expect(events).toContainEqual({
+      type: "thinking_delta",
+      thinking: "Plan step one. ",
+    });
+    expect(events).toContainEqual({
+      type: "thinking_delta",
+      thinking: "Detailed thought.",
+    });
+    // Encrypted blob must never surface as visible thinking.
+    for (const e of events) {
+      if (e.type === "thinking_delta") {
+        expect(e.thinking).not.toContain("ENCRYPTED_BLOB");
+      }
+    }
   });
 
   // -----------------------------------------------------------------------
@@ -1524,6 +1586,23 @@ describe("OpenRouterProvider reasoning", () => {
       config: { thinking: { type: "disabled" } },
     });
     expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+  });
+
+  test("nests effort under reasoning and omits top-level reasoning_effort", async () => {
+    const provider = new OpenRouterProvider("or-key", "moonshotai/kimi-k2.6");
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { enabled: true }, effort: "max" },
+    });
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toEqual({
+      enabled: true,
+      effort: "xhigh",
+      summary: "detailed",
+    });
+    // Critical: must NOT also send the OpenAI-native flat field — OpenRouter
+    // rejects requests that carry both forms for reasoning models.
+    expect(lastCreateParams).not.toHaveProperty("reasoning_effort");
   });
 });
 

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -176,10 +176,17 @@ export class OpenAIChatCompletionsProvider implements Provider {
         params.max_completion_tokens = maxTokens;
       }
 
+      // Subclasses (OpenRouter) may already have nested effort under
+      // `reasoning.effort` via `buildExtraCreateParams`. Skip the flat
+      // `reasoning_effort` assignment in that case to avoid sending both forms,
+      // which OpenRouter rejects on reasoning models.
+      const nestedReasoningEffort = (
+        params as { reasoning?: { effort?: unknown } }
+      ).reasoning?.effort;
       const reasoningEffort = effort
         ? EFFORT_TO_REASONING_EFFORT[effort]
         : undefined;
-      if (reasoningEffort) {
+      if (reasoningEffort && typeof nestedReasoningEffort !== "string") {
         params.reasoning_effort =
           reasoningEffort === "xhigh" && this.maxReasoningEffort === "high"
             ? "high"
@@ -307,6 +314,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
             const deltaWithReasoning = choice.delta as {
               reasoning?: string | null;
               reasoning_content?: string | null;
+              reasoning_details?: Array<{
+                type?: string;
+                summary?: string | null;
+                text?: string | null;
+              }> | null;
             };
             const reasoningContent =
               deltaWithReasoning.reasoning_content ??
@@ -314,6 +326,24 @@ export class OpenAIChatCompletionsProvider implements Provider {
             if (reasoningContent) {
               reasoningText += reasoningContent;
               onEvent?.({ type: "thinking_delta", thinking: reasoningContent });
+            }
+
+            // OpenRouter's documented streaming shape for reasoning summaries
+            // (e.g. Kimi K2.6) puts visible thinking under
+            // `delta.reasoning_details[]` with entries like
+            // `{ type: "reasoning.summary", summary: "..." }` or
+            // `{ type: "reasoning.text", text: "..." }`. `reasoning.encrypted`
+            // entries are opaque and skipped.
+            const reasoningDetails = deltaWithReasoning.reasoning_details;
+            if (Array.isArray(reasoningDetails)) {
+              for (const entry of reasoningDetails) {
+                if (entry.type === "reasoning.encrypted") continue;
+                const piece = entry.summary ?? entry.text;
+                if (piece) {
+                  reasoningText += piece;
+                  onEvent?.({ type: "thinking_delta", thinking: piece });
+                }
+              }
             }
 
             if (choice.delta.tool_calls) {


### PR DESCRIPTION
Addresses Codex+Devin feedback on #30953. Suppress base-class top-level reasoning_effort when a subclass nests effort under reasoning.effort, and parse delta.reasoning_details entries so Kimi-style summary chunks surface as thinking deltas.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->