### PR TITLE
fix(notifications): fail deterministic check when no usable copy or fallback

### DIFF
--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -195,6 +195,35 @@ describe("checkRenderedCopyQuality (via runDeterministicChecks)", () => {
     expect(result.reason).toContain("fallback leak");
   });
 
+  test("fails when no selected channel has copy and fallback body is empty", async () => {
+    // Silent-no-delivery guard: if every selected channel is missing from
+    // renderedCopy AND the broadcaster's composeFallbackCopy can't produce
+    // a usable body (no template for sourceEventName → buildGenericCopy
+    // returns body=""), the gate must fail-closed rather than letting
+    // dispatchDecision report 0/N sent.
+    const signal = makeSignal({ sourceEventName: "user.send_notification" });
+    const decision = makeDecision({
+      selectedChannels: ["vellum"],
+      renderedCopy: {},
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fallback");
+  });
+
+  test("passes when no selected channel has copy but fallback yields a usable body", async () => {
+    // schedule.notify has a copy-composer template that produces a usable
+    // body even with empty payload — the broadcaster's fallback path will
+    // deliver, so the deterministic gate must allow it through.
+    const signal = makeSignal({ sourceEventName: "schedule.notify" });
+    const decision = makeDecision({
+      selectedChannels: ["vellum"],
+      renderedCopy: {},
+    });
+    const result = await runDeterministicChecks(signal, decision, context);
+    expect(result.passed).toBe(true);
+  });
+
   test("passes when shouldNotify is false regardless of copy contents", async () => {
     const signal = makeSignal({ sourceEventName: "user.send_notification" });
     const decision = makeDecision({

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -12,6 +12,7 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "../memory/db-connection.js";
 import { notificationEvents } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
+import { composeFallbackCopy } from "./copy-composer.js";
 import type { NotificationSignal } from "./signal.js";
 import type { NotificationChannel, NotificationDecision } from "./types.js";
 
@@ -254,6 +255,13 @@ function checkDedupe(
  * in `renderedCopy` and are left for the broadcaster's
  * `composeFallbackCopy` rescue at delivery time.
  *
+ * If `renderedCopy` is empty for every selected channel, the
+ * broadcaster's fallback must produce a usable body — otherwise the
+ * signal would be silently dropped at delivery (broadcaster skips
+ * empty-body channels, `dispatchDecision` reports 0/N sent). In that
+ * case, require `composeFallbackCopy` to yield a non-empty body for
+ * at least one selected channel; otherwise fail-closed.
+ *
  * The event-name-match branch is skipped for `assistant_tool`
  * pass-through decisions because the producer supplied the body
  * verbatim — a coincidental match with the event name is the user's
@@ -275,11 +283,13 @@ function checkRenderedCopyQuality(
     .trim();
   const rawEventName = signal.sourceEventName.toLowerCase();
 
+  let anyChannelHasCopy = false;
   for (const channel of decision.selectedChannels) {
     const copy = decision.renderedCopy[channel];
     if (!copy) {
       continue;
     }
+    anyChannelHasCopy = true;
     const trimmedBody = copy.body.trim();
     if (trimmedBody.length === 0) {
       return {
@@ -298,6 +308,20 @@ function checkRenderedCopyQuality(
       return {
         passed: false,
         reason: "rendered copy body is the source event name (fallback leak)",
+      };
+    }
+  }
+
+  if (!anyChannelHasCopy && decision.selectedChannels.length > 0) {
+    const fallback = composeFallbackCopy(signal, decision.selectedChannels);
+    const fallbackUsable = decision.selectedChannels.some(
+      (ch) => (fallback[ch]?.body ?? "").trim().length > 0,
+    );
+    if (!fallbackUsable) {
+      return {
+        passed: false,
+        reason:
+          "rendered copy missing for all selected channels and fallback body is empty (would silently drop)",
       };
     }
   }


### PR DESCRIPTION
Addresses Codex feedback on #30992. When every selectedChannel was missing from renderedCopy, the gate silently passed, the broadcaster skipped delivery, and dispatchDecision reported the signal as 0/1 sent — a silent no-delivery. Require either at least one selected channel has copy, or composeFallbackCopy() returns a usable body. Preserves the post-decision channel expansion leniency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->