### PR TITLE
fix(macos): scope isEventNameLeak to raw event-name form

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -178,10 +178,13 @@ extension AppDelegate {
         }
     }
 
-    /// Returns `true` if `candidate` matches `sourceEventName` either raw
-    /// (e.g. `"user.send_notification"`) or after `.`/`_` are replaced with
-    /// spaces (e.g. `"user send notification"`). Case-insensitive.
-    /// Used by the sanitize helpers below to detect event-name fallback leaks.
+    /// Returns `true` if `candidate` matches the raw `sourceEventName` form
+    /// (e.g. `"user.send_notification"` or `"USER.SEND_NOTIFICATION"`).
+    /// Case-insensitive but structural separators must be preserved — we
+    /// deliberately do NOT match space-normalized variants because legitimate
+    /// template titles like `"Guardian Question"` (for `guardian.question`)
+    /// would otherwise be flagged as leaks. Used by the sanitize helpers
+    /// below to detect event-name fallback leaks.
     nonisolated static func isEventNameLeak(
         _ candidate: String,
         sourceEventName: String
@@ -189,11 +192,7 @@ extension AppDelegate {
         let trimmedCandidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let rawEvent = sourceEventName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !rawEvent.isEmpty, !trimmedCandidate.isEmpty else { return false }
-        if trimmedCandidate == rawEvent { return true }
-        let normalizedEvent = rawEvent
-            .replacingOccurrences(of: "_", with: " ")
-            .replacingOccurrences(of: ".", with: " ")
-        return trimmedCandidate == normalizedEvent
+        return trimmedCandidate == rawEvent
     }
 
     /// Sanitize a user-visible notification title. Returns `"Notification"`

--- a/clients/macos/vellum-assistantTests/NotificationCopySanitizationTests.swift
+++ b/clients/macos/vellum-assistantTests/NotificationCopySanitizationTests.swift
@@ -42,14 +42,25 @@ final class NotificationCopySanitizationTests: XCTestCase {
         XCTAssertEqual(result, "Notification")
     }
 
-    func testTitleNormalizedEventNameFallsBackToPlaceholder() {
-        // copy-composer's legacy buildGenericCopy substituted "." and "_" with
-        // spaces — guard against that derived form leaking too.
-        let result = AppDelegate.sanitizeNotificationTitle(
-            "user send notification",
-            sourceEventName: "user.send_notification"
+    func testTitleHumanizedTemplateTitleIsNotFlagged() {
+        // copy-composer templates produce legitimate humanized titles like
+        // "Guardian Question" for `guardian.question` and "Activity Complete"
+        // for `activity.complete`. These must pass through unchanged — they
+        // are intentional copy, not raw event-name leaks.
+        XCTAssertEqual(
+            AppDelegate.sanitizeNotificationTitle(
+                "Guardian Question",
+                sourceEventName: "guardian.question"
+            ),
+            "Guardian Question"
         )
-        XCTAssertEqual(result, "Notification")
+        XCTAssertEqual(
+            AppDelegate.sanitizeNotificationTitle(
+                "Activity Complete",
+                sourceEventName: "activity.complete"
+            ),
+            "Activity Complete"
+        )
     }
 
     func testTitleCaseInsensitiveEventNameLeakIsCaught() {
@@ -86,12 +97,15 @@ final class NotificationCopySanitizationTests: XCTestCase {
         XCTAssertEqual(result, "(no preview available)")
     }
 
-    func testBodyNormalizedEventNameFallsBackToPlaceholder() {
+    func testBodyHumanizedFormIsNotFlagged() {
+        // Humanized space-separated variants of the event name are legitimate
+        // copy (e.g. template-derived body text). They must not be replaced
+        // with the generic placeholder.
         let result = AppDelegate.sanitizeNotificationBody(
             "user send notification",
             sourceEventName: "user.send_notification"
         )
-        XCTAssertEqual(result, "(no preview available)")
+        XCTAssertEqual(result, "user send notification")
     }
 
     // MARK: - isEventNameLeak edge cases


### PR DESCRIPTION
Tighten the leak check so humanized template titles like 'Guardian Question' and 'Activity Complete' (legitimate copy from copy-composer.ts) aren't replaced with the generic 'Notification' fallback. Adds regression coverage. Addresses Codex feedback on #30969.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->