### PR TITLE
fix(notifications): preserve vellum copy when urgency forces vellum prepend

### DIFF
--- a/assistant/src/notifications/__tests__/decision-engine.test.ts
+++ b/assistant/src/notifications/__tests__/decision-engine.test.ts
@@ -188,7 +188,7 @@ describe("assistant_tool pass-through in notification decision engine", () => {
     expect(decision.deepLinkTarget).toBeUndefined();
   });
 
-  test("preferredChannels narrows selection to the intersection with availableChannels", async () => {
+  test("preferredChannels narrows selection but renderedCopy covers all available channels", async () => {
     const signal = makeAssistantToolSignal({
       contextPayload: {
         requestedMessage: "fyi only to telegram",
@@ -202,7 +202,44 @@ describe("assistant_tool pass-through in notification decision engine", () => {
 
     expect(decision.selectedChannels).toEqual(["telegram"]);
     expect(decision.renderedCopy.telegram?.body).toBe("fyi only to telegram");
-    expect(decision.renderedCopy.vellum).toBeUndefined();
+    // Even though vellum is not selected, its rendered copy must be
+    // populated so downstream guards that may force-prepend vellum
+    // (e.g. urgency forcing in emit-signal) still have the verbatim copy.
+    expect(decision.renderedCopy.vellum?.body).toBe("fyi only to telegram");
+  });
+
+  test("urgent + preferredChannels excluding vellum still leaves renderedCopy.vellum populated", async () => {
+    const signal = makeAssistantToolSignal({
+      contextPayload: {
+        requestedMessage: "urgent telegram-preferred message",
+        requestedTitle: "Heads up",
+        preferredChannels: ["telegram"],
+      },
+      attentionHints: {
+        requiresAction: true,
+        urgency: "high",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+    });
+    const decision = await evaluateSignal(signal, [
+      "vellum",
+      "telegram",
+    ] as NotificationChannel[]);
+
+    // Decision engine selects telegram (the preferred channel). The
+    // urgency-forced vellum prepend happens later in emit-signal; what
+    // matters here is that renderedCopy for vellum is already prepared
+    // with the verbatim copy so the prepend doesn't lose the message.
+    expect(decision.selectedChannels).toEqual(["telegram"]);
+    expect(decision.renderedCopy.telegram?.body).toBe(
+      "urgent telegram-preferred message",
+    );
+    expect(decision.renderedCopy.telegram?.title).toBe("Heads up");
+    expect(decision.renderedCopy.vellum?.body).toBe(
+      "urgent telegram-preferred message",
+    );
+    expect(decision.renderedCopy.vellum?.title).toBe("Heads up");
   });
 
   test("preferredChannels falls back to default channel set when no overlap with availableChannels", async () => {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -863,15 +863,22 @@ export async function evaluateSignal(
       !Array.isArray(payload.deepLinkMetadata)
         ? (payload.deepLinkMetadata as Record<string, unknown>)
         : undefined;
+    // Populate renderedCopy and conversationActions for every available
+    // channel — not just `selectedChannels`. Downstream guards
+    // (routing-intent expansion in `enforceRoutingIntent`, urgency-forced
+    // vellum prepending in `emit-signal`) may widen `selectedChannels`
+    // beyond what we picked here. Pre-seeding copy for all channels ensures
+    // the verbatim message survives those expansions rather than falling
+    // back to an empty `composeFallbackCopy` body.
     let decision: NotificationDecision = {
       shouldNotify: selectedChannels.length > 0,
       selectedChannels,
       reasoningSummary: "assistant_tool pass-through",
       renderedCopy: Object.fromEntries(
-        selectedChannels.map((ch) => [ch, { title, body }]),
+        availableChannels.map((ch) => [ch, { title, body }]),
       ) as NotificationDecision["renderedCopy"],
       conversationActions: Object.fromEntries(
-        selectedChannels.map((ch) => [ch, { action: "start_new" as const }]),
+        availableChannels.map((ch) => [ch, { action: "start_new" as const }]),
       ) as NotificationDecision["conversationActions"],
       dedupeKey: signal.signalId,
       confidence: 1.0,


### PR DESCRIPTION
When an urgent assistant_tool notification is sent with preferredChannels excluding vellum, the emit-signal urgency guard prepends vellum without copy and the broadcaster's composeFallbackCopy returns empty body for non-templated events. Populate renderedCopy at decision time for all configured channels so urgency-forced-vellum preserves the verbatim message. Addresses Codex feedback on #30984.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/30995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->