### PR TITLE
fix(macos): defer panel dismissal until async conversation lookup succeeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -216,8 +216,6 @@ extension MainWindowView {
             feedStore: feedStore,
             meetStatusViewModel: meetStatusViewModel,
             onFeedConversationOpened: { daemonConversationId in
-                activeHomeDetailPanel = nil
-                onDismiss()
                 Task { @MainActor in
                     let found = await conversationManager.selectConversationByConversationIdAsync(daemonConversationId)
                     let activeLocalId = conversationManager.activeConversationId
@@ -228,6 +226,8 @@ extension MainWindowView {
                         windowState.showToast(message: "Couldn't open the conversation.", style: .error)
                         return
                     }
+                    activeHomeDetailPanel = nil
+                    onDismiss()
                     windowState.selection = .conversation(id)
                 }
             },
@@ -297,14 +297,17 @@ extension MainWindowView {
     private func goToThreadHandler(for item: FeedItem) -> (() -> Void)? {
         guard let daemonConversationId = item.conversationId else { return nil }
         return {
-            activeHomeDetailPanel = nil
             Task { @MainActor in
                 let found = await conversationManager.selectConversationByConversationIdAsync(daemonConversationId)
                 let activeLocalId = conversationManager.activeConversationId
                 panelCoordinatorLog.info(
                     "Go to Thread: daemonConversationId=\(daemonConversationId, privacy: .public) feedItemId=\(item.id, privacy: .public) found=\(found, privacy: .public) activeLocalId=\(activeLocalId?.uuidString ?? "<nil>", privacy: .public)"
                 )
-                guard found, let id = activeLocalId else { return }
+                guard found, let id = activeLocalId else {
+                    windowState.showToast(message: "Couldn't open the conversation.", style: .error)
+                    return
+                }
+                activeHomeDetailPanel = nil
                 windowState.selection = .conversation(id)
             }
         }


### PR DESCRIPTION
Addresses Devin feedback on #30990. In onFeedConversationOpened and goToThreadHandler, the home detail panel was dismissed before the async conversation lookup completed, leaving the user navigated away with no context on failure. Move dismissal inside the Task after the guard succeeds, and show an error toast in goToThreadHandler's failure path to match onFeedConversationOpened.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->