### PR TITLE
fix(a2a): use platform assistant ID in completeA2AInvite response

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -80,11 +80,13 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
     expect(result.success).toBe(true);
     expect(result.sender).toBeDefined();
+    expect(result.sender!.assistantId).toBe("sender-platform-id-789");
     expect(result.sender!.gatewayUrl).toBe("https://sender.example.com");
     expect(result.sender!.displayName).toBeDefined();
     expect(result.error).toBeUndefined();
@@ -111,6 +113,7 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: acceptorWithUppercase,
     });
     expect(result.success).toBe(true);
@@ -125,6 +128,7 @@ describe("completeA2AInvite", () => {
     const created = createA2AInvite({});
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(result.success).toBe(true);
@@ -142,6 +146,7 @@ describe("completeA2AInvite", () => {
   test("invalid token returns not_found error", () => {
     const result = completeA2AInvite({
       token: "invalid-token-that-does-not-exist",
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
@@ -164,6 +169,7 @@ describe("completeA2AInvite", () => {
 
     const result = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
 
@@ -178,6 +184,7 @@ describe("completeA2AInvite", () => {
     // First completion
     const first = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(first.success).toBe(true);
@@ -185,6 +192,7 @@ describe("completeA2AInvite", () => {
     // Second completion with same acceptor
     const second = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(second.success).toBe(true);
@@ -197,6 +205,7 @@ describe("completeA2AInvite", () => {
     // First completion
     const first = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: ACCEPTOR,
     });
     expect(first.success).toBe(true);
@@ -204,6 +213,7 @@ describe("completeA2AInvite", () => {
     // Second completion with different acceptor
     const second = completeA2AInvite({
       token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
       acceptor: {
         assistantId: "different-assistant-456",
         displayName: "Different Bot",

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -150,6 +150,7 @@ export function createA2AInvite(params: {
 
 export function completeA2AInvite(params: {
   token: string;
+  senderAssistantId: string;
   acceptor: {
     assistantId: string;
     displayName: string;
@@ -203,7 +204,6 @@ export function completeA2AInvite(params: {
     })
     .run();
 
-  // Resolve this assistant's identity for the response
   const displayName = getAssistantName() ?? "Vellum Assistant";
   let gatewayUrl: string;
   try {
@@ -211,11 +211,14 @@ export function completeA2AInvite(params: {
   } catch {
     gatewayUrl = "";
   }
-  const assistantId = displayName;
 
   return {
     success: true,
-    sender: { assistantId, displayName, gatewayUrl },
+    sender: {
+      assistantId: params.senderAssistantId,
+      displayName,
+      gatewayUrl,
+    },
   };
 }
 

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -66,8 +66,9 @@ function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
-  const { token, acceptor } = body as {
+  const { token, senderAssistantId, acceptor } = body as {
     token?: unknown;
+    senderAssistantId?: unknown;
     acceptor?: {
       assistantId?: unknown;
       displayName?: unknown;
@@ -78,6 +79,11 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
   if (typeof token !== "string" || !token) {
     throw new BadRequestError(
       "token is required and must be a non-empty string",
+    );
+  }
+  if (typeof senderAssistantId !== "string" || !senderAssistantId) {
+    throw new BadRequestError(
+      "senderAssistantId is required and must be a non-empty string",
     );
   }
   if (
@@ -96,6 +102,7 @@ function handleCompleteA2AInvite({ body = {} }: RouteHandlerArgs) {
 
   const result = completeA2AInvite({
     token,
+    senderAssistantId,
     acceptor: {
       assistantId: acceptor.assistantId,
       displayName: acceptor.displayName,


### PR DESCRIPTION
## Summary
- Fix identity invariant violation: `completeA2AInvite()` was setting `sender.assistantId = displayName` instead of a stable platform ID
- Add required `senderAssistantId` parameter to the complete endpoint — the platform passes this since the daemon does not know its own platform ID
- The returned `sender.assistantId` is now the stable platform assistant ID, matching what the receiver stores as its contact address

Fixes Devin P1 review on #31015.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->