### PR TITLE
fix(memory-v2): hoist CLI-help reminder to section header

### DIFF
--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -766,6 +766,7 @@ const INJECTION_HEADER =
  *   - <skill-2 content>
  *
  *   ### CLI Commands You Can Use
+ *   Run `assistant <command> --help` for full usage.
  *   - `assistant <name-1>`: <description-1>
  *   - `assistant <name-2>`: <description-2>
  */
@@ -835,13 +836,11 @@ async function renderInjectionBlock(
   for (const slug of cliCommandSlugs) {
     const entry = getCliCommandCapability(slug);
     if (!entry) continue;
-    cliCommandLines.push(
-      `- \`assistant ${entry.id}\`: ${entry.description} (run \`assistant ${entry.id} --help\` for full usage)`,
-    );
+    cliCommandLines.push(`- \`assistant ${entry.id}\`: ${entry.description}`);
   }
   if (cliCommandLines.length > 0) {
     sections.push(
-      `### CLI Commands You Can Use\n${cliCommandLines.join("\n")}`,
+      `### CLI Commands You Can Use\nRun \`assistant <command> --help\` for full usage.\n${cliCommandLines.join("\n")}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Drop the per-bullet \`(run \\\`assistant <name> --help\\\` for full usage)\` suffix and replace it with a single \`Run \\\`assistant <command> --help\\\` for full usage.\` note under the \`### CLI Commands You Can Use\` section header.

## Original prompt
Velissa pointed out the per-bullet \`--help\` suffix is repetitive noise once the model has seen a few rows; collapse it to a single section-level note. Pure render-layer change, no behavior or embedding shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->