### PR TITLE
fix(memory): keep subagent transcripts on generic role labels

### DIFF
--- a/assistant/src/export/__tests__/transcript-formatter.test.ts
+++ b/assistant/src/export/__tests__/transcript-formatter.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { z } from "zod";
+
+type TestMessage = {
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+};
+
+const parentMessages: TestMessage[] = [
+  {
+    id: "msg-parent-1",
+    conversationId: "parent-conv",
+    role: "user",
+    content: JSON.stringify([{ type: "text", text: "go research foo" }]),
+    createdAt: 1_700_000_000_000,
+    metadata: null,
+  },
+  {
+    id: "msg-parent-2",
+    conversationId: "parent-conv",
+    role: "assistant",
+    content: JSON.stringify([{ type: "text", text: "spawning subagent" }]),
+    createdAt: 1_700_000_001_000,
+    metadata: JSON.stringify({
+      subagentNotification: {
+        subagentId: "sa-1",
+        label: "research-foo",
+        status: "completed",
+        conversationId: "child-conv-1",
+      },
+    }),
+  },
+];
+
+const childMessages: TestMessage[] = [
+  {
+    id: "msg-child-1",
+    conversationId: "child-conv-1",
+    role: "user",
+    content: JSON.stringify([
+      { type: "text", text: "Objective: research foo and report back." },
+    ]),
+    createdAt: 1_700_000_002_000,
+    metadata: null,
+  },
+  {
+    id: "msg-child-2",
+    conversationId: "child-conv-1",
+    role: "assistant",
+    content: JSON.stringify([
+      { type: "text", text: "I found that foo is a bar." },
+    ]),
+    createdAt: 1_700_000_003_000,
+    metadata: null,
+  },
+];
+
+const messageMetadataSchema = z.object({
+  subagentNotification: z
+    .object({
+      subagentId: z.string(),
+      label: z.string(),
+      status: z.enum(["running", "completed", "failed", "aborted"]),
+      conversationId: z.string().optional(),
+    })
+    .optional(),
+});
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  getConversation: (_id: string) => null,
+  getMessages: (id: string) =>
+    id === "child-conv-1" ? childMessages : parentMessages,
+  messageMetadataSchema,
+}));
+
+mock.module("../../util/truncate.js", () => ({
+  truncate: (s: string) => s,
+}));
+
+mock.module("../../daemon/date-context.js", () => ({
+  formatLocalTimestamp: (_ts: number, _tz?: string) => "TIME",
+}));
+
+const { formatMessageSliceForTranscript } =
+  await import("../transcript-formatter.js");
+
+describe("formatMessageSliceForTranscript subagent labels", () => {
+  test("embedded subagent transcripts render with generic role labels even when parent display names are provided", () => {
+    const out = formatMessageSliceForTranscript(parentMessages, {
+      assistantName: "Bob",
+      userName: "Alice",
+    });
+
+    // Parent messages use the provided display names.
+    expect(out).toContain("## Alice (TIME)");
+    expect(out).toContain("## Bob (TIME)");
+
+    // Subagent block headers must use generic labels — the child "user" message
+    // is actually the parent assistant's objective, so labeling it "Alice"
+    // would misattribute the assistant's tasking text to the human user.
+    expect(out).toContain("### Subagent: research-foo (completed)");
+    expect(out).toContain("> **User** (TIME)");
+    expect(out).toContain("> **Assistant** (TIME)");
+    expect(out).not.toContain("> **Alice**");
+    expect(out).not.toContain("> **Bob**");
+  });
+
+  test("without display-name options, parent and subagent both use generic labels", () => {
+    const out = formatMessageSliceForTranscript(parentMessages);
+
+    expect(out).toContain("## User (TIME)");
+    expect(out).toContain("## Assistant (TIME)");
+    expect(out).toContain("> **User** (TIME)");
+    expect(out).toContain("> **Assistant** (TIME)");
+  });
+});

--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -121,10 +121,14 @@ type TranscriptMessage = ReturnType<typeof getMessages>[number];
  * Format a slice of messages as a transcript body (no top-of-conversation
  * header). Used by background jobs that process incremental slices — the
  * memory-retrospective job re-renders only the messages added since its
- * last successful run rather than the whole conversation. The format
- * matches `buildAnalysisTranscript` per message so downstream agents see a
- * consistent shape regardless of whether the input is a full transcript or
- * a slice.
+ * last successful run rather than the whole conversation. The per-message
+ * structural shape matches `buildAnalysisTranscript` (header line, body,
+ * optional subagent block) so downstream agents see consistent framing.
+ * The participant *labels*, however, intentionally diverge: this function
+ * honors `TranscriptFormatOptions` so the memory-retrospective prompt can
+ * render the conversation under the assistant and user display names,
+ * while `buildAnalysisTranscript` always uses generic "User"/"Assistant"
+ * labels for the analyze-conversation flow.
  */
 export function formatMessageSliceForTranscript(
   messages: TranscriptMessage[],
@@ -165,7 +169,14 @@ function appendMessageBlock(
           const subMessages = getMessages(notif.conversationId);
           lines.push(`### Subagent: ${notif.label} (${notif.status})`);
           lines.push("");
-          lines.push(formatSubagentMessages(subMessages, options));
+          // Subagent conversations persist the parent assistant's objective
+          // as a `user` message (see subagent/manager.ts), so reusing the
+          // parent's display-name options would render the assistant's
+          // tasking text under the human user's name. Keep child transcripts
+          // on generic role labels — and only pass through the time zone.
+          lines.push(
+            formatSubagentMessages(subMessages, { timeZone: options.timeZone }),
+          );
           lines.push("");
         }
       }


### PR DESCRIPTION
Addresses Codex+Devin feedback on #30952. Don't pass parent display-name options into embedded subagent transcripts (their 'user' messages are the parent assistant's tasking text). Update buildAnalysisTranscript docstring to reflect the intentional label divergence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->