### PR TITLE
feat(a2a): add authenticated sender-side A2A invite completion endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9718,6 +9718,16 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/integrations/a2a/invite/complete:
+    post:
+      operationId: integrations_a2a_invite_complete_post
+      summary: Complete A2A invite (sender side)
+      description: Called by the platform to finalize the sender side of a link-based A2A connection.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/integrations/ingress/config:
     get:
       operationId: integrations_ingress_config_get

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for A2A invite completion handler (sender side).
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
+  getAssistantContactMetadata,
+  getContact,
+} from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { findById } from "../../../memory/invite-store.js";
+import { completeA2AInvite, createA2AInvite } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: {
+  a2aEnabled?: boolean;
+  publicBaseUrl?: string;
+  ingressEnabled?: boolean;
+}): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  if (opts.publicBaseUrl !== undefined) {
+    setNestedValue(raw, "ingress.publicBaseUrl", opts.publicBaseUrl);
+  }
+  if (opts.ingressEnabled !== undefined) {
+    setNestedValue(raw, "ingress.enabled", opts.ingressEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+const ACCEPTOR = {
+  assistantId: "acceptor-assistant-123",
+  displayName: "Acceptor Bot",
+  gatewayUrl: "https://acceptor.example.com",
+};
+
+describe("completeA2AInvite", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "https://sender.example.com",
+      ingressEnabled: true,
+    });
+  });
+
+  test("happy path: promotes placeholder contact and returns sender identity", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sender).toBeDefined();
+    expect(result.sender!.gatewayUrl).toBe("https://sender.example.com");
+    expect(result.sender!.displayName).toBeDefined();
+    expect(result.error).toBeUndefined();
+
+    // Verify the placeholder contact was promoted
+    const invite = findById(created.inviteId!);
+    expect(invite).not.toBeNull();
+
+    const contact = getContact(invite!.contactId);
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Acceptor Bot");
+    expect(contact!.channels).toHaveLength(1);
+    expect(contact!.channels[0]!.type).toBe("a2a");
+    expect(contact!.channels[0]!.status).toBe("active");
+    expect(contact!.channels[0]!.policy).toBe("allow");
+  });
+
+  test("contact channel address is acceptor.assistantId.toLowerCase()", () => {
+    const created = createA2AInvite({});
+    const acceptorWithUppercase = {
+      ...ACCEPTOR,
+      assistantId: "UPPER-Case-ID-123",
+    };
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: acceptorWithUppercase,
+    });
+    expect(result.success).toBe(true);
+
+    const invite = findById(created.inviteId!);
+    const contact = getContact(invite!.contactId);
+    expect(contact!.channels[0]!.address).toBe("upper-case-id-123");
+    expect(contact!.channels[0]!.externalUserId).toBe("UPPER-Case-ID-123");
+  });
+
+  test("assistantContactMetadata has correct assistantId and gatewayUrl", () => {
+    const created = createA2AInvite({});
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(result.success).toBe(true);
+
+    const invite = findById(created.inviteId!);
+    const metadata = getAssistantContactMetadata(invite!.contactId);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.species).toBe("vellum");
+    expect(metadata!.metadata).toEqual({
+      assistantId: "acceptor-assistant-123",
+      gatewayUrl: "https://acceptor.example.com",
+    });
+  });
+
+  test("invalid token returns not_found error", () => {
+    const result = completeA2AInvite({
+      token: "invalid-token-that-does-not-exist",
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("not_found");
+  });
+
+  test("expired invite returns expired error", () => {
+    // Create an invite that expires immediately
+    const created = createA2AInvite({ expiresInHours: 0 });
+    expect(created.success).toBe(true);
+
+    // The invite was just created with 0 hours expiry, so expiresAt ~= now
+    // Manually expire it by updating the DB
+    const sqlite = getSqlite();
+    sqlite.run(
+      "UPDATE assistant_ingress_invites SET expires_at = ? WHERE id = ?",
+      [Date.now() - 1000, created.inviteId!],
+    );
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("expired");
+  });
+
+  test("already-redeemed by same acceptor returns idempotent success", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    // First completion
+    const first = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(first.success).toBe(true);
+
+    // Second completion with same acceptor
+    const second = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(second.success).toBe(true);
+  });
+
+  test("already-redeemed by different acceptor returns error", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    // First completion
+    const first = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(first.success).toBe(true);
+
+    // Second completion with different acceptor
+    const second = completeA2AInvite({
+      token: created.token!,
+      acceptor: {
+        assistantId: "different-assistant-456",
+        displayName: "Different Bot",
+        gatewayUrl: "https://different.example.com",
+      },
+    });
+
+    expect(second.success).toBe(false);
+    expect(second.error).toBe("already_redeemed_by_other");
+  });
+});

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -15,8 +15,16 @@ import {
   setNestedValue,
 } from "../../config/loader.js";
 import { searchContacts, upsertContact } from "../../contacts/contact-store.js";
+import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
-import { createInvite } from "../../memory/invite-store.js";
+import { getDb } from "../../memory/db-connection.js";
+import {
+  claimA2AInvite,
+  createInvite,
+  hashToken,
+} from "../../memory/invite-store.js";
+import { assistantContactMetadata } from "../../memory/schema.js";
+import { getAssistantName } from "../identity-helpers.js";
 // ── Result types ────────────────────────────────────────────────────
 
 export interface A2AConfigResult {
@@ -32,6 +40,12 @@ export interface CreateA2AInviteResult {
   token?: string;
   expiresAt?: number;
   senderGatewayUrl?: string;
+  error?: string;
+}
+
+export interface CompleteA2AInviteResult {
+  success: boolean;
+  sender?: { assistantId: string; displayName: string; gatewayUrl: string };
   error?: string;
 }
 
@@ -117,5 +131,78 @@ export function createA2AInvite(params: {
     token: rawToken,
     expiresAt: invite.expiresAt,
     senderGatewayUrl: publicBaseUrl,
+  };
+}
+
+// ── A2A invite completion (sender side) ───────────────────────────
+
+export function completeA2AInvite(params: {
+  token: string;
+  acceptor: {
+    assistantId: string;
+    displayName: string;
+    gatewayUrl: string;
+  };
+}): CompleteA2AInviteResult {
+  const tokenHash = hashToken(params.token);
+  const claimResult = claimA2AInvite({
+    tokenHash,
+    redeemedByExternalUserId: params.acceptor.assistantId,
+  });
+
+  if (!claimResult.claimed || !claimResult.invite) {
+    return { success: false, error: claimResult.error };
+  }
+
+  const invite = claimResult.invite;
+
+  // Promote the placeholder contact with the acceptor's identity
+  upsertContact({
+    id: invite.contactId,
+    displayName: params.acceptor.displayName,
+    contactType: "assistant",
+    role: "contact",
+    channels: [
+      {
+        type: "a2a",
+        address: params.acceptor.assistantId.toLowerCase(),
+        externalUserId: params.acceptor.assistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  // Write assistant contact metadata
+  const db = getDb();
+  const metadataJson = JSON.stringify({
+    assistantId: params.acceptor.assistantId,
+    gatewayUrl: params.acceptor.gatewayUrl,
+  } satisfies VellumAssistantMetadata);
+  db.insert(assistantContactMetadata)
+    .values({
+      contactId: invite.contactId,
+      species: "vellum",
+      metadata: metadataJson,
+    })
+    .onConflictDoUpdate({
+      target: assistantContactMetadata.contactId,
+      set: { species: "vellum", metadata: metadataJson },
+    })
+    .run();
+
+  // Resolve this assistant's identity for the response
+  const displayName = getAssistantName() ?? "Vellum Assistant";
+  let gatewayUrl: string;
+  try {
+    gatewayUrl = getPublicBaseUrl(getConfig());
+  } catch {
+    gatewayUrl = "";
+  }
+  const assistantId = displayName;
+
+  return {
+    success: true,
+    sender: { assistantId, displayName, gatewayUrl },
   };
 }

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -364,6 +364,59 @@ export function findActiveVoiceInvites(params: {
 }
 
 // ---------------------------------------------------------------------------
+// claimA2AInvite — validate + consume an A2A invite token
+// ---------------------------------------------------------------------------
+
+export function claimA2AInvite(params: {
+  tokenHash: string;
+  redeemedByExternalUserId: string;
+}): { claimed: boolean; invite: IngressInvite | null; error?: string } {
+  const invite = findByTokenHash(params.tokenHash);
+
+  if (!invite) {
+    return { claimed: false, invite: null, error: "not_found" };
+  }
+
+  if (invite.sourceChannel !== "a2a") {
+    return { claimed: false, invite, error: "wrong_channel" };
+  }
+
+  // Idempotency: if already redeemed by the same acceptor, return success
+  if (invite.status === "redeemed") {
+    if (invite.redeemedByExternalUserId === params.redeemedByExternalUserId) {
+      return { claimed: true, invite };
+    }
+    return { claimed: false, invite, error: "already_redeemed_by_other" };
+  }
+
+  if (invite.status !== "active") {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  if (Date.now() >= invite.expiresAt) {
+    markInviteExpired(invite.id);
+    return { claimed: false, invite, error: "expired" };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { claimed: false, invite, error: "already_redeemed" };
+  }
+
+  const recorded = recordInviteUse({
+    inviteId: invite.id,
+    externalUserId: params.redeemedByExternalUserId,
+  });
+
+  if (!recorded) {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  // Re-read to get updated state
+  const updated = findByTokenHash(params.tokenHash);
+  return { claimed: true, invite: updated };
+}
+
+// ---------------------------------------------------------------------------
 // findByInviteCodeHash
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -687,6 +687,12 @@ for (const endpoint of INTERNAL_ENDPOINTS) {
   });
 }
 
+// A2A invite completion: gateway-only (platform-orchestrated)
+registerPolicy("integrations/a2a/invite/complete", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});
+
 // Admin control-plane endpoints: gateway-only
 registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -11,6 +11,7 @@ import { isA2AEnabled } from "../../../a2a/feature-gate.js";
 import { getConfig } from "../../../config/loader.js";
 import {
   clearA2AConfig,
+  completeA2AInvite,
   createA2AInvite,
   getA2AConfig,
   setA2AConfig,
@@ -61,6 +62,49 @@ function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
   return result;
 }
 
+function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
+  const { token, acceptor } = body as {
+    token?: unknown;
+    acceptor?: {
+      assistantId?: unknown;
+      displayName?: unknown;
+      gatewayUrl?: unknown;
+    };
+  };
+
+  if (typeof token !== "string" || !token) {
+    throw new BadRequestError(
+      "token is required and must be a non-empty string",
+    );
+  }
+  if (
+    !acceptor ||
+    typeof acceptor.assistantId !== "string" ||
+    !acceptor.assistantId ||
+    typeof acceptor.displayName !== "string" ||
+    !acceptor.displayName ||
+    typeof acceptor.gatewayUrl !== "string" ||
+    !acceptor.gatewayUrl
+  ) {
+    throw new BadRequestError(
+      "acceptor must include non-empty assistantId, displayName, and gatewayUrl",
+    );
+  }
+
+  const result = completeA2AInvite({
+    token,
+    acceptor: {
+      assistantId: acceptor.assistantId,
+      displayName: acceptor.displayName,
+      gatewayUrl: acceptor.gatewayUrl,
+    },
+  });
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to complete A2A invite");
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -106,5 +150,16 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: handleCreateA2AInvite,
+  },
+  {
+    operationId: "integrations_a2a_invite_complete_post",
+    endpoint: "integrations/a2a/invite/complete",
+    method: "POST",
+    summary: "Complete A2A invite (sender side)",
+    description:
+      "Called by the platform to finalize the sender side of a link-based A2A connection.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleCompleteA2AInvite,
   },
 ];


### PR DESCRIPTION
## Summary
- Add `POST /v1/integrations/a2a/invite/complete` endpoint (gateway-service-only, `internal.write` scope)
- Add `claimA2AInvite()` to invite-store with atomic token validation and idempotent retry handling
- Promotes placeholder contact to active with acceptor's platform assistant ID, returns sender identity for platform orchestration

Part of plan: a2a-link-trusted-contact.md (PR 2 of 3)