### PR TITLE
chore(openapi): regenerate spec for fromAssistant field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7961,6 +7961,8 @@ paths:
                             - system
                         noteworthy:
                           type: boolean
+                        fromAssistant:
+                          type: boolean
                         metadata:
                           type: object
                           propertyNames:
@@ -7972,7 +7974,6 @@ paths:
                         - id
                         - type
                         - priority
-                        - title
                         - summary
                         - timestamp
                         - status
@@ -8125,6 +8126,8 @@ paths:
                       - system
                   noteworthy:
                     type: boolean
+                  fromAssistant:
+                    type: boolean
                   metadata:
                     type: object
                     propertyNames:
@@ -8136,7 +8139,6 @@ paths:
                   - id
                   - type
                   - priority
-                  - title
                   - summary
                   - timestamp
                   - status


### PR DESCRIPTION
## Summary
- Regenerates `assistant/openapi.yaml` to add the `fromAssistant: boolean` property and drop `title` from the required set on home-feed item schemas.
- Unblocks the `OpenAPI Spec Check` job on main, which has been failing since #31062 / #31063 landed without a corresponding spec regeneration.

## Original prompt
The user pointed at a specific failing CI job (`OpenAPI Spec Check` on the main-branch run for commit 872c611) and asked for a narrowly-scoped fix. The job's logs showed `openapi.yaml is stale. Run: bun run generate:openapi` with the diff localized to the home-feed item schema. The fix is purely to re-run the generator and commit the result — no source code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->