### PR TITLE
fix(chrome-ext): install dependencies before building

### DIFF
--- a/clients/chrome-extension/build.sh
+++ b/clients/chrome-extension/build.sh
@@ -68,6 +68,15 @@ EXT_VERSION_FULL="$EXT_VERSION"
 EXT_VERSION="${EXT_VERSION%%-*}"
 
 # ---------------------------------------------------------------------------
+# Ensure dependencies are installed before building.
+# --frozen-lockfile is preferred (fast, won't modify the lockfile); fall back
+# to a regular install for first-time setups or lockfile drift.
+# ---------------------------------------------------------------------------
+echo "Installing dependencies..."
+(cd "$SCRIPT_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install) \
+  || { echo "❌ Dependency install failed."; exit 1; }
+
+# ---------------------------------------------------------------------------
 # Build function — shared by initial build and watch-triggered rebuilds.
 # ---------------------------------------------------------------------------
 do_build() {


### PR DESCRIPTION
## Prompt / plan

Closes ATL-626

### Problem

`vel up` spawns `bash build.sh run` for the chrome extension, but `build.sh` does not run `bun install` before type-checking or bundling. When dependencies are not already present in `node_modules`, the build fails with TS2307/TS7026/TS2875 errors for all React/JSX types:

```
popup/screens/MainScreen.tsx(1,50): error TS2307: Cannot find module 'react' or its corresponding type declarations.
popup/screens/MainScreen.tsx(57,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found.
```

### Root cause analysis

1. **How did the code get into this state?** PR #29942 (Chrome Extension React + Tailwind Migration) added React as a dependency to `package.json` but did not update `build.sh` to install dependencies before building. The pre-React extension had no npm dependencies, so `build.sh` never needed an install step.

2. **What decisions led to it?** PR #30336 recognized the missing install but only patched individual CI workflows (`release.yml`, `build-chrome-extension.yaml`) with explicit `bun install --frozen-lockfile` steps. This surface-level fix masked the root cause in CI while leaving `vel up` and standalone `build.sh` invocations broken.

3. **Warning signs missed?** The CI workflow (`pr-chrome-extension.yaml`) already had its own `bun install` step, which should have signaled that `build.sh` isn't self-contained — unlike `clients/macos/build.sh`, which installs its own dependencies (lines 926–931).

4. **Prevention:** Client build scripts should be self-contained: any script that runs `tsc` or a bundler should ensure its dependencies are installed first. This matches the established pattern in `clients/macos/build.sh`.

### What changed

Added `bun install --frozen-lockfile` (with fallback to `bun install`) before the first `do_build()` call in `build.sh`. The install runs once at script start, not inside `do_build()`, so watched rebuilds in `run` mode don't re-install.

### Why this approach

- Makes `build.sh` self-contained — works regardless of invocation path (`vel up`, standalone, CI)
- Matches the pattern in `clients/macos/build.sh` (lines 926–931)
- `bun install --frozen-lockfile` is idempotent (~5ms when deps already present)
- `--frozen-lockfile` first (CI-safe, won't modify lockfile); falls back to regular install for first-time setups

### Alternatives considered and rejected

| Alternative | Why rejected |
|------------|-------------|
| Add `ensureChromeExtDeps()` to `vel up` in platform repo | Cross-repo change; only fixes `vel up` path; leaves standalone `build.sh` broken |
| Add chrome-extension to `setup.sh` | Only fixes fresh-setup path; `clients/macos/` isn't in `setup.sh` either — client builds are self-contained |
| Fix tsconfig `types: []` | Red herring — `types` only controls [global ambient type inclusion](https://www.typescriptlang.org/tsconfig/types.html), not module resolution. TypeScript 6.0 will make `types: []` the [default](https://github.com/microsoft/typescript/issues/62195) |
| Install inside `do_build()` | Would re-run on every watched rebuild unnecessarily |

### References

- [TypeScript `types` option docs](https://www.typescriptlang.org/tsconfig/types.html) — confirms `types: []` does not affect `@types/*` resolution for imports
- [TypeScript PR #41330](https://github.com/microsoft/TypeScript/pull/41330) — `jsx: "react-jsx"` auto-includes JSX types even with `types: []`
- [TypeScript #62195](https://github.com/microsoft/typescript/issues/62195) — TypeScript 6.0 will default to `types: []`

### In-flight work

Branch `do/lum-1541-move-chrome-extension` moves chrome-ext from `clients/` to `apps/` — does not add `bun install` either. Minor merge conflict expected (comment path update only).

## Test plan

1. Verified fix by removing `node_modules`, running `bash build.sh build` — deps installed automatically, typecheck and build passed
2. Verified idempotency: with deps present, `bun install --frozen-lockfile` completes in ~5ms
3. CI will validate the change end-to-end via `pr-chrome-extension.yaml`

Link to Devin session: https://app.devin.ai/sessions/b9e71f09a98f493a92175b2c2b89d03d
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->