### PR TITLE
feat(home): timestamps, urgent tint, unread weight; drop generic header

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -105,6 +105,8 @@ struct HomeGallerySection: View {
                             iconForeground: VColor.feedDigestStrong,
                             iconBackground: VColor.feedDigestWeak,
                             title: "While you were away, I ran the email clean job and deleted 26 emails…",
+                            timestamp: Date().addingTimeInterval(-2 * 60 * 60),
+                            status: .new,
                             onDismiss: {},
                             onTap: {}
                         )
@@ -114,6 +116,8 @@ struct HomeGallerySection: View {
                             iconForeground: VColor.feedDigestStrong,
                             iconBackground: VColor.feedDigestWeak,
                             title: "There's also 4 low priority updates if you want to have a look.",
+                            timestamp: Date().addingTimeInterval(-30 * 60),
+                            status: .seen,
                             onDismiss: {},
                             onTap: {}
                         )
@@ -123,6 +127,8 @@ struct HomeGallerySection: View {
                             iconForeground: VColor.feedDigestStrong,
                             iconBackground: VColor.feedDigestWeak,
                             title: "Urgent: your flight to SFO boards in 35 minutes.",
+                            timestamp: Date(),
+                            status: .new,
                             isUrgent: true,
                             onDismiss: {},
                             onTap: {}
@@ -224,14 +230,11 @@ struct HomeGallerySection: View {
 
                 GallerySectionHeader(
                     title: "HomeGreetingHeader",
-                    description: "Home feed header with a leading avatar, a greeting title, and a trailing New Chat pill CTA."
+                    description: "Home feed header with a leading avatar and a trailing New Chat pill CTA."
                 )
 
                 VCard(background: VColor.surfaceBase) {
-                    HomeGreetingHeader(
-                        greeting: "Here's what's been going on",
-                        onStartNewChat: {}
-                    ) {
+                    HomeGreetingHeader(onStartNewChat: {}) {
                         if let image = NSImage(systemSymbolName: "person.circle.fill", accessibilityDescription: nil) {
                             VAvatarImage(image: image, size: 40)
                         } else {

--- a/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
@@ -3,24 +3,19 @@ import VellumAssistantShared
 
 /// Greeting header for the Home feed.
 ///
-/// Displays a caller-provided avatar, a greeting title (e.g. "Here's what's
-/// been going on"), and a primary "New Chat" pill CTA on the trailing edge.
+/// Displays a caller-provided avatar on the leading edge and a primary
+/// "New Chat" pill CTA on the trailing edge. The avatar speaks for itself —
+/// the row deliberately carries no headline copy.
 ///
 /// The caller is responsible for sizing the avatar (typical: 40x40pt) and for
 /// any outer padding around the header.
 struct HomeGreetingHeader<Avatar: View>: View {
-    let greeting: String
     let onStartNewChat: () -> Void
     @ViewBuilder let avatar: () -> Avatar
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.md) {
             avatar()
-
-            Text(greeting)
-                .font(VFont.titleLarge)
-                .foregroundStyle(VColor.contentEmphasized)
-                .lineLimit(1)
 
             Spacer()
 

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Assembles the redesigned Home page: a centered editorial column with
-/// three blocks — a greeting header (avatar + title + "New Chat" CTA), an
+/// three blocks — a greeting header (avatar + "New Chat" CTA), an
 /// optional dismissible "have you tried…" suggestion bar, and a
 /// time-grouped feed of recap rows (Today / Yesterday / Older).
 ///
@@ -64,10 +64,7 @@ struct HomePageView: View {
                 // greeting-first appearance.
                 MeetStatusPanel(viewModel: meetStatusViewModel)
 
-                HomeGreetingHeader(
-                    greeting: "Here's what's been going on",
-                    onStartNewChat: onStartNewChat
-                ) {
+                HomeGreetingHeader(onStartNewChat: onStartNewChat) {
                     // Inline avatar rendering so this view owns its own
                     // avatar resolution without depending on other views.
                     greetingAvatar
@@ -263,6 +260,8 @@ struct HomePageView: View {
             iconForeground: iconForeground(for: item),
             iconBackground: iconBackground(for: item),
             title: item.title,
+            timestamp: item.timestamp,
+            status: item.status,
             isUrgent: showsUrgency && isUrgent(item),
             showsPersonaAvatar: item.fromAssistant == true,
             onDismiss: { dismissItem(item) },
@@ -330,16 +329,14 @@ struct HomePageView: View {
     // MARK: - Skeleton
 
     /// Skeleton silhouette that mirrors the new three-block layout:
-    /// a greeting row (avatar + title bone), the "have you tried…"
+    /// a greeting row (avatar + New Chat CTA), the "have you tried…"
     /// suggestion bar (rounded 16pt pill bar, ~60pt tall), and a single
     /// "Today" group header with three 48pt recap bones. Designed so the
     /// first paint doesn't shift when real data lands.
     private var skeleton: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
-            // Greeting row: avatar + title bone + New Chat CTA bone
             HStack(spacing: VSpacing.md) {
                 VSkeletonBone(width: 40, height: 40, radius: 20)
-                VSkeletonBone(width: 280, height: 28)
                 Spacer()
                 VSkeletonBone(width: 96, height: 32, radius: VRadius.md)
             }

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -3,15 +3,17 @@ import VellumAssistantShared
 
 /// Compact row used in the time-bucketed Home feed.
 ///
-/// Layout: a 26pt tinted icon circle + a single-line title + a trailing
-/// hover-only Dismiss affordance + a whole-row tap target. The row
-/// itself is intentionally slim (icon pill drives the height) so a list
-/// of recaps reads as a dense time-feed rather than a stack of cards.
+/// Layout: a 26pt tinted icon circle + a single-line title + a fixed-width
+/// trailing timestamp + a hover-only Dismiss affordance + a whole-row tap
+/// target. The row itself is intentionally slim (icon pill drives the
+/// height) so a list of recaps reads as a dense time-feed rather than a
+/// stack of cards.
 ///
-/// The Dismiss affordance appears only while the pointer is over the
-/// row (Figma `3596:79329` — hover state). Its tap is isolated from the
-/// outer row Button so clicking "Dismiss" never fires the row's
-/// `onTap` — SwiftUI resolves the innermost tappable first.
+/// The Dismiss affordance appears only while the pointer is over the row
+/// (Figma `3596:79329` — hover state). Its tap is isolated from the outer
+/// row Button so clicking "Dismiss" never fires the row's `onTap` — SwiftUI
+/// resolves the innermost tappable first. The timestamp uses a fixed
+/// width so the title doesn't reflow when the dismiss affordance appears.
 struct HomeRecapRow: View {
     let icon: VIcon
     /// Foreground color for the icon glyph. Callers pass one of the
@@ -23,10 +25,15 @@ struct HomeRecapRow: View {
     /// of the foreground token — e.g. `VColor.feedNudgeWeak`).
     let iconBackground: Color
     let title: String
-    /// When `true`, render a leading red dot to flag an urgent inbox
-    /// item (urgency `.high` or `.critical`). When `false`, the dot
-    /// and its surrounding spacing are omitted entirely so non-urgent
-    /// rows align flush with the icon circle (no spacing artifact).
+    /// Event time used to render a relative-time label ("2h ago",
+    /// "just now") in the trailing metadata slot.
+    let timestamp: Date
+    /// Lifecycle state — `.new` rows render the title in an emphasised
+    /// weight so unread items stand out from ones the user has seen.
+    let status: FeedItemStatus
+    /// When `true`, paint a negative-weak row background tint so urgent
+    /// items pop in a dense feed — a 6pt red dot alone is too quiet for
+    /// `urgency >= .high` items.
     var isUrgent: Bool = false
     /// When `true`, render the persona avatar in the leading icon slot
     /// instead of the category icon circle. Used for assistant-initiated
@@ -38,27 +45,39 @@ struct HomeRecapRow: View {
 
     @State private var isHovering: Bool = false
 
+    private var titleFont: Font {
+        status == .new ? VFont.bodyMediumEmphasised : VFont.bodyMediumDefault
+    }
+
+    private var backgroundFill: Color {
+        if isUrgent { return VColor.systemNegativeWeak }
+        return isHovering ? VColor.surfaceLift : VColor.surfaceOverlay
+    }
+
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: VSpacing.sm) {
-                if isUrgent {
-                    // Decorative — the row's combined accessibilityLabel
-                    // below already announces "Urgent" before the title.
-                    VBadge(style: .dot, color: VColor.systemNegativeStrong)
-                        .accessibilityHidden(true)
-                }
                 leadingIcon
                     .frame(width: 26, height: 26)
 
                 Text(title)
                     // Mock uses #A9B2BB which is `contentSecondary` in the
                     // dark palette (see ColorTokens.swift).
-                    .font(VFont.bodyMediumDefault)
+                    .font(titleFont)
                     .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
                 Spacer(minLength: VSpacing.sm)
+
+                Text(timestamp.relativeShortString())
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+                    // Fixed width keeps the timestamp anchored when the
+                    // dismiss affordance appears on hover.
+                    .frame(width: 64, alignment: .trailing)
+                    .accessibilityHidden(true)
 
                 if isHovering {
                     // Wrapping the dismiss in its own Button keeps the tap
@@ -86,7 +105,7 @@ struct HomeRecapRow: View {
         .padding(EdgeInsets(top: VSpacing.sm, leading: VSpacing.md, bottom: VSpacing.sm, trailing: VSpacing.md))
         .background(
             RoundedRectangle(cornerRadius: VRadius.md, style: .continuous)
-                .fill(isHovering ? VColor.surfaceLift : VColor.surfaceOverlay)
+                .fill(backgroundFill)
         )
         .onHover { isHovering = $0 }
         .accessibilityElement(children: .combine)

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -127,7 +127,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                     "homeGreetingHeader",
                     "HomeGreetingHeader",
                     keywords: ["greeting", "header", "home", "avatar", "new chat"],
-                    description: "Home feed header with a leading avatar, a greeting title, and a trailing New Chat pill CTA."
+                    description: "Home feed header with a leading avatar and a trailing New Chat pill CTA."
                 ),
             ]
         case .icons:

--- a/clients/shared/Utilities/ISO8601Formatting.swift
+++ b/clients/shared/Utilities/ISO8601Formatting.swift
@@ -35,3 +35,21 @@ extension String {
         return try? Date.ISO8601FormatStyle().parse(self)
     }
 }
+
+// MARK: - Relative time
+
+extension Date {
+
+    /// Compact relative-time string for inline metadata ("just now", "2h ago").
+    ///
+    /// `RelativeDateTimeFormatter` rounds anything under a minute to "0 sec.
+    /// ago" / "in 0 sec." which reads as a glitch in a feed; collapse that
+    /// window to "just now". `now` is injected so tests can pin a reference.
+    public func relativeShortString(now: Date = Date()) -> String {
+        let delta = abs(now.timeIntervalSince(self))
+        if delta < 60 { return "just now" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: now)
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the corporate \"Here's what's been going on\" title from the Home greeting (avatar + New Chat CTA now stand alone).
- Renders a relative timestamp ("2h ago" / "just now") in a fixed-width trailing slot on every recap row, anchored so the dismiss affordance can't shift it on hover.
- Tints urgent rows with `systemNegativeWeak` row backgrounds (replacing the 6pt red dot) so urgency reads at a glance in a dense feed.
- Bolds unread row titles via `VFont.bodyMediumEmphasised` when `FeedItem.status == .new`; seen/acted-on/dismissed stay default weight.
- Adds a shared `Date.relativeShortString(now:)` helper alongside the existing ISO formatting extensions.

## Original prompt

Velissa's notification-center-v3 UI critique items #1/#3/#4/#6 — kill the corporate "Here's what's been going on" header, add per-row timestamps, make urgent rows louder via row-background tint, and bold unread rows. Sidd wanted all six items shipped in parallel; this PR bundles the four that are macOS-UI-only and HomeRecapRow/HomePageView-local. Items #2 (assistant_tool avatar) and #5 (title-truncation fix) are running in separate parallel /do agents.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->