### PR TITLE
fix(notifications): fall back to non-vellum rendered copy in home-feed guard

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -285,6 +285,58 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls).toHaveLength(0);
   });
 
+  test("falls back to a non-vellum channel's rendered copy when vellum copy is absent", async () => {
+    // Regression: when `preferredChannels` narrows an assistant_tool signal
+    // to a non-vellum channel (e.g. telegram), the broadcaster ships real
+    // copy on that channel but `renderedCopy.vellum` is undefined. The
+    // guard must still write to the home feed using the first available
+    // rendered copy entry rather than skipping silently.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "cli-12345",
+    });
+    const decision = makeDecision({
+      selectedChannels: ["telegram"],
+      renderedCopy: {
+        telegram: { title: "Telegram title", body: "Telegram body" },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBe("Telegram title");
+    expect(appendCalls[0]!.summary).toBe("Telegram body");
+  });
+
+  test("falls back to requestedTitle/requestedMessage payload keys", async () => {
+    // Regression: the `notifications send` CLI surface stores the
+    // user-supplied copy on the signal payload under `requestedTitle` and
+    // `requestedMessage`. If the decision strips renderedCopy.vellum (e.g.
+    // routed only to a non-vellum channel that also lacks renderedCopy),
+    // the home-feed guard must still recover the copy from the payload.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "cli-12345",
+      contextPayload: {
+        requestedTitle: "Requested title",
+        requestedMessage: "Requested message body",
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBe("Requested title");
+    expect(appendCalls[0]!.summary).toBe("Requested message body");
+  });
+
   test("uses payload title/body when rendered copy is absent", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -25,6 +25,7 @@ import type { NotificationSignal } from "./signal.js";
 import type {
   NotificationDecision,
   NotificationDeliveryResult,
+  RenderedChannelCopy,
 } from "./types.js";
 
 const log = getLogger("home-feed-side-effect");
@@ -51,9 +52,14 @@ export async function writeHomeFeedItemForSignal(
 ): Promise<FeedItem | null> {
   if (!shouldMirrorToHomeFeed(signal)) return null;
 
-  const renderedCopy = decision.renderedCopy.vellum;
-  const payloadTitle = readPayloadString(signal.contextPayload, "title");
-  const payloadBody = readPayloadString(signal.contextPayload, "body");
+  const renderedCopy =
+    decision.renderedCopy.vellum ?? firstRenderedCopy(decision.renderedCopy);
+  const payloadTitle =
+    readPayloadString(signal.contextPayload, "title") ??
+    readPayloadString(signal.contextPayload, "requestedTitle");
+  const payloadBody =
+    readPayloadString(signal.contextPayload, "body") ??
+    readPayloadString(signal.contextPayload, "requestedMessage");
 
   const resolvedTitle =
     renderedCopy?.title?.trim() || payloadTitle?.trim() || "";
@@ -184,6 +190,15 @@ function readPayloadString(payload: unknown, key: string): string | undefined {
   if (!payload || typeof payload !== "object") return undefined;
   const value = (payload as Record<string, unknown>)[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function firstRenderedCopy(
+  renderedCopy: NotificationDecision["renderedCopy"],
+): RenderedChannelCopy | undefined {
+  for (const copy of Object.values(renderedCopy)) {
+    if (copy && (copy.title?.trim() || copy.body?.trim())) return copy;
+  }
+  return undefined;
 }
 
 // ── Noteworthy derivation ─────────────────────────────────────────────


### PR DESCRIPTION
Guard against silently skipping home-feed writes when a signal is routed only to a non-vellum channel. Falls back to the first available rendered copy entry (or requestedTitle/requestedMessage). Addresses Codex feedback on #30964.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->