### PR TITLE
fix(a2a): validate expiresInHours and resolve gateway URL before mutations

### DIFF
--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -224,4 +224,25 @@ describe("completeA2AInvite", () => {
     expect(second.success).toBe(false);
     expect(second.error).toBe("already_redeemed_by_other");
   });
+
+  test("fails before claiming token when public base URL is not configured", () => {
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    setConfig({ publicBaseUrl: "", ingressEnabled: true });
+
+    const result = completeA2AInvite({
+      token: created.token!,
+      senderAssistantId: "sender-platform-id-789",
+      acceptor: ACCEPTOR,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("public base URL");
+
+    // Verify the invite was NOT consumed
+    const invite = findById(created.inviteId!);
+    expect(invite!.status).toBe("active");
+    expect(invite!.useCount).toBe(0);
+  });
 });

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -157,6 +157,19 @@ export function completeA2AInvite(params: {
     gatewayUrl: string;
   };
 }): CompleteA2AInviteResult {
+  // Resolve sender identity before any mutations so we fail cleanly
+  const displayName = getAssistantName() ?? "Vellum Assistant";
+  let gatewayUrl: string;
+  try {
+    gatewayUrl = getPublicBaseUrl(getConfig());
+  } catch {
+    return {
+      success: false,
+      error:
+        "No public base URL configured. Set ingress.publicBaseUrl in config.",
+    };
+  }
+
   const tokenHash = hashToken(params.token);
   const claimResult = claimA2AInvite({
     tokenHash,
@@ -203,14 +216,6 @@ export function completeA2AInvite(params: {
       set: { species: "vellum", metadata: metadataJson },
     })
     .run();
-
-  const displayName = getAssistantName() ?? "Vellum Assistant";
-  let gatewayUrl: string;
-  try {
-    gatewayUrl = getPublicBaseUrl(getConfig());
-  } catch {
-    gatewayUrl = "";
-  }
 
   return {
     success: true,

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -57,8 +57,21 @@ function handleClearA2AConfig() {
 
 function handleCreateA2AInvite({ body = {} }: RouteHandlerArgs) {
   assertA2AFlag();
-  const { expiresInHours } = body as { expiresInHours?: number };
-  const result = createA2AInvite({ expiresInHours });
+  const { expiresInHours } = body as { expiresInHours?: unknown };
+  if (expiresInHours !== undefined) {
+    if (
+      typeof expiresInHours !== "number" ||
+      !Number.isFinite(expiresInHours) ||
+      expiresInHours <= 0
+    ) {
+      throw new BadRequestError(
+        "expiresInHours must be a positive finite number",
+      );
+    }
+  }
+  const result = createA2AInvite({
+    expiresInHours: expiresInHours as number | undefined,
+  });
   if (!result.success) {
     throw new BadRequestError(result.error ?? "Failed to create A2A invite");
   }


### PR DESCRIPTION
## Summary
- Validate `expiresInHours` at the route handler: reject non-number, non-finite, and non-positive values before any side effects (A2A auto-enable, placeholder contact creation)
- Move gateway URL resolution in `completeA2AInvite()` before token claim and contact promotion — if the URL is unavailable, the call fails without consuming the invite or mutating contact state

Addresses Codex P2 review feedback on #31015.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->