### PR TITLE
refactor(notifications): drop event-name body fallback in copy-composer

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -147,7 +147,10 @@ describe("notification decision strategy", () => {
       expect(copy.telegram!.deliveryText).toBe("Take out the trash");
     });
 
-    test("unknown event name produces generic copy with urgency prefix", () => {
+    test("unknown event name produces generic copy with empty body", () => {
+      // The event-name-derived body fallback was removed; the deterministic
+      // `checkRenderedCopyQuality` check in deterministic-checks.ts will
+      // suppress notifications that end up with an empty body.
       const signal = makeSignal({
         sourceEventName: "some_novel.event",
         attentionHints: {
@@ -161,12 +164,16 @@ describe("notification decision strategy", () => {
       const copy = composeFallbackCopy(signal, channels);
       expect(copy.vellum).toBeDefined();
       expect(copy.vellum!.title).toBe("Notification");
-      expect(copy.vellum!.body).toContain("Urgent:");
-      expect(copy.vellum!.body).toContain("action required");
-      expect(copy.telegram!.deliveryText).toBe(copy.telegram!.body);
+      expect(copy.vellum!.body).toBe("");
+      // Telegram deliveryText falls back to title when body is empty; the
+      // checkRenderedCopyQuality check still suppresses on empty body.
+      expect(copy.telegram!.body).toBe("");
     });
 
-    test("unknown event name without urgency produces clean generic copy", () => {
+    test("unknown event name without urgency also produces empty body", () => {
+      // The event-name-derived body fallback was removed; the deterministic
+      // `checkRenderedCopyQuality` check in deterministic-checks.ts will
+      // suppress notifications that end up with an empty body.
       const signal = makeSignal({
         sourceEventName: "background.sync_complete",
         attentionHints: {
@@ -179,10 +186,8 @@ describe("notification decision strategy", () => {
 
       const copy = composeFallbackCopy(signal, channels);
       expect(copy.vellum).toBeDefined();
-      expect(copy.vellum!.body).not.toContain("Urgent:");
-      expect(copy.vellum!.body).not.toContain("action required");
-      // Dots and underscores in event name are replaced with spaces
-      expect(copy.vellum!.body).toContain("background sync complete");
+      expect(copy.vellum!.title).toBe("Notification");
+      expect(copy.vellum!.body).toBe("");
     });
 
     test("fallback copy is generated for every requested channel", () => {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -605,11 +605,11 @@ export function composeFallbackCopy(
 
   const baseCopy: RenderedChannelCopy = template
     ? template(signal.contextPayload)
-    : buildGenericCopy(signal);
+    : buildGenericCopy();
 
   const result: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {};
   for (const ch of channels) {
-    result[ch] = applyChannelDefaults(ch, baseCopy, signal);
+    result[ch] = applyChannelDefaults(ch, baseCopy);
   }
   return result;
 }
@@ -617,12 +617,11 @@ export function composeFallbackCopy(
 function applyChannelDefaults(
   channel: NotificationChannel,
   baseCopy: RenderedChannelCopy,
-  signal: NotificationSignal,
 ): RenderedChannelCopy {
   const copy: RenderedChannelCopy = { ...baseCopy };
 
   if (channel === "telegram") {
-    copy.deliveryText = buildChatSurfaceFallbackDeliveryText(baseCopy, signal);
+    copy.deliveryText = buildChatSurfaceFallbackDeliveryText(baseCopy);
   }
 
   return copy;
@@ -630,7 +629,6 @@ function applyChannelDefaults(
 
 function buildChatSurfaceFallbackDeliveryText(
   baseCopy: RenderedChannelCopy,
-  signal: NotificationSignal,
 ): string {
   const explicit = nonEmpty(baseCopy.deliveryText);
   if (explicit) return explicit;
@@ -641,23 +639,20 @@ function buildChatSurfaceFallbackDeliveryText(
   const title = nonEmpty(baseCopy.title);
   if (title) return title;
 
-  return signal.sourceEventName.replace(/[._]/g, " ");
+  // No usable text: return empty string. The deterministic
+  // `checkRenderedCopyQuality` (see deterministic-checks.ts) suppresses
+  // notifications with empty bodies, so this will not reach users.
+  return "";
 }
 
 /**
- * Build generic copy when no template matches. Uses the signal's
- * sourceEventName and attention hints to produce something reasonable.
+ * Build generic copy when no template matches. Returns an empty body so
+ * the deterministic `checkRenderedCopyQuality` (see deterministic-checks.ts)
+ * suppresses the notification rather than rendering an event-name placeholder.
  */
-function buildGenericCopy(signal: NotificationSignal): RenderedChannelCopy {
-  const humanName = signal.sourceEventName.replace(/[._]/g, " ");
-  const urgencyPrefix =
-    signal.attentionHints.urgency === "high" ? "Urgent: " : "";
-  const actionSuffix = signal.attentionHints.requiresAction
-    ? " — action required"
-    : "";
-
+function buildGenericCopy(): RenderedChannelCopy {
   return {
     title: "Notification",
-    body: `${urgencyPrefix}${humanName}${actionSuffix}`,
+    body: "",
   };
 }


### PR DESCRIPTION
## Summary
- `buildGenericCopy()` now returns an empty body instead of a body derived from the source event name
- `buildChatSurfaceFallbackDeliveryText()` similarly returns empty string instead of event-name-derived text
- The fail-closed check added in PR 4 will suppress any resulting empty-body notification, so no garbage reaches users

Part of plan: notifications-rewrite.md (PR 6 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->