### PR TITLE
feat(web): port AssistantShell layout from platform repo

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellumai/web",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1",
+        "@radix-ui/react-popover": "1.1.15",
         "@radix-ui/react-slot": "1.2.4",
         "@tanstack/react-query": "5.90.21",
         "@vellum/design-library": "file:../../packages/design-library",
@@ -143,6 +144,14 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@hey-api/client-fetch": ["@hey-api/client-fetch@0.13.1", "", { "peerDependencies": { "@hey-api/openapi-ts": "< 2" } }, "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA=="],
 
     "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA=="],
@@ -191,9 +200,49 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 
@@ -367,6 +416,8 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
@@ -437,6 +488,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
@@ -502,6 +555,8 @@
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -669,7 +724,13 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-router": ["react-router@7.15.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -743,6 +804,10 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
@@ -768,6 +833,10 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hey-api/client-fetch": "0.13.1",
+    "@radix-ui/react-popover": "1.1.15",
     "@radix-ui/react-slot": "1.2.4",
     "@tanstack/react-query": "5.90.21",
     "@vellum/design-library": "file:../../packages/design-library",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,8 @@
-import { Outlet, useLocation, useNavigate } from "react-router";
 import { useCallback, useRef } from "react";
-import { AssistantShell } from "./components/shell/assistant-shell.js";
-import { SideMenu } from "./components/shell/side-menu.js";
+import { Outlet, useLocation, useNavigate } from "react-router";
+
+import { AssistantShell } from "@/components/shell/assistant-shell.js";
+import { SideMenu } from "@/components/shell/side-menu.js";
 
 export function App() {
   const navigate = useNavigate();
@@ -31,6 +32,14 @@ export function App() {
     navigate("/home");
   }, [navigate]);
 
+  const handleGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  const handleGoForward = useCallback(() => {
+    navigate(1);
+  }, [navigate]);
+
   const isHomeActive = location.pathname === "/home";
 
   return (
@@ -41,8 +50,8 @@ export function App() {
       isHomeActive={isHomeActive}
       canGoBack={canGoBack}
       canGoForward={canGoForward}
-      onGoBack={() => navigate(-1)}
-      onGoForward={() => navigate(1)}
+      onGoBack={handleGoBack}
+      onGoForward={handleGoForward}
     >
       <Outlet />
     </AssistantShell>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,21 +1,33 @@
-import { Link, Outlet } from "react-router";
+import { Outlet, useLocation, useNavigate } from "react-router";
+import { useCallback } from "react";
+import { AssistantShell } from "./components/shell/assistant-shell.js";
+import { SideMenu } from "./components/shell/side-menu.js";
 
 export function App() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleStartNewConversation = useCallback(() => {
+    navigate("/");
+  }, [navigate]);
+
+  const handleOpenHome = useCallback(() => {
+    navigate("/home");
+  }, [navigate]);
+
+  const isHomeActive = location.pathname === "/home";
+
   return (
-    <div>
-      <header>
-        <h1>vellum-assistant · apps/web</h1>
-        <nav>
-          <Link to="/conversations/new">New conversation</Link>
-          {" · "}
-          <Link to="/library">Library</Link>
-          {" · "}
-          <Link to="/settings/general">Settings</Link>
-        </nav>
-      </header>
-      <main>
-        <Outlet />
-      </main>
-    </div>
+    <AssistantShell
+      sideMenu={(args) => <SideMenu {...args} />}
+      onStartNewConversation={handleStartNewConversation}
+      onOpenHome={handleOpenHome}
+      isHomeActive={isHomeActive}
+      canGoBack={window.history.length > 1}
+      onGoBack={() => navigate(-1)}
+      onGoForward={() => navigate(1)}
+    >
+      <Outlet />
+    </AssistantShell>
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,11 +1,27 @@
 import { Outlet, useLocation, useNavigate } from "react-router";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { AssistantShell } from "./components/shell/assistant-shell.js";
 import { SideMenu } from "./components/shell/side-menu.js";
 
 export function App() {
   const navigate = useNavigate();
   const location = useLocation();
+
+  const historyIndexRef = useRef(0);
+  const maxHistoryIndexRef = useRef(0);
+
+  const prevLocationRef = useRef(location);
+  if (prevLocationRef.current !== location) {
+    historyIndexRef.current = window.history.state?.idx ?? 0;
+    maxHistoryIndexRef.current = Math.max(
+      maxHistoryIndexRef.current,
+      historyIndexRef.current,
+    );
+    prevLocationRef.current = location;
+  }
+
+  const canGoBack = historyIndexRef.current > 0;
+  const canGoForward = historyIndexRef.current < maxHistoryIndexRef.current;
 
   const handleStartNewConversation = useCallback(() => {
     navigate("/");
@@ -23,7 +39,8 @@ export function App() {
       onStartNewConversation={handleStartNewConversation}
       onOpenHome={handleOpenHome}
       isHomeActive={isHomeActive}
-      canGoBack={window.history.length > 1}
+      canGoBack={canGoBack}
+      canGoForward={canGoForward}
       onGoBack={() => navigate(-1)}
       onGoForward={() => navigate(1)}
     >

--- a/apps/web/src/components/shell/assistant-shell-header.tsx
+++ b/apps/web/src/components/shell/assistant-shell-header.tsx
@@ -1,5 +1,5 @@
-import { ChevronLeft, ChevronRight, House, Menu as MenuIcon, MessageSquarePlus, PanelLeft, Search } from "lucide-react";
 import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight, House, Menu as MenuIcon, MessageSquarePlus, PanelLeft, Search } from "lucide-react";
 import { Button } from "@vellum/design-library";
 
 export interface AssistantShellHeaderProps {

--- a/apps/web/src/components/shell/assistant-shell-header.tsx
+++ b/apps/web/src/components/shell/assistant-shell-header.tsx
@@ -1,0 +1,140 @@
+import { ChevronLeft, ChevronRight, House, Menu as MenuIcon, MessageSquarePlus, PanelLeft, Search } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@vellum/design-library";
+
+export interface AssistantShellHeaderProps {
+  isMobile: boolean;
+  drawerOpen: boolean;
+  collapsed: boolean;
+  toggleSidebar: () => void;
+  topBarCenter?: ReactNode;
+  topBarRightSlot?: ReactNode;
+  onStartNewConversation?: () => void;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
+  onGoBack?: () => void;
+  onGoForward?: () => void;
+  onSearchClick?: () => void;
+  onOpenHome?: () => void;
+  isHomeActive?: boolean;
+}
+
+export function AssistantShellHeader({
+  isMobile,
+  drawerOpen,
+  collapsed,
+  toggleSidebar,
+  topBarCenter,
+  topBarRightSlot,
+  onStartNewConversation,
+  canGoBack,
+  canGoForward,
+  onGoBack,
+  onGoForward,
+  onSearchClick,
+  onOpenHome,
+  isHomeActive,
+}: AssistantShellHeaderProps) {
+  return (
+    <header
+      className={`flex w-full shrink-0 items-center gap-4 px-4 pt-4${isMobile ? " pb-4" : ""}`}
+      style={{
+        background: "var(--surface-base)",
+        minHeight:
+          "calc(40px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+        paddingTop:
+          "calc(16px + var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 transition-[min-width] duration-150 ease-in-out"
+        style={!isMobile ? { minWidth: collapsed ? 48 : 230 } : undefined}
+      >
+        {isMobile ? (
+          <Button
+            variant="ghost"
+            iconOnly={<MenuIcon />}
+            aria-label="Open navigation"
+            aria-expanded={drawerOpen}
+            aria-controls="assistant-side-menu"
+            onClick={toggleSidebar}
+          />
+        ) : (
+          <Button
+            variant="ghost"
+            iconOnly={<PanelLeft />}
+            aria-label="Toggle sidebar"
+            aria-expanded={!collapsed}
+            aria-controls="assistant-side-menu"
+            onClick={toggleSidebar}
+          />
+        )}
+        {!isMobile ? (
+          <>
+            {onOpenHome ? (
+              <Button
+                variant="ghost"
+                iconOnly={<House />}
+                aria-label="Home"
+                aria-current={isHomeActive ? "page" : undefined}
+                onClick={onOpenHome}
+              />
+            ) : null}
+            {onSearchClick ? (
+              <Button
+                variant="ghost"
+                iconOnly={<Search />}
+                aria-label="Search (Ctrl+K)"
+                title="Search (Ctrl+K)"
+                onClick={onSearchClick}
+              />
+            ) : null}
+            <Button
+              variant="ghost"
+              iconOnly={<ChevronLeft />}
+              aria-label="Back (Ctrl+[)"
+              title="Back (Ctrl+[)"
+              disabled={!canGoBack}
+              className={!canGoBack ? "opacity-35" : undefined}
+              onClick={onGoBack}
+            />
+            <Button
+              variant="ghost"
+              iconOnly={<ChevronRight />}
+              aria-label="Forward (Ctrl+])"
+              title="Forward (Ctrl+])"
+              disabled={!canGoForward}
+              className={!canGoForward ? "opacity-35" : undefined}
+              onClick={onGoForward}
+            />
+          </>
+        ) : null}
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-center justify-center">
+        {topBarCenter}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {isMobile && onSearchClick ? (
+          <Button
+            variant="ghost"
+            iconOnly={<Search />}
+            aria-label="Search (Ctrl+K)"
+            title="Search (Ctrl+K)"
+            onClick={onSearchClick}
+          />
+        ) : null}
+        {onStartNewConversation ? (
+          <Button
+            variant="ghost"
+            iconOnly={<MessageSquarePlus />}
+            aria-label="New conversation"
+            onClick={onStartNewConversation}
+          />
+        ) : null}
+        {topBarRightSlot}
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/shell/assistant-shell.tsx
+++ b/apps/web/src/components/shell/assistant-shell.tsx
@@ -1,0 +1,404 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { AssistantShellHeader } from "./assistant-shell-header.js";
+import { haptic } from "../../utils/haptics.js";
+import { MOBILE_MEDIA_QUERY, useIsMobile } from "../../hooks/use-is-mobile.js";
+import { useVisibleViewport } from "../../hooks/use-visible-viewport.js";
+
+/**
+ * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
+ * is treated as the soft keyboard opening. Below this we assume incidental
+ * drift from browser chrome / pinch-zoom and leave the layout alone.
+ */
+const KEYBOARD_OPEN_THRESHOLD_PX = 100;
+
+/**
+ * LocalStorage key used to persist the collapsed state of the sidebar rail
+ * across reloads.
+ */
+export const ASSISTANT_SIDEBAR_COLLAPSED_STORAGE_KEY =
+  "assistantSidebarCollapsed";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function readPersistedCollapsed(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return (
+      window.localStorage.getItem(ASSISTANT_SIDEBAR_COLLAPSED_STORAGE_KEY) ===
+      "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function shouldCloseDrawerOnViewportChange(isMobile: boolean): boolean {
+  return !isMobile;
+}
+
+/**
+ * Returns `true` when the keyboard event matches Ctrl/Cmd + one of the given
+ * keys and the active element is not an input surface.
+ */
+export function shouldHandleShortcut(
+  event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "key">,
+  activeElement: Element | null,
+  key: string | string[],
+): boolean {
+  const modifierPressed = event.metaKey || event.ctrlKey;
+  if (!modifierPressed) {
+    return false;
+  }
+  const keys = Array.isArray(key) ? key : [key];
+  if (!keys.includes(event.key)) {
+    return false;
+  }
+  if (!activeElement) {
+    return true;
+  }
+  const tag = activeElement.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+    return false;
+  }
+  if (activeElement.getAttribute("contenteditable") === "true") {
+    return false;
+  }
+  return true;
+}
+
+export type AssistantShellSideMenuVariant = "rail" | "overlay";
+
+export interface AssistantShellSideMenuArgs {
+  collapsed: boolean;
+  variant: AssistantShellSideMenuVariant;
+  onClose?: () => void;
+  onSearch?: () => void;
+}
+
+export interface AssistantShellProps {
+  /**
+   * Render-prop for the side menu content. Receives whether the rail is
+   * collapsed and which variant to render (`"rail"` on desktop, `"overlay"`
+   * on mobile).
+   */
+  sideMenu: (args: AssistantShellSideMenuArgs) => ReactNode;
+  topBarRightSlot?: ReactNode;
+  topBarCenter?: ReactNode;
+  onStartNewConversation?: () => void;
+  onToggleCommandPalette?: () => void;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
+  onGoBack?: () => void;
+  onGoForward?: () => void;
+  onOpenHome?: () => void;
+  isHomeActive?: boolean;
+  children: ReactNode;
+  /**
+   * Overlay nodes that must remain anchored to the visual viewport — not
+   * to the shell's chat-content coordinate space. Rendered outside the inner
+   * wrapper that carries the iOS visual-viewport `translate3d`.
+   */
+  viewportOverlays?: ReactNode;
+}
+
+export function AssistantShell({
+  sideMenu,
+  topBarRightSlot,
+  topBarCenter,
+  onStartNewConversation,
+  onToggleCommandPalette,
+  canGoBack,
+  canGoForward,
+  onGoBack,
+  onGoForward,
+  onOpenHome,
+  isHomeActive,
+  children,
+  viewportOverlays,
+}: AssistantShellProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(readPersistedCollapsed);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    try {
+      window.localStorage.setItem(
+        ASSISTANT_SIDEBAR_COLLAPSED_STORAGE_KEY,
+        String(collapsed),
+      );
+    } catch {
+      // Storage unavailable (private mode, quota, etc.)
+    }
+  }, [collapsed]);
+
+  const isMobile = useIsMobile();
+  const visibleViewport = useVisibleViewport();
+  const keyboardOpen =
+    isMobile &&
+    visibleViewport !== null &&
+    visibleViewport.keyboardHeight > KEYBOARD_OPEN_THRESHOLD_PX;
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (shouldCloseDrawerOnViewportChange(isMobile)) {
+      setDrawerOpen(false);
+    }
+  }, [isMobile]);
+
+  const drawerVisible = isMobile && drawerOpen;
+
+  const toggleSidebar = useCallback(() => {
+    if (typeof window === "undefined") {
+      setCollapsed((value) => !value);
+      return;
+    }
+    haptic.light();
+    if (window.matchMedia(MOBILE_MEDIA_QUERY).matches) {
+      setDrawerOpen((value) => !value);
+    } else {
+      setCollapsed((value) => !value);
+    }
+  }, []);
+
+  // Ctrl/Cmd+\ shortcut to toggle sidebar
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldHandleShortcut(event, document.activeElement, "\\")) {
+        return;
+      }
+      event.preventDefault();
+      toggleSidebar();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [toggleSidebar]);
+
+  // Ctrl/Cmd+K shortcut for command palette
+  useEffect(() => {
+    if (typeof window === "undefined" || !onToggleCommandPalette) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key !== "k") {
+        return;
+      }
+      event.preventDefault();
+      onToggleCommandPalette();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onToggleCommandPalette]);
+
+  // Ctrl/Cmd+[ and Ctrl/Cmd+] shortcuts for back/forward navigation
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldHandleShortcut(event, document.activeElement, ["[", "]"])) {
+        return;
+      }
+      event.preventDefault();
+      if (event.key === "[" && onGoBack) {
+        onGoBack();
+      } else if (event.key === "]" && onGoForward) {
+        onGoForward();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onGoBack, onGoForward]);
+
+  // Mobile drawer — focus trap, ESC to close, body-scroll-lock
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!drawerVisible) {
+      return;
+    }
+
+    drawerRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        drawerRef.current &&
+        !drawerRef.current.contains(document.activeElement)
+      ) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        setDrawerOpen(false);
+        return;
+      }
+      if (event.key !== "Tab" || !drawerRef.current) {
+        return;
+      }
+      const focusable =
+        drawerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) {
+        event.preventDefault();
+        return;
+      }
+      const active = document.activeElement as HTMLElement | null;
+      const isInDrawer = drawerRef.current.contains(active);
+
+      if (event.shiftKey) {
+        if (!isInDrawer || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (!isInDrawer || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousBodyOverflow;
+    };
+  }, [drawerVisible]);
+
+  // iOS visual-viewport keyboard tracking
+  const followVisualViewport =
+    keyboardOpen &&
+    visibleViewport !== null &&
+    (visibleViewport.offsetTop !== 0 || visibleViewport.offsetLeft !== 0);
+  const shellTransform = followVisualViewport
+    ? `translate3d(${visibleViewport.offsetLeft}px, ${visibleViewport.offsetTop}px, 0)`
+    : undefined;
+
+  return (
+    <div
+      className="app-shell"
+      style={{
+        background: "var(--surface-base)",
+        height:
+          keyboardOpen && visibleViewport
+            ? `${visibleViewport.height}px`
+            : "100dvh",
+        paddingBottom: keyboardOpen
+          ? "0px"
+          : "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft:
+          "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight:
+          "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+        isolation: "isolate",
+      }}
+    >
+      <div
+        className="flex min-w-0 flex-col overflow-hidden h-full w-full"
+        style={{
+          transform: shellTransform,
+          transformOrigin: shellTransform ? "0 0" : undefined,
+        }}
+      >
+        <AssistantShellHeader
+          isMobile={isMobile}
+          drawerOpen={drawerOpen}
+          collapsed={collapsed}
+          toggleSidebar={toggleSidebar}
+          topBarCenter={topBarCenter}
+          topBarRightSlot={topBarRightSlot}
+          onStartNewConversation={onStartNewConversation}
+          canGoBack={canGoBack}
+          canGoForward={canGoForward}
+          onGoBack={onGoBack}
+          onGoForward={onGoForward}
+          onSearchClick={onToggleCommandPalette}
+          onOpenHome={onOpenHome}
+          isHomeActive={isHomeActive}
+        />
+
+        {isMobile ? (
+          <main className="relative flex min-w-0 flex-1 min-h-0 overflow-hidden">
+            {children}
+            {drawerVisible ? (
+              <div
+                ref={drawerRef}
+                className="fixed inset-0"
+                style={{ zIndex: 40 }}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Assistant navigation"
+              >
+                <aside
+                  id="assistant-side-menu"
+                  className="relative flex h-full w-full flex-col shadow-xl"
+                  style={{
+                    background: "var(--surface-lift)",
+                    borderRight: "1px solid var(--border-base)",
+                    zIndex: 50,
+                    paddingTop:
+                      "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+                    paddingBottom:
+                      "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+                    paddingLeft:
+                      "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+                  }}
+                >
+                  {sideMenu({
+                    collapsed: false,
+                    variant: "overlay",
+                    onClose: () => setDrawerOpen(false),
+                    onSearch: onToggleCommandPalette,
+                  })}
+                </aside>
+              </div>
+            ) : null}
+          </main>
+        ) : (
+          <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden">
+            <aside
+              id="assistant-side-menu"
+              className="shrink-0"
+              aria-label="Assistant navigation"
+            >
+              {sideMenu({ collapsed, variant: "rail" })}
+            </aside>
+            <main
+              className="min-w-0 flex-1 overflow-y-auto"
+              style={{ flex: 1 }}
+            >
+              {children}
+            </main>
+          </div>
+        )}
+      </div>
+      {viewportOverlays}
+    </div>
+  );
+}

--- a/apps/web/src/components/shell/assistant-shell.tsx
+++ b/apps/web/src/components/shell/assistant-shell.tsx
@@ -201,7 +201,7 @@ export function AssistantShell({
       return;
     }
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.key !== "k") {
+      if (!shouldHandleShortcut(event, document.activeElement, "k")) {
         return;
       }
       event.preventDefault();

--- a/apps/web/src/components/shell/assistant-shell.tsx
+++ b/apps/web/src/components/shell/assistant-shell.tsx
@@ -6,10 +6,11 @@ import {
   type ReactNode,
 } from "react";
 
+import { haptic } from "@/utils/haptics.js";
+import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile.js";
+import { useVisibleViewport } from "@/hooks/use-visible-viewport.js";
+
 import { AssistantShellHeader } from "./assistant-shell-header.js";
-import { haptic } from "../../utils/haptics.js";
-import { MOBILE_MEDIA_QUERY, useIsMobile } from "../../hooks/use-is-mobile.js";
-import { useVisibleViewport } from "../../hooks/use-visible-viewport.js";
 
 /**
  * Threshold (in px) below which a `innerHeight − visualViewport.height` delta
@@ -35,9 +36,6 @@ const FOCUSABLE_SELECTOR = [
 ].join(",");
 
 export function readPersistedCollapsed(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
   try {
     return (
       window.localStorage.getItem(ASSISTANT_SIDEBAR_COLLAPSED_STORAGE_KEY) ===
@@ -135,9 +133,6 @@ export function AssistantShell({
   const [collapsed, setCollapsed] = useState<boolean>(readPersistedCollapsed);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
     try {
       window.localStorage.setItem(
         ASSISTANT_SIDEBAR_COLLAPSED_STORAGE_KEY,
@@ -165,10 +160,6 @@ export function AssistantShell({
   const drawerVisible = isMobile && drawerOpen;
 
   const toggleSidebar = useCallback(() => {
-    if (typeof window === "undefined") {
-      setCollapsed((value) => !value);
-      return;
-    }
     haptic.light();
     if (window.matchMedia(MOBILE_MEDIA_QUERY).matches) {
       setDrawerOpen((value) => !value);
@@ -179,9 +170,6 @@ export function AssistantShell({
 
   // Ctrl/Cmd+\ shortcut to toggle sidebar
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
     const onKeyDown = (event: KeyboardEvent) => {
       if (!shouldHandleShortcut(event, document.activeElement, "\\")) {
         return;
@@ -197,7 +185,7 @@ export function AssistantShell({
 
   // Ctrl/Cmd+K shortcut for command palette
   useEffect(() => {
-    if (typeof window === "undefined" || !onToggleCommandPalette) {
+    if (!onToggleCommandPalette) {
       return;
     }
     const onKeyDown = (event: KeyboardEvent) => {
@@ -215,9 +203,6 @@ export function AssistantShell({
 
   // Ctrl/Cmd+[ and Ctrl/Cmd+] shortcuts for back/forward navigation
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
     const onKeyDown = (event: KeyboardEvent) => {
       if (!shouldHandleShortcut(event, document.activeElement, ["[", "]"])) {
         return;
@@ -344,7 +329,7 @@ export function AssistantShell({
         />
 
         {isMobile ? (
-          <main className="relative flex min-w-0 flex-1 min-h-0 overflow-hidden">
+          <main className="relative flex min-w-0 flex-1 min-h-0 overflow-y-auto">
             {children}
             {drawerVisible ? (
               <div

--- a/apps/web/src/components/shell/side-menu.tsx
+++ b/apps/web/src/components/shell/side-menu.tsx
@@ -1,0 +1,101 @@
+import { House, Library, MessageSquare, Settings, X } from "lucide-react";
+import { NavLink } from "react-router";
+import { Button } from "@vellum/design-library";
+import type { AssistantShellSideMenuArgs } from "./assistant-shell.js";
+
+function NavItem({
+  to,
+  icon,
+  label,
+  collapsed,
+  onClick,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  collapsed: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <NavLink
+      to={to}
+      onClick={onClick}
+      className={({ isActive }) =>
+        [
+          "flex items-center gap-3 rounded-lg px-3 py-2 text-body-small-default transition-colors",
+          isActive
+            ? "bg-[var(--surface-lift)]"
+            : "hover:bg-[var(--surface-lift)]",
+          collapsed ? "justify-center" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")
+      }
+      style={{ color: "var(--content-default)" }}
+    >
+      <span className="shrink-0">{icon}</span>
+      {!collapsed ? <span>{label}</span> : null}
+    </NavLink>
+  );
+}
+
+export function SideMenu({ collapsed, variant, onClose }: AssistantShellSideMenuArgs) {
+  const isOverlay = variant === "overlay";
+  const handleNavClick = isOverlay ? onClose : undefined;
+
+  return (
+    <nav
+      className="flex flex-col gap-1 p-2"
+      style={{
+        width: isOverlay ? "100%" : collapsed ? 52 : 240,
+        transition: "width 150ms ease-in-out",
+      }}
+    >
+      {isOverlay ? (
+        <div className="flex items-center justify-between px-2 pb-2">
+          <span
+            className="text-title-small"
+            style={{ color: "var(--content-default)" }}
+          >
+            Vellum
+          </span>
+          <Button
+            variant="ghost"
+            iconOnly={<X />}
+            aria-label="Close navigation"
+            onClick={onClose}
+          />
+        </div>
+      ) : null}
+
+      <NavItem
+        to="/home"
+        icon={<House size={18} />}
+        label="Home"
+        collapsed={collapsed}
+        onClick={handleNavClick}
+      />
+      <NavItem
+        to="/"
+        icon={<MessageSquare size={18} />}
+        label="Chat"
+        collapsed={collapsed}
+        onClick={handleNavClick}
+      />
+      <NavItem
+        to="/library"
+        icon={<Library size={18} />}
+        label="Library"
+        collapsed={collapsed}
+        onClick={handleNavClick}
+      />
+      <NavItem
+        to="/settings/general"
+        icon={<Settings size={18} />}
+        label="Settings"
+        collapsed={collapsed}
+        onClick={handleNavClick}
+      />
+    </nav>
+  );
+}

--- a/apps/web/src/components/shell/side-menu.tsx
+++ b/apps/web/src/components/shell/side-menu.tsx
@@ -1,6 +1,8 @@
-import { House, Library, MessageSquare, Settings, X } from "lucide-react";
+import { type ReactNode } from "react";
 import { NavLink } from "react-router";
+import { House, Library, MessageSquare, Settings, X } from "lucide-react";
 import { Button } from "@vellum/design-library";
+
 import type { AssistantShellSideMenuArgs } from "./assistant-shell.js";
 
 function NavItem({
@@ -11,7 +13,7 @@ function NavItem({
   onClick,
 }: {
   to: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   collapsed: boolean;
   onClick?: () => void;

--- a/apps/web/src/hooks/use-visible-viewport.ts
+++ b/apps/web/src/hooks/use-visible-viewport.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+
+export interface VisibleViewport {
+  /** Height of the visual viewport in pixels — the area actually visible to the user. */
+  height: number;
+  /**
+   * Height in pixels of the on-screen keyboard (or other virtual widget)
+   * that's covering the layout viewport. `0` when no keyboard is visible.
+   */
+  keyboardHeight: number;
+  /**
+   * Offset in pixels between the top edge of the visual viewport and the top
+   * edge of the layout viewport. iOS sets this when it auto-positions the
+   * visible viewport above the soft keyboard. Always `0` on Android and
+   * desktop. Always `0` while pinch-zoomed (we ignore zoom-induced offset).
+   */
+  offsetTop: number;
+  /**
+   * Offset in pixels between the left edge of the visual viewport and the
+   * layout viewport. Non-zero only during pinch-zoom panning (which we
+   * ignore, see `offsetTop`). Exposed for completeness and to round-trip
+   * symmetrically with `offsetTop` through `translate()`.
+   */
+  offsetLeft: number;
+}
+
+/**
+ * Read the current visual-viewport state.
+ *
+ * Exported so unit tests can drive the function against a stubbed
+ * `window.visualViewport` without mounting React.
+ */
+export function readVisibleViewport(): VisibleViewport | null {
+  if (typeof window === "undefined" || !window.visualViewport) {
+    return null;
+  }
+  const vv = window.visualViewport;
+  // When pinch-zoomed (scale > 1) the visual viewport height shrinks in CSS
+  // pixels, which would otherwise inflate keyboardHeight and falsely trigger
+  // keyboard-open detection. Only derive keyboardHeight at ~1.0 scale.
+  const isZoomed = Math.abs(vv.scale - 1) > 0.05;
+  return {
+    height: vv.height,
+    keyboardHeight: isZoomed ? 0 : Math.max(0, window.innerHeight - vv.height),
+    offsetTop: isZoomed ? 0 : vv.offsetTop,
+    offsetLeft: isZoomed ? 0 : vv.offsetLeft,
+  };
+}
+
+/**
+ * Tracks the VisualViewport API so callers can size and position containers
+ * to the area actually visible to the user.
+ *
+ * On iOS the soft keyboard shrinks `visualViewport.height` while
+ * `window.innerHeight` (and `100dvh`) stays at the full layout viewport.
+ * Sizing a container to `height` keeps the layout inside the visible region.
+ *
+ * Returns `null` in browsers that lack the API; callers should fall back to
+ * `100dvh` (and no transform) in that case.
+ *
+ * @see https://developer.chrome.com/blog/visual-viewport-api/
+ * @see https://bugs.webkit.org/show_bug.cgi?id=207049
+ */
+export function useVisibleViewport(): VisibleViewport | null {
+  const [state, setState] = useState<VisibleViewport | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) {
+      return;
+    }
+    const vv = window.visualViewport;
+    const update = () => setState(readVisibleViewport());
+    update();
+    // `resize` fires on width/height/scale changes; `scroll` fires on
+    // offsetTop/offsetLeft changes. Both must be observed — iOS commonly
+    // fires one without the other during a single keyboard transition.
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  return state;
+}

--- a/apps/web/src/hooks/use-visible-viewport.ts
+++ b/apps/web/src/hooks/use-visible-viewport.ts
@@ -31,7 +31,7 @@ export interface VisibleViewport {
  * `window.visualViewport` without mounting React.
  */
 export function readVisibleViewport(): VisibleViewport | null {
-  if (typeof window === "undefined" || !window.visualViewport) {
+  if (!window.visualViewport) {
     return null;
   }
   const vv = window.visualViewport;
@@ -65,7 +65,7 @@ export function useVisibleViewport(): VisibleViewport | null {
   const [state, setState] = useState<VisibleViewport | null>(null);
 
   useEffect(() => {
-    if (typeof window === "undefined" || !window.visualViewport) {
+    if (!window.visualViewport) {
       return;
     }
     const vv = window.visualViewport;

--- a/apps/web/src/utils/haptics.ts
+++ b/apps/web/src/utils/haptics.ts
@@ -1,0 +1,20 @@
+/**
+ * Thin haptic-feedback wrapper. On native Capacitor platforms this delegates
+ * to `@capacitor/haptics`; on web it's a no-op. The lazy import ensures the
+ * Capacitor plugin's `registerPlugin()` call (which throws without the full
+ * runtime) never runs in a plain browser context.
+ */
+export const haptic = {
+  light: async () => {
+    /* no-op until Capacitor is integrated */
+  },
+  medium: async () => {
+    /* no-op until Capacitor is integrated */
+  },
+  success: async () => {
+    /* no-op until Capacitor is integrated */
+  },
+  error: async () => {
+    /* no-op until Capacitor is integrated */
+  },
+};


### PR DESCRIPTION
## Prompt / plan

Port the AssistantShell layout components from `vellum-assistant-platform` to provide the production app shell structure (collapsible sidebar, header bar with navigation, keyboard shortcuts, mobile drawer).

## What changed

Ports the app shell from the platform repo and applies assistant repo conventions:

**New files:**
- `components/shell/assistant-shell.tsx` — Core layout: collapsible sidebar rail (desktop), mobile drawer with focus trap + Escape-close, iOS virtual keyboard tracking via VisualViewport API, keyboard shortcuts (Ctrl+\, Ctrl+K, Ctrl+[/])
- `components/shell/assistant-shell-header.tsx` — Top bar: sidebar toggle, back/forward/home nav buttons, search + compose buttons, responsive desktop/mobile variants
- `components/shell/side-menu.tsx` — Navigation using React Router NavLink with active state highlighting, rail (desktop) and overlay (mobile) variants
- `hooks/use-visible-viewport.ts` — iOS keyboard avoidance hook tracking `window.visualViewport` for proper layout sizing when soft keyboard appears
- `utils/haptics.ts` — Capacitor haptic feedback stub (no-op until native integration)

**Modified files:**
- `App.tsx` — Replaced bare header/main with AssistantShell wrapper, wired navigation callbacks and history tracking for back/forward
- `package.json` — Added `@radix-ui/react-popover` (required by design library's Popover, used by shell)

## Bug fixes included

1. **`canGoForward` was never wired** — App.tsx passed `onGoForward` but not `canGoForward`, so the forward button was permanently disabled. Fixed by tracking React Router's `window.history.state.idx` across location changes to determine forward availability. This bug also exists in the platform source.

2. **Ctrl+K shortcut missing input guard** — The Ctrl+K handler for command palette didn't call `shouldHandleShortcut()`, so pressing Ctrl+K in a text field would fire the command palette instead of allowing normal text input. Fixed to use the same guard as Ctrl+\ and Ctrl+[/]. This bug also exists in the platform source.

3. **Mobile `<main>` used `overflow-hidden`** — The desktop layout correctly uses `overflow-y-auto` on `<main>` so child routes can scroll, but the mobile layout used `overflow-hidden` which clips tall content. Changed to `overflow-y-auto` for consistency. The platform source has this same issue.

## Convention alignment

All ported files were audited against `STYLE_GUIDE.md` and `CONVENTIONS.md`:

- **Import order**: external → alias (`@/`) → relative, per STYLE_GUIDE.md
- **`@/` alias**: Cross-module imports use `@/hooks/...`, `@/utils/...` instead of deep relative paths like `../../hooks/...`
- **Destructured React types**: `import { type ReactNode } from "react"` instead of `React.ReactNode`
- **Removed dead `typeof window === "undefined"` guards**: This is a Vite SPA where `window` is always defined. The platform used these for Next.js SSR compatibility. Removed 6 instances across `assistant-shell.tsx` and `use-visible-viewport.ts`.
- **`useCallback` for all handlers**: Wrapped inline arrow functions (`() => navigate(-1)`) in `useCallback` to prevent unnecessary re-renders

## Test plan

- `bun run lint` — zero errors
- `bunx tsc --noEmit` — passes
- CI: Lint, Type Check & Build — green

Link to Devin session: https://app.devin.ai/sessions/536ceadb023a4059908b0609b9833bc1
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->