### PR TITLE
feat(design-library): add Modal, BottomSheet, Toast, and ConfirmDialog

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -6,6 +6,7 @@
       "name": "@vellum/design-library",
       "dependencies": {
         "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-popover": "1.1.15",
         "@radix-ui/react-radio-group": "1.3.8",
         "@radix-ui/react-slider": "1.3.6",
@@ -14,6 +15,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "1.16.0",
+        "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
       },
       "devDependencies": {
@@ -250,6 +252,8 @@
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
 
     "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
 
@@ -637,6 +641,8 @@
 
     "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -698,6 +704,8 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "1.3.3",
+    "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-popover": "1.1.15",
     "@radix-ui/react-radio-group": "1.3.8",
     "@radix-ui/react-slider": "1.3.6",
@@ -45,6 +46,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "1.16.0",
+    "sonner": "2.0.7",
     "tailwind-merge": "3.6.0"
   }
 }

--- a/packages/design-library/src/components/bottom-sheet.stories.tsx
+++ b/packages/design-library/src/components/bottom-sheet.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Share } from "lucide-react";
+
+import { Button } from "./button.js";
+import { BottomSheet } from "./bottom-sheet.js";
+
+const meta: Meta = {
+  title: "Components/BottomSheet",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <BottomSheet.Root>
+      <BottomSheet.Trigger asChild>
+        <Button>Open Bottom Sheet</Button>
+      </BottomSheet.Trigger>
+      <BottomSheet.Content>
+        <BottomSheet.Header>
+          <BottomSheet.Title>Select an Option</BottomSheet.Title>
+          <BottomSheet.Description>
+            Choose one of the actions below.
+          </BottomSheet.Description>
+        </BottomSheet.Header>
+        <BottomSheet.Body>
+          <div className="flex flex-col gap-2">
+            <Button variant="ghost" className="justify-start">
+              Option 1
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              Option 2
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              Option 3
+            </Button>
+          </div>
+        </BottomSheet.Body>
+        <BottomSheet.Footer>
+          <BottomSheet.Close asChild>
+            <Button variant="outlined">Cancel</Button>
+          </BottomSheet.Close>
+        </BottomSheet.Footer>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <BottomSheet.Root>
+      <BottomSheet.Trigger asChild>
+        <Button variant="outlined">Share</Button>
+      </BottomSheet.Trigger>
+      <BottomSheet.Content>
+        <BottomSheet.Header>
+          <BottomSheet.Title icon={Share}>Share with</BottomSheet.Title>
+        </BottomSheet.Header>
+        <BottomSheet.Body>
+          <div className="flex flex-col gap-2">
+            <Button variant="ghost" className="justify-start">
+              Copy Link
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              Send via Email
+            </Button>
+          </div>
+        </BottomSheet.Body>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  ),
+};

--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -1,0 +1,196 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { type LucideIcon } from "lucide-react";
+import { type ComponentProps, type ReactNode } from "react";
+
+import { cn } from "../utils/cn.js";
+import { usePortalContainer } from "../utils/portal-container.js";
+
+/**
+ * `BottomSheet` primitive built on `@radix-ui/react-dialog`.
+ *
+ * A full-width dialog anchored to the bottom of the viewport with rounded
+ * top corners and a slide-up entrance animation. Designed for mobile
+ * surfaces like menus, pickers, and confirmation sheets.
+ *
+ * Compound API: `BottomSheet.Root`, `BottomSheet.Trigger`,
+ * `BottomSheet.Content`, `BottomSheet.Title`, `BottomSheet.Description`,
+ * `BottomSheet.Close`, `BottomSheet.Header`, `BottomSheet.Body`,
+ * `BottomSheet.Footer`.
+ *
+ * Adoption is consumer-driven — consumers decide whether to mount
+ * `BottomSheet.Root` vs `Popover.Root` based on `useIsMobile()`.
+ *
+ * @see https://www.radix-ui.com/primitives/docs/components/dialog
+ */
+
+const Root = Dialog.Root;
+
+function Trigger(props: ComponentProps<typeof Dialog.Trigger>) {
+  return <Dialog.Trigger data-slot="bottom-sheet-trigger" {...props} />;
+}
+
+interface BottomSheetContentProps extends ComponentProps<typeof Dialog.Content> {
+  overlayClassName?: string;
+  children?: ReactNode;
+}
+
+function Content({
+  overlayClassName,
+  className,
+  children,
+  ref,
+  ...props
+}: BottomSheetContentProps) {
+  const container = usePortalContainer();
+  return (
+    <Dialog.Portal container={container ?? undefined}>
+      <Dialog.Overlay
+        className={cn("fixed inset-0 z-50 bg-black/50", overlayClassName)}
+      />
+      <Dialog.Content
+        ref={ref}
+        data-slot="bottom-sheet-content"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 flex w-full flex-col rounded-t-[24px] border-t bg-[var(--surface-lift)] border-[var(--border-base)] shadow-xl focus:outline-none",
+          "max-h-[50dvh]",
+          "data-[state=open]:animate-[bottomSheetIn_180ms_ease-out]",
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex min-h-0 flex-1 flex-col px-4 pt-4 pb-[calc(16px+var(--safe-area-inset-bottom,env(safe-area-inset-bottom,0px)))]">
+          {children}
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  );
+}
+
+interface BottomSheetTitleProps extends ComponentProps<typeof Dialog.Title> {
+  icon?: LucideIcon;
+}
+
+function Title({
+  icon: Icon,
+  className,
+  children,
+  ref,
+  ...props
+}: BottomSheetTitleProps) {
+  return (
+    <Dialog.Title
+      ref={ref}
+      data-slot="bottom-sheet-title"
+      className={cn(
+        "flex items-center gap-3 text-title-medium text-[var(--content-default)]",
+        className,
+      )}
+      {...props}
+    >
+      {Icon ? (
+        <span
+          aria-hidden="true"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+          style={{
+            backgroundColor:
+              "color-mix(in oklab, var(--primary-base) 16%, transparent)",
+          }}
+        >
+          <Icon className="h-5 w-5 text-[var(--primary-base)]" />
+        </span>
+      ) : null}
+      <span className="min-w-0 truncate">{children}</span>
+    </Dialog.Title>
+  );
+}
+
+function Description({
+  className,
+  children,
+  ref,
+  ...props
+}: ComponentProps<typeof Dialog.Description>) {
+  return (
+    <Dialog.Description
+      ref={ref}
+      data-slot="bottom-sheet-description"
+      className={cn(
+        "mt-1 whitespace-pre-line text-body-medium-lighter text-[var(--content-secondary)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Dialog.Description>
+  );
+}
+
+function Close(props: ComponentProps<typeof Dialog.Close>) {
+  return <Dialog.Close data-slot="bottom-sheet-close" {...props} />;
+}
+
+function Header({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bottom-sheet-header"
+      className={cn("flex flex-col gap-1", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Body({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bottom-sheet-body"
+      className={cn(
+        "flex-1 overflow-y-auto pt-4 text-[var(--content-default)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Footer({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bottom-sheet-footer"
+      className={cn("flex justify-end gap-2 pt-4", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+const BottomSheet = {
+  Root,
+  Trigger,
+  Content,
+  Title,
+  Description,
+  Close,
+  Header,
+  Body,
+  Footer,
+};
+
+export { BottomSheet };
+export type { BottomSheetContentProps, BottomSheetTitleProps };

--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -45,6 +45,7 @@ function Content({
   return (
     <Dialog.Portal container={container ?? undefined}>
       <Dialog.Overlay
+        data-slot="bottom-sheet-overlay"
         className={cn("fixed inset-0 z-50 bg-black/50", overlayClassName)}
       />
       <Dialog.Content

--- a/packages/design-library/src/components/confirm-dialog.stories.tsx
+++ b/packages/design-library/src/components/confirm-dialog.stories.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "./button.js";
+import { ConfirmDialog } from "./confirm-dialog.js";
+
+const meta: Meta = {
+  title: "Components/ConfirmDialog",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: function DefaultStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Confirm</Button>
+        <ConfirmDialog
+          open={open}
+          title="Confirm Action"
+          message="Are you sure you want to proceed? This action cannot be undone."
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const Destructive: Story = {
+  render: function DestructiveStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button variant="danger" onClick={() => setOpen(true)}>
+          Delete Item
+        </Button>
+        <ConfirmDialog
+          open={open}
+          title="Delete Item"
+          message="This will permanently delete this item. This action cannot be undone."
+          confirmLabel="Delete"
+          cancelLabel="Keep"
+          destructive
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const CustomLabels: Story = {
+  render: function CustomLabelsStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button variant="outlined" onClick={() => setOpen(true)}>
+          Publish Draft
+        </Button>
+        <ConfirmDialog
+          open={open}
+          title="Publish Draft"
+          message="Publishing will make this content visible to all users."
+          confirmLabel="Publish Now"
+          cancelLabel="Not Yet"
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};

--- a/packages/design-library/src/components/confirm-dialog.tsx
+++ b/packages/design-library/src/components/confirm-dialog.tsx
@@ -72,9 +72,7 @@ function ConfirmDialog({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p className="whitespace-pre-line text-body-medium-lighter text-[var(--content-secondary)]">
-            {message}
-          </p>
+          <Modal.Description>{message}</Modal.Description>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="outlined" onClick={onCancel}>

--- a/packages/design-library/src/components/confirm-dialog.tsx
+++ b/packages/design-library/src/components/confirm-dialog.tsx
@@ -1,0 +1,97 @@
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "./button.js";
+import { Modal } from "./modal.js";
+
+/**
+ * Pre-composed confirmation dialog built on `Modal`.
+ *
+ * Renders a small modal with a title, message, and Cancel / Confirm
+ * buttons. Supports a `destructive` variant that styles the confirm
+ * button as danger and shows a warning icon.
+ *
+ * Focus is auto-directed to the confirm button on open so pressing
+ * Enter confirms without requiring Tab. Escape closes only this dialog,
+ * not any parent modal it may be stacked inside.
+ */
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const CONFIRM_BUTTON_ATTR = "data-confirm-dialog-confirm";
+
+function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onCancel();
+        }
+      }}
+    >
+      <Modal.Content
+        size="sm"
+        hideCloseButton
+        onOpenAutoFocus={(event) => {
+          const content = event.currentTarget as HTMLElement | null;
+          const confirmButton = content?.querySelector<HTMLButtonElement>(
+            `[${CONFIRM_BUTTON_ATTR}]`,
+          );
+          if (confirmButton) {
+            event.preventDefault();
+            confirmButton.focus();
+          }
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCancel();
+        }}
+      >
+        <Modal.Header>
+          <Modal.Title icon={destructive ? AlertTriangle : undefined}>
+            {title}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="whitespace-pre-line text-body-medium-lighter text-[var(--content-secondary)]">
+            {message}
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outlined" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={destructive ? "danger" : "primary"}
+            onClick={onConfirm}
+            {...{ [CONFIRM_BUTTON_ATTR]: "" }}
+          >
+            {confirmLabel}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export { ConfirmDialog };
+export type { ConfirmDialogProps };

--- a/packages/design-library/src/components/modal.stories.tsx
+++ b/packages/design-library/src/components/modal.stories.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Settings } from "lucide-react";
+
+import { Button } from "./button.js";
+import { Modal } from "./modal.js";
+
+const meta: Meta = {
+  title: "Components/Modal",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Modal.Root>
+      <Modal.Trigger asChild>
+        <Button>Open Modal</Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title>Modal Title</Modal.Title>
+          <Modal.Description>
+            This is a description of the modal content.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-body-medium-default">
+            Modal body content goes here.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined">Cancel</Button>
+          </Modal.Close>
+          <Button variant="primary">Save</Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <Modal.Root>
+      <Modal.Trigger asChild>
+        <Button>Settings</Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title icon={Settings}>Preferences</Modal.Title>
+          <Modal.Description>
+            Configure your account preferences.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-body-medium-default">Settings form content.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined">Cancel</Button>
+          </Modal.Close>
+          <Button variant="primary">Save Changes</Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  ),
+};
+
+export const Sizes: Story = {
+  render: function SizesStory() {
+    const [size, setSize] = useState<"sm" | "md" | "lg" | "xl">("md");
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div className="flex gap-2">
+        {(["sm", "md", "lg", "xl"] as const).map((s) => (
+          <Button
+            key={s}
+            variant="outlined"
+            size="compact"
+            onClick={() => {
+              setSize(s);
+              setOpen(true);
+            }}
+          >
+            {s}
+          </Button>
+        ))}
+        <Modal.Root open={open} onOpenChange={setOpen}>
+          <Modal.Content size={size}>
+            <Modal.Header>
+              <Modal.Title>Size: {size}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <p className="text-body-medium-default">
+                This modal is using the &quot;{size}&quot; size preset.
+              </p>
+            </Modal.Body>
+            <Modal.Footer>
+              <Modal.Close asChild>
+                <Button variant="outlined">Close</Button>
+              </Modal.Close>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal.Root>
+      </div>
+    );
+  },
+};
+
+export const NoCloseButton: Story = {
+  render: () => (
+    <Modal.Root>
+      <Modal.Trigger asChild>
+        <Button>Open (no close button)</Button>
+      </Modal.Trigger>
+      <Modal.Content hideCloseButton>
+        <Modal.Header>
+          <Modal.Title>Confirm Action</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Modal.Description>
+            This modal has no close button — dismiss via the footer buttons.
+          </Modal.Description>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined">Cancel</Button>
+          </Modal.Close>
+          <Button variant="primary">Confirm</Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  ),
+};

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -1,0 +1,219 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { X, type LucideIcon } from "lucide-react";
+import { type ComponentProps, type ReactNode } from "react";
+
+import { cn } from "../utils/cn.js";
+import { usePortalContainer } from "../utils/portal-container.js";
+
+/**
+ * Modal primitive built on `@radix-ui/react-dialog`.
+ *
+ * Compound API: `Modal.Root`, `Modal.Trigger`, `Modal.Content`,
+ * `Modal.Title`, `Modal.Description`, `Modal.Close`, `Modal.Header`,
+ * `Modal.Body`, `Modal.Footer`.
+ *
+ * Content is portaled into the element provided by the nearest
+ * `<PortalContainerProvider>` so design tokens resolve inside the portal.
+ * Falls back to `document.body` when no provider is mounted.
+ *
+ * @see https://www.radix-ui.com/primitives/docs/components/dialog
+ */
+
+type ModalSize = "sm" | "md" | "lg" | "xl";
+
+const SIZE_CLASSES: Record<ModalSize, string> = {
+  sm: "max-w-[400px]",
+  md: "max-w-[560px]",
+  lg: "max-w-[800px]",
+  xl: "max-w-[1100px]",
+};
+
+const Root = Dialog.Root;
+
+function Trigger(props: ComponentProps<typeof Dialog.Trigger>) {
+  return <Dialog.Trigger data-slot="modal-trigger" {...props} />;
+}
+
+interface ModalContentProps extends ComponentProps<typeof Dialog.Content> {
+  size?: ModalSize;
+  hideCloseButton?: boolean;
+  overlayClassName?: string;
+  children?: ReactNode;
+}
+
+function Content({
+  size = "md",
+  hideCloseButton = false,
+  overlayClassName,
+  className,
+  children,
+  ref,
+  ...props
+}: ModalContentProps) {
+  const container = usePortalContainer();
+  return (
+    <Dialog.Portal container={container ?? undefined}>
+      <Dialog.Overlay
+        className={cn(
+          "fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4",
+          overlayClassName,
+        )}
+      >
+        <Dialog.Content
+          ref={ref}
+          data-slot="modal-content"
+          className={cn(
+            "relative flex max-h-[calc(100vh-2rem)] w-full flex-col rounded-xl border shadow-xl",
+            SIZE_CLASSES[size],
+            "bg-[var(--surface-lift)] border-[var(--border-base)]",
+            "focus:outline-none",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {!hideCloseButton ? (
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="absolute top-3 right-3 flex h-6 w-6 cursor-pointer items-center justify-center rounded bg-transparent text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          ) : null}
+        </Dialog.Content>
+      </Dialog.Overlay>
+    </Dialog.Portal>
+  );
+}
+
+interface ModalTitleProps extends ComponentProps<typeof Dialog.Title> {
+  icon?: LucideIcon;
+}
+
+function Title({
+  icon: Icon,
+  className,
+  children,
+  ref,
+  ...props
+}: ModalTitleProps) {
+  return (
+    <Dialog.Title
+      ref={ref}
+      data-slot="modal-title"
+      className={cn(
+        "flex items-center gap-3 text-title-medium text-[var(--content-default)]",
+        className,
+      )}
+      {...props}
+    >
+      {Icon ? (
+        <span
+          aria-hidden="true"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+          style={{
+            backgroundColor:
+              "color-mix(in oklab, var(--primary-base) 16%, transparent)",
+          }}
+        >
+          <Icon className="h-5 w-5 text-[var(--primary-base)]" />
+        </span>
+      ) : null}
+      <span className="min-w-0 truncate">{children}</span>
+    </Dialog.Title>
+  );
+}
+
+function Description({
+  className,
+  children,
+  ref,
+  ...props
+}: ComponentProps<typeof Dialog.Description>) {
+  return (
+    <Dialog.Description
+      ref={ref}
+      data-slot="modal-description"
+      className={cn(
+        "mt-1 whitespace-pre-line text-body-medium-lighter text-[var(--content-secondary)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Dialog.Description>
+  );
+}
+
+function Close(props: ComponentProps<typeof Dialog.Close>) {
+  return <Dialog.Close data-slot="modal-close" {...props} />;
+}
+
+function Header({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="modal-header"
+      className={cn("flex flex-col gap-1 p-4 pr-10", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Body({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="modal-body"
+      className={cn(
+        "flex-1 overflow-y-auto px-4 pb-4 text-[var(--content-default)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Footer({
+  className,
+  children,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="modal-footer"
+      className={cn("flex justify-end gap-2 px-4 pb-4", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+const Modal = {
+  Root,
+  Trigger,
+  Content,
+  Title,
+  Description,
+  Close,
+  Header,
+  Body,
+  Footer,
+};
+
+export { Modal };
+export type { ModalSize, ModalContentProps, ModalTitleProps };

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -54,6 +54,7 @@ function Content({
   return (
     <Dialog.Portal container={container ?? undefined}>
       <Dialog.Overlay
+        data-slot="modal-overlay"
         className={cn(
           "fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4",
           overlayClassName,

--- a/packages/design-library/src/components/toast.stories.tsx
+++ b/packages/design-library/src/components/toast.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "./button.js";
+import { toast, Toaster } from "./toast.js";
+
+const meta: Meta = {
+  title: "Components/Toast",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <Story />
+        <Toaster />
+      </>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant="outlined"
+        onClick={() => toast("Default notification")}
+      >
+        Default
+      </Button>
+      <Button
+        variant="outlined"
+        onClick={() => toast.info("Informational message")}
+      >
+        Info
+      </Button>
+      <Button
+        variant="outlined"
+        onClick={() => toast.warning("Something needs attention")}
+      >
+        Warning
+      </Button>
+      <Button
+        variant="outlined"
+        onClick={() => toast.error("Something went wrong")}
+      >
+        Error
+      </Button>
+      <Button
+        variant="outlined"
+        onClick={() => toast.success("Action completed")}
+      >
+        Success
+      </Button>
+    </div>
+  ),
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <Button
+      onClick={() =>
+        toast.info("File uploaded", {
+          description: "your-document.pdf was uploaded successfully.",
+        })
+      }
+    >
+      Toast with description
+    </Button>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <Button
+      onClick={() =>
+        toast.error("Message deleted", {
+          action: {
+            label: "Undo",
+            onClick: () => toast.success("Message restored"),
+          },
+        })
+      }
+    >
+      Toast with action
+    </Button>
+  ),
+};

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -1,0 +1,176 @@
+import {
+  CircleAlert,
+  CircleCheck,
+  Info,
+  OctagonX,
+  X,
+} from "lucide-react";
+import { type ReactNode } from "react";
+import { toast as sonnerToast, Toaster as SonnerToaster } from "sonner";
+
+import { cn } from "../utils/cn.js";
+
+/**
+ * Toast notification system built on `sonner`.
+ *
+ * Provides an imperative `toast()` API with variant methods
+ * (`toast.info()`, `toast.warning()`, `toast.error()`, `toast.success()`)
+ * and a `<Toaster />` provider component.
+ *
+ * @see https://sonner.emilkowal.dev
+ */
+
+type ToastVariant = "default" | "info" | "warning" | "error" | "success";
+
+interface ToastOptions {
+  description?: string;
+  duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  id?: string;
+}
+
+const VARIANT_STYLES: Record<
+  ToastVariant,
+  { container: string; icon: string; iconElement: ReactNode }
+> = {
+  default: {
+    container:
+      "bg-[var(--surface-lift)] border-[var(--border-base)] text-[var(--content-default)]",
+    icon: "text-[var(--content-tertiary)]",
+    iconElement: null,
+  },
+  info: {
+    container:
+      "bg-[var(--surface-overlay)] border-[var(--border-element)] text-[var(--content-default)]",
+    icon: "text-[var(--content-secondary)]",
+    iconElement: <Info className="h-4 w-4" />,
+  },
+  warning: {
+    container:
+      "bg-[var(--system-mid-weak)] border-[var(--system-mid-strong)] text-[var(--system-mid-strong)]",
+    icon: "text-[var(--system-mid-strong)]",
+    iconElement: <CircleAlert className="h-4 w-4" />,
+  },
+  error: {
+    container:
+      "bg-[var(--system-negative-weak)] border-[var(--system-negative-strong)] text-[var(--system-negative-strong)]",
+    icon: "text-[var(--system-negative-strong)]",
+    iconElement: <OctagonX className="h-4 w-4" />,
+  },
+  success: {
+    container:
+      "bg-[var(--system-positive-weak)] border-[var(--system-positive-strong)] text-[var(--system-positive-strong)]",
+    icon: "text-[var(--system-positive-strong)]",
+    iconElement: <CircleCheck className="h-4 w-4" />,
+  },
+};
+
+function ToastContent({
+  message,
+  variant = "default",
+  options,
+  onDismiss,
+}: {
+  message: string;
+  variant?: ToastVariant;
+  options?: ToastOptions;
+  onDismiss: () => void;
+}) {
+  const styles = VARIANT_STYLES[variant];
+  return (
+    <div
+      role="alert"
+      data-slot="toast"
+      className={cn(
+        "flex w-full max-h-[300px] items-start gap-3 rounded-lg border p-3 shadow-lg",
+        styles.container,
+      )}
+    >
+      {styles.iconElement ? (
+        <span className={cn("mt-0.5 shrink-0", styles.icon)}>
+          {styles.iconElement}
+        </span>
+      ) : null}
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="text-body-medium-default">{message}</p>
+        {options?.description ? (
+          <p className="text-body-small-default opacity-70">
+            {options.description}
+          </p>
+        ) : null}
+        {options?.action ? (
+          <button
+            type="button"
+            onClick={() => {
+              options.action?.onClick();
+              onDismiss();
+            }}
+            className="mt-1.5 cursor-pointer bg-transparent text-body-small-default underline underline-offset-2 hover:no-underline"
+          >
+            {options.action.label}
+          </button>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Close"
+        className="shrink-0 cursor-pointer rounded bg-transparent p-0.5 opacity-50 transition-opacity hover:opacity-100"
+      >
+        <X className="h-3.5 w-3.5" strokeWidth={2} />
+      </button>
+    </div>
+  );
+}
+
+function showToast(
+  message: string,
+  variant: ToastVariant = "default",
+  options?: ToastOptions,
+) {
+  return sonnerToast.custom(
+    (id) => (
+      <ToastContent
+        message={message}
+        variant={variant}
+        options={options}
+        onDismiss={() => sonnerToast.dismiss(id)}
+      />
+    ),
+    { duration: options?.duration, id: options?.id },
+  );
+}
+
+const toast = Object.assign(
+  (message: string, options?: ToastOptions) =>
+    showToast(message, "default", options),
+  {
+    info: (message: string, options?: ToastOptions) =>
+      showToast(message, "info", options),
+    warning: (message: string, options?: ToastOptions) =>
+      showToast(message, "warning", options),
+    error: (message: string, options?: ToastOptions) =>
+      showToast(message, "error", options),
+    success: (message: string, options?: ToastOptions) =>
+      showToast(message, "success", options),
+  },
+);
+
+function Toaster() {
+  return (
+    <SonnerToaster
+      data-slot="toaster"
+      position="bottom-right"
+      toastOptions={{
+        unstyled: true,
+        style: { width: "356px" },
+      }}
+    />
+  );
+}
+
+export { toast, Toaster, ToastContent };
+export type { ToastVariant, ToastOptions };

--- a/packages/design-library/src/components/toast.tsx
+++ b/packages/design-library/src/components/toast.tsx
@@ -32,6 +32,8 @@ interface ToastOptions {
   id?: string;
 }
 
+const ASSERTIVE_VARIANTS = new Set<ToastVariant>(["error", "warning"]);
+
 const VARIANT_STYLES: Record<
   ToastVariant,
   { container: string; icon: string; iconElement: ReactNode }
@@ -82,7 +84,7 @@ function ToastContent({
   const styles = VARIANT_STYLES[variant];
   return (
     <div
-      role="alert"
+      role={ASSERTIVE_VARIANTS.has(variant) ? "alert" : "status"}
       data-slot="toast"
       className={cn(
         "flex w-full max-h-[300px] items-start gap-3 rounded-lg border p-3 shadow-lg",
@@ -161,14 +163,15 @@ const toast = Object.assign(
 
 function Toaster() {
   return (
-    <SonnerToaster
-      data-slot="toaster"
-      position="bottom-right"
-      toastOptions={{
-        unstyled: true,
-        style: { width: "356px" },
-      }}
-    />
+    <div data-slot="toaster">
+      <SonnerToaster
+        position="bottom-right"
+        toastOptions={{
+          unstyled: true,
+          style: { width: "356px" },
+        }}
+      />
+    </div>
   );
 }
 

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -89,6 +89,28 @@ export {
   type SliderProps,
   type SliderValue,
 } from "./components/slider.js";
+export {
+  Modal,
+  type ModalSize,
+  type ModalContentProps,
+  type ModalTitleProps,
+} from "./components/modal.js";
+export {
+  BottomSheet,
+  type BottomSheetContentProps,
+  type BottomSheetTitleProps,
+} from "./components/bottom-sheet.js";
+export {
+  toast,
+  Toaster,
+  ToastContent,
+  type ToastVariant,
+  type ToastOptions,
+} from "./components/toast.js";
+export {
+  ConfirmDialog,
+  type ConfirmDialogProps,
+} from "./components/confirm-dialog.js";
 export { cn } from "./utils/cn.js";
 export {
   PortalContainerProvider,

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -399,4 +399,9 @@
   100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 
+@keyframes bottomSheetIn {
+  0% { opacity: 0; transform: translateY(100%); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
 


### PR DESCRIPTION
## Prompt / plan

Tier 2 overlay components for the design library, ported from the platform repo's `web/src/components/app/core/` and adapted to follow assistant repo conventions. These are the next layer of reusable UI primitives after the Tier 1 form/navigation components merged in PR #31087.

**Components added:**

| Component | Lines | Platform imports | Description |
|-----------|-------|-----------------|-------------|
| **Modal** | 210 | 27 | Radix Dialog with size presets (sm/md/lg/xl), compound API |
| **BottomSheet** | 173 | 12 | Bottom-anchored dialog with slide-up animation, safe-area insets |
| **Toast** | 171 | 6 | Sonner-based notifications with 5 variants (default/info/warning/error/success) |
| **ConfirmDialog** | 96 | 26 | Pre-composed confirmation modal with auto-focus and stacked Escape handling |

**Improvements over platform source:**

- **No `forwardRef`** — uses React 19 ref-as-prop pattern via `ComponentProps<>` per [React 19 changelog](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop)
- **`data-slot` on every root element** — enables CSS-only styling overrides per [shadcn/ui v4 convention](https://ui.shadcn.com/docs/changelog/2025-03-data-slot)
- **Function declarations** — not `const` assignments or `forwardRef` wrappers
- **Portal container integration** — uses `usePortalContainer()` from the design library (not app-specific `useAppRootContainer`)
- **No `"use client"` directives** — pure React, no Next.js framework dependency
- **`cn()` utility** — consistent class merging via design library's own `cn`
- **Modal close button uses plain HTML** — avoids circular dependency (Modal importing Button for close affordance), uses a simple `<button>` with matching styles instead
- **Typography replaced with Tailwind classes** — Modal Title/Description use `text-title-medium` / `text-body-medium-lighter` utility classes directly, avoiding a component dependency for simple text styling

**Dependencies added:** `@radix-ui/react-dialog@1.1.15`, `sonner@2.0.7`

**Animation keyframe added:** `bottomSheetIn` in `tokens.css` for the slide-up entrance.

Part of LUM-1543

## Test plan

- `bunx tsc --noEmit` passes cleanly
- Components can be verified visually via Storybook stories (to be added)

Link to Devin session: https://app.devin.ai/sessions/536ceadb023a4059908b0609b9833bc1
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->