### PR TITLE
feat(macos): persona avatar in HomeDetailPanel header for assistant rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -43,6 +43,11 @@ struct HomeDetailPanel<Content: View>: View {
     /// attachments footer to the bottom and wants the body text field to
     /// expand into the empty space above it.
     var scrollable: Bool = true
+    /// When `true`, render the 32pt persona avatar in the header's leading
+    /// slot instead of the category icon chip. Used for assistant-initiated
+    /// feed rows (`FeedItem.fromAssistant == true`) so the detail header
+    /// matches its list-row counterpart.
+    var showsPersonaAvatar: Bool = false
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -83,7 +88,11 @@ struct HomeDetailPanel<Content: View>: View {
     private var header: some View {
         HStack(spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
-                if let icon {
+                if showsPersonaAvatar {
+                    personaAvatar
+                        .frame(width: 32, height: 32)
+                        .accessibilityHidden(true)
+                } else if let icon {
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .fill(iconBackground ?? VColor.surfaceBase)
                         .frame(width: 32, height: 32)
@@ -132,5 +141,39 @@ struct HomeDetailPanel<Content: View>: View {
             bottom: VSpacing.md,
             trailing: VSpacing.lg
         ))
+    }
+
+    /// 32pt persona avatar rendered into the header's leading slot for
+    /// assistant-initiated rows. Mirrors `HomeRecapRow.personaAvatar` at a
+    /// larger size; a follow-up extraction can dedupe this with
+    /// `HomePageView.greetingAvatar` and `HomeRecapRow.personaAvatar`.
+    @ViewBuilder
+    private var personaAvatar: some View {
+        let appearance = AvatarAppearanceManager.shared
+        let size: CGFloat = 32
+        if appearance.customAvatarImage != nil {
+            VAvatarImage(
+                image: appearance.fullAvatarImage,
+                size: size,
+                showBorder: false
+            )
+        } else if let bodyShape = appearance.characterBodyShape,
+                  let eyes = appearance.characterEyeStyle,
+                  let color = appearance.characterColor {
+            AnimatedAvatarView(
+                bodyShape: bodyShape,
+                eyeStyle: eyes,
+                color: color,
+                size: size,
+                entryAnimationEnabled: false
+            )
+            .frame(width: size, height: size)
+        } else {
+            VAvatarImage(
+                image: appearance.fullAvatarImage,
+                size: size,
+                showBorder: false
+            )
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -149,16 +149,30 @@ struct HomeGallerySection: View {
                     description: "Reusable white right-side panel container with a standardized header (icon + title + \"Go to Thread\" action + dismiss)."
                 )
 
-                HomeDetailPanel(
-                    icon: .file,
-                    title: "Panel title",
-                    onGoToThread: {},
-                    onDismiss: {}
-                ) {
-                    Text("Detail content goes here.")
-                        .padding(VSpacing.lg)
+                VStack(spacing: VSpacing.lg) {
+                    HomeDetailPanel(
+                        icon: .file,
+                        title: "Panel title",
+                        onGoToThread: {},
+                        onDismiss: {}
+                    ) {
+                        Text("Detail content goes here.")
+                            .padding(VSpacing.lg)
+                    }
+                    .frame(height: 260)
+
+                    HomeDetailPanel(
+                        icon: .bell,
+                        title: "Assistant-initiated",
+                        onGoToThread: {},
+                        onDismiss: {},
+                        showsPersonaAvatar: true
+                    ) {
+                        Text("Persona avatar replaces the category chip when the row originated from the assistant.")
+                            .padding(VSpacing.lg)
+                    }
+                    .frame(height: 260)
                 }
-                .frame(height: 520)
             }
 
             // MARK: - HomeSuggestionPillBar

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -280,7 +280,8 @@ extension MainWindowView {
                 iconForeground: iconForegroundForFeedItem(item),
                 iconBackground: iconBackgroundForFeedItem(item),
                 onGoToThread: goToThreadHandler(for: item),
-                onDismiss: { activeHomeDetailPanel = nil }
+                onDismiss: { activeHomeDetailPanel = nil },
+                showsPersonaAvatar: item.fromAssistant == true
             ) {
                 Text(item.summary).font(VFont.bodyMediumDefault).foregroundStyle(VColor.contentSecondary).padding(VSpacing.lg)
             }


### PR DESCRIPTION
## Summary

- Add a `showsPersonaAvatar` flag to `HomeDetailPanel` that swaps the category icon chip for the 32pt persona avatar.
- Branch on `item.fromAssistant == true` in `PanelCoordinator.homeDetailPanelContent` so assistant-initiated rows mirror their list-row treatment from PR #31060.
- Gallery preview updated to exercise both shapes.

## Original prompt

Round-2 polish for the home notification surface. PR #31060 swapped the leading icon for the persona avatar on list rows when a `FeedItem` originated from the assistant (`fromAssistant == true`), but the right-hand `HomeDetailPanel` header still rendered a generic bell for the same items. This PR extends the substitution to the detail panel so the surface reads consistently across list and detail views.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->