### PR TITLE
fix(compactor): suppress web_search guard on adjustTailIndexForToolPairing

### DIFF
--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -466,6 +466,8 @@ export function adjustTailIndexForToolPairing(
     const m = messages[k];
     if (
       m.role === "user" &&
+      // guard:allow-tool-result-only — server-side web_search_tool_result is
+      // self-paired inside its assistant message and never spans user turns.
       !m.content.some((block) => block.type === "tool_result")
     ) {
       return k;


### PR DESCRIPTION
## Summary
- Add inline `guard:allow-tool-result-only` annotation to the new `adjustTailIndexForToolPairing` check in `context/compactor.ts` so the `web_search_tool_result` structural guard test passes.
- The check is intentionally `tool_result`-only: server-side web_search_tool_result is self-paired inside its assistant message and never spans user-turn boundaries, so it never affects tail adjustment. The function's JSDoc already documents this; the inline annotation just brings the suppression marker into the guard's +/- 3 line window.

## Original prompt
CI job 76600405793 on run 26054883540 failed on `conversation-history-web-search.test.ts`: the "no source file has raw tool_result type checks without web_search_tool_result handling" structural guard flagged a new raw `block.type === "tool_result"` check at `context/compactor.ts:469`, introduced by the recent compactor tail-pairing fix (#31035). Fix only this specific CI failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->