### PR TITLE
[LUM-1587] polish: soften risk level chip colors to muted pastel palette

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RiskBadgeView.swift
@@ -3,11 +3,9 @@ import VellumAssistantShared
 
 /// A small colored pill that displays a risk level label.
 ///
-/// Color-coded by risk level:
-/// - `"low"` — green (`VColor.systemPositiveStrong`)
-/// - `"medium"` — amber (`VColor.systemMidStrong`)
-/// - `"high"` — red (`VColor.systemNegativeStrong`)
-/// - Any other value — gray (`VColor.contentSecondary`)
+/// Uses the design system's "weak" palette — muted pastel backgrounds with
+/// the corresponding strong semantic color for text — so the badge conveys
+/// risk without visually competing with chat content.
 ///
 /// When `onTap` is provided the badge renders as a tappable button with a
 /// tooltip; otherwise it is a plain, non-interactive label.
@@ -53,6 +51,19 @@ struct RiskBadgeView: View {
     private var backgroundColor: Color {
         switch riskLevel.lowercased() {
         case "low":
+            VColor.systemPositiveWeak
+        case "medium":
+            VColor.systemMidWeak
+        case "high":
+            VColor.systemNegativeWeak
+        default:
+            VColor.surfaceBase
+        }
+    }
+
+    private var textColor: Color {
+        switch riskLevel.lowercased() {
+        case "low":
             VColor.systemPositiveStrong
         case "medium":
             VColor.systemMidStrong
@@ -60,16 +71,6 @@ struct RiskBadgeView: View {
             VColor.systemNegativeStrong
         default:
             VColor.contentSecondary
-        }
-    }
-
-    private var textColor: Color {
-        switch riskLevel.lowercased() {
-        case "medium":
-            // Amber background is light — use dark text for contrast.
-            VColor.auxBlack
-        default:
-            VColor.auxWhite
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -153,12 +153,21 @@ private struct V3TrustRuleRow: View {
     let onEdit: () -> Void
     let onDelete: () -> Void
 
-    private func riskColor(_ risk: String) -> Color {
+    private func riskBackgroundColor(_ risk: String) -> Color {
+        switch risk.lowercased() {
+        case "low": return VColor.systemPositiveWeak
+        case "medium": return VColor.systemMidWeak
+        case "high": return VColor.systemNegativeWeak
+        default: return VColor.surfaceBase
+        }
+    }
+
+    private func riskTextColor(_ risk: String) -> Color {
         switch risk.lowercased() {
         case "low": return VColor.systemPositiveStrong
         case "medium": return VColor.systemMidStrong
         case "high": return VColor.systemNegativeStrong
-        default: return VColor.contentTertiary
+        default: return VColor.contentSecondary
         }
     }
 
@@ -185,8 +194,8 @@ private struct V3TrustRuleRow: View {
             Text(rule.risk.lowercased())
                 .font(VFont.labelDefault)
                 .padding(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
-                .background(riskColor(rule.risk).opacity(0.15))
-                .foregroundStyle(riskColor(rule.risk))
+                .background(riskBackgroundColor(rule.risk))
+                .foregroundStyle(riskTextColor(rule.risk))
                 .clipShape(Capsule())
 
             // Origin / modified indicators

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -35,8 +35,8 @@ public struct GuardianDecisionBubble: View {
         }
     }
 
-    /// Maps `decision.riskLevel` to a semantic color for badges and accents.
-    private var riskColor: Color {
+    /// Strong semantic color for card accents (border tint, header icon).
+    private var riskAccentColor: Color {
         switch decision.riskLevel?.lowercased() {
         case "high":
             return VColor.systemNegativeStrong
@@ -45,6 +45,23 @@ public struct GuardianDecisionBubble: View {
         default:
             return VColor.systemPositiveStrong
         }
+    }
+
+    /// Muted background for the inline risk badge pill.
+    private var riskBadgeBackgroundColor: Color {
+        switch decision.riskLevel?.lowercased() {
+        case "high":
+            return VColor.systemNegativeWeak
+        case "medium":
+            return VColor.systemMidWeak
+        default:
+            return VColor.systemPositiveWeak
+        }
+    }
+
+    /// Text color for the inline risk badge pill.
+    private var riskBadgeTextColor: Color {
+        riskAccentColor
     }
 
     public var body: some View {
@@ -57,12 +74,12 @@ public struct GuardianDecisionBubble: View {
 
     // MARK: - Pending (actionable)
 
-    /// The accent color for the card border and header icon. Uses `riskColor`
-    /// when a risk level is present on a tool_approval; otherwise falls back to
-    /// the kind-derived accent from `headerConfig`.
+    /// The accent color for the card border and header icon. Uses the strong
+    /// risk semantic color when a risk level is present on a tool_approval;
+    /// otherwise falls back to the kind-derived accent from `headerConfig`.
     private var cardAccent: Color {
         if decision.kind == "tool_approval", decision.riskLevel != nil {
-            return riskColor
+            return riskAccentColor
         }
         return headerConfig.accent
     }
@@ -88,12 +105,12 @@ public struct GuardianDecisionBubble: View {
                     if let risk = decision.riskLevel {
                         Text(risk.uppercased())
                             .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.auxWhite)
+                            .foregroundStyle(riskBadgeTextColor)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.vertical, VSpacing.xxs)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.sm)
-                                    .fill(riskColor)
+                                    .fill(riskBadgeBackgroundColor)
                             )
                     }
 

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -50,18 +50,29 @@ public struct GuardianDecisionBubble: View {
     /// Muted background for the inline risk badge pill.
     private var riskBadgeBackgroundColor: Color {
         switch decision.riskLevel?.lowercased() {
-        case "high":
-            return VColor.systemNegativeWeak
+        case "low":
+            return VColor.systemPositiveWeak
         case "medium":
             return VColor.systemMidWeak
+        case "high":
+            return VColor.systemNegativeWeak
         default:
-            return VColor.systemPositiveWeak
+            return VColor.surfaceBase
         }
     }
 
     /// Text color for the inline risk badge pill.
     private var riskBadgeTextColor: Color {
-        riskAccentColor
+        switch decision.riskLevel?.lowercased() {
+        case "low":
+            return VColor.systemPositiveStrong
+        case "medium":
+            return VColor.systemMidStrong
+        case "high":
+            return VColor.systemNegativeStrong
+        default:
+            return VColor.contentSecondary
+        }
     }
 
     public var body: some View {

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -191,17 +191,19 @@ public struct PermissionPromptView: View {
 
     private var v3RiskBadgeBackgroundColor: Color {
         switch confirmation.riskLevel.lowercased() {
-        case "low": VColor.systemPositiveStrong
-        case "medium": VColor.systemMidStrong
-        case "high": VColor.systemNegativeStrong
-        default: VColor.contentSecondary
+        case "low": VColor.systemPositiveWeak
+        case "medium": VColor.systemMidWeak
+        case "high": VColor.systemNegativeWeak
+        default: VColor.surfaceBase
         }
     }
 
     private var v3RiskBadgeTextColor: Color {
         switch confirmation.riskLevel.lowercased() {
-        case "medium": VColor.auxBlack
-        default: VColor.auxWhite
+        case "low": VColor.systemPositiveStrong
+        case "medium": VColor.systemMidStrong
+        case "high": VColor.systemNegativeStrong
+        default: VColor.contentSecondary
         }
     }
 


### PR DESCRIPTION
Switches all risk level badge backgrounds from saturated Strong tokens to muted Weak tokens, matching the existing `VBadge.subtle` design system pattern and [Figma specs](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=725-2529). The Strong tokens were designed for text/icon foreground use — using them as solid fill backgrounds created visually harsh pills that competed with content.

## Root cause analysis

**How did the code get into this state?** The original risk badge implementations used Strong semantic tokens (`systemPositiveStrong`, `systemMidStrong`, `systemNegativeStrong`) as solid badge fill backgrounds. These tokens are saturated colors meant for text/icon foreground, not background fills. The design system already had the correct pattern in `VBadge` with its `.subtle` emphasis mode (Weak backgrounds + Strong text), but the risk badges were implemented separately without following it.

**What can we prevent this from recurring?** Risk color mapping is now consistent across all four badge-rendering locations, using the same Weak/Strong token pairing. Future risk badges should follow this established pattern.

**Alternatives rejected:**
- **Refactor to use `VBadge` directly** — `RiskBadgeView` has custom interactivity (tap-to-edit, tooltip, provenance text) that VBadge doesn't support. Scope creep for a polish ticket.
- **New "soft" color tokens** — Unnecessary; existing `Weak` tokens serve this purpose.
- **Opacity-based approach** (`Strong.opacity(0.15)`) — Less maintainable than semantic tokens; doesn't adapt correctly across themes. Removed this pattern from `TrustRulesView` where it was previously used.

## Prompt / plan

Closes [LUM-1587](https://linear.app/vellum/issue/LUM-1587/polish-soften-risk-level-chip-colors-on-tool-calls). Token mapping aligned to Figma mocks: [Low](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=725-2529), [High](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=725-2530), [Medium](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=1072-12849).

## Test plan

Code-level verification: all four badge-rendering locations (`RiskBadgeView`, `PermissionPromptView`, `GuardianDecisionBubble`, `TrustRulesView`) share the same token mapping — `Weak` backgrounds, `Strong` text, neutral `surfaceBase`/`contentSecondary` for unknown risk levels. No CI Swift build available; requires local Xcode verification.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/e251185d84a74f77ae62bdb52a0b2ac6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->