### PR TITLE
fix(memory): clear lastInjectedImages when memory is disabled

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -371,6 +371,7 @@ export class ConversationGraphMemory {
       // stale <memory> block after the user disables memory.
       this.lastInjectedBlock = null;
       this.lastInjectedNodeIds = [];
+      this.lastInjectedImages = new Map();
       return noopResult;
     }
 


### PR DESCRIPTION
Mirror the other reset sites by also clearing the resolved-image Map when memory.enabled flips false. Addresses Codex/Devin feedback on #30943.