### PR TITLE
fix(notifications): scope rendered-copy check to decision-time channels

### DIFF
--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -137,19 +137,62 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     expect(result.reason).toContain("fallback leak");
   });
 
-  test("fails when rendered copy is missing for a selected channel", async () => {
-    const decision = makeDecision({
-      selectedChannels: ["vellum"],
-      renderedCopy: {},
+  test("passes when channel was appended post-decision (urgency-forced vellum prepend)", async () => {
+    // Regression: emit-signal.ts prepends `vellum` to selectedChannels for
+    // high/critical urgency without populating renderedCopy.vellum. The
+    // broadcaster's composeFallbackCopy rescue handles those channels at
+    // delivery time, so the deterministic check must not fail-closed here.
+    const signal = makeSignal({
+      attentionHints: {
+        requiresAction: false,
+        urgency: "high",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
     });
-    const result = await runDeterministicChecks(
-      makeSignal(),
-      decision,
-      context,
-    );
+    const decision = makeDecision({
+      selectedChannels: ["vellum", "telegram"],
+      renderedCopy: {
+        telegram: { title: "Reminder", body: "Time to drink water" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, {
+      connectedChannels: ["vellum", "telegram"],
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  test("passes when enforceRoutingIntent expanded channels post-decision", async () => {
+    // Regression: enforceRoutingIntent can expand selectedChannels to
+    // all_channels / multi_channel without populating renderedCopy for the
+    // added channels. Broadcaster fallback covers them — check must allow.
+    const decision = makeDecision({
+      selectedChannels: ["vellum", "telegram", "slack"],
+      renderedCopy: {
+        vellum: { title: "Reminder", body: "Time to drink water" },
+      },
+    });
+    const result = await runDeterministicChecks(makeSignal(), decision, {
+      connectedChannels: ["vellum", "telegram", "slack"],
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  test("still validates body quality for channels with rendered copy", async () => {
+    // Even when some channels lack copy (broadcaster fallback territory),
+    // channels that DO have copy must still pass the empty/event-name checks.
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      selectedChannels: ["vellum", "telegram"],
+      renderedCopy: {
+        telegram: { title: "Reminder", body: "user.send_notification" },
+      },
+    });
+    const result = await runDeterministicChecks(signal, decision, {
+      connectedChannels: ["vellum", "telegram"],
+    });
     expect(result.passed).toBe(false);
-    expect(result.reason).toContain("rendered copy missing");
-    expect(result.reason).toContain("vellum");
+    expect(result.reason).toContain("fallback leak");
   });
 
   test("passes when shouldNotify is false regardless of copy contents", async () => {

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -248,10 +248,16 @@ function checkDedupe(
  * accidental fallback leak (empty body, or body that is just the raw
  * source event name like "user.send_notification").
  *
- * The empty-body branch is unconditional. The event-name-match branch
- * is skipped for `assistant_tool` pass-through decisions because the
- * producer supplied the body verbatim — a coincidental match with the
- * event name is the user's intent, not a fallback leak.
+ * Only validates channels that the decision engine actually emitted
+ * copy for. Channels appended after the decision (urgency-forced
+ * `vellum` prepend, `enforceRoutingIntent` expansion) have no entry
+ * in `renderedCopy` and are left for the broadcaster's
+ * `composeFallbackCopy` rescue at delivery time.
+ *
+ * The event-name-match branch is skipped for `assistant_tool`
+ * pass-through decisions because the producer supplied the body
+ * verbatim — a coincidental match with the event name is the user's
+ * intent, not a fallback leak.
  */
 function checkRenderedCopyQuality(
   signal: NotificationSignal,
@@ -272,10 +278,7 @@ function checkRenderedCopyQuality(
   for (const channel of decision.selectedChannels) {
     const copy = decision.renderedCopy[channel];
     if (!copy) {
-      return {
-        passed: false,
-        reason: `rendered copy missing for selected channel ${channel}`,
-      };
+      continue;
     }
     const trimmedBody = copy.body.trim();
     if (trimmedBody.length === 0) {


### PR DESCRIPTION
Prevents fail-closed guard from suppressing urgent notifications when emit-signal forces-vellum or enforceRoutingIntent expands channels post-decision. Lets the broadcaster's composeFallbackCopy rescue these channels as before. Addresses Codex (P1) and Devin feedback on #30965.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->