### PR TITLE
feat(memory-v2): synthetic memories for assistant CLI subcommands

### DIFF
--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -62,6 +62,20 @@ import { log } from "./logger.js";
  */
 export async function buildCliProgram(): Promise<Command> {
   await initFeatureFlagOverrides({ retryBackoffsMs: [], callTimeoutMs: 200 });
+  return buildCliProgramTree();
+}
+
+/**
+ * Synchronously build the CLI program tree without pre-populating the
+ * feature-flag cache. Use this from inside the daemon, where flags are
+ * already initialized — calling `buildCliProgram` from there would round-trip
+ * to the gateway unnecessarily.
+ *
+ * Same shape as `buildCliProgram` minus the async feature-flag init: registers
+ * the full subcommand set (conditionally gated on email / external-plugins
+ * flags via `getConfigReadOnly()`) and installs the workspace-preAction hook.
+ */
+export function buildCliProgramTree(): Command {
   const program = new Command();
 
   program

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -36,6 +36,19 @@ export function maybeSeedMemoryV2Skills(config: AssistantConfig): void {
 }
 
 /**
+ * Fire-and-forget seed of the v2 CLI-subcommand entries (indexed alongside
+ * concept pages and skills in `memory_v2_concept_pages` under the
+ * `cli-commands/<name>` slug prefix). Dynamic import keeps v2 code out of the
+ * startup graph when the gate is off. Never awaits — startup must not block.
+ */
+export function maybeSeedMemoryV2CliCommands(config: AssistantConfig): void {
+  if (!config.memory.v2.enabled) return;
+  void import("../memory/v2/cli-command-store.js")
+    .then(({ seedV2CliCommandEntries }) => seedV2CliCommandEntries())
+    .catch((err) => log.warn({ err }, "Failed to seed v2 CLI-command entries"));
+}
+
+/**
  * Build the v2 BM25 corpus stats (per-token document frequencies + avg doc
  * length), then re-seed the v2 skill entries so any skills written during
  * cold start with the legacy TF encoder get rewritten with stemmed BM25
@@ -70,18 +83,41 @@ export async function rebuildBm25CorpusStatsAndReseedSkills(
   }
 
   if (!config.memory.v2.enabled) return;
-  try {
-    const { seedV2SkillEntries } = await import("../memory/v2/skill-store.js");
-    await seedV2SkillEntries({ throwOnError: true });
-    log.info(
-      "Memory v2 skill embeddings re-seeded with BM25 vectors after corpus-stats build",
-    );
-  } catch (err) {
-    log.warn(
-      { err },
-      "Failed to re-seed v2 skill entries after BM25 corpus-stats build — skills seeded during cold start may keep TF-only sparse vectors until next reseed",
-    );
-  }
+
+  // Skills and CLI commands share the unified collection but are independent
+  // catalogs — reseed in parallel so the second one isn't gated on the first.
+  await Promise.all([
+    (async () => {
+      try {
+        const { seedV2SkillEntries } =
+          await import("../memory/v2/skill-store.js");
+        await seedV2SkillEntries({ throwOnError: true });
+        log.info(
+          "Memory v2 skill embeddings re-seeded with BM25 vectors after corpus-stats build",
+        );
+      } catch (err) {
+        log.warn(
+          { err },
+          "Failed to re-seed v2 skill entries after BM25 corpus-stats build — skills seeded during cold start may keep TF-only sparse vectors until next reseed",
+        );
+      }
+    })(),
+    (async () => {
+      try {
+        const { seedV2CliCommandEntries } =
+          await import("../memory/v2/cli-command-store.js");
+        await seedV2CliCommandEntries({ throwOnError: true });
+        log.info(
+          "Memory v2 CLI-command embeddings re-seeded with BM25 vectors after corpus-stats build",
+        );
+      } catch (err) {
+        log.warn(
+          { err },
+          "Failed to re-seed v2 CLI-command entries after BM25 corpus-stats build — entries seeded during cold start may keep TF-only sparse vectors until next reseed",
+        );
+      }
+    })(),
+  ]);
 }
 
 /**

--- a/assistant/src/daemon/skill-memory-refresh.ts
+++ b/assistant/src/daemon/skill-memory-refresh.ts
@@ -5,7 +5,10 @@ import {
   seedUninstalledCatalogSkillMemories,
 } from "../memory/graph/capability-seed.js";
 import { getLogger } from "../util/logger.js";
-import { maybeSeedMemoryV2Skills } from "./memory-v2-startup.js";
+import {
+  maybeSeedMemoryV2CliCommands,
+  maybeSeedMemoryV2Skills,
+} from "./memory-v2-startup.js";
 
 const log = getLogger("skill-memory-refresh");
 
@@ -14,6 +17,7 @@ export function refreshSkillCapabilityMemories(
 ): void {
   seedSkillGraphNodes();
   maybeSeedMemoryV2Skills(config);
+  maybeSeedMemoryV2CliCommands(config);
   void seedUninstalledCatalogSkillMemories()
     .then(() => {
       // Re-run after the async catalog fetch populates the cache so stale

--- a/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/cli-command-store.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for `assistant/src/memory/v2/cli-command-store.ts`.
+ *
+ * Coverage matrix:
+ *   - `seedV2CliCommandEntries` enumerates the program tree and upserts one
+ *     `cli-commands/<name>` point per top-level subcommand.
+ *   - It skips the auto-injected `help` builtin.
+ *   - It calls `pruneSlugsWithPrefixExcept("cli-commands/", ...)` with the
+ *     current id list under the `cli-command` kind so stale rows clear.
+ *   - The legacy `kind` backfill runs once per process before pruning.
+ *   - It populates the `entries` cache so `getCliCommandCapability` resolves
+ *     both bare names and unified-collection slugs.
+ *   - It swallows embedding-backend errors and leaves prior cache intact.
+ *   - Stale in-flight results yield to the latest requested generation.
+ *
+ * Hermetic by design: the embedding backend, Qdrant module, and CLI program
+ * tree are module-mocked so the suite never touches a real backend or the
+ * full Commander wire-up.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// ---------------------------------------------------------------------------
+// Programmable test state
+// ---------------------------------------------------------------------------
+
+interface UpsertCall {
+  slug: string;
+  dense: number[];
+  sparse: { indices: number[]; values: number[] };
+  updatedAt: number;
+  kind?: string;
+}
+
+interface PruneCall {
+  prefix: string;
+  activeSuffixes: readonly string[];
+  options?: { kind?: string };
+}
+
+interface BackfillCall {
+  prefix: string;
+  kind: string;
+  allowedSuffixes: ReadonlySet<string>;
+}
+
+interface CommandSpec {
+  name: string;
+  description: string;
+  helpText: string;
+}
+
+interface TestState {
+  commands: CommandSpec[];
+  embedThrows: Error | null;
+  embedReturn: number[][];
+  sparseReturn: { indices: number[]; values: number[] };
+  upsertCalls: UpsertCall[];
+  pruneCalls: PruneCall[];
+  upsertThrows: Error | null;
+  backfillCalls: BackfillCall[];
+  backfillThrows: Error | null;
+  callSequence: Array<"upsert" | "prune" | "backfill">;
+}
+
+const state: TestState = {
+  commands: [],
+  embedThrows: null,
+  embedReturn: [],
+  sparseReturn: { indices: [1], values: [1] },
+  upsertCalls: [],
+  pruneCalls: [],
+  upsertThrows: null,
+  backfillCalls: [],
+  backfillThrows: null,
+  callSequence: [],
+};
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: {
+      qdrant: { url: "http://127.0.0.1:6333", vectorSize: 3, onDisk: false },
+      v2: { bm25_k1: 1.2, bm25_b: 0.75 },
+    },
+  }),
+}));
+
+// Stub the CLI program tree so tests don't need to wire the entire Commander
+// registration graph. Each test stages `state.commands`; the mock returns a
+// fresh `Command` tree whose children carry the staged help text.
+mock.module("../../../cli/program.js", () => ({
+  buildCliProgramTree: () => {
+    const program = new Command();
+    program.name("assistant");
+    for (const spec of state.commands) {
+      const child = program.command(spec.name).description(spec.description);
+      // helpInformation() is built from Commander state — stub it directly so
+      // the seeded content matches the test fixture verbatim.
+      child.helpInformation = () => spec.helpText;
+    }
+    return program;
+  },
+}));
+
+mock.module("../../embedding-backend.js", () => ({
+  embedWithBackend: async (_config: unknown, inputs: unknown[]) => {
+    if (state.embedThrows) throw state.embedThrows;
+    const vectors = state.embedReturn.length
+      ? state.embedReturn
+      : inputs.map(() => [0.1, 0.2, 0.3]);
+    return { provider: "local", model: "test-model", vectors };
+  },
+  generateSparseEmbedding: () => state.sparseReturn,
+}));
+
+mock.module("../sparse-bm25.js", () => ({
+  generateBm25DocEmbedding: () => state.sparseReturn,
+  getConceptPageCorpusStats: () => null,
+}));
+
+mock.module("../anisotropy.js", () => ({
+  applyCorrectionIfCalibrated: async (v: number[]) => v,
+}));
+
+mock.module("../page-index.js", () => ({
+  invalidatePageIndex: () => {},
+}));
+
+mock.module("../qdrant.js", () => ({
+  upsertConceptPageEmbedding: async (params: UpsertCall) => {
+    if (state.upsertThrows) throw state.upsertThrows;
+    state.callSequence.push("upsert");
+    state.upsertCalls.push(params);
+  },
+  pruneSlugsWithPrefixExcept: async (
+    prefix: string,
+    activeSuffixes: readonly string[],
+    options?: { kind?: string },
+  ) => {
+    state.callSequence.push("prune");
+    state.pruneCalls.push({ prefix, activeSuffixes, options });
+  },
+  backfillKindOnPointsWithPrefix: async (
+    prefix: string,
+    kind: string,
+    allowedSuffixes: ReadonlySet<string>,
+  ) => {
+    if (state.backfillThrows) throw state.backfillThrows;
+    state.callSequence.push("backfill");
+    state.backfillCalls.push({ prefix, kind, allowedSuffixes });
+    return 0;
+  },
+}));
+
+const {
+  seedV2CliCommandEntries,
+  getCliCommandCapability,
+  listCliCommandEntries,
+  isCliCommandSlug,
+  _resetCliCommandStoreForTests,
+} = await import("../cli-command-store.js");
+
+function resetState(): void {
+  state.commands = [];
+  state.embedThrows = null;
+  state.embedReturn = [];
+  state.sparseReturn = { indices: [1], values: [1] };
+  state.upsertCalls.length = 0;
+  state.pruneCalls.length = 0;
+  state.upsertThrows = null;
+  state.backfillCalls.length = 0;
+  state.backfillThrows = null;
+  state.callSequence.length = 0;
+  _resetCliCommandStoreForTests();
+}
+
+beforeEach(resetState);
+afterEach(resetState);
+
+describe("seedV2CliCommandEntries", () => {
+  test("upserts each top-level command under cli-commands/<name>", async () => {
+    state.commands = [
+      {
+        name: "attachment",
+        description: "Manage file attachments for conversations",
+        helpText: "Usage: assistant attachment ...",
+      },
+      {
+        name: "browser",
+        description: "Control the browser via the running assistant.",
+        helpText: "Usage: assistant browser ...",
+      },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2CliCommandEntries();
+
+    expect(state.upsertCalls).toHaveLength(2);
+    const slugs = state.upsertCalls.map((c) => c.slug).sort();
+    expect(slugs).toEqual(["cli-commands/attachment", "cli-commands/browser"]);
+    expect(state.upsertCalls.every((c) => c.kind === "cli-command")).toBe(true);
+  });
+
+  test("skips Commander's auto-injected `help` builtin", async () => {
+    state.commands = [
+      {
+        name: "attachment",
+        description: "Manage file attachments",
+        helpText: "Usage: assistant attachment ...",
+      },
+      {
+        name: "help",
+        description: "display help for command",
+        helpText: "Usage: assistant help ...",
+      },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+
+    expect(state.upsertCalls.map((c) => c.slug)).toEqual([
+      "cli-commands/attachment",
+    ]);
+  });
+
+  test("calls pruneSlugsWithPrefixExcept with kind: 'cli-command'", async () => {
+    state.commands = [
+      {
+        name: "config",
+        description: "Manage configuration",
+        helpText: "...",
+      },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+
+    expect(state.pruneCalls).toHaveLength(1);
+    expect(state.pruneCalls[0].prefix).toBe("cli-commands/");
+    expect([...state.pruneCalls[0].activeSuffixes]).toEqual(["config"]);
+    expect(state.pruneCalls[0].options).toEqual({ kind: "cli-command" });
+  });
+
+  test("runs backfill before prune so legacy kindless points are reachable", async () => {
+    state.commands = [
+      {
+        name: "config",
+        description: "Manage configuration",
+        helpText: "...",
+      },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+
+    expect(state.backfillCalls).toHaveLength(1);
+    expect(state.backfillCalls[0].prefix).toBe("cli-commands/");
+    expect(state.backfillCalls[0].kind).toBe("cli-command");
+    expect([...state.backfillCalls[0].allowedSuffixes]).toEqual(["config"]);
+    expect(state.callSequence.filter((s) => s !== "upsert")).toEqual([
+      "backfill",
+      "prune",
+    ]);
+  });
+
+  test("backfill only runs once across repeated seeds in the same process", async () => {
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+    state.embedReturn = [[0.4, 0.5, 0.6]];
+    await seedV2CliCommandEntries();
+
+    expect(state.backfillCalls).toHaveLength(1);
+    expect(state.pruneCalls).toHaveLength(2);
+  });
+
+  test("populates the entries cache so getCliCommandCapability resolves both forms", async () => {
+    state.commands = [
+      {
+        name: "attachment",
+        description: "Manage file attachments",
+        helpText: "Usage: assistant attachment ...",
+      },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    expect(getCliCommandCapability("attachment")).toBeNull();
+
+    await seedV2CliCommandEntries();
+
+    const byId = getCliCommandCapability("attachment");
+    const bySlug = getCliCommandCapability("cli-commands/attachment");
+    expect(byId).not.toBeNull();
+    expect(byId?.id).toBe("attachment");
+    expect(byId?.description).toBe("Manage file attachments");
+    expect(byId?.content).toContain('"assistant attachment"');
+    expect(byId?.content).toContain("Manage file attachments");
+    expect(byId?.content).toContain("Usage: assistant attachment ...");
+    expect(bySlug).toEqual(byId);
+
+    expect(getCliCommandCapability("unknown-command")).toBeNull();
+    expect(getCliCommandCapability("cli-commands/unknown")).toBeNull();
+  });
+
+  test("isCliCommandSlug recognises the prefix", () => {
+    expect(isCliCommandSlug("cli-commands/attachment")).toBe(true);
+    expect(isCliCommandSlug("skills/example")).toBe(false);
+    expect(isCliCommandSlug("alice")).toBe(false);
+  });
+
+  test("listCliCommandEntries returns frozen sorted snapshots", async () => {
+    state.commands = [
+      { name: "browser", description: "Control browser", helpText: "..." },
+      { name: "attachment", description: "Manage attachments", helpText: "." },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2CliCommandEntries();
+
+    const snapshot = listCliCommandEntries();
+    expect(snapshot.map((e) => e.id)).toEqual(["attachment", "browser"]);
+    expect(Object.isFrozen(snapshot[0])).toBe(true);
+  });
+
+  test("swallows embedWithBackend errors and leaves prior cache intact", async () => {
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2CliCommandEntries();
+    const before = getCliCommandCapability("config");
+    expect(before).not.toBeNull();
+
+    state.upsertCalls.length = 0;
+    state.pruneCalls.length = 0;
+    state.embedThrows = new Error("backend exploded");
+
+    await expect(seedV2CliCommandEntries()).resolves.toBeUndefined();
+
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(0);
+    const after = getCliCommandCapability("config");
+    expect(after).toEqual(before);
+  });
+
+  test("propagates embedding errors when throwOnError is set", async () => {
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedThrows = new Error("backend exploded");
+
+    await expect(
+      seedV2CliCommandEntries({ throwOnError: true }),
+    ).rejects.toThrow("backend exploded");
+  });
+
+  test("skips stale in-flight seed results when a newer refresh is requested", async () => {
+    state.commands = [
+      { name: "config", description: "Manage configuration", helpText: "..." },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    const firstSeed = seedV2CliCommandEntries();
+    state.commands = [
+      { name: "browser", description: "Control browser", helpText: "..." },
+    ];
+    const secondSeed = seedV2CliCommandEntries();
+
+    await Promise.all([firstSeed, secondSeed]);
+
+    expect(state.upsertCalls.map((c) => c.slug)).toEqual([
+      "cli-commands/browser",
+    ]);
+    expect(getCliCommandCapability("config")).toBeNull();
+    expect(getCliCommandCapability("browser")).not.toBeNull();
+  });
+
+  test("empty command set still calls prune to clear stale rows", async () => {
+    state.commands = [];
+
+    await seedV2CliCommandEntries();
+
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(1);
+    expect(state.pruneCalls[0].activeSuffixes).toEqual([]);
+  });
+});

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -162,6 +162,38 @@ mock.module("../skill-store.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// CLI-command-store mock
+// ---------------------------------------------------------------------------
+//
+// Mirrors the skill-store mock. CLI subcommand synthetic entries flow through
+// the unified pipeline under the `cli-commands/<name>` slug prefix and render
+// under `### CLI Commands You Can Use`. Tests stage `cliCommandState.entries`
+// and rely on `stageTurn` plumbing to land slugs in the candidate set.
+
+interface CliCommandEntryStub {
+  id: string;
+  description: string;
+  content: string;
+}
+
+const cliCommandState = {
+  entries: new Map<string, CliCommandEntryStub>(),
+};
+
+mock.module("../cli-command-store.js", () => ({
+  getCliCommandCapability: (idOrSlug: string) => {
+    const id = idOrSlug.startsWith("cli-commands/")
+      ? idOrSlug.slice("cli-commands/".length)
+      : idOrSlug;
+    return cliCommandState.entries.get(id) ?? null;
+  },
+  isCliCommandSlug: (slug: string) => slug.startsWith("cli-commands/"),
+  CLI_COMMAND_SLUG_PREFIX: "cli-commands/",
+  cliCommandSlugFor: (name: string) => `cli-commands/${name}`,
+  listCliCommandEntries: () => Array.from(cliCommandState.entries.values()),
+}));
+
+// ---------------------------------------------------------------------------
 // Activation-log store mock
 // ---------------------------------------------------------------------------
 //
@@ -484,6 +516,7 @@ function resetState(): void {
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   skillState.entries.clear();
+  cliCommandState.entries.clear();
   telemetryState.recordCalls.length = 0;
   telemetryState.recordShouldThrow = false;
   pageStoreState.failingSlugs.clear();
@@ -500,6 +533,13 @@ function resetState(): void {
 function stageSkills(entries: SkillEntry[]): void {
   for (const entry of entries) {
     skillState.entries.set(entry.id, entry);
+  }
+}
+
+/** Stage cli-command-store cache entries for the upcoming render. */
+function stageCliCommands(entries: CliCommandEntryStub[]): void {
+  for (const entry of entries) {
+    cliCommandState.entries.set(entry.id, entry);
   }
 }
 
@@ -1058,6 +1098,153 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.toInject).toEqual([]);
     expect(result.block).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // CLI-command synthetic entries — same unified-pool plumbing as skills.
+  // ---------------------------------------------------------------------------
+
+  test("renders a retrieved cli-commands/<name> slug under CLI Commands You Can Use", async () => {
+    stageTurn([{ slug: "cli-commands/attachment", denseScore: 0.9 }]);
+    stageCliCommands([
+      {
+        id: "attachment",
+        description: "Manage file attachments for conversations",
+        content: 'The "assistant attachment" CLI command is available...',
+      },
+    ]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "How do I register a video?",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.toInject).toEqual(["cli-commands/attachment"]);
+    expect(result.block).not.toBeNull();
+    const headerIdx = result.block!.indexOf("### CLI Commands You Can Use");
+    const lineIdx = result.block!.indexOf(
+      "- `assistant attachment`: Manage file attachments for conversations",
+    );
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(lineIdx).toBeGreaterThan(headerIdx);
+  });
+
+  test("renders concepts, skills, then cli-commands in that order in mixed blocks", async () => {
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.95 },
+      { slug: "skills/example-skill-a", denseScore: 0.85 },
+      { slug: "cli-commands/config", denseScore: 0.75 },
+    ]);
+    stageSkills([
+      {
+        id: "example-skill-a",
+        content:
+          'The "Example Skill A" skill (example-skill-a) is available. Helps with examples.',
+      },
+    ]);
+    stageCliCommands([
+      {
+        id: "config",
+        description: "Manage configuration",
+        content: 'The "assistant config" CLI command is available...',
+      },
+    ]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Help me",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(new Set(result.toInject)).toEqual(
+      new Set([
+        "alice-vscode",
+        "skills/example-skill-a",
+        "cli-commands/config",
+      ]),
+    );
+    const conceptIdx = result.block!.indexOf(
+      "# memory/concepts/alice-vscode.md",
+    );
+    const skillsIdx = result.block!.indexOf("### Skills You Can Use");
+    const cliIdx = result.block!.indexOf("### CLI Commands You Can Use");
+    expect(conceptIdx).toBeGreaterThan(-1);
+    expect(skillsIdx).toBeGreaterThan(conceptIdx);
+    expect(cliIdx).toBeGreaterThan(skillsIdx);
+  });
+
+  test("cli-command slugs whose entry is missing from the cache are dropped silently", async () => {
+    stageTurn([{ slug: "cli-commands/missing-command", denseScore: 0.9 }]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "anything",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.toInject).toEqual([]);
+    expect(result.block).toBeNull();
+
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([]);
+  });
+
+  test("cli-commands participate in everInjected so they dedupe across turns", async () => {
+    const entry = {
+      id: "config",
+      description: "Manage configuration",
+      content: 'The "assistant config" CLI command is available...',
+    };
+    stageTurn([{ slug: "cli-commands/config", denseScore: 0.9 }]);
+    stageCliCommands([entry]);
+    const result1 = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "config",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+    expect(result1.toInject).toEqual(["cli-commands/config"]);
+    expect(result1.block).toContain("### CLI Commands You Can Use");
+
+    stageTurn([{ slug: "cli-commands/config", denseScore: 0.9 }]);
+    stageCliCommands([entry]);
+    const result2 = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "more config",
+      assistantMessage: "ok",
+      nowText: "Now",
+      messageId: "msg-2",
+      config: makeConfig(),
+    });
+    expect(result2.toInject).toEqual([]);
+    expect(result2.block).toBeNull();
+
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([
+      { slug: "cli-commands/config", turn: 1 },
+    ]);
   });
 
   test("context-load mode renders topNow even when every slug was previously injected", async () => {

--- a/assistant/src/memory/v2/cli-command-content.ts
+++ b/assistant/src/memory/v2/cli-command-content.ts
@@ -1,0 +1,19 @@
+/**
+ * Render the prose-style capability statement embedded into the unified
+ * `memory_v2_concept_pages` Qdrant collection (under the `cli-commands/<name>`
+ * slug prefix). Mirrors `buildSkillContent` in shape — a short prose lead-in
+ * followed by the dense capability material — so activation scoring weighs
+ * both natural-language intent and structured help text.
+ *
+ * Intentionally uncapped: CLI `--help` output averages 1–2 KB and the longest
+ * (browser, oauth) hits ~3.4 KB. The embedding backend handles inputs of this
+ * size without trouble, and trimming would drop the very examples and flag
+ * descriptions that make commands semantically findable.
+ */
+export function buildCliCommandContent(
+  name: string,
+  description: string,
+  helpText: string,
+): string {
+  return `The "assistant ${name}" CLI command is available. ${description}.\n\nFull help:\n${helpText}`;
+}

--- a/assistant/src/memory/v2/cli-command-store.ts
+++ b/assistant/src/memory/v2/cli-command-store.ts
@@ -1,0 +1,304 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — `assistant` CLI subcommands → embedded capability entries
+// ---------------------------------------------------------------------------
+//
+// Enumerate the top-level `assistant` CLI subcommands, render each as a prose
+// capability statement that wraps the full `helpInformation()` output, embed
+// dense + sparse, and upsert into `memory_v2_concept_pages` under the slug
+// `cli-commands/<name>`. The router scores these alongside concept pages and
+// skill entries; the injection layer surfaces hits under `### CLI Commands
+// You Can Use` so the model can semantically discover a CLI capability it
+// would not otherwise know to reach for.
+//
+// Mirrors `skill-store.ts` deliberately: same single-flight + generation
+// coalescing, same dense + sparse + corpus-stats-aware sparse encoding, same
+// payload-kind discriminator, same atomic cache replacement. Differences:
+//   - No remote catalog — the source of truth is the local Commander tree.
+//   - No per-entry feature-flag filter — flag gating already happens during
+//     `buildCliProgramTree` (e.g. email/plugins commands are conditionally
+//     registered).
+//   - No MCP-style augmentation — Commander's description is the canonical
+//     summary.
+
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
+import {
+  embedWithBackend,
+  generateSparseEmbedding,
+} from "../embedding-backend.js";
+import { buildCliCommandContent } from "./cli-command-content.js";
+import { invalidatePageIndex } from "./page-index.js";
+import {
+  backfillKindOnPointsWithPrefix,
+  pruneSlugsWithPrefixExcept,
+  upsertConceptPageEmbedding,
+} from "./qdrant.js";
+import {
+  generateBm25DocEmbedding,
+  getConceptPageCorpusStats,
+} from "./sparse-bm25.js";
+import type { CliCommandEntry } from "./types.js";
+
+const log = getLogger("memory-v2-cli-command-store");
+
+/**
+ * Slug prefix under which CLI-command embeddings are indexed in
+ * `memory_v2_concept_pages`. Concept-page slugs must match
+ * `[a-z0-9][a-z0-9-]*(/...)*`, and `cli-commands` matches that pattern, so the
+ * prefix coexists with hand-authored concept pages without escape work.
+ */
+export const CLI_COMMAND_SLUG_PREFIX = "cli-commands/";
+
+/**
+ * Payload discriminator written on every CLI-command-seeded Qdrant point.
+ * Keeps CLI rows distinguishable from user-authored concept pages and from
+ * skill rows that happen to live in adjacent namespaces, so prefix pruning
+ * never deletes a hand-authored page sitting under `cli-commands/...`.
+ */
+const CLI_COMMAND_PAYLOAD_KIND = "cli-command";
+
+/** Compose the unified-collection slug for a CLI command name. */
+export function cliCommandSlugFor(name: string): string {
+  return `${CLI_COMMAND_SLUG_PREFIX}${name}`;
+}
+
+/**
+ * Module-level cache of rendered CLI-command entries keyed by command name.
+ * `null` until the first successful seed run completes; replaced atomically
+ * on each successful re-seed so callers always see a consistent snapshot.
+ */
+let entries: Map<string, CliCommandEntry> | null = null;
+let requestedSeedGeneration = 0;
+let processedSeedGeneration = 0;
+let activeSeedDrain: Promise<void> | null = null;
+let lastSeedError: unknown = null;
+const seedWaiters: Array<{ generation: number; resolve: () => void }> = [];
+
+/**
+ * In-process latch for the legacy `kind` backfill. New upserts always write
+ * `kind`, so once the latch is set there is no follow-up work to do this
+ * process.
+ */
+let legacyKindBackfillDone = false;
+
+/**
+ * Seed (or re-seed) CLI-command embeddings into the unified concept-page
+ * collection. Idempotent. Best-effort for background callers (errors are
+ * logged but swallowed); pass `{ throwOnError: true }` from synchronous CLI
+ * paths that want failures surfaced.
+ *
+ * Single-flight + coalesced: at most one seed runs at a time. Requests made
+ * while a seed is in flight advance the requested generation; stale in-flight
+ * snapshots are skipped before they write embeddings or replace the cache.
+ */
+export async function seedV2CliCommandEntries(
+  opts: { throwOnError?: boolean } = {},
+): Promise<void> {
+  const generation = ++requestedSeedGeneration;
+  const waiter = new Promise<void>((resolve) => {
+    seedWaiters.push({ generation, resolve });
+  });
+  startSeedDrainIfNeeded();
+  await waiter;
+  if (opts.throwOnError && lastSeedError) {
+    throw lastSeedError;
+  }
+}
+
+function startSeedDrainIfNeeded(): void {
+  if (activeSeedDrain) return;
+  if (processedSeedGeneration >= requestedSeedGeneration) return;
+
+  activeSeedDrain = drainSeedQueue().finally(() => {
+    activeSeedDrain = null;
+    startSeedDrainIfNeeded();
+  });
+}
+
+async function drainSeedQueue(): Promise<void> {
+  while (processedSeedGeneration < requestedSeedGeneration) {
+    const generationToProcess = requestedSeedGeneration;
+    await runSeedV2CliCommandEntries(generationToProcess);
+    processedSeedGeneration = generationToProcess;
+    resolveSeedWaiters();
+  }
+}
+
+function resolveSeedWaiters(): void {
+  for (let i = seedWaiters.length - 1; i >= 0; i -= 1) {
+    const waiter = seedWaiters[i]!;
+    if (waiter.generation > processedSeedGeneration) continue;
+    seedWaiters.splice(i, 1);
+    waiter.resolve();
+  }
+}
+
+async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
+  try {
+    const config = getConfig();
+    // Dynamic import so callers that only need `getCliCommandCapability` or
+    // `listCliCommandEntries` (e.g. the render path inside `injection.ts` and
+    // the `page-index.ts` dependency loader) never drag the full CLI command
+    // graph into their import tree. The CLI tree pulls in many provider and
+    // workspace modules whose presence has been a recurring source of test-
+    // mock cascades and circular-import surprises.
+    const { buildCliProgramTree } = await import("../../cli/program.js");
+    const program = buildCliProgramTree();
+
+    const seeds: CliCommandEntry[] = [];
+    for (const cmd of program.commands) {
+      const name = cmd.name();
+      // Skip the `help` builtin Commander adds automatically — it carries no
+      // capability information of its own and is uniform across commands.
+      if (name === "help") continue;
+      const description = cmd.description();
+      const content = buildCliCommandContent(
+        name,
+        description,
+        cmd.helpInformation(),
+      );
+      seeds.push({ id: name, description, content });
+    }
+
+    const nextEntries = new Map<string, CliCommandEntry>();
+    let denseVectors: number[][] = [];
+    let encodeSparse: (
+      input: string,
+    ) => ReturnType<typeof generateSparseEmbedding> = generateSparseEmbedding;
+    if (seeds.length > 0) {
+      const embedded = await embedWithBackend(
+        config,
+        seeds.map((s) => s.content),
+      );
+      denseVectors = await Promise.all(
+        embedded.vectors.map((v) =>
+          applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
+        ),
+      );
+
+      // CLI commands share the concept-page Qdrant collection, so the sparse
+      // vector must use the same stemmed BM25 encoding as the concept-page
+      // documents. Fall back to the legacy TF encoder only during the cold-
+      // start window before corpus stats finish building — same rationale as
+      // the skill-store path.
+      const corpusStats = getConceptPageCorpusStats();
+      encodeSparse = (input: string) =>
+        corpusStats
+          ? generateBm25DocEmbedding(input, corpusStats, {
+              k1: config.memory.v2.bm25_k1,
+              b: config.memory.v2.bm25_b,
+            })
+          : generateSparseEmbedding(input);
+    }
+
+    if (generation !== requestedSeedGeneration) {
+      log.info(
+        { generation, latestGeneration: requestedSeedGeneration },
+        "Skipping stale v2 CLI-command seed result",
+      );
+      lastSeedError = null;
+      return;
+    }
+
+    if (seeds.length > 0) {
+      const now = Date.now();
+      await Promise.all(
+        seeds.map((seed, i) =>
+          upsertConceptPageEmbedding({
+            slug: cliCommandSlugFor(seed.id),
+            dense: denseVectors[i],
+            sparse: encodeSparse(seed.content),
+            updatedAt: now,
+            kind: CLI_COMMAND_PAYLOAD_KIND,
+          }),
+        ),
+      );
+      for (const seed of seeds) {
+        nextEntries.set(seed.id, seed);
+      }
+    }
+
+    // The CLI tree is always available (no remote catalog), so pruning is
+    // unconditional. Run the legacy `kind` backfill once per process so
+    // pre-discriminator rows become prunable.
+    const knownIds = new Set(seeds.map((s) => s.id));
+    if (!legacyKindBackfillDone) {
+      try {
+        await backfillKindOnPointsWithPrefix(
+          CLI_COMMAND_SLUG_PREFIX,
+          CLI_COMMAND_PAYLOAD_KIND,
+          knownIds,
+        );
+        legacyKindBackfillDone = true;
+      } catch (err) {
+        log.warn(
+          { err },
+          "Failed to backfill kind on legacy CLI-command points — pruning may leave orphans this run",
+        );
+      }
+    }
+    await pruneSlugsWithPrefixExcept(
+      CLI_COMMAND_SLUG_PREFIX,
+      seeds.map((s) => s.id),
+      { kind: CLI_COMMAND_PAYLOAD_KIND },
+    );
+
+    // Atomically replace the cache only after every step above succeeds.
+    entries = nextEntries;
+    invalidatePageIndex();
+    lastSeedError = null;
+  } catch (err) {
+    lastSeedError = err;
+    log.warn({ err }, "Failed to seed v2 CLI-command entries");
+  }
+}
+
+/**
+ * Synchronous lookup of a previously-seeded `CliCommandEntry` by command
+ * name. Returns `null` when the cache has not yet been populated, when the
+ * id is unknown, or when a prior seed run dropped the id.
+ *
+ * Accepts either a bare command name (`attachment`) or its unified-collection
+ * slug (`cli-commands/attachment`) so render-side callers can pass through
+ * what they have without a manual prefix strip.
+ *
+ * Returns a frozen copy so callers cannot mutate the underlying cache entry.
+ */
+export function getCliCommandCapability(
+  idOrSlug: string,
+): CliCommandEntry | null {
+  const id = idOrSlug.startsWith(CLI_COMMAND_SLUG_PREFIX)
+    ? idOrSlug.slice(CLI_COMMAND_SLUG_PREFIX.length)
+    : idOrSlug;
+  const entry = entries?.get(id);
+  return entry ? Object.freeze({ ...entry }) : null;
+}
+
+/** True iff the slug refers to a CLI-command entry in the unified collection. */
+export function isCliCommandSlug(slug: string): boolean {
+  return slug.startsWith(CLI_COMMAND_SLUG_PREFIX);
+}
+
+/**
+ * Snapshot of the in-process CLI-command cache, sorted by command name (ASCII
+ * order) for determinism. Returns a freshly allocated array of frozen entry
+ * copies on each call.
+ */
+export function listCliCommandEntries(): CliCommandEntry[] {
+  if (!entries) return [];
+  return [...entries.values()]
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((entry) => Object.freeze({ ...entry }));
+}
+
+/** @internal Test-only: clear the module-level cache. */
+export function _resetCliCommandStoreForTests(): void {
+  entries = null;
+  requestedSeedGeneration = 0;
+  processedSeedGeneration = 0;
+  activeSeedDrain = null;
+  seedWaiters.splice(0, seedWaiters.length);
+  lastSeedError = null;
+  legacyKindBackfillDone = false;
+}

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -38,6 +38,10 @@ import {
   spreadActivation,
 } from "./activation.js";
 import { hydrate, save } from "./activation-store.js";
+import {
+  getCliCommandCapability,
+  isCliCommandSlug,
+} from "./cli-command-store.js";
 import { getEdgeIndex } from "./edge-index.js";
 import { readPage, renderPageContent } from "./page-store.js";
 import { runRouter } from "./router.js";
@@ -355,20 +359,22 @@ async function finalizeInjection(args: {
   // on that user message and the agent keeps seeing it across subsequent turns
   // until compaction evicts the turn.
   //
-  // Skill slugs whose in-process cache entry is missing (e.g. startup race
-  // between the skill seed and the first turn, or stale Qdrant index pointing
-  // at an uninstalled skill) are excluded from `everInjected` so future
-  // per-turn runs re-attempt attachment once the cache is populated. Without
-  // this, the slug would be marked injected even though `renderInjectionBlock`
-  // silently dropped it.
-  const missingSkillSlugs = new Set(
+  // Synthetic slugs (skills, CLI commands) whose in-process cache entry is
+  // missing (e.g. startup race between the seed and the first turn, or stale
+  // Qdrant index pointing at an uninstalled skill / removed CLI command) are
+  // excluded from `everInjected` so future per-turn runs re-attempt attachment
+  // once the cache is populated. Without this, the slug would be marked
+  // injected even though `renderInjectionBlock` silently dropped it.
+  const missingSyntheticSlugs = new Set(
     slugsToRender.filter(
-      (slug) => isSkillSlug(slug) && !getSkillCapability(slug),
+      (slug) =>
+        (isSkillSlug(slug) && !getSkillCapability(slug)) ||
+        (isCliCommandSlug(slug) && !getCliCommandCapability(slug)),
     ),
   );
   const everInjectedSet = new Set(priorEverInjected.map((entry) => entry.slug));
   const newlyInjected = slugsToRender.filter(
-    (slug) => !everInjectedSet.has(slug) && !missingSkillSlugs.has(slug),
+    (slug) => !everInjectedSet.has(slug) && !missingSyntheticSlugs.has(slug),
   );
   const nextEverInjected: EverInjectedEntry[] = [
     ...priorEverInjected,
@@ -728,18 +734,18 @@ const INJECTION_HEADER =
  * distinguish "file vanished" (stale index) from "file is malformed"
  * (data-corruption / programmer error).
  *
- * Skill slugs whose entry the cache no longer knows (e.g. uninstalled
- * mid-run) are silently dropped, mirroring the missing-pages behavior but
- * without entering `missingSlugs` — the skill catalog is the source of
- * truth for skill availability, not on-disk concept pages, so a missing
- * skill is an expected catalog-level outcome rather than a stale-index
- * bug.
+ * Skill and CLI-command slugs whose entry the in-process cache no longer
+ * knows (e.g. uninstalled mid-run, or a CLI command removed between seeds)
+ * are silently dropped, mirroring the missing-pages behavior but without
+ * entering `missingSlugs` — the synthetic catalogs are the source of truth
+ * for those entries, not on-disk concept pages.
  *
  * Each concept-page section is rendered as a path header followed by either
  * the page's `summary` (when present in frontmatter) or the full page (the
- * fallback for pages predating the summary field). Skills sit at the end
- * under `### Skills You Can Use`, unchanged. The leading `**CRITICAL:**`
- * line tells the agent how to read the block.
+ * fallback for pages predating the summary field). Skills sit after the
+ * concept sections under `### Skills You Can Use`, and CLI subcommands sit
+ * after the skills under `### CLI Commands You Can Use`. The leading
+ * `**CRITICAL:**` line tells the agent how to read the block.
  *
  *   **CRITICAL:** These are page summaries. Read the page file if it looks relevant.
  *
@@ -758,13 +764,23 @@ const INJECTION_HEADER =
  *   ### Skills You Can Use
  *   - <skill-1 content>
  *   - <skill-2 content>
+ *
+ *   ### CLI Commands You Can Use
+ *   - `assistant <name-1>`: <description-1>
+ *   - `assistant <name-2>`: <description-2>
  */
 async function renderInjectionBlock(
   workspaceDir: string,
   slugs: string[],
 ): Promise<RenderInjectionBlockResult> {
-  const conceptSlugs = slugs.filter((s) => !isSkillSlug(s));
-  const skillSlugs = slugs.filter((s) => isSkillSlug(s));
+  const conceptSlugs: string[] = [];
+  const skillSlugs: string[] = [];
+  const cliCommandSlugs: string[] = [];
+  for (const slug of slugs) {
+    if (isSkillSlug(slug)) skillSlugs.push(slug);
+    else if (isCliCommandSlug(slug)) cliCommandSlugs.push(slug);
+    else conceptSlugs.push(slug);
+  }
 
   const settled = await Promise.allSettled(
     conceptSlugs.map((slug) => readPage(workspaceDir, slug)),
@@ -813,6 +829,20 @@ async function renderInjectionBlock(
   }
   if (skillLines.length > 0) {
     sections.push(`### Skills You Can Use\n${skillLines.join("\n")}`);
+  }
+
+  const cliCommandLines: string[] = [];
+  for (const slug of cliCommandSlugs) {
+    const entry = getCliCommandCapability(slug);
+    if (!entry) continue;
+    cliCommandLines.push(
+      `- \`assistant ${entry.id}\`: ${entry.description} (run \`assistant ${entry.id} --help\` for full usage)`,
+    );
+  }
+  if (cliCommandLines.length > 0) {
+    sections.push(
+      `### CLI Commands You Can Use\n${cliCommandLines.join("\n")}`,
+    );
   }
 
   if (sections.length === 0) {

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -80,11 +80,12 @@ let cache: CachedIndex | null = null;
 /**
  * Return a `PageIndex` for `workspaceDir`. Cached module-locally; the cache
  * is invalidated by `invalidatePageIndex` (called by daemon-side hooks when
- * concept pages or skill entries change).
+ * concept pages, skill entries, or CLI-command entries change).
  *
  * Cold builds list every concept page in parallel, drop pages whose read
- * rejects, append seeded skill entries from `listSkillEntries()`, sort by
- * slug for deterministic IDs, then resolve outgoing edges to numeric IDs.
+ * rejects, append seeded skill entries from `listSkillEntries()` and CLI
+ * command entries from `listCliCommandEntries()`, sort by slug for
+ * deterministic IDs, then resolve outgoing edges to numeric IDs.
  */
 export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
   if (cache && cache.workspaceDir === workspaceDir) {
@@ -107,19 +108,28 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     outgoingSlugs: string[];
   }
 
-  const { listSkillEntries, SKILL_SLUG_PREFIX } =
-    await import("./skill-store.js");
+  const [
+    { listSkillEntries, SKILL_SLUG_PREFIX },
+    { listCliCommandEntries, CLI_COMMAND_SLUG_PREFIX },
+  ] = await Promise.all([
+    import("./skill-store.js"),
+    import("./cli-command-store.js"),
+  ]);
 
-  // Build the skill-slug set first so we can drop colliding concept pages.
-  // Collision policy: **skill entries win**. Skill rows are seeded from the
-  // curated catalog and the router needs them to be reachable under their
-  // canonical slugs; a hand-authored page sitting under `skills/<id>` is
-  // either a stale leftover from a prior write or a user mistake. `bySlug`
-  // is last-writer-wins, so without explicit dedupe one side would silently
-  // shadow the other depending on iteration order.
+  // Build the synthetic-slug sets first so we can drop colliding concept
+  // pages. Collision policy: **synthetic entries win**. Skill and CLI rows
+  // are seeded from authoritative in-process catalogs; a hand-authored page
+  // sitting under `skills/<id>` or `cli-commands/<name>` is either a stale
+  // leftover from a prior write or a user mistake. `bySlug` is last-writer-
+  // wins, so without explicit dedupe one side would silently shadow the
+  // other depending on iteration order.
   const skillEntries = listSkillEntries();
   const skillSlugs = new Set(
     skillEntries.map((entry) => `${SKILL_SLUG_PREFIX}${entry.id}`),
+  );
+  const cliCommandEntries = listCliCommandEntries();
+  const cliCommandSlugs = new Set(
+    cliCommandEntries.map((entry) => `${CLI_COMMAND_SLUG_PREFIX}${entry.id}`),
   );
 
   const drafts: DraftEntry[] = [];
@@ -142,6 +152,13 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       );
       continue;
     }
+    if (cliCommandSlugs.has(slug)) {
+      log.warn(
+        { slug },
+        "Dropping concept page from index — slug collides with a seeded CLI-command entry; CLI command wins",
+      );
+      continue;
+    }
     const summarySource = page.frontmatter.summary?.trim() || page.body.trim();
     drafts.push({
       slug,
@@ -154,6 +171,14 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     drafts.push({
       slug: `${SKILL_SLUG_PREFIX}${entry.id}`,
       summary: normalizeSummary(entry.content),
+      outgoingSlugs: [],
+    });
+  }
+
+  for (const entry of cliCommandEntries) {
+    drafts.push({
+      slug: `${CLI_COMMAND_SLUG_PREFIX}${entry.id}`,
+      summary: normalizeSummary(entry.description),
       outgoingSlugs: [],
     });
   }

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -115,3 +115,26 @@ export interface SkillEntry {
   id: string;
   content: string;
 }
+
+// ---------------------------------------------------------------------------
+// CLI-command entries (synthetic concept-collection rows, not on-disk pages)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-CLI-subcommand capability snapshot held in-process and embedded into the
+ * unified `memory_v2_concept_pages` Qdrant collection under the slug
+ * `cli-commands/<name>`. `content` is the full `helpInformation()` output for
+ * the top-level subcommand — the embedding target, intentionally uncapped so
+ * activation hints in flag descriptions and examples carry semantic weight.
+ * `description` is the one-line Commander description, rendered terse in
+ * `### CLI Commands You Can Use` so the injection block stays compact even
+ * for verbose `--help` outputs.
+ *
+ * Plain interface (no Zod) — same in-process-only justification as
+ * `SkillEntry`.
+ */
+export interface CliCommandEntry {
+  id: string;
+  description: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- Embed every top-level `assistant` CLI subcommand's `helpInformation()` output into `memory_v2_concept_pages` under `cli-commands/<name>`, mirroring the existing skill-store pattern (single-flight seeding, dense + BM25 sparse, generation-coalesced refresh, kind-scoped pruning).
- New `### CLI Commands You Can Use` partition in `renderInjectionBlock` so retrieved CLI slugs render as terse `- \`assistant <name>\`: <description>` bullets while the full `--help` body drives semantic matching.
- Wire seed + post-corpus-stats BM25 reseed into `refreshSkillCapabilityMemories` / `rebuildBm25CorpusStatsAndReseedSkills`; both stay fire-and-forget per the daemon-startup contract, with skill and CLI reseeds now running in parallel.

## Original prompt
Add synthetic memory entries for every \`assistant\` CLI subcommand, embedded the same way memory v2 already embeds skills, so the router can semantically surface a relevant CLI command (e.g. \`assistant attachment register\` for "attach a video file") even when the model wouldn't otherwise know to reach for it. Use the top-level subcommand's \`--help\` output as the embed body, gate the work behind \`memory.v2.enabled\`, and render hits in a new \`### CLI Commands You Can Use\` section in the per-turn injection block.

## Test plan
- [ ] `cd assistant && bunx tsc --noEmit`
- [ ] `cd assistant && bun test src/memory/v2/__tests__/cli-command-store.test.ts`
- [ ] `cd assistant && bun test src/memory/v2/__tests__/injection.test.ts`
- [ ] `cd assistant && bun test src/memory/v2/__tests__/skill-store.test.ts src/memory/v2/__tests__/page-index.test.ts src/memory/v2/__tests__/router.test.ts` (regression — pre-existing tests still pass)
- [ ] After daemon restart, confirm `assistant memory v2 activation --query "register a video attachment"` (or equivalent) surfaces \`cli-commands/attachment\` near the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->