### PR TITLE
test(cli/notifications): mock exitFromIpcResult to unblock test suite

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -28,6 +28,11 @@ mock.module("../../../ipc/cli-client.js", () => ({
     ipcCalls.push({ method, params });
     return ipcResponse;
   },
+  exitFromIpcResult: (r: { ok: false; error?: string }) => {
+    process.stderr.write((r.error ?? "Unknown error") + "\n");
+    process.exitCode = 1;
+    return undefined as never;
+  },
 }));
 
 import { Command } from "commander";
@@ -40,6 +45,7 @@ import { registerNotificationsCommand } from "../notifications.js";
 
 interface CommandResult {
   parsed: Record<string, unknown>;
+  stderr: string;
   exitCode: number;
 }
 
@@ -52,7 +58,9 @@ interface CommandResult {
  */
 async function runCommand(args: string[]): Promise<CommandResult> {
   const chunks: string[] = [];
+  const stderrChunks: string[] = [];
   const originalWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
 
   process.exitCode = 0;
 
@@ -60,6 +68,11 @@ async function runCommand(args: string[]): Promise<CommandResult> {
     chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
     return true;
   }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: string | Buffer) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  }) as typeof process.stderr.write;
 
   try {
     const program = new Command();
@@ -76,6 +89,7 @@ async function runCommand(args: string[]): Promise<CommandResult> {
     // Commander throws on .exitOverride() for --help/errors; ignore
   } finally {
     process.stdout.write = originalWrite;
+    process.stderr.write = originalStderrWrite;
   }
 
   const exitCode = process.exitCode ?? 0;
@@ -87,7 +101,7 @@ async function runCommand(args: string[]): Promise<CommandResult> {
     ? (JSON.parse(firstLine) as Record<string, unknown>)
     : {};
 
-  return { parsed, exitCode };
+  return { parsed, stderr: stderrChunks.join(""), exitCode };
 }
 
 function lastSendBody(): Record<string, unknown> {
@@ -273,7 +287,7 @@ describe("notifications send", () => {
       error: "Daemon rejected the signal",
     };
 
-    const { parsed, exitCode } = await runCommand([
+    const { stderr, exitCode } = await runCommand([
       "send",
       "--source-channel",
       "assistant_tool",
@@ -284,8 +298,7 @@ describe("notifications send", () => {
     ]);
 
     expect(exitCode).toBe(1);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toBe("Daemon rejected the signal");
+    expect(stderr).toContain("Daemon rejected the signal");
   });
 });
 


### PR DESCRIPTION
## Summary
- Mock `exitFromIpcResult` in `notifications.test.ts` so the IPC-error path doesn't call `process.exit()` mid-run, which was killing the bun test process after test #8 and failing the file.
- Capture `stderr` in `runCommand` and update the `send surfaces IPC error response` assertions to check `stderr` (where `exitFromIpcResult` writes the error) instead of JSON stdout.
- Mirrors the existing pattern in `avatar.test.ts` and other CLI tests that exercise commands using `exitFromIpcResult`.

## Original prompt
PR #30988 migrated `notifications send` to use `exitFromIpcResult` for IPC error mapping (per the cli AGENTS.md pattern) but didn't update the test, which assumed the old `writeOutput + process.exitCode = 1` shape. As a result, every CI run on main was failing the `notifications.test.ts` file because `exitFromIpcResult`'s real implementation calls `process.exit(10)` and terminates the entire bun test process. Fix the test to match the new pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->