### PR TITLE
chore(notifications): drop removed-code reference from broadcaster test header

### DIFF
--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -1,12 +1,8 @@
 /**
- * Regression tests for the NotificationBroadcaster's last-resort copy
- * resolution path. The broadcaster previously used `signal.sourceEventName`
- * as a body fallback when neither `decision.renderedCopy[channel]` nor
- * `composeFallbackCopy(...)[channel]` produced usable copy, which leaked
- * raw event-name strings (e.g. "user.send_notification") to user-visible
- * notification bodies. The pre-send `checkRenderedCopyQuality` in
- * deterministic-checks.ts only inspects `decision.renderedCopy`, so the
- * broadcaster must enforce the same fail-closed posture locally.
+ * Verifies the NotificationBroadcaster's fail-closed copy-resolution
+ * invariant: when neither `decision.renderedCopy[channel]` nor
+ * `composeFallbackCopy(...)[channel]` produces usable copy, the channel
+ * must be dropped rather than delivered with a synthesized body.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";


### PR DESCRIPTION
Rewrite the broadcaster.test.ts file header to describe the current fail-closed invariant without narrating the removed signal.sourceEventName fallback branch. Addresses Codex feedback on #30978 (CLAUDE.md code-comments rule).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->