### PR TITLE
fix(macos): work around bash 3.2 case-pattern parser bug in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -619,10 +619,14 @@ assert_no_external_symlinks() {
     stray=$(find "$root" -type l 2>/dev/null | while IFS= read -r link; do
         local target
         target=$(readlink -f "$link" 2>/dev/null || true)
+        # Leading `(` on each pattern works around a bash 3.2 parser bug
+        # that rejects `case` patterns beginning with `/` inside `$(...)`
+        # command substitutions. macOS system bash (and CI runners) ships
+        # 3.2, so dropping the `(` re-breaks the build.
         case "$target" in
-            "$root"/*) ;;
-            "") echo "$link -> (broken)"; break;;
-            *) echo "$link -> $target"; break;;
+            ("$root"/*) ;;
+            ("") echo "$link -> (broken)"; break;;
+            (*) echo "$link -> $target"; break;;
         esac
     done)
     if [ -n "$stray" ]; then


### PR DESCRIPTION
## Summary

- `assert_no_external_symlinks` in `clients/macos/build.sh` (added in #30981) hit a bash 3.2 parser bug: `case` patterns beginning with `/` inside a `$(...)` command substitution produce `syntax error near unexpected token ';;'` before the function ever runs.
- The `CI Main macOS Build & Tests` workflow runs on GitHub-hosted macOS runners, whose system bash is 3.2.57, so `./build.sh binaries` aborts at line 623 on every push to `main`.
- Fix: prefix each case pattern with the optional `(` (`("\$root"/*)`, `("")`, `(*)`). This is valid in bash 3.2+ and sidesteps the parser bug. Added a short comment so a future cleanup doesn't drop the `(` thinking it's noise.

## Original prompt

Fix the failing `Build binaries` job in run 26062959947 (`CI Main macOS Build & Tests` on `main`). The single failure is `./build.sh: line 623: syntax error near unexpected token ';;'` — a bash 3.2 parser bug in `assert_no_external_symlinks`. Scope strictly to that one CI issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->