### PR TITLE
feat(notifications): add optional noteworthy field to FeedItem schema

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -116,6 +116,19 @@ describe("feedItemSchema — valid minimal items", () => {
     expect(parsed.category).toBeUndefined();
     expect(parsed.metadata).toBeUndefined();
   });
+
+  test("noteworthy field passes through when present", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNotification(),
+      noteworthy: true,
+    });
+    expect(parsed.noteworthy).toBe(true);
+  });
+
+  test("items without noteworthy field still parse (backward compat)", () => {
+    const parsed = feedItemSchema.parse(minimalNotification());
+    expect(parsed.noteworthy).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -243,5 +256,23 @@ describe("parseFeedFile", () => {
         updatedAt: NOW_ISO,
       }),
     ).toThrow();
+  });
+
+  test("accepts a file with a noteworthy item", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [{ ...minimalNotification(), noteworthy: true }],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items[0]?.noteworthy).toBe(true);
+  });
+
+  test("accepts a file whose items omit noteworthy (backward compat)", () => {
+    const parsed = parseFeedFile({
+      version: 2,
+      items: [minimalNotification()],
+      updatedAt: NOW_ISO,
+    });
+    expect(parsed.items[0]?.noteworthy).toBeUndefined();
   });
 });

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -106,6 +106,8 @@ export interface FeedItem {
   detailPanel?: FeedItemDetailPanel;
   /** Broad category for grouping and filtering feed items. */
   category?: FeedItemCategory;
+  /** True when this item represents an assistant-initiated share or a high-importance system event. Used by clients to split inbox vs activity surfaces. */
+  noteworthy?: boolean;
   /** Arbitrary structured data the detail panel or other consumers can use. */
   metadata?: Record<string, unknown>;
   /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
@@ -208,6 +210,7 @@ export const feedItemSchema = z.object({
   conversationId: z.string().optional(),
   detailPanel: feedItemDetailPanelSchema.optional(),
   category: feedItemCategorySchema.optional(),
+  noteworthy: z.boolean().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string(),
 });

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -131,6 +131,8 @@ public struct FeedItem: Codable, Sendable, Identifiable {
     public let detailPanel: FeedItemDetailPanel?
     /// Broad category for grouping and filtering feed items.
     public let category: FeedItemCategory?
+    /// True when this item represents an assistant-initiated share or a high-importance system event. Used by clients to split inbox vs activity surfaces.
+    public let noteworthy: Bool?
     /// Arbitrary structured data the detail panel or other consumers can use.
     public let metadata: [String: AnyCodable]?
     /// Internal: writer-record time, used for ordering + TTL.
@@ -150,6 +152,7 @@ public struct FeedItem: Codable, Sendable, Identifiable {
         conversationId: String? = nil,
         detailPanel: FeedItemDetailPanel? = nil,
         category: FeedItemCategory? = nil,
+        noteworthy: Bool? = nil,
         metadata: [String: AnyCodable]? = nil,
         createdAt: Date
     ) {
@@ -166,6 +169,7 @@ public struct FeedItem: Codable, Sendable, Identifiable {
         self.conversationId = conversationId
         self.detailPanel = detailPanel
         self.category = category
+        self.noteworthy = noteworthy
         self.metadata = metadata
         self.createdAt = createdAt
     }
@@ -186,6 +190,7 @@ extension FeedItem: Equatable {
             && lhs.conversationId == rhs.conversationId
             && lhs.detailPanel == rhs.detailPanel
             && lhs.category == rhs.category
+            && lhs.noteworthy == rhs.noteworthy
             && lhs.metadata == rhs.metadata
             && lhs.createdAt == rhs.createdAt
     }

--- a/clients/shared/Tests/FeedItemCodingTests.swift
+++ b/clients/shared/Tests/FeedItemCodingTests.swift
@@ -142,6 +142,52 @@ final class FeedItemCodingTests: XCTestCase {
         XCTAssertNil(item.urgency)
         XCTAssertNil(item.conversationId)
         XCTAssertNil(item.detailPanel)
+        XCTAssertNil(item.noteworthy)
+    }
+
+    // MARK: - Noteworthy flag (PR 9)
+
+    /// Synthesized `Codable` handles the optional `noteworthy: Bool?`
+    /// field automatically — these two cases just pin the wire contract.
+    func testDecodesNoteworthyTrue() throws {
+        let json = Data(
+            """
+            {
+              "id": "notif-noteworthy",
+              "type": "notification",
+              "priority": 80,
+              "title": "Assistant shared a doc",
+              "summary": "Quarterly planning draft.",
+              "timestamp": "2026-04-14T10:00:00Z",
+              "status": "new",
+              "noteworthy": true,
+              "createdAt": "2026-04-14T10:00:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+        XCTAssertEqual(item.noteworthy, true)
+    }
+
+    func testDecodesNoteworthyAbsent() throws {
+        let json = Data(
+            """
+            {
+              "id": "notif-plain",
+              "type": "notification",
+              "priority": 50,
+              "title": "Routine update",
+              "summary": "Nothing to see here.",
+              "timestamp": "2026-04-14T10:00:00Z",
+              "status": "new",
+              "createdAt": "2026-04-14T10:00:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+        XCTAssertNil(item.noteworthy)
     }
 
     // MARK: - Round-trip


### PR DESCRIPTION
## Summary
- Adds optional `noteworthy: boolean` field to TS FeedItem interface and Zod schema
- Mirrors the field in the Swift FeedItem decoder
- Sets up the inbox/activity split (PR 10 populates this field; PR 12 consumes it on the client)

Part of plan: notifications-rewrite.md (PR 9 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->