### PR TITLE
test(memory): pin router off in v2 routing activation-pipeline test

### DIFF
--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -216,8 +216,13 @@ function createTestDb(): DrizzleDb {
 }
 
 function makeConfig(v2Enabled: boolean, memoryEnabled = true): AssistantConfig {
+  // Pin `router.enabled: false` so these tests exercise the activation
+  // pipeline. Router-mode coverage lives in `memory/v2/__tests__/injection.test.ts`.
   return applyNestedDefaults({
-    memory: { enabled: memoryEnabled, v2: { enabled: v2Enabled } },
+    memory: {
+      enabled: memoryEnabled,
+      v2: { enabled: v2Enabled, router: { enabled: false } },
+    },
   }) as AssistantConfig;
 }
 


### PR DESCRIPTION
## Summary
- `conversation-graph-memory-v2-routing.test.ts` exercises the activation pipeline (Qdrant ANN + spreading activation) with stubbed embedding/Qdrant deps.
- PR #31018 flipped `memory.v2.router.enabled` to `true` by default, so `injectMemoryV2Block` started routing through `injectViaRouter` and the activation stubs were never reached — four assertions broke.
- Pin `router.enabled: false` in this suite's `makeConfig`. Router-mode coverage already exists in `memory/v2/__tests__/injection.test.ts`, which uses the same pattern.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/26049176490/job/76581153550 — the test failure surfaced after PR #31018 enabled `memory.v2.router.enabled` by default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->