### PR TITLE
fix(notifications): mirror assistant_tool to home feed + fix deriveNoteworthy ordering

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -161,6 +161,40 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(conversationLookups).toHaveLength(0);
   });
 
+  test("assistant_tool source mirrors to the home feed even without a background conversation or async hint", async () => {
+    // Regression: the `notifications send` CLI/skill emits with
+    // `sourceChannel: "assistant_tool"`, a synthetic `cli-<ts>` source
+    // context id that does not resolve to a conversation, and
+    // `isAsyncBackground: false`. Before the fix, `shouldMirrorToHomeFeed`
+    // returned `false` for this shape and the Inbox stayed empty.
+    conversationRow = null;
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "cli-12345",
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Shared from CLI", body: "Body from CLI share" },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBe("Shared from CLI");
+    expect(appendCalls[0]!.noteworthy).toBe(true);
+    // The assistant_tool short-circuit must not consult the conversation store.
+    expect(conversationLookups).toHaveLength(0);
+  });
+
   test("vellum delivery result conversationId propagates onto the feed item", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal();
@@ -310,7 +344,7 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.noteworthy).toBe(true);
   });
 
-  test("activity.failed with critical urgency is noteworthy", async () => {
+  test("activity.failed with critical urgency is noteworthy (scheduler source)", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceChannel: "scheduler",
@@ -330,7 +364,7 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.noteworthy).toBe(true);
   });
 
-  test("activity.failed with low urgency is not noteworthy", async () => {
+  test("activity.failed with low urgency is not noteworthy (scheduler source)", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceChannel: "scheduler",
@@ -348,6 +382,54 @@ describe("writeHomeFeedItemForSignal", () => {
 
     expect(item?.noteworthy).toBe(false);
     expect(appendCalls[0]!.noteworthy).toBe(false);
+  });
+
+  test("activity.failed from background-job-runner shape (assistant_tool + medium) is NOT noteworthy", async () => {
+    // Regression: `runtime/background-job-runner.ts` emits activity.failed
+    // with `sourceChannel: "assistant_tool"` and `urgency: "medium"`. Before
+    // the fix, the assistant_tool short-circuit short-circuited noteworthy
+    // to true, so every routine watcher/heartbeat failure landed in the
+    // Inbox. The activity.failed rule must run first and require critical
+    // urgency.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "activity.failed",
+      contextPayload: { title: "Job failed", body: "Routine failure" },
+      attentionHints: {
+        requiresAction: false,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(false);
+    expect(appendCalls[0]!.noteworthy).toBe(false);
+  });
+
+  test("activity.failed from assistant_tool with critical urgency IS noteworthy", async () => {
+    // Companion to the regression test above: a background-job-runner
+    // shape that opts up to critical urgency should still reach the Inbox.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "activity.failed",
+      contextPayload: { title: "Job failed", body: "Critical failure" },
+      attentionHints: {
+        requiresAction: false,
+        urgency: "critical",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.noteworthy).toBe(true);
+    expect(appendCalls[0]!.noteworthy).toBe(true);
   });
 
   test("credential.health_alert is noteworthy regardless of source channel", async () => {

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -159,8 +159,16 @@ function deriveDetailPanelKind(
  * `sourceContextId` is best-effort — it may not be a conversation id
  * (e.g. scheduler job id, watcher event id), so a lookup failure
  * falls through to "not a background conversation" rather than throwing.
+ *
+ * `assistant_tool` is the source channel used by the `notifications send`
+ * skill (and by background-job failure emits). These signals represent
+ * the assistant actively choosing to share, so we mirror them into the
+ * home feed without requiring a background-typed conversation or the
+ * `isAsyncBackground` hint — the CLI surface intentionally does not
+ * expose either.
  */
 function shouldMirrorToHomeFeed(signal: NotificationSignal): boolean {
+  if (signal.sourceChannel === "assistant_tool") return true;
   if (signal.attentionHints.isAsyncBackground) return true;
   if (!signal.sourceContextId) return false;
   try {
@@ -193,13 +201,15 @@ const NOTEWORTHY_EVENT_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 function deriveNoteworthy(signal: NotificationSignal): boolean {
+  // Background-job failures emit with `sourceChannel: "assistant_tool"`
+  // (see `runtime/background-job-runner.ts`), so the activity.failed rule
+  // must run BEFORE the assistant_tool short-circuit — otherwise every
+  // routine watcher/heartbeat failure would land in the Inbox instead of
+  // staying in the activity feed.
+  if (signal.sourceEventName === "activity.failed") {
+    return signal.attentionHints.urgency === "critical";
+  }
   if (signal.sourceChannel === "assistant_tool") return true;
   if (NOTEWORTHY_EVENT_NAMES.has(signal.sourceEventName)) return true;
-  if (
-    signal.sourceEventName === "activity.failed" &&
-    signal.attentionHints.urgency === "critical"
-  ) {
-    return true;
-  }
   return false;
 }


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for notifications-rewrite:

1. **Assistant-tool signals never reached the home feed** — `shouldMirrorToHomeFeed()` required `isAsyncBackground=true` or a background-typed conversation, neither of which the CLI sets. Extended to also mirror when `sourceChannel === "assistant_tool"`. Without this, the macOS Inbox section was permanently empty for the use case the rewrite was designed around.

2. **`deriveNoteworthy` flagged every background-job failure as Inbox** — the `assistant_tool` short-circuit ran before the `activity.failed && urgency==="critical"` rule, so every routine watcher/heartbeat/job failure landed in the Inbox. Reordered to check `activity.failed` first.

Regression tests added for both production shapes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->