### PR TITLE
fix(notifications): suppress OS banner for non-urgent signals

### DIFF
--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -295,6 +295,7 @@ describe("guardian-dispatch", () => {
       conversationId: "conv-from-thread-created",
       title: "Guardian alert",
       sourceEventName: "guardian.question",
+      silent: false,
     };
     mockEmitResult = {
       signalId: "sig-4",

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -156,6 +156,7 @@ describe("notification deep-link metadata", () => {
             conversationId: "conv-123",
             conversationType: "notification",
           },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -179,6 +180,7 @@ describe("notification deep-link metadata", () => {
         {
           sourceEventName: "test.event",
           copy: { title: "Alert", body: "No deep link" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -199,6 +201,7 @@ describe("notification deep-link metadata", () => {
           sourceEventName: "guardian.question",
           copy: { title: "Guardian Question", body: "What is the code?" },
           deepLinkTarget: { conversationId },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -215,6 +218,7 @@ describe("notification deep-link metadata", () => {
         {
           sourceEventName: "test.event",
           copy: { title: "T", body: "B" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -231,6 +235,7 @@ describe("notification deep-link metadata", () => {
         {
           sourceEventName: "test.event",
           copy: { title: "T", body: "B" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -247,6 +252,7 @@ describe("notification deep-link metadata", () => {
         {
           sourceEventName: "guardian.question",
           copy: { title: "Alert", body: "Body" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -268,6 +274,7 @@ describe("notification deep-link metadata", () => {
             conversationId: "conv-task-run-42",
             workItemId: "work-item-7",
           },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -287,6 +294,7 @@ describe("notification deep-link metadata", () => {
           sourceEventName: "guardian.question",
           copy: { title: "Question", body: "Body" },
           deepLinkTarget: { conversationId: "conv-1", messageId: "msg-1" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -309,6 +317,7 @@ describe("notification deep-link metadata", () => {
           sourceEventName: "schedule.notify",
           copy: { title: "Reminder", body: "Take out the trash" },
           deepLinkTarget: { conversationId: "conv-new-convo-001" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -332,6 +341,7 @@ describe("notification deep-link metadata", () => {
             body: "Still need to take out the trash",
           },
           deepLinkTarget: { conversationId: "conv-reused-convo-042" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -358,6 +368,7 @@ describe("notification deep-link metadata", () => {
             conversationId: stableConversationId,
             messageId: "msg-seed-1",
           },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -371,6 +382,7 @@ describe("notification deep-link metadata", () => {
             conversationId: stableConversationId,
             messageId: "msg-seed-2",
           },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -402,6 +414,7 @@ describe("notification deep-link metadata", () => {
           sourceEventName: "schedule.notify",
           copy: { title: "Reminder", body: "First" },
           deepLinkTarget: { conversationId, messageId: "msg-a" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -411,6 +424,7 @@ describe("notification deep-link metadata", () => {
           sourceEventName: "schedule.notify",
           copy: { title: "Reminder", body: "Second" },
           deepLinkTarget: { conversationId, messageId: "msg-b" },
+          urgency: "medium",
         },
         { channel: "vellum" },
       );
@@ -442,6 +456,7 @@ describe("notification deep-link metadata", () => {
             sourceEventName: "activity.complete",
             copy: { title: "Activity", body },
             deepLinkTarget: { conversationId: boundConvId },
+            urgency: "medium",
           },
           { channel: "vellum" },
         );

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -31,8 +31,6 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-
-
 const emitCalls: unknown[] = [];
 let mockConversationCreated: ConversationCreatedInfo | null = null;
 let mockEmitResult: {
@@ -189,6 +187,7 @@ describe("ASK_GUARDIAN canonical notification path", () => {
       conversationId: "conv-from-thread-callback",
       title: "Guardian question",
       sourceEventName: "guardian.question",
+      silent: false,
     };
     mockEmitResult = {
       signalId: "sig-2",

--- a/assistant/src/__tests__/notification-platform-adapter.test.ts
+++ b/assistant/src/__tests__/notification-platform-adapter.test.ts
@@ -37,7 +37,8 @@ interface FetchCall {
 }
 
 const fetchCalls: FetchCall[] = [];
-const fetchResponses: Array<{ ok: boolean; status: number; body?: string }> = [];
+const fetchResponses: Array<{ ok: boolean; status: number; body?: string }> =
+  [];
 let clientAvailable = true;
 
 mock.module("../platform/client.js", () => ({
@@ -84,6 +85,7 @@ function makePayload(
     copy: { title: "Reminder", body: "Check the oven!" },
     deepLinkTarget: { type: "conversation", id: "conv-1" },
     contextPayload: { jobId: "job-1" },
+    urgency: "medium",
     ...overrides,
   };
 }
@@ -118,9 +120,7 @@ describe("PlatformPushAdapter", () => {
     expect(fetchCalls).toHaveLength(1);
 
     const call = fetchCalls[0]!;
-    expect(call.path).toBe(
-      "/v1/assistants/test-assistant-id/push/dispatch/",
-    );
+    expect(call.path).toBe("/v1/assistants/test-assistant-id/push/dispatch/");
     expect(call.method).toBe("POST");
     expect(call.body.delivery_id).toBe("delivery-uuid-1");
     expect(call.body.source_event_name).toBe("schedule.notify");
@@ -216,6 +216,7 @@ describe("PlatformPushAdapter", () => {
     const payload: ChannelDeliveryPayload = {
       sourceEventName: "schedule.notify",
       copy: { title: "Hi", body: "Hello" },
+      urgency: "medium",
     };
 
     const result = await adapter.send(payload, makeDestination());

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -58,6 +58,7 @@ function makePayload(
       title: "Reminder",
       body: "Check the oven now!",
     },
+    urgency: "medium",
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/notification-vellum-adapter.test.ts
+++ b/assistant/src/__tests__/notification-vellum-adapter.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import { VellumAdapter } from "../notifications/adapters/macos.js";
+import type {
+  ChannelDeliveryPayload,
+  ChannelDestination,
+} from "../notifications/types.js";
+
+function makePayload(
+  overrides?: Partial<ChannelDeliveryPayload>,
+): ChannelDeliveryPayload {
+  return {
+    deliveryId: "delivery-uuid-1",
+    sourceEventName: "schedule.notify",
+    copy: { title: "Reminder", body: "Hello" },
+    urgency: "medium",
+    ...overrides,
+  };
+}
+
+function makeDestination(
+  overrides?: Partial<ChannelDestination>,
+): ChannelDestination {
+  return {
+    channel: "vellum",
+    ...overrides,
+  };
+}
+
+function captureBroadcast(): {
+  adapter: VellumAdapter;
+  sent: ServerMessage[];
+} {
+  const sent: ServerMessage[] = [];
+  const adapter = new VellumAdapter((msg) => sent.push(msg));
+  return { adapter, sent };
+}
+
+describe("VellumAdapter silent flag", () => {
+  test("non-urgent (low) urgency broadcasts silent: true", async () => {
+    const { adapter, sent } = captureBroadcast();
+    const result = await adapter.send(
+      makePayload({ urgency: "low" }),
+      makeDestination(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sent).toHaveLength(1);
+    const intent = sent[0] as Extract<
+      ServerMessage,
+      { type: "notification_intent" }
+    >;
+    expect(intent.type).toBe("notification_intent");
+    expect(intent.silent).toBe(true);
+  });
+
+  test("non-urgent (medium) urgency broadcasts silent: true", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(makePayload({ urgency: "medium" }), makeDestination());
+
+    const intent = sent[0] as Extract<
+      ServerMessage,
+      { type: "notification_intent" }
+    >;
+    expect(intent.silent).toBe(true);
+  });
+
+  test("urgent (high) urgency broadcasts silent: false", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(makePayload({ urgency: "high" }), makeDestination());
+
+    const intent = sent[0] as Extract<
+      ServerMessage,
+      { type: "notification_intent" }
+    >;
+    expect(intent.silent).toBe(false);
+  });
+
+  test("critical urgency broadcasts silent: false", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(makePayload({ urgency: "critical" }), makeDestination());
+
+    const intent = sent[0] as Extract<
+      ServerMessage,
+      { type: "notification_intent" }
+    >;
+    expect(intent.silent).toBe(false);
+  });
+
+  test("broadcasts title, body, deepLinkTarget, and deliveryId verbatim", async () => {
+    const { adapter, sent } = captureBroadcast();
+    await adapter.send(
+      makePayload({
+        deliveryId: "delivery-xyz",
+        copy: { title: "T", body: "B" },
+        deepLinkTarget: { conversationId: "conv-abc" },
+        urgency: "high",
+      }),
+      makeDestination(),
+    );
+
+    const intent = sent[0] as Extract<
+      ServerMessage,
+      { type: "notification_intent" }
+    >;
+    expect(intent.deliveryId).toBe("delivery-xyz");
+    expect(intent.title).toBe("T");
+    expect(intent.body).toBe("B");
+    expect(intent.deepLinkMetadata).toEqual({ conversationId: "conv-abc" });
+    expect(intent.silent).toBe(false);
+  });
+});

--- a/assistant/src/daemon/message-types/notifications.ts
+++ b/assistant/src/daemon/message-types/notifications.ts
@@ -14,6 +14,20 @@ export interface NotificationIntent {
    * Clients not bound to this guardian should ignore the notification.
    */
   targetGuardianPrincipalId?: string;
+  /**
+   * When true, the client must NOT post this intent to the OS notification
+   * surface (`UNUserNotificationCenter` on macOS). Non-banner side effects
+   * (guardian filtering, fallback dedup, mark-unseen + history catch-up on
+   * the paired conversation) still run. The home-feed inbox entry is
+   * written independently by `home-feed-side-effect.ts` and is unaffected
+   * by this flag.
+   *
+   * Set by the server based on `attentionHints.urgency`: true for
+   * `low`/`medium`, false for `high`/`critical`. The notification center
+   * is the always-on canonical inbox; the OS banner is reserved for
+   * signals the user opted into push for (urgency >= high).
+   */
+  silent?: boolean;
 }
 
 /** Server push — broadcast when a notification creates a new vellum conversation. */
@@ -39,6 +53,13 @@ export interface NotificationConversationCreated {
    * conversation is attributed correctly.
    */
   source?: string;
+  /**
+   * Mirrors `NotificationIntent.silent`. When true the client must not
+   * post a fallback OS banner for this conversation — the sidebar entry
+   * still appears, but the always-on inbox is the only surfaced channel.
+   * Derived from the originating signal's `attentionHints.urgency`.
+   */
+  silent?: boolean;
 }
 
 /** Client ack sent after UNUserNotificationCenter.add() completes (or fails). */

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -3,8 +3,13 @@
  * and mobile clients via the daemon's event broadcast mechanism.
  *
  * The adapter broadcasts a `notification_intent` message that the Vellum
- * client can use to display a native notification (e.g. NSUserNotification
- * or UNUserNotificationCenter).
+ * client uses for two distinct purposes: paired-conversation bookkeeping
+ * (mark-unseen + history catch-up, fallback dedup) and posting an OS
+ * banner via `UNUserNotificationCenter`. The banner posting is gated by
+ * the `silent` flag — set to true for non-urgent (`low`/`medium`) signals
+ * so the notification center inbox still receives the entry but the OS
+ * does not surface a push banner. Urgent signals (`high`/`critical`)
+ * broadcast with `silent: false` and fire the banner.
  *
  * Guardian-sensitive notifications (approval requests, escalation alerts)
  * are annotated with `targetGuardianPrincipalId` so that only clients
@@ -75,6 +80,9 @@ export class VellumAdapter implements ChannelAdapter {
           ? guardianPrincipalId
           : undefined;
 
+      const silent =
+        payload.urgency !== "high" && payload.urgency !== "critical";
+
       this.broadcast({
         type: "notification_intent",
         deliveryId: payload.deliveryId,
@@ -83,6 +91,7 @@ export class VellumAdapter implements ChannelAdapter {
         body: payload.copy.body,
         deepLinkMetadata: payload.deepLinkTarget,
         targetGuardianPrincipalId,
+        silent,
       } as ServerMessage);
 
       log.info(
@@ -90,6 +99,7 @@ export class VellumAdapter implements ChannelAdapter {
           sourceEventName: payload.sourceEventName,
           title: payload.copy.title,
           guardianScoped: targetGuardianPrincipalId != null,
+          silent,
         },
         "Vellum notification intent broadcast",
       );

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -45,6 +45,11 @@ export interface ConversationCreatedInfo {
   groupId?: string;
   /** Semantic source from the signal producer (e.g. "schedule", "reminder"). */
   source?: string;
+  /**
+   * Mirrors the vellum adapter's `silent` flag. When true the client
+   * must skip the fallback OS banner — the sidebar entry still appears.
+   */
+  silent: boolean;
 }
 export type OnConversationCreatedFn = (info: ConversationCreatedInfo) => void;
 export interface BroadcastDecisionOptions {
@@ -252,6 +257,9 @@ export class NotificationBroadcaster {
 
         const conversationTitle =
           copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
+        const conversationSilent =
+          signal.attentionHints.urgency !== "high" &&
+          signal.attentionHints.urgency !== "critical";
         const info: ConversationCreatedInfo = {
           conversationId: pairing.conversationId,
           title: conversationTitle,
@@ -259,6 +267,7 @@ export class NotificationBroadcaster {
           targetGuardianPrincipalId,
           groupId: signal.conversationMetadata?.groupId,
           source: signal.conversationMetadata?.source,
+          silent: conversationSilent,
         };
 
         // The per-dispatch onConversationCreated callback fires whenever a vellum
@@ -306,6 +315,7 @@ export class NotificationBroadcaster {
         copy,
         deepLinkTarget,
         contextPayload: signal.contextPayload,
+        urgency: signal.attentionHints.urgency,
       };
 
       // Compute conversation decision audit fields for the delivery record

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -88,6 +88,7 @@ function getBroadcaster(): NotificationBroadcaster {
           targetGuardianPrincipalId: info.targetGuardianPrincipalId,
           groupId: info.groupId,
           source: info.source,
+          silent: info.silent,
         });
         log.info(
           {

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -7,6 +7,7 @@
 
 import type { ChannelPolicies } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
+import type { AttentionHints } from "./signal.js";
 
 /**
  * Derived from the channel policy registry: only channels whose
@@ -81,6 +82,13 @@ export interface ChannelDeliveryPayload {
   deepLinkTarget?: Record<string, unknown>;
   /** Original signal context payload — available for channel-specific structured rendering. */
   contextPayload?: Record<string, unknown>;
+  /**
+   * Forwarded from the originating signal so adapters can make
+   * urgency-aware decisions (e.g. the vellum adapter suppresses the OS
+   * banner for non-urgent intents while still emitting the conversation
+   * pairing side effects).
+   */
+  urgency: AttentionHints["urgency"];
 }
 
 /** Interface that each channel adapter must implement. */

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -102,6 +102,15 @@ extension AppDelegate {
         // so no fallback is needed.
         guard !NSApp.isActive else { return }
 
+        // Silent conversations must not generate any OS banner — the sidebar
+        // entry plus the home-feed inbox are the only surfaced channels. The
+        // matching notification_intent will also arrive with silent=true; we
+        // skip scheduling the fallback so a slow intent can never race the
+        // 750ms timer into firing a banner.
+        if msg.silent == true {
+            return
+        }
+
         scheduleNotificationFallback(
             conversationId: msg.conversationId,
             title: sanitizedTitle,

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -418,6 +418,22 @@ extension AppDelegate {
             )
         }
 
+        // Silent intents reach the inbox via the home-feed file but must not
+        // fire an OS banner. Ack the delivery so the audit trail records the
+        // intentional suppression as a success, not a failure.
+        if msg.silent == true {
+            log.info("Skipping OS banner for silent notification_intent (source: \(msg.sourceEventName))")
+            if let deliveryId = msg.deliveryId {
+                sendNotificationIntentResult(
+                    deliveryId: deliveryId,
+                    success: true,
+                    errorMessage: nil,
+                    errorCode: nil
+                )
+            }
+            return
+        }
+
         postNotificationIntent(
             sourceEventName: msg.sourceEventName,
             title: msg.title,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2902,8 +2902,14 @@ public struct NotificationIntent: Codable, Sendable {
     /// displayed by clients whose guardian identity matches this principal ID.
     /// Clients not bound to this guardian should ignore the notification.
     public let targetGuardianPrincipalId: String?
+    /// When true, the client must NOT post this intent to the OS notification
+    /// surface (`UNUserNotificationCenter` on macOS). Non-banner side effects
+    /// (guardian filtering, fallback dedup, mark-unseen + history catch-up on
+    /// the paired conversation) still run. The home-feed inbox entry is
+    /// written independently and is unaffected by this flag.
+    public let silent: Bool?
 
-    public init(type: String, deliveryId: String? = nil, sourceEventName: String, title: String, body: String, deepLinkMetadata: [String: AnyCodable]? = nil, targetGuardianPrincipalId: String? = nil) {
+    public init(type: String, deliveryId: String? = nil, sourceEventName: String, title: String, body: String, deepLinkMetadata: [String: AnyCodable]? = nil, targetGuardianPrincipalId: String? = nil, silent: Bool? = nil) {
         self.type = type
         self.deliveryId = deliveryId
         self.sourceEventName = sourceEventName
@@ -2911,6 +2917,7 @@ public struct NotificationIntent: Codable, Sendable {
         self.body = body
         self.deepLinkMetadata = deepLinkMetadata
         self.targetGuardianPrincipalId = targetGuardianPrincipalId
+        self.silent = silent
     }
 }
 
@@ -2989,8 +2996,11 @@ public struct NotificationConversationCreated: Codable, Sendable {
     /// Semantic source of the conversation (e.g. "schedule", "reminder").
     /// Allows clients to override the default "notification" source.
     public let source: String?
+    /// Mirrors `NotificationIntent.silent`. When true, the client must
+    /// skip the fallback OS banner — the sidebar entry still appears.
+    public let silent: Bool?
 
-    public init(type: String, conversationId: String, title: String, sourceEventName: String, targetGuardianPrincipalId: String? = nil, groupId: String? = nil, source: String? = nil) {
+    public init(type: String, conversationId: String, title: String, sourceEventName: String, targetGuardianPrincipalId: String? = nil, groupId: String? = nil, source: String? = nil, silent: Bool? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.title = title
@@ -2998,6 +3008,7 @@ public struct NotificationConversationCreated: Codable, Sendable {
         self.targetGuardianPrincipalId = targetGuardianPrincipalId
         self.groupId = groupId
         self.source = source
+        self.silent = silent
     }
 }
 


### PR DESCRIPTION
## Summary
- Vellum channel now broadcasts \`notification_intent\` with \`silent: true\` when the signal's urgency is \`low\` or \`medium\`; macOS skips \`UNUserNotificationCenter.safeAdd\` for silent intents while still running guardian filtering, fallback dedup, and mark-unseen + history catch-up on the paired conversation.
- \`notification_conversation_created\` carries the same \`silent\` flag so \`AppDelegate+Conversations.handleNotificationConversationCreated\` skips scheduling the fallback banner timer when silent — closes the race where a slow intent could let the 750 ms fallback fire a banner.
- Home-feed inbox writes are unchanged (handled independently by \`home-feed-side-effect.ts\`), so the always-on inbox still receives every assistant_tool / background signal regardless of urgency.

## Original prompt
While testing the recent \`--preferred-channels\` additive fix (#31034), the user noticed that running \`assistant notifications send --message "..."\` without \`--urgent\` still posts a macOS OS-level banner. The intended model is that the notification center inbox is the always-on canonical surface and the OS push banner is reserved for signals explicitly marked urgent. Asked to flip the vellum delivery so non-urgent signals land in the inbox without firing a banner, and only urgent (\`high\`/\`critical\`) signals trigger \`UNUserNotificationCenter\`.

## Test plan
- [x] \`bunx tsc --noEmit\` clean.
- [x] New \`notification-vellum-adapter.test.ts\` covers all four urgency levels (low/medium → silent: true; high/critical → silent: false) plus a verbatim title/body/deep-link assertion.
- [x] Existing adapter, broadcaster, deep-link, guardian-dispatch, and home-feed-side-effect tests pass with the new required \`urgency\` field on \`ChannelDeliveryPayload\` and the new required \`silent\` field on \`ConversationCreatedInfo\`.
- [ ] After restart: \`assistant notifications send --message "silent test"\` → home-feed inbox entry appears, no OS banner; \`assistant notifications send --message "urgent test" --urgent\` → both banner and inbox entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->