### PR TITLE
feat(notifications): bypass LLM classifier for assistant_tool-sourced signals

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the assistant_tool pass-through path in the notification
+ * decision engine. When a producer hands us a verbatim message via
+ * contextPayload.requestedMessage, the engine must skip the LLM call
+ * entirely and use the producer-supplied copy as-is.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks (must precede imports from mocked modules) ──────────────────
+
+mock.module("../../channels/config.js", () => ({
+  getDeliverableChannels: () => ["vellum", "telegram"],
+}));
+
+mock.module("../decisions-store.js", () => ({
+  createDecision: () => {},
+}));
+
+mock.module("../preference-summary.js", () => ({
+  getPreferenceSummary: () => undefined,
+}));
+
+mock.module("../conversation-candidates.js", () => ({
+  buildConversationCandidates: () => undefined,
+  serializeCandidatesForPrompt: () => undefined,
+}));
+
+mock.module("../../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => null,
+}));
+
+mock.module("../../prompts/system-prompt.js", () => ({
+  buildCoreIdentityContext: () => null,
+}));
+
+mock.module("../../contacts/contact-store.js", () => ({
+  listGuardianChannels: () => null,
+}));
+
+// Provider mock — if `getConfiguredProvider` is ever called by the
+// assistant_tool pass-through path, this throw makes the test fail
+// loudly instead of silently exercising the LLM path.
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => {
+    throw new Error(
+      "getConfiguredProvider should NOT be invoked for assistant_tool pass-through",
+    );
+  },
+  createTimeout: () => ({
+    signal: new AbortController().signal,
+    cleanup: () => {},
+  }),
+  extractToolUse: () => null,
+  userMessage: (text: string) => ({ role: "user", content: text }),
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Imports (after all mocks) ─────────────────────────────────────────
+
+import { evaluateSignal } from "../decision-engine.js";
+import type { NotificationSignal } from "../signal.js";
+import type { NotificationChannel } from "../types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeAssistantToolSignal(
+  overrides?: Partial<NotificationSignal>,
+): NotificationSignal {
+  return {
+    signalId: "sig-assistant-tool-test-1",
+    createdAt: Date.now(),
+    sourceChannel: "assistant_tool",
+    sourceContextId: "tool-call-1",
+    sourceEventName: "user.send_notification",
+    contextPayload: {
+      requestedMessage: "exact verbatim text here",
+      requestedTitle: "Custom Title",
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("assistant_tool pass-through in notification decision engine", () => {
+  test("uses producer-supplied title and body verbatim, no LLM call", async () => {
+    const signal = makeAssistantToolSignal();
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "telegram",
+    ] as NotificationChannel[]);
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.selectedChannels).toContain("vellum");
+    expect(decision.renderedCopy.vellum?.body).toBe("exact verbatim text here");
+    expect(decision.renderedCopy.vellum?.title).toBe("Custom Title");
+    expect(decision.conversationActions?.vellum?.action).toBe("start_new");
+    expect(decision.reasoningSummary).toBe("assistant_tool pass-through");
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.confidence).toBe(1.0);
+    expect(decision.dedupeKey).toBe(signal.signalId);
+  });
+
+  test("derives title from body when requestedTitle is not supplied", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "First sentence. Second sentence follows here.",
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+    ] as NotificationChannel[]);
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.renderedCopy.vellum?.body).toBe(
+      "First sentence. Second sentence follows here.",
+    );
+    expect(decision.renderedCopy.vellum?.title).toBe("First sentence.");
+    expect(decision.reasoningSummary).toBe("assistant_tool pass-through");
+  });
+
+  test("critical urgency selects all available channels", async () => {
+    const signal = makeAssistantToolSignal({
+      attentionHints: {
+        requiresAction: true,
+        urgency: "critical",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    });
+    const availableChannels = ["vellum", "telegram"] as NotificationChannel[];
+    const decision = await evaluateSignal(signal, availableChannels);
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.selectedChannels).toEqual(
+      expect.arrayContaining(availableChannels),
+    );
+    expect(decision.selectedChannels.length).toBe(availableChannels.length);
+    expect(decision.renderedCopy.vellum?.body).toBe("exact verbatim text here");
+    expect(decision.renderedCopy.telegram?.body).toBe(
+      "exact verbatim text here",
+    );
+    expect(decision.conversationActions?.vellum?.action).toBe("start_new");
+    expect(decision.conversationActions?.telegram?.action).toBe("start_new");
+  });
+});

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -59,6 +59,21 @@ const DECISION_TIMEOUT_MS = 15_000;
 const PROMPT_VERSION = "v4";
 
 /**
+ * Derive a short notification title from a message body. Used when an
+ * assistant_tool-sourced signal supplies `requestedMessage` without an
+ * explicit `requestedTitle`: trims to the first sentence terminator when
+ * present, then caps the result at 60 characters with an ellipsis.
+ */
+function deriveTitle(body: string): string {
+  const firstSentenceEnd = body.search(/[.!?](\s|$)/);
+  const candidate =
+    firstSentenceEnd > 0 ? body.slice(0, firstSentenceEnd + 1) : body;
+  return candidate.length > 60
+    ? candidate.slice(0, 60).trim() + "…"
+    : candidate.trim();
+}
+
+/**
  * Maximum character budget for identity context injected into the notification
  * decision prompt. We truncate to prevent oversized prompts when SOUL.md /
  * IDENTITY.md / users/<slug>.md are large — exceeding the provider context
@@ -789,6 +804,63 @@ export async function evaluateSignal(
       { err: errMsg },
       "Failed to build conversation candidates, proceeding without candidates",
     );
+  }
+
+  // Assistant-tool pass-through: when a producer hands us a verbatim
+  // message body via contextPayload.requestedMessage, skip the LLM
+  // classifier entirely. The producer has already done the routing and
+  // copy decisions — we just enforce the standard post-decision guards
+  // and persist the result.
+  if (
+    signal.sourceChannel === "assistant_tool" &&
+    typeof signal.contextPayload === "object" &&
+    signal.contextPayload != null &&
+    typeof (signal.contextPayload as Record<string, unknown>)
+      .requestedMessage === "string" &&
+    (
+      (signal.contextPayload as Record<string, unknown>)
+        .requestedMessage as string
+    ).trim().length > 0
+  ) {
+    const payload = signal.contextPayload as Record<string, unknown>;
+    const body = (payload.requestedMessage as string).trim();
+    const title =
+      typeof payload.requestedTitle === "string" &&
+      payload.requestedTitle.trim().length > 0
+        ? (payload.requestedTitle as string).trim()
+        : deriveTitle(body);
+    const isUrgent =
+      signal.attentionHints.urgency === "critical" ||
+      signal.attentionHints.urgency === "high";
+    const selectedChannels = isUrgent
+      ? [...availableChannels]
+      : availableChannels.includes("vellum")
+        ? ["vellum" as NotificationChannel]
+        : [];
+    let decision: NotificationDecision = {
+      shouldNotify: selectedChannels.length > 0,
+      selectedChannels,
+      reasoningSummary: "assistant_tool pass-through",
+      renderedCopy: Object.fromEntries(
+        selectedChannels.map((ch) => [ch, { title, body }]),
+      ) as NotificationDecision["renderedCopy"],
+      conversationActions: Object.fromEntries(
+        selectedChannels.map((ch) => [ch, { action: "start_new" as const }]),
+      ) as NotificationDecision["conversationActions"],
+      dedupeKey: signal.signalId,
+      confidence: 1.0,
+      fallbackUsed: false,
+    };
+    decision = enforceGuardianRequestCode(decision, signal);
+    decision = enforceAccessRequestInstructions(decision, signal);
+    decision = enforceHeartbeatAlertCopy(decision, signal);
+    decision = enforceGuardianCallConversationAffinity(decision, signal);
+    decision = enforceConversationAffinity(
+      decision,
+      signal.conversationAffinityHint,
+    );
+    decision.persistedDecisionId = persistDecision(signal, decision);
+    return decision;
   }
 
   const provider = await getConfiguredProvider("notificationDecision");


### PR DESCRIPTION
## Summary
- Adds early-return in decision-engine for `sourceChannel: assistant_tool` signals that include `contextPayload.requestedMessage`
- Producer-supplied title/body pass through verbatim — no LLM rewriting
- Adds `deriveTitle()` helper for when only message is supplied
- LLM path untouched for all other source channels

Part of plan: notifications-rewrite.md (PR 3 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->