### PR TITLE
fix(web): use Vite built-in base path handling and bind to all interfaces

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,35 @@
 import path from "node:path";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+const BASE = "/assistant/";
+
+/**
+ * Redirect /assistant → /assistant/ so the browser gets a proper 301 instead
+ * of Vite's default "did you mean /assistant/?" HTML interstitial page.
+ */
+function basePathRedirect(): Plugin {
+  return {
+    name: "base-path-redirect",
+    configureServer(server) {
+      const pathWithoutSlash = BASE.slice(0, -1);
+      server.middlewares.use((req, res, next) => {
+        if (req.url === pathWithoutSlash) {
+          res.writeHead(301, { Location: BASE });
+          res.end();
+          return;
+        }
+        next();
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  base: "/assistant/",
-  plugins: [tailwindcss(), react()],
+  base: BASE,
+  plugins: [basePathRedirect(), tailwindcss(), react()],
   resolve: {
     alias: {
       "@/": path.resolve(import.meta.dirname, "src") + "/",
@@ -14,6 +38,7 @@ export default defineConfig({
   server: {
     port: 3001,
     strictPort: true,
+    host: true,
   },
   build: {
     outDir: "dist",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,8 +16,12 @@ function basePathRedirect(): Plugin {
     configureServer(server) {
       const pathWithoutSlash = BASE.slice(0, -1);
       server.middlewares.use((req, res, next) => {
-        if (req.url === pathWithoutSlash) {
-          res.writeHead(301, { Location: BASE });
+        const url = req.url ?? "";
+        const qsIndex = url.indexOf("?");
+        const pathname = qsIndex === -1 ? url : url.slice(0, qsIndex);
+        if (pathname === pathWithoutSlash) {
+          const qs = qsIndex === -1 ? "" : url.slice(qsIndex);
+          res.writeHead(301, { Location: `${BASE}${qs}` });
           res.end();
           return;
         }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,39 +1,11 @@
 import path from "node:path";
-import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-const BASE = "/assistant/";
-
-/**
- * Redirect /assistant → /assistant/ so the browser gets a proper 301 instead
- * of Vite's default "did you mean /assistant/?" HTML interstitial page.
- */
-function basePathRedirect(): Plugin {
-  return {
-    name: "base-path-redirect",
-    configureServer(server) {
-      const pathWithoutSlash = BASE.slice(0, -1);
-      server.middlewares.use((req, res, next) => {
-        const url = req.url ?? "";
-        const qsIndex = url.indexOf("?");
-        const pathname = qsIndex === -1 ? url : url.slice(0, qsIndex);
-        if (pathname === pathWithoutSlash) {
-          const qs = qsIndex === -1 ? "" : url.slice(qsIndex);
-          res.writeHead(301, { Location: `${BASE}${qs}` });
-          res.end();
-          return;
-        }
-        next();
-      });
-    },
-  };
-}
-
 export default defineConfig({
-  base: BASE,
-  plugins: [basePathRedirect(), tailwindcss(), react()],
+  base: "/assistant",
+  plugins: [tailwindcss(), react()],
   resolve: {
     alias: {
       "@/": path.resolve(import.meta.dirname, "src") + "/",


### PR DESCRIPTION
## Prompt / plan

Two local dev issues surfaced after the initial scaffold (PR #31007) merged:

1. Visiting `localhost:3001/assistant` (no trailing slash) shows Vite's HTML interstitial page ("did you mean /assistant/?") instead of working directly.
2. The Caddy edge proxy (running in Docker via `docker-compose`) reverse-proxies to `host.docker.internal:3001`, but Vite only binds to `localhost` by default, causing HTTP 502.

## What this does

**Use `base` without trailing slash** — Changes `base: "/assistant/"` to `base: "/assistant"`. Since [Vite 4.0+](https://github.com/vitejs/vite/pull/10723), specifying `base` without a trailing slash means Vite natively handles both `/assistant` and `/assistant/` — no custom middleware or redirect plugin needed.

**Bind to all interfaces** — Adds `host: true` to the dev server config so Vite listens on `0.0.0.0:3001` instead of `127.0.0.1:3001`. This allows Docker containers on the same host to reach it via `host.docker.internal`.

Both changes are dev-server-only — they do not affect production builds.

## Test plan

- `curl -I http://localhost:3001/assistant` should serve the SPA (no interstitial)
- `curl -I http://localhost:3001/assistant/` should also work
- `curl -I http://localhost:3001/assistant/library` should serve the SPA
- Server binds to network interfaces (shown by `Network: http://172.x.x.x:3001/assistant/` in Vite output)

## Human review checklist

- [ ] Is `host: true` acceptable for local dev? It exposes the dev server on LAN — standard for Docker workflows but worth noting. Ref: [Vite server.host docs](https://vite.dev/config/server-options#server-host)
- [ ] Confirm Vite version in use is 4.0+ (required for trailing-slash-free `base` to work correctly)

Link to Devin session: https://app.devin.ai/sessions/57905118879948a69946c94c6cd332d7
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->