### PR TITLE
feat(web): configure Vite dev server for vel up integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ directories until the move is complete.
 
 | Directory | Status |
 |---|---|
-| `apps/web/` | Scaffold only — Vite + React Router v7 toolchain landed, no app code yet. The live web app is currently maintained in a separate, non-public repository and will land here as the migration completes. |
+| `apps/web/` | Active migration target — Vite + React Router v7 SPA for the assistant web app. Code is being incrementally migrated from a separate repo. See [`apps/web/README.md`](apps/web/README.md) for local dev setup. |
 | `apps/chrome-extension/` | Move in progress from [`clients/chrome-extension/`](https://github.com/vellum-ai/vellum-assistant/tree/main/clients/chrome-extension). |
 
 ## Submitting a pull request

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,20 +1,7 @@
 # apps/web
 
-> ## Status: scaffold in progress
->
-> This directory is the future open-source home for the Vellum web
-> app. **No application code lives here yet** — only the Vite + React
-> Router v7 toolchain, an empty shell, and placeholder routes that
-> exist to validate the build.
->
-> The live web app is currently maintained in a separate, non-public
-> repository and will land here as the migration completes. Feature
-> work, bug fixes, and other contributions for the web app are not
-> accepted in `apps/web/` during the scaffold phase — PRs that add
-> product features or non-scaffold code will be redirected.
-
 Vite + [React Router v7](https://reactrouter.com/) SPA for the
-vellum-assistant web app surfaces (assistant + docs).
+Vellum assistant web app (chat, settings, library, docs).
 
 ## Stack
 
@@ -23,10 +10,108 @@ vellum-assistant web app surfaces (assistant + docs).
   [React Router v7](https://reactrouter.com/start/modes) in
   **library / data-router mode** (`createBrowserRouter` +
   `<RouterProvider>`).
+- [Zustand](https://zustand.docs.pmnd.rs/) for shared client state
+  (messages, streaming, interactions, conversations).
+- [TanStack React Query](https://tanstack.com/query/latest) for server
+  state (API calls, caching, mutations).
+- [HeyAPI](https://heyapi.dev/) for OpenAPI client generation with
+  React Query plugin.
 - TypeScript with `NodeNext` module resolution — relative imports use
   `.js` extensions even for `.tsx` sources.
 - Bun for dependency management; self-contained `bun.lock` per
   [`apps/AGENTS.md`](../AGENTS.md).
+
+## Local development
+
+### With `vel up` (recommended)
+
+The `vel up web` command in the
+[vellum-assistant-platform](https://github.com/vellum-ai/vellum-assistant-platform)
+repo starts all required services:
+
+```bash
+vel up web
+```
+
+This starts:
+1. Docker Compose services (Postgres, Valkey, SeaweedFS, Caddy edge proxy)
+2. Django backend on `localhost:8000`
+3. **This Vite dev server on `localhost:3001`**
+4. Caddy edge proxy on `localhost:3000` (canonical browser entry point)
+
+The Caddy proxy routes:
+- `/v1/*`, `/_allauth/*`, `/accounts/*` -> Django `:8000`
+- Everything else -> Vite `:3001`
+
+Browse to **http://localhost:3000** (not :3001 directly) so auth
+cookies and API calls route correctly.
+
+### Without `vel up` (standalone)
+
+If you need to run the web app without the full `vel up` orchestration
+(e.g., working on pure UI without backend):
+
+```bash
+cd apps/web
+bun install
+bun run dev        # Vite dev server on localhost:3001
+```
+
+To connect to a running Django backend, ensure the Caddy edge proxy is
+running (via `docker compose up edge-proxy` in the platform repo) or
+configure your browser to send API requests to `localhost:8000`
+directly.
+
+### Other commands
+
+```bash
+bun run build      # Production build to dist/
+bun run preview    # Serve the production build locally
+bun run typecheck  # bunx tsc --noEmit
+bun run lint       # eslint
+```
+
+## Architecture
+
+See [`CONVENTIONS.md`](./CONVENTIONS.md) for code organization
+(domain-based architecture), state management patterns (Zustand +
+React Query), component conventions, and framework strategy.
+
+See [`STYLE_GUIDE.md`](./STYLE_GUIDE.md) for naming, imports,
+TypeScript rules, and formatting.
+
+## Directory structure
+
+```
+src/
+  App.tsx                    # root layout component
+  main.tsx                   # entry point (createRoot, RouterProvider)
+  routes.tsx                 # route tree (createBrowserRouter)
+  domains/                   # business domain modules
+    messages/                # message lifecycle
+    conversations/           # conversation CRUD, grouping, selection
+    streaming/               # SSE transport, event parsing
+    interactions/            # user-facing prompts
+  hooks/                     # cross-domain shared hooks
+  utils/                     # cross-domain shared utilities
+  types/                     # cross-domain shared types
+  lib/                       # configured third-party wrappers
+  runtime/                   # framework adapters, platform bridges
+  components/                # cross-domain shared UI
+  pages/                     # route-level page components
+  generated/                 # auto-generated code (HeyAPI) — gitignored
+```
+
+## Path alias
+
+Use `@/` to import from `src/`:
+
+```ts
+import { useMessageStore } from "@/domains/messages/use-message-store.js";
+```
+
+Configured in both `vite.config.ts` (`resolve.alias`) and
+`tsconfig.json` (`paths`) for editor support.
 
 ## Why library mode?
 
@@ -34,17 +119,16 @@ React Router v7 ships two
 [modes](https://reactrouter.com/start/modes): _library / data-router_
 mode (pure-client SPA built around `createBrowserRouter`) and
 _framework_ mode (file-based routes, generated types, per-route code
-splitting; can be configured to produce a static SPA via
-[`ssr: false`](https://reactrouter.com/how-to/spa)).
+splitting).
 
 Library mode is the established React SPA pattern. Fewer conventions
 to learn, fewer build-time plugins, no generated types directory — the
-more recognizable shape for new contributors to this open source repo.
-Framework mode is a defensible alternative when the app grows enough
-that per-route code splitting or generated param types become worth
-their conventions; the React Router API used in day-to-day code
-(`<Link>`, `<Outlet>`, `useParams`, `useNavigate`) is the same in both
-modes, so switching later is a restructure rather than a rewrite.
+more recognizable shape for contributors. Framework mode is a
+defensible alternative when the app grows enough that per-route code
+splitting becomes worth its conventions; the React Router API used in
+day-to-day code (`<Link>`, `<Outlet>`, `useParams`, `useNavigate`) is
+the same in both modes, so switching later is a restructure rather
+than a rewrite.
 
 ## Runtime/auth adapter seam
 
@@ -52,8 +136,7 @@ modes, so switching later is a restructure rather than a rewrite.
 typed `RuntimeAuthAdapter` interface (`ensureSession` +
 `getAuthHeader`) so the shell does not hard-code hosted Vellum login.
 Hosted, local, self-hosted, and Electron runtimes plug in via the same
-interface from their respective hosts. No implementation is included
-in the scaffold.
+interface from their respective hosts.
 
 ## SSR/build-safe rendering
 
@@ -61,17 +144,6 @@ Even though this is an SPA, route and layout components must not
 access `window` / `localStorage` / `document` during synchronous
 render. Client-only reads belong in `useEffect` or in a runtime
 adapter implementation. This keeps the door open for future static
-prerendering or hybrid runtimes without ad-hoc rewrites. See Vite's
+prerendering or hybrid runtimes. See Vite's
 [SSR guidance](https://vite.dev/guide/ssr.html) for the underlying
 reasoning.
-
-## Local development
-
-```bash
-bun install
-bun run dev        # Vite dev server
-bun run build      # Production build to dist/
-bun run preview    # Serve the production build
-bun run typecheck  # bunx tsc --noEmit
-bun run lint       # eslint
-```

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,7 +13,10 @@
     "noEmit": true,
     "allowJs": false,
     "isolatedModules": true,
-    "types": []
+    "types": [],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": [
     "src/**/*.ts",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,8 +1,18 @@
+import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@/": path.resolve(__dirname, "src") + "/",
+    },
+  },
+  server: {
+    port: 3001,
+    strictPort: true,
+  },
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@/": path.resolve(__dirname, "src") + "/",
+      "@/": path.resolve(import.meta.dirname, "src") + "/",
     },
   },
   server: {


### PR DESCRIPTION
## Prompt / plan

Prepare `apps/web` for the incremental migration from the platform repo's Next.js app. This is the first PR in a series — it makes the Vite dev server compatible with the existing `vel up` orchestration (Caddy edge proxy on `:3000` → Vite on `:3001`) and updates the README so developers can start working here today.

A companion PR in the platform repo will update `vel up` to point its "web" service at this directory instead of platform's `web/`.

## Changes

1. **`vite.config.ts`** — Serve on port 3001 (`strictPort: true`) to match the Caddy proxy routing; add `@/` → `src/` resolve alias.
2. **`tsconfig.json`** — Add `paths` mapping (`@/*` → `./src/*`) for TypeScript editor support of the same alias.
3. **`README.md`** — Remove the "scaffold in progress" notice; add local dev instructions for both `vel up` and standalone workflows; document the target directory structure, path alias, and stack (Zustand, TanStack Query, HeyAPI).

## Things for reviewers to verify

- [ ] Port 3001 + `strictPort` matches your Caddy config expectations
- [ ] The README documents future directories/stack (domains/, Zustand, etc.) that don't exist in `src/` yet — confirm this aspirational documentation is acceptable at this stage
- [ ] `@/` alias: Vite uses `resolve.alias`, TypeScript uses `paths` with `noEmit: true` — both are needed for runtime + editor resolution

## Test plan

- `bun run typecheck` passes (tsconfig paths are valid)
- `bun run dev` starts on port 3001 and refuses to fall back to another port (`strictPort`)
- Existing `bun run build` continues to produce output in `dist/`

Link to Devin session: https://app.devin.ai/sessions/57905118879948a69946c94c6cd332d7
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->