### PR TITLE
fix(compactor): preserve tool_use/tool_result pairing across cut

### DIFF
--- a/assistant/src/__tests__/compactor-tail-resolution.test.ts
+++ b/assistant/src/__tests__/compactor-tail-resolution.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from "bun:test";
 
-import { canonicalDateTimeKey } from "../context/compactor.js";
+import {
+  adjustTailIndexForToolPairing,
+  canonicalDateTimeKey,
+} from "../context/compactor.js";
+import type { Message } from "../providers/types.js";
+
+const userText = (text: string): Message => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+const userToolResult = (toolUseId: string): Message => ({
+  role: "user",
+  content: [{ type: "tool_result", tool_use_id: toolUseId, content: "ok" }],
+});
+
+const userToolResultAndText = (toolUseId: string, text: string): Message => ({
+  role: "user",
+  content: [
+    { type: "tool_result", tool_use_id: toolUseId, content: "ok" },
+    { type: "text", text },
+  ],
+});
+
+const assistantToolUse = (id: string): Message => ({
+  role: "assistant",
+  content: [{ type: "tool_use", id, name: "Bash", input: {} }],
+});
+
+const assistantText = (text: string): Message => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+});
+
+const assistantWebSearch = (id: string): Message => ({
+  role: "assistant",
+  content: [
+    { type: "server_tool_use", id, name: "web_search", input: {} },
+    { type: "web_search_tool_result", tool_use_id: id, content: [] },
+  ],
+});
 
 describe("canonicalDateTimeKey", () => {
   const stored = "2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)";
@@ -37,5 +77,71 @@ describe("canonicalDateTimeKey", () => {
     expect(canonicalDateTimeKey("hello world")).toBeNull();
     expect(canonicalDateTimeKey("2026-04-02")).toBeNull();
     expect(canonicalDateTimeKey("01:52:33")).toBeNull();
+  });
+});
+
+describe("adjustTailIndexForToolPairing", () => {
+  it("returns tailIndex unchanged when the tail starts on a clean user turn", () => {
+    const messages: Message[] = [
+      userText("hi"),
+      assistantText("hello"),
+      userText("how are you"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 2)).toBe(2);
+  });
+
+  it("walks back past the orphan tool_result cluster to the prior user turn", () => {
+    const messages: Message[] = [
+      userText("setup"),
+      assistantText("ok"),
+      userText("run a command"),
+      assistantToolUse("X"),
+      userToolResult("X"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 4)).toBe(2);
+  });
+
+  it("keeps walking when the candidate also leads with tool_result", () => {
+    const messages: Message[] = [
+      userText("first"),
+      userText("second"),
+      assistantToolUse("X1"),
+      userToolResult("X1"),
+      assistantToolUse("X2"),
+      userToolResult("X2"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 5)).toBe(1);
+  });
+
+  it("returns 0 when the walk falls off the front of the array", () => {
+    const messages: Message[] = [
+      userToolResult("X"),
+      assistantToolUse("Y"),
+      userToolResult("Y"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 2)).toBe(0);
+  });
+
+  it("ignores server-side web_search_tool_result blocks", () => {
+    const messages: Message[] = [
+      userText("look it up"),
+      assistantWebSearch("WS1"),
+      userText("thanks"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 2)).toBe(2);
+  });
+
+  it("treats mixed tool_result + text user messages as unsafe", () => {
+    const messages: Message[] = [
+      userText("kick off"),
+      assistantToolUse("X"),
+      userToolResultAndText("X", "and here is more text"),
+    ];
+    expect(adjustTailIndexForToolPairing(messages, 2)).toBe(0);
+  });
+
+  it("returns tailIndex unchanged when tailIndex is 0", () => {
+    const messages: Message[] = [userText("only one")];
+    expect(adjustTailIndexForToolPairing(messages, 0)).toBe(0);
   });
 });

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -439,6 +439,42 @@ function resolveTailStartIndex(
   return null;
 }
 
+/**
+ * Walk a model-chosen tail index backward until it lands on a user message
+ * that does not contain client-side `tool_result` blocks. Prevents the
+ * orphan-`tool_result` failure where the matching assistant `tool_use` sits
+ * in the discarded prefix and Anthropic rejects the next call with
+ * `unexpected tool_use_id found in tool_result blocks`.
+ *
+ * Walking back (rather than forward) preserves the recent context the model
+ * deliberately chose to keep; the tail just expands by the few messages
+ * needed to re-anchor the orphaned `tool_result` against its `tool_use`.
+ *
+ * Returns 0 when the walk falls off the front — the caller treats this as
+ * "nothing to compact" via the existing `tailIndex === 0` branch.
+ *
+ * Only `type === "tool_result"` blocks count. Server-side tools
+ * (`server_tool_use` / `web_search_tool_result`) are self-paired inside an
+ * assistant message and never trigger an adjustment.
+ */
+export function adjustTailIndexForToolPairing(
+  messages: Message[],
+  tailIndex: number,
+): number {
+  let k = tailIndex;
+  while (k > 0) {
+    const m = messages[k];
+    if (
+      m.role === "user" &&
+      !m.content.some((block) => block.type === "tool_result")
+    ) {
+      return k;
+    }
+    k--;
+  }
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Retained-image hydration
 // ---------------------------------------------------------------------------
@@ -655,8 +691,12 @@ export async function runAssistantDrivenCompaction(
   }
 
   const timestamps = buildTimestampIndex(args.messages);
-  const tailIndex = resolveTailStartIndex(args.messages, timestamps, parsed);
-  if (tailIndex == null) {
+  const resolvedTailIndex = resolveTailStartIndex(
+    args.messages,
+    timestamps,
+    parsed,
+  );
+  if (resolvedTailIndex == null) {
     log.warn(
       {
         timestamp: parsed.tailStartTimestamp,
@@ -678,6 +718,22 @@ export async function runAssistantDrivenCompaction(
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
       summaryCalls: 1,
     };
+  }
+
+  const tailIndex = adjustTailIndexForToolPairing(
+    args.messages,
+    resolvedTailIndex,
+  );
+  if (tailIndex !== resolvedTailIndex) {
+    log.info(
+      {
+        conversationId: args.conversationId,
+        originalTailIndex: resolvedTailIndex,
+        tailIndex,
+        walkedBy: resolvedTailIndex - tailIndex,
+      },
+      "Adjusted compaction tail backward to preserve tool_use/tool_result pairing",
+    );
   }
 
   if (tailIndex === 0) {
@@ -762,6 +818,9 @@ export async function runAssistantDrivenCompaction(
       compactedMessages: compactableMessages.length,
       compactedPersistedMessages,
       tailIndex,
+      ...(tailIndex !== resolvedTailIndex
+        ? { originalTailIndex: resolvedTailIndex }
+        : {}),
       retainedImages: resolved.length,
       summaryChars: summaryText.length,
     },
@@ -885,10 +944,12 @@ export async function runEmergencyCompaction(
 
   const splitIndex = findLastToolPairStart(args.messages);
   if (splitIndex == null || splitIndex === 0) {
-    log.info(
-      "Emergency compaction: no tool pair found — falling through",
+    log.info("Emergency compaction: no tool pair found — falling through");
+    return emptyResult(
+      args,
+      thresholdTokens,
+      "no tool pair for emergency split",
     );
-    return emptyResult(args, thresholdTokens, "no tool pair for emergency split");
   }
 
   const keptTail = stripInjectionsForCompaction(
@@ -904,8 +965,7 @@ export async function runEmergencyCompaction(
   const prefixBudget = args.maxInputTokens - instructionBudget - outputBudget;
 
   let prefixEstimate = estimatePromptTokens(prefix, args.systemPrompt, {
-    providerName:
-      args.provider.tokenEstimationProvider ?? args.provider.name,
+    providerName: args.provider.tokenEstimationProvider ?? args.provider.name,
   });
 
   if (prefixEstimate > prefixBudget && prefix.length > 1) {
@@ -920,10 +980,7 @@ export async function runEmergencyCompaction(
     // Drop messages from the front until we fit. Keep at least the first
     // message (may be an existing summary) and try to preserve recent context.
     let dropCount = 0;
-    while (
-      prefixEstimate > prefixBudget &&
-      dropCount < prefix.length - 1
-    ) {
+    while (prefixEstimate > prefixBudget && dropCount < prefix.length - 1) {
       dropCount++;
       const truncated = prefix.slice(dropCount);
       prefixEstimate = estimatePromptTokens(truncated, args.systemPrompt, {
@@ -1015,7 +1072,8 @@ export async function runEmergencyCompaction(
       compactedMessages: compactedCount,
       keptTailMessages: keptTail.length,
       summaryChars: summaryText.length,
-      prefixTruncated: prefix[0]?.content?.[0]?.type === "text" &&
+      prefixTruncated:
+        prefix[0]?.content?.[0]?.type === "text" &&
         (prefix[0].content[0] as { text: string }).text.includes("truncated"),
     },
     "Applied emergency mid-turn compaction",


### PR DESCRIPTION
## Summary

- `runAssistantDrivenCompaction` now nudges the model-chosen `tailIndex` backward to a user message that does not lead with `tool_result` blocks before slicing the tail.
- New exported helper `adjustTailIndexForToolPairing` in `assistant/src/context/compactor.ts` plus unit coverage in `assistant/src/__tests__/compactor-tail-resolution.test.ts`.
- When the walk reaches index 0, the existing "tail at head — nothing to compact" branch handles abort; an `info` log records the adjustment when it fires.

## Original prompt

A production compaction at `tailIndex: 90` produced a payload where the leading tail user message carried a `tool_result` block whose matching `tool_use` had been summarized away. Anthropic rejected the next call 281 ms later with `messages.2.content.0: unexpected tool_use_id found in tool_result blocks` and the conversation stalled. The compactor needed to stop landing the cut on a message whose tool-pairing partner is about to be discarded, without losing recent context the model deliberately chose to preserve.

## Test plan

- [x] `cd assistant && bun test src/__tests__/compactor-tail-resolution.test.ts`
- [x] `cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->