### PR TITLE
feat(home-feed): persona avatar for assistant-sent notifications

### DIFF
--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -108,6 +108,8 @@ export interface FeedItem {
   category?: FeedItemCategory;
   /** True when this item represents an assistant-initiated share or a high-importance system event. Used by clients to split inbox vs activity surfaces. */
   noteworthy?: boolean;
+  /** True when the assistant herself emitted this item (e.g. via the `notifications send` skill). Drives clients to swap the row's leading icon for the persona avatar; system-generated items keep the category icon. */
+  fromAssistant?: boolean;
   /** Arbitrary structured data the detail panel or other consumers can use. */
   metadata?: Record<string, unknown>;
   /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
@@ -211,6 +213,7 @@ export const feedItemSchema = z.object({
   detailPanel: feedItemDetailPanelSchema.optional(),
   category: feedItemCategorySchema.optional(),
   noteworthy: z.boolean().optional(),
+  fromAssistant: z.boolean().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string(),
 });

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -425,6 +425,34 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.noteworthy).toBe(true);
   });
 
+  test("assistant_tool source sets fromAssistant=true", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "user.send_notification",
+      contextPayload: { title: "Tool share", body: "Body" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.fromAssistant).toBe(true);
+    expect(appendCalls[0]!.fromAssistant).toBe(true);
+  });
+
+  test("non-assistant_tool source sets fromAssistant=false", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "scheduler",
+      sourceEventName: "schedule.notify",
+      contextPayload: { title: "Reminder", body: "Time to do thing" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.fromAssistant).toBe(false);
+    expect(appendCalls[0]!.fromAssistant).toBe(false);
+  });
+
   test("scheduler source with schedule.notify is not noteworthy", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -102,6 +102,7 @@ export async function writeHomeFeedItemForSignal(
     status: "new",
     category,
     noteworthy: deriveNoteworthy(signal),
+    fromAssistant: signal.sourceChannel === "assistant_tool",
     ...(urgency ? { urgency } : {}),
     ...(conversationId ? { conversationId } : {}),
     ...(panelKind ? { detailPanel: { kind: panelKind } } : {}),

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -276,6 +276,7 @@ public final class HomeFeedStore {
             detailPanel: item.detailPanel,
             category: item.category,
             noteworthy: item.noteworthy,
+            fromAssistant: item.fromAssistant,
             metadata: item.metadata,
             createdAt: item.createdAt
         )

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -264,6 +264,7 @@ struct HomePageView: View {
             iconBackground: iconBackground(for: item),
             title: item.title,
             isUrgent: showsUrgency && isUrgent(item),
+            showsPersonaAvatar: item.fromAssistant == true,
             onDismiss: { dismissItem(item) },
             onTap: { openItem(item) }
         )

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -28,6 +28,11 @@ struct HomeRecapRow: View {
     /// and its surrounding spacing are omitted entirely so non-urgent
     /// rows align flush with the icon circle (no spacing artifact).
     var isUrgent: Bool = false
+    /// When `true`, render the persona avatar in the leading icon slot
+    /// instead of the category icon circle. Used for assistant-initiated
+    /// feed rows (`FeedItem.fromAssistant == true`) so the surface reads
+    /// as "your assistant sent this" rather than a generic system bell.
+    var showsPersonaAvatar: Bool = false
     let onDismiss: () -> Void
     let onTap: () -> Void
 
@@ -42,13 +47,8 @@ struct HomeRecapRow: View {
                     VBadge(style: .dot, color: VColor.systemNegativeStrong)
                         .accessibilityHidden(true)
                 }
-                ZStack {
-                    Circle().fill(iconBackground)
-                    // 12pt glyph inside a 26pt circle ≈ 7pt padding, per mock.
-                    VIconView(icon, size: 12)
-                        .foregroundStyle(iconForeground)
-                }
-                .frame(width: 26, height: 26)
+                leadingIcon
+                    .frame(width: 26, height: 26)
 
                 Text(title)
                     // Mock uses #A9B2BB which is `contentSecondary` in the
@@ -92,5 +92,55 @@ struct HomeRecapRow: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(isUrgent ? "Urgent, \(title)" : title))
         .accessibilityAction(named: Text("Dismiss"), onDismiss)
+    }
+
+    /// 26pt leading slot: persona avatar for assistant-initiated rows,
+    /// otherwise the tinted category icon circle. Both render into the
+    /// same 26pt frame so toggling `showsPersonaAvatar` never shifts the
+    /// row's horizontal layout.
+    @ViewBuilder
+    private var leadingIcon: some View {
+        if showsPersonaAvatar {
+            personaAvatar
+        } else {
+            ZStack {
+                Circle().fill(iconBackground)
+                VIconView(icon, size: 12)
+                    .foregroundStyle(iconForeground)
+            }
+        }
+    }
+
+    /// Mirrors `HomePageView.greetingAvatar` but at 26pt. Falls back to
+    /// the static avatar image when neither a custom image nor a full
+    /// animated-character config is available.
+    @ViewBuilder
+    private var personaAvatar: some View {
+        let appearance = AvatarAppearanceManager.shared
+        let size: CGFloat = 26
+        if appearance.customAvatarImage != nil {
+            VAvatarImage(
+                image: appearance.fullAvatarImage,
+                size: size,
+                showBorder: false
+            )
+        } else if let bodyShape = appearance.characterBodyShape,
+                  let eyes = appearance.characterEyeStyle,
+                  let color = appearance.characterColor {
+            AnimatedAvatarView(
+                bodyShape: bodyShape,
+                eyeStyle: eyes,
+                color: color,
+                size: size,
+                entryAnimationEnabled: false
+            )
+            .frame(width: size, height: size)
+        } else {
+            VAvatarImage(
+                image: appearance.fullAvatarImage,
+                size: size,
+                showBorder: false
+            )
+        }
     }
 }

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -133,6 +133,8 @@ public struct FeedItem: Codable, Sendable, Identifiable {
     public let category: FeedItemCategory?
     /// True when this item represents an assistant-initiated share or a high-importance system event. Used by clients to split inbox vs activity surfaces.
     public let noteworthy: Bool?
+    /// True when the assistant herself emitted this item (e.g. via the `notifications send` skill). Drives clients to swap the row's leading icon for the persona avatar; system-generated items keep the category icon.
+    public let fromAssistant: Bool?
     /// Arbitrary structured data the detail panel or other consumers can use.
     public let metadata: [String: AnyCodable]?
     /// Internal: writer-record time, used for ordering + TTL.
@@ -153,6 +155,7 @@ public struct FeedItem: Codable, Sendable, Identifiable {
         detailPanel: FeedItemDetailPanel? = nil,
         category: FeedItemCategory? = nil,
         noteworthy: Bool? = nil,
+        fromAssistant: Bool? = nil,
         metadata: [String: AnyCodable]? = nil,
         createdAt: Date
     ) {
@@ -170,6 +173,7 @@ public struct FeedItem: Codable, Sendable, Identifiable {
         self.detailPanel = detailPanel
         self.category = category
         self.noteworthy = noteworthy
+        self.fromAssistant = fromAssistant
         self.metadata = metadata
         self.createdAt = createdAt
     }
@@ -191,6 +195,7 @@ extension FeedItem: Equatable {
             && lhs.detailPanel == rhs.detailPanel
             && lhs.category == rhs.category
             && lhs.noteworthy == rhs.noteworthy
+            && lhs.fromAssistant == rhs.fromAssistant
             && lhs.metadata == rhs.metadata
             && lhs.createdAt == rhs.createdAt
     }


### PR DESCRIPTION
## Summary

- Daemon: add optional `fromAssistant: boolean` to `FeedItem` (Zod + TS); populate from `signal.sourceChannel === \"assistant_tool\"` in `home-feed-side-effect.ts`.
- Swift mirror: add `fromAssistant: Bool?` to `FeedItem` (Codable init + Equatable). Hash is identifier-only so untouched.
- macOS UI: `HomeRecapRow` gains `showsPersonaAvatar` flag — when true, the 26pt leading slot renders the persona avatar (custom image, animated character, or static fallback) instead of the tinted category icon. `HomePageView` passes `item.fromAssistant == true` through.

Shape choice: went with **B** (`fromAssistant?: boolean`) over **A** (`sourceChannel?: enum`). This field is a UI-driver flag — clients don't need to route on every possible `NotificationSourceChannel` value, they only need to know \"did the assistant emit this herself\". Carrying the full enum would leak a daemon-internal taxonomy onto the wire with no consumer for the extra values. If a future client needs finer-grained source data we can widen then.

System-generated rows (heartbeat, job failures, watchers — `sourceChannel != \"assistant_tool\"`) keep the existing category icons. The 26pt frame is preserved on both branches so toggling the flag never shifts row layout.

## Test plan

- [x] `bun test src/notifications/__tests__/home-feed-side-effect.test.ts` — 24 pass (2 new: assistant_tool → true, scheduler → false)
- [x] `bunx tsc --noEmit` clean
- [ ] Visual check: send a notification via `assistant notifications send` and confirm the row renders the persona avatar; trigger a watcher/heartbeat and confirm the bell icon stays.

## Original prompt

Velissa's critique #2 — when a feed item originated from the assistant herself (sourceChannel=assistant_tool), the row should show her persona avatar instead of a generic bell icon. Calls out this as the highest identity-shift per LOC in the home feed. Sidd wants all six critique items shipped in parallel; this PR ships #2 (the avatar work, which spans daemon → Swift).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->