### PR TITLE
fix(openrouter): stop doubling Kimi K2.6 thinking tokens

### DIFF
--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+
+type ReasoningDetail = {
+  type?: string;
+  summary?: string | null;
+  text?: string | null;
+};
+
+type MockChunkDelta = {
+  content?: string | null;
+  reasoning?: string | null;
+  reasoning_content?: string | null;
+  reasoning_details?: ReasoningDetail[] | null;
+};
+
+type MockChunk = {
+  choices: Array<{ delta: MockChunkDelta; finish_reason?: string | null }>;
+  model?: string;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+  };
+};
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+function stubProvider(chunks: MockChunk[]): {
+  provider: OpenAIChatCompletionsProvider;
+  events: Array<{ type: string; thinking?: string; text?: string }>;
+} {
+  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model");
+  // Swap the SDK client for a stub whose chat.completions.create returns our
+  // canned async iterable.
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async () => makeStream(chunks),
+      },
+    },
+  };
+  const events: Array<{ type: string; thinking?: string; text?: string }> = [];
+  (provider as unknown as { __events: typeof events }).__events = events;
+  return { provider, events };
+}
+
+async function runStream(
+  provider: OpenAIChatCompletionsProvider,
+  events: Array<{ type: string; thinking?: string; text?: string }>,
+): Promise<{
+  thinking: string;
+}> {
+  const response = await provider.sendMessage(
+    [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    undefined,
+    undefined,
+    {
+      onEvent: (e) => {
+        events.push(e as { type: string; thinking?: string; text?: string });
+      },
+    },
+  );
+  const thinkingBlock = response.content.find((b) => b.type === "thinking") as
+    | { type: "thinking"; thinking: string }
+    | undefined;
+  return { thinking: thinkingBlock?.thinking ?? "" };
+}
+
+describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
+  test("emits flat reasoning_content once (Fireworks/DeepSeek/Together/Groq shape)", async () => {
+    const { provider, events } = stubProvider([
+      { choices: [{ delta: { reasoning_content: "hello " } }] },
+      { choices: [{ delta: { reasoning_content: "world" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas.map((d) => d.thinking)).toEqual(["hello ", "world"]);
+    expect(thinking).toBe("hello world");
+  });
+
+  test("emits flat reasoning once (OpenRouter non-Kimi shape)", async () => {
+    const { provider, events } = stubProvider([
+      { choices: [{ delta: { reasoning: "step " } }] },
+      { choices: [{ delta: { reasoning: "two" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas.map((d) => d.thinking)).toEqual(["step ", "two"]);
+    expect(thinking).toBe("step two");
+  });
+
+  test("emits reasoning_details once when only details present", async () => {
+    const { provider, events } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              reasoning_details: [{ type: "reasoning.text", text: "alpha " }],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.summary", summary: "beta" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas.map((d) => d.thinking)).toEqual(["alpha ", "beta"]);
+    expect(thinking).toBe("alpha beta");
+  });
+
+  test("skips reasoning.encrypted entries entirely", async () => {
+    const { provider, events } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.encrypted", text: "opaque" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas).toEqual([]);
+    expect(thinking).toBe("");
+  });
+
+  test("falls back to flat reasoning when details carry only encrypted entries", async () => {
+    const { provider, events } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              reasoning: "visible ",
+              reasoning_details: [
+                { type: "reasoning.encrypted", text: "opaque" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas.map((d) => d.thinking)).toEqual(["visible "]);
+    expect(thinking).toBe("visible ");
+  });
+
+  test("does NOT double-emit when Kimi K2.6 mirrors text into both fields", async () => {
+    // OpenRouter Kimi K2.6 with `reasoning.summary` set sends the same token
+    // in both `delta.reasoning` and `delta.reasoning_details[].text`. The
+    // structured field is preferred and the flat field is skipped, so each
+    // token appears exactly once in the output stream.
+    const { provider, events } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              reasoning: "it ",
+              reasoning_details: [{ type: "reasoning.text", text: "it " }],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              reasoning: "worked",
+              reasoning_details: [{ type: "reasoning.text", text: "worked" }],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              reasoning: "!",
+              reasoning_details: [{ type: "reasoning.text", text: "!" }],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 3 },
+      },
+    ]);
+    const { thinking } = await runStream(provider, events);
+    const deltas = events.filter((e) => e.type === "thinking_delta");
+    expect(deltas.map((d) => d.thinking)).toEqual(["it ", "worked", "!"]);
+    expect(thinking).toBe("it worked!");
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -309,8 +309,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
             // Compatibility providers disagree on the field name: Fireworks /
             // DeepSeek / Together / Groq stream `reasoning_content`; OpenRouter
-            // (per its ChatAssistantMessage spec) streams `reasoning`. Accept
-            // both so we don't silently drop thinking from either family.
+            // (per its ChatAssistantMessage spec) streams `reasoning`, and for
+            // reasoning summaries (e.g. Kimi K2.6) also populates
+            // `delta.reasoning_details[]` (entries are `reasoning.summary`,
+            // `reasoning.text`, or opaque `reasoning.encrypted`).
+            //
+            // Kimi K2.6 mirrors the same token into BOTH `delta.reasoning` and
+            // `delta.reasoning_details[].text` per chunk — prefer details when
+            // they carry visible text, otherwise fall through to the flat
+            // field. The encrypted-only case must fall through too, so the
+            // flat `reasoning` field isn't silently dropped.
             const deltaWithReasoning = choice.delta as {
               reasoning?: string | null;
               reasoning_content?: string | null;
@@ -320,29 +328,31 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 text?: string | null;
               }> | null;
             };
-            const reasoningContent =
-              deltaWithReasoning.reasoning_content ??
-              deltaWithReasoning.reasoning;
-            if (reasoningContent) {
-              reasoningText += reasoningContent;
-              onEvent?.({ type: "thinking_delta", thinking: reasoningContent });
-            }
 
-            // OpenRouter's documented streaming shape for reasoning summaries
-            // (e.g. Kimi K2.6) puts visible thinking under
-            // `delta.reasoning_details[]` with entries like
-            // `{ type: "reasoning.summary", summary: "..." }` or
-            // `{ type: "reasoning.text", text: "..." }`. `reasoning.encrypted`
-            // entries are opaque and skipped.
+            let sawVisibleDetail = false;
             const reasoningDetails = deltaWithReasoning.reasoning_details;
             if (Array.isArray(reasoningDetails)) {
               for (const entry of reasoningDetails) {
                 if (entry.type === "reasoning.encrypted") continue;
                 const piece = entry.summary ?? entry.text;
                 if (piece) {
+                  sawVisibleDetail = true;
                   reasoningText += piece;
                   onEvent?.({ type: "thinking_delta", thinking: piece });
                 }
+              }
+            }
+
+            if (!sawVisibleDetail) {
+              const reasoningContent =
+                deltaWithReasoning.reasoning_content ??
+                deltaWithReasoning.reasoning;
+              if (reasoningContent) {
+                reasoningText += reasoningContent;
+                onEvent?.({
+                  type: "thinking_delta",
+                  thinking: reasoningContent,
+                });
               }
             }
 


### PR DESCRIPTION
## Summary

- Restructure the OpenAI-compat chat-completions stream parser so the two reasoning sources are mutually exclusive: prefer `delta.reasoning_details[]` when it carries visible content, otherwise fall back to flat `delta.reasoning_content`/`delta.reasoning`.
- Fixes Kimi K2.6 via OpenRouter, which mirrors the same reasoning token into both fields per chunk and was being double-emitted (rendered as "itit worked worked!!" in the macOS Thought process UI).
- Adds a focused regression test covering Kimi K2.6 mirroring plus four other provider shapes (Fireworks/DeepSeek flat field, OpenRouter non-Kimi flat field, details-only, encrypted-only fallback).

## Original prompt

While streaming Kimi K2.6 thinking via OpenRouter the macOS Thought process panel rendered each token twice ("itit worked worked!! let let me me check check…"). Root-cause analysis traced it to the OpenAI-compat chat-completions stream parser in `chat-completions-provider.ts`, which had separate branches for `delta.reasoning` and `delta.reasoning_details[]` that both fired when OpenRouter populated both fields for Kimi K2.6 (forced into `reasoning.summary = "detailed"` mode). The fix makes the parser pick one source per chunk and pins the behavior with a focused regression test that mocks the OpenAI SDK stream.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->