### PR TITLE
chore(notifications): polish stale comments and deprecated-flag references

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -33,9 +33,7 @@ assistant.share when omitted.
 Examples:
   $ assistant notifications send --message "Build finished"
   $ assistant notifications send --message "Pager: prod is down" --urgent
-  $ assistant notifications send --source-channel scheduler --source-event-name schedule.notify --message "Stand-up in 5 minutes" --urgency high
-  $ assistant notifications send --source-channel watcher --source-event-name watcher.notification --message "File changed" --no-requires-action --is-async-background
-  $ assistant notifications send --message "Deploy complete" --preferred-channels vellum,telegram --json`,
+  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
       );
 
       // -------------------------------------------------------------------------
@@ -123,8 +121,6 @@ Examples:
 Arguments:
   --message            The notification body text (required, must be non-empty)
   --urgent             Shortcut that maps to urgency=critical + requires-action=true
-  --source-channel     One of the registered source channels (default: assistant_tool)
-  --source-event-name  One of the registered event names (default: assistant.share)
 
 Behavioral notes:
   - The signal is emitted through the full notification pipeline: event store,
@@ -142,8 +138,6 @@ Behavioral notes:
 Examples:
   $ assistant notifications send --message "Task complete"
   $ assistant notifications send --message "Pager: prod is down" --urgent
-  $ assistant notifications send --source-channel scheduler --source-event-name schedule.notify --message "Meeting in 5 min" --urgency high --title "Reminder"
-  $ assistant notifications send --source-channel watcher --source-event-name watcher.notification --message "Detected change" --no-requires-action --is-async-background --json
   $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
         )
         .action(

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -639,16 +639,21 @@ function buildChatSurfaceFallbackDeliveryText(
   const title = nonEmpty(baseCopy.title);
   if (title) return title;
 
-  // No usable text: return empty string. The deterministic
-  // `checkRenderedCopyQuality` (see deterministic-checks.ts) suppresses
-  // notifications with empty bodies, so this will not reach users.
+  // No usable text: return empty string. The broadcaster's empty-body skip in
+  // `broadcaster.ts` suppresses fallback-derived empty bodies; the
+  // deterministic `checkRenderedCopyQuality` (see deterministic-checks.ts)
+  // covers the same case when the empty body originates in
+  // `decision.renderedCopy`.
   return "";
 }
 
 /**
- * Build generic copy when no template matches. Returns an empty body so
- * the deterministic `checkRenderedCopyQuality` (see deterministic-checks.ts)
- * suppresses the notification rather than rendering an event-name placeholder.
+ * Build generic copy when no template matches. Returns an empty body so the
+ * notification is suppressed rather than rendering an event-name placeholder.
+ * The broadcaster's empty-body skip in `broadcaster.ts` catches fallback-derived
+ * empty bodies; the deterministic `checkRenderedCopyQuality` (see
+ * deterministic-checks.ts) covers the same case when the empty body originates
+ * in `decision.renderedCopy`.
  */
 function buildGenericCopy(): RenderedChannelCopy {
   return {

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -164,8 +164,9 @@ function deriveDetailPanelKind(
  * skill (and by background-job failure emits). These signals represent
  * the assistant actively choosing to share, so we mirror them into the
  * home feed without requiring a background-typed conversation or the
- * `isAsyncBackground` hint — the CLI surface intentionally does not
- * expose either.
+ * `isAsyncBackground` hint — the documented (SKILL.md) CLI surface
+ * intentionally does not expose either; internal call sites that still set
+ * the hint keep working unchanged.
  */
 function shouldMirrorToHomeFeed(signal: NotificationSignal): boolean {
   if (signal.sourceChannel === "assistant_tool") return true;

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -34,10 +34,6 @@ struct HomePageView: View {
 
     private let maxContentWidth: CGFloat = 960
 
-    /// Count of items routed into the Background activity section —
-    /// every visible feed item with `noteworthy != true`.
-    private var activityCount: Int { activityItems.count }
-
     var body: some View {
         Group {
             if let state = store.state {
@@ -138,7 +134,7 @@ struct HomePageView: View {
                     }
                     .padding(.top, VSpacing.sm)
                 } label: {
-                    Text("Background activity (\(activityCount))")
+                    Text("Background activity (\(activityItems.count))")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }


### PR DESCRIPTION
## Summary
Bundles 4 small polish fixes from round 2 plan review:

1. Updates stale comments in `copy-composer.ts` to point at the broadcaster's fail-closed skip (the real safeguard for the fallback path)
2. Clarifies the comment in `home-feed-side-effect.ts` about the CLI surface (the flag is still on the CLI for back-compat — only SKILL.md doesn't document it)
3. Trims CLI help-text examples and arg descriptions to match the slim SKILL.md surface (option declarations stay for internal callers)
4. Inlines `activityCount` wrapper in `HomePageView.swift`

No behavior changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->