### PR TITLE
Add Doctor diagnostic tool to self-knowledge skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -892,7 +892,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-18T20:18:10+00:00"
+      "updatedAt": "2026-05-18T20:18:10Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -746,7 +746,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-18T09:42:41-06:00"
+      "updatedAt": "2026-05-18T14:08:28-06:00"
     },
     {
       "id": "typescript-eval",
@@ -892,7 +892,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-11T00:04:24-07:00"
+      "updatedAt": "2026-05-18T20:18:10+00:00"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -106,6 +106,13 @@ For questions the docs and CLI can't answer (internal architecture, how a specif
    - `assistant/docs/architecture/` — Detailed architecture docs (security, memory, etc.)
 6. Read the relevant source files to answer the question.
 
+### 4. Doctor — Diagnostic Tool (Platform Assistants Only)
+
+The Doctor is a built-in diagnostic tool available at **Settings → Debug → Doctor** (`/settings/debug?tab=doctor`).
+When a platform assistant encounters errors (connection failures, crash loops, out-of-storage), suggest running the Doctor to diagnose the issue.
+
+The Doctor is gated behind a feature flag and only available for platform-hosted assistants. If the user reports runtime issues, guide them to run the Doctor before escalating to support.
+
 ### Resolution Order
 
 1. **CLI first** — if the question is about current state, config, or capabilities, the CLI has it.


### PR DESCRIPTION
## Prompt / plan

Add the Doctor diagnostic tool to the vellum-self-knowledge skill so the assistant knows to suggest it when platform users encounter runtime issues.

## Test plan

Verified SKILL.md structure and frontmatter are valid. The addition follows the existing sources-of-truth pattern.

Link to Devin session: https://app.devin.ai/sessions/1606c5f871a843599a27c43b5270b845
Requested by: @m-abboud
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->