### PR TITLE
feat(notifications): add fail-closed guard against empty or event-name-fallback copy

### DIFF
--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the deterministic pre-send checks.
+ *
+ * Focus: the rendered-copy quality check that suppresses notifications
+ * with empty bodies or bodies that leak the raw source event name
+ * (the `buildGenericCopy` fallback path).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+import { getDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { notificationEvents } from "../../memory/schema.js";
+import {
+  type DeterministicCheckContext,
+  runDeterministicChecks,
+} from "../deterministic-checks.js";
+import type { NotificationSignal } from "../signal.js";
+import type { NotificationDecision } from "../types.js";
+
+initializeDb();
+
+beforeEach(() => {
+  getDb().delete(notificationEvents).run();
+});
+
+function makeSignal(
+  overrides?: Partial<NotificationSignal>,
+): NotificationSignal {
+  return {
+    signalId: `sig-${crypto.randomUUID()}`,
+    createdAt: Date.now(),
+    sourceChannel: "scheduler",
+    sourceContextId: "ctx-1",
+    sourceEventName: "schedule.notify",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeDecision(
+  overrides?: Partial<NotificationDecision>,
+): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: ["vellum"],
+    reasoningSummary: "test",
+    renderedCopy: {
+      vellum: { title: "Reminder", body: "Time to drink water" },
+    },
+    dedupeKey: `dk-${crypto.randomUUID()}`,
+    confidence: 0.9,
+    fallbackUsed: false,
+    ...overrides,
+  };
+}
+
+const context: DeterministicCheckContext = {
+  connectedChannels: ["vellum"],
+};
+
+describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
+  test("passes when body is real non-empty text", async () => {
+    const result = await runDeterministicChecks(
+      makeSignal(),
+      makeDecision(),
+      context,
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails when body is empty", async () => {
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "" },
+      },
+    });
+    const result = await runDeterministicChecks(
+      makeSignal(),
+      decision,
+      context,
+    );
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  test("fails when body is whitespace only", async () => {
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "   \n  " },
+      },
+    });
+    const result = await runDeterministicChecks(
+      makeSignal(),
+      decision,
+      context,
+    );
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  test("fails when body is the raw source event name", async () => {
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "user.send_notification" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fallback leak");
+  });
+
+  test("fails when body matches the normalized source event name", async () => {
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "user send notification" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fallback leak");
+  });
+
+  test("fails when rendered copy is missing for a selected channel", async () => {
+    const decision = makeDecision({
+      selectedChannels: ["vellum"],
+      renderedCopy: {},
+    });
+    const result = await runDeterministicChecks(
+      makeSignal(),
+      decision,
+      context,
+    );
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("rendered copy missing");
+    expect(result.reason).toContain("vellum");
+  });
+
+  test("passes when shouldNotify is false regardless of copy contents", async () => {
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      shouldNotify: false,
+      // Empty body + event-name body would both fail the copy check if
+      // shouldNotify were true. Short-circuit must skip the check.
+      renderedCopy: {
+        vellum: { title: "", body: "" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(true);
+  });
+});

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -88,6 +88,16 @@ export async function runDeterministicChecks(
     return dedupeCheck;
   }
 
+  // Check 5: Rendered copy quality (fail-closed)
+  const copyCheck = checkRenderedCopyQuality(signal, decision);
+  if (!copyCheck.passed) {
+    log.info(
+      { signalId: signal.signalId, reason: copyCheck.reason },
+      "Deterministic check failed: rendered copy quality",
+    );
+    return copyCheck;
+  }
+
   return { passed: true };
 }
 
@@ -228,6 +238,56 @@ function checkDedupe(
       { err: errMsg },
       "Dedupe check failed, allowing notification through",
     );
+  }
+
+  return { passed: true };
+}
+
+/**
+ * Fail-closed check that the rendered copy is real text and not an
+ * accidental fallback leak (empty body, or body that is just the raw
+ * source event name like "user.send_notification"). Catches cases where
+ * `buildGenericCopy` synthesizes a placeholder from the event name.
+ */
+function checkRenderedCopyQuality(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+): CheckResult {
+  if (!decision.shouldNotify) {
+    return { passed: true };
+  }
+
+  const normalizedEventName = signal.sourceEventName
+    .replace(/[._]/g, " ")
+    .toLowerCase()
+    .trim();
+  const rawEventName = signal.sourceEventName.toLowerCase();
+
+  for (const channel of decision.selectedChannels) {
+    const copy = decision.renderedCopy[channel];
+    if (!copy) {
+      return {
+        passed: false,
+        reason: `rendered copy missing for selected channel ${channel}`,
+      };
+    }
+    const trimmedBody = copy.body.trim();
+    if (trimmedBody.length === 0) {
+      return {
+        passed: false,
+        reason: "rendered copy body is empty",
+      };
+    }
+    const normalizedBody = trimmedBody.toLowerCase();
+    if (
+      normalizedBody === normalizedEventName ||
+      normalizedBody === rawEventName
+    ) {
+      return {
+        passed: false,
+        reason: "rendered copy body is the source event name (fallback leak)",
+      };
+    }
   }
 
   return { passed: true };


### PR DESCRIPTION
## Summary
- Adds `checkRenderedCopyQuality` deterministic check that suppresses notifications with empty bodies or bodies equal to the source event name
- Wires it into `runDeterministicChecks` after dedupe
- Closes a class of leaks where raw event names like `user.send_notification` were rendering as user-visible body text

Part of plan: notifications-rewrite.md (PR 4 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->