### PR TITLE
skill(app-builder): add Mobile-First Mode for ios interface

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -54,49 +54,66 @@ Each record is a JSON file at `<slug>/records/<uuid>.json` with shape:
 
 All new apps use `formatVersion: 2`: source files live under `src/` and compiled output lives under `dist/`. The build system compiles TSX to JS automatically when `app_refresh` is called.
 
-## Platform & Mobile-First Mode
+## Responsive Baseline & Mobile-First Mode
 
-The conversation context surfaces a `<turn_context>` block with an `interface:` field (values include `macos`, `ios`, `web`, `phone`). **When `interface` is a mobile interface (currently `ios`; any future mobile-web / android identifier counts too), build mobile-first.** Drop desktop defaults and apply the overrides below for this build.
+Every app must be responsive across the full width range — phone (~360px) to desktop (~1400px+). The conversation context's `<turn_context>` block carries an `interface:` field (values include `macos`, `ios`, `web`, `phone`); that field doesn't toggle responsiveness on or off — it shifts the **design priority**.
 
-When `interface` is `macos` or `web`, keep the desktop-flavored defaults from the rest of this skill. The app must still render acceptably at narrow widths, but design decisions should target the larger surface.
+- **`interface: ios`** (or any future mobile-web / android identifier) — mobile-first build. Design the narrow viewport first and progressively enhance upward at wider widths.
+- **`interface: macos` / `web`** — desktop-first build. Design the larger composition first; the narrow-width fallback must still meet the universal baseline below but doesn't need to feel like a native mobile app.
+- **Field absent or ambiguous** — default to desktop-first unless the user's request itself implies phone use ("for my iPhone home screen", "a tap-tracker I'll use on the go").
 
-When the field is absent or ambiguous, default to desktop — unless the user's request itself implies phone use (e.g. "for my iPhone home screen", "a tap-tracker I'll use on the go").
+### Universal baseline (every build, regardless of interface)
 
-### Mobile-first overrides
+These rules aren't mobile-specific — they're touch / responsive a11y baselines that any user-resizable WebView needs.
 
 **Viewport & safe areas**
 
 - Viewport meta: `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">`. Never set `user-scalable=no` — it blocks accessibility zoom.
-- Pad the root container with `env(safe-area-inset-*)` so content clears the notch and home indicator, e.g. `padding-top: max(var(--v-spacing-lg), env(safe-area-inset-top))`, mirrored for `-bottom`/`-left`/`-right`.
-- Use `100dvh` (dynamic viewport height), not `100vh`, for full-height containers. `vh` is wrong while the iOS address bar is showing and creates a layout jump on scroll.
+- Pad the root container with `env(safe-area-inset-*)` so content clears the notch / home indicator when the app is opened on a notched device: `padding-top: max(var(--v-spacing-lg), env(safe-area-inset-top))`, mirrored for `-bottom`/`-left`/`-right`. On desktop the env vars resolve to `0` and the `max()` falls through to the design-system value — no-op.
+- Use `100dvh` (dynamic viewport height), not `100vh`, for full-height containers. `100vh` creates a scroll-jump on every mobile browser regardless of build mode.
+
+**Form controls**
+
+- `<input>`, `<textarea>`, `<select>` must be `font-size: 16px` or larger, or iOS Safari will zoom on focus and break the layout. This applies to every build — anyone may open a desktop-built app on their phone.
+- Add `inputmode` to text fields with structured input: `numeric` for integers, `decimal` for amounts, `email`, `tel`, `url`. Add matching `autocomplete` and `autocapitalize` hints where appropriate.
+
+**Touch & hover**
+
+- Interactive elements (buttons, list rows, nav items, toggles, icon buttons) must be ≥44×44pt. `.v-button` already meets this; for custom controls, set `min-height: 44px` explicitly.
+- Gate hover affordances behind `@media (hover: hover)` so they don't stick on touch devices visiting a desktop-built app.
+- Disable text selection on app chrome (headers, nav, buttons) with `user-select: none; -webkit-user-select: none` so long-press doesn't pop the iOS selection menu over interactive elements.
+
+**Layout fluidity**
+
+- Fluid widths only — no fixed-pixel layouts. Use `%`, `fr`, `minmax`, `clamp()` instead of `px` on container widths.
+- Horizontal-scroll tables don't work on narrow screens. At narrow widths, collapse rows into stacked cards with labels and values arranged vertically. (Mobile-first builds can use cards everywhere; desktop-first builds can keep the table at wide widths and switch to cards below a breakpoint.)
+- `vellum.widgets.*` chart containers should be sized in `vw`/`%`, not fixed `px`. Prefer simpler chart types (sparkline, bar) at narrow widths — dense multi-series charts lose detail.
+
+### Mobile-first priorities (`interface: ios` or future mobile identifier)
+
+These are the **design priority differences** that mobile-first builds adopt on top of the universal baseline. They reflect "narrow viewport is the primary experience, wider widths progressively enhance."
 
 **Typography**
 
-- Default body text to `--v-font-size-lg` (17px), not `--v-font-size-base` (14px) — the desktop base is too small to read comfortably on a phone.
-- Form controls (`<input>`, `<textarea>`, `<select>`) must be `font-size: 16px` or larger, or iOS Safari will zoom on focus and break the layout.
+- Default body text to `--v-font-size-lg` (17px), not `--v-font-size-base` (14px) — the desktop base is too small to read comfortably on a phone. At wider widths the same 17px reads fine.
 
-**Tap targets & spacing**
+**Spacing**
 
-- Interactive elements (buttons, list rows, nav items, toggles, icon buttons) must be at least 44×44pt. `.v-button` already meets this; for custom controls, set `min-height: 44px` explicitly.
 - Bump default vertical rhythm one step (e.g. `--v-spacing-md` → `--v-spacing-lg` between cards and sections) so users can comfortably scroll-stop on each item.
 
 **Layout**
 
-- One column, top-to-bottom. No side rails, no two-pane master/detail, no fixed-width sidebars. Default to `flex-direction: column`; only opt into a multi-column grid above a width breakpoint (`@media (min-width: 720px)`).
-- Bottom-anchor the primary action (e.g. "Add", "Save") so the thumb can reach it: `position: sticky; bottom: env(safe-area-inset-bottom)` over the scrolling list.
+- One column as the **default**, not as a narrow-width fallback. `flex-direction: column` first; opt into a multi-column grid only above a width breakpoint (`@media (min-width: 720px)`). No side rails, no two-pane master/detail, no fixed-width sidebars in the default view.
+- Bottom-anchor the primary action (e.g. "Add", "Save") so the thumb can reach it: `position: sticky; bottom: env(safe-area-inset-bottom)` over the scrolling list. On wider widths you may re-flow it back inline.
 - Replace side modals and popovers with bottom sheets that animate up from the bottom edge.
-- Cards over tables. Horizontal-scroll tables don't work — render each row as a stacked card with labels and values vertically arranged.
 
 **Interaction**
 
-- Don't rely on `:hover` for affordance. Wrap hover styles in `@media (hover: hover)` so they don't stick on touch.
-- Skip the Tab/Enter/Esc keyboard pattern from "Interaction Standards" — on mobile, focus comes from taps, submit from the soft keyboard's `return`, dismissal from a swipe down on bottom sheets.
-- Add `inputmode` to text fields with structured input: `numeric` for integers, `decimal` for amounts, `email`, `tel`, `url`. Add matching `autocomplete` and `autocapitalize="off"` where appropriate.
-- Disable text selection on app chrome (headers, nav, buttons) with `user-select: none; -webkit-user-select: none` so long-press doesn't pop the iOS selection menu over interactive elements.
+- Skip the Tab/Enter/Esc keyboard pattern from "Interaction Standards" as the primary affordance — on mobile, focus comes from taps, submit from the soft keyboard's `return`, dismissal from a swipe down on bottom sheets. Keyboard support is still allowed (external-keyboard users exist on iPad) but isn't the design driver.
 
-**Charts & visualisations**
+### Desktop-first priorities (`interface: macos` / `web`)
 
-Use `vellum.widgets.*` chart helpers as usual — they handle DPI. Size containers in `vw`/`%`, not fixed `px`, and prefer simpler chart types (sparkline, bar) over dense multi-series charts that lose detail at small widths.
+The default behaviour the rest of this skill describes — multi-column composition, hover-rich affordances, denser information, side modals, inline primary actions. The universal baseline above is the floor: the narrow-width view must still work and follow the touch / responsive a11y rules, but it doesn't need to feel native to mobile.
 
 Everything else in this skill applies unchanged.
 
@@ -458,7 +475,7 @@ Every app must meet these baselines:
 - **Confirmation for destructive actions:** Use `window.vellum.confirm(title, message)` before deleting or resetting. Returns `Promise<boolean>`.
 - **Form validation:** Validate before submit, show errors inline, disable submit during async operations.
 - **Loading states:** Never show a blank screen while data loads. Use skeleton shimmer or spinners.
-- **Keyboard navigation:** `Tab` between elements, `Enter` to submit, `Escape` to close/cancel. *(Replaced by touch idioms on mobile — see [Mobile-First Mode](#platform--mobile-first-mode).)*
+- **Keyboard navigation:** `Tab` between elements, `Enter` to submit, `Escape` to close/cancel. *(De-prioritised on mobile-first builds — see [Responsive Baseline & Mobile-First Mode](#responsive-baseline--mobile-first-mode).)*
 
 ## Presentation Slide Design
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -54,6 +54,52 @@ Each record is a JSON file at `<slug>/records/<uuid>.json` with shape:
 
 All new apps use `formatVersion: 2`: source files live under `src/` and compiled output lives under `dist/`. The build system compiles TSX to JS automatically when `app_refresh` is called.
 
+## Platform & Mobile-First Mode
+
+The conversation context surfaces a `<turn_context>` block with an `interface:` field (values include `macos`, `ios`, `web`, `phone`). **When `interface` is a mobile interface (currently `ios`; any future mobile-web / android identifier counts too), build mobile-first.** Drop desktop defaults and apply the overrides below for this build.
+
+When `interface` is `macos` or `web`, keep the desktop-flavored defaults from the rest of this skill. The app must still render acceptably at narrow widths, but design decisions should target the larger surface.
+
+When the field is absent or ambiguous, default to desktop — unless the user's request itself implies phone use (e.g. "for my iPhone home screen", "a tap-tracker I'll use on the go").
+
+### Mobile-first overrides
+
+**Viewport & safe areas**
+
+- Viewport meta: `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">`. Never set `user-scalable=no` — it blocks accessibility zoom.
+- Pad the root container with `env(safe-area-inset-*)` so content clears the notch and home indicator, e.g. `padding-top: max(var(--v-spacing-lg), env(safe-area-inset-top))`, mirrored for `-bottom`/`-left`/`-right`.
+- Use `100dvh` (dynamic viewport height), not `100vh`, for full-height containers. `vh` is wrong while the iOS address bar is showing and creates a layout jump on scroll.
+
+**Typography**
+
+- Default body text to `--v-font-size-lg` (17px), not `--v-font-size-base` (14px) — the desktop base is too small to read comfortably on a phone.
+- Form controls (`<input>`, `<textarea>`, `<select>`) must be `font-size: 16px` or larger, or iOS Safari will zoom on focus and break the layout.
+
+**Tap targets & spacing**
+
+- Interactive elements (buttons, list rows, nav items, toggles, icon buttons) must be at least 44×44pt. `.v-button` already meets this; for custom controls, set `min-height: 44px` explicitly.
+- Bump default vertical rhythm one step (e.g. `--v-spacing-md` → `--v-spacing-lg` between cards and sections) so users can comfortably scroll-stop on each item.
+
+**Layout**
+
+- One column, top-to-bottom. No side rails, no two-pane master/detail, no fixed-width sidebars. Default to `flex-direction: column`; only opt into a multi-column grid above a width breakpoint (`@media (min-width: 720px)`).
+- Bottom-anchor the primary action (e.g. "Add", "Save") so the thumb can reach it: `position: sticky; bottom: env(safe-area-inset-bottom)` over the scrolling list.
+- Replace side modals and popovers with bottom sheets that animate up from the bottom edge.
+- Cards over tables. Horizontal-scroll tables don't work — render each row as a stacked card with labels and values vertically arranged.
+
+**Interaction**
+
+- Don't rely on `:hover` for affordance. Wrap hover styles in `@media (hover: hover)` so they don't stick on touch.
+- Skip the Tab/Enter/Esc keyboard pattern from "Interaction Standards" — on mobile, focus comes from taps, submit from the soft keyboard's `return`, dismissal from a swipe down on bottom sheets.
+- Add `inputmode` to text fields with structured input: `numeric` for integers, `decimal` for amounts, `email`, `tel`, `url`. Add matching `autocomplete` and `autocapitalize="off"` where appropriate.
+- Disable text selection on app chrome (headers, nav, buttons) with `user-select: none; -webkit-user-select: none` so long-press doesn't pop the iOS selection menu over interactive elements.
+
+**Charts & visualisations**
+
+Use `vellum.widgets.*` chart helpers as usual — they handle DPI. Size containers in `vw`/`%`, not fixed `px`, and prefer simpler chart types (sparkline, bar) over dense multi-series charts that lose detail at small widths.
+
+Everything else in this skill applies unchanged.
+
 ## Workflow
 
 ### 0. Preflight — Pin to a high-quality model
@@ -412,7 +458,7 @@ Every app must meet these baselines:
 - **Confirmation for destructive actions:** Use `window.vellum.confirm(title, message)` before deleting or resetting. Returns `Promise<boolean>`.
 - **Form validation:** Validate before submit, show errors inline, disable submit during async operations.
 - **Loading states:** Never show a blank screen while data loads. Use skeleton shimmer or spinners.
-- **Keyboard navigation:** `Tab` between elements, `Enter` to submit, `Escape` to close/cancel.
+- **Keyboard navigation:** `Tab` between elements, `Enter` to submit, `Escape` to close/cancel. *(Replaced by touch idioms on mobile — see [Mobile-First Mode](#platform--mobile-first-mode).)*
 
 ## Presentation Slide Design
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -56,7 +56,7 @@ All new apps use `formatVersion: 2`: source files live under `src/` and compiled
 
 ## Responsive Baseline & Mobile-First Mode
 
-Every app must be responsive across the full width range — phone (~360px) to desktop (~1400px+). The conversation context's `<turn_context>` block carries an `interface:` field (values include `macos`, `ios`, `web`, `phone`); that field doesn't toggle responsiveness on or off — it shifts the **design priority**.
+Every app must be responsive across the full width range — phone (~360px) to desktop (~1400px+). The conversation context's `<turn_context>` block carries an `interface:` field. Visual interfaces are `macos`, `ios`, and `web`; the field doesn't toggle responsiveness on or off — it shifts the **design priority**. Non-visual values like `phone` represent voice channels that can't render apps at all and don't need to be considered here.
 
 - **`interface: ios`** (or any future mobile-web / android identifier) — mobile-first build. Design the narrow viewport first and progressively enhance upward at wider widths.
 - **`interface: macos` / `web`** — desktop-first build. Design the larger composition first; the narrow-width fallback must still meet the universal baseline below but doesn't need to feel like a native mobile app.


### PR DESCRIPTION
## Summary

- Adds a `## Platform & Mobile-First Mode` section to `assistant/src/config/bundled-skills/app-builder/SKILL.md` that tells the agent to read the `<turn_context>` block's `interface:` field (already injected at `assistant/src/daemon/conversation-runtime-assembly.ts:859-860`) and switch to mobile-first defaults when it's `ios` (or any future mobile-web / android identifier).
- Mobile-first overrides cover: viewport / safe-area insets (`viewport-fit=cover`, `env(safe-area-inset-*)`, `100dvh`), typography minimums (17px body / ≥16px form controls to avoid iOS focus-zoom), 44pt tap targets, single-column layout with sticky bottom action, bottom sheets over side modals, cards over horizontal-scroll tables, `@media (hover: hover)` gating, `inputmode` / `autocomplete` hints, `user-select: none` on chrome, and `vw`/`%` chart sizing.
- Cross-referenced from the existing "Keyboard navigation" baseline in Interaction Standards so an agent landing there out of order still gets pointed at the new section.
- Pure prompt update — no code, no schema, no test changes. Desktop guidance is left exactly as-is for `macos`/`web` interfaces.

Closes #31043

## Test plan

- [x] Read the new section end-to-end for consistency with the rest of the skill (token names, code-fence formatting, anchor in cross-reference).
- [ ] Spot-check on iOS: ask the assistant to build a simple app (e.g. "habit tracker") from an iOS-interface conversation and confirm it uses single-column layout, ≥44pt tap targets, 16px+ form fields, `viewport-fit=cover`, and bottom-anchored primary action.
- [ ] Spot-check on macOS: confirm desktop builds are unchanged in feel — no accidental mobile defaults bleeding into the desktop path.

## Caveats worth flagging on review

- Detection is anchored on `<turn_context>`'s `interface` field rather than `<channel_capabilities>`'s `client_os`. The capabilities block is skipped on the "happy path" (full-capability non-macOS clients — which on iOS often qualifies), so `client_os: ios` is not reliably present. `interface:` in `<turn_context>` is always set when known.
- Future mobile interface names (`android`, `mobile-web`, etc.) are not enumerated in code yet. The prose says "currently `ios`; any future mobile-web / android identifier counts too" so the agent treats new names correctly without another skill update — happy to tighten this if the team has a preferred convention.
- The existing example app's `<meta viewport>` was deliberately left as-is (`width=device-width, initial-scale=1.0`). The Mobile section provides its own pattern (`viewport-fit=cover`) so the desktop example stays a clean reference for the desktop path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->