### PR TITLE
fix(app-control): sync active session on late dispatched-start promotion

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -1006,6 +1006,67 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
+    test("confirmed-A,dispatch-B,dispatch-C,C-fails-first,B-confirms syncs active to B", async () => {
+      // A confirmed, B and C dispatched, C returns `missing` first →
+      // rollback restores active to A. Then B returns `running` →
+      // confirmed advances to B; active must advance alongside it,
+      // otherwise the tool reports B started while
+      // app_control_observe/actions for B target A.
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      const pA = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.a" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdA = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(reqIdA, payload({ pngBase64: PNG_A }));
+      await pA;
+      expect(_getConfirmedAppControlSession()?.app).toBe("com.example.a");
+
+      sentMessages.length = 0;
+      const pB = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.b" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdB = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+
+      sentMessages.length = 0;
+      const pC = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.c" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const reqIdC = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.c");
+
+      // C fails first → rollback restores active to confirmed (A).
+      proxy.resolve(reqIdC, payload({ state: "missing" }));
+      await pC;
+      expect(_getActiveAppControlSession()?.app).toBe("com.example.a");
+      expect(_getConfirmedAppControlSession()?.app).toBe("com.example.a");
+
+      // B confirms after C's rollback. Confirmed advances to B AND active
+      // must advance to B too — otherwise non-start tool calls against B
+      // would be rejected because active still targets A.
+      proxy.resolve(reqIdB, payload({ pngBase64: PNG_B }));
+      await pB;
+      expect(_getConfirmedAppControlSession()?.app).toBe("com.example.b");
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.b");
+
+      proxy.dispose();
+    });
+
     test("first-start failure releases the lock (no prior session to restore)", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -400,6 +400,13 @@ export class HostAppControlProxy extends HostProxyBase<
    *    dispatched start that confirms wins, which is the right baseline
    *    for the rollback path: if a newer start later fails, rollback
    *    restores the most recently confirmed session, not an older one.
+   *
+   * Also advance the active pointer when it is strictly older than the
+   * newly-confirmed session. This handles the case where an even newer
+   * optimistic write has already failed and rolled active back to the
+   * previous confirmed session; without this, observe/actions for the
+   * newly-confirmed session would target the older app. A newer
+   * in-flight optimistic write (higher `dispatchedAt`) is preserved.
    */
   private promoteStartIfCurrent(
     attempted: ActiveAppControlSession | undefined,
@@ -415,6 +422,9 @@ export class HostAppControlProxy extends HostProxyBase<
       return;
     }
     confirmedAppControlSession = attempted;
+    if (activeAppControlSession.dispatchedAt < attempted.dispatchedAt) {
+      activeAppControlSession = attempted;
+    }
   }
 
   /**


### PR DESCRIPTION
When a newer dispatch fails before an earlier one returns running, promoteStartIfCurrent now updates activeAppControlSession alongside confirmedAppControlSession. Adds a regression test for the C-fails-first-then-B-confirms ordering. Addresses Codex feedback on #30957.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->