### PR TITLE
feat(a2a): add authenticated receiver-side A2A invite redemption endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9728,6 +9728,16 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/integrations/a2a/invite/redeem:
+    post:
+      operationId: integrations_a2a_invite_redeem_post
+      summary: Redeem A2A invite (receiver side)
+      description: Called by the platform to create a trusted contact on the receiver side of a link-based A2A connection.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/integrations/ingress/config:
     get:
       operationId: integrations_ingress_config_get

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for A2A invite redemption handler (receiver side).
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
+  getAssistantContactMetadata,
+  getContact,
+} from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { getA2AConfig, redeemA2AInvite } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: { a2aEnabled?: boolean }): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+const SENDER = {
+  assistantId: "sender-assistant-123",
+  displayName: "Sender Bot",
+  gatewayUrl: "https://sender.example.com",
+};
+
+describe("redeemA2AInvite", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfig({ a2aEnabled: false });
+  });
+
+  test("happy path: creates local contact with sender identity", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+
+    expect(result.success).toBe(true);
+    expect(result.contactId).toBeDefined();
+    expect(result.alreadyConnected).toBeUndefined();
+    expect(result.error).toBeUndefined();
+
+    const contact = getContact(result.contactId!);
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Sender Bot");
+    expect(contact!.channels).toHaveLength(1);
+    expect(contact!.channels[0]!.type).toBe("a2a");
+    expect(contact!.channels[0]!.status).toBe("active");
+    expect(contact!.channels[0]!.policy).toBe("allow");
+  });
+
+  test("idempotency: already-connected sender returns alreadyConnected", () => {
+    const first = redeemA2AInvite({ sender: SENDER });
+    expect(first.success).toBe(true);
+
+    const second = redeemA2AInvite({ sender: SENDER });
+    expect(second.success).toBe(true);
+    expect(second.alreadyConnected).toBe(true);
+    expect(second.contactId).toBe(first.contactId);
+  });
+
+  test("auto-enables A2A if disabled", () => {
+    setConfig({ a2aEnabled: false });
+
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    // Verify A2A was auto-enabled by checking config
+    const config = getA2AConfig();
+    expect(config.enabled).toBe(true);
+  });
+
+  test("assistantContactMetadata has correct assistantId and gatewayUrl", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    const metadata = getAssistantContactMetadata(result.contactId!);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.species).toBe("vellum");
+    expect(metadata!.metadata).toEqual({
+      assistantId: "sender-assistant-123",
+      gatewayUrl: "https://sender.example.com",
+    });
+  });
+
+  test("channel address uses sender.assistantId.toLowerCase()", () => {
+    const senderWithUppercase = {
+      ...SENDER,
+      assistantId: "UPPER-Case-SENDER-ID",
+    };
+
+    const result = redeemA2AInvite({ sender: senderWithUppercase });
+    expect(result.success).toBe(true);
+
+    const contact = getContact(result.contactId!);
+    expect(contact!.channels[0]!.address).toBe("upper-case-sender-id");
+    expect(contact!.channels[0]!.externalUserId).toBe("UPPER-Case-SENDER-ID");
+  });
+
+  test("does not make outbound fetch calls", () => {
+    // This test verifies that redeemA2AInvite is purely local — no fetch mock
+    // is installed. If it tried to fetch, the call would fail and the test
+    // would throw.
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+  });
+});

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -5,6 +5,7 @@
  * - setA2AConfig()     — set a2a.enabled = true
  * - clearA2AConfig()   — set a2a.enabled = false
  * - createA2AInvite()  — create a shareable invite token for link-based contact creation
+ * - redeemA2AInvite()  — receiver-side: create trusted contact from sender identity
  */
 
 import {
@@ -14,7 +15,11 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
-import { searchContacts, upsertContact } from "../../contacts/contact-store.js";
+import {
+  findContactByAddress,
+  searchContacts,
+  upsertContact,
+} from "../../contacts/contact-store.js";
 import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getDb } from "../../memory/db-connection.js";
@@ -46,6 +51,13 @@ export interface CreateA2AInviteResult {
 export interface CompleteA2AInviteResult {
   success: boolean;
   sender?: { assistantId: string; displayName: string; gatewayUrl: string };
+  error?: string;
+}
+
+export interface RedeemA2AInviteResult {
+  success: boolean;
+  contactId?: string;
+  alreadyConnected?: boolean;
   error?: string;
 }
 
@@ -205,4 +217,65 @@ export function completeA2AInvite(params: {
     success: true,
     sender: { assistantId, displayName, gatewayUrl },
   };
+}
+
+// ── A2A invite redemption (receiver side) ─────────────────────────
+
+export function redeemA2AInvite(params: {
+  sender: {
+    assistantId: string;
+    displayName: string;
+    gatewayUrl: string;
+  };
+}): RedeemA2AInviteResult {
+  // 1. Ensure A2A channel is enabled (auto-enable if needed)
+  const config = getA2AConfig();
+  if (!config.enabled) {
+    setA2AConfig();
+  }
+
+  // 2. Check for existing active contact with this sender
+  const existing = findContactByAddress("a2a", params.sender.assistantId);
+  if (
+    existing &&
+    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
+  ) {
+    return { success: true, alreadyConnected: true, contactId: existing.id };
+  }
+
+  // 3. Create the sender as a local trusted contact
+  const contact = upsertContact({
+    displayName: params.sender.displayName,
+    contactType: "assistant",
+    role: "contact",
+    channels: [
+      {
+        type: "a2a",
+        address: params.sender.assistantId.toLowerCase(),
+        externalUserId: params.sender.assistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  // 4. Write assistant contact metadata
+  const db = getDb();
+  const metadataJson = JSON.stringify({
+    assistantId: params.sender.assistantId,
+    gatewayUrl: params.sender.gatewayUrl,
+  } satisfies VellumAssistantMetadata);
+  db.insert(assistantContactMetadata)
+    .values({
+      contactId: contact.id,
+      species: "vellum",
+      metadata: metadataJson,
+    })
+    .onConflictDoUpdate({
+      target: assistantContactMetadata.contactId,
+      set: { species: "vellum", metadata: metadataJson },
+    })
+    .run();
+
+  return { success: true, contactId: contact.id };
 }

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -693,6 +693,12 @@ registerPolicy("integrations/a2a/invite/complete", {
   allowedPrincipalTypes: ["svc_gateway"],
 });
 
+// A2A invite redemption: gateway-only (platform-orchestrated)
+registerPolicy("integrations/a2a/invite/redeem", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});
+
 // Admin control-plane endpoints: gateway-only
 registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -1,10 +1,12 @@
 /**
  * Route handlers for A2A integration config endpoints.
  *
- * GET    /v1/integrations/a2a/config  — get current A2A config status
- * POST   /v1/integrations/a2a/config  — enable A2A channel
- * DELETE /v1/integrations/a2a/config  — disable A2A channel
- * POST   /v1/integrations/a2a/invite  — create a shareable A2A invite token
+ * GET    /v1/integrations/a2a/config          — get current A2A config status
+ * POST   /v1/integrations/a2a/config          — enable A2A channel
+ * DELETE /v1/integrations/a2a/config          — disable A2A channel
+ * POST   /v1/integrations/a2a/invite          — create a shareable A2A invite token
+ * POST   /v1/integrations/a2a/invite/complete — sender-side invite completion
+ * POST   /v1/integrations/a2a/invite/redeem   — receiver-side invite redemption
  */
 
 import { isA2AEnabled } from "../../../a2a/feature-gate.js";
@@ -14,6 +16,7 @@ import {
   completeA2AInvite,
   createA2AInvite,
   getA2AConfig,
+  redeemA2AInvite,
   setA2AConfig,
 } from "../../../daemon/handlers/config-a2a.js";
 import { BadRequestError } from "../errors.js";
@@ -105,6 +108,42 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
   return result;
 }
 
+function handleRedeemA2AInvite({ body = {} }: RouteHandlerArgs) {
+  const { sender } = body as {
+    sender?: {
+      assistantId?: unknown;
+      displayName?: unknown;
+      gatewayUrl?: unknown;
+    };
+  };
+
+  if (
+    !sender ||
+    typeof sender.assistantId !== "string" ||
+    !sender.assistantId ||
+    typeof sender.displayName !== "string" ||
+    !sender.displayName ||
+    typeof sender.gatewayUrl !== "string" ||
+    !sender.gatewayUrl
+  ) {
+    throw new BadRequestError(
+      "sender must include non-empty assistantId, displayName, and gatewayUrl",
+    );
+  }
+
+  const result = redeemA2AInvite({
+    sender: {
+      assistantId: sender.assistantId,
+      displayName: sender.displayName,
+      gatewayUrl: sender.gatewayUrl,
+    },
+  });
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to redeem A2A invite");
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -161,5 +200,16 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: handleCompleteA2AInvite,
+  },
+  {
+    operationId: "integrations_a2a_invite_redeem_post",
+    endpoint: "integrations/a2a/invite/redeem",
+    method: "POST",
+    summary: "Redeem A2A invite (receiver side)",
+    description:
+      "Called by the platform to create a trusted contact on the receiver side of a link-based A2A connection.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleRedeemA2AInvite,
   },
 ];


### PR DESCRIPTION
## Summary
- Add `POST /v1/integrations/a2a/invite/redeem` endpoint (gateway-service-only, `internal.write` scope)
- Creates trusted contact on receiver side with sender's platform assistant ID as canonical address
- No outbound HTTP calls — receives sender identity directly from platform orchestration

Part of plan: a2a-link-trusted-contact.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->