### PR TITLE
feat(notifications): add --urgent flag and default source fields to CLI

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // Test isolation: mock logger and IPC client
 // ---------------------------------------------------------------------------
 
-mock.module("../../util/logger.js", () => ({
+mock.module("../../../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -23,7 +23,7 @@ let ipcResponse: { ok: boolean; result?: unknown; error?: string } = {
   result: {},
 };
 
-mock.module("../../ipc/cli-client.js", () => ({
+mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
     return ipcResponse;
@@ -32,7 +32,7 @@ mock.module("../../ipc/cli-client.js", () => ({
 
 import { Command } from "commander";
 
-import { registerNotificationsCommand } from "../commands/notifications.js";
+import { registerNotificationsCommand } from "../notifications.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -90,6 +90,12 @@ async function runCommand(args: string[]): Promise<CommandResult> {
   return { parsed, exitCode };
 }
 
+function lastSendBody(): Record<string, unknown> {
+  expect(ipcCalls).toHaveLength(1);
+  expect(ipcCalls[0].method).toBe("emit_notification_signal");
+  return ipcCalls[0].params?.body as Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
@@ -132,13 +138,10 @@ describe("notifications send", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.signalId).toBe("mock-id");
 
-    expect(ipcCalls).toHaveLength(1);
-    const call = ipcCalls[0];
-    expect(call.method).toBe("emit_notification_signal");
-    const callBody = call.params?.body as Record<string, unknown>;
-    expect(callBody?.sourceChannel).toBe("assistant_tool");
-    expect(callBody?.sourceEventName).toBe("user.send_notification");
-    const payload = callBody?.contextPayload as Record<string, unknown>;
+    const body = lastSendBody();
+    expect(body.sourceChannel).toBe("assistant_tool");
+    expect(body.sourceEventName).toBe("user.send_notification");
+    const payload = body.contextPayload as Record<string, unknown>;
     expect(payload.requestedMessage).toBe("Hello");
   });
 
@@ -160,9 +163,7 @@ describe("notifications send", () => {
     expect(exitCode).toBe(0);
     expect(parsed.ok).toBe(true);
 
-    expect(ipcCalls).toHaveLength(1);
-    const emitBody = ipcCalls[0].params?.body as Record<string, unknown>;
-    const hints = emitBody?.attentionHints as Record<string, unknown>;
+    const hints = lastSendBody().attentionHints as Record<string, unknown>;
     expect(hints.urgency).toBe("high");
     expect(hints.requiresAction).toBe(true);
     expect(hints.isAsyncBackground).toBe(true);
@@ -184,9 +185,7 @@ describe("notifications send", () => {
     expect(exitCode).toBe(0);
     expect(parsed.ok).toBe(true);
 
-    expect(ipcCalls).toHaveLength(1);
-    const dlBody = ipcCalls[0].params?.body as Record<string, unknown>;
-    const payload = dlBody?.contextPayload as Record<string, unknown>;
+    const payload = lastSendBody().contextPayload as Record<string, unknown>;
     expect(payload.preferredChannels).toEqual(["telegram", "slack"]);
   });
 
@@ -230,8 +229,8 @@ describe("notifications send", () => {
     expect(exitCode).toBe(0);
     expect(parsed.ok).toBe(true);
 
-    const callBody = ipcCalls[0].params?.body as Record<string, unknown>;
-    expect(callBody.conversationAffinityHint).toEqual({ vellum: "conv-123" });
+    const body = lastSendBody();
+    expect(body.conversationAffinityHint).toEqual({ vellum: "conv-123" });
   });
 
   test("send omits conversationAffinityHint when --conversation-id not passed", async () => {
@@ -245,8 +244,8 @@ describe("notifications send", () => {
       "Hi",
     ]);
 
-    const callBody = ipcCalls[0].params?.body as Record<string, unknown>;
-    expect(callBody.conversationAffinityHint).toBeUndefined();
+    const body = lastSendBody();
+    expect(body.conversationAffinityHint).toBeUndefined();
   });
 
   test("send rejects empty --conversation-id", async () => {
@@ -287,6 +286,93 @@ describe("notifications send", () => {
     expect(exitCode).toBe(1);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toBe("Daemon rejected the signal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// send — minimal-surface ergonomics (--urgent and source defaults)
+// ---------------------------------------------------------------------------
+
+describe("notifications send — minimal-surface ergonomics", () => {
+  test("--urgent maps to urgency=critical + requiresAction=true", async () => {
+    const { exitCode } = await runCommand([
+      "send",
+      "--message",
+      "Pager: prod is down",
+      "--urgent",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const hints = lastSendBody().attentionHints as Record<string, unknown>;
+    expect(hints.urgency).toBe("critical");
+    expect(hints.requiresAction).toBe(true);
+  });
+
+  test("missing --source-channel defaults to 'assistant_tool'", async () => {
+    const { exitCode } = await runCommand(["send", "--message", "hello"]);
+
+    expect(exitCode).toBe(0);
+    const body = lastSendBody();
+    expect(body.sourceChannel).toBe("assistant_tool");
+    // The context payload echoes the source channel via requestedBySource.
+    const payload = body.contextPayload as Record<string, unknown>;
+    expect(payload.requestedBySource).toBe("assistant_tool");
+  });
+
+  test("missing --source-event-name defaults to 'assistant.share'", async () => {
+    const { exitCode } = await runCommand(["send", "--message", "hello"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastSendBody().sourceEventName).toBe("assistant.share");
+  });
+
+  test("explicit --urgency high still overrides defaults when --urgent is absent", async () => {
+    const { exitCode } = await runCommand([
+      "send",
+      "--message",
+      "stand-up reminder",
+      "--urgency",
+      "high",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const hints = lastSendBody().attentionHints as Record<string, unknown>;
+    expect(hints.urgency).toBe("high");
+    // Without --urgent or --requires-action, requiresAction stays at the new
+    // default of false.
+    expect(hints.requiresAction).toBe(false);
+  });
+
+  test("explicit --urgency wins even when --urgent is also passed (back-compat)", async () => {
+    const { exitCode } = await runCommand([
+      "send",
+      "--message",
+      "deploy complete",
+      "--urgent",
+      "--urgency",
+      "medium",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const hints = lastSendBody().attentionHints as Record<string, unknown>;
+    expect(hints.urgency).toBe("medium");
+    // --urgent still flips requiresAction since no explicit flag was passed.
+    expect(hints.requiresAction).toBe(true);
+  });
+
+  test("explicit --no-requires-action wins even when --urgent is passed", async () => {
+    const { exitCode } = await runCommand([
+      "send",
+      "--message",
+      "fyi only",
+      "--urgent",
+      "--no-requires-action",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const hints = lastSendBody().attentionHints as Record<string, unknown>;
+    expect(hints.urgency).toBe("critical");
+    expect(hints.requiresAction).toBe(false);
   });
 });
 
@@ -342,7 +428,9 @@ describe("notifications list", () => {
     expect(parsed.ok).toBe(true);
 
     expect(ipcCalls).toHaveLength(1);
-    expect((ipcCalls[0].params?.body as Record<string, unknown>)?.limit).toBe(5);
+    expect((ipcCalls[0].params?.body as Record<string, unknown>)?.limit).toBe(
+      5,
+    );
   });
 
   test("list passes --source-event-name to IPC", async () => {

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -26,11 +26,16 @@ source channel, event name, and attention hints. The decision engine evaluates
 whether and where to deliver the notification based on connected channels,
 urgency, and user preferences.
 
+Minimal usage: only --message is required. Add --urgent for a push + visual
+flag in the inbox. Source channel/event name fall back to assistant_tool /
+assistant.share when omitted.
+
 Examples:
-  $ assistant notifications send --source-channel assistant_tool --source-event-name user.send_notification --message "Build finished"
+  $ assistant notifications send --message "Build finished"
+  $ assistant notifications send --message "Pager: prod is down" --urgent
   $ assistant notifications send --source-channel scheduler --source-event-name schedule.notify --message "Stand-up in 5 minutes" --urgency high
   $ assistant notifications send --source-channel watcher --source-event-name watcher.notification --message "File changed" --no-requires-action --is-async-background
-  $ assistant notifications send --source-channel assistant_tool --source-event-name user.send_notification --message "Deploy complete" --preferred-channels vellum,telegram --json`,
+  $ assistant notifications send --message "Deploy complete" --preferred-channels vellum,telegram --json`,
       );
 
       // -------------------------------------------------------------------------
@@ -40,28 +45,33 @@ Examples:
       notifications
         .command("send")
         .description(
-          "Send a notification through the unified notification router",
-        )
-        .requiredOption(
-          "--source-channel <channel>",
-          "Source channel producing this notification",
-        )
-        .requiredOption(
-          "--source-event-name <name>",
-          "Event name for audit, routing, and dedupe grouping",
+          "Send a notification through the unified notification router. Only --message is required; pass --urgent for a push + visual flag.",
         )
         .requiredOption(
           "--message <message>",
           "Notification message the user should receive",
         )
+        .option(
+          "--urgent",
+          "Mark this notification as urgent (fires push + visual flag in inbox)",
+          false,
+        )
+        .option(
+          "--source-channel <channel>",
+          "Source channel producing this notification (default: assistant_tool)",
+        )
+        .option(
+          "--source-event-name <name>",
+          "Event name for audit, routing, and dedupe grouping (default: assistant.share)",
+        )
         .option("--title <title>", "Optional notification title")
         .option(
           "--urgency <urgency>",
-          "Urgency hint: low, medium, high, critical (default: medium)",
+          "Urgency hint: low, medium, high, critical (default: low; use --urgent for critical)",
         )
         .option(
           "--requires-action",
-          "Whether the notification expects user action (default: true)",
+          "Whether the notification expects user action (default: false; use --urgent to force true)",
         )
         .option(
           "--no-requires-action",
@@ -111,15 +121,18 @@ Examples:
           "after",
           `
 Arguments:
-  --source-channel     One of the registered source channels (see "assistant notifications --help")
-  --source-event-name  One of the registered event names (see "assistant notifications --help")
   --message            The notification body text (required, must be non-empty)
+  --urgent             Shortcut that maps to urgency=critical + requires-action=true
+  --source-channel     One of the registered source channels (default: assistant_tool)
+  --source-event-name  One of the registered event names (default: assistant.share)
 
 Behavioral notes:
   - The signal is emitted through the full notification pipeline: event store,
     decision engine, deterministic checks, and channel dispatch.
-  - --requires-action defaults to true; use --no-requires-action to disable.
-  - --urgency defaults to medium if not specified.
+  - --urgent overrides --urgency and --requires-action defaults so the signal
+    is treated as critical and requires user action. Explicit --urgency /
+    --requires-action flags still win for back-compat.
+  - Without --urgent, --urgency defaults to low and --requires-action to false.
   - --preferred-channels are hints only; the decision engine may override them.
   - --dedupe-key suppresses duplicate signals with the same key.
   - --conversation-id pins delivery to an existing vellum conversation
@@ -127,20 +140,22 @@ Behavioral notes:
     binding-based pairing for their external threads.
 
 Examples:
-  $ assistant notifications send --source-channel assistant_tool --source-event-name user.send_notification --message "Task complete"
+  $ assistant notifications send --message "Task complete"
+  $ assistant notifications send --message "Pager: prod is down" --urgent
   $ assistant notifications send --source-channel scheduler --source-event-name schedule.notify --message "Meeting in 5 min" --urgency high --title "Reminder"
   $ assistant notifications send --source-channel watcher --source-event-name watcher.notification --message "Detected change" --no-requires-action --is-async-background --json
-  $ assistant notifications send --source-channel assistant_tool --source-event-name user.send_notification --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
+  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
         )
         .action(
           async (
             opts: {
-              sourceChannel: string;
-              sourceEventName: string;
+              sourceChannel?: string;
+              sourceEventName?: string;
               message: string;
+              urgent: boolean;
               title?: string;
               urgency?: string;
-              requiresAction: boolean;
+              requiresAction?: boolean;
               isAsyncBackground: boolean;
               visibleInSourceNow: boolean;
               deadlineAt?: string;
@@ -153,6 +168,11 @@ Examples:
             cmd: Command,
           ) => {
             try {
+              // Apply defaults for optional source fields (minimal-surface
+              // ergonomics; explicit values from the CLI still win).
+              const sourceChannel = opts.sourceChannel ?? "assistant_tool";
+              const sourceEventName = opts.sourceEventName ?? "assistant.share";
+
               // Validate --message (keep basic validation for immediate CLI feedback)
               const message = opts.message.trim();
               if (message.length === 0) {
@@ -164,8 +184,15 @@ Examples:
                 return;
               }
 
+              // --urgent is a shortcut for urgency=critical + requiresAction=true.
+              // Explicit --urgency / --requires-action flags still win so the
+              // back-compat path keeps working during the deprecation window.
+              const urgentDefaults = opts.urgent
+                ? { urgency: "critical", requiresAction: true }
+                : { urgency: "low", requiresAction: false };
+
               // Validate --urgency
-              const urgency = opts.urgency ?? "medium";
+              const urgency = opts.urgency ?? urgentDefaults.urgency;
               if (
                 urgency !== "low" &&
                 urgency !== "medium" &&
@@ -179,6 +206,8 @@ Examples:
                 process.exitCode = 1;
                 return;
               }
+              const requiresAction =
+                opts.requiresAction ?? urgentDefaults.requiresAction;
 
               // Parse --deadline-at
               let deadlineAt: number | undefined;
@@ -241,11 +270,11 @@ Examples:
                 reason: string;
               }>("emit_notification_signal", {
                 body: {
-                  sourceChannel: opts.sourceChannel,
-                  sourceEventName: opts.sourceEventName,
+                  sourceChannel,
+                  sourceEventName,
                   sourceContextId,
                   attentionHints: {
-                    requiresAction: opts.requiresAction ?? true,
+                    requiresAction,
                     urgency,
                     deadlineAt,
                     isAsyncBackground: opts.isAsyncBackground ?? false,
@@ -253,7 +282,7 @@ Examples:
                   },
                   contextPayload: {
                     requestedMessage: message,
-                    requestedBySource: opts.sourceChannel,
+                    requestedBySource: sourceChannel,
                     ...(opts.title ? { requestedTitle: opts.title } : {}),
                     ...(preferredChannels?.length ? { preferredChannels } : {}),
                     ...(deepLinkMetadata ? { deepLinkMetadata } : {}),


### PR DESCRIPTION
## Summary
- Adds `--urgent` boolean flag that maps to `urgency: critical` + `requiresAction: true`
- Makes `--source-channel` default to `assistant_tool` and `--source-event-name` default to `assistant.share`
- Keeps old flags accepted for back-compat during the deprecation window

Part of plan: notifications-rewrite.md (PR 1 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->