### PR TITLE
fix(tests): mock cli-command-store in memory-v2 lifecycle test

### DIFF
--- a/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
+++ b/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
@@ -71,6 +71,13 @@ mock.module("../memory/v2/skill-store.js", () => ({
   },
 }));
 
+// Mock the sibling CLI-command seeder so `rebuildBm25CorpusStatsAndReseedSkills`
+// (which runs both reseeds in parallel) does not invoke the real Qdrant-backed
+// implementation and emit warnings that break the no-warnings assertions below.
+mock.module("../memory/v2/cli-command-store.js", () => ({
+  seedV2CliCommandEntries: async (): Promise<void> => {},
+}));
+
 mock.module("../memory/v2/qdrant.js", () => ({
   ensureConceptPageCollection: async (): Promise<{ migrated: boolean }> => {
     state.ensureCollectionCallCount += 1;


### PR DESCRIPTION
## Summary
- Add a `mock.module` for `../memory/v2/cli-command-store.js` in `lifecycle-memory-v2-seed.test.ts` so the parallel reseed call introduced in #31070 does not invoke the real Qdrant-backed implementation.
- Restores the no-warnings invariant in the `rebuildBm25CorpusStatsAndReseedSkills > builds corpus stats then re-seeds skills when v2 is enabled` case.

## Original prompt
Fix the specific CI issue in the failing job at https://github.com/vellum-ai/vellum-assistant/actions/runs/26066854108/job/76639499135 — the `Test` job failed because `lifecycle-memory-v2-seed.test.ts:312` expected zero `warnCalls` but received one. Scope the fix to the failing assertion only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->