### PR TITLE
fix(notifications): honor deepLinkMetadata/preferredChannels and skip event-name check on assistant_tool pass-through

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -156,4 +156,68 @@ describe("assistant_tool pass-through in notification decision engine", () => {
     expect(decision.conversationActions?.vellum?.action).toBe("start_new");
     expect(decision.conversationActions?.telegram?.action).toBe("start_new");
   });
+
+  test("threads contextPayload.deepLinkMetadata through to decision.deepLinkTarget", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "with deep link",
+        deepLinkMetadata: { route: "settings", anchor: "notifications" },
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+    ] as NotificationChannel[]);
+
+    expect(decision.deepLinkTarget).toEqual({
+      route: "settings",
+      anchor: "notifications",
+    });
+  });
+
+  test("omits deepLinkTarget when deepLinkMetadata is not a plain object", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "no deep link",
+        deepLinkMetadata: ["not", "a", "plain", "object"],
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+    ] as NotificationChannel[]);
+
+    expect(decision.deepLinkTarget).toBeUndefined();
+  });
+
+  test("preferredChannels narrows selection to the intersection with availableChannels", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "fyi only to telegram",
+        preferredChannels: ["telegram"],
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "telegram",
+    ] as NotificationChannel[]);
+
+    expect(decision.selectedChannels).toEqual(["telegram"]);
+    expect(decision.renderedCopy.telegram?.body).toBe("fyi only to telegram");
+    expect(decision.renderedCopy.vellum).toBeUndefined();
+  });
+
+  test("preferredChannels falls back to default channel set when no overlap with availableChannels", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "fyi",
+        preferredChannels: ["disconnected_channel"],
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "telegram",
+    ] as NotificationChannel[]);
+
+    expect(decision.selectedChannels).toEqual(["vellum"]);
+    expect(decision.renderedCopy.vellum?.body).toBe("fyi");
+  });
 });

--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -165,4 +165,50 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     const result = await runDeterministicChecks(signal, decision, context);
     expect(result.passed).toBe(true);
   });
+
+  test("passes assistant_tool pass-through even when body matches normalized event name", async () => {
+    // The pass-through path produces verbatim user-supplied body text.
+    // A coincidental match with the source event name is the user's
+    // intent, not a fallback leak — the check must not suppress it.
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+    });
+    const decision = makeDecision({
+      reasoningSummary: "assistant_tool pass-through",
+      renderedCopy: {
+        vellum: { title: "Assistant share", body: "assistant share" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails assistant_tool pass-through with empty body (empty-body branch still fires)", async () => {
+    const signal = makeSignal({ sourceChannel: "assistant_tool" });
+    const decision = makeDecision({
+      reasoningSummary: "assistant_tool pass-through",
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  test("still fails non-pass-through decision when body matches event name", async () => {
+    // Regression guard: the pass-through short-circuit must not weaken
+    // the check for LLM/fallback paths.
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      reasoningSummary: "llm classification",
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "user.send_notification" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fallback leak");
+  });
 });

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -832,11 +832,37 @@ export async function evaluateSignal(
     const isUrgent =
       signal.attentionHints.urgency === "critical" ||
       signal.attentionHints.urgency === "high";
-    const selectedChannels = isUrgent
+    const defaultChannels: NotificationChannel[] = isUrgent
       ? [...availableChannels]
       : availableChannels.includes("vellum")
         ? ["vellum" as NotificationChannel]
         : [];
+    // Honor `--preferred-channels` when supplied: intersect with the
+    // available channel set so we never try to deliver on something
+    // disconnected. If the intersection is empty, fall back to the
+    // default channel set rather than producing a no-deliver decision.
+    const preferredChannelsRaw = Array.isArray(payload.preferredChannels)
+      ? (payload.preferredChannels as unknown[]).filter(
+          (c): c is string => typeof c === "string",
+        )
+      : undefined;
+    let selectedChannels = defaultChannels;
+    if (preferredChannelsRaw && preferredChannelsRaw.length > 0) {
+      const availableSet = new Set<string>(availableChannels);
+      const preferredAvailable = preferredChannelsRaw.filter((c) =>
+        availableSet.has(c),
+      ) as NotificationChannel[];
+      if (preferredAvailable.length > 0) {
+        selectedChannels = preferredAvailable;
+      }
+    }
+    // Thread `--deep-link-metadata` through when supplied as a plain object.
+    const deepLinkTarget =
+      payload.deepLinkMetadata != null &&
+      typeof payload.deepLinkMetadata === "object" &&
+      !Array.isArray(payload.deepLinkMetadata)
+        ? (payload.deepLinkMetadata as Record<string, unknown>)
+        : undefined;
     let decision: NotificationDecision = {
       shouldNotify: selectedChannels.length > 0,
       selectedChannels,
@@ -850,6 +876,7 @@ export async function evaluateSignal(
       dedupeKey: signal.signalId,
       confidence: 1.0,
       fallbackUsed: false,
+      ...(deepLinkTarget ? { deepLinkTarget } : {}),
     };
     decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceAccessRequestInstructions(decision, signal);

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -246,8 +246,12 @@ function checkDedupe(
 /**
  * Fail-closed check that the rendered copy is real text and not an
  * accidental fallback leak (empty body, or body that is just the raw
- * source event name like "user.send_notification"). Catches cases where
- * `buildGenericCopy` synthesizes a placeholder from the event name.
+ * source event name like "user.send_notification").
+ *
+ * The empty-body branch is unconditional. The event-name-match branch
+ * is skipped for `assistant_tool` pass-through decisions because the
+ * producer supplied the body verbatim — a coincidental match with the
+ * event name is the user's intent, not a fallback leak.
  */
 function checkRenderedCopyQuality(
   signal: NotificationSignal,
@@ -257,6 +261,8 @@ function checkRenderedCopyQuality(
     return { passed: true };
   }
 
+  const isAssistantToolPassthrough =
+    decision.reasoningSummary === "assistant_tool pass-through";
   const normalizedEventName = signal.sourceEventName
     .replace(/[._]/g, " ")
     .toLowerCase()
@@ -277,6 +283,9 @@ function checkRenderedCopyQuality(
         passed: false,
         reason: "rendered copy body is empty",
       };
+    }
+    if (isAssistantToolPassthrough) {
+      continue;
     }
     const normalizedBody = trimmedBody.toLowerCase();
     if (


### PR DESCRIPTION
## Summary
- Thread `contextPayload.deepLinkMetadata` from `--deep-link-metadata` into `decision.deepLinkTarget` on the assistant_tool pass-through path. Previously dropped silently.
- Honor `contextPayload.preferredChannels` from `--preferred-channels` on the pass-through path: intersect with `availableChannels`; fall back to the default channel set when the intersection is empty (no silent no-deliver).
- Short-circuit `checkRenderedCopyQuality`'s event-name-match branch when \`decision.reasoningSummary === \"assistant_tool pass-through\"\`. Producer-supplied verbatim body that coincidentally matches the source event name (e.g. \`--message \"assistant share\"\` with default \`assistant.share\` event) is the user's intent, not a fallback leak. Empty-body check still fires in all cases.

Adds 4 new decision-engine tests (deepLinkMetadata threading + plain-object guard + preferred-channels narrow + preferred-channels-fallback) and 3 new deterministic-checks tests (pass-through event-name match passes; pass-through empty body still fails; non-pass-through event-name match still fails as regression guard).

## Original prompt
Three known minor follow-ups from the notifications-rewrite plan, all in the assistant_tool pass-through path. After the 13-PR rewrite landed and went through three review rounds, an integration audit flagged that the CLI accepts \`--deep-link-metadata\` and \`--preferred-channels\` flags that the new pass-through path silently no-ops, and that the new fail-closed rendered-copy check can spuriously suppress legitimate verbatim user messages whose body coincidentally matches the source event name. Bundle as one PR since the fixes touch adjacent code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->