### PR TITLE
feat(memory): enable v2 router by default with balanced profile

### DIFF
--- a/assistant/src/__tests__/workspace-migration-087-memory-router-balanced-profile.test.ts
+++ b/assistant/src/__tests__/workspace-migration-087-memory-router-balanced-profile.test.ts
@@ -1,0 +1,203 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { memoryRouterBalancedProfileMigration } from "../workspace/migrations/087-memory-router-balanced-profile.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-087-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("087-memory-router-balanced-profile migration", () => {
+  test("has correct migration id", () => {
+    expect(memoryRouterBalancedProfileMigration.id).toBe(
+      "087-memory-router-balanced-profile",
+    );
+  });
+
+  test("replaces seeded Sonnet 4.6 + 1M context with balanced profile", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          memoryRouter: {
+            model: "claude-sonnet-4-6",
+            contextWindow: { maxInputTokens: 1_000_000 },
+          },
+        },
+      },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("creates the call site when missing", () => {
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("writes a fresh starter config when config.json is absent", () => {
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("runs on non-Anthropic workspaces (unlike 077)", () => {
+    writeConfig({
+      llm: { default: { provider: "openai", model: "gpt-5.4" } },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("overwrites user customizations on memoryRouter", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          memoryRouter: {
+            model: "claude-haiku-4-5-20251001",
+            effort: "low",
+          },
+        },
+      },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+
+  test("is idempotent — second run does not change the call site", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          memoryRouter: {
+            model: "claude-sonnet-4-6",
+            contextWindow: { maxInputTokens: 1_000_000 },
+          },
+        },
+      },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+    const afterFirst = readFileSync(configPath(), "utf-8");
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+    const afterSecond = readFileSync(configPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("skips when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          memoryRouter: { model: "claude-sonnet-4-6" },
+        },
+      },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.memoryRouter).toEqual({
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  test("preserves sibling call-site entries", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          mainAgent: { model: "claude-opus-4-7", maxTokens: 32000 },
+          memoryRouter: {
+            model: "claude-sonnet-4-6",
+            contextWindow: { maxInputTokens: 1_000_000 },
+          },
+        },
+      },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.mainAgent).toEqual({
+      model: "claude-opus-4-7",
+      maxTokens: 32000,
+    });
+    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+  });
+});

--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -33,7 +33,7 @@ describe("MemoryV2ConfigSchema", () => {
         dtype: "q8",
       },
       router: {
-        enabled: false,
+        enabled: true,
         max_page_ids: 25,
         router_prompt_path: null,
       },
@@ -161,9 +161,9 @@ describe("MemoryV2ConfigSchema", () => {
     expect(() => MemoryV2ConfigSchema.parse({ epsilon: 1.5 })).toThrow();
   });
 
-  test("router defaults to disabled with max_page_ids=25", () => {
+  test("router defaults to enabled with max_page_ids=25", () => {
     const parsed = MemoryV2ConfigSchema.parse({});
-    expect(parsed.router.enabled).toBe(false);
+    expect(parsed.router.enabled).toBe(true);
     expect(parsed.router.max_page_ids).toBe(25);
   });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -260,9 +260,9 @@ export const MemoryV2ConfigSchema = z
       .object({
         enabled: z
           .boolean()
-          .default(false)
+          .default(true)
           .describe(
-            "Whether to use the LLM router as the per-turn page-selection mechanism in place of spreading activation. Disabled by default — opt in once the router orchestration and dispatcher land.",
+            "Whether to use the LLM router as the per-turn page-selection mechanism in place of spreading activation. Enabled by default.",
           ),
         max_page_ids: z
           .number()
@@ -283,9 +283,9 @@ export const MemoryV2ConfigSchema = z
             "Optional path to a file whose contents replace the bundled router prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, and `{{PAGE_INDEX}}`, which are substituted at runtime. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
           ),
       })
-      .default({ enabled: false, max_page_ids: 25, router_prompt_path: null })
+      .default({ enabled: true, max_page_ids: 25, router_prompt_path: null })
       .describe(
-        "LLM router configuration. When enabled, a single Sonnet router call replaces spreading activation for per-turn page selection.",
+        "LLM router configuration. When enabled, a single router LLM call replaces spreading activation for per-turn page selection.",
       ),
   })
   .describe(

--- a/assistant/src/workspace/migrations/087-memory-router-balanced-profile.ts
+++ b/assistant/src/workspace/migrations/087-memory-router-balanced-profile.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Set callSites.memoryRouter to { profile: "balanced" }, dropping the explicit
+// model and 1M context-window override seeded by 077 — accepts page-index
+// truncation on workspaces larger than the balanced profile's context window.
+export const memoryRouterBalancedProfileMigration: WorkspaceMigration = {
+  id: "087-memory-router-balanced-profile",
+  description:
+    "Set callSites.memoryRouter to { profile: 'balanced' }, dropping the seeded model and contextWindow override",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    const configExisted = existsSync(configPath);
+
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const callSites = readObject(llm.callSites) ?? {};
+    const existing = readObject(callSites.memoryRouter);
+
+    if (
+      existing !== null &&
+      Object.keys(existing).length === 1 &&
+      existing.profile === "balanced"
+    ) {
+      return;
+    }
+
+    callSites.memoryRouter = { profile: "balanced" };
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -84,6 +84,7 @@ import { systemPromptPrefixToFileMigration } from "./083-system-prompt-prefix-to
 import { removeLegacySkillsIndexMigration } from "./084-remove-legacy-skills-index.js";
 import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "./085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 import { revertStaleGeminiMisRewritesMigration } from "./086-revert-stale-gemini-mis-rewrites.js";
+import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanced-profile.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -179,4 +180,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   removeLegacySkillsIndexMigration,
   memoryV2Bm25BReembedDisabledV2PagesMigration,
   revertStaleGeminiMisRewritesMigration,
+  memoryRouterBalancedProfileMigration,
 ];


### PR DESCRIPTION
## Summary

- Flip `memory.v2.router.enabled` schema default from `false` → `true`, making the LLM router the per-turn page-selection mechanism out of the box (replaces spreading activation by default).
- Add migration 087 to set `callSites.memoryRouter` to `{ profile: "balanced" }` on all workspaces, dropping the Sonnet 4.6 + 1M-context override seeded by 077. The balanced managed profile fully governs model/effort/thinking/maxTokens/context window.
- Accepts page-index truncation on workspaces that exceed the balanced profile's context window — the explicit trade-off for letting the standard profile control the call site.

## Original prompt

Enable the memory v2 router by default and switch its call site to the standard `balanced` managed profile so future profile tweaks propagate automatically instead of staying locked to the migration-077 Sonnet 4.6 + 1M-context seed. After discussing the trade-off (balanced caps at 200k vs. the prior 1M), we chose to fully defer to the profile rather than carry over the context override.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->