### PR TITLE
fix(cli/notifications): mirror exitFromIpcResult status-code mapping in test mock

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -28,22 +28,28 @@ let ipcResponse: {
   result: {},
 };
 
+const exitCodeFromIpcResult = (r: { statusCode?: number }): number => {
+  if (r.statusCode === undefined) return 10;
+  if (r.statusCode >= 500) return 3;
+  if (r.statusCode >= 400) return 2;
+  return 1;
+};
+
 mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
     return ipcResponse;
   },
-  exitFromIpcResult: (r: { ok: false; error?: string }) => {
+  exitFromIpcResult: (r: {
+    ok: false;
+    error?: string;
+    statusCode?: number;
+  }) => {
     process.stderr.write((r.error ?? "Unknown error") + "\n");
-    process.exitCode = 1;
+    process.exitCode = exitCodeFromIpcResult(r);
     return undefined as never;
   },
-  exitCodeFromIpcResult: (r: { statusCode?: number }) => {
-    if (r.statusCode === undefined) return 10;
-    if (r.statusCode >= 500) return 3;
-    if (r.statusCode >= 400) return 2;
-    return 1;
-  },
+  exitCodeFromIpcResult,
 }));
 
 import { Command } from "commander";


### PR DESCRIPTION
Addresses Codex feedback on #31005. The mock for exitFromIpcResult in the notifications test always set exit code 1, while the real helper maps transport failures to 10, 5xx to 3, 4xx to 2, and other cases to 1. The mock now delegates to the same status-code mapping the real helper uses, so a regression in the exit-code contract would surface instead of silently passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->