### PR TITLE
Warm kata apt rootfs asynchronously

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -6,8 +6,9 @@ set -eu
 chmod 1777 /tmp 2>/dev/null || true
 
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ] && [ -x /app/assistant/docker-init-apt-root.sh ]; then
-  . /app/assistant/docker-kata-apt-env.sh
-  /app/assistant/docker-init-apt-root.sh
+  export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
+  # Warm the chroot used by kata apt wrappers without blocking assistant readiness.
+  /app/assistant/docker-init-apt-root.sh &
 fi
 
 if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -8,6 +8,7 @@ chmod 1777 /tmp 2>/dev/null || true
 KATA_APT_INIT_PID=""
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ] && [ -x /app/assistant/docker-init-apt-root.sh ]; then
   export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
+  . /app/assistant/docker-kata-apt-env.sh
   # Warm the chroot used by kata apt wrappers without blocking assistant readiness.
   /app/assistant/docker-init-apt-root.sh &
   KATA_APT_INIT_PID="$!"
@@ -17,7 +18,6 @@ wait_for_kata_apt_root() {
   if [ -n "${KATA_APT_INIT_PID}" ]; then
     wait "${KATA_APT_INIT_PID}"
     KATA_APT_INIT_PID=""
-    . /app/assistant/docker-kata-apt-env.sh
   fi
 }
 

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -5,11 +5,21 @@ set -eu
 # processes (the `assistant` user, bun's tmpdir, scratch writes) can use it.
 chmod 1777 /tmp 2>/dev/null || true
 
+KATA_APT_INIT_PID=""
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ] && [ -x /app/assistant/docker-init-apt-root.sh ]; then
   export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
   # Warm the chroot used by kata apt wrappers without blocking assistant readiness.
   /app/assistant/docker-init-apt-root.sh &
+  KATA_APT_INIT_PID="$!"
 fi
+
+wait_for_kata_apt_root() {
+  if [ -n "${KATA_APT_INIT_PID}" ]; then
+    wait "${KATA_APT_INIT_PID}"
+    KATA_APT_INIT_PID=""
+    . /app/assistant/docker-kata-apt-env.sh
+  fi
+}
 
 if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
@@ -24,6 +34,7 @@ fi
 if [ -d /workspace/.entrypoint.d ]; then
   for hook in /workspace/.entrypoint.d/*.sh; do
     [ -r "$hook" ] || continue
+    wait_for_kata_apt_root
     . "$hook" || echo "Warning: workspace hook $hook exited $?" >&2
   done
 fi

--- a/assistant/docker-init-apt-root.sh
+++ b/assistant/docker-init-apt-root.sh
@@ -2,14 +2,24 @@
 set -eu
 
 DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
+ROOT_PARENT="$(dirname "${DATA_ROOT}")"
 SENTINEL="${DATA_ROOT}/.rootfs-initialized"
-LOCK_DIR="${DATA_ROOT}/.rootfs-init.lock"
+BOOTSTRAP_ROOT="${DATA_ROOT}.bootstrap.$$"
+PROBE_ROOT="${DATA_ROOT}.probe.$$"
+LOCK_DIR="${DATA_ROOT}.rootfs-init.lock"
 LOCK_PID="${LOCK_DIR}/pid"
 HOST_PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then
   exit 0
 fi
+
+case "${DATA_ROOT}" in
+  ''|/)
+    echo "Warning: invalid VELLUM_APT_DATA_ROOT '${DATA_ROOT}'; falling back to image-root apt installs" >&2
+    exit 0
+    ;;
+esac
 
 # Bootstrap the alternate root with the host toolchain so the wrapper
 # binaries in /usr/local/bin do not recurse back into this script.
@@ -20,7 +30,7 @@ rootfs_ready() {
 }
 
 acquire_init_lock() {
-  if ! mkdir -p "${DATA_ROOT}"; then
+  if ! mkdir -p "${ROOT_PARENT}"; then
     return 1
   fi
 
@@ -60,9 +70,9 @@ acquire_init_lock() {
   done
 
   printf '%s\n' "$$" >"${LOCK_PID}" 2>/dev/null || true
-  trap 'rm -rf "${LOCK_DIR}"' EXIT
-  trap 'rm -rf "${LOCK_DIR}"; exit 130' INT
-  trap 'rm -rf "${LOCK_DIR}"; exit 143' TERM
+  trap 'rm -rf "${LOCK_DIR}" "${BOOTSTRAP_ROOT}" "${PROBE_ROOT}"' EXIT
+  trap 'rm -rf "${LOCK_DIR}" "${BOOTSTRAP_ROOT}" "${PROBE_ROOT}"; exit 130' INT
+  trap 'rm -rf "${LOCK_DIR}" "${BOOTSTRAP_ROOT}" "${PROBE_ROOT}"; exit 143' TERM
 }
 
 check_sane_mount() {
@@ -120,15 +130,16 @@ if rootfs_ready; then
   exit 0
 fi
 
-if grep -qs " ${DATA_ROOT} .*noexec" /proc/mounts; then
+if grep -qs " ${DATA_ROOT} .*noexec" /proc/mounts || grep -qs " ${ROOT_PARENT} .*noexec" /proc/mounts; then
   echo "Warning: ${DATA_ROOT} is mounted noexec; skipping persistent apt rootfs bootstrap" >&2
   exit 0
 fi
 
-if ! check_sane_mount "${DATA_ROOT}"; then
+if ! check_sane_mount "${PROBE_ROOT}"; then
   echo "Warning: ${DATA_ROOT} cannot host a chrootable apt rootfs here; falling back to image-root apt installs" >&2
   exit 0
 fi
+rm -rf "${PROBE_ROOT}"
 
 if [ -x "${DATA_ROOT}/bin/sh" ] && [ -x "${DATA_ROOT}/usr/bin/apt-get" ]; then
   touch "${SENTINEL}"
@@ -148,6 +159,9 @@ fi
 MIRROR="${VELLUM_APT_DATA_MIRROR:-http://deb.debian.org/debian}"
 ARCH="$(/usr/bin/dpkg --print-architecture)"
 
-debootstrap --variant=minbase --arch="${ARCH}" "${SUITE}" "${DATA_ROOT}" "${MIRROR}"
+rm -rf "${BOOTSTRAP_ROOT}"
+debootstrap --variant=minbase --arch="${ARCH}" "${SUITE}" "${BOOTSTRAP_ROOT}" "${MIRROR}"
 
+rm -rf "${DATA_ROOT}"
+mv "${BOOTSTRAP_ROOT}" "${DATA_ROOT}"
 touch "${SENTINEL}"

--- a/assistant/docker-init-apt-root.sh
+++ b/assistant/docker-init-apt-root.sh
@@ -20,9 +20,15 @@ rootfs_ready() {
 }
 
 acquire_init_lock() {
-  mkdir -p "${DATA_ROOT}"
+  if ! mkdir -p "${DATA_ROOT}"; then
+    return 1
+  fi
 
   while ! mkdir "${LOCK_DIR}" 2>/dev/null; do
+    if [ ! -d "${LOCK_DIR}" ]; then
+      return 1
+    fi
+
     if rootfs_ready; then
       exit 0
     fi
@@ -30,7 +36,7 @@ acquire_init_lock() {
     if [ ! -r "${LOCK_PID}" ]; then
       sleep 1
       if [ ! -r "${LOCK_PID}" ]; then
-        rm -rf "${LOCK_DIR}" 2>/dev/null || true
+        rm -rf "${LOCK_DIR}" 2>/dev/null || return 1
       fi
       continue
     fi
@@ -40,14 +46,14 @@ acquire_init_lock() {
       ''|*[!0-9]*)
         sleep 1
         if [ "$(cat "${LOCK_PID}" 2>/dev/null || true)" = "${lock_pid}" ]; then
-          rm -rf "${LOCK_DIR}" 2>/dev/null || true
+          rm -rf "${LOCK_DIR}" 2>/dev/null || return 1
         fi
         ;;
       *)
         if kill -0 "${lock_pid}" 2>/dev/null; then
           sleep 1
         else
-          rm -rf "${LOCK_DIR}" 2>/dev/null || true
+          rm -rf "${LOCK_DIR}" 2>/dev/null || return 1
         fi
         ;;
     esac
@@ -105,7 +111,10 @@ if rootfs_ready; then
   exit 0
 fi
 
-acquire_init_lock
+if ! acquire_init_lock; then
+  echo "Warning: ${DATA_ROOT} cannot host the apt rootfs lock; falling back to image-root apt installs" >&2
+  exit 0
+fi
 
 if rootfs_ready; then
   exit 0

--- a/assistant/docker-init-apt-root.sh
+++ b/assistant/docker-init-apt-root.sh
@@ -3,6 +3,8 @@ set -eu
 
 DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
 SENTINEL="${DATA_ROOT}/.rootfs-initialized"
+LOCK_DIR="${DATA_ROOT}/.rootfs-init.lock"
+LOCK_PID="${LOCK_DIR}/pid"
 HOST_PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" != "kata" ]; then
@@ -12,6 +14,50 @@ fi
 # Bootstrap the alternate root with the host toolchain so the wrapper
 # binaries in /usr/local/bin do not recurse back into this script.
 export PATH="${HOST_PATH}"
+
+rootfs_ready() {
+  [ -f "${SENTINEL}" ] && [ -x "${DATA_ROOT}/bin/sh" ] && [ -x "${DATA_ROOT}/usr/bin/apt-get" ]
+}
+
+acquire_init_lock() {
+  mkdir -p "${DATA_ROOT}"
+
+  while ! mkdir "${LOCK_DIR}" 2>/dev/null; do
+    if rootfs_ready; then
+      exit 0
+    fi
+
+    if [ ! -r "${LOCK_PID}" ]; then
+      sleep 1
+      if [ ! -r "${LOCK_PID}" ]; then
+        rm -rf "${LOCK_DIR}" 2>/dev/null || true
+      fi
+      continue
+    fi
+
+    lock_pid="$(cat "${LOCK_PID}" 2>/dev/null || true)"
+    case "${lock_pid}" in
+      ''|*[!0-9]*)
+        sleep 1
+        if [ "$(cat "${LOCK_PID}" 2>/dev/null || true)" = "${lock_pid}" ]; then
+          rm -rf "${LOCK_DIR}" 2>/dev/null || true
+        fi
+        ;;
+      *)
+        if kill -0 "${lock_pid}" 2>/dev/null; then
+          sleep 1
+        else
+          rm -rf "${LOCK_DIR}" 2>/dev/null || true
+        fi
+        ;;
+    esac
+  done
+
+  printf '%s\n' "$$" >"${LOCK_PID}" 2>/dev/null || true
+  trap 'rm -rf "${LOCK_DIR}"' EXIT
+  trap 'rm -rf "${LOCK_DIR}"; exit 130' INT
+  trap 'rm -rf "${LOCK_DIR}"; exit 143' TERM
+}
 
 check_sane_mount() {
   target="$1"
@@ -55,7 +101,13 @@ EOF
   return 0
 }
 
-if [ -f "${SENTINEL}" ] && [ -x "${DATA_ROOT}/bin/sh" ] && [ -x "${DATA_ROOT}/usr/bin/apt-get" ]; then
+if rootfs_ready; then
+  exit 0
+fi
+
+acquire_init_lock
+
+if rootfs_ready; then
   exit 0
 fi
 
@@ -86,8 +138,6 @@ fi
 
 MIRROR="${VELLUM_APT_DATA_MIRROR:-http://deb.debian.org/debian}"
 ARCH="$(/usr/bin/dpkg --print-architecture)"
-
-mkdir -p "${DATA_ROOT}"
 
 debootstrap --variant=minbase --arch="${ARCH}" "${SUITE}" "${DATA_ROOT}" "${MIRROR}"
 


### PR DESCRIPTION
## Summary
- Move kata apt rootfs initialization off the blocking assistant startup path so debootstrap can warm in the background while Bun starts.
- Add a lock around rootfs initialization so the background warmer and the first apt/dpkg wrapper call cannot run debootstrap against the same target concurrently.

Closes #30960

## Original prompt
The assistant container was visibly extracting Debian base packages before the assistant became available when running with the kata sandbox runtime. The request was to understand why that was happening and make the work happen in parallel, or otherwise stop it from serially blocking startup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->