### PR TITLE
fix(macos): never display raw source-event-name strings in notification UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -67,10 +67,19 @@ extension AppDelegate {
             }
         }
 
+        // Sanitize the title before it reaches sidebar display or the fallback
+        // notification banner. Server-side checks should prevent empty or
+        // event-name-leak titles, but this guard ensures the sidebar never
+        // shows a raw event name like "user.send_notification".
+        let sanitizedTitle = AppDelegate.sanitizeNotificationTitle(
+            msg.title,
+            sourceEventName: msg.sourceEventName
+        )
+
         ensureMainWindowExists()
         mainWindow?.conversationManager.createNotificationConversation(
             conversationId: msg.conversationId,
-            title: msg.title,
+            title: sanitizedTitle,
             sourceEventName: msg.sourceEventName,
             groupId: msg.groupId,
             source: msg.source
@@ -95,7 +104,7 @@ extension AppDelegate {
 
         scheduleNotificationFallback(
             conversationId: msg.conversationId,
-            title: msg.title,
+            title: sanitizedTitle,
             sourceEventName: msg.sourceEventName
         )
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -178,6 +178,62 @@ extension AppDelegate {
         }
     }
 
+    /// Returns `true` if `candidate` matches `sourceEventName` either raw
+    /// (e.g. `"user.send_notification"`) or after `.`/`_` are replaced with
+    /// spaces (e.g. `"user send notification"`). Case-insensitive.
+    /// Used by the sanitize helpers below to detect event-name fallback leaks.
+    nonisolated static func isEventNameLeak(
+        _ candidate: String,
+        sourceEventName: String
+    ) -> Bool {
+        let trimmedCandidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let rawEvent = sourceEventName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !rawEvent.isEmpty, !trimmedCandidate.isEmpty else { return false }
+        if trimmedCandidate == rawEvent { return true }
+        let normalizedEvent = rawEvent
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: ".", with: " ")
+        return trimmedCandidate == normalizedEvent
+    }
+
+    /// Sanitize a user-visible notification title. Returns `"Notification"`
+    /// when the title is empty/whitespace or matches the source event name.
+    /// Server-side checks should already suppress these, but this guard
+    /// ensures users never see raw event-name strings like
+    /// `"user.send_notification"` in the sidebar or notification banner.
+    /// Logs a warning when substitution fires so regressions remain visible.
+    nonisolated static func sanitizeNotificationTitle(
+        _ title: String,
+        sourceEventName: String
+    ) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let leak = isEventNameLeak(trimmed, sourceEventName: sourceEventName)
+        guard trimmed.isEmpty || leak else { return title }
+        log.warning("""
+        Sanitized notification title (source: \(sourceEventName, privacy: .public)): \
+        empty=\(trimmed.isEmpty, privacy: .public), leak=\(leak, privacy: .public)
+        """)
+        return "Notification"
+    }
+
+    /// Sanitize a user-visible notification body. Returns
+    /// `"(no preview available)"` when the body is empty/whitespace or
+    /// matches the source event name. See ``sanitizeNotificationTitle``
+    /// for rationale.
+    nonisolated static func sanitizeNotificationBody(
+        _ body: String,
+        sourceEventName: String
+    ) -> String {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        let leak = isEventNameLeak(trimmed, sourceEventName: sourceEventName)
+        guard trimmed.isEmpty || leak else { return body }
+        log.warning("""
+        Sanitized notification body (source: \(sourceEventName, privacy: .public)): \
+        empty=\(trimmed.isEmpty, privacy: .public), leak=\(leak, privacy: .public)
+        """)
+        return "(no preview available)"
+    }
+
     private func conversationId(from deepLinkMetadata: [String: AnyCodable]?) -> String? {
         if let direct = deepLinkMetadata?["conversationId"]?.value as? String {
             return direct
@@ -234,8 +290,8 @@ extension AppDelegate {
         deliveryId: String? = nil
     ) {
         let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
+        content.title = Self.sanitizeNotificationTitle(title, sourceEventName: sourceEventName)
+        content.body = Self.sanitizeNotificationBody(body, sourceEventName: sourceEventName)
         content.sound = .default
         content.categoryIdentifier = "NOTIFICATION_INTENT"
 

--- a/clients/macos/vellum-assistantTests/NotificationCopySanitizationTests.swift
+++ b/clients/macos/vellum-assistantTests/NotificationCopySanitizationTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Last-mile defense against raw `sourceEventName` strings leaking into the
+/// notification UI. Server-side checks (deterministic-checks
+/// `checkRenderedCopyQuality`) suppress these at emit time; these tests cover
+/// the client-side guard that runs even if a bad payload slips past the
+/// server.
+final class NotificationCopySanitizationTests: XCTestCase {
+
+    // MARK: - sanitizeNotificationTitle
+
+    func testTitlePassthroughForRealCopy() {
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "New email from Alice",
+            sourceEventName: "email.received"
+        )
+        XCTAssertEqual(result, "New email from Alice")
+    }
+
+    func testTitleEmptyStringFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "",
+            sourceEventName: "email.received"
+        )
+        XCTAssertEqual(result, "Notification")
+    }
+
+    func testTitleWhitespaceOnlyFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "   \n  ",
+            sourceEventName: "email.received"
+        )
+        XCTAssertEqual(result, "Notification")
+    }
+
+    func testTitleRawEventNameFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "user.send_notification",
+            sourceEventName: "user.send_notification"
+        )
+        XCTAssertEqual(result, "Notification")
+    }
+
+    func testTitleNormalizedEventNameFallsBackToPlaceholder() {
+        // copy-composer's legacy buildGenericCopy substituted "." and "_" with
+        // spaces — guard against that derived form leaking too.
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "user send notification",
+            sourceEventName: "user.send_notification"
+        )
+        XCTAssertEqual(result, "Notification")
+    }
+
+    func testTitleCaseInsensitiveEventNameLeakIsCaught() {
+        let result = AppDelegate.sanitizeNotificationTitle(
+            "USER.SEND_NOTIFICATION",
+            sourceEventName: "user.send_notification"
+        )
+        XCTAssertEqual(result, "Notification")
+    }
+
+    // MARK: - sanitizeNotificationBody
+
+    func testBodyPassthroughForRealCopy() {
+        let result = AppDelegate.sanitizeNotificationBody(
+            "Alice replied to your message.",
+            sourceEventName: "email.received"
+        )
+        XCTAssertEqual(result, "Alice replied to your message.")
+    }
+
+    func testBodyEmptyStringFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationBody(
+            "",
+            sourceEventName: "email.received"
+        )
+        XCTAssertEqual(result, "(no preview available)")
+    }
+
+    func testBodyRawEventNameFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationBody(
+            "user.send_notification",
+            sourceEventName: "user.send_notification"
+        )
+        XCTAssertEqual(result, "(no preview available)")
+    }
+
+    func testBodyNormalizedEventNameFallsBackToPlaceholder() {
+        let result = AppDelegate.sanitizeNotificationBody(
+            "user send notification",
+            sourceEventName: "user.send_notification"
+        )
+        XCTAssertEqual(result, "(no preview available)")
+    }
+
+    // MARK: - isEventNameLeak edge cases
+
+    func testEmptyCandidateIsNotLeak() {
+        XCTAssertFalse(AppDelegate.isEventNameLeak("", sourceEventName: "user.send_notification"))
+    }
+
+    func testEmptySourceEventNameIsNeverLeak() {
+        XCTAssertFalse(AppDelegate.isEventNameLeak("Notification", sourceEventName: ""))
+    }
+
+    func testPartialMatchIsNotLeak() {
+        // We only flag exact matches (raw or normalized). A title that merely
+        // contains the event name is allowed through — it's a real composed
+        // string, not a fallback leak.
+        XCTAssertFalse(AppDelegate.isEventNameLeak(
+            "Got a user.send_notification event",
+            sourceEventName: "user.send_notification"
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Audits macOS client paths that previously fell back to `sourceEventName` for user-visible title/body when proper copy was missing
- Replaces those fallbacks with a generic placeholder (or skips render) so users never see raw event names like `user.send_notification`

Part of plan: notifications-rewrite.md (PR 7 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->