### PR TITLE
feat(design-library): add PortalContainerProvider, usePortalContainer, and Popover component

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellum/design-library",
       "dependencies": {
+        "@radix-ui/react-popover": "1.1.15",
         "@radix-ui/react-slot": "1.2.4",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
@@ -126,6 +127,14 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.7.0", "", { "dependencies": { "glob": "^13.0.1", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -224,9 +233,49 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 
@@ -360,6 +409,8 @@
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
@@ -408,6 +459,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
@@ -437,6 +490,8 @@
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -540,6 +595,12 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
@@ -592,6 +653,10 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
@@ -609,6 +674,10 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -9,7 +9,8 @@
     ".": "./src/index.ts",
     "./tokens.css": "./src/tokens.css",
     "./components/*": "./src/components/*.tsx",
-    "./utils/*": "./src/utils/*.ts"
+    "./utils/*": "./src/utils/*.ts",
+    "./utils/portal-container": "./src/utils/portal-container.tsx"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",
@@ -35,6 +36,7 @@
     "vite": "8.0.11"
   },
   "dependencies": {
+    "@radix-ui/react-popover": "1.1.15",
     "@radix-ui/react-slot": "1.2.4",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/packages/design-library/src/components/popover.stories.tsx
+++ b/packages/design-library/src/components/popover.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "./button.js";
+import { Popover } from "./popover.js";
+
+const meta: Meta = {
+  title: "Components/Popover",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <Button>Open Popover</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <div className="flex flex-col gap-2 p-2">
+          <p className="text-body-medium-default">Popover content</p>
+          <p className="text-body-medium-lighter text-[color:var(--content-secondary)]">
+            This is a popover with default styling.
+          </p>
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  ),
+};
+
+export const WithCloseButton: Story = {
+  render: () => (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <Button variant="outlined">Settings</Button>
+      </Popover.Trigger>
+      <Popover.Content side="bottom" align="start" className="w-64">
+        <div className="flex flex-col gap-3 p-2">
+          <p className="text-body-medium-default">Settings</p>
+          <p className="text-body-medium-lighter text-[color:var(--content-secondary)]">
+            Configure your preferences.
+          </p>
+          <div className="flex justify-end">
+            <Popover.Close asChild>
+              <Button variant="ghost" size="compact">Close</Button>
+            </Popover.Close>
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  ),
+};
+
+export const Sides: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      {(["top", "right", "bottom", "left"] as const).map((side) => (
+        <Popover.Root key={side}>
+          <Popover.Trigger asChild>
+            <Button variant="outlined" size="compact">{side}</Button>
+          </Popover.Trigger>
+          <Popover.Content side={side}>
+            <p className="p-2 text-body-small-default">
+              Popover on {side}
+            </p>
+          </Popover.Content>
+        </Popover.Root>
+      ))}
+    </div>
+  ),
+};

--- a/packages/design-library/src/components/popover.tsx
+++ b/packages/design-library/src/components/popover.tsx
@@ -1,0 +1,85 @@
+import * as RadixPopover from "@radix-ui/react-popover";
+import { type ComponentProps } from "react";
+
+import { cn } from "../utils/cn.js";
+import { usePortalContainer } from "../utils/portal-container.jsx";
+
+/**
+ * Compound `Popover` primitive built on `@radix-ui/react-popover`.
+ *
+ * Preserves Radix's focus trap, outside-click dismissal, Escape handling,
+ * and `side` / `align` / `sideOffset` positioning. Content is portaled
+ * into the element provided by the nearest `<PortalContainerProvider>` so
+ * design tokens (CSS variables) resolve inside the portal. Falls back to
+ * `document.body` when no provider is mounted.
+ *
+ * Usage:
+ *
+ * ```tsx
+ * <Popover.Root>
+ *   <Popover.Trigger asChild>
+ *     <Button>Open</Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content side="bottom" align="start">
+ *     …
+ *     <Popover.Close asChild>
+ *       <Button variant="ghost">Close</Button>
+ *     </Popover.Close>
+ *   </Popover.Content>
+ * </Popover.Root>
+ * ```
+ *
+ * @see https://www.radix-ui.com/primitives/docs/components/popover
+ */
+const Root = RadixPopover.Root;
+const Trigger = RadixPopover.Trigger;
+const Close = RadixPopover.Close;
+const Anchor = RadixPopover.Anchor;
+
+type ContentProps = ComponentProps<typeof RadixPopover.Content>;
+
+function Content({
+  className,
+  children,
+  sideOffset = 6,
+  align = "center",
+  ref,
+  ...rest
+}: ContentProps) {
+  const portalContainer = usePortalContainer();
+  return (
+    <RadixPopover.Portal container={portalContainer ?? undefined}>
+      <RadixPopover.Content
+        ref={ref}
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 rounded-lg bg-[var(--surface-lift)] p-2 shadow-[var(--shadow-popover)] outline-none",
+          "text-[color:var(--content-default)]",
+          "data-[state=open]:animate-[popoverIn_120ms_ease-out]",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </RadixPopover.Content>
+    </RadixPopover.Portal>
+  );
+}
+
+/**
+ * Convenience namespace so callers write `<Popover.Root>` /
+ * `<Popover.Trigger>` / `<Popover.Content>` / `<Popover.Close>` without
+ * importing each symbol separately. Mirrors Radix's own compound-component
+ * ergonomics.
+ */
+const Popover = {
+  Root,
+  Trigger,
+  Content,
+  Close,
+  Anchor,
+};
+
+export { Popover, type ContentProps as PopoverContentProps };

--- a/packages/design-library/src/components/popover.tsx
+++ b/packages/design-library/src/components/popover.tsx
@@ -2,7 +2,7 @@ import * as RadixPopover from "@radix-ui/react-popover";
 import { type ComponentProps } from "react";
 
 import { cn } from "../utils/cn.js";
-import { usePortalContainer } from "../utils/portal-container.jsx";
+import { usePortalContainer } from "../utils/portal-container.js";
 
 /**
  * Compound `Popover` primitive built on `@radix-ui/react-popover`.

--- a/packages/design-library/src/components/popover.tsx
+++ b/packages/design-library/src/components/popover.tsx
@@ -32,9 +32,24 @@ import { usePortalContainer } from "../utils/portal-container.js";
  * @see https://www.radix-ui.com/primitives/docs/components/popover
  */
 const Root = RadixPopover.Root;
-const Trigger = RadixPopover.Trigger;
-const Close = RadixPopover.Close;
-const Anchor = RadixPopover.Anchor;
+
+type TriggerProps = ComponentProps<typeof RadixPopover.Trigger>;
+
+function Trigger(props: TriggerProps) {
+  return <RadixPopover.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+type CloseProps = ComponentProps<typeof RadixPopover.Close>;
+
+function Close(props: CloseProps) {
+  return <RadixPopover.Close data-slot="popover-close" {...props} />;
+}
+
+type AnchorProps = ComponentProps<typeof RadixPopover.Anchor>;
+
+function Anchor(props: AnchorProps) {
+  return <RadixPopover.Anchor data-slot="popover-anchor" {...props} />;
+}
 
 type ContentProps = ComponentProps<typeof RadixPopover.Content>;
 

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -44,4 +44,4 @@ export {
   PortalContainerProvider,
   usePortalContainer,
   type PortalContainerProviderProps,
-} from "./utils/portal-container.jsx";
+} from "./utils/portal-container.js";

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -35,4 +35,13 @@ export {
   type TypographyVariant,
   type TypographyAs,
 } from "./components/typography.js";
+export {
+  Popover,
+  type PopoverContentProps,
+} from "./components/popover.js";
 export { cn } from "./utils/cn.js";
+export {
+  PortalContainerProvider,
+  usePortalContainer,
+  type PortalContainerProviderProps,
+} from "./utils/portal-container.jsx";

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -113,6 +113,9 @@
   /* Aux */
   --aux-white: #FFFFFF;
 
+  /* Shadow */
+  --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.10), 0 4px 12px 0 rgba(0, 0, 0, 0.10);
+
   /* Derived */
   --ring: color-mix(in srgb, var(--system-positive-strong) 30%, transparent);
   --border-overlay: var(--border-disabled);
@@ -181,6 +184,9 @@
   /* Aux */
   --aux-white: #FFFFFF;
 
+  /* Shadow */
+  --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 4px 12px 0 rgba(0, 0, 0, 0.25);
+
   /* Derived */
   --border-overlay: var(--border-hover);
   --ghost-hover: var(--border-base);
@@ -236,6 +242,9 @@
 
   /* Aux */
   --aux-white: #FFFFFF;
+
+  /* Shadow */
+  --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 4px 12px 0 rgba(0, 0, 0, 0.25);
 
   /* Derived */
   --border-overlay: var(--border-hover);
@@ -379,6 +388,15 @@
   font-size: var(--text-chat-size);
   font-weight: var(--text-chat-weight);
   line-height: var(--text-chat-line-height);
+}
+
+/* ---------------------------------------------------------------------------
+ * Overlay animation keyframes.
+ * --------------------------------------------------------------------------- */
+
+@keyframes popoverIn {
+  0% { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 

--- a/packages/design-library/src/utils/portal-container.tsx
+++ b/packages/design-library/src/utils/portal-container.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Context for configuring where portaled content (popovers, modals, menus,
+ * dropdowns, bottom sheets, etc.) renders in the DOM.
+ *
+ * Design systems need portal containers to ensure overlays render inside a
+ * theme-scoped element so CSS variables resolve correctly. Without this,
+ * portaling to `document.body` loses access to scoped design tokens.
+ *
+ * **Pattern precedent:** Chakra UI (`PortalManager`), Blueprint
+ * (`PortalProvider`), react-md (`PortalContainerProvider`), and Ark UI
+ * (`EnvironmentProvider`) all use this same context-based approach.
+ *
+ * @see https://www.radix-ui.com/primitives/docs/utilities/portal
+ * @see https://github.com/palantir/blueprint/pull/6260
+ * @see https://react-md.dev/components/portal-container-provider
+ */
+const PortalContainerContext = createContext<HTMLElement | null>(null);
+
+export interface PortalContainerProviderProps {
+  /** The DOM element that portaled content should render into. */
+  container: HTMLElement | null;
+  children: ReactNode;
+}
+
+/**
+ * Provides a portal target element to all descendant design library
+ * components that render overlays (Popover, Modal, Menu, etc.).
+ *
+ * Mount this at the top of your app shell, passing the element that has
+ * your theme's CSS variables in scope. Overlay components read this
+ * context internally and fall back to `document.body` when no provider
+ * is mounted.
+ *
+ * Nestable — an inner provider overrides the outer one for its subtree,
+ * which is useful for rendering overlays inside dialogs or shadow DOM.
+ *
+ * ```tsx
+ * function AppShell({ children }: { children: ReactNode }) {
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   const [container, setContainer] = useState<HTMLElement | null>(null);
+ *   useEffect(() => { setContainer(ref.current); }, []);
+ *
+ *   return (
+ *     <div ref={ref} className="app-root">
+ *       <PortalContainerProvider container={container}>
+ *         {children}
+ *       </PortalContainerProvider>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+function PortalContainerProvider({
+  container,
+  children,
+}: PortalContainerProviderProps) {
+  return (
+    <PortalContainerContext value={container}>
+      {children}
+    </PortalContainerContext>
+  );
+}
+
+/**
+ * Returns the nearest portal container element, or `null` when called
+ * outside a `<PortalContainerProvider>`.
+ *
+ * Overlay components pass the result to Radix's `Portal` `container`
+ * prop (coerced to `undefined` so Radix falls back to `document.body`
+ * when no provider is mounted):
+ *
+ * ```tsx
+ * const container = usePortalContainer();
+ * <RadixPopover.Portal container={container ?? undefined}>
+ * ```
+ */
+function usePortalContainer(): HTMLElement | null {
+  return useContext(PortalContainerContext);
+}
+
+export { PortalContainerProvider, usePortalContainer };


### PR DESCRIPTION
## Prompt / plan

Add a context-based portal container primitive and a Popover component to the design library, following the industry-standard pattern used by Chakra UI ([`PortalManager`](https://v2.chakra-ui.com/docs/components/portal)), Blueprint ([`PortalProvider`](https://github.com/palantir/blueprint/pull/6260)), react-md ([`PortalContainerProvider`](https://react-md.dev/components/portal-container-provider)), and Ark UI ([`EnvironmentProvider`](https://ark-ui.com/docs/utilities/environment)).

### Why this is needed

Overlay components (popovers, modals, menus, dropdowns) portal their content to escape parent stacking contexts. By default, Radix portals to `document.body`, which loses access to scoped CSS variables (design tokens like `--surface-lift`, `--content-default`). The platform repo solved this with `AppRootProvider` / `useAppRootContainer()` — 17 components consume it.

For the design library, we need to decouple the portal container plumbing (reusable) from the app-specific `<div class="app-root">` element (app chrome). This PR adds the reusable primitive; consuming apps provide their own root element.

### What's included

**`PortalContainerProvider` + `usePortalContainer`** (`utils/portal-container.tsx`):
- Thin React context + provider holding an `HTMLElement | null`
- Nestable — inner providers override outer ones (useful for overlays inside dialogs or shadow DOM)
- Falls back gracefully: when no provider is mounted, `usePortalContainer()` returns `null`, and Radix falls back to `document.body`

**`Popover`** (`components/popover.tsx`):
- Compound component built on [`@radix-ui/react-popover`](https://www.radix-ui.com/primitives/docs/components/popover) v1.1.15
- Parts: `Root`, `Trigger`, `Content`, `Close`, `Anchor`
- `Content` portals into the nearest `PortalContainerProvider` automatically
- Follows design library conventions: function declarations, `data-slot` on every DOM-rendering part (`popover-trigger`, `popover-content`, `popover-close`, `popover-anchor`), `ComponentProps`, no `forwardRef`, named exports only
- `Root` is a `const` re-export — purely logical state container with no DOM element (exempt from data-slot/function declaration rules)

**Design tokens** (added to `tokens.css`):
- `--shadow-popover` for all three themes (light / dark / velvet) — darker shadow for dark themes
- `popoverIn` keyframe animation (fade + slight translateY + scale)

**Storybook stories** for visual testing (default, with close button, side variants).

### Alternatives considered

- **Radix `container` prop only (no context)**: Requires every overlay component to accept and thread through a container prop from the app. Doesn't scale — 17+ components would need this prop.
- **`EnvironmentProvider` pattern (Ark UI)**: Provides the entire `document` / root node, designed for iframes and Shadow DOM. Overkill — we just need a portal target element.
- **Keeping portal logic app-specific**: Would mean every consuming app reimplements the same context pattern. Since this is infrastructure every overlay component needs, it belongs in the shared library.
- **Bare `const` re-exports for pass-through Radix parts**: Initially used for Trigger/Close/Anchor, but converted to function declarations with `data-slot` per AGENTS.md rules 2 & 3 and the Card/Tag convention. Radix's Slot composition correctly merges `data-*` attributes onto the child when `asChild` is used.

## Test plan

- `bun run typecheck` passes in `packages/design-library/` (no errors)
- `bunx tsc --noEmit` passes in `apps/web/` (no errors — verifies subpath exports work)
- Storybook stories added for visual verification
- CI checks (9/9 passing)

Link to Devin session: https://app.devin.ai/sessions/536ceadb023a4059908b0609b9833bc1
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->