### PR TITLE
fix(notifications): close raw-event-name leak in broadcaster last-resort fallback

### DIFF
--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression tests for the NotificationBroadcaster's last-resort copy
+ * resolution path. The broadcaster previously used `signal.sourceEventName`
+ * as a body fallback when neither `decision.renderedCopy[channel]` nor
+ * `composeFallbackCopy(...)[channel]` produced usable copy, which leaked
+ * raw event-name strings (e.g. "user.send_notification") to user-visible
+ * notification bodies. The pre-send `checkRenderedCopyQuality` in
+ * deterministic-checks.ts only inspects `decision.renderedCopy`, so the
+ * broadcaster must enforce the same fail-closed posture locally.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { NotificationSignal } from "../signal.js";
+import type {
+  ChannelAdapter,
+  ChannelDeliveryPayload,
+  ChannelDestination,
+  DeliveryResult,
+  NotificationDecision,
+} from "../types.js";
+
+// ── Module mocks ────────────────────────────────────────────────────────
+//
+// `mock.module` is hoisted, so these intercepts apply before the module
+// under test resolves its imports. State is reset in `beforeEach`.
+
+let composeFallbackReturn: Record<string, unknown> = {};
+
+mock.module("../copy-composer.js", () => ({
+  composeFallbackCopy: () => composeFallbackReturn,
+}));
+
+mock.module("../destination-resolver.js", () => ({
+  resolveDestinations: (channels: string[]) => {
+    const map = new Map<string, ChannelDestination>();
+    for (const ch of channels) {
+      map.set(ch, { channel: ch as ChannelDestination["channel"] });
+    }
+    return map;
+  },
+}));
+
+mock.module("../conversation-pairing.js", () => ({
+  pairDeliveryWithConversation: async () => ({
+    conversationId: undefined,
+    messageId: undefined,
+    strategy: "start_new_conversation",
+    createdNewConversation: false,
+    conversationFallbackUsed: false,
+  }),
+}));
+
+mock.module("../deliveries-store.js", () => ({
+  createDelivery: () => {},
+  updateDeliveryStatus: () => {},
+  findDeliveryByDecisionAndChannel: () => undefined,
+}));
+
+mock.module("../adapters/macos.js", () => ({
+  isGuardianSensitiveEvent: () => false,
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const { NotificationBroadcaster } = await import("../broadcaster.js");
+
+// ── Test fixtures ───────────────────────────────────────────────────────
+
+function makeSignal(
+  overrides: Partial<NotificationSignal> = {},
+): NotificationSignal {
+  return {
+    signalId: "sig-test-1",
+    createdAt: 1700000000000,
+    sourceChannel: "scheduler",
+    sourceContextId: "ctx-1",
+    sourceEventName: "user.send_notification",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeDecision(
+  overrides: Partial<NotificationDecision> = {},
+): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: ["vellum"],
+    reasoningSummary: "test",
+    renderedCopy: {},
+    dedupeKey: "dk-1",
+    confidence: 1,
+    fallbackUsed: false,
+    persistedDecisionId: "dec-1",
+    ...overrides,
+  };
+}
+
+interface CapturedSend {
+  payload: ChannelDeliveryPayload;
+  destination: ChannelDestination;
+}
+
+function makeCapturingAdapter(channel: "vellum"): {
+  adapter: ChannelAdapter;
+  sends: CapturedSend[];
+} {
+  const sends: CapturedSend[] = [];
+  const adapter: ChannelAdapter = {
+    channel,
+    async send(
+      payload: ChannelDeliveryPayload,
+      destination: ChannelDestination,
+    ): Promise<DeliveryResult> {
+      sends.push({ payload, destination });
+      return { success: true };
+    },
+  };
+  return { adapter, sends };
+}
+
+beforeEach(() => {
+  composeFallbackReturn = {};
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("NotificationBroadcaster last-resort copy resolution", () => {
+  test(
+    "skips channel and does not leak raw event name when both decision " +
+      "copy and fallback composer return no usable copy",
+    async () => {
+      // Fallback composer returns nothing for the channel — the formerly
+      // leaky `??` branch in broadcaster.ts would synthesize
+      // `{ title: "Notification", body: signal.sourceEventName }`.
+      composeFallbackReturn = {};
+
+      const { adapter, sends } = makeCapturingAdapter("vellum");
+      const broadcaster = new NotificationBroadcaster([adapter]);
+
+      const signal = makeSignal();
+      const decision = makeDecision({ renderedCopy: {} });
+
+      const results = await broadcaster.broadcastDecision(signal, decision);
+
+      // Adapter must NOT receive a payload at all — the channel is skipped
+      // before the adapter is invoked, so the leak path cannot fire.
+      expect(sends.length).toBe(0);
+
+      expect(results.length).toBe(1);
+      expect(results[0]?.status).toBe("skipped");
+      expect(results[0]?.errorMessage).toContain("rendered copy");
+    },
+  );
+
+  test("skips channel when fallback composer returns an entry with an empty body", async () => {
+    // `composeFallbackCopy` can produce empty bodies via `buildGenericCopy`
+    // when no template matches the source event. The broadcaster must
+    // refuse to deliver empty-body copy rather than passing it through.
+    composeFallbackReturn = {
+      vellum: { title: "Notification", body: "" },
+    };
+
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({ renderedCopy: {} });
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    expect(sends.length).toBe(0);
+    expect(results.length).toBe(1);
+    expect(results[0]?.status).toBe("skipped");
+  });
+
+  test("delivers normally when fallback composer returns a usable body", async () => {
+    composeFallbackReturn = {
+      vellum: { title: "Reminder", body: "Time to drink water" },
+    };
+
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    const signal = makeSignal();
+    const decision = makeDecision({ renderedCopy: {} });
+
+    const results = await broadcaster.broadcastDecision(signal, decision);
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.copy.body).toBe("Time to drink water");
+    expect(results.length).toBe(1);
+    expect(results[0]?.status).toBe("sent");
+  });
+});

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -145,10 +145,25 @@ export class NotificationBroadcaster {
         if (!fallbackCopy) {
           fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
         }
-        copy = fallbackCopy[channel] ?? {
-          title: "Notification",
-          body: signal.sourceEventName,
-        };
+        copy = fallbackCopy[channel];
+      }
+
+      // Fail closed: if neither the decision nor the fallback composer produced
+      // a usable body, skip the channel rather than leaking the raw event name
+      // as placeholder text. The pre-send `checkRenderedCopyQuality` only sees
+      // `decision.renderedCopy`, so this is the last guard before delivery.
+      if (!copy || !copy.body?.trim()) {
+        log.warn(
+          { channel, signalId: signal.signalId },
+          "No usable rendered copy available -- skipping channel to avoid leaking event name",
+        );
+        results.push({
+          channel,
+          destination: destination.endpoint ?? channel,
+          status: "skipped",
+          errorMessage: `No usable rendered copy for channel: ${channel}`,
+        });
+        continue;
       }
 
       // For tool_grant_request signals, prefer the deterministic template seed


### PR DESCRIPTION
## Summary
- Broadcaster's last-resort fallback for missing rendered copy was setting `body: signal.sourceEventName`, bypassing PR 4's deterministic-check guard (which only inspects `decision.renderedCopy`)
- Replaces the leak path with channel-skip + warning so raw event-name strings cannot reach users

Fixes gap identified during plan review for notifications-rewrite.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->