### PR TITLE
feat(macos/gallery): add urgent HomeRecapRow variant for visual review

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -117,6 +117,16 @@ struct HomeGallerySection: View {
                             onDismiss: {},
                             onTap: {}
                         )
+
+                        HomeRecapRow(
+                            icon: .bell,
+                            iconForeground: VColor.feedDigestStrong,
+                            iconBackground: VColor.feedDigestWeak,
+                            title: "Urgent: your flight to SFO boards in 35 minutes.",
+                            isUrgent: true,
+                            onDismiss: {},
+                            onTap: {}
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Adds an isUrgent: true HomeRecapRow example to HomeGallerySection so the new red-dot treatment from #30973 has Component Gallery coverage (the sanctioned visual review surface per clients/macos/AGENTS.md). Addresses Devin feedback on #30973.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->