### PR TITLE
feat(a2a): link-based trusted contact flow (JARVIS-875)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9728,6 +9728,16 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/integrations/a2a/invite/redeem:
+    post:
+      operationId: integrations_a2a_invite_redeem_post
+      summary: Redeem A2A invite (receiver side)
+      description: Called by the platform to create a trusted contact on the receiver side of a link-based A2A connection.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/integrations/ingress/config:
     get:
       operationId: integrations_ingress_config_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9708,11 +9708,11 @@ paths:
       responses:
         "200":
           description: Successful response
-  /v1/integrations/a2a/connect:
+  /v1/integrations/a2a/invite:
     post:
-      operationId: integrations_a2a_connect_post
-      summary: Connect to assistant
-      description: Initiate an A2A connection to a peer assistant by guardian handle.
+      operationId: integrations_a2a_invite_post
+      summary: Create A2A invite
+      description: Create a shareable A2A invite token for link-based contact creation.
       tags:
         - integrations
       responses:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9718,6 +9718,16 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/integrations/a2a/invite/complete:
+    post:
+      operationId: integrations_a2a_invite_complete_post
+      summary: Complete A2A invite (sender side)
+      description: Called by the platform to finalize the sender side of a link-based A2A connection.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/integrations/ingress/config:
     get:
       operationId: integrations_ingress_config_get

--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -48,7 +48,10 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
-import { findContactByAddress } from "../../contacts/contact-store.js";
+import {
+  findContactByAddress,
+  upsertContact,
+} from "../../contacts/contact-store.js";
 import {
   clearA2AConfig,
   getA2AConfig,
@@ -146,82 +149,34 @@ afterEach(() => {
 });
 
 // ===========================================================================
-// Test: connection initiation -> trusted contact flow
+// Test: trusted contact setup (platform-mediated)
 // ===========================================================================
 
-describe("e2e: connection initiation -> trusted contact flow", () => {
-  test("connectToAssistant creates local contact with a2a channel", async () => {
+describe("e2e: trusted contact setup", () => {
+  test("upsertContact creates a2a channel for assistant contact", () => {
     setConfigEnabled(true);
 
-    // Mock the agent card endpoint on the peer gateway
-    fetchResponseMap["agent-card.json"] = {
-      ok: true,
-      status: 200,
-      body: JSON.stringify({ name: "Peer Assistant" }),
-    };
-
-    const { connectToAssistant } =
-      await import("../../daemon/handlers/config-a2a.js");
-
-    const result = await connectToAssistant({
-      guardianHandle: "assistant-b",
-      gatewayUrl: "https://peer.example.com",
+    upsertContact({
+      displayName: "Peer Assistant",
+      contactType: "assistant",
+      role: "contact",
+      channels: [
+        {
+          type: "a2a",
+          address: "assistant-b",
+          externalUserId: "assistant-b",
+          status: "active",
+          policy: "allow",
+        },
+      ],
     });
 
-    // Connection succeeds
-    expect(result.success).toBe(true);
-    expect(result.contactId).toBeTruthy();
-    expect(result.alreadyConnected).toBeFalsy();
-
-    // Local contact created with a2a channel
     const contact = findContactByAddress("a2a", "assistant-b");
     expect(contact).not.toBeNull();
     expect(contact!.channels.some((ch) => ch.type === "a2a")).toBe(true);
     const a2aChannel = contact!.channels.find((ch) => ch.type === "a2a");
     expect(a2aChannel!.status).toBe("active");
     expect(a2aChannel!.address).toBe("assistant-b");
-
-    // Agent card was fetched from peer gateway
-    const agentCardFetch = fetchCalls.find((c) =>
-      c.url.includes("agent-card.json"),
-    );
-    expect(agentCardFetch).toBeTruthy();
-    expect(agentCardFetch!.url).toBe(
-      "https://peer.example.com/.well-known/agent-card.json",
-    );
-  });
-
-  test("connectToAssistant is idempotent for existing connection", async () => {
-    setConfigEnabled(true);
-
-    fetchResponseMap["agent-card.json"] = {
-      ok: true,
-      status: 200,
-      body: JSON.stringify({ name: "Peer Assistant" }),
-    };
-
-    const { connectToAssistant } =
-      await import("../../daemon/handlers/config-a2a.js");
-
-    // First connection
-    const first = await connectToAssistant({
-      guardianHandle: "assistant-b",
-      gatewayUrl: "https://peer.example.com",
-    });
-    expect(first.success).toBe(true);
-    expect(first.alreadyConnected).toBeFalsy();
-
-    // Clear fetch calls to track second attempt
-    fetchCalls.length = 0;
-
-    // Second connection attempt — should detect existing contact
-    const second = await connectToAssistant({
-      guardianHandle: "assistant-b",
-      gatewayUrl: "https://peer.example.com",
-    });
-    expect(second.success).toBe(true);
-    expect(second.alreadyConnected).toBe(true);
-    expect(second.contactId).toBe(first.contactId);
   });
 });
 
@@ -554,20 +509,21 @@ describe("e2e: full A2A round-trip", () => {
   test("connect, establish trust, send message, deliver response, push notification", async () => {
     setConfigEnabled(true);
 
-    // Step 1: Assistant A connects to Assistant B
-    fetchResponseMap["agent-card.json"] = {
-      ok: true,
-      status: 200,
-      body: JSON.stringify({ name: "Assistant B" }),
-    };
-    const { connectToAssistant } =
-      await import("../../daemon/handlers/config-a2a.js");
-
-    const connectResult = await connectToAssistant({
-      guardianHandle: "assistant-b",
-      gatewayUrl: "https://b.example.com",
+    // Step 1: Create trusted contact for Assistant B (platform-mediated)
+    upsertContact({
+      displayName: "Assistant B",
+      contactType: "assistant",
+      role: "contact",
+      channels: [
+        {
+          type: "a2a",
+          address: "assistant-b",
+          externalUserId: "assistant-b",
+          status: "active",
+          policy: "allow",
+        },
+      ],
     });
-    expect(connectResult.success).toBe(true);
 
     // Step 2: Verify trusted contact was created
     const contact = findContactByAddress("a2a", "assistant-b");

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -80,11 +80,13 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
     expect(result.success).toBe(true);
     expect(result.sender).toBeDefined();
+    expect(result.sender!.assistantId).toBe("sender-platform-id-789");
     expect(result.sender!.gatewayUrl).toBe("https://sender.example.com");
     expect(result.sender!.displayName).toBeDefined();
     expect(result.error).toBeUndefined();
@@ -111,6 +113,7 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: acceptorWithUppercase,
     });
     expect(result.success).toBe(true);
@@ -125,6 +128,7 @@ describe("completeA2AInvite", () => {
     const created = createA2AInvite({});
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(result.success).toBe(true);
@@ -142,6 +146,7 @@ describe("completeA2AInvite", () => {
   test("invalid token returns not_found error", () => {
     const result = completeA2AInvite({
       token: "invalid-token-that-does-not-exist",
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
@@ -164,6 +169,7 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
@@ -178,6 +184,7 @@ describe("completeA2AInvite", () => {
     // First completion
     const first = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(first.success).toBe(true);
@@ -185,6 +192,7 @@ describe("completeA2AInvite", () => {
     // Second completion with same acceptor
     const second = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(second.success).toBe(true);
@@ -197,6 +205,7 @@ describe("completeA2AInvite", () => {
     // First completion
     const first = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(first.success).toBe(true);
@@ -204,6 +213,7 @@ describe("completeA2AInvite", () => {
     // Second completion with different acceptor
     const second = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: {
         assistantId: "different-assistant-456",
         displayName: "Different Bot",

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -224,4 +224,25 @@ describe("completeA2AInvite", () => {
     expect(second.success).toBe(false);
     expect(second.error).toBe("already_redeemed_by_other");
   });
+
+  test("fails before claiming token when public base URL is not configured", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    setConfig({ publicBaseUrl: "", ingressEnabled: true });
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("public base URL");
+
+    // Verify the invite was NOT consumed
+    const invite = findById(created.inviteId!);
+    expect(invite!.status).toBe("active");
+    expect(invite!.useCount).toBe(0);
+  });
 });

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for A2A invite completion handler (sender side).
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
+  getAssistantContactMetadata,
+  getContact,
+} from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { findById } from "../../../memory/invite-store.js";
+import { completeA2AInvite, createA2AInvite } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: {
+  a2aEnabled?: boolean;
+  publicBaseUrl?: string;
+  ingressEnabled?: boolean;
+}): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  if (opts.publicBaseUrl !== undefined) {
+    setNestedValue(raw, "ingress.publicBaseUrl", opts.publicBaseUrl);
+  }
+  if (opts.ingressEnabled !== undefined) {
+    setNestedValue(raw, "ingress.enabled", opts.ingressEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+const ACCEPTOR = {
+  assistantId: "acceptor-assistant-123",
+  displayName: "Acceptor Bot",
+  gatewayUrl: "https://acceptor.example.com",
+};
+
+describe("completeA2AInvite", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "https://sender.example.com",
+      ingressEnabled: true,
+    });
+  });
+
+  test("happy path: promotes placeholder contact and returns sender identity", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sender).toBeDefined();
+    expect(result.sender!.gatewayUrl).toBe("https://sender.example.com");
+    expect(result.sender!.displayName).toBeDefined();
+    expect(result.error).toBeUndefined();
+
+    // Verify the placeholder contact was promoted
+    const invite = findById(created.inviteId!);
+    expect(invite).not.toBeNull();
+
+    const contact = getContact(invite!.contactId);
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Acceptor Bot");
+    expect(contact!.channels).toHaveLength(1);
+    expect(contact!.channels[0]!.type).toBe("a2a");
+    expect(contact!.channels[0]!.status).toBe("active");
+    expect(contact!.channels[0]!.policy).toBe("allow");
+  });
+
+  test("contact channel address is acceptor.assistantId.toLowerCase()", () => {
+    const created = createA2AInvite({});
+    const acceptorWithUppercase = {
+      ...ACCEPTOR,
+      assistantId: "UPPER-Case-ID-123",
+    };
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: acceptorWithUppercase,
+    });
+    expect(result.success).toBe(true);
+
+    const invite = findById(created.inviteId!);
+    const contact = getContact(invite!.contactId);
+    expect(contact!.channels[0]!.address).toBe("upper-case-id-123");
+    expect(contact!.channels[0]!.externalUserId).toBe("UPPER-Case-ID-123");
+  });
+
+  test("assistantContactMetadata has correct assistantId and gatewayUrl", () => {
+    const created = createA2AInvite({});
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(result.success).toBe(true);
+
+    const invite = findById(created.inviteId!);
+    const metadata = getAssistantContactMetadata(invite!.contactId);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.species).toBe("vellum");
+    expect(metadata!.metadata).toEqual({
+      assistantId: "acceptor-assistant-123",
+      gatewayUrl: "https://acceptor.example.com",
+    });
+  });
+
+  test("invalid token returns not_found error", () => {
+    const result = completeA2AInvite({
+      token: "invalid-token-that-does-not-exist",
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("not_found");
+  });
+
+  test("expired invite returns expired error", () => {
+    // Create an invite that expires immediately
+    const created = createA2AInvite({ expiresInHours: 0 });
+    expect(created.success).toBe(true);
+
+    // The invite was just created with 0 hours expiry, so expiresAt ~= now
+    // Manually expire it by updating the DB
+    const sqlite = getSqlite();
+    sqlite.run(
+      "UPDATE assistant_ingress_invites SET expires_at = ? WHERE id = ?",
+      [Date.now() - 1000, created.inviteId!],
+    );
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("expired");
+  });
+
+  test("already-redeemed by same acceptor returns idempotent success", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    // First completion
+    const first = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(first.success).toBe(true);
+
+    // Second completion with same acceptor
+    const second = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(second.success).toBe(true);
+  });
+
+  test("already-redeemed by different acceptor returns error", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    // First completion
+    const first = completeA2AInvite({
+      token: created.token!,
+      acceptor: ACCEPTOR,
+    });
+    expect(first.success).toBe(true);
+
+    // Second completion with different acceptor
+    const second = completeA2AInvite({
+      token: created.token!,
+      acceptor: {
+        assistantId: "different-assistant-456",
+        displayName: "Different Bot",
+        gatewayUrl: "https://different.example.com",
+      },
+    });
+
+    expect(second.success).toBe(false);
+    expect(second.error).toBe("already_redeemed_by_other");
+  });
+});

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for A2A invite creation handler.
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import { getContact } from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { findById } from "../../../memory/invite-store.js";
+import { createA2AInvite, getA2AConfig } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: {
+  a2aEnabled?: boolean;
+  publicBaseUrl?: string;
+  ingressEnabled?: boolean;
+}): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  if (opts.publicBaseUrl !== undefined) {
+    setNestedValue(raw, "ingress.publicBaseUrl", opts.publicBaseUrl);
+  }
+  if (opts.ingressEnabled !== undefined) {
+    setNestedValue(raw, "ingress.enabled", opts.ingressEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+describe("createA2AInvite", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "https://example.vellum.ai",
+      ingressEnabled: true,
+    });
+  });
+
+  test("returns success with inviteId, token, expiresAt, senderGatewayUrl", () => {
+    const result = createA2AInvite({});
+    expect(result.success).toBe(true);
+    expect(result.inviteId).toBeDefined();
+    expect(result.token).toBeDefined();
+    expect(result.expiresAt).toBeDefined();
+    expect(result.senderGatewayUrl).toBe("https://example.vellum.ai");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("creates invite in DB with source_channel=a2a, status=active, max_uses=1", () => {
+    const result = createA2AInvite({});
+    expect(result.inviteId).toBeDefined();
+
+    const invite = findById(result.inviteId!);
+    expect(invite).not.toBeNull();
+    expect(invite!.sourceChannel).toBe("a2a");
+    expect(invite!.status).toBe("active");
+    expect(invite!.maxUses).toBe(1);
+  });
+
+  test("auto-enables A2A if not already on", () => {
+    // A2A starts disabled
+    expect(getA2AConfig().enabled).toBe(false);
+
+    const result = createA2AInvite({});
+    expect(result.success).toBe(true);
+
+    // A2A should now be enabled
+    expect(getA2AConfig().enabled).toBe(true);
+  });
+
+  test("creates placeholder contact with no channels, bound to invite via contactId", () => {
+    const result = createA2AInvite({});
+    expect(result.inviteId).toBeDefined();
+
+    const invite = findById(result.inviteId!);
+    expect(invite).not.toBeNull();
+
+    const contact = getContact(invite!.contactId);
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Pending A2A invite");
+    expect(contact!.channels).toHaveLength(0);
+  });
+
+  test("returns error when public base URL is not configured", () => {
+    setConfig({
+      a2aEnabled: false,
+      publicBaseUrl: "",
+      ingressEnabled: true,
+    });
+
+    const result = createA2AInvite({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("public base URL");
+  });
+
+  test("custom expiry via expiresInHours", () => {
+    const before = Date.now();
+    const result = createA2AInvite({ expiresInHours: 24 });
+    const after = Date.now();
+    expect(result.success).toBe(true);
+
+    const invite = findById(result.inviteId!);
+    expect(invite).not.toBeNull();
+
+    const expectedMinMs = before + 24 * 60 * 60 * 1000;
+    const expectedMaxMs = after + 24 * 60 * 60 * 1000;
+    expect(invite!.expiresAt).toBeGreaterThanOrEqual(expectedMinMs);
+    expect(invite!.expiresAt).toBeLessThanOrEqual(expectedMaxMs);
+  });
+
+  test("default expiry is 72 hours", () => {
+    const before = Date.now();
+    const result = createA2AInvite({});
+    const after = Date.now();
+    expect(result.success).toBe(true);
+
+    const invite = findById(result.inviteId!);
+    expect(invite).not.toBeNull();
+
+    const expectedMinMs = before + 72 * 60 * 60 * 1000;
+    const expectedMaxMs = after + 72 * 60 * 60 * 1000;
+    expect(invite!.expiresAt).toBeGreaterThanOrEqual(expectedMinMs);
+    expect(invite!.expiresAt).toBeLessThanOrEqual(expectedMaxMs);
+  });
+});

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for A2A invite redemption handler (receiver side).
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
+  getAssistantContactMetadata,
+  getContact,
+} from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { getA2AConfig, redeemA2AInvite } from "../config-a2a.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: { a2aEnabled?: boolean }): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+const SENDER = {
+  assistantId: "sender-assistant-123",
+  displayName: "Sender Bot",
+  gatewayUrl: "https://sender.example.com",
+};
+
+describe("redeemA2AInvite", () => {
+  beforeEach(() => {
+    resetTables();
+    setConfig({ a2aEnabled: false });
+  });
+
+  test("happy path: creates local contact with sender identity", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+
+    expect(result.success).toBe(true);
+    expect(result.contactId).toBeDefined();
+    expect(result.alreadyConnected).toBeUndefined();
+    expect(result.error).toBeUndefined();
+
+    const contact = getContact(result.contactId!);
+    expect(contact).not.toBeNull();
+    expect(contact!.displayName).toBe("Sender Bot");
+    expect(contact!.channels).toHaveLength(1);
+    expect(contact!.channels[0]!.type).toBe("a2a");
+    expect(contact!.channels[0]!.status).toBe("active");
+    expect(contact!.channels[0]!.policy).toBe("allow");
+  });
+
+  test("idempotency: already-connected sender returns alreadyConnected", () => {
+    const first = redeemA2AInvite({ sender: SENDER });
+    expect(first.success).toBe(true);
+
+    const second = redeemA2AInvite({ sender: SENDER });
+    expect(second.success).toBe(true);
+    expect(second.alreadyConnected).toBe(true);
+    expect(second.contactId).toBe(first.contactId);
+  });
+
+  test("auto-enables A2A if disabled", () => {
+    setConfig({ a2aEnabled: false });
+
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    // Verify A2A was auto-enabled by checking config
+    const config = getA2AConfig();
+    expect(config.enabled).toBe(true);
+  });
+
+  test("assistantContactMetadata has correct assistantId and gatewayUrl", () => {
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+
+    const metadata = getAssistantContactMetadata(result.contactId!);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.species).toBe("vellum");
+    expect(metadata!.metadata).toEqual({
+      assistantId: "sender-assistant-123",
+      gatewayUrl: "https://sender.example.com",
+    });
+  });
+
+  test("channel address uses sender.assistantId.toLowerCase()", () => {
+    const senderWithUppercase = {
+      ...SENDER,
+      assistantId: "UPPER-Case-SENDER-ID",
+    };
+
+    const result = redeemA2AInvite({ sender: senderWithUppercase });
+    expect(result.success).toBe(true);
+
+    const contact = getContact(result.contactId!);
+    expect(contact!.channels[0]!.address).toBe("upper-case-sender-id");
+    expect(contact!.channels[0]!.externalUserId).toBe("UPPER-Case-SENDER-ID");
+  });
+
+  test("does not make outbound fetch calls", () => {
+    // This test verifies that redeemA2AInvite is purely local — no fetch mock
+    // is installed. If it tried to fetch, the call would fail and the test
+    // would throw.
+    const result = redeemA2AInvite({ sender: SENDER });
+    expect(result.success).toBe(true);
+  });
+});

--- a/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
@@ -20,7 +20,6 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../../config/loader.js";
-import { findContactByAddress } from "../../../contacts/contact-store.js";
 import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { clearA2AConfig, getA2AConfig, setA2AConfig } from "../config-a2a.js";
@@ -92,72 +91,5 @@ describe("clearA2AConfig", () => {
     const result = clearA2AConfig();
     expect(result.success).toBe(true);
     expect(result.enabled).toBe(false);
-  });
-});
-
-describe("connectToAssistant", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
-  test("returns error when gatewayUrl is not provided and handle cannot be resolved", async () => {
-    const { connectToAssistant } = await import("../config-a2a.js");
-    const result = await connectToAssistant({
-      guardianHandle: "peer-assistant",
-    });
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("gatewayUrl");
-  });
-
-  test("detects duplicate connection and returns alreadyConnected", async () => {
-    // Manually create a contact with an a2a channel to simulate existing connection
-    const { upsertContact } =
-      await import("../../../contacts/contact-store.js");
-    upsertContact({
-      displayName: "Peer Bot",
-      contactType: "assistant",
-      role: "contact",
-      channels: [
-        {
-          type: "a2a",
-          address: "peer-handle",
-          externalUserId: "peer-handle",
-          status: "active",
-          policy: "allow",
-        },
-      ],
-    });
-
-    // Verify the contact exists
-    const existing = findContactByAddress("a2a", "peer-handle");
-    expect(existing).not.toBeNull();
-
-    // Mock resolveGuardianHandle to return matching data
-    const { connectToAssistant } = await import("../config-a2a.js");
-
-    // We need to mock the fetch for the agent card
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: string) => {
-      if (url.includes("agent-card.json")) {
-        return new Response(JSON.stringify({ name: "Peer Bot" }), {
-          status: 200,
-        });
-      }
-      // Return success for message:send
-      return new Response(JSON.stringify({ task: { id: "t1" } }), {
-        status: 200,
-      });
-    }) as typeof fetch;
-
-    try {
-      const result = await connectToAssistant({
-        guardianHandle: "peer-handle",
-        gatewayUrl: "https://peer.example.com",
-      });
-      expect(result.success).toBe(true);
-      expect(result.alreadyConnected).toBe(true);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
   });
 });

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -5,6 +5,7 @@
  * - setA2AConfig()     — set a2a.enabled = true
  * - clearA2AConfig()   — set a2a.enabled = false
  * - createA2AInvite()  — create a shareable invite token for link-based contact creation
+ * - redeemA2AInvite()  — receiver-side: create trusted contact from sender identity
  */
 
 import {
@@ -14,7 +15,11 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
-import { searchContacts, upsertContact } from "../../contacts/contact-store.js";
+import {
+  findContactByAddress,
+  searchContacts,
+  upsertContact,
+} from "../../contacts/contact-store.js";
 import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getDb } from "../../memory/db-connection.js";
@@ -46,6 +51,13 @@ export interface CreateA2AInviteResult {
 export interface CompleteA2AInviteResult {
   success: boolean;
   sender?: { assistantId: string; displayName: string; gatewayUrl: string };
+  error?: string;
+}
+
+export interface RedeemA2AInviteResult {
+  success: boolean;
+  contactId?: string;
+  alreadyConnected?: boolean;
   error?: string;
 }
 
@@ -205,4 +217,65 @@ export function completeA2AInvite(params: {
     success: true,
     sender: { assistantId, displayName, gatewayUrl },
   };
+}
+
+// ── A2A invite redemption (receiver side) ─────────────────────────
+
+export function redeemA2AInvite(params: {
+  sender: {
+    assistantId: string;
+    displayName: string;
+    gatewayUrl: string;
+  };
+}): RedeemA2AInviteResult {
+  // 1. Ensure A2A channel is enabled (auto-enable if needed)
+  const config = getA2AConfig();
+  if (!config.enabled) {
+    setA2AConfig();
+  }
+
+  // 2. Check for existing active contact with this sender
+  const existing = findContactByAddress("a2a", params.sender.assistantId);
+  if (
+    existing &&
+    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
+  ) {
+    return { success: true, alreadyConnected: true, contactId: existing.id };
+  }
+
+  // 3. Create the sender as a local trusted contact
+  const contact = upsertContact({
+    displayName: params.sender.displayName,
+    contactType: "assistant",
+    role: "contact",
+    channels: [
+      {
+        type: "a2a",
+        address: params.sender.assistantId.toLowerCase(),
+        externalUserId: params.sender.assistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  // 4. Write assistant contact metadata
+  const db = getDb();
+  const metadataJson = JSON.stringify({
+    assistantId: params.sender.assistantId,
+    gatewayUrl: params.sender.gatewayUrl,
+  } satisfies VellumAssistantMetadata);
+  db.insert(assistantContactMetadata)
+    .values({
+      contactId: contact.id,
+      species: "vellum",
+      metadata: metadataJson,
+    })
+    .onConflictDoUpdate({
+      target: assistantContactMetadata.contactId,
+      set: { species: "vellum", metadata: metadataJson },
+    })
+    .run();
+
+  return { success: true, contactId: contact.id };
 }

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -150,6 +150,7 @@ export function createA2AInvite(params: {
 
 export function completeA2AInvite(params: {
   token: string;
+  senderAssistantId: string;
   acceptor: {
     assistantId: string;
     displayName: string;
@@ -203,7 +204,6 @@ export function completeA2AInvite(params: {
     })
     .run();
 
-  // Resolve this assistant's identity for the response
   const displayName = getAssistantName() ?? "Vellum Assistant";
   let gatewayUrl: string;
   try {
@@ -211,11 +211,14 @@ export function completeA2AInvite(params: {
   } catch {
     gatewayUrl = "";
   }
-  const assistantId = displayName;
 
   return {
     success: true,
-    sender: { assistantId, displayName, gatewayUrl },
+    sender: {
+      assistantId: params.senderAssistantId,
+      displayName,
+      gatewayUrl,
+    },
   };
 }
 

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -157,6 +157,19 @@ export function completeA2AInvite(params: {
     gatewayUrl: string;
   };
 }): CompleteA2AInviteResult {
+  // Resolve sender identity before any mutations so we fail cleanly
+  const displayName = getAssistantName() ?? "Vellum Assistant";
+  let gatewayUrl: string;
+  try {
+    gatewayUrl = getPublicBaseUrl(getConfig());
+  } catch {
+    return {
+      success: false,
+      error:
+        "No public base URL configured. Set ingress.publicBaseUrl in config.",
+    };
+  }
+
   const tokenHash = hashToken(params.token);
   const claimResult = claimA2AInvite({
     tokenHash,
@@ -203,14 +216,6 @@ export function completeA2AInvite(params: {
       set: { species: "vellum", metadata: metadataJson },
     })
     .run();
-
-  const displayName = getAssistantName() ?? "Vellum Assistant";
-  let gatewayUrl: string;
-  try {
-    gatewayUrl = getPublicBaseUrl(getConfig());
-  } catch {
-    gatewayUrl = "";
-  }
 
   return {
     success: true,

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -1,14 +1,12 @@
 /**
  * A2A channel configuration handler.
  *
- * Follows the same pattern as config-telegram.ts:
- * - getA2AConfig()       — read a2a.enabled, count active a2a contact_channels
- * - setA2AConfig()       — set a2a.enabled = true, register callback routes
- * - clearA2AConfig()     — set a2a.enabled = false
- * - connectToAssistant() — resolve handle, create contact + channel
+ * - getA2AConfig()     — read a2a.enabled, count active a2a contact_channels
+ * - setA2AConfig()     — set a2a.enabled = true
+ * - clearA2AConfig()   — set a2a.enabled = false
+ * - createA2AInvite()  — create a shareable invite token for link-based contact creation
  */
 
-import { AGENT_CARD_PATH } from "../../a2a/protocol-constants.js";
 import {
   getConfig,
   invalidateConfigCache,
@@ -16,14 +14,9 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
-import {
-  findContactByAddress,
-  searchContacts,
-  upsertContact,
-} from "../../contacts/contact-store.js";
-import type { VellumAssistantMetadata } from "../../contacts/types.js";
-import { getDb } from "../../memory/db-connection.js";
-import { assistantContactMetadata } from "../../memory/schema.js";
+import { searchContacts, upsertContact } from "../../contacts/contact-store.js";
+import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import { createInvite } from "../../memory/invite-store.js";
 // ── Result types ────────────────────────────────────────────────────
 
 export interface A2AConfigResult {
@@ -33,11 +26,13 @@ export interface A2AConfigResult {
   error?: string;
 }
 
-export interface ConnectToAssistantResult {
+export interface CreateA2AInviteResult {
   success: boolean;
-  contactId?: string;
+  inviteId?: string;
+  token?: string;
+  expiresAt?: number;
+  senderGatewayUrl?: string;
   error?: string;
-  alreadyConnected?: boolean;
 }
 
 // ── Config operations ───────────────────────────────────────────────
@@ -77,132 +72,50 @@ export function clearA2AConfig(): A2AConfigResult {
   return { success: true, enabled: false, activeConnections: 0 };
 }
 
-// ── Handle resolution (stubbable) ───────────────────────────────────
+// ── A2A invite creation ────────────────────────────────────────────
 
-export interface ResolvedAssistant {
-  assistantId: string;
-  gatewayUrl: string;
-  displayName: string;
-}
-
-/**
- * Resolve a guardian handle to an assistant's gateway URL and identity.
- *
- * For MVP, this fetches the peer's agent card from the gateway URL.
- * When the platform API for handle resolution is available, this function
- * will be updated to use it.
- */
-export async function resolveGuardianHandle(
-  guardianHandle: string,
-  gatewayUrl?: string,
-): Promise<ResolvedAssistant> {
-  if (!gatewayUrl) {
-    throw new Error(
-      `A2A connection requires the peer's gatewayUrl. ` +
-        `Please provide gatewayUrl for handle "${guardianHandle}".`,
-    );
-  }
-
-  const cardUrl = `${gatewayUrl}${AGENT_CARD_PATH}`;
-  try {
-    const res = await fetch(cardUrl);
-    if (!res.ok) {
-      throw new Error(
-        `Agent card fetch failed (${res.status}): ${await res.text()}`,
-      );
-    }
-    const card = (await res.json()) as { name?: string };
-    return {
-      assistantId: guardianHandle,
-      gatewayUrl,
-      displayName: card.name ?? guardianHandle,
-    };
-  } catch (err) {
-    if (err instanceof Error && err.message.startsWith("Agent card fetch")) {
-      throw err;
-    }
-    throw new Error(
-      `Failed to reach peer assistant at ${cardUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-// ── Connection initiation ───────────────────────────────────────────
-
-export async function connectToAssistant(params: {
-  guardianHandle: string;
-  gatewayUrl?: string;
-}): Promise<ConnectToAssistantResult> {
-  const { guardianHandle, gatewayUrl } = params;
-
-  // 1. Ensure A2A channel is enabled (auto-enable on first connect)
+export function createA2AInvite(params: {
+  expiresInHours?: number;
+}): CreateA2AInviteResult {
+  // 1. Ensure A2A channel is enabled (auto-enable on first invite)
   const config = getA2AConfig();
   if (!config.enabled) {
     setA2AConfig();
   }
 
-  // 2. Resolve the peer assistant's identity
-  let resolved: ResolvedAssistant;
+  // 2. Resolve public base URL
+  let publicBaseUrl: string;
   try {
-    resolved = await resolveGuardianHandle(guardianHandle, gatewayUrl);
-  } catch (err) {
+    publicBaseUrl = getPublicBaseUrl(getConfig());
+  } catch {
     return {
       success: false,
-      error: err instanceof Error ? err.message : String(err),
+      error:
+        "No public base URL configured. Set ingress.publicBaseUrl in config.",
     };
   }
 
-  // 3. Check for existing connection (idempotent)
-  const existing = findContactByAddress("a2a", resolved.assistantId);
-  if (existing) {
-    const activeChannel = existing.channels.find(
-      (ch) => ch.type === "a2a" && ch.status === "active",
-    );
-    if (activeChannel) {
-      return {
-        success: true,
-        contactId: existing.id,
-        alreadyConnected: true,
-      };
-    }
-  }
-
-  // 4. Create local contact + channel + assistant_contact_metadata
+  // 3. Create placeholder contact (no channels — will be bound on acceptance)
   const contact = upsertContact({
-    displayName: resolved.displayName,
+    displayName: "Pending A2A invite",
     contactType: "assistant",
     role: "contact",
-    channels: [
-      {
-        type: "a2a",
-        address: resolved.assistantId,
-        externalUserId: resolved.assistantId,
-        status: "active",
-        policy: "allow",
-      },
-    ],
   });
 
-  const db = getDb();
-  const metadataJson = JSON.stringify({
-    assistantId: resolved.assistantId,
-    gatewayUrl: resolved.gatewayUrl,
-  } satisfies VellumAssistantMetadata);
+  // 4. Create the invite
+  const expiresInMs = (params.expiresInHours ?? 72) * 60 * 60 * 1000;
+  const { invite, rawToken } = createInvite({
+    sourceChannel: "a2a",
+    contactId: contact.id,
+    maxUses: 1,
+    expiresInMs,
+  });
 
-  db.insert(assistantContactMetadata)
-    .values({
-      contactId: contact.id,
-      species: "vellum",
-      metadata: metadataJson,
-    })
-    .onConflictDoUpdate({
-      target: assistantContactMetadata.contactId,
-      set: {
-        species: "vellum",
-        metadata: metadataJson,
-      },
-    })
-    .run();
-
-  return { success: true, contactId: contact.id };
+  return {
+    success: true,
+    inviteId: invite.id,
+    token: rawToken,
+    expiresAt: invite.expiresAt,
+    senderGatewayUrl: publicBaseUrl,
+  };
 }

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -15,8 +15,16 @@ import {
   setNestedValue,
 } from "../../config/loader.js";
 import { searchContacts, upsertContact } from "../../contacts/contact-store.js";
+import type { VellumAssistantMetadata } from "../../contacts/types.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
-import { createInvite } from "../../memory/invite-store.js";
+import { getDb } from "../../memory/db-connection.js";
+import {
+  claimA2AInvite,
+  createInvite,
+  hashToken,
+} from "../../memory/invite-store.js";
+import { assistantContactMetadata } from "../../memory/schema.js";
+import { getAssistantName } from "../identity-helpers.js";
 // ── Result types ────────────────────────────────────────────────────
 
 export interface A2AConfigResult {
@@ -32,6 +40,12 @@ export interface CreateA2AInviteResult {
   token?: string;
   expiresAt?: number;
   senderGatewayUrl?: string;
+  error?: string;
+}
+
+export interface CompleteA2AInviteResult {
+  success: boolean;
+  sender?: { assistantId: string; displayName: string; gatewayUrl: string };
   error?: string;
 }
 
@@ -117,5 +131,78 @@ export function createA2AInvite(params: {
     token: rawToken,
     expiresAt: invite.expiresAt,
     senderGatewayUrl: publicBaseUrl,
+  };
+}
+
+// ── A2A invite completion (sender side) ───────────────────────────
+
+export function completeA2AInvite(params: {
+  token: string;
+  acceptor: {
+    assistantId: string;
+    displayName: string;
+    gatewayUrl: string;
+  };
+}): CompleteA2AInviteResult {
+  const tokenHash = hashToken(params.token);
+  const claimResult = claimA2AInvite({
+    tokenHash,
+    redeemedByExternalUserId: params.acceptor.assistantId,
+  });
+
+  if (!claimResult.claimed || !claimResult.invite) {
+    return { success: false, error: claimResult.error };
+  }
+
+  const invite = claimResult.invite;
+
+  // Promote the placeholder contact with the acceptor's identity
+  upsertContact({
+    id: invite.contactId,
+    displayName: params.acceptor.displayName,
+    contactType: "assistant",
+    role: "contact",
+    channels: [
+      {
+        type: "a2a",
+        address: params.acceptor.assistantId.toLowerCase(),
+        externalUserId: params.acceptor.assistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  // Write assistant contact metadata
+  const db = getDb();
+  const metadataJson = JSON.stringify({
+    assistantId: params.acceptor.assistantId,
+    gatewayUrl: params.acceptor.gatewayUrl,
+  } satisfies VellumAssistantMetadata);
+  db.insert(assistantContactMetadata)
+    .values({
+      contactId: invite.contactId,
+      species: "vellum",
+      metadata: metadataJson,
+    })
+    .onConflictDoUpdate({
+      target: assistantContactMetadata.contactId,
+      set: { species: "vellum", metadata: metadataJson },
+    })
+    .run();
+
+  // Resolve this assistant's identity for the response
+  const displayName = getAssistantName() ?? "Vellum Assistant";
+  let gatewayUrl: string;
+  try {
+    gatewayUrl = getPublicBaseUrl(getConfig());
+  } catch {
+    gatewayUrl = "";
+  }
+  const assistantId = displayName;
+
+  return {
+    success: true,
+    sender: { assistantId, displayName, gatewayUrl },
   };
 }

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -364,6 +364,59 @@ export function findActiveVoiceInvites(params: {
 }
 
 // ---------------------------------------------------------------------------
+// claimA2AInvite — validate + consume an A2A invite token
+// ---------------------------------------------------------------------------
+
+export function claimA2AInvite(params: {
+  tokenHash: string;
+  redeemedByExternalUserId: string;
+}): { claimed: boolean; invite: IngressInvite | null; error?: string } {
+  const invite = findByTokenHash(params.tokenHash);
+
+  if (!invite) {
+    return { claimed: false, invite: null, error: "not_found" };
+  }
+
+  if (invite.sourceChannel !== "a2a") {
+    return { claimed: false, invite, error: "wrong_channel" };
+  }
+
+  // Idempotency: if already redeemed by the same acceptor, return success
+  if (invite.status === "redeemed") {
+    if (invite.redeemedByExternalUserId === params.redeemedByExternalUserId) {
+      return { claimed: true, invite };
+    }
+    return { claimed: false, invite, error: "already_redeemed_by_other" };
+  }
+
+  if (invite.status !== "active") {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  if (Date.now() >= invite.expiresAt) {
+    markInviteExpired(invite.id);
+    return { claimed: false, invite, error: "expired" };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { claimed: false, invite, error: "already_redeemed" };
+  }
+
+  const recorded = recordInviteUse({
+    inviteId: invite.id,
+    externalUserId: params.redeemedByExternalUserId,
+  });
+
+  if (!recorded) {
+    return { claimed: false, invite, error: "not_found" };
+  }
+
+  // Re-read to get updated state
+  const updated = findByTokenHash(params.tokenHash);
+  return { claimed: true, invite: updated };
+}
+
+// ---------------------------------------------------------------------------
 // findByInviteCodeHash
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -687,6 +687,12 @@ for (const endpoint of INTERNAL_ENDPOINTS) {
   });
 }
 
+// A2A invite completion: gateway-only (platform-orchestrated)
+registerPolicy("integrations/a2a/invite/complete", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});
+
 // Admin control-plane endpoints: gateway-only
 registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -693,6 +693,12 @@ registerPolicy("integrations/a2a/invite/complete", {
   allowedPrincipalTypes: ["svc_gateway"],
 });
 
+// A2A invite redemption: gateway-only (platform-orchestrated)
+registerPolicy("integrations/a2a/invite/redeem", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});
+
 // Admin control-plane endpoints: gateway-only
 registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -243,6 +243,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "integrations/slack/channel/config:DELETE",
     scopes: ["settings.write"],
   },
+  { endpoint: "integrations/a2a/invite", scopes: ["settings.write"] },
   { endpoint: "channel-verification-sessions", scopes: ["settings.write"] },
   {
     endpoint: "channel-verification-sessions:DELETE",

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -66,8 +66,9 @@ function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
-  const { token, acceptor } = body as {
+  const { token, senderAssistantId, acceptor } = body as {
     token?: unknown;
+    senderAssistantId?: unknown;
     acceptor?: {
       assistantId?: unknown;
       displayName?: unknown;
@@ -78,6 +79,11 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
   if (typeof token !== "string" || !token) {
     throw new BadRequestError(
       "token is required and must be a non-empty string",
+    );
+  }
+  if (typeof senderAssistantId !== "string" || !senderAssistantId) {
+    throw new BadRequestError(
+      "senderAssistantId is required and must be a non-empty string",
     );
   }
   if (
@@ -96,6 +102,7 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
 
   const result = completeA2AInvite({
     token,
+    senderAssistantId,
     acceptor: {
       assistantId: acceptor.assistantId,
       displayName: acceptor.displayName,

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -11,6 +11,7 @@ import { isA2AEnabled } from "../../../a2a/feature-gate.js";
 import { getConfig } from "../../../config/loader.js";
 import {
   clearA2AConfig,
+  completeA2AInvite,
   createA2AInvite,
   getA2AConfig,
   setA2AConfig,
@@ -61,6 +62,49 @@ function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
   return result;
 }
 
+function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
+  const { token, acceptor } = body as {
+    token?: unknown;
+    acceptor?: {
+      assistantId?: unknown;
+      displayName?: unknown;
+      gatewayUrl?: unknown;
+    };
+  };
+
+  if (typeof token !== "string" || !token) {
+    throw new BadRequestError(
+      "token is required and must be a non-empty string",
+    );
+  }
+  if (
+    !acceptor ||
+    typeof acceptor.assistantId !== "string" ||
+    !acceptor.assistantId ||
+    typeof acceptor.displayName !== "string" ||
+    !acceptor.displayName ||
+    typeof acceptor.gatewayUrl !== "string" ||
+    !acceptor.gatewayUrl
+  ) {
+    throw new BadRequestError(
+      "acceptor must include non-empty assistantId, displayName, and gatewayUrl",
+    );
+  }
+
+  const result = completeA2AInvite({
+    token,
+    acceptor: {
+      assistantId: acceptor.assistantId,
+      displayName: acceptor.displayName,
+      gatewayUrl: acceptor.gatewayUrl,
+    },
+  });
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to complete A2A invite");
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -106,5 +150,16 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: handleCreateA2AInvite,
+  },
+  {
+    operationId: "integrations_a2a_invite_complete_post",
+    endpoint: "integrations/a2a/invite/complete",
+    method: "POST",
+    summary: "Complete A2A invite (sender side)",
+    description:
+      "Called by the platform to finalize the sender side of a link-based A2A connection.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleCompleteA2AInvite,
   },
 ];

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -1,10 +1,12 @@
 /**
  * Route handlers for A2A integration config endpoints.
  *
- * GET    /v1/integrations/a2a/config  — get current A2A config status
- * POST   /v1/integrations/a2a/config  — enable A2A channel
- * DELETE /v1/integrations/a2a/config  — disable A2A channel
- * POST   /v1/integrations/a2a/invite  — create a shareable A2A invite token
+ * GET    /v1/integrations/a2a/config          — get current A2A config status
+ * POST   /v1/integrations/a2a/config          — enable A2A channel
+ * DELETE /v1/integrations/a2a/config          — disable A2A channel
+ * POST   /v1/integrations/a2a/invite          — create a shareable A2A invite token
+ * POST   /v1/integrations/a2a/invite/complete — sender-side invite completion
+ * POST   /v1/integrations/a2a/invite/redeem   — receiver-side invite redemption
  */
 
 import { isA2AEnabled } from "../../../a2a/feature-gate.js";
@@ -14,6 +16,7 @@ import {
   completeA2AInvite,
   createA2AInvite,
   getA2AConfig,
+  redeemA2AInvite,
   setA2AConfig,
 } from "../../../daemon/handlers/config-a2a.js";
 import { BadRequestError } from "../errors.js";
@@ -105,6 +108,42 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
   return result;
 }
 
+function handleRedeemA2AInvite({ body = {} }: RouteHandlerArgs) {
+  const { sender } = body as {
+    sender?: {
+      assistantId?: unknown;
+      displayName?: unknown;
+      gatewayUrl?: unknown;
+    };
+  };
+
+  if (
+    !sender ||
+    typeof sender.assistantId !== "string" ||
+    !sender.assistantId ||
+    typeof sender.displayName !== "string" ||
+    !sender.displayName ||
+    typeof sender.gatewayUrl !== "string" ||
+    !sender.gatewayUrl
+  ) {
+    throw new BadRequestError(
+      "sender must include non-empty assistantId, displayName, and gatewayUrl",
+    );
+  }
+
+  const result = redeemA2AInvite({
+    sender: {
+      assistantId: sender.assistantId,
+      displayName: sender.displayName,
+      gatewayUrl: sender.gatewayUrl,
+    },
+  });
+  if (!result.success) {
+    throw new BadRequestError(result.error ?? "Failed to redeem A2A invite");
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -161,5 +200,16 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: handleCompleteA2AInvite,
+  },
+  {
+    operationId: "integrations_a2a_invite_redeem_post",
+    endpoint: "integrations/a2a/invite/redeem",
+    method: "POST",
+    summary: "Redeem A2A invite (receiver side)",
+    description:
+      "Called by the platform to create a trusted contact on the receiver side of a link-based A2A connection.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleRedeemA2AInvite,
   },
 ];

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -1,17 +1,17 @@
 /**
  * Route handlers for A2A integration config endpoints.
  *
- * GET    /v1/integrations/a2a/config    — get current A2A config status
- * POST   /v1/integrations/a2a/config    — enable A2A channel
- * DELETE /v1/integrations/a2a/config    — disable A2A channel
- * POST   /v1/integrations/a2a/connect   — initiate connection to a peer assistant
+ * GET    /v1/integrations/a2a/config  — get current A2A config status
+ * POST   /v1/integrations/a2a/config  — enable A2A channel
+ * DELETE /v1/integrations/a2a/config  — disable A2A channel
+ * POST   /v1/integrations/a2a/invite  — create a shareable A2A invite token
  */
 
 import { isA2AEnabled } from "../../../a2a/feature-gate.js";
 import { getConfig } from "../../../config/loader.js";
 import {
   clearA2AConfig,
-  connectToAssistant,
+  createA2AInvite,
   getA2AConfig,
   setA2AConfig,
 } from "../../../daemon/handlers/config-a2a.js";
@@ -51,18 +51,12 @@ function handleClearA2AConfig() {
   return clearA2AConfig();
 }
 
-async function handleConnectToAssistant({ body = {} }: RouteHandlerArgs) {
+function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
   assertA2AFlag();
-  const { guardianHandle, gatewayUrl } = body as {
-    guardianHandle?: string;
-    gatewayUrl?: string;
-  };
-  if (!guardianHandle) {
-    throw new BadRequestError("guardianHandle is required");
-  }
-  const result = await connectToAssistant({ guardianHandle, gatewayUrl });
+  const { expiresInHours } = body as { expiresInHours?: number };
+  const result = createA2AInvite({ expiresInHours });
   if (!result.success) {
-    throw new BadRequestError(result.error ?? "Failed to connect to assistant");
+    throw new BadRequestError(result.error ?? "Failed to create A2A invite");
   }
   return result;
 }
@@ -103,14 +97,14 @@ export const ROUTES: RouteDefinition[] = [
     handler: () => handleClearA2AConfig(),
   },
   {
-    operationId: "integrations_a2a_connect_post",
-    endpoint: "integrations/a2a/connect",
+    operationId: "integrations_a2a_invite_post",
+    endpoint: "integrations/a2a/invite",
     method: "POST",
-    summary: "Connect to assistant",
+    summary: "Create A2A invite",
     description:
-      "Initiate an A2A connection to a peer assistant by guardian handle.",
+      "Create a shareable A2A invite token for link-based contact creation.",
     tags: ["integrations"],
     requirePolicyEnforcement: true,
-    handler: handleConnectToAssistant,
+    handler: handleCreateA2AInvite,
   },
 ];

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -57,8 +57,21 @@ function handleClearA2AConfig() {
 
 function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
   assertA2AFlag();
-  const { expiresInHours } = body as { expiresInHours?: number };
-  const result = createA2AInvite({ expiresInHours });
+  const { expiresInHours } = body as { expiresInHours?: unknown };
+  if (expiresInHours !== undefined) {
+    if (
+      typeof expiresInHours !== "number" ||
+      !Number.isFinite(expiresInHours) ||
+      expiresInHours <= 0
+    ) {
+      throw new BadRequestError(
+        "expiresInHours must be a positive finite number",
+      );
+    }
+  }
+  const result = createA2AInvite({
+    expiresInHours: expiresInHours as number | undefined,
+  });
   if (!result.success) {
     throw new BadRequestError(result.error ?? "Failed to create A2A invite");
   }


### PR DESCRIPTION
## Summary
Platform-mediated A2A trusted contact creation via shareable invite links. User A creates an invite from their authenticated session; User B opens the link in the Vellum app; the platform authenticates both users and orchestrates authenticated calls to both assistants to create the bidirectional trusted-contact relationship.

**Key design decisions:**
- Platform is the trust broker — no public gateway endpoints, no peer-to-peer callbacks
- Platform assistant ID is the canonical A2A contact identity (gateway URL stored as delivery metadata only)
- No SSRF surface — assistants never fetch arbitrary user-supplied URLs during trust creation
- Direct-connect path (`POST /v1/integrations/a2a/connect`) removed in favor of the invite flow

**New endpoints:**
- `POST /v1/integrations/a2a/invite` — create shareable invite token (actor-accessible, `settings.write`)
- `POST /v1/integrations/a2a/invite/complete` — finalize sender side (gateway-service-only, `internal.write`)
- `POST /v1/integrations/a2a/invite/redeem` — create receiver-side contact (gateway-service-only, `internal.write`)

## PRs merged into feature branch
- #31004: Add invite creation endpoint + remove direct-connect path
- #31006: Add sender-side invite completion endpoint
- #31010: Add receiver-side invite redemption endpoint

## Test plan
- [ ] Verify `POST /v1/integrations/a2a/invite` creates an invite and returns token + gateway URL
- [ ] Verify `POST /v1/integrations/a2a/invite/complete` validates token, promotes placeholder contact, returns sender identity
- [ ] Verify `POST /v1/integrations/a2a/invite/redeem` creates trusted contact with sender's platform assistant ID
- [ ] Verify idempotency: repeated redeem with same sender returns `alreadyConnected: true`
- [ ] Verify expired/invalid/reused tokens fail cleanly
- [ ] Verify A2A auto-enables on both invite creation and redemption
- [ ] Verify the old `POST /v1/integrations/a2a/connect` endpoint no longer exists

Closes JARVIS-875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Linear issue: [ATL-610](https://linear.app/vellum/issue/ATL-610/security-a2a-connect-endpoint-missing-policy-lacks-url-validation)