### PR TITLE
feat(design-library): add Notice component

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4",
         "clsx": "2.1.1",
+        "lucide-react": "1.16.0",
         "tailwind-merge": "3.6.0",
       },
       "devDependencies": {
@@ -35,6 +36,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "lucide-react": ["lucide-react@1.16.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "1.2.4",
     "clsx": "2.1.1",
+    "lucide-react": "1.16.0",
     "tailwind-merge": "3.6.0"
   }
 }

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -1,0 +1,149 @@
+import {
+  CircleAlert,
+  CircleCheck,
+  Info,
+  OctagonX,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+
+import { cn } from "../utils/cn.js";
+import { Typography } from "./typography.js";
+
+export type NoticeTone = "info" | "success" | "warning" | "error" | "neutral";
+
+export interface NoticeProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "title" | "role"> {
+  tone?: NoticeTone;
+  title?: ReactNode;
+  children?: ReactNode;
+  icon?: ReactNode;
+  onDismiss?: () => void;
+  actions?: ReactNode;
+}
+
+interface ToneClasses {
+  container: string;
+  icon: string;
+  DefaultIcon: LucideIcon | null;
+}
+
+const TONE_CLASSES: Record<NoticeTone, ToneClasses> = {
+  info: {
+    container:
+      "bg-[var(--surface-overlay)] border-[var(--border-element)]",
+    icon: "text-[var(--content-secondary)]",
+    DefaultIcon: Info,
+  },
+  success: {
+    container:
+      "bg-[var(--system-positive-weak)] border-[color-mix(in_srgb,var(--system-positive-strong)_25%,transparent)]",
+    icon: "text-[var(--system-positive-strong)]",
+    DefaultIcon: CircleCheck,
+  },
+  warning: {
+    container:
+      "bg-[var(--system-mid-weak)] border-[color-mix(in_srgb,var(--system-mid-strong)_30%,transparent)]",
+    icon: "text-[var(--system-mid-strong)]",
+    DefaultIcon: CircleAlert,
+  },
+  error: {
+    container:
+      "bg-[var(--system-negative-weak)] border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)]",
+    icon: "text-[var(--system-negative-strong)]",
+    DefaultIcon: OctagonX,
+  },
+  neutral: {
+    container: "bg-[var(--surface-overlay)] border-[var(--border-base)]",
+    icon: "text-[var(--content-secondary)]",
+    DefaultIcon: null,
+  },
+};
+
+export const Notice = forwardRef<HTMLDivElement, NoticeProps>(function Notice(
+  {
+    tone = "info",
+    title,
+    children,
+    icon,
+    onDismiss,
+    actions,
+    className,
+    ...rest
+  },
+  ref,
+) {
+  const toneClasses = TONE_CLASSES[tone];
+  const role = tone === "error" ? "alert" : "status";
+
+  const resolvedIcon =
+    icon === undefined
+      ? toneClasses.DefaultIcon
+        ? <toneClasses.DefaultIcon className="h-4 w-4" aria-hidden="true" />
+        : null
+      : icon;
+
+  return (
+    <div
+      {...rest}
+      ref={ref}
+      role={role}
+      className={cn(
+        "relative flex w-full items-start gap-3 rounded-lg border p-3",
+        "text-[var(--content-default)]",
+        toneClasses.container,
+        className,
+      )}
+    >
+      {resolvedIcon ? (
+        <span
+          className={cn(
+            "mt-0.5 flex shrink-0 items-center justify-center",
+            toneClasses.icon,
+          )}
+        >
+          {resolvedIcon}
+        </span>
+      ) : null}
+
+      <div className="min-w-0 flex-1 space-y-1">
+        {title ? (
+          <Typography
+            variant="body-medium-default"
+            as="p"
+            className="text-[var(--content-emphasised)]"
+          >
+            {title}
+          </Typography>
+        ) : null}
+        {children ? (
+          <Typography
+            variant="body-medium-lighter"
+            as="div"
+            className="text-[var(--content-secondary)]"
+          >
+            {children}
+          </Typography>
+        ) : null}
+        {actions ? <div className="mt-2 flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+
+      {onDismiss ? (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className={cn(
+            "shrink-0 cursor-pointer rounded bg-transparent p-0.5",
+            "text-[var(--content-secondary)] opacity-70 transition-opacity",
+            "hover:opacity-100 focus-visible:outline-none focus-visible:ring-2",
+            "focus-visible:ring-[var(--ring)]",
+          )}
+        >
+          <X className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
+  );
+});


### PR DESCRIPTION
## Prompt / plan

Migrate the `Notice` component from `vellum-assistant-platform` (`web/src/components/app/core/Notice/Notice.tsx`) to the design library in `vellum-assistant` (`packages/design-library/`).

### What changed

1. **Notice component** — `packages/design-library/src/components/notice.tsx`
   - Migrated from `web/src/components/app/core/Notice/Notice.tsx` in the platform repo
   - Removed `"use client"` directive
   - Updated imports to use the existing local `cn` utility and `Typography` component (already on main)
   - Pure UI primitive: inline alert/banner with 5 tone variants (info, success, warning, error, neutral)
   - Accessibility: `role="alert"` for error tone, `role="status"` for others
   - Supports `forwardRef`, dismissible via `onDismiss`, action slot, icon override

2. **Dependency** — added `lucide-react@1.16.0` (for `CircleAlert`, `CircleCheck`, `Info`, `OctagonX`, `X` icons)

Note: `cn` utility, `Typography` component, `clsx`, and `tailwind-merge` were already added to main by parallel migration PRs — this PR only adds the Notice component and its `lucide-react` dependency.

### Why safe

- Additive only — only adds `notice.tsx` and one dependency
- Zero Next.js imports — pure React + Tailwind, framework-agnostic
- `bun run typecheck` passes in both `packages/design-library/` and `apps/web/`
- `bun run build` passes in `apps/web/`

### Companion PR

Migration guard table updated in [vellum-ai/vellum-assistant-platform#7053](https://github.com/vellum-ai/vellum-assistant-platform/pull/7053) (merged).

## Test plan

- `bun run typecheck` in `packages/design-library/` — passes
- `bun run typecheck` in `apps/web/` — passes
- `bun run build` in `apps/web/` — passes

Link to Devin session: https://app.devin.ai/sessions/5ee284ba175c43b496703236355dbf97
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->