### PR TITLE
fix(notifications): scope home-feed fallback copy to selected channels

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -312,6 +312,63 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.summary).toBe("Telegram body");
   });
 
+  test("ignores rendered copy for channels not in selectedChannels", async () => {
+    // Regression: routing-intent enforcement can prune selectedChannels
+    // without pruning renderedCopy, leaving copy entries for channels that
+    // were never delivered. The fallback must only consider channels that
+    // actually shipped — otherwise an unselected channel's copy can land in
+    // Home in place of the selected channel's copy.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "cli-12345",
+    });
+    const decision = makeDecision({
+      selectedChannels: ["telegram"],
+      renderedCopy: {
+        slack: {
+          title: "Slack title (unselected)",
+          body: "Slack body (unselected)",
+        },
+        telegram: { title: "Telegram title", body: "Telegram body" },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBe("Telegram title");
+    expect(appendCalls[0]!.summary).toBe("Telegram body");
+  });
+
+  test("skips fallback when only unselected channels have rendered copy", async () => {
+    // Regression: if every renderedCopy entry is for a channel that was
+    // pruned from selectedChannels, treat it as no copy at all rather than
+    // surfacing the stale entry.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "cli-12345",
+    });
+    const decision = makeDecision({
+      selectedChannels: ["telegram"],
+      renderedCopy: {
+        slack: {
+          title: "Slack title (unselected)",
+          body: "Slack body (unselected)",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
   test("falls back to requestedTitle/requestedMessage payload keys", async () => {
     // Regression: the `notifications send` CLI surface stores the
     // user-supplied copy on the signal payload under `requestedTitle` and

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -53,7 +53,8 @@ export async function writeHomeFeedItemForSignal(
   if (!shouldMirrorToHomeFeed(signal)) return null;
 
   const renderedCopy =
-    decision.renderedCopy.vellum ?? firstRenderedCopy(decision.renderedCopy);
+    decision.renderedCopy.vellum ??
+    firstSelectedRenderedCopy(decision.renderedCopy, decision.selectedChannels);
   const payloadTitle =
     readPayloadString(signal.contextPayload, "title") ??
     readPayloadString(signal.contextPayload, "requestedTitle");
@@ -192,10 +193,19 @@ function readPayloadString(payload: unknown, key: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function firstRenderedCopy(
+/**
+ * Routing-intent enforcement can prune `selectedChannels` without also
+ * pruning `renderedCopy`, so iterating `renderedCopy` directly risks
+ * surfacing copy for a channel that was never delivered. Walk
+ * `selectedChannels` in order instead so the channel that actually shipped
+ * wins.
+ */
+function firstSelectedRenderedCopy(
   renderedCopy: NotificationDecision["renderedCopy"],
+  selectedChannels: NotificationDecision["selectedChannels"],
 ): RenderedChannelCopy | undefined {
-  for (const copy of Object.values(renderedCopy)) {
+  for (const channel of selectedChannels) {
+    const copy = renderedCopy[channel];
     if (copy && (copy.title?.trim() || copy.body?.trim())) return copy;
   }
   return undefined;


### PR DESCRIPTION
Addresses Codex feedback on #30991. The non-vellum rendered-copy fallback scanned every renderedCopy entry, which could include channels that routing-intent enforcement had pruned from selectedChannels. Restrict the scan to channels actually in decision.selectedChannels so the fallback picks the channel that was delivered, not a stale renderedCopy entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->