### PR TITLE
feat(macos): fade read home feed rows to make unread state pop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -54,6 +54,11 @@ struct HomeRecapRow: View {
         return isHovering ? VColor.surfaceLift : VColor.surfaceOverlay
     }
 
+    private var contentOpacity: Double {
+        if isUrgent { return 1.0 }
+        return status == .new ? 1.0 : 0.55
+    }
+
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: VSpacing.sm) {
@@ -99,6 +104,7 @@ struct HomeRecapRow: View {
                 }
             }
             .contentShape(Rectangle())
+            .opacity(contentOpacity)
         }
         .buttonStyle(.plain)
         .pointerCursor()


### PR DESCRIPTION
## Summary

- Dim home feed row content to 55% opacity when `status != .new` so the read/unread transition is visible at a glance. Urgent rows stay full-strength regardless of read state.
- Existing emphasised-on-unread title weight stays untouched; the two cues compound.

## Original prompt

Round-2 polish for the home notification surface. PR #31062 added bold-on-unread title weight, but user feedback indicates the differentiation is too subtle. Adding a row-content opacity reduction on read rows (urgent rows excepted) provides a stronger visual cue without restructuring the layout. Future work could add a dedicated unread indicator dot — out of scope here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->