### PR TITLE
Repair malformed memory v2 summary frontmatter

### DIFF
--- a/assistant/src/__tests__/workspace-migration-088-repair-memory-v2-summary-frontmatter.test.ts
+++ b/assistant/src/__tests__/workspace-migration-088-repair-memory-v2-summary-frontmatter.test.ts
@@ -95,6 +95,27 @@ describe("088-repair-memory-v2-summary-frontmatter migration", () => {
     );
   });
 
+  test("repairs quoted-looking summaries with unescaped inner quotes", () => {
+    const filePath = writeConcept(
+      "people/bob.md",
+      [
+        "---",
+        "edges: []",
+        "summary: 'Bob's project: track follow-ups.'",
+        "---",
+        "Body",
+      ].join("\n"),
+    );
+
+    expect(() => parseFrontmatter(filePath)).toThrow();
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(parseFrontmatter(filePath).summary).toBe(
+      "Bob's project: track follow-ups.",
+    );
+  });
+
   test("removes null summary values", () => {
     const filePath = writeConcept(
       "objects/example-channel.md",
@@ -124,6 +145,22 @@ describe("088-repair-memory-v2-summary-frontmatter migration", () => {
     expect(parseFrontmatter(filePath).summary).toBe(
       "Already safe: quoted text.",
     );
+  });
+
+  test("leaves simple unquoted summaries unchanged", () => {
+    const original = [
+      "---",
+      "edges: []",
+      "summary: Simple text",
+      "---",
+      "Body",
+    ].join("\n");
+    const filePath = writeConcept("objects/simple.md", original);
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(read(filePath)).toBe(original);
+    expect(parseFrontmatter(filePath).summary).toBe("Simple text");
   });
 
   test("ignores markdown outside memory concepts", () => {

--- a/assistant/src/__tests__/workspace-migration-088-repair-memory-v2-summary-frontmatter.test.ts
+++ b/assistant/src/__tests__/workspace-migration-088-repair-memory-v2-summary-frontmatter.test.ts
@@ -1,0 +1,166 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { parse as parseYaml } from "yaml";
+
+import { repairMemoryV2SummaryFrontmatterMigration } from "../workspace/migrations/088-repair-memory-v2-summary-frontmatter.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-088-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function conceptPath(relativePath: string): string {
+  return join(workspaceDir, "memory", "concepts", relativePath);
+}
+
+function writeConcept(relativePath: string, content: string): string {
+  const filePath = conceptPath(relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+function read(filePath: string): string {
+  return readFileSync(filePath, "utf-8");
+}
+
+function parseFrontmatter(filePath: string): Record<string, unknown> {
+  const raw = read(filePath);
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) throw new Error("Missing frontmatter");
+  return (parseYaml(match[1]) ?? {}) as Record<string, unknown>;
+}
+
+describe("088-repair-memory-v2-summary-frontmatter migration", () => {
+  test("quotes unquoted summary values that contain YAML mapping syntax", () => {
+    const filePath = writeConcept(
+      "projects/example.md",
+      [
+        "---",
+        "edges: []",
+        "ref_files: []",
+        "ref_urls: []",
+        "summary: Example project: preserve the original summary text.",
+        "---",
+        "Body stays unchanged.",
+      ].join("\n"),
+    );
+
+    expect(() => parseFrontmatter(filePath)).toThrow();
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    const parsed = parseFrontmatter(filePath);
+    expect(parsed.summary).toBe(
+      "Example project: preserve the original summary text.",
+    );
+    expect(read(filePath)).toContain("\nBody stays unchanged.");
+  });
+
+  test("quotes partially quoted summary values", () => {
+    const filePath = writeConcept(
+      "people/alice.md",
+      [
+        "---",
+        "edges: []",
+        'summary: "Alice" - reported an issue: follow up tomorrow.',
+        "---",
+        "Body",
+      ].join("\n"),
+    );
+
+    expect(() => parseFrontmatter(filePath)).toThrow();
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(parseFrontmatter(filePath).summary).toBe(
+      '"Alice" - reported an issue: follow up tomorrow.',
+    );
+  });
+
+  test("removes null summary values", () => {
+    const filePath = writeConcept(
+      "objects/example-channel.md",
+      ["---", "edges: []", "summary: null", "---", "Body"].join("\n"),
+    );
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    const parsed = parseFrontmatter(filePath);
+    expect(Object.hasOwn(parsed, "summary")).toBe(false);
+    expect(read(filePath)).not.toContain("summary:");
+  });
+
+  test("leaves already quoted summaries unchanged", () => {
+    const original = [
+      "---",
+      "edges: []",
+      'summary: "Already safe: quoted text."',
+      "---",
+      "Body",
+    ].join("\n");
+    const filePath = writeConcept("objects/quoted.md", original);
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(read(filePath)).toBe(original);
+    expect(parseFrontmatter(filePath).summary).toBe(
+      "Already safe: quoted text.",
+    );
+  });
+
+  test("ignores markdown outside memory concepts", () => {
+    const filePath = join(workspaceDir, "notes", "example.md");
+    mkdirSync(dirname(filePath), { recursive: true });
+    const original = [
+      "---",
+      "summary: Outside concepts: should not be touched.",
+      "---",
+      "Body",
+    ].join("\n");
+    writeFileSync(filePath, original, "utf-8");
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(read(filePath)).toBe(original);
+  });
+
+  test("repairs nested concept pages and is idempotent", () => {
+    const filePath = writeConcept(
+      "arcs/2026-05-18/example.md",
+      [
+        "---",
+        "edges: []",
+        "summary: Nested page: one-time repair.",
+        "---",
+        "Body",
+      ].join("\n"),
+    );
+
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+    const once = read(filePath);
+    repairMemoryV2SummaryFrontmatterMigration.run(workspaceDir);
+
+    expect(read(filePath)).toBe(once);
+    expect(parseFrontmatter(filePath).summary).toBe(
+      "Nested page: one-time repair.",
+    );
+  });
+});

--- a/assistant/src/workspace/migrations/088-repair-memory-v2-summary-frontmatter.ts
+++ b/assistant/src/workspace/migrations/088-repair-memory-v2-summary-frontmatter.ts
@@ -1,0 +1,122 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const repairMemoryV2SummaryFrontmatterMigration: WorkspaceMigration = {
+  id: "088-repair-memory-v2-summary-frontmatter",
+  description:
+    "Quote malformed memory v2 frontmatter summary values and remove null summaries",
+
+  run(workspaceDir: string): void {
+    const conceptsDir = join(workspaceDir, "memory", "concepts");
+    repairMarkdownFiles(conceptsDir);
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only data repair.
+  },
+};
+
+function repairMarkdownFiles(rootDir: string): void {
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        repairConceptPage(entryPath);
+      }
+    }
+  }
+}
+
+function repairConceptPage(filePath: string): void {
+  let stat;
+  try {
+    stat = statSync(filePath);
+  } catch {
+    return;
+  }
+  if (!stat.isFile()) return;
+
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch {
+    return;
+  }
+
+  const repaired = repairFrontmatterSummary(raw);
+  if (repaired === null || repaired === raw) return;
+
+  try {
+    writeFileSync(filePath, repaired, "utf-8");
+  } catch {
+    // Best-effort repair. A single unreadable page must not block startup.
+  }
+}
+
+function repairFrontmatterSummary(raw: string): string | null {
+  const match = raw.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)(\r?\n|$)([\s\S]*)$/);
+  if (!match) return null;
+
+  const [, openDelimiter, frontmatter, closeDelimiter, afterClose, body] =
+    match;
+  const newline = openDelimiter.endsWith("\r\n") ? "\r\n" : "\n";
+  const lines = frontmatter.split(/\r?\n/);
+  const repairedLines: string[] = [];
+  let changed = false;
+
+  for (const line of lines) {
+    const summary = line.match(/^summary:(.*)$/);
+    if (!summary) {
+      repairedLines.push(line);
+      continue;
+    }
+
+    const value = summary[1].trim();
+    if (isNullSummaryValue(value)) {
+      changed = true;
+      continue;
+    }
+
+    if (isAlreadySafeSingleLineYamlString(value)) {
+      repairedLines.push(line);
+      continue;
+    }
+
+    repairedLines.push(`summary: ${JSON.stringify(value)}`);
+    changed = true;
+  }
+
+  if (!changed) return null;
+  return `${openDelimiter}${repairedLines.join(
+    newline,
+  )}${closeDelimiter}${afterClose}${body}`;
+}
+
+function isNullSummaryValue(value: string): boolean {
+  return value === "" || value === "~" || value.toLowerCase() === "null";
+}
+
+function isAlreadySafeSingleLineYamlString(value: string): boolean {
+  if (/^[|>][-+]?$/.test(value)) {
+    return true;
+  }
+  if (value.length < 2) return false;
+
+  const first = value[0];
+  if (first !== '"' && first !== "'") return false;
+  return value[value.length - 1] === first;
+}

--- a/assistant/src/workspace/migrations/088-repair-memory-v2-summary-frontmatter.ts
+++ b/assistant/src/workspace/migrations/088-repair-memory-v2-summary-frontmatter.ts
@@ -91,12 +91,14 @@ function repairFrontmatterSummary(raw: string): string | null {
       continue;
     }
 
-    if (isAlreadySafeSingleLineYamlString(value)) {
+    if (!needsSummaryRepair(value)) {
       repairedLines.push(line);
       continue;
     }
 
-    repairedLines.push(`summary: ${JSON.stringify(value)}`);
+    repairedLines.push(
+      `summary: ${JSON.stringify(normalizeSummaryValue(value))}`,
+    );
     changed = true;
   }
 
@@ -110,13 +112,69 @@ function isNullSummaryValue(value: string): boolean {
   return value === "" || value === "~" || value.toLowerCase() === "null";
 }
 
-function isAlreadySafeSingleLineYamlString(value: string): boolean {
-  if (/^[|>][-+]?$/.test(value)) {
-    return true;
+function needsSummaryRepair(value: string): boolean {
+  if (/^[|>][-+]?$/.test(value)) return false;
+  if (isSafeQuotedYamlString(value)) return false;
+  if (startsOrEndsWithQuote(value)) return true;
+  return /:\s/.test(value);
+}
+
+function normalizeSummaryValue(value: string): string {
+  if (hasUnsafeOuterQuotes(value)) {
+    return value.slice(1, -1);
   }
+  return value;
+}
+
+function startsOrEndsWithQuote(value: string): boolean {
+  return (
+    value.startsWith('"') ||
+    value.endsWith('"') ||
+    value.startsWith("'") ||
+    value.endsWith("'")
+  );
+}
+
+function isSafeQuotedYamlString(value: string): boolean {
   if (value.length < 2) return false;
 
   const first = value[0];
   if (first !== '"' && first !== "'") return false;
-  return value[value.length - 1] === first;
+  if (value[value.length - 1] !== first) return false;
+
+  const inner = value.slice(1, -1);
+  return first === "'"
+    ? hasOnlyEscapedSingleQuotes(inner)
+    : hasOnlyEscapedDoubleQuotes(inner);
+}
+
+function hasUnsafeOuterQuotes(value: string): boolean {
+  return (
+    value.length >= 2 &&
+    value[0] === value[value.length - 1] &&
+    (value[0] === '"' || value[0] === "'") &&
+    !isSafeQuotedYamlString(value)
+  );
+}
+
+function hasOnlyEscapedSingleQuotes(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] !== "'") continue;
+    if (value[i + 1] !== "'") return false;
+    i += 1;
+  }
+  return true;
+}
+
+function hasOnlyEscapedDoubleQuotes(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] !== '"') continue;
+
+    let backslashes = 0;
+    for (let j = i - 1; j >= 0 && value[j] === "\\"; j -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) return false;
+  }
+  return true;
 }

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -85,6 +85,7 @@ import { removeLegacySkillsIndexMigration } from "./084-remove-legacy-skills-ind
 import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "./085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 import { revertStaleGeminiMisRewritesMigration } from "./086-revert-stale-gemini-mis-rewrites.js";
 import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanced-profile.js";
+import { repairMemoryV2SummaryFrontmatterMigration } from "./088-repair-memory-v2-summary-frontmatter.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -181,4 +182,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   memoryV2Bm25BReembedDisabledV2PagesMigration,
   revertStaleGeminiMisRewritesMigration,
   memoryRouterBalancedProfileMigration,
+  repairMemoryV2SummaryFrontmatterMigration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration 088 to repair memory v2 concept-page `summary:` frontmatter that was written as invalid YAML.
- Quote unquoted/partially quoted summary scalars and remove null summaries while leaving non-concept markdown alone.
- Add focused migration coverage for malformed summaries, null summaries, nested concept pages, and idempotency.

## Original prompt
The user asked to put up a PR fixing the malformed memory YAML pages cataloged from the feedback log. The feedback bundle did not contain the private concept Markdown files, so this PR fixes the workspace data shape with an append-only migration that repairs those pages on affected installs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->