### PR TITLE
[codex] Fix ClickHouse LLM inspector recovery

### DIFF
--- a/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
@@ -53,12 +53,42 @@ function fakeFetchReturning(
   }) as typeof fetch;
 }
 
+function fakeFetchReturningSequence(
+  bodies: string[],
+  recorder?: FakeFetchCall[],
+): typeof fetch {
+  let idx = 0;
+  return ((url: string | URL | Request, init?: RequestInit) => {
+    recorder?.push({
+      url: typeof url === "string" ? url : url.toString(),
+      init,
+    });
+    const body = bodies[Math.min(idx, bodies.length - 1)] ?? "";
+    idx += 1;
+    return Promise.resolve(
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/x-ndjson" },
+      }),
+    );
+  }) as typeof fetch;
+}
+
 function makeSource(opts: {
   body?: string;
   status?: number;
   recorder?: FakeFetchCall[];
   resolveTurnMessageIds?: (messageId: string) => string[];
-  resolveMessage?: (messageId: string) => { metadata: string | null } | null;
+  resolveMessage?: (messageId: string) => {
+    metadata: string | null;
+    conversationId?: string;
+    createdAt?: number;
+  } | null;
+  resolveTurnTimeBounds?: (
+    conversationId: string,
+    messageCreatedAt: number,
+  ) => { startTime: number; endTime: number } | null;
+  fetchImpl?: typeof fetch;
 }) {
   return new ClickHouseLlmRequestLogSource(DEFAULT_CONFIG, {
     resolveUrl: async () => "https://ch.example.test:8443",
@@ -66,11 +96,10 @@ function makeSource(opts: {
     resolveAssistantId: async () => "asst-fixture-001",
     resolveTurnMessageIds: opts.resolveTurnMessageIds ?? (() => []),
     resolveMessage: opts.resolveMessage ?? (() => null),
-    fetchImpl: fakeFetchReturning(
-      opts.body ?? "",
-      opts.status ?? 200,
-      opts.recorder,
-    ),
+    resolveTurnTimeBounds: opts.resolveTurnTimeBounds ?? (() => null),
+    fetchImpl:
+      opts.fetchImpl ??
+      fakeFetchReturning(opts.body ?? "", opts.status ?? 200, opts.recorder),
   });
 }
 
@@ -132,7 +161,9 @@ describe("ClickHouseLlmRequestLogSource", () => {
     const call = recorder[0]!;
     const parsed = new URL(call.url);
     expect(parsed.searchParams.get("database")).toBe("default");
-    expect(parsed.searchParams.get("param_assistant_id")).toBe("asst-fixture-001");
+    expect(parsed.searchParams.get("param_assistant_id")).toBe(
+      "asst-fixture-001",
+    );
     expect(parsed.searchParams.get("param_log_id")).toBe("log-1");
     expect(call.init?.method).toBe("POST");
     const auth = (call.init?.headers as Record<string, string>).Authorization;
@@ -162,6 +193,69 @@ describe("ClickHouseLlmRequestLogSource", () => {
     const src = makeSource({ body: "" });
     const rows = await src.getRequestLogsByMessageId("msg-x");
     expect(rows).toEqual([]);
+  });
+
+  test("getRequestLogsByMessageId recovers rows mirrored before message_id backfill", async () => {
+    const recorder: FakeFetchCall[] = [];
+    const unlinkedRow = {
+      ...SAMPLE_ROW,
+      id: "log-unlinked",
+      message_id: "",
+      created_at: "1778465138000",
+    };
+    const src = makeSource({
+      recorder,
+      resolveTurnMessageIds: () => ["msg-assistant"],
+      resolveMessage: () => ({
+        metadata: null,
+        conversationId: "conv-1",
+        createdAt: 1778465139000,
+      }),
+      resolveTurnTimeBounds: () => ({
+        startTime: 1778465137000,
+        endTime: 1778465140000,
+      }),
+      fetchImpl: fakeFetchReturningSequence(
+        ["", JSON.stringify(unlinkedRow) + "\n"],
+        recorder,
+      ),
+    });
+
+    const rows = await src.getRequestLogsByMessageId("msg-assistant");
+
+    expect(rows).toEqual([
+      {
+        id: "log-unlinked",
+        conversationId: "conv-1",
+        messageId: null,
+        provider: "anthropic",
+        requestPayload: '{"foo":1}',
+        responsePayload: '{"bar":2}',
+        createdAt: 1778465138000,
+        agentLoopExitReason: "no_tool_calls",
+      },
+    ]);
+    expect(recorder).toHaveLength(2);
+
+    const exactQuery = recorder[0]!;
+    expect(String(exactQuery.init?.body)).toContain(
+      "message_id IN ({id_0:String})",
+    );
+
+    const recoveryQuery = recorder[1]!;
+    const parsed = new URL(recoveryQuery.url);
+    expect(parsed.searchParams.get("param_conversation_id")).toBe("conv-1");
+    expect(parsed.searchParams.get("param_start_ms")).toBe("1778465137000");
+    expect(parsed.searchParams.get("param_end_ms")).toBe("1778465140000");
+    const body = String(recoveryQuery.init?.body ?? "");
+    expect(body).toContain("conversation_id = {conversation_id:String}");
+    expect(body).toContain("message_id = ''");
+    expect(body).toContain(
+      "created_at >= fromUnixTimestamp64Milli({start_ms:Int64})",
+    );
+    expect(body).toContain(
+      "created_at <= fromUnixTimestamp64Milli({end_ms:Int64})",
+    );
   });
 
   test("getRequestLogsByMessageId binds message ids via parameterized placeholders", async () => {

--- a/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
+++ b/assistant/src/__tests__/llm-request-log-source-clickhouse.test.ts
@@ -258,6 +258,41 @@ describe("ClickHouseLlmRequestLogSource", () => {
     );
   });
 
+  test("getRequestLogsByMessageId keeps recovered rows chronologically ordered", async () => {
+    const linkedRow = {
+      ...SAMPLE_ROW,
+      id: "log-linked",
+      message_id: "msg-assistant",
+      created_at: "1778465139000",
+    };
+    const unlinkedRow = {
+      ...SAMPLE_ROW,
+      id: "log-unlinked",
+      message_id: "",
+      created_at: "1778465138000",
+    };
+    const src = makeSource({
+      resolveTurnMessageIds: () => ["msg-assistant"],
+      resolveMessage: () => ({
+        metadata: null,
+        conversationId: "conv-1",
+        createdAt: 1778465139000,
+      }),
+      resolveTurnTimeBounds: () => ({
+        startTime: 1778465137000,
+        endTime: 1778465140000,
+      }),
+      fetchImpl: fakeFetchReturningSequence([
+        JSON.stringify(linkedRow) + "\n",
+        JSON.stringify(unlinkedRow) + "\n",
+      ]),
+    });
+
+    const rows = await src.getRequestLogsByMessageId("msg-assistant");
+
+    expect(rows.map((row) => row.id)).toEqual(["log-unlinked", "log-linked"]);
+  });
+
   test("getRequestLogsByMessageId binds message ids via parameterized placeholders", async () => {
     // Regression for ATL-537. `getAssistantMessageIdsInTurn` returns the
     // caller-supplied id straight through when the message lookup misses,

--- a/assistant/src/memory/llm-request-log-source-clickhouse.ts
+++ b/assistant/src/memory/llm-request-log-source-clickhouse.ts
@@ -194,7 +194,9 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
       seen.add(row.id);
       merged.push(row);
     }
-    return merged;
+    return merged.sort(
+      (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+    );
   }
 
   private async selectByMessageIds(ids: string[]): Promise<LogRow[]> {

--- a/assistant/src/memory/llm-request-log-source-clickhouse.ts
+++ b/assistant/src/memory/llm-request-log-source-clickhouse.ts
@@ -8,12 +8,10 @@
  * (`clickhouse:url`, `clickhouse:password`); database/table/user come
  * from workspace config.
  *
- * Known limitation: the mirror is INSERT-only. A row inserted locally
- * with `message_id = NULL` and backfilled later will appear in
- * ClickHouse with `message_id = ''` forever. Reads via this source for
- * the most-recent ~minute of activity therefore have lower fidelity
- * than the local source. Acceptable for the "internal use while we
- * finetune prompts" use case; revisit when mirror updates are added.
+ * The mirror is INSERT-only. A row inserted locally with `message_id = NULL`
+ * and backfilled later will appear in ClickHouse with `message_id = ''`
+ * forever, so message-id reads also recover empty-message-id rows inside the
+ * local turn time window.
  */
 import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -22,6 +20,7 @@ import { getLogger } from "../util/logger.js";
 import {
   getAssistantMessageIdsInTurn,
   getMessageById,
+  getTurnTimeBounds,
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import type { LlmRequestLogSource } from "./llm-request-log-source.js";
@@ -66,6 +65,8 @@ export type ClickHouseFetch = typeof fetch;
 /** Minimal subset of the SQLite message row the fork-source fallback needs. */
 export interface ClickHouseMessageRow {
   metadata: string | null;
+  conversationId?: string;
+  createdAt?: number;
 }
 
 export interface ClickHouseLlmRequestLogSourceDeps {
@@ -79,6 +80,11 @@ export interface ClickHouseLlmRequestLogSourceDeps {
   resolveTurnMessageIds?: (messageId: string) => string[];
   /** Override the message lookup (default: `getMessageById`). */
   resolveMessage?: (messageId: string) => ClickHouseMessageRow | null;
+  /** Override turn time-bound resolution (default: `getTurnTimeBounds`). */
+  resolveTurnTimeBounds?: (
+    conversationId: string,
+    messageCreatedAt: number,
+  ) => { startTime: number; endTime: number } | null;
   /** Override fetch for testing. */
   fetchImpl?: ClickHouseFetch;
 }
@@ -95,6 +101,10 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
   private readonly resolveMessage: (
     messageId: string,
   ) => ClickHouseMessageRow | null;
+  private readonly resolveTurnTimeBounds: (
+    conversationId: string,
+    messageCreatedAt: number,
+  ) => { startTime: number; endTime: number } | null;
   private readonly fetchImpl: ClickHouseFetch;
 
   constructor(
@@ -112,6 +122,8 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
     this.resolveTurnMessageIds =
       deps.resolveTurnMessageIds ?? getAssistantMessageIdsInTurn;
     this.resolveMessage = deps.resolveMessage ?? getMessageById;
+    this.resolveTurnTimeBounds =
+      deps.resolveTurnTimeBounds ?? getTurnTimeBounds;
     this.fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
   }
 
@@ -137,8 +149,7 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
   }
 
   async getRequestLogsByMessageId(messageId: string): Promise<LogRow[]> {
-    const turnIds = this.resolveTurnMessageIds(messageId);
-    let rows = await this.selectByMessageIds(turnIds);
+    let rows = await this.selectRowsForMessage(messageId);
 
     if (rows.length === 0) {
       // Fork-source fallback. Mirror behavior of the local source: when no
@@ -157,8 +168,7 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
               ? parsed.data.forkSourceMessageId
               : null;
           if (sourceMessageId && sourceMessageId !== messageId) {
-            const sourceTurnIds = this.resolveTurnMessageIds(sourceMessageId);
-            rows = await this.selectByMessageIds(sourceTurnIds);
+            rows = await this.selectRowsForMessage(sourceMessageId);
           }
         } catch {
           // metadata not JSON / schema mismatch — no fork fallback, return []
@@ -169,6 +179,22 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
     return rows.sort(
       (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
     );
+  }
+
+  private async selectRowsForMessage(messageId: string): Promise<LogRow[]> {
+    const turnIds = this.resolveTurnMessageIds(messageId);
+    const rows = await this.selectByMessageIds(turnIds);
+    const unlinkedRows = await this.selectUnlinkedLogsInTurn(messageId);
+    if (unlinkedRows.length === 0) return rows;
+
+    const seen = new Set(rows.map((row) => row.id));
+    const merged = [...rows];
+    for (const row of unlinkedRows) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+      merged.push(row);
+    }
+    return merged;
   }
 
   private async selectByMessageIds(ids: string[]): Promise<LogRow[]> {
@@ -205,6 +231,49 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
       LIMIT 1 BY id
       FORMAT JSONEachRow`;
     const rows = await this.exec(sql, params);
+    return rows.map((r) => this.toLogRow(r));
+  }
+
+  private async selectUnlinkedLogsInTurn(messageId: string): Promise<LogRow[]> {
+    const message = this.resolveMessage(messageId);
+    if (
+      !message ||
+      typeof message.conversationId !== "string" ||
+      typeof message.createdAt !== "number"
+    ) {
+      return [];
+    }
+    const bounds = this.resolveTurnTimeBounds(
+      message.conversationId,
+      message.createdAt,
+    );
+    if (!bounds || bounds.endTime <= bounds.startTime) return [];
+
+    const aid = await this.assistantId();
+    const sql = `SELECT
+        id,
+        conversation_id,
+        message_id,
+        provider,
+        request_payload,
+        response_payload,
+        toUnixTimestamp64Milli(created_at) AS created_at,
+        agent_loop_exit_reason
+      FROM ${this.tableRef()}
+      WHERE assistant_id = {assistant_id:String}
+        AND conversation_id = {conversation_id:String}
+        AND message_id = ''
+        AND created_at >= fromUnixTimestamp64Milli({start_ms:Int64})
+        AND created_at <= fromUnixTimestamp64Milli({end_ms:Int64})
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1 BY id
+      FORMAT JSONEachRow`;
+    const rows = await this.exec(sql, {
+      assistant_id: aid,
+      conversation_id: message.conversationId,
+      start_ms: String(bounds.startTime),
+      end_ms: String(bounds.endTime),
+    });
     return rows.map((r) => this.toLogRow(r));
   }
 
@@ -248,7 +317,11 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       log.error(
-        { status: res.status, table: this.config.table, bodySnippet: body.slice(0, 200) },
+        {
+          status: res.status,
+          table: this.config.table,
+          bodySnippet: body.slice(0, 200),
+        },
         "ClickHouse query failed",
       );
       throw new Error(


### PR DESCRIPTION
## Summary

- Recover ClickHouse LLM request log rows whose mirrored `message_id` is still empty because the insert-only mirror saw them before local backfill.
- Scope the recovery query to the local turn time window and conversation so Slack/background turns can show their calls in the inspector without broad ClickHouse scans.
- Add a regression test covering the empty-`message_id` ClickHouse path.

## Root Cause

The UI was sending the correct persisted assistant message id. The ClickHouse log source only queried exact `message_id` values, but the mirror is insert-only: rows inserted locally before `backfillMessageIdOnLogs()` can remain in ClickHouse as `message_id = ''`. Slack turns hit that path more often, so the inspector could report zero calls even though local logs existed.

## Validation

- `cd assistant && bun test src/__tests__/llm-request-log-source-clickhouse.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-commit formatting + lint hook
- pre-push assistant typecheck + lint hook