### PR TITLE
[codex] Harden A2A connect policy and SSRF checks

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7959,6 +7959,8 @@ paths:
                             - background
                             - email
                             - system
+                        noteworthy:
+                          type: boolean
                         metadata:
                           type: object
                           propertyNames:
@@ -8121,6 +8123,8 @@ paths:
                       - background
                       - email
                       - system
+                  noteworthy:
+                    type: boolean
                   metadata:
                     type: object
                     propertyNames:

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -24,6 +24,7 @@ let fetchResponseMap: Record<
   { ok: boolean; status: number; body: string }
 > = {};
 let defaultFetchResponse = { ok: true, status: 200, body: "{}" };
+const resolvePublicHost = async () => ["93.184.216.34"];
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing modules under test
@@ -166,6 +167,7 @@ describe("e2e: connection initiation -> trusted contact flow", () => {
     const result = await connectToAssistant({
       guardianHandle: "assistant-b",
       gatewayUrl: "https://peer.example.com",
+      resolveHostAddresses: resolvePublicHost,
     });
 
     // Connection succeeds
@@ -207,6 +209,7 @@ describe("e2e: connection initiation -> trusted contact flow", () => {
     const first = await connectToAssistant({
       guardianHandle: "assistant-b",
       gatewayUrl: "https://peer.example.com",
+      resolveHostAddresses: resolvePublicHost,
     });
     expect(first.success).toBe(true);
     expect(first.alreadyConnected).toBeFalsy();
@@ -218,6 +221,7 @@ describe("e2e: connection initiation -> trusted contact flow", () => {
     const second = await connectToAssistant({
       guardianHandle: "assistant-b",
       gatewayUrl: "https://peer.example.com",
+      resolveHostAddresses: resolvePublicHost,
     });
     expect(second.success).toBe(true);
     expect(second.alreadyConnected).toBe(true);
@@ -566,6 +570,7 @@ describe("e2e: full A2A round-trip", () => {
     const connectResult = await connectToAssistant({
       guardianHandle: "assistant-b",
       gatewayUrl: "https://b.example.com",
+      resolveHostAddresses: resolvePublicHost,
     });
     expect(connectResult.success).toBe(true);
 

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -1,9 +1,22 @@
 import type { Command } from "commander";
 
-import { cliIpcCall } from "../../ipc/cli-client.js";
+import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+
+function handleNotificationIpcError(
+  result: { ok: boolean; error?: string; statusCode?: number },
+  cmd: Command,
+): void {
+  if (shouldOutputJson(cmd)) {
+    writeOutput(cmd, { ok: false, error: result.error });
+    process.exitCode = 1;
+    return;
+  }
+
+  exitFromIpcResult(result);
+}
 
 // ---------------------------------------------------------------------------
 // Command registration
@@ -289,11 +302,7 @@ Examples:
                 },
               });
 
-              if (!result.ok) {
-                writeOutput(cmd, { ok: false, error: result.error });
-                process.exitCode = 1;
-                return;
-              }
+              if (!result.ok) return handleNotificationIpcError(result, cmd);
 
               const signal = result.result!;
 

--- a/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
@@ -23,9 +23,16 @@ import {
 import { findContactByAddress } from "../../../contacts/contact-store.js";
 import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
-import { clearA2AConfig, getA2AConfig, setA2AConfig } from "../config-a2a.js";
+import {
+  clearA2AConfig,
+  getA2AConfig,
+  resolveGuardianHandle,
+  setA2AConfig,
+} from "../config-a2a.js";
 
 initializeDb();
+
+const resolvePublicHost = async () => ["93.184.216.34"];
 
 function resetTables(): void {
   const sqlite = getSqlite();
@@ -95,6 +102,113 @@ describe("clearA2AConfig", () => {
   });
 });
 
+describe("resolveGuardianHandle", () => {
+  test("fetches the normalized agent card URL with timeout and no redirects", async () => {
+    const originalFetch = globalThis.fetch;
+    let captured:
+      | { input: string | URL | Request; init: RequestInit | undefined }
+      | undefined;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = { input, init };
+      return new Response(JSON.stringify({ name: "Peer Bot" }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await resolveGuardianHandle(
+        "peer-handle",
+        "https://peer.example.com/some/path?ignored=true",
+        { resolveHostAddresses: resolvePublicHost },
+      );
+
+      expect(result).toEqual({
+        assistantId: "peer-handle",
+        gatewayUrl: "https://peer.example.com",
+        displayName: "Peer Bot",
+      });
+      expect(captured).toBeDefined();
+      expect(captured!.input).toBe(
+        "https://peer.example.com/.well-known/agent-card.json",
+      );
+      expect(captured!.init?.redirect).toBe("manual");
+      expect(captured!.init?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each([
+    ["http://peer.example.com", "https"],
+    ["https://127.0.0.1", "local or private network"],
+    ["https://169.254.169.254", "local or private network"],
+    ["https://metadata.google.internal", "local or private network"],
+    ["https://peer.example.com/admin#", "fragment"],
+  ] as const)("rejects unsafe gatewayUrl %s", async (gatewayUrl, message) => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = (async (
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      fetchCalled = true;
+      return new Response("{}");
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        resolveGuardianHandle("peer-handle", gatewayUrl, {
+          resolveHostAddresses: resolvePublicHost,
+        }),
+      ).rejects.toThrow(message);
+      expect(fetchCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rejects a gateway host that resolves to a private address", async () => {
+    await expect(
+      resolveGuardianHandle("peer-handle", "https://peer.example.com", {
+        resolveHostAddresses: async () => ["10.0.0.5"],
+      }),
+    ).rejects.toThrow("local or private network");
+  });
+
+  test("does not reflect upstream response bodies in agent card errors", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      return new Response("internal metadata secret", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      let error: unknown;
+      try {
+        await resolveGuardianHandle("peer-handle", "https://peer.example.com", {
+          resolveHostAddresses: resolvePublicHost,
+        });
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Agent card fetch failed with status 404.",
+      );
+      expect((error as Error).message).not.toContain(
+        "internal metadata secret",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("connectToAssistant", () => {
   beforeEach(() => {
     resetTables();
@@ -153,6 +267,7 @@ describe("connectToAssistant", () => {
       const result = await connectToAssistant({
         guardianHandle: "peer-handle",
         gatewayUrl: "https://peer.example.com",
+        resolveHostAddresses: resolvePublicHost,
       });
       expect(result.success).toBe(true);
       expect(result.alreadyConnected).toBe(true);

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -24,7 +24,15 @@ import {
 import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getDb } from "../../memory/db-connection.js";
 import { assistantContactMetadata } from "../../memory/schema.js";
+import {
+  isPrivateOrLocalHost,
+  type ResolveHostAddresses,
+  resolveHostAddresses,
+  resolveRequestAddress,
+} from "../../tools/network/url-safety.js";
 // ── Result types ────────────────────────────────────────────────────
+
+const AGENT_CARD_FETCH_TIMEOUT_MS = 5_000;
 
 export interface A2AConfigResult {
   success: boolean;
@@ -85,6 +93,58 @@ export interface ResolvedAssistant {
   displayName: string;
 }
 
+interface ResolveGuardianHandleOptions {
+  fetchImpl?: typeof fetch;
+  resolveHostAddresses?: ResolveHostAddresses;
+}
+
+function parsePeerGatewayUrl(gatewayUrl: string): URL {
+  const trimmed = gatewayUrl.trim();
+  if (trimmed.includes("#")) {
+    throw new Error("A2A gatewayUrl must not include a URL fragment.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("A2A gatewayUrl must be a valid URL.");
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error("A2A gatewayUrl must use https.");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("A2A gatewayUrl must not include credentials.");
+  }
+  if (isPrivateOrLocalHost(parsed.hostname)) {
+    throw new Error(
+      "A2A gatewayUrl must not target a local or private network address.",
+    );
+  }
+
+  return new URL(parsed.origin);
+}
+
+async function assertPublicGatewayHost(
+  gatewayUrl: URL,
+  resolveHost: ResolveHostAddresses,
+): Promise<void> {
+  const resolution = await resolveRequestAddress(
+    gatewayUrl.hostname,
+    resolveHost,
+    false,
+  );
+  if (resolution.blockedAddress) {
+    throw new Error(
+      "A2A gatewayUrl must not resolve to a local or private network address.",
+    );
+  }
+  if (resolution.addresses.length === 0) {
+    throw new Error("Unable to resolve A2A gatewayUrl host.");
+  }
+}
+
 /**
  * Resolve a guardian handle to an assistant's gateway URL and identity.
  *
@@ -95,6 +155,7 @@ export interface ResolvedAssistant {
 export async function resolveGuardianHandle(
   guardianHandle: string,
   gatewayUrl?: string,
+  options: ResolveGuardianHandleOptions = {},
 ): Promise<ResolvedAssistant> {
   if (!gatewayUrl) {
     throw new Error(
@@ -103,28 +164,57 @@ export async function resolveGuardianHandle(
     );
   }
 
-  const cardUrl = `${gatewayUrl}${AGENT_CARD_PATH}`;
+  const normalizedGuardianHandle = guardianHandle.trim();
+  const peerGatewayUrl = parsePeerGatewayUrl(gatewayUrl);
+  await assertPublicGatewayHost(
+    peerGatewayUrl,
+    options.resolveHostAddresses ?? resolveHostAddresses,
+  );
+
+  const cardUrl = new URL(AGENT_CARD_PATH, peerGatewayUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  let res: Response;
   try {
-    const res = await fetch(cardUrl);
-    if (!res.ok) {
-      throw new Error(
-        `Agent card fetch failed (${res.status}): ${await res.text()}`,
-      );
-    }
-    const card = (await res.json()) as { name?: string };
-    return {
-      assistantId: guardianHandle,
-      gatewayUrl,
-      displayName: card.name ?? guardianHandle,
-    };
+    res = await fetchImpl(cardUrl.href, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(AGENT_CARD_FETCH_TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    });
   } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Agent card fetch")) {
-      throw err;
+    if (
+      err instanceof Error &&
+      (err.name === "AbortError" || err.name === "TimeoutError")
+    ) {
+      throw new Error("Timed out fetching peer assistant agent card.");
     }
-    throw new Error(
-      `Failed to reach peer assistant at ${cardUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new Error("Failed to fetch peer assistant agent card.");
   }
+
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error("Agent card fetch failed: redirects are not allowed.");
+  }
+  if (!res.ok) {
+    throw new Error(`Agent card fetch failed with status ${res.status}.`);
+  }
+
+  let card: { name?: unknown };
+  try {
+    card = (await res.json()) as { name?: unknown };
+  } catch {
+    throw new Error("Agent card response was not valid JSON.");
+  }
+
+  const displayName =
+    typeof card.name === "string" && card.name.trim()
+      ? card.name
+      : normalizedGuardianHandle;
+
+  return {
+    assistantId: normalizedGuardianHandle,
+    gatewayUrl: peerGatewayUrl.origin,
+    displayName,
+  };
 }
 
 // ── Connection initiation ───────────────────────────────────────────
@@ -132,8 +222,17 @@ export async function resolveGuardianHandle(
 export async function connectToAssistant(params: {
   guardianHandle: string;
   gatewayUrl?: string;
+  fetchImpl?: typeof fetch;
+  resolveHostAddresses?: ResolveHostAddresses;
 }): Promise<ConnectToAssistantResult> {
-  const { guardianHandle, gatewayUrl } = params;
+  const guardianHandle = params.guardianHandle.trim();
+  const { gatewayUrl } = params;
+  if (!guardianHandle) {
+    return {
+      success: false,
+      error: "guardianHandle is required",
+    };
+  }
 
   // 1. Ensure A2A channel is enabled (auto-enable on first connect)
   const config = getA2AConfig();
@@ -144,7 +243,10 @@ export async function connectToAssistant(params: {
   // 2. Resolve the peer assistant's identity
   let resolved: ResolvedAssistant;
   try {
-    resolved = await resolveGuardianHandle(guardianHandle, gatewayUrl);
+    resolved = await resolveGuardianHandle(guardianHandle, gatewayUrl, {
+      fetchImpl: params.fetchImpl,
+      resolveHostAddresses: params.resolveHostAddresses,
+    });
   } catch (err) {
     return {
       success: false,

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -175,6 +175,26 @@ describe("enforcePolicy", () => {
     expect(policy!.requiredScopes).toContain("chat.read");
   });
 
+  test.each([
+    ["integrations/a2a/config", "settings.read"],
+    ["integrations/a2a/config:POST", "settings.write"],
+    ["integrations/a2a/config:DELETE", "settings.write"],
+    ["integrations/a2a/connect", "settings.write"],
+  ] as const)("A2A endpoint %s requires %s", (endpoint, expectedScope) => {
+    authDisabled = false;
+    const policy = getPolicy(endpoint);
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toEqual([expectedScope]);
+  });
+
+  test("A2A connect denies callers without settings.write", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({ scopes: ["settings.read"] });
+    const result = enforcePolicy("integrations/a2a/connect", ctx);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
   // -- STT transcribe policy ------------------------------------------------
 
   test("stt/transcribe is registered as a protected endpoint", () => {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -234,6 +234,13 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   },
   { endpoint: "integrations/telegram/commands", scopes: ["settings.write"] },
   { endpoint: "integrations/telegram/setup", scopes: ["settings.write"] },
+  { endpoint: "integrations/a2a/config", scopes: ["settings.read"] },
+  { endpoint: "integrations/a2a/config:POST", scopes: ["settings.write"] },
+  {
+    endpoint: "integrations/a2a/config:DELETE",
+    scopes: ["settings.write"],
+  },
+  { endpoint: "integrations/a2a/connect", scopes: ["settings.write"] },
   { endpoint: "integrations/slack/channel/config", scopes: ["settings.read"] },
   {
     endpoint: "integrations/slack/channel/config:POST",

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -54,13 +54,19 @@ function handleClearA2AConfig() {
 async function handleConnectToAssistant({ body = {} }: RouteHandlerArgs) {
   assertA2AFlag();
   const { guardianHandle, gatewayUrl } = body as {
-    guardianHandle?: string;
-    gatewayUrl?: string;
+    guardianHandle?: unknown;
+    gatewayUrl?: unknown;
   };
-  if (!guardianHandle) {
+  if (typeof guardianHandle !== "string" || !guardianHandle.trim()) {
     throw new BadRequestError("guardianHandle is required");
   }
-  const result = await connectToAssistant({ guardianHandle, gatewayUrl });
+  if (gatewayUrl !== undefined && typeof gatewayUrl !== "string") {
+    throw new BadRequestError("gatewayUrl must be a string");
+  }
+  const result = await connectToAssistant({
+    guardianHandle,
+    gatewayUrl,
+  });
   if (!result.success) {
     throw new BadRequestError(result.error ?? "Failed to connect to assistant");
   }

--- a/gateway/src/__tests__/ipc-route-policy.test.ts
+++ b/gateway/src/__tests__/ipc-route-policy.test.ts
@@ -66,6 +66,19 @@ describe("ipc-route-policy: inference provider connections", () => {
   });
 });
 
+describe("ipc-route-policy: A2A integrations", () => {
+  test.each([
+    ["integrations_a2a_config_get", "settings.read"],
+    ["integrations_a2a_config_post", "settings.write"],
+    ["integrations_a2a_config_delete", "settings.write"],
+    ["integrations_a2a_connect_post", "settings.write"],
+  ] as const)("%s requires %s", (operationId, expectedScope) => {
+    const policy = getIpcRoutePolicy(operationId);
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toEqual([expectedScope]);
+  });
+});
+
 describe("ipc-route-policy: ATL-315 Batch 18 — new operationIds", () => {
   // Batch 18 added IPC policy entries for operationIds shipped after the
   // initial ATL-315 cutover. Without these entries, an authenticated edge

--- a/gateway/src/auth/ipc-route-policy.ts
+++ b/gateway/src/auth/ipc-route-policy.ts
@@ -227,6 +227,12 @@ const POLICY_TABLE: PolicyEntry[] = [
   ["integrations_ingress_config_put", ["settings.write"]],
   ["integrations_oauth_start_post", ["settings.write"]],
 
+  // Integrations / A2A
+  ["integrations_a2a_config_get", ["settings.read"]],
+  ["integrations_a2a_config_post", ["settings.write"]],
+  ["integrations_a2a_config_delete", ["settings.write"]],
+  ["integrations_a2a_connect_post", ["settings.write"]],
+
   // Integrations / Slack channel
   ["integrations_slack_channel_config_get", ["settings.read"]],
   ["integrations_slack_channel_config_post", ["settings.write"]],


### PR DESCRIPTION
Fixes ATL-610.

## Summary
- Add missing `settings.read` / `settings.write` policy coverage for A2A integration config and connect routes on both the assistant HTTP path and gateway IPC proxy path.
- Harden A2A peer gateway discovery to require HTTPS, reject fragments and credentials, reject local/private/cloud-metadata targets including DNS resolutions to private addresses, use a 5s timeout, block redirects, and avoid reflecting upstream response bodies.
- Validate A2A connect request body field types before invoking the handler.

## Root Cause
`POST /v1/integrations/a2a/connect` opted into policy enforcement, but the route policy registries did not contain A2A entries, so enforcement fell through. The peer agent-card resolver also constructed the fetch URL by string concatenation and reflected non-2xx upstream bodies, which left SSRF and probing edges open.

## Notes
There is no separate A2A disconnect route in this codebase. The existing disable path is `DELETE /v1/integrations/a2a/config`, and this PR maps it to `settings.write`.

## Validation
- `cd assistant && bun test src/daemon/handlers/__tests__/config-a2a.test.ts src/runtime/auth/__tests__/route-policy.test.ts`
- `cd assistant && bun test src/a2a/__tests__/e2e-a2a-channel.test.ts`
- `cd assistant && bun test src/runtime/auth/__tests__/guard-tests.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd gateway && bun test src/__tests__/ipc-route-policy.test.ts`
- `cd gateway && bun test src/__tests__/ipc-route-policy-coverage.test.ts`
- `cd gateway && bunx tsc --noEmit`
- Commit hook: Prettier, assistant/gateway eslint, assistant typecheck
- Push hook: assistant typecheck, assistant/gateway eslint