### PR TITLE
feat(macos/home): show assistant name + larger avatar in greeting header

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -234,13 +234,16 @@ struct HomeGallerySection: View {
                 )
 
                 VCard(background: VColor.surfaceBase) {
-                    HomeGreetingHeader(onStartNewChat: {}) {
+                    HomeGreetingHeader(
+                        onStartNewChat: {},
+                        name: "Example Assistant"
+                    ) {
                         if let image = NSImage(systemSymbolName: "person.circle.fill", accessibilityDescription: nil) {
-                            VAvatarImage(image: image, size: 40)
+                            VAvatarImage(image: image, size: 56)
                         } else {
                             Circle()
                                 .fill(VColor.surfaceActive)
-                                .frame(width: 40, height: 40)
+                                .frame(width: 56, height: 56)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
@@ -3,25 +3,30 @@ import VellumAssistantShared
 
 /// Greeting header for the Home feed.
 ///
-/// Displays a caller-provided avatar on the leading edge and a primary
-/// "New Chat" pill CTA on the trailing edge. The avatar speaks for itself —
-/// the row deliberately carries no headline copy.
+/// Displays a caller-provided avatar on the leading edge and an optional
+/// display name next to it, with a primary "New Chat" pill CTA on the
+/// trailing edge.
 ///
-/// The caller is responsible for sizing the avatar (typical: 40x40pt) and for
-/// any outer padding around the header.
+/// The caller is responsible for sizing the avatar and for any outer padding
+/// around the header.
 struct HomeGreetingHeader<Avatar: View>: View {
     let onStartNewChat: () -> Void
+    let name: String?
     @ViewBuilder let avatar: () -> Avatar
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.md) {
             avatar()
 
+            if let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty {
+                Text(trimmed)
+                    .font(VFont.titleLarge)
+                    .foregroundStyle(VColor.contentEmphasized)
+            }
+
             Spacer()
 
-            // `leftIcon` is the VButton API for a leading icon (there is no
-            // `iconLeft`). `VIcon.squarePen` is the codebase's existing token
-            // for the "pen-to-square" / new conversation glyph.
             VButton(
                 label: "New Chat",
                 leftIcon: VIcon.squarePen.rawValue,

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -64,9 +64,10 @@ struct HomePageView: View {
                 // greeting-first appearance.
                 MeetStatusPanel(viewModel: meetStatusViewModel)
 
-                HomeGreetingHeader(onStartNewChat: onStartNewChat) {
-                    // Inline avatar rendering so this view owns its own
-                    // avatar resolution without depending on other views.
+                HomeGreetingHeader(
+                    onStartNewChat: onStartNewChat,
+                    name: store.state?.assistantName
+                ) {
                     greetingAvatar
                 }
                 .padding(.top, VSpacing.xxl)
@@ -148,12 +149,12 @@ struct HomePageView: View {
     // MARK: - Greeting avatar
 
     /// Inline avatar rendering so this view doesn't depend on another
-    /// view's internals. 40pt sizing matches the Figma spec for the new
-    /// greeting row.
+    /// view's internals. 56pt sizing gives the greeting row visual weight
+    /// alongside the display-name heading.
     @ViewBuilder
     private var greetingAvatar: some View {
         let appearance = AvatarAppearanceManager.shared
-        let avatarSize: CGFloat = 40
+        let avatarSize: CGFloat = 56
         if appearance.customAvatarImage != nil {
             VAvatarImage(
                 image: appearance.fullAvatarImage,


### PR DESCRIPTION
## Summary

- Add an optional `name` parameter to `HomeGreetingHeader` rendered as a heading next to the avatar.
- Pass `store.state?.assistantName` from `HomePageView`; bump greeting avatar from 40pt to 56pt so the header carries visual weight after the previous headline removal.

## Original prompt

Round-2 polish for the home notification surface. After PR #31062 removed the "Here's what's been going on" headline, the greeting header felt bare — just a tiny avatar floating next to "New Chat". This PR enlarges the avatar and adds the configured assistant display name beside it as a heading, with no subtitle. The display name flows from the existing `RelationshipState.assistantName` already plumbed through `HomeStore`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->