### PR TITLE
fix(notifications): skip home-feed write when title/summary would fall back to raw event name

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -146,8 +146,13 @@ describe("writeHomeFeedItemForSignal", () => {
         visibleInSourceNow: false,
       },
     });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Async title", body: "Async body" },
+      },
+    });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -159,6 +164,11 @@ describe("writeHomeFeedItemForSignal", () => {
   test("vellum delivery result conversationId propagates onto the feed item", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal();
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Routed title", body: "Routed body" },
+      },
+    });
     const deliveryResults: NotificationDeliveryResult[] = [
       {
         channel: "telegram",
@@ -176,7 +186,7 @@ describe("writeHomeFeedItemForSignal", () => {
 
     const item = await writeHomeFeedItemForSignal(
       signal,
-      makeDecision(),
+      decision,
       deliveryResults,
     );
 
@@ -184,7 +194,7 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.conversationId).toBe("conv-vellum-1");
   });
 
-  test("falls back to sourceEventName when no rendered copy or payload title is present", async () => {
+  test("returns null and does not write when no rendered copy or payload title/body is present", async () => {
     conversationRow = { conversationType: "scheduled" };
     const signal = makeSignal({
       sourceEventName: "watcher.notification",
@@ -193,7 +203,66 @@ describe("writeHomeFeedItemForSignal", () => {
 
     const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
 
-    expect(item?.title).toBe("watcher.notification");
-    expect(item?.summary).toBe("watcher.notification");
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
+  test("returns null when only the title is available but the summary would fall back to event name", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "Real title" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
+  test("returns null when only the summary is available but the title would fall back to event name", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { body: "Real body" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
+  test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { title: "   ", body: "\t\n" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "   ", body: "   " },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
+  test("uses payload title/body when rendered copy is absent", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "watcher.notification",
+      contextPayload: { title: "Payload title", body: "Payload body" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).not.toBeNull();
+    expect(item?.title).toBe("Payload title");
+    expect(item?.summary).toBe("Payload body");
+    expect(appendCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -55,6 +55,18 @@ export async function writeHomeFeedItemForSignal(
   const payloadTitle = readPayloadString(signal.contextPayload, "title");
   const payloadBody = readPayloadString(signal.contextPayload, "body");
 
+  const resolvedTitle =
+    renderedCopy?.title?.trim() || payloadTitle?.trim() || "";
+  const resolvedSummary =
+    renderedCopy?.body?.trim() || payloadBody?.trim() || "";
+  if (!resolvedTitle || !resolvedSummary) {
+    log.warn(
+      { signalId: signal.signalId, sourceEventName: signal.sourceEventName },
+      "Home-feed write skipped: no real title or summary available (would have fallen back to event name)",
+    );
+    return null;
+  }
+
   const conversationId = deliveryResults.find(
     (r) => r.channel === "vellum",
   )?.conversationId;
@@ -76,8 +88,8 @@ export async function writeHomeFeedItemForSignal(
     id: `notif:${signal.signalId}`,
     type: "notification",
     priority: 50,
-    title: renderedCopy?.title ?? payloadTitle ?? signal.sourceEventName,
-    summary: renderedCopy?.body ?? payloadBody ?? signal.sourceEventName,
+    title: resolvedTitle,
+    summary: resolvedSummary,
     timestamp: now,
     createdAt: now,
     status: "new",


### PR DESCRIPTION
## Summary
- Skips home-feed item write when no real title or summary is available (instead of falling back to `signal.sourceEventName`)
- Removes one of the surfaces where raw event names were leaking into user-visible feed entries

Part of plan: notifications-rewrite.md (PR 5 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->