### PR TITLE
Add doctor backup type with separate directory, retention, and route

### DIFF
--- a/gateway/src/backup/backup-routes.ts
+++ b/gateway/src/backup/backup-routes.ts
@@ -14,8 +14,8 @@
 import { readConfigFileOrEmpty } from "../config-file-utils.js";
 import { getLogger } from "../logger.js";
 import { listSnapshotsInDir, type SnapshotEntry } from "./list-snapshots.js";
-import { getLocalBackupsDir } from "./paths.js";
-import { createSnapshotNow } from "./backup-worker.js";
+import { getDoctorBackupsDir, getLocalBackupsDir } from "./paths.js";
+import { createDoctorSnapshot, createSnapshotNow } from "./backup-worker.js";
 
 const log = getLogger("backup-routes");
 
@@ -98,6 +98,9 @@ export function createListBackupsHandler(_deps: BackupRouteDeps) {
         offsitePools.push({ destination: dest, snapshots });
       }
 
+      const doctorDir = getDoctorBackupsDir();
+      const doctorSnapshots = await listSnapshotsInDir(doctorDir);
+
       return Response.json({
         local: {
           directory: localDir,
@@ -108,6 +111,10 @@ export function createListBackupsHandler(_deps: BackupRouteDeps) {
           encrypted: pool.destination.encrypt,
           snapshots: pool.snapshots.map(snapshotToJson),
         })),
+        doctor: {
+          directory: doctorDir,
+          snapshots: doctorSnapshots.map(snapshotToJson),
+        },
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -145,7 +152,49 @@ export function createBackupSnapshotHandler(deps: BackupRouteDeps) {
 
       if (message.includes("already in progress")) {
         return Response.json(
-          { error: "Conflict", message: "A backup snapshot is already in progress" },
+          {
+            error: "Conflict",
+            message: "A backup snapshot is already in progress",
+          },
+          { status: 409 },
+        );
+      }
+
+      return Response.json(
+        { error: "Internal Server Error", message },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+/**
+ * POST /v1/backups/doctor — doctor-initiated backup snapshot.
+ *
+ * Uses a separate directory and retention policy from scheduled backups
+ * (max 3, auto-expire after 3 days). No auth required — only reachable
+ * from within the pod via vembda exec.
+ */
+export function createDoctorBackupHandler(deps: BackupRouteDeps) {
+  return async function handleDoctorBackup(_req: Request): Promise<Response> {
+    try {
+      const result = await createDoctorSnapshot(deps);
+
+      return Response.json({
+        success: true,
+        local: snapshotToJson(result.local),
+        duration_ms: result.durationMs,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ err }, "Doctor backup snapshot failed");
+
+      if (message.includes("already in progress")) {
+        return Response.json(
+          {
+            error: "Conflict",
+            message: "A backup snapshot is already in progress",
+          },
           { status: 409 },
         );
       }

--- a/gateway/src/backup/backup-worker.ts
+++ b/gateway/src/backup/backup-worker.ts
@@ -29,13 +29,21 @@ import { getLogger } from "../logger.js";
 import { getGatewaySecurityDir } from "../paths.js";
 import { ensureBackupKey } from "./backup-key.js";
 import type { SnapshotEntry } from "./list-snapshots.js";
+import { pruneDirByCountAndAge } from "./list-snapshots.js";
 import { pruneLocalSnapshots, writeLocalSnapshot } from "./local-writer.js";
-import type { BackupDestination, OffsiteWriteResult } from "./offsite-writer.js";
+import type {
+  BackupDestination,
+  OffsiteWriteResult,
+} from "./offsite-writer.js";
 import {
   pruneOffsiteSnapshotsInAll,
   writeOffsiteSnapshotToAll,
 } from "./offsite-writer.js";
-import { getBackupKeyPath, getLocalBackupsDir } from "./paths.js";
+import {
+  getBackupKeyPath,
+  getDoctorBackupsDir,
+  getLocalBackupsDir,
+} from "./paths.js";
 
 const log = getLogger("backup-worker");
 
@@ -89,8 +97,7 @@ function readBackupConfig(): BackupConfig {
   const enabled = backup.enabled === true;
   const intervalHours =
     typeof backup.intervalHours === "number" ? backup.intervalHours : 6;
-  const retention =
-    typeof backup.retention === "number" ? backup.retention : 3;
+  const retention = typeof backup.retention === "number" ? backup.retention : 3;
 
   const offsiteRaw = (backup.offsite ?? {}) as Record<string, unknown>;
   const offsiteEnabled = offsiteRaw.enabled !== false;
@@ -99,7 +106,9 @@ function readBackupConfig(): BackupConfig {
     destinations = offsiteRaw.destinations
       .filter(
         (d): d is { path: string; encrypt?: boolean } =>
-          d && typeof d === "object" && typeof (d as Record<string, unknown>).path === "string",
+          d &&
+          typeof d === "object" &&
+          typeof (d as Record<string, unknown>).path === "string",
       )
       .map((d) => ({
         path: d.path,
@@ -330,6 +339,118 @@ export async function createSnapshotNow(
     const result = await performBackup(config, now, deps);
     writeLastRunAt(now.getTime());
     return result;
+  } finally {
+    snapshotInProgress = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Doctor backup
+// ---------------------------------------------------------------------------
+
+/** Max doctor backups kept on disk. */
+const DOCTOR_MAX_COUNT = 3;
+
+/** Doctor backups older than this many days are pruned. */
+const DOCTOR_MAX_AGE_DAYS = 3;
+
+export interface DoctorBackupResult {
+  local: SnapshotEntry;
+  durationMs: number;
+}
+
+/**
+ * Create a doctor-initiated backup. Stored in a separate directory from
+ * scheduled backups with its own retention (max 3, 3-day expiry). Local
+ * only — no offsite mirroring.
+ */
+export async function createDoctorSnapshot(
+  deps: BackupDeps,
+): Promise<DoctorBackupResult> {
+  if (snapshotInProgress) {
+    throw new Error("A backup snapshot is already in progress");
+  }
+
+  const startTimestamp = Date.now();
+  const doctorDir = getDoctorBackupsDir();
+  const now = new Date();
+
+  snapshotInProgress = true;
+  try {
+    // Export plaintext vbundle from the daemon
+    const serviceToken = mintServiceToken();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), EXPORT_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(
+        `${deps.assistantRuntimeBaseUrl}/v1/migrations/export`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${serviceToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ description: "Doctor backup" }),
+          signal: controller.signal,
+        },
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Daemon export failed (${response.status}): ${body.slice(0, 500)}`,
+      );
+    }
+
+    // Stream the response body to a temp file
+    const tempPath = join(
+      tmpdir(),
+      `vellum-doctor-backup-${randomUUID()}.vbundle`,
+    );
+    try {
+      const readableBody = response.body;
+      if (!readableBody) {
+        throw new Error("Daemon export returned an empty response body");
+      }
+
+      const writeStream = createWriteStream(tempPath);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Bun's ReadableStream type doesn't match Node's web ReadableStream
+      const nodeReadable = Readable.fromWeb(readableBody as any);
+      await pipeline(nodeReadable, writeStream);
+
+      // Write to the doctor backup directory
+      const localResult = await writeLocalSnapshot(tempPath, doctorDir, now);
+
+      // Apply doctor-specific retention (max count + max age)
+      await pruneDirByCountAndAge(
+        doctorDir,
+        DOCTOR_MAX_COUNT,
+        DOCTOR_MAX_AGE_DAYS,
+        now,
+      );
+
+      log.info(
+        { localPath: localResult.path },
+        "Doctor backup snapshot complete",
+      );
+
+      return {
+        local: localResult,
+        durationMs: Date.now() - startTimestamp,
+      };
+    } catch (err) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // best-effort
+      }
+      throw err;
+    }
   } finally {
     snapshotInProgress = false;
   }

--- a/gateway/src/backup/list-snapshots.ts
+++ b/gateway/src/backup/list-snapshots.ts
@@ -95,3 +95,54 @@ export async function pruneDir(
 
   return { kept, deleted };
 }
+
+/**
+ * Apply combined count + age retention. Deletes snapshots that exceed
+ * `maxCount` OR are older than `maxAgeDays`, whichever is more aggressive.
+ */
+export async function pruneDirByCountAndAge(
+  dir: string,
+  maxCount: number,
+  maxAgeDays: number,
+  now?: Date,
+): Promise<{
+  kept: SnapshotEntry[];
+  deleted: SnapshotEntry[];
+  skipped?: boolean;
+}> {
+  try {
+    await stat(dirname(dir));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kept: [], deleted: [], skipped: true };
+    }
+    throw err;
+  }
+
+  const snapshots = await listSnapshotsInDir(dir);
+  const cutoff = new Date(
+    (now ?? new Date()).getTime() - maxAgeDays * 24 * 60 * 60 * 1000,
+  );
+
+  const kept: SnapshotEntry[] = [];
+  const deleted: SnapshotEntry[] = [];
+
+  for (let i = 0; i < snapshots.length; i++) {
+    const entry = snapshots[i];
+    if (i >= maxCount || entry.createdAt < cutoff) {
+      deleted.push(entry);
+    } else {
+      kept.push(entry);
+    }
+  }
+
+  for (const entry of deleted) {
+    try {
+      await unlink(entry.path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  return { kept, deleted };
+}

--- a/gateway/src/backup/paths.ts
+++ b/gateway/src/backup/paths.ts
@@ -55,6 +55,15 @@ export function getLocalBackupsDir(override?: string | null): string {
   return override ?? join(getBackupRootDir(), "local");
 }
 
+/**
+ * Returns the directory for doctor-initiated backups. These are stored
+ * separately from scheduled/manual backups and have their own retention
+ * policy (max 3, auto-expire after 3 days).
+ */
+export function getDoctorBackupsDir(): string {
+  return join(getBackupRootDir(), "doctor");
+}
+
 // ---------------------------------------------------------------------------
 // Backup filenames
 // ---------------------------------------------------------------------------

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -102,8 +102,9 @@ import {
 } from "./http/routes/migration-proxy.js";
 import { createMigrationRollbackProxyHandler } from "./http/routes/migration-rollback-proxy.js";
 import {
-  createListBackupsHandler,
   createBackupSnapshotHandler,
+  createDoctorBackupHandler,
+  createListBackupsHandler,
 } from "./backup/backup-routes.js";
 import { startBackupWorker } from "./backup/backup-worker.js";
 import {
@@ -480,6 +481,7 @@ async function main() {
   };
   const handleListBackups = createListBackupsHandler(backupDeps);
   const handleCreateBackup = createBackupSnapshotHandler(backupDeps);
+  const handleDoctorBackup = createDoctorBackupHandler(backupDeps);
 
   const handleRuntimeProxy = createRuntimeProxyHandler(config);
 
@@ -1094,6 +1096,12 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => handleCreateBackup(req),
+    },
+    {
+      path: "/v1/backups/doctor",
+      method: "POST",
+      auth: "none",
+      handler: (req) => handleDoctorBackup(req),
     },
 
     // ── Channel readiness ──


### PR DESCRIPTION
Adds a new "doctor" backup type stored in `~/.vellum/backups/doctor/`, separate from scheduled backups. Doctor backups have their own retention policy (max 3 copies, auto-expire after 3 days) and don't count against the normal 3-backup limit. A new internal gateway route `POST /v1/backups/doctor` creates these backups, and the list endpoint now includes them. This supports the doctor's pre-modification backup prompt in the companion platform PR.

## Prompt / plan
Implements the gateway half of the doctor backup feature: separate directory, age+count pruning via `pruneDirByCountAndAge()`, `createDoctorSnapshot()` function, and HTTP route handler.

## Test plan
- Typecheck passes (`bunx tsc --noEmit`)
- Lint passes (`bun run lint`)
- Backwards compatible: old doctor hitting new gateway gets the new endpoint; new doctor hitting old gateway gracefully handles 404

Link to Devin session: https://app.devin.ai/sessions/71d7dc9bc69e4656bd911e275e2d011f
Requested by: @m-abboud
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->