### PR TITLE
[LUM-1610] Fix multiple loading states + missing/duplicate thinking indicators

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -144,11 +144,14 @@ enum TranscriptProjector {
         let lastVisibleIsAssistant = lastVisible?.role == .assistant
         let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
         let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
+        let bubbleShowsOwnStreamingIndicator = !(lastVisible?.toolCalls.isEmpty ?? true)
+            && (lastVisible?.toolCalls.allSatisfy { $0.isComplete } ?? false)
         let isStreamingWithoutText = isSending
             && (lastVisible?.isStreaming == true)
             && (lastVisible?.text.isEmpty ?? true)
             && !hasActiveToolCall
             && !canInlineProcessing
+            && !bubbleShowsOwnStreamingIndicator
 
         let isStreamingWithText = isSending
             && (lastVisible?.isStreaming == true)

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -138,7 +138,7 @@ enum TranscriptProjector {
             $0.toolCalls.contains(where: { !$0.isComplete })
         })
 
-        let wouldShowThinking = isSending
+        let wouldShowThinking = (isSending || isThinking)
             && (isThinking || !(lastVisible?.isStreaming == true))
             && !hasActiveToolCall
         let lastVisibleIsAssistant = lastVisible?.role == .assistant

--- a/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TranscriptProjector.swift
@@ -143,6 +143,7 @@ enum TranscriptProjector {
             && !hasActiveToolCall
         let lastVisibleIsAssistant = lastVisible?.role == .assistant
         let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
+            && (lastVisible?.text.isEmpty ?? true)
         let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
         let bubbleShowsOwnStreamingIndicator = !(lastVisible?.toolCalls.isEmpty ?? true)
             && (lastVisible?.toolCalls.allSatisfy { $0.isComplete } ?? false)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -285,6 +285,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     func clearCurrentTurnTracking() {
         idleFallbackTask?.cancel()
         idleFallbackTask = nil
+        if let existingId = currentAssistantMessageId {
+            messageManager.batchUpdateMessages { msgs in
+                msgs.finalizeStreamingMessage(id: existingId)
+            }
+        }
         currentAssistantMessageId = nil
         currentTurnUserText = nil
         currentAssistantHasText = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -287,7 +287,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         idleFallbackTask = nil
         if let existingId = currentAssistantMessageId {
             messageManager.batchUpdateMessages { msgs in
-                msgs.finalizeStreamingMessage(id: existingId)
+                msgs.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
             }
         }
         currentAssistantMessageId = nil


### PR DESCRIPTION
Fixes four related issues in the macOS chat client's thinking indicator and streaming state management during multi-tool agentic loops:

1. **Orphaned streaming state** (`clearCurrentTurnTracking` in `ChatViewModel.swift`): When clearing turn tracking, the current assistant message's `isStreaming` flag wasn't set to `false`, leaving orphaned loading indicators on completed tool-call bubbles. Fixed by calling `finalizeStreamingMessage(id:, completeToolCalls: .none)` before clearing the ID — uses `.none` to only clear `isStreaming` without overriding callers' prior tool-call finalization choices.

2. **Missing thinking indicator between tool calls** (`TranscriptProjector.swift`): The `wouldShowThinking` condition gated on `isSending`, but the `"thinking"` activity phase unconditionally sets `isSending = false` to prevent the 60s watchdog. This suppressed the thinking dots (●●●) during the exact phase they should be visible — between tool calls when the LLM is reasoning about the next action. Fixed by changing the gate to `(isSending || isThinking)`, matching the `isAssistantBusy` pattern already recommended by `ChatViewModel`'s own documentation. The second sub-condition `(isThinking || !(lastVisible?.isStreaming == true))` prevents dots from appearing during text streaming: when `activity_state("streaming")` fires, `isThinking` is cleared to `false` and `lastVisible.isStreaming` is `true`, so `wouldShowThinking` becomes `false`.

3. **Duplicate typing indicators when tools complete** (`TranscriptProjector.swift`): Two independent code paths both showed `TypingIndicatorView` for the same state (streaming, no text, all tool calls complete): (a) `ChatBubbleToolStatusView`'s `trailingStatus` renders a typing indicator inside the bubble when `message.isStreaming && !hasText && allToolCallsComplete`, and (b) `latestEdgeActivityRow` renders a standalone typing indicator at the scroll edge via `isStreamingWithoutText`. Fixed by gating `isStreamingWithoutText` on `!bubbleShowsOwnStreamingIndicator` — when the bubble already handles the indicator internally (all tool calls complete), the standalone indicator is suppressed.

4. **Thinking indicator invisible when last message has text** (`TranscriptProjector.swift`): When the last assistant message already had text content (e.g., "Good data. Composing and sending now.") and the assistant entered a thinking phase, `canInlineProcessing` absorbed the indicator into the progress card's `ThinkingStepRow`. But when the card is collapsed, this indicator is invisible — the user sees the composer say "Working on it..." with no visual feedback in the chat itself. Fixed by adding `(lastVisible?.text.isEmpty ?? true)` to `canInlineProcessing`, so the processing is only inlined when the message has no text yet. When text is already present, `shouldShowThinkingIndicator` becomes true and standalone ●●● dots appear below the message.

### Root Cause Analysis

**How did the code get into this state?** The transcript projection logic grew organically with multiple overlapping state flags (`isSending`, `isThinking`, `isStreaming`, `canInlineProcessing`, `isStreamingWithoutText`, etc.). Each indicator or state check was added locally without auditing the full matrix of interactions. The `wouldShowThinking` condition was written when `isSending` was the primary activity signal; the `isThinking` state was added later (with `isSending = false` in the thinking phase to suppress the watchdog) but `TranscriptProjector` wasn't updated. The `canInlineProcessing` flag assumed that inlining the indicator into the progress card was always sufficient, but didn't account for collapsed cards or messages that already had visible content.

**What can we do to prevent this pattern?** Consider consolidating these into a single enum-based state machine that makes mutual exclusion explicit and prevents multiple indicators from firing simultaneously.

## Prompt / plan

Closes LUM-1610

## Test plan

- Code review of event flow through `handleAssistantActivityState` → `TranscriptProjector.project()` → `MessageListContentView`
- Verified `isThinking` lifecycle: set only during genuine thinking phases, cleared on every transition out
- Verified `bubbleShowsOwnStreamingIndicator` only fires when the bubble has completed tool calls
- Verified `canInlineProcessing` text gate: inlines only when no text, shows standalone when text present
- Verified no thinking dots during streaming: `isThinking = false` + `isStreaming = true` → `wouldShowThinking = false`
- CI passes (macOS build/tests skipped in CI as expected — needs local Xcode verification)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/f5f0a300b4a8471dabdaad266a22f2da
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->