### PR TITLE
feat(macos): add collapsible Activity section to homepage feed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -30,8 +30,14 @@ struct HomePageView: View {
 
     @AppStorage("homeSuggestionsDismissed") private var suggestionsDismissed: Bool = false
     @State private var activeFilter: FeedItemCategory? = nil
+    @State private var isActivityExpanded: Bool = false
 
     private let maxContentWidth: CGFloat = 960
+
+    /// Count of items routed into the Background activity section. Always 0
+    /// today; will be derived from `FeedItem.noteworthy` once that field is
+    /// populated server-side.
+    private var activityCount: Int { 0 }
 
     var body: some View {
         Group {
@@ -118,6 +124,15 @@ struct HomePageView: View {
                             }
                         }
                     }
+                }
+
+                DisclosureGroup(isExpanded: $isActivityExpanded) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {}
+                        .padding(.top, VSpacing.sm)
+                } label: {
+                    Text("Background activity (\(activityCount))")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
 
                 Spacer(minLength: VSpacing.xxl)


### PR DESCRIPTION
## Summary
- Adds a collapsible "Background activity" disclosure section below the existing feed on the homepage
- Empty placeholder for now — PR 12 will route non-noteworthy items into it once the `noteworthy` field is populated server-side
- Styled with muted secondary visual treatment

Part of plan: notifications-rewrite.md (PR 11 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->