### PR TITLE
fix(cli/notifications): map list subcommand exit codes via exitCodeFromIpcResult

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -515,8 +515,37 @@ describe("notifications list", () => {
 
     const { parsed, exitCode } = await runCommand(["list"]);
 
-    expect(exitCode).toBe(1);
+    // Transport failure (no statusCode) maps to exit 10 per exitCodeFromIpcResult.
+    expect(exitCode).toBe(10);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Could not connect");
+  });
+
+  test("list maps daemon 4xx to exit 2", async () => {
+    ipcResponse = {
+      ok: false,
+      error: "Invalid limit",
+      statusCode: 400,
+    };
+
+    const { parsed, exitCode } = await runCommand(["list"]);
+
+    expect(exitCode).toBe(2);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Invalid limit");
+  });
+
+  test("list maps daemon 5xx to exit 3", async () => {
+    ipcResponse = {
+      ok: false,
+      error: "Internal daemon error",
+      statusCode: 500,
+    };
+
+    const { parsed, exitCode } = await runCommand(["list"]);
+
+    expect(exitCode).toBe(3);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Internal daemon error");
   });
 });

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -412,7 +412,7 @@ Examples:
 
               if (!result.ok) {
                 writeOutput(cmd, { ok: false, error: result.error });
-                process.exitCode = 1;
+                process.exitCode = exitCodeFromIpcResult(result);
                 return;
               }
 


### PR DESCRIPTION
Addresses feedback on #31012.

The `send` subcommand maps IPC error status codes to differentiated exit codes via `exitCodeFromIpcResult(result)`, but `list` hardcoded `process.exitCode = 1` for all IPC failures. This meant transport errors (should be 10), 4xx (should be 2), and 5xx (should be 3) all exited 1 for `list` — an inconsistency within the same file that broke scripts branching on exit codes.

## Changes
- `assistant/src/cli/commands/notifications.ts`: replace the hardcoded `process.exitCode = 1` in the `list` action's IPC-error branch with `exitCodeFromIpcResult(result)`, matching `send`.
- `assistant/src/cli/commands/__tests__/notifications.test.ts`: update the existing connection-failure test to expect exit 10 (no statusCode → transport error), and add two new cases covering 4xx → 2 and 5xx → 3 for `list`, mirroring the existing `send` coverage.

## Verification
`bun test src/cli/commands/__tests__/notifications.test.ts` → 22 pass, 0 fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->