### PR TITLE
feat(macos): visually flag urgent inbox items

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -118,6 +118,7 @@ struct HomePageView: View {
                                     iconForeground: iconForeground(for: item),
                                     iconBackground: iconBackground(for: item),
                                     title: item.title,
+                                    isUrgent: isUrgent(item),
                                     onDismiss: { dismissItem(item) },
                                     onTap: { openItem(item) }
                                 )
@@ -181,32 +182,38 @@ struct HomePageView: View {
 
     // MARK: - Feed grouping
 
-    /// Categories present in the visible feed (non-dismissed, non-high-urgency).
-    /// Drives the filter bar — only categories with items get a pill.
+    /// True for items the inbox surfaces with a leading red dot — `urgency`
+    /// of `.high` or `.critical`.
+    private func isUrgent(_ item: FeedItem) -> Bool {
+        item.urgency == .high || item.urgency == .critical
+    }
+
+    /// Categories present in the visible feed (non-dismissed). Drives the
+    /// filter bar — only categories with items get a pill.
     private var presentCategories: Set<FeedItemCategory> {
         var cats = Set<FeedItemCategory>()
         for item in feedStore.items {
             guard item.status != .dismissed else { continue }
-            if item.urgency == .high || item.urgency == .critical { continue }
             cats.insert(item.category ?? .system)
         }
         return cats
     }
 
-    /// Sorts the feed by `priority desc, createdAt desc`, hides
+    /// Sorts the feed with urgent items pinned to the top, then by
+    /// `priority desc, createdAt desc` within each urgency group. Hides
     /// dismissed items (so `dismissItem(_:)` gives immediate feedback
-    /// without waiting for a server refresh to rewrite the array),
-    /// then buckets via `HomeFeedTimeGroup.bucket(_:)`.
+    /// without waiting for a server refresh to rewrite the array), then
+    /// buckets via `HomeFeedTimeGroup.bucket(_:)`.
     private var feedBuckets: [(group: HomeFeedTimeGroup, items: [FeedItem])] {
         let sorted = feedStore.items.sorted { a, b in
+            let aUrgent = isUrgent(a)
+            let bUrgent = isUrgent(b)
+            if aUrgent != bUrgent { return aUrgent }
             if a.priority != b.priority { return a.priority > b.priority }
             return a.createdAt > b.createdAt
         }
         let filtered = sorted.filter { item in
             guard item.status != .dismissed else { return false }
-            // High/critical urgency items are surfaced as macOS system
-            // notifications instead of appearing in the feed.
-            if item.urgency == .high || item.urgency == .critical { return false }
             if let active = activeFilter {
                 return (item.category ?? .system) == active
             }

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -23,6 +23,11 @@ struct HomeRecapRow: View {
     /// of the foreground token — e.g. `VColor.feedNudgeWeak`).
     let iconBackground: Color
     let title: String
+    /// When `true`, render a leading red dot to flag an urgent inbox
+    /// item (urgency `.high` or `.critical`). When `false`, the dot
+    /// and its surrounding spacing are omitted entirely so non-urgent
+    /// rows align flush with the icon circle (no spacing artifact).
+    var isUrgent: Bool = false
     let onDismiss: () -> Void
     let onTap: () -> Void
 
@@ -31,6 +36,12 @@ struct HomeRecapRow: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: VSpacing.sm) {
+                if isUrgent {
+                    // Decorative — the row's combined accessibilityLabel
+                    // below already announces "Urgent" before the title.
+                    VBadge(style: .dot, color: VColor.systemNegativeStrong)
+                        .accessibilityHidden(true)
+                }
                 ZStack {
                     Circle().fill(iconBackground)
                     // 12pt glyph inside a 26pt circle ≈ 7pt padding, per mock.
@@ -79,7 +90,7 @@ struct HomeRecapRow: View {
         )
         .onHover { isHovering = $0 }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(title))
+        .accessibilityLabel(Text(isUrgent ? "Urgent, \(title)" : title))
         .accessibilityAction(named: Text("Dismiss"), onDismiss)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a red dot visual flag to inbox feed items with `urgency: critical` or `high`
- Sorts urgent items to the top of the inbox section (Activity section unchanged)
- Includes "Urgent" accessibility label for VoiceOver

Part of plan: notifications-rewrite.md (PR 13 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->