### PR TITLE
docs(design-library): add Tailwind class naming conventions

### DIFF
--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -8,6 +8,36 @@ This package follows the same coding style as the web app. See
 [`apps/web/STYLE_GUIDE.md`](../../apps/web/STYLE_GUIDE.md) for naming,
 imports, formatting, and TypeScript conventions.
 
+## Tailwind class naming
+
+Tailwind scans source files as plain text — it cannot evaluate runtime
+expressions. **Never construct class names with string interpolation.**
+
+```ts
+// BAD — Tailwind cannot detect these classes
+className={`btn-${variant} size-${size}`}
+
+// GOOD — static strings are always detectable
+const VARIANT_CLASSES: Record<Variant, string> = {
+  primary: "btn-primary",
+  secondary: "btn-secondary",
+};
+className={VARIANT_CLASSES[variant]}
+```
+
+Choose the pattern that fits the component's complexity:
+
+| Complexity | Pattern | When to use |
+|---|---|---|
+| Simple (1–2 variant axes) | `Record<Variant, string>` map | Button, Badge |
+| Multi-axis variants | [`cva`](https://cva.style/docs) (class-variance-authority) | Tag, Alert |
+| Conditional composition | `cn()` (clsx + tailwind-merge) | Any override/merge scenario |
+
+All three keep class strings statically present in source so Tailwind's
+scanner can detect them.
+
+**Reference:** [Tailwind CSS — Detecting classes in source files](https://tailwindcss.com/docs/detecting-classes-in-source-files#dynamic-class-names)
+
 ## Usage
 
 Components are imported via the `exports` map:


### PR DESCRIPTION
## Prompt / plan

The scaffold PR (#31007) shipped with a placeholder Button that used dynamic class interpolation (`vdl-btn-${variant}`), which Tailwind's scanner cannot statically detect. That was fixed on merge, but we need permanent documentation so future component authors never repeat the mistake.

## What this does

Adds a "Tailwind class naming" section to `packages/design-library/README.md` documenting:

1. **The rule**: never construct class names with string interpolation
2. **Why**: Tailwind scans source as plain text and cannot evaluate runtime expressions
3. **Three approved patterns** (with a decision table):
   - `Record<Variant, string>` maps — for simple 1–2 axis variants
   - `cva` (class-variance-authority) — for complex multi-axis variants
   - `cn()` (clsx + tailwind-merge) — for conditional composition / caller overrides

Links to the [official Tailwind docs](https://tailwindcss.com/docs/detecting-classes-in-source-files#dynamic-class-names) as the authoritative reference.

## Test plan

Documentation-only change — no runtime behavior affected. Verified markdown renders correctly.

## Human review checklist

- [ ] Do we want this guidance here (README) vs. STYLE_GUIDE or AGENTS.md? README was chosen because it's package-scoped and the first thing a contributor reads when working in the design library.
- [ ] Are the three pattern recommendations (Record, cva, cn) the right set to standardize on?
- [ ] Is the `cva.style/docs` link stable/correct?

Link to Devin session: https://app.devin.ai/sessions/57905118879948a69946c94c6cd332d7
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->