### PR TITLE
fix(providers): auto-create connection when saving profile for new provider

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -85,6 +85,8 @@ mock.module("../memory/embedding-backend.js", () => ({
 // test doesn't migrate — stub it out so the guard logic stays the focus.
 mock.module("../providers/inference/connections.js", () => ({
   listConnections: () => [],
+  createConnection: () => ({ ok: false, error: { code: "already_exists" } }),
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS: new Set(["openai-compatible"]),
 }));
 
 import { ROUTES } from "../runtime/routes/conversation-query-routes.js";

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -71,7 +71,10 @@ import {
   memoryV2ActivationLogs,
   messages,
 } from "../../../memory/schema.js";
-import { createConnection } from "../../../providers/inference/connections.js";
+import {
+  createConnection,
+  getConnection,
+} from "../../../providers/inference/connections.js";
 import { ROUTES } from "../conversation-query-routes.js";
 
 // Local subset: this test only exercises a single concept row.
@@ -485,6 +488,34 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
 
     expect(savedProfile.provider).toBe("fireworks");
     expect(savedProfile.provider_connection).toBe("fireworks");
+  });
+
+  test("auto-creates provider_connection when no connection exists for provider", async () => {
+    const result = await replaceProfileRoute.handler({
+      pathParams: { name: "custom" },
+      body: {
+        provider: "openrouter",
+        model: "anthropic/claude-sonnet-4-6",
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    const savedProfile = (
+      savedRawConfig?.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      }
+    ).profiles.custom;
+
+    expect(savedProfile.provider).toBe("openrouter");
+    expect(savedProfile.provider_connection).toBe("openrouter-personal");
+
+    const conn = getConnection(getDb(), "openrouter-personal");
+    expect(conn).not.toBeNull();
+    expect(conn!.provider).toBe("openrouter");
+    expect(conn!.auth).toEqual({
+      type: "api_key",
+      credential: "credential/openrouter/api_key",
+    });
   });
 
   describe("managed profile guard", () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -660,28 +660,26 @@ async function handleReplaceInferenceProfile({
   const fragment = parsed.data as Record<string, unknown>;
   if (!isManaged && fragment.provider && !fragment.provider_connection) {
     const provider = fragment.provider as string;
-    if (!PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
-      const db = getDb();
-      const candidates = listConnections(db, { provider });
-      const existing = candidates[0];
-      if (existing) {
-        fragment.provider_connection = existing.name;
-      } else {
-        const connectionName = `${provider}-personal`;
-        const isKeyless = provider === "ollama";
-        const result = createConnection(db, {
-          name: connectionName,
-          provider,
-          auth: isKeyless
-            ? { type: "none" }
-            : {
-                type: "api_key",
-                credential: credentialKey(provider, "api_key"),
-              },
-        });
-        if (result.ok) {
-          fragment.provider_connection = connectionName;
-        }
+    const db = getDb();
+    const candidates = listConnections(db, { provider });
+    const active = candidates.find((c) => c.status === "active");
+    if (active) {
+      fragment.provider_connection = active.name;
+    } else if (!PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
+      const connectionName = `${provider}-personal`;
+      const isKeyless = provider === "ollama";
+      const result = createConnection(db, {
+        name: connectionName,
+        provider,
+        auth: isKeyless
+          ? { type: "none" }
+          : {
+              type: "api_key",
+              credential: credentialKey(provider, "api_key"),
+            },
+      });
+      if (result.ok) {
+        fragment.provider_connection = connectionName;
       }
     }
   }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -65,9 +65,14 @@ import { getLlmRequestLogSource } from "../../memory/llm-request-log-source.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../memory/memory-v2-activation-log-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
-import { listConnections } from "../../providers/inference/connections.js";
+import {
+  createConnection,
+  listConnections,
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
+} from "../../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { initializeProviders } from "../../providers/registry.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { validateAllowlistFile } from "../../security/secret-allowlist.js";
 import { resolvePricingForUsage } from "../../util/pricing.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -654,12 +659,30 @@ async function handleReplaceInferenceProfile({
   // inherit a stale connection from the default layer.
   const fragment = parsed.data as Record<string, unknown>;
   if (!isManaged && fragment.provider && !fragment.provider_connection) {
-    const candidates = listConnections(getDb(), {
-      provider: fragment.provider as string,
-    });
-    const active = candidates.find((c) => c.status === "active");
-    if (active) {
-      fragment.provider_connection = active.name;
+    const provider = fragment.provider as string;
+    if (!PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
+      const db = getDb();
+      const candidates = listConnections(db, { provider });
+      const existing = candidates[0];
+      if (existing) {
+        fragment.provider_connection = existing.name;
+      } else {
+        const connectionName = `${provider}-personal`;
+        const isKeyless = provider === "ollama";
+        const result = createConnection(db, {
+          name: connectionName,
+          provider,
+          auth: isKeyless
+            ? { type: "none" }
+            : {
+                type: "api_key",
+                credential: credentialKey(provider, "api_key"),
+              },
+        });
+        if (result.ok) {
+          fragment.provider_connection = connectionName;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- When creating a custom profile for a provider with no existing DB connection (e.g. OpenRouter on first use), the profile handler now auto-creates a `{provider}-personal` connection instead of leaving `provider_connection` unset
- This prevents `deepMerge` from inheriting a stale `provider_connection` (like `"anthropic-managed"`) from the default config layer, which caused a provider mismatch error at dispatch time
- Also picks up any existing connection (regardless of status) so the field is always explicit in the saved config

## Original prompt
RCA on JARVIS-884 revealed that creating a new OpenRouter profile and switching to it caused a provider resolution mismatch. The profile was saved without `provider_connection`, so `deepMerge` let the default layer's `"anthropic-managed"` leak through. At dispatch time, the mismatch between the connection's provider (anthropic) and the profile's declared provider (openrouter) threw an error. The auto-recovery also failed because no openrouter connection existed yet in the DB.

## Test plan
- [ ] New test: `auto-creates provider_connection when no connection exists for provider` — creates an OpenRouter profile with no pre-existing connection, verifies the saved profile has `provider_connection: "openrouter-personal"` and the DB row was created with correct auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->