### PR TITLE
fix(notifications): drop manufactured titles from home-feed items

### DIFF
--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -129,6 +129,15 @@ describe("feedItemSchema — valid minimal items", () => {
     const parsed = feedItemSchema.parse(minimalNotification());
     expect(parsed.noteworthy).toBeUndefined();
   });
+
+  test("title is optional and may be omitted", () => {
+    const { title: _omitted, ...rest } = minimalNotification();
+    const parsed = feedItemSchema.parse(rest);
+    expect(parsed.title).toBeUndefined();
+    expect(parsed.summary).toBe(
+      "You mentioned wanting to review the onboarding designs.",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -89,7 +89,13 @@ export interface FeedItem {
   type: FeedItemType;
   /** Integer in [0, 100]; higher values sort earlier. */
   priority: number;
-  title: string;
+  /**
+   * Optional short header. Omit when the source did not supply one — the
+   * notification pipeline never manufactures a title from rendered copy
+   * (LLM-echoed bodies stutter against `summary`). Clients fall back to
+   * `summary` when rendering a row.
+   */
+  title?: string;
   summary: string;
   /** Event time (ISO-8601). */
   timestamp: string;
@@ -202,7 +208,7 @@ export const feedItemSchema = z.object({
   id: z.string(),
   type: feedItemTypeSchema,
   priority: z.number().int().min(0).max(100),
-  title: z.string(),
+  title: z.string().optional(),
   summary: z.string(),
   timestamp: z.string(),
   status: feedItemStatusSchema.default("new"),

--- a/assistant/src/notifications/__tests__/emit-signal-home-feed.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-home-feed.test.ts
@@ -144,6 +144,7 @@ describe("emitNotificationSignal home-feed wire-up", () => {
       sourceEventName: "schedule.notify",
       sourceChannel: "scheduler",
       sourceContextId: "conv-source-1",
+      contextPayload: { title: "Background job done" },
       attentionHints: {
         requiresAction: false,
         urgency: "medium",

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -83,9 +83,11 @@ beforeEach(() => {
 });
 
 describe("writeHomeFeedItemForSignal", () => {
-  test("background conversation signal writes a feed item with rendered copy", async () => {
+  test("background conversation signal writes a feed item with payload title + rendered body", async () => {
     conversationRow = { conversationType: "background" };
-    const signal = makeSignal();
+    const signal = makeSignal({
+      contextPayload: { title: "Background job done" },
+    });
     const decision = makeDecision({
       renderedCopy: {
         vellum: {
@@ -172,6 +174,7 @@ describe("writeHomeFeedItemForSignal", () => {
       sourceChannel: "assistant_tool",
       sourceEventName: "assistant.share",
       sourceContextId: "cli-12345",
+      contextPayload: { title: "Shared from CLI" },
       attentionHints: {
         requiresAction: false,
         urgency: "low",
@@ -254,7 +257,11 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls).toHaveLength(0);
   });
 
-  test("returns null when only the summary is available but the title would fall back to event name", async () => {
+  test("writes a feed item with undefined title when only the body is available", async () => {
+    // Regression: when `notifications send` is called without `--title`, the
+    // notification pipeline must not manufacture a title (the LLM's rendered
+    // copy echoes the body into `renderedCopy.title`). Leave `title`
+    // undefined so renderers fall back to `summary` instead of stuttering.
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({
       sourceEventName: "example.event",
@@ -263,8 +270,36 @@ describe("writeHomeFeedItemForSignal", () => {
 
     const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
 
-    expect(item).toBeNull();
-    expect(appendCalls).toHaveLength(0);
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.summary).toBe("Real body");
+  });
+
+  test("ignores LLM-rendered title when no payload title was supplied", async () => {
+    // The LLM often echoes the body verbatim into `renderedCopy.title` when
+    // the source didn't pass one. The home-feed writer must NOT promote that
+    // echo into the feed item — only an explicit source title is honored.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceEventName: "example.event",
+      contextPayload: { body: "Real body" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Real body",
+          body: "Real body",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.title).toBeUndefined();
+    expect(appendCalls[0]!.summary).toBe("Real body");
   });
 
   test("treats whitespace-only rendered copy and payload values as missing and returns null", async () => {
@@ -296,6 +331,7 @@ describe("writeHomeFeedItemForSignal", () => {
       sourceChannel: "assistant_tool",
       sourceEventName: "assistant.share",
       sourceContextId: "cli-12345",
+      contextPayload: { title: "Telegram title" },
     });
     const decision = makeDecision({
       selectedChannels: ["telegram"],
@@ -323,6 +359,7 @@ describe("writeHomeFeedItemForSignal", () => {
       sourceChannel: "assistant_tool",
       sourceEventName: "assistant.share",
       sourceContextId: "cli-12345",
+      contextPayload: { title: "Telegram title" },
     });
     const decision = makeDecision({
       selectedChannels: ["telegram"],

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -62,14 +62,17 @@ export async function writeHomeFeedItemForSignal(
     readPayloadString(signal.contextPayload, "body") ??
     readPayloadString(signal.contextPayload, "requestedMessage");
 
-  const resolvedTitle =
-    renderedCopy?.title?.trim() || payloadTitle?.trim() || "";
+  // Source the title from the payload only. The LLM's `renderedCopy.title`
+  // often echoes the body when no explicit title was passed, which stutters
+  // against `summary` in the row. Leave undefined when absent; renderers
+  // fall back to `summary`.
+  const resolvedTitle = payloadTitle?.trim() || undefined;
   const resolvedSummary =
     renderedCopy?.body?.trim() || payloadBody?.trim() || "";
-  if (!resolvedTitle || !resolvedSummary) {
+  if (!resolvedSummary) {
     log.warn(
       { signalId: signal.signalId, sourceEventName: signal.sourceEventName },
-      "Home-feed write skipped: no real title or summary available (would have fallen back to event name)",
+      "Home-feed write skipped: no summary available (would have fallen back to event name)",
     );
     return null;
   }
@@ -95,7 +98,7 @@ export async function writeHomeFeedItemForSignal(
     id: `notif:${signal.signalId}`,
     type: "notification",
     priority: 50,
-    title: resolvedTitle,
+    ...(resolvedTitle ? { title: resolvedTitle } : {}),
     summary: resolvedSummary,
     timestamp: now,
     createdAt: now,

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomePermissionDetailCard.swift
@@ -10,7 +10,7 @@ import VellumAssistantShared
 ///   - `details` (String?) — additional context
 ///   - `missingScopes` ([String]?) — list of missing permission scopes
 ///
-/// Falls back to `item.title` when metadata is absent.
+/// Falls back to `item.title` (or `summary` when title is nil) when metadata is absent.
 struct HomePermissionDetailCard: View {
     let item: FeedItem
 
@@ -151,7 +151,7 @@ struct HomePermissionDetailCard: View {
     // MARK: - Fallback
 
     private var fallbackContent: some View {
-        Text(item.title)
+        Text(item.title ?? item.summary)
             .font(VFont.bodyMediumDefault)
             .foregroundStyle(VColor.contentSecondary)
             .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -255,11 +255,13 @@ struct HomePageView: View {
     /// items live in the inbox, not the activity section.
     @ViewBuilder
     private func recapRow(for item: FeedItem, showsUrgency: Bool) -> some View {
+        // Fall back to `summary` when `title` is nil — the daemon omits
+        // the title when no source title was supplied.
         HomeRecapRow(
             icon: icon(for: item),
             iconForeground: iconForeground(for: item),
             iconBackground: iconBackground(for: item),
-            title: item.title,
+            title: item.title ?? item.summary,
             timestamp: item.timestamp,
             status: item.status,
             isUrgent: showsUrgency && isUrgent(item),

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -264,10 +264,11 @@ extension MainWindowView {
                 HomePermissionDetailCard(item: item)
             }
         case .generic(let item):
-            // When `title` is the same string as `summary`, the body row
-            // already conveys it — rendering both stacks the same text in
-            // the header and the content area.
-            let trimmedTitle = item.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Suppress the header title when it duplicates the summary —
+            // defense in depth in case a future producer manufactures one.
+            // The daemon already omits `title` when no source title was
+            // supplied.
+            let trimmedTitle = (item.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             let trimmedSummary = item.summary.trimmingCharacters(in: .whitespacesAndNewlines)
             let headerTitle: String? =
                 trimmedTitle.isEmpty || trimmedTitle == trimmedSummary

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -115,7 +115,11 @@ public struct FeedItem: Codable, Sendable, Identifiable {
     public let type: FeedItemType
     /// Integer in [0, 100]; higher values sort earlier.
     public let priority: Int
-    public let title: String
+    /// Optional short header. The daemon omits this when the source did
+    /// not supply one (e.g. `notifications send` without `--title`) — the
+    /// notification pipeline never manufactures a title from rendered
+    /// copy. Renderers fall back to `summary` when nil.
+    public let title: String?
     public let summary: String
     /// Event time.
     public let timestamp: Date
@@ -144,7 +148,7 @@ public struct FeedItem: Codable, Sendable, Identifiable {
         id: String,
         type: FeedItemType,
         priority: Int,
-        title: String,
+        title: String? = nil,
         summary: String,
         timestamp: Date,
         status: FeedItemStatus,

--- a/clients/shared/Tests/FeedItemCodingTests.swift
+++ b/clients/shared/Tests/FeedItemCodingTests.swift
@@ -145,6 +145,30 @@ final class FeedItemCodingTests: XCTestCase {
         XCTAssertNil(item.noteworthy)
     }
 
+    /// The daemon omits `title` when the source did not supply one (e.g.
+    /// `notifications send` without `--title`) so it never echoes the
+    /// LLM-rendered body into the title. Codable's synthesized decoder
+    /// must accept the missing key and leave `title == nil`.
+    func testDecodesWithMissingTitle() throws {
+        let json = Data(
+            """
+            {
+              "id": "notif-no-title",
+              "type": "notification",
+              "priority": 50,
+              "summary": "hi husband. thinking about you",
+              "timestamp": "2026-04-14T10:00:00Z",
+              "status": "new",
+              "createdAt": "2026-04-14T10:00:00Z"
+            }
+            """.utf8
+        )
+
+        let item = try decoder.decode(FeedItem.self, from: json)
+        XCTAssertNil(item.title)
+        XCTAssertEqual(item.summary, "hi husband. thinking about you")
+    }
+
     // MARK: - Noteworthy flag (PR 9)
 
     /// Synthesized `Codable` handles the optional `noteworthy: Bool?`


### PR DESCRIPTION
## Summary

- Make `FeedItem.title` optional end-to-end (Zod schema + TS interface + Swift mirror) so the daemon can omit it when no source title was supplied.
- Stop sourcing `resolvedTitle` from `renderedCopy.title` in `home-feed-side-effect.ts` — the LLM frequently echoes the body into the rendered title and that stutter was the root cause of the macOS list-row duplication. Now `title` is sourced only from the payload (`title` / `requestedTitle`); when absent, the feed item lands with `title: undefined` and Swift renderers fall back to `summary`.
- Skip-write check now requires only `resolvedSummary`. Tests updated to match: the "only body provided" case now writes a titleless item, and a new regression test pins that `renderedCopy.title` is ignored when no payload title was passed.

PR #31039's `title == summary` band-aid in `PanelCoordinator.swift` is kept as defense in depth.

## Original prompt

Velissa's critique #5 — when `notifications send` is called without `--title`, the daemon's LLM-rendered copy echoes the body verbatim into `renderedCopy.title`, producing a row that reads:

> **hi husband.**
> hi husband. thinking about you

PR #31039 patched the macOS detail panel symptomatically. This PR is the upstream half: drop the LLM-rendered title fallback, make title optional all the way through the contract, and let renderers fall back to summary when nil. Part of the broader notification-center UI critique landing in parallel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->