### PR TITLE
fix(macos): de-dupe home detail panel when title == summary

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -22,7 +22,9 @@ struct HomeDetailPanel<Content: View>: View {
     static var defaultWidth: CGFloat { 601 }
 
     let icon: VIcon?
-    let title: String
+    /// Pass `nil` (or a whitespace-only string) to suppress the header title
+    /// when the body already conveys it.
+    let title: String?
     /// Optional foreground tint for the icon chip. Falls back to
     /// `VColor.primaryBase` when `nil`.
     var iconForeground: Color? = nil
@@ -92,10 +94,12 @@ struct HomeDetailPanel<Content: View>: View {
                         .accessibilityHidden(true)
                 }
 
-                Text(title)
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentEmphasized)
-                    .accessibilityAddTraits(.isHeader)
+                if let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(title)
+                        .font(VFont.titleSmall)
+                        .foregroundStyle(VColor.contentEmphasized)
+                        .accessibilityAddTraits(.isHeader)
+                }
             }
 
             Spacer(minLength: 0)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -264,9 +264,18 @@ extension MainWindowView {
                 HomePermissionDetailCard(item: item)
             }
         case .generic(let item):
+            // When `title` is the same string as `summary`, the body row
+            // already conveys it — rendering both stacks the same text in
+            // the header and the content area.
+            let trimmedTitle = item.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedSummary = item.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+            let headerTitle: String? =
+                trimmedTitle.isEmpty || trimmedTitle == trimmedSummary
+                    ? nil
+                    : item.title
             HomeDetailPanel(
                 icon: iconForFeedItem(item),
-                title: item.title,
+                title: headerTitle,
                 iconForeground: iconForegroundForFeedItem(item),
                 iconBackground: iconBackgroundForFeedItem(item),
                 onGoToThread: goToThreadHandler(for: item),


### PR DESCRIPTION
## Summary

- Make `HomeDetailPanel.title` optional and skip the header `Text(title)` when nil or whitespace-only.
- In the generic case of `PanelCoordinator.homeDetailPanelContent`, pass `nil` for the header title when the trimmed `FeedItem.title` equals the trimmed `FeedItem.summary` (or is empty), so the body row carries the message and the header doesn't restate it.

## Original prompt

In the homepage notification center, when a notification was sent without an explicit `--title`, the daemon's notification pipeline filled the `FeedItem.title` with the same text as the body, so the right-side detail panel rendered the same text in its header *and* in its body — duplicative and pointless. The fix should drop the redundant title from the detail panel without disturbing call sites that do pass distinct titles (e.g. the permission-chat detail card and the component gallery).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->