### PR TITLE
fix(tests): allow optional title in HomeFeedStoreTests fixture helper

### DIFF
--- a/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
@@ -14,7 +14,7 @@ final class HomeFeedStoreTests: XCTestCase {
         id: String = "item-1",
         type: FeedItemType = .notification,
         status: FeedItemStatus = .new,
-        title: String = "Fixture title",
+        title: String? = "Fixture title",
         priority: Int = 60,
         noteworthy: Bool? = nil,
         timestamp: Date = Date(timeIntervalSince1970: 1_760_000_000),


### PR DESCRIPTION
## Summary
- `FeedItem.title` became `String?` after #31063, but `makeFeedItem` in `HomeFeedStoreTests` still declared `title: String`, breaking the macOS Tests CI job when callers passed `item.title` (an optional) through the helper.
- Widen the helper's `title` parameter to `String?` (keeping the same default literal) so existing callers continue to compile and pass-through calls like `makeFeedItem(id: item.id, status: .seen, title: item.title)` type-check.

## Original prompt
Fix the specific CI issue in the macOS Tests job at https://github.com/vellum-ai/vellum-assistant/actions/runs/26064192605/job/76631211476 only — no scope creep. The failure was a Swift compile error in `HomeFeedStoreTests.swift:285` where `item.title` (now `String?`) was being passed into a helper that required a non-optional `String`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->