### PR TITLE
fix(oauth): retry 502s from platform proxy and add inter-wave backoff

### DIFF
--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -422,13 +422,16 @@ async function executeBatchCall(
 /** Max concurrent individual getMessage requests (matches batch concurrency) */
 const INDIVIDUAL_CONCURRENCY = BATCH_CONCURRENCY;
 
+/** Delay between waves of individual fetches to avoid rate-limit storms (ms). */
+const INTER_WAVE_DELAY_MS = 500;
+
 /**
  * Fetch all messages individually using getMessage (no batch endpoint).
  * Used as a fallback when the batch API is unavailable (e.g. platform connections
  * that cannot expose raw tokens for the multipart batch endpoint).
  *
- * Processes messages in waves of INDIVIDUAL_CONCURRENCY to avoid unbounded
- * parallelism that would trigger 429s on high-volume paths like senderDigest.
+ * Processes messages in waves of INDIVIDUAL_CONCURRENCY with a brief inter-wave
+ * delay to avoid triggering upstream rate limits on high-volume paths.
  */
 async function fetchMessagesIndividually(
   connection: OAuthConnection,
@@ -441,6 +444,10 @@ async function fetchMessagesIndividually(
   const results: GmailMessage[] = [];
   for (let i = 0; i < messageIds.length; i += INDIVIDUAL_CONCURRENCY) {
     signal?.throwIfAborted();
+    // Delay between waves (skip before the first wave)
+    if (i > 0) {
+      await signalAwareSleep(INTER_WAVE_DELAY_MS, signal);
+    }
     const wave = messageIds.slice(i, i + INDIVIDUAL_CONCURRENCY);
     const waveResults = await Promise.all(
       wave.map((id) =>

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -261,17 +261,57 @@ describe("PlatformOAuthConnection", () => {
     ).rejects.toThrow(CredentialRequiredError);
   });
 
-  test("502 response throws ProviderUnreachableError", async () => {
+  test("502 response retries then throws ProviderUnreachableError", async () => {
+    let callCount = 0;
     const client = makeMockClient(
-      mock(
-        async () => new Response("", { status: 502 }),
-      ) as unknown as typeof globalThis.fetch,
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 502 });
+      }) as unknown as typeof globalThis.fetch,
     );
 
     const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
     await expect(
       conn.request({ method: "GET", path: "/test" }),
     ).rejects.toThrow(ProviderUnreachableError);
+    // 1 initial + 3 retries = 4 total attempts
+    expect(callCount).toBe(4);
+  });
+
+  test("502 response includes detail from response body", async () => {
+    const client = makeMockClient(
+      mock(
+        async () => new Response("upstream timeout after 30s", { status: 502 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(/upstream timeout after 30s/);
+  });
+
+  test("502 recovers on retry", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response("", { status: 502 });
+        }
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: { ok: true } }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({ method: "GET", path: "/test" });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ ok: true });
+    expect(callCount).toBe(3);
   });
 
   test("withToken throws clear error", async () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,5 +1,6 @@
 import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
 import { getHttpRetryDelay, isRetryableStatus, sleep } from "../util/retry.js";
 import type {
   OAuthConnection,
@@ -7,6 +8,7 @@ import type {
   OAuthConnectionResponse,
 } from "./connection.js";
 
+const log = getLogger("platform-oauth-connection");
 const MAX_RETRIES = 3;
 
 export class CredentialRequiredError extends BackendError {
@@ -111,17 +113,24 @@ export class PlatformOAuthConnection implements OAuthConnection {
         throw new CredentialRequiredError();
       }
 
-      if (response.status === 502) {
-        throw new ProviderUnreachableError();
-      }
-
       if (
         !response.ok &&
         isRetryableStatus(response.status) &&
         attempt < MAX_RETRIES
       ) {
+        log.warn(
+          { status: response.status, attempt, provider: "platform-proxy" },
+          `Retryable status ${response.status} from platform proxy (attempt ${attempt + 1}/${MAX_RETRIES + 1})`,
+        );
         await sleep(getHttpRetryDelay(response, attempt));
         continue;
+      }
+
+      if (response.status === 502) {
+        const detail = await response.text().catch(() => "");
+        throw new ProviderUnreachableError(
+          `The external service provider is temporarily unreachable (HTTP 502).${detail ? ` Detail: ${detail}` : ""} This may be a transient issue — retry after a brief pause.`,
+        );
       }
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- **502 now retried**: Platform proxy 502 responses are retried with exponential backoff (up to 3 retries) instead of failing immediately. After retries are exhausted, the error now includes the response body for diagnostics.
- **Inter-wave delay**: Individual message fetches (used by platform-managed connections that can't access the batch API) now wait 500ms between waves to avoid triggering upstream rate limits.
- **Logging**: Added warn-level logging on each retryable status from the platform proxy for observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->