### PR TITLE
fix(design-library): configure tailwind-merge to fix text color stripping + fix Tag token

### DIFF
--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -270,6 +270,7 @@ export function Button({
       disabled={asChild ? undefined : disabled}
       aria-disabled={isSlotDisabled ? true : rest["aria-disabled"]}
       data-disabled={isSlotDisabled ? "" : undefined}
+      data-slot="button"
       tabIndex={isSlotDisabled ? -1 : rest.tabIndex}
       onClick={isSlotDisabled ? handleBlockedClick : onClick}
       title={title ?? tooltip}

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
     "active:scale-[0.97]",
     "disabled:cursor-not-allowed disabled:active:scale-100",
     "aria-disabled:cursor-not-allowed aria-disabled:pointer-events-none aria-disabled:opacity-60 aria-disabled:active:scale-100",
-    "text-[color:var(--vbtn-fg)]",
+    "[color:var(--vbtn-fg)]",
   ].join(" "),
   {
     variants: {

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
     "active:scale-[0.97]",
     "disabled:cursor-not-allowed disabled:active:scale-100",
     "aria-disabled:cursor-not-allowed aria-disabled:pointer-events-none aria-disabled:opacity-60 aria-disabled:active:scale-100",
-    "[color:var(--vbtn-fg)]",
+    "text-[color:var(--vbtn-fg)]",
   ].join(" "),
   {
     variants: {

--- a/packages/design-library/src/components/card.tsx
+++ b/packages/design-library/src/components/card.tsx
@@ -32,7 +32,7 @@ interface CardSectionProps extends ComponentProps<"div"> {
 
 const BASE_SURFACE_CLASSES = [
   "bg-[var(--surface-lift)]",
-  "[color:var(--content-default)]",
+  "text-[color:var(--content-default)]",
   "rounded-xl",
 ].join(" ");
 
@@ -132,7 +132,7 @@ function CardHeader({
       className={cn(
         PADDING_CLASSES[padding],
         "border-b border-[var(--border-base)]",
-        "[color:var(--content-default)]",
+        "text-[color:var(--content-default)]",
         className,
       )}
     >

--- a/packages/design-library/src/components/card.tsx
+++ b/packages/design-library/src/components/card.tsx
@@ -32,7 +32,7 @@ interface CardSectionProps extends ComponentProps<"div"> {
 
 const BASE_SURFACE_CLASSES = [
   "bg-[var(--surface-lift)]",
-  "text-[color:var(--content-default)]",
+  "[color:var(--content-default)]",
   "rounded-xl",
 ].join(" ");
 
@@ -132,7 +132,7 @@ function CardHeader({
       className={cn(
         PADDING_CLASSES[padding],
         "border-b border-[var(--border-base)]",
-        "text-[color:var(--content-default)]",
+        "[color:var(--content-default)]",
         className,
       )}
     >

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -33,30 +33,30 @@ const TONE_CLASSES: Record<NoticeTone, ToneClasses> = {
   info: {
     container:
       "bg-[var(--surface-overlay)] border-[var(--border-element)]",
-    icon: "text-[var(--content-secondary)]",
+    icon: "[color:var(--content-secondary)]",
     DefaultIcon: Info,
   },
   success: {
     container:
       "bg-[var(--system-positive-weak)] border-[color-mix(in_srgb,var(--system-positive-strong)_25%,transparent)]",
-    icon: "text-[var(--system-positive-strong)]",
+    icon: "[color:var(--system-positive-strong)]",
     DefaultIcon: CircleCheck,
   },
   warning: {
     container:
       "bg-[var(--system-mid-weak)] border-[color-mix(in_srgb,var(--system-mid-strong)_30%,transparent)]",
-    icon: "text-[var(--system-mid-strong)]",
+    icon: "[color:var(--system-mid-strong)]",
     DefaultIcon: CircleAlert,
   },
   error: {
     container:
       "bg-[var(--system-negative-weak)] border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)]",
-    icon: "text-[var(--system-negative-strong)]",
+    icon: "[color:var(--system-negative-strong)]",
     DefaultIcon: OctagonX,
   },
   neutral: {
     container: "bg-[var(--surface-overlay)] border-[var(--border-base)]",
-    icon: "text-[var(--content-secondary)]",
+    icon: "[color:var(--content-secondary)]",
     DefaultIcon: null,
   },
 };
@@ -90,7 +90,7 @@ export function Notice({
       data-slot="notice"
       className={cn(
         "relative flex w-full items-start gap-3 rounded-lg border p-3",
-        "text-[var(--content-default)]",
+        "[color:var(--content-default)]",
         toneClasses.container,
         className,
       )}
@@ -111,7 +111,7 @@ export function Notice({
           <Typography
             variant="body-medium-default"
             as="p"
-            className="text-[var(--content-emphasised)]"
+            className="[color:var(--content-emphasised)]"
           >
             {title}
           </Typography>
@@ -120,7 +120,7 @@ export function Notice({
           <Typography
             variant="body-medium-lighter"
             as="div"
-            className="text-[var(--content-secondary)]"
+            className="[color:var(--content-secondary)]"
           >
             {children}
           </Typography>
@@ -135,7 +135,7 @@ export function Notice({
           aria-label="Dismiss"
           className={cn(
             "shrink-0 cursor-pointer rounded bg-transparent p-0.5",
-            "text-[var(--content-secondary)] opacity-70 transition-opacity",
+            "[color:var(--content-secondary)] opacity-70 transition-opacity",
             "hover:opacity-100 focus-visible:outline-none focus-visible:ring-2",
             "focus-visible:ring-[var(--ring)]",
           )}

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -33,30 +33,30 @@ const TONE_CLASSES: Record<NoticeTone, ToneClasses> = {
   info: {
     container:
       "bg-[var(--surface-overlay)] border-[var(--border-element)]",
-    icon: "[color:var(--content-secondary)]",
+    icon: "text-[color:var(--content-secondary)]",
     DefaultIcon: Info,
   },
   success: {
     container:
       "bg-[var(--system-positive-weak)] border-[color-mix(in_srgb,var(--system-positive-strong)_25%,transparent)]",
-    icon: "[color:var(--system-positive-strong)]",
+    icon: "text-[color:var(--system-positive-strong)]",
     DefaultIcon: CircleCheck,
   },
   warning: {
     container:
       "bg-[var(--system-mid-weak)] border-[color-mix(in_srgb,var(--system-mid-strong)_30%,transparent)]",
-    icon: "[color:var(--system-mid-strong)]",
+    icon: "text-[color:var(--system-mid-strong)]",
     DefaultIcon: CircleAlert,
   },
   error: {
     container:
       "bg-[var(--system-negative-weak)] border-[color-mix(in_srgb,var(--system-negative-strong)_25%,transparent)]",
-    icon: "[color:var(--system-negative-strong)]",
+    icon: "text-[color:var(--system-negative-strong)]",
     DefaultIcon: OctagonX,
   },
   neutral: {
     container: "bg-[var(--surface-overlay)] border-[var(--border-base)]",
-    icon: "[color:var(--content-secondary)]",
+    icon: "text-[color:var(--content-secondary)]",
     DefaultIcon: null,
   },
 };
@@ -90,7 +90,7 @@ export function Notice({
       data-slot="notice"
       className={cn(
         "relative flex w-full items-start gap-3 rounded-lg border p-3",
-        "[color:var(--content-default)]",
+        "text-[color:var(--content-default)]",
         toneClasses.container,
         className,
       )}
@@ -111,7 +111,7 @@ export function Notice({
           <Typography
             variant="body-medium-default"
             as="p"
-            className="[color:var(--content-emphasised)]"
+            className="text-[color:var(--content-emphasised)]"
           >
             {title}
           </Typography>
@@ -120,7 +120,7 @@ export function Notice({
           <Typography
             variant="body-medium-lighter"
             as="div"
-            className="[color:var(--content-secondary)]"
+            className="text-[color:var(--content-secondary)]"
           >
             {children}
           </Typography>
@@ -135,7 +135,7 @@ export function Notice({
           aria-label="Dismiss"
           className={cn(
             "shrink-0 cursor-pointer rounded bg-transparent p-0.5",
-            "[color:var(--content-secondary)] opacity-70 transition-opacity",
+            "text-[color:var(--content-secondary)] opacity-70 transition-opacity",
             "hover:opacity-100 focus-visible:outline-none focus-visible:ring-2",
             "focus-visible:ring-[var(--ring)]",
           )}

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -28,7 +28,7 @@ const tagVariants = cva(
         positive: "bg-[var(--system-positive-weak)]",
         negative: "bg-[var(--system-negative-weak)]",
         warning: "bg-[var(--system-mid-weak)]",
-        neutral: "bg-[var(--system-neutral-weak)]",
+        neutral: "bg-[var(--tag-bg-neutral)]",
       },
     },
     defaultVariants: {

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -20,7 +20,7 @@ const tagVariants = cva(
   [
     "inline-flex items-center gap-1 h-6 px-2 py-1 rounded-[6px] whitespace-nowrap select-none",
     "text-body-small-emphasised leading-none",
-    "[color:var(--content-default)]",
+    "text-[color:var(--content-default)]",
   ].join(" "),
   {
     variants: {
@@ -124,7 +124,7 @@ export function Tag({
           className={cn(
             "inline-flex items-center justify-center rounded-full",
             "h-3.5 w-3.5 -mr-0.5 cursor-pointer",
-            "[color:var(--content-secondary)]",
+            "text-[color:var(--content-secondary)]",
             "transition-colors duration-150",
             "hover:bg-[color-mix(in_srgb,currentColor_15%,transparent)]",
             "focus-visible:outline-none",

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -20,7 +20,7 @@ const tagVariants = cva(
   [
     "inline-flex items-center gap-1 h-6 px-2 py-1 rounded-[6px] whitespace-nowrap select-none",
     "text-body-small-emphasised leading-none",
-    "text-[var(--content-default)]",
+    "[color:var(--content-default)]",
   ].join(" "),
   {
     variants: {
@@ -124,7 +124,7 @@ export function Tag({
           className={cn(
             "inline-flex items-center justify-center rounded-full",
             "h-3.5 w-3.5 -mr-0.5 cursor-pointer",
-            "text-[var(--content-secondary)]",
+            "[color:var(--content-secondary)]",
             "transition-colors duration-150",
             "hover:bg-[color-mix(in_srgb,currentColor_15%,transparent)]",
             "focus-visible:outline-none",

--- a/packages/design-library/src/utils/cn.test.ts
+++ b/packages/design-library/src/utils/cn.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { cn } from "./cn.js";
+
+describe("cn — tailwind-merge typography / text-color interaction", () => {
+  test("preserves text-color alongside typography utility", () => {
+    const result = cn("text-[color:var(--vbtn-fg)]", "text-body-medium-default");
+    expect(result).toContain("text-[color:var(--vbtn-fg)]");
+    expect(result).toContain("text-body-medium-default");
+  });
+
+  test("consumer text-color className overrides base text-color", () => {
+    expect(cn("text-[color:var(--vbtn-fg)]", "text-white")).toBe("text-white");
+    expect(cn("text-[color:var(--content-default)]", "text-red-500")).toBe(
+      "text-red-500",
+    );
+  });
+
+  test("typography utilities deduplicate against each other", () => {
+    expect(cn("text-body-medium-default", "text-body-small-emphasised")).toBe(
+      "text-body-small-emphasised",
+    );
+    expect(cn("text-lg", "text-body-medium-default")).toBe(
+      "text-body-medium-default",
+    );
+  });
+
+  test("tag: text-color + typography coexist in same cn() call", () => {
+    const result = cn(
+      "text-body-small-emphasised",
+      "text-[color:var(--content-default)]",
+    );
+    expect(result).toContain("text-body-small-emphasised");
+    expect(result).toContain("text-[color:var(--content-default)]");
+  });
+});

--- a/packages/design-library/src/utils/cn.ts
+++ b/packages/design-library/src/utils/cn.ts
@@ -1,5 +1,43 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+/**
+ * Custom typography `@utility` classes defined in `tokens.css`. These set
+ * font-family / font-size / font-weight / line-height — NOT text color.
+ *
+ * By default `tailwind-merge` classifies any unknown `text-*` class as
+ * text-color and deduplicates it against real color utilities like
+ * `text-[color:var(--token)]` or `text-white`. Registering these names
+ * under the `font-size` class group tells twMerge they are typography
+ * utilities so they coexist with text-color classes instead of conflicting.
+ *
+ * When adding a new `@utility text-*` class in `tokens.css`, add the
+ * suffix here too (e.g. `text-heading-xl` → add `"heading-xl"`).
+ *
+ * @see https://github.com/dcastil/tailwind-merge/blob/main/docs/configuration.md#class-groups
+ */
+const TYPOGRAPHY_UTILITIES = [
+  "title-large",
+  "title-medium",
+  "title-small",
+  "body-large-default",
+  "body-large-lighter",
+  "body-medium-default",
+  "body-medium-lighter",
+  "body-small-default",
+  "body-small-emphasised",
+  "label-medium-default",
+  "label-small-default",
+  "chat",
+];
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [{ text: TYPOGRAPHY_UTILITIES }],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/packages/design-library/tsconfig.json
+++ b/packages/design-library/tsconfig.json
@@ -15,5 +15,5 @@
     "types": []
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", ".storybook/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Prompt / plan

Fix unreadable button text color in Storybook (black text on near-black primary button) and apply the same fix across all affected design library components.

## Why needed

`tailwind-merge` (used by `cn()`) misclassifies our custom `@utility text-body-*` typography classes as **text-color** utilities because they share the `text-` prefix. When `cn()` combines a text-color class like `text-[color:var(--vbtn-fg)]` with a typography class like `text-body-medium-default`, `twMerge` treats them as conflicting and keeps only the last one — silently stripping the text color. The button then inherits the page body color (`--content-default`) instead of its intended foreground token (`--vbtn-fg`).

## What changed

**Configure `tailwind-merge` to distinguish typography from text-color** via [`extendTailwindMerge`](https://github.com/dcastil/tailwind-merge/blob/main/docs/configuration.md#class-groups) in `cn.ts`. The 12 custom typography utility names are registered under the `font-size` class group so they no longer collide with text-color utilities. This is the same pattern the platform repo already uses in `web/src/lib/utils.ts`.

With the config in place, all components use standard `text-[color:var(...)]` [arbitrary value syntax](https://tailwindcss.com/docs/adding-custom-styles#arbitrary-values), which:
- Coexists with typography utilities without conflict
- Preserves consumer `className` override semantics (e.g. `<Button className="text-white" />` correctly wins)
- Correctly deduplicates typography classes against each other

### Files changed

- **`cn.ts`**: Replace default `twMerge` with `extendTailwindMerge` registering 12 typography utility names under `font-size` class group
- **`cn.test.ts`** (new): Unit tests verifying typography + text-color coexistence, consumer override behavior, and typography deduplication
- **Button, Card, Notice**: Revert earlier `[color:var(...)]` back to correct `text-[color:var(...)]`
- **Tag**: Fix undefined `--system-neutral-weak` token → correct `--tag-bg-neutral` (matches platform source)
- **`tsconfig.json`**: Exclude `*.test.ts` from type-check (`bun:test` types are runtime-only)

## Alternatives NOT taken

- **`[color:var(...)]` arbitrary property syntax** (previous approach): Produces identical CSS but is opaque to `tailwind-merge` — consumer `text-white` overrides don't resolve against it. Rejected after Devin Review correctly identified this breaks the `className` API contract.
- **Inline `style={{ color: "var(--vbtn-fg)" }}`**: Bypasses `tailwind-merge` entirely but loses Tailwind variant support (`hover:`, `dark:`, `disabled:`) and breaks the utility-class convention.

## Root cause analysis

1. **How did the code get into this state?** Typography `@utility text-*` classes were defined in `tokens.css` using the standard Tailwind v4 `@utility` directive. The `text-` prefix is the natural naming convention, but `tailwind-merge` uses that same prefix for both font-size and text-color class groups. Our custom names don't match built-in font-size values (`sm`, `lg`, `xl`), so `twMerge` falls through to the text-color group.
2. **What decisions led to it?** Using default `twMerge` without configuring custom class groups. The platform repo had already solved this exact problem but the fix wasn't carried over during setup.
3. **Warning signs missed?** The platform's `web/src/lib/utils.ts` already had `extendTailwindMerge` with the typography utilities registered — this should have been the starting point.
4. **Prevention:** `cn.ts` now has a JSDoc comment instructing contributors to add new typography utility names to the array when adding new `@utility text-*` classes in `tokens.css`.

## Test plan

- `bun test src/utils/cn.test.ts` — 4 tests verifying all merge behaviors
- `bunx tsc --noEmit` — type-check passes
- CI: Lint ✅, Type Check ✅, Test ✅
- The "Lint, Type Check & Test" combined job failure is a pre-existing IPC route policy test (`integrations_a2a_invite_complete_post/redeem_post` missing from `ipc-route-policy.ts`) — confirmed failing on main

Link to Devin session: https://app.devin.ai/sessions/86b00b0278b64800b3d9ee83cbc8a109
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->