### PR TITLE
chore(gitignore): ignore .agents/skills shared symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,11 @@ CLAUDE.md
 !assistant/CLAUDE.md
 .agents/*
 !.agents/skills/
+
+# Shared claude-skills symlinks under .agents/skills/ are gitignored; only
+# repo-local skills are tracked. Mirrors the .claude/skills/ pattern above.
+.agents/skills/*
+!.agents/skills/testing-design-library-storybook/
 .codex
 .vellum
 


### PR DESCRIPTION
## Summary

- Add \`.agents/skills/*\` to \`.gitignore\` with an explicit un-ignore for the only repo-local skill (\`testing-design-library-storybook\`), mirroring the \`.claude/skills\` pattern that's already in place.
- Removes ~35 untracked symlinks from every worktree's \`git status\`, so the \`.claude/ship\` wrapper's \`git add -A\` no longer pulls them in and trips the generic-examples pre-commit hook on path strings.

## Original prompt

Three previous /do agents (PRs #31080, #31081, #31082) each had to manually sidestep the \`.claude/ship\` script because its \`git add -A\` was staging worktree-mirrored \`.agents/skills/*\` symlinks, whose paths got rejected by the generic-examples pre-commit hook. Root cause: \`.agents/skills/\` is re-included by \`!.agents/skills/\` in \`.gitignore\` without a subsequent ignore-children rule, so every shared skill symlink shows up as untracked. The \`.claude/skills\` block already solves the same problem for its mirror; this PR copies that pattern to \`.agents/skills\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->