### PR TITLE
fix(tests): update media-retry budget after dimension-based image token estimate

### DIFF
--- a/assistant/src/__tests__/conversation-media-retry.test.ts
+++ b/assistant/src/__tests__/conversation-media-retry.test.ts
@@ -23,7 +23,11 @@ function makeImageBlockWithSize(
 ): Extract<ContentBlock, { type: "image" }> {
   return {
     type: "image",
-    source: { type: "base64", media_type: "image/png", data: "A".repeat(dataLength) },
+    source: {
+      type: "base64",
+      media_type: "image/png",
+      data: "A".repeat(dataLength),
+    },
   };
 }
 
@@ -103,16 +107,19 @@ describe("stripMediaPayloadsForRetry", () => {
   // ---------------------------------------------------------------------------
 
   test("budget-aware: keeps images that fit within token budget", () => {
-    // Non-Anthropic estimation: estimateTextTokens(base64Data) + overhead (~19 tokens).
-    // Data length 4000 → 1000 data tokens + 19 overhead ≈ 1019 tokens/image.
-    // Budget of 3500 allows 3 images (3 * 1019 = 3057 <= 3500) but not 4.
-    const images = Array.from({ length: 5 }, () => makeImageBlockWithSize(4000));
+    // Dimension-based estimation: when the base64 data has no parseable image
+    // header, fall back to IMAGE_MAX_TOKENS (1600) + overhead (~19 tokens) ≈
+    // 1619 tokens/image. Budget of 5000 allows 3 images (3 * 1619 = 4857
+    // <= 5000) but not 4 (4 * 1619 = 6476 > 5000).
+    const images = Array.from({ length: 5 }, () =>
+      makeImageBlockWithSize(4000),
+    );
     const messages: Message[] = [
       makeUserMessage({ type: "text", text: "describe these" }, ...images),
     ];
 
     const result = stripMediaPayloadsForRetry(messages, {
-      mediaTokenBudget: 3500,
+      mediaTokenBudget: 5000,
       providerName: "mock",
     });
     expect(result.modified).toBe(true);
@@ -120,7 +127,9 @@ describe("stripMediaPayloadsForRetry", () => {
     const content = result.messages[0].content;
     const keptImages = content.filter((b) => b.type === "image");
     const stubs = content.filter(
-      (b) => b.type === "text" && (b as { text: string }).text.includes("Image omitted"),
+      (b) =>
+        b.type === "text" &&
+        (b as { text: string }).text.includes("Image omitted"),
     );
     expect(keptImages.length).toBe(3);
     expect(stubs.length).toBe(2);
@@ -174,7 +183,9 @@ describe("stripMediaPayloadsForRetry", () => {
     const content = result.messages[0].content;
     const keptImages = content.filter((b) => b.type === "image");
     const stubs = content.filter(
-      (b) => b.type === "text" && (b as { text: string }).text.includes("Image omitted"),
+      (b) =>
+        b.type === "text" &&
+        (b as { text: string }).text.includes("Image omitted"),
     );
     expect(keptImages.length).toBe(3);
     expect(stubs.length).toBe(2);


### PR DESCRIPTION
## Summary
- The recently merged dimension-based image token estimator (#31056) changed per-image cost from base64-length-based to a fixed ~1600 token fallback when image headers can't be parsed.
- The fake images in \`conversation-media-retry.test.ts\` use plain \`\"A\".repeat(...)\` data with no parseable header, so each one now costs ~1619 tokens instead of the ~1019 the test was calibrated against.
- Bump the budget from 3500 → 5000 so the 3-images-fit / 4-don't boundary is preserved.

## Original prompt
Fix the specific CI issue in the \`Test\` job of run [26062959961](https://github.com/vellum-ai/vellum-assistant/actions/runs/26062959961/job/76627268908) on \`main\`. The job failed on \`stripMediaPayloadsForRetry > budget-aware: keeps images that fit within token budget\` — expected 3 kept images, received 2 — after the dimension-based image token estimate landed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->