### PR TITLE
feat(design-library): add Typography + ProgressBar components with cn utility

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "@vellum/design-library",
+      "dependencies": {
+        "clsx": "2.1.1",
+        "tailwind-merge": "3.6.0",
+      },
       "devDependencies": {
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -23,6 +27,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
@@ -30,6 +36,8 @@
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "./components/*": "./src/components/*.tsx"
+    "./components/*": "./src/components/*.tsx",
+    "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit"
@@ -21,5 +22,9 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "typescript": "5.9.3"
+  },
+  "dependencies": {
+    "clsx": "2.1.1",
+    "tailwind-merge": "3.6.0"
   }
 }

--- a/packages/design-library/src/components/progress-bar.tsx
+++ b/packages/design-library/src/components/progress-bar.tsx
@@ -1,0 +1,52 @@
+import { forwardRef } from "react";
+
+import { cn } from "../utils/cn.js";
+
+export interface ProgressBarProps {
+  value: number;
+  "aria-label"?: string;
+  className?: string;
+  height?: number;
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
+  function ProgressBar(
+    { value, "aria-label": ariaLabel, className, height = 6 },
+    ref,
+  ) {
+    const clamped = clamp01(value);
+    const percent = clamped * 100;
+    const valueNow = Math.round(percent);
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuenow={valueNow}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className={cn(
+          "rounded-full overflow-hidden bg-[var(--surface-lift)]",
+          className,
+        )}
+        style={{ height }}
+      >
+        <div
+          className="h-full bg-[var(--content-default)] rounded-full"
+          style={{
+            width: `${percent}%`,
+            transition: "width 400ms cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
+        />
+      </div>
+    );
+  },
+);

--- a/packages/design-library/src/components/typography.tsx
+++ b/packages/design-library/src/components/typography.tsx
@@ -1,0 +1,74 @@
+import {
+  createElement,
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+
+import { cn } from "../utils/cn.js";
+
+export type TypographyVariant =
+  | "title-large"
+  | "title-medium"
+  | "title-small"
+  | "body-large-lighter"
+  | "body-large-default"
+  | "body-medium-lighter"
+  | "body-medium-default"
+  | "body-small-default"
+  | "body-small-emphasised"
+  | "label-medium-default"
+  | "label-small-default"
+  | "chat";
+
+const VARIANT_CLASS: Record<TypographyVariant, string> = {
+  "title-large": "text-title-large",
+  "title-medium": "text-title-medium",
+  "title-small": "text-title-small",
+  "body-large-lighter": "text-body-large-lighter",
+  "body-large-default": "text-body-large-default",
+  "body-medium-lighter": "text-body-medium-lighter",
+  "body-medium-default": "text-body-medium-default",
+  "body-small-default": "text-body-small-default",
+  "body-small-emphasised": "text-body-small-emphasised",
+  "label-medium-default": "text-label-medium-default",
+  "label-small-default": "text-label-small-default",
+  chat: "text-chat",
+};
+
+export type TypographyAs =
+  | "span"
+  | "p"
+  | "div"
+  | "label"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6";
+
+export interface TypographyProps extends HTMLAttributes<HTMLElement> {
+  variant: TypographyVariant;
+  as?: TypographyAs;
+  className?: string;
+  children?: ReactNode;
+  htmlFor?: string;
+}
+
+export const Typography = forwardRef<HTMLElement, TypographyProps>(
+  function Typography(
+    { variant, as = "span", className, children, ...rest },
+    ref,
+  ) {
+    return createElement(
+      as,
+      {
+        ...rest,
+        ref,
+        className: cn(VARIANT_CLASS[variant], className),
+      },
+      children,
+    );
+  },
+);

--- a/packages/design-library/src/utils/cn.ts
+++ b/packages/design-library/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Prompt / plan

Migrate Typography and ProgressBar components from `vellum-assistant-platform` to the design library in `vellum-assistant`, along with a shared `cn` utility.

### What changed

**1. `cn` utility** (`packages/design-library/src/utils/cn.ts`)
- Wraps `clsx` + `tailwind-merge` — the standard pattern for composing Tailwind classes with conflict resolution
- Added `clsx@2.1.1` and `tailwind-merge@3.6.0` as exact-pinned dependencies (not peer deps, since the design library owns this)
- Exported via new `"./utils/*": "./src/utils/*.ts"` entry in `package.json`

**2. Typography** (`packages/design-library/src/components/typography.tsx`)
- Migrated from `web/src/components/app/core/Typography/Typography.tsx` in vellum-assistant-platform
- Removed `"use client"` directive (not needed in Vite/non-Next.js)
- Replaced `@/lib/utils` import with relative `../utils/cn.js` (NodeNext resolution)
- Preserved all exports: `TypographyVariant`, `TypographyAs`, `TypographyProps`, `Typography`
- Preserved `forwardRef` pattern, `VARIANT_CLASS` map, `htmlFor` prop

**3. ProgressBar** (`packages/design-library/src/components/progress-bar.tsx`)
- Migrated from `web/src/components/app/core/ProgressBar/ProgressBar.tsx` in vellum-assistant-platform
- Removed `"use client"` directive
- Replaced `@/lib/utils` import with relative `../utils/cn.js`
- Preserved all exports: `ProgressBarProps`, `ProgressBar`
- Preserved `clamp01` helper, accessibility attributes (`role="progressbar"`, `aria-*`)

### Why these components belong in the design library
- Both are pure UI primitives: React + Tailwind only, zero Next.js or app-specific imports
- Single-file components with no subcomponent dependencies
- Already used across the platform as foundational building blocks

### Why this is safe
- Additive-only: no existing files modified beyond `package.json` exports
- `bun run typecheck` passes in both `packages/design-library/` and `apps/web/`
- `bun run build` passes in `apps/web/`

### Companion PR
- Migration guard table update: https://github.com/vellum-ai/vellum-assistant-platform/pull/7059

## Test plan
- `bun run typecheck` in `packages/design-library/` — passes
- `bun run typecheck` in `apps/web/` — passes
- `bun run build` in `apps/web/` — passes
- CI checks all passing

Link to Devin session: https://app.devin.ai/sessions/15f9eddd51934bd6947800cecc6292be
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->