### PR TITLE
fix(macos): apply daemon-vs-local ID fix to onFeedConversationOpened

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -215,17 +215,21 @@ extension MainWindowView {
             store: homeStore,
             feedStore: feedStore,
             meetStatusViewModel: meetStatusViewModel,
-            onFeedConversationOpened: { conversationId in
-                guard let uuid = UUID(uuidString: conversationId) else {
-                    panelCoordinatorLog.error(
-                        "HomeFeed: daemon returned non-UUID conversationId \(conversationId, privacy: .public); cannot navigate"
-                    )
-                    windowState.showToast(message: "Couldn't open the conversation.", style: .error)
-                    return
-                }
+            onFeedConversationOpened: { daemonConversationId in
                 activeHomeDetailPanel = nil
                 onDismiss()
-                windowState.selection = .conversation(uuid)
+                Task { @MainActor in
+                    let found = await conversationManager.selectConversationByConversationIdAsync(daemonConversationId)
+                    let activeLocalId = conversationManager.activeConversationId
+                    panelCoordinatorLog.info(
+                        "HomeFeed: opened conversation daemonConversationId=\(daemonConversationId, privacy: .public) found=\(found, privacy: .public) activeLocalId=\(activeLocalId?.uuidString ?? "<nil>", privacy: .public)"
+                    )
+                    guard found, let id = activeLocalId else {
+                        windowState.showToast(message: "Couldn't open the conversation.", style: .error)
+                        return
+                    }
+                    windowState.selection = .conversation(id)
+                }
             },
             onStartNewChat: {
                 activeHomeDetailPanel = nil


### PR DESCRIPTION
Mirror the onGoToThread fix from #30968 into onFeedConversationOpened in PanelCoordinator so feed-item navigation uses notification_intent deepLinkMetadata.conversationId rather than the daemon-side ID. Addresses Devin feedback on #30968.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->