### PR TITLE
fix(context): use dimension-based image token estimate for all providers

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -219,36 +219,7 @@ describe("token estimator", () => {
     expect(largeFileTokens).toBe(smallFileTokens);
   });
 
-  // Non-Anthropic providers use base64 payload size for image estimation
-  test("scales image token estimate with base64 payload size (non-Anthropic)", () => {
-    const smallImageTokens = estimateContentBlockTokens(
-      {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: "image/png",
-          data: "a".repeat(64),
-        },
-      },
-      { providerName: "openai" },
-    );
-    const largeImageTokens = estimateContentBlockTokens(
-      {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: "image/png",
-          data: "a".repeat(60_000),
-        },
-      },
-      { providerName: "openai" },
-    );
-
-    expect(largeImageTokens).toBeGreaterThan(smallImageTokens);
-    expect(largeImageTokens - smallImageTokens).toBeGreaterThan(1000);
-  });
-
-  test("estimates Anthropic image tokens from dimensions, not base64 size", () => {
+  test("estimates image tokens from dimensions, not base64 size", () => {
     // Build a minimal valid PNG header encoding 1920x1080 dimensions.
     // PNG header: 8-byte signature + 4-byte IHDR length + 4-byte "IHDR" + 4-byte width + 4-byte height = 24 bytes minimum
     const pngHeader = Buffer.alloc(24);
@@ -278,55 +249,49 @@ describe("token estimator", () => {
     const fullPayload = Buffer.concat([pngHeader, padding]);
     const base64Data = fullPayload.toString("base64");
 
-    const anthropicTokens = estimateContentBlockTokens(
-      {
-        type: "image",
-        source: { type: "base64", media_type: "image/png", data: base64Data },
-      },
-      { providerName: "anthropic" },
-    );
-
     // 1920x1080 scaled to fit 1568px bounding box: dimScale = 1568/1920 = 0.8167
     // scaledWidth = round(1920 * 0.8167) = 1568, scaledHeight = round(1080 * 0.8167) = 882
     // pixels = 1568 * 882 = 1,382,976 > 1,200,000 → mpScale = sqrt(1200000/1382976) = 0.9315
     // scaledWidth = round(1568 * 0.9315) = 1461, scaledHeight = round(882 * 0.9315) = 822
     // tokens = ceil(1461 * 822 / 750) = ceil(1601.26) = ~1,602
-    // With IMAGE_BLOCK_OVERHEAD_TOKENS and media_type overhead, still well under 5000
-    expect(anthropicTokens).toBeLessThan(5_000);
-
-    // Verify it's NOT using base64 size (which would be ~50,000+ tokens)
-    const nonAnthropicTokens = estimateContentBlockTokens(
-      {
-        type: "image",
-        source: { type: "base64", media_type: "image/png", data: base64Data },
-      },
-      { providerName: "openai" },
-    );
-    expect(nonAnthropicTokens).toBeGreaterThan(50_000);
+    // With IMAGE_BLOCK_OVERHEAD_TOKENS and media_type overhead, still well under 5000.
+    // Same result for every provider — dimension-based estimate is universal.
+    for (const providerName of ["anthropic", "openai", "openrouter"]) {
+      const tokens = estimateContentBlockTokens(
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: base64Data },
+        },
+        { providerName },
+      );
+      expect(tokens).toBeLessThan(5_000);
+    }
   });
 
-  test("falls back to max tokens when Anthropic image dimensions can't be parsed", () => {
+  test("falls back to max tokens when image dimensions can't be parsed", () => {
     // Corrupted base64 that won't parse as a valid image header
     const corruptedData = Buffer.from(
       "not-a-valid-image-header-at-all",
     ).toString("base64");
 
-    const tokens = estimateContentBlockTokens(
-      {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: "image/png",
-          data: corruptedData,
+    for (const providerName of ["anthropic", "openai", "openrouter"]) {
+      const tokens = estimateContentBlockTokens(
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: corruptedData,
+          },
         },
-      },
-      { providerName: "anthropic" },
-    );
+        { providerName },
+      );
 
-    // Should fall back to ANTHROPIC_IMAGE_MAX_TOKENS (1,600)
-    // Total = 16 (block overhead) + ceil(9/4) (media_type) + 1600 = 1619
-    expect(tokens).toBeGreaterThanOrEqual(1_600);
-    expect(tokens).toBeLessThan(2_000);
+      // Falls back to the per-image cap (1,600 tokens). Total = 16 (block
+      // overhead) + ceil(9/4) (media_type) + 1600 = 1619.
+      expect(tokens).toBeGreaterThanOrEqual(1_600);
+      expect(tokens).toBeLessThan(2_000);
+    }
   });
 
   test("Anthropic image tokens are the same for same-dimension images regardless of payload size", () => {

--- a/assistant/src/__tests__/openrouter-token-estimation.test.ts
+++ b/assistant/src/__tests__/openrouter-token-estimation.test.ts
@@ -5,7 +5,11 @@ import { OpenRouterProvider } from "../providers/openrouter/client.js";
 import type { Message } from "../providers/types.js";
 
 /** Build a minimal valid PNG header encoding the given dimensions. */
-function makePngBase64(width: number, height: number, paddingBytes = 0): string {
+function makePngBase64(
+  width: number,
+  height: number,
+  paddingBytes = 0,
+): string {
   const header = Buffer.alloc(24);
   header[0] = 0x89;
   header[1] = 0x50;
@@ -41,13 +45,13 @@ describe("OpenRouterProvider token estimation routing", () => {
     expect(provider.tokenEstimationProvider).toBe("openrouter");
   });
 
-  test("estimatePromptTokens applies Anthropic image scaling when routed via OpenRouter", () => {
+  test("estimatePromptTokens applies dimension-based image scaling when routed via OpenRouter to Anthropic", () => {
     const provider = new OpenRouterProvider(
       "fake-key",
       "anthropic/claude-opus-4-6",
     );
     // 1920x1080 screenshot with ~200 KB of pixel data → base64/4 would be ~65k
-    // tokens; dimension-based Anthropic rules land around 1.6k tokens.
+    // tokens; dimension-based rules land around 1.6k tokens.
     const messages: Message[] = [
       {
         role: "user",
@@ -68,33 +72,38 @@ describe("OpenRouterProvider token estimation routing", () => {
       providerName: provider.tokenEstimationProvider,
     });
 
-    // Dimension-based estimate should be well under 5k; base64/4 would exceed 50k.
     expect(estimated).toBeLessThan(5_000);
   });
 
-  test("estimatePromptTokens falls back to base64/4 for non-Anthropic OpenRouter models", () => {
-    const provider = new OpenRouterProvider("fake-key", "x-ai/grok-4.20-beta");
-    const messages: Message[] = [
-      {
-        role: "user",
-        content: [
-          {
-            type: "image",
-            source: {
-              type: "base64",
-              media_type: "image/png",
-              data: makePngBase64(1920, 1080, 200_000),
+  test("estimatePromptTokens applies dimension-based image scaling for non-Anthropic OpenRouter models", () => {
+    // A naive base64/4 estimate on a 1920x1080 screenshot (~200 KB) lands near
+    // 65k tokens and trips spurious compaction long before the real context
+    // window fills. Vision models on OpenRouter — both anthropic/* and
+    // non-Anthropic (Kimi K2.6, Grok, etc.) — must use the dimension-based
+    // formula.
+    for (const model of ["moonshotai/kimi-k2.6", "x-ai/grok-4.20-beta"]) {
+      const provider = new OpenRouterProvider("fake-key", model);
+      const messages: Message[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: makePngBase64(1920, 1080, 200_000),
+              },
             },
-          },
-        ],
-      },
-    ];
+          ],
+        },
+      ];
 
-    const estimated = estimatePromptTokens(messages, "system", {
-      providerName: provider.tokenEstimationProvider,
-    });
+      const estimated = estimatePromptTokens(messages, "system", {
+        providerName: provider.tokenEstimationProvider,
+      });
 
-    // Base64/4 heuristic on ~200 KB of image data → far more than 10k tokens.
-    expect(estimated).toBeGreaterThan(50_000);
+      expect(estimated).toBeLessThan(5_000);
+    }
   });
 });

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -33,18 +33,24 @@ const OTHER_BLOCK_TOKENS = 16;
 const SYSTEM_PROMPT_OVERHEAD_TOKENS = 8;
 const GEMINI_INLINE_FILE_MIME_TYPES = new Set(["application/pdf"]);
 
-// Anthropic scales images to fit within 1568x1568 maintaining aspect ratio,
-// then charges ~(width * height) / 750 tokens.
-const ANTHROPIC_IMAGE_MAX_DIMENSION = 1568;
-// Anthropic caps images at ~1.2 megapixels in addition to the 1568px dimension limit.
-// Images exceeding this are further scaled down. The docs state images above ~1,600 tokens
-// are resized. 1,200,000 / 750 = 1,600 tokens, matching the documented threshold.
-// Reference table (max sizes that won't be resized):
+// Dimension-based image token estimate, used as a universal default for every
+// provider. The formula and constants below come from Anthropic's published
+// vision spec — scale to a 1568x1568 bounding box, then charge
+// ~(width * height) / 750 tokens, with a ~1.2-megapixel cap that lands at
+// ~1,600 tokens per image. Reference table (max sizes that won't be resized):
 //   1:1 → 1092x1092 (~1,590 tokens)   1:2 → 784x1568 (~1,639 tokens)
 // See: https://platform.claude.com/docs/en/build-with-claude/vision#evaluate-image-size
-const ANTHROPIC_IMAGE_MAX_PIXELS = 1_200_000;
-const ANTHROPIC_IMAGE_TOKENS_PER_PIXEL = 1 / 750;
-const ANTHROPIC_IMAGE_MAX_TOKENS = 1_600;
+//
+// Other multimodal providers (OpenAI/GPT-4V tile pricing, Moonshot/Kimi,
+// Gemini fixed-cost, OpenRouter pass-through) price differently in detail,
+// but every published rate lands in the same hundreds-to-low-thousands range
+// per image. Using this formula as the default gets compaction within ~2-3x
+// of reality instead of the ~30-100x over-counting produced by treating the
+// raw base64 payload as if it were text.
+const IMAGE_MAX_DIMENSION = 1568;
+const IMAGE_MAX_PIXELS = 1_200_000;
+const IMAGE_TOKENS_PER_PIXEL = 1 / 750;
+const IMAGE_MAX_TOKENS = 1_600;
 
 // Anthropic renders each PDF page as an image (~1,568 tokens at standard
 // resolution) plus any extracted text. Typical PDF pages are 50-150 KB.
@@ -103,45 +109,37 @@ function estimateFileDataTokens(
   return 0;
 }
 
-function estimateAnthropicImageTokens(width: number, height: number): number {
+function estimateImageTokensByDimensions(
+  width: number,
+  height: number,
+): number {
   // Step 1: Scale to fit within 1568px bounding box
-  const dimScale = Math.min(
-    1,
-    ANTHROPIC_IMAGE_MAX_DIMENSION / Math.max(width, height),
-  );
+  const dimScale = Math.min(1, IMAGE_MAX_DIMENSION / Math.max(width, height));
   let scaledWidth = Math.round(width * dimScale);
   let scaledHeight = Math.round(height * dimScale);
 
   // Step 2: Scale further if exceeds megapixel budget
   const pixels = scaledWidth * scaledHeight;
-  if (pixels > ANTHROPIC_IMAGE_MAX_PIXELS) {
-    const mpScale = Math.sqrt(ANTHROPIC_IMAGE_MAX_PIXELS / pixels);
+  if (pixels > IMAGE_MAX_PIXELS) {
+    const mpScale = Math.sqrt(IMAGE_MAX_PIXELS / pixels);
     scaledWidth = Math.round(scaledWidth * mpScale);
     scaledHeight = Math.round(scaledHeight * mpScale);
   }
 
-  return Math.ceil(
-    scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL,
-  );
+  return Math.ceil(scaledWidth * scaledHeight * IMAGE_TOKENS_PER_PIXEL);
 }
 
 function estimateImageTokens(
   block: Extract<ContentBlock, { type: "image" }>,
-  options?: TokenEstimatorOptions,
 ): number {
-  if (options?.providerName === "anthropic") {
-    const dims = parseImageDimensions(
-      block.source.data,
-      block.source.media_type,
-    );
-    if (dims) {
-      return estimateAnthropicImageTokens(dims.width, dims.height);
-    }
-    // Fallback: if dimensions can't be parsed, use Anthropic's max
-    return ANTHROPIC_IMAGE_MAX_TOKENS;
+  const dims = parseImageDimensions(block.source.data, block.source.media_type);
+  if (dims) {
+    return estimateImageTokensByDimensions(dims.width, dims.height);
   }
-  // Non-Anthropic: keep existing base64-size heuristic
-  return estimateTextTokens(block.source.data);
+  // Dimensions unparseable (corrupt header, exotic format): use the per-image
+  // cap rather than the raw base64 length, which over-counts by 30-100x for
+  // non-Anthropic providers and trips spurious compaction.
+  return IMAGE_MAX_TOKENS;
 }
 
 export function estimateContentBlockTokens(
@@ -188,7 +186,7 @@ export function estimateContentBlockTokens(
       return (
         IMAGE_BLOCK_OVERHEAD_TOKENS +
         estimateTextTokens(block.source.media_type) +
-        estimateImageTokens(block, options)
+        estimateImageTokens(block)
       );
     case "file":
       return (


### PR DESCRIPTION
## Summary
- Drop the `providerName === \"anthropic\"` branch in `estimateImageTokens` and route every provider through the dimension-based formula. Non-Anthropic vision models (e.g. Kimi K2.6 on OpenRouter) previously fell through to a base64-length/4 heuristic that over-counted a single 1920×1080 screenshot at ~65k tokens — 30–100× the real cost — tripping spurious compaction long before the real context window filled.
- The Anthropic formula (scale to 1568px, charge ~width·height/750 tokens, cap at ~1,600) lands within ~2–3× of every documented vision-model rate, so it serves as a sane universal default. Constants renamed from `ANTHROPIC_IMAGE_*` to drop the provider-specific prefix, and `estimateAnthropicImageTokens` renamed to `estimateImageTokensByDimensions`.
- Tests: flipped the OpenRouter non-Anthropic image-estimation test from asserting base64/4 overcount to asserting the dimension-based estimate, and added Kimi K2.6 to the covered cases. Updated `context-token-estimator.test.ts` accordingly.

## Original prompt
> I think we're misestimating image tokens for the purposes of compaction when using kimi k2.6 on openrouter

Confirmed: the estimator only used Anthropic's dimension formula for `providerName === \"anthropic\"`; every other provider used `ceil(base64.length / 4)`, which over-counts images by 30–100×. The fix is general — promote the dimension formula to the universal default — since the same bug affects every non-Anthropic vision model on every provider, not just Kimi K2.6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->