### PR TITLE
fix(macos): align Go to Thread navigation with notification_intent deepLinkMetadata

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -265,17 +265,44 @@ extension MainWindowView {
                 title: item.title,
                 iconForeground: iconForegroundForFeedItem(item),
                 iconBackground: iconBackgroundForFeedItem(item),
-                onGoToThread: item.conversationId.flatMap { id in
-                    UUID(uuidString: id).map { uuid in
-                        { activeHomeDetailPanel = nil; windowState.selection = .conversation(uuid) }
-                    }
-                },
+                onGoToThread: goToThreadHandler(for: item),
                 onDismiss: { activeHomeDetailPanel = nil }
             ) {
                 Text(item.summary).font(VFont.bodyMediumDefault).foregroundStyle(VColor.contentSecondary).padding(VSpacing.lg)
             }
         case nil:
             EmptyView()
+        }
+    }
+
+    /// Builds the "Go to Thread" handler for the home detail panel.
+    ///
+    /// `FeedItem.conversationId` carries the **daemon-side** conversation
+    /// ID (mirrored from `notification_intent.deepLinkMetadata.conversationId`
+    /// and `notification_deliveries.conversation_id`). `ViewSelection`'s
+    /// `.conversation(UUID)` requires the **client-local** `ConversationModel.id`,
+    /// which is a separately generated UUID — same shape, different namespace.
+    /// We must round-trip through `selectConversationByConversationIdAsync(_:)`
+    /// to resolve the daemon ID to the matching local model (fetching on
+    /// demand if it isn't in the sidebar yet), then drive selection off the
+    /// resolved local UUID. The same pattern is used by the logs panel's
+    /// `onSelectConversation` callback above.
+    ///
+    /// Returns `nil` when the feed item has no associated conversation —
+    /// `HomeDetailPanel` hides the button when the handler is `nil`.
+    private func goToThreadHandler(for item: FeedItem) -> (() -> Void)? {
+        guard let daemonConversationId = item.conversationId else { return nil }
+        return {
+            activeHomeDetailPanel = nil
+            Task { @MainActor in
+                let found = await conversationManager.selectConversationByConversationIdAsync(daemonConversationId)
+                let activeLocalId = conversationManager.activeConversationId
+                panelCoordinatorLog.info(
+                    "Go to Thread: daemonConversationId=\(daemonConversationId, privacy: .public) feedItemId=\(item.id, privacy: .public) found=\(found, privacy: .public) activeLocalId=\(activeLocalId?.uuidString ?? "<nil>", privacy: .public)"
+                )
+                guard found, let id = activeLocalId else { return }
+                windowState.selection = .conversation(id)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Diagnoses and fixes "Go to Thread" button routing to wrong conversation
- Ensures notification popover navigation uses `deepLinkMetadata.conversationId` from the SSE event as canonical source
- Adds debug logging to surface future mismatches in logs

Part of plan: notifications-rewrite.md (PR 8 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->