### PR TITLE
fix(memory): preserve memoryRouter on BYOK installs and respect user customizations

### DIFF
--- a/assistant/src/__tests__/workspace-migration-087-memory-router-balanced-profile.test.ts
+++ b/assistant/src/__tests__/workspace-migration-087-memory-router-balanced-profile.test.ts
@@ -99,9 +99,18 @@ describe("087-memory-router-balanced-profile migration", () => {
     expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
   });
 
-  test("runs on non-Anthropic workspaces (unlike 077)", () => {
+  test("skips BYOK / non-Anthropic workspaces to avoid breaking memoryRouter", () => {
+    // `balanced` resolves to the managed Anthropic connection, which BYOK
+    // installs disable. Rewriting to `balanced` there would silently disable
+    // memory injection (getConfiguredProvider returns null). Preserve whatever
+    // memoryRouter config the workspace already has — including absence.
     writeConfig({
-      llm: { default: { provider: "openai", model: "gpt-5.4" } },
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+        callSites: {
+          memoryRouter: { model: "gpt-5.4" },
+        },
+      },
     });
 
     memoryRouterBalancedProfileMigration.run(workspaceDir);
@@ -109,10 +118,23 @@ describe("087-memory-router-balanced-profile migration", () => {
     const config = readConfig() as {
       llm: { callSites: Record<string, Record<string, unknown>> };
     };
-    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+    expect(config.llm.callSites.memoryRouter).toEqual({ model: "gpt-5.4" });
   });
 
-  test("overwrites user customizations on memoryRouter", () => {
+  test("skips BYOK workspaces with no existing memoryRouter entry", () => {
+    writeConfig({
+      llm: { default: { provider: "gemini" } },
+    });
+
+    memoryRouterBalancedProfileMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites?.memoryRouter).toBeUndefined();
+  });
+
+  test("preserves user customizations on memoryRouter (non-077-seeded shape)", () => {
     writeConfig({
       llm: {
         default: { provider: "anthropic" },
@@ -130,7 +152,10 @@ describe("087-memory-router-balanced-profile migration", () => {
     const config = readConfig() as {
       llm: { callSites: Record<string, Record<string, unknown>> };
     };
-    expect(config.llm.callSites.memoryRouter).toEqual({ profile: "balanced" });
+    expect(config.llm.callSites.memoryRouter).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      effort: "low",
+    });
   });
 
   test("is idempotent — second run does not change the call site", () => {

--- a/assistant/src/workspace/migrations/087-memory-router-balanced-profile.ts
+++ b/assistant/src/workspace/migrations/087-memory-router-balanced-profile.ts
@@ -3,9 +3,25 @@ import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";
 
-// Set callSites.memoryRouter to { profile: "balanced" }, dropping the explicit
-// model and 1M context-window override seeded by 077 — accepts page-index
-// truncation on workspaces larger than the balanced profile's context window.
+// Upgrade callSites.memoryRouter from the 077-seeded
+// {model: "claude-sonnet-4-6", contextWindow: {maxInputTokens: 1_000_000}}
+// shape to {profile: "balanced"} so the router rides the workspace's active
+// inference profile (with thinking enabled, higher effort, etc.) instead of a
+// bare model pin.
+//
+// Two skip conditions guard against runtime regressions:
+//
+//   1. BYOK / non-Anthropic workspaces. `balanced` resolves to the managed
+//      Anthropic connection (see seedInferenceProfiles), which off-platform
+//      installs explicitly disable. Forcing `balanced` there would make
+//      getConfiguredProvider("memoryRouter") return null and silently
+//      disable memory injection. Detect this by inspecting llm.default.provider
+//      — same heuristic migration 077 used to gate its seed.
+//
+//   2. User-customized memoryRouter config. If the existing entry isn't the
+//      exact 077-seeded shape (and isn't already {profile: "balanced"}), the
+//      user — or a platform overlay — chose those values deliberately. Match
+//      077's pattern of preserving any prior config.
 export const memoryRouterBalancedProfileMigration: WorkspaceMigration = {
   id: "087-memory-router-balanced-profile",
   description:
@@ -28,14 +44,16 @@ export const memoryRouterBalancedProfileMigration: WorkspaceMigration = {
     }
 
     const llm = readObject(config.llm) ?? {};
+
+    const explicitProvider = readString(readObject(llm.default)?.provider);
+    if (explicitProvider !== undefined && explicitProvider !== "anthropic") {
+      return;
+    }
+
     const callSites = readObject(llm.callSites) ?? {};
     const existing = readObject(callSites.memoryRouter);
 
-    if (
-      existing !== null &&
-      Object.keys(existing).length === 1 &&
-      existing.profile === "balanced"
-    ) {
+    if (existing !== null && !isSeededBy077(existing)) {
       return;
     }
 
@@ -49,9 +67,25 @@ export const memoryRouterBalancedProfileMigration: WorkspaceMigration = {
   },
 };
 
+// True when the entry looks exactly like what migration 077 wrote: a model pin
+// of claude-sonnet-4-6 plus the 1M-token context window, and nothing else.
+function isSeededBy077(entry: Record<string, unknown>): boolean {
+  const keys = Object.keys(entry);
+  if (keys.length !== 2) return false;
+  if (entry.model !== "claude-sonnet-4-6") return false;
+  const contextWindow = readObject(entry.contextWindow);
+  if (contextWindow === null) return false;
+  const cwKeys = Object.keys(contextWindow);
+  return cwKeys.length === 1 && contextWindow.maxInputTokens === 1_000_000;
+}
+
 function readObject(value: unknown): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
Addresses feedback on #31018.

Migration 087 unconditionally rewrote `llm.callSites.memoryRouter` to `{profile: "balanced"}` for all workspaces. Two problems:

1. **BYOK regression** (Codex P1): `balanced` resolves to the managed Anthropic connection, which off-platform installs disable. After enabling the router by default in #31018, this caused `getConfiguredProvider("memoryRouter")` to return `null` and silently disable memory injection on personal-OpenAI / Gemini installs.
2. **User customization clobber** (Devin): unlike migration 077, 087 overwrote user-defined memoryRouter config.

This PR adds two skip conditions to the migration's `run()`:

- **BYOK gate**: if `llm.default.provider` is explicitly set to a non-Anthropic provider, skip (mirrors 077's check).
- **User-customization gate**: only rewrite when the existing entry is absent or matches the exact 077-seeded shape (`{model: "claude-sonnet-4-6", contextWindow: {maxInputTokens: 1_000_000}}`). Anything else is preserved.

Migration id stays the same — modifying `run()` logic is safe because the runner records `applied` state and won't re-run for users who already applied 087.

## Test plan
- [x] `bun test src/__tests__/workspace-migration-087-memory-router-balanced-profile.test.ts` (10 pass)
- New test cases: BYOK with existing config, BYOK with no config, user-customized non-077 shape