### PR TITLE
feat(notifications): set noteworthy flag when writing FeedItems

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -265,4 +265,102 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(item?.summary).toBe("Payload body");
     expect(appendCalls).toHaveLength(1);
   });
+
+  // ── noteworthy derivation ────────────────────────────────────────────
+
+  test("assistant_tool source marks the feed item noteworthy", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "user.send_notification",
+      contextPayload: { title: "Tool share", body: "Body" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(true);
+    expect(appendCalls[0]!.noteworthy).toBe(true);
+  });
+
+  test("scheduler source with schedule.notify is not noteworthy", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "scheduler",
+      sourceEventName: "schedule.notify",
+      contextPayload: { title: "Reminder", body: "Time to do thing" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(false);
+    expect(appendCalls[0]!.noteworthy).toBe(false);
+  });
+
+  test("assistant_tool source with guardian.question event still wins (noteworthy true)", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "guardian.question",
+      contextPayload: { title: "Question", body: "Approve?" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(true);
+    expect(appendCalls[0]!.noteworthy).toBe(true);
+  });
+
+  test("activity.failed with critical urgency is noteworthy", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "scheduler",
+      sourceEventName: "activity.failed",
+      contextPayload: { title: "Job failed", body: "Critical failure" },
+      attentionHints: {
+        requiresAction: false,
+        urgency: "critical",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(true);
+    expect(appendCalls[0]!.noteworthy).toBe(true);
+  });
+
+  test("activity.failed with low urgency is not noteworthy", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "scheduler",
+      sourceEventName: "activity.failed",
+      contextPayload: { title: "Job failed", body: "Routine failure" },
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(false);
+    expect(appendCalls[0]!.noteworthy).toBe(false);
+  });
+
+  test("credential.health_alert is noteworthy regardless of source channel", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "watcher",
+      sourceEventName: "credential.health_alert",
+      contextPayload: { title: "Credential expired", body: "Reconnect" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(true);
+    expect(appendCalls[0]!.noteworthy).toBe(true);
+  });
 });

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -94,6 +94,7 @@ export async function writeHomeFeedItemForSignal(
     createdAt: now,
     status: "new",
     category,
+    noteworthy: deriveNoteworthy(signal),
     ...(urgency ? { urgency } : {}),
     ...(conversationId ? { conversationId } : {}),
     ...(panelKind ? { detailPanel: { kind: panelKind } } : {}),
@@ -174,4 +175,31 @@ function readPayloadString(payload: unknown, key: string): string | undefined {
   if (!payload || typeof payload !== "object") return undefined;
   const value = (payload as Record<string, unknown>)[key];
   return typeof value === "string" ? value : undefined;
+}
+
+// ── Noteworthy derivation ─────────────────────────────────────────────
+//
+// Clients split the feed into inbox-style (noteworthy) and activity-style
+// (routine) surfaces. Assistant-initiated shares and a small allow-list of
+// high-importance system events land in the inbox; routine background
+// signals stay in activity.
+
+const NOTEWORTHY_EVENT_NAMES: ReadonlySet<string> = new Set([
+  "guardian.question",
+  "guardian.channel_activation",
+  "ingress.access_request",
+  "ingress.escalation",
+  "credential.health_alert",
+]);
+
+function deriveNoteworthy(signal: NotificationSignal): boolean {
+  if (signal.sourceChannel === "assistant_tool") return true;
+  if (NOTEWORTHY_EVENT_NAMES.has(signal.sourceEventName)) return true;
+  if (
+    signal.sourceEventName === "activity.failed" &&
+    signal.attentionHints.urgency === "critical"
+  ) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- Adds `deriveNoteworthy()` helper to `home-feed-side-effect`
- Populates the `FeedItem.noteworthy` field (added in PR 9) based on source channel + event name + urgency
- Assistant-initiated shares and high-importance system events get `noteworthy: true`; routine background events get `false`

Part of plan: notifications-rewrite.md (PR 10 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->