### PR TITLE
Poll gateway config changes as a fallback

### DIFF
--- a/gateway/src/__tests__/config-file-watcher.test.ts
+++ b/gateway/src/__tests__/config-file-watcher.test.ts
@@ -42,6 +42,31 @@ function makeEvent(
   };
 }
 
+function makeManualIntervalTimer() {
+  let intervalFn: (() => void) | undefined;
+  let cleared = false;
+  type IntervalHandle = ReturnType<typeof setInterval>;
+  const timer = 1 as unknown as IntervalHandle;
+  return {
+    timerApi: {
+      setInterval: (fn: () => void, _delayMs: number) => {
+        intervalFn = fn;
+        return timer;
+      },
+      clearInterval: (_timer: IntervalHandle) => {
+        cleared = true;
+      },
+    },
+    runInterval: () => {
+      if (!intervalFn) {
+        throw new Error("interval was not scheduled");
+      }
+      intervalFn();
+    },
+    isCleared: () => cleared,
+  };
+}
+
 afterEach(() => {
   try {
     if (existsSync(configPath)) unlinkSync(configPath);
@@ -51,6 +76,38 @@ afterEach(() => {
 });
 
 describe("ConfigFileWatcher", () => {
+  test("polls config changes when file watcher events are missed", () => {
+    const events: ConfigChangeEvent[] = [];
+    const timer = makeManualIntervalTimer();
+    const watcher = new ConfigFileWatcher(
+      (event) => {
+        events.push(event);
+      },
+      { pollIntervalMs: 10, timerApi: timer.timerApi },
+    );
+
+    try {
+      watcher.start();
+      writeConfig({
+        twilio: {
+          setupStarted: true,
+        },
+      });
+
+      timer.runInterval();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].changedKeys).toEqual(new Set(["twilio"]));
+      expect(events[0].changedFields.get("twilio")).toEqual(
+        new Set(["setupStarted"]),
+      );
+    } finally {
+      watcher.stop();
+    }
+
+    expect(timer.isCleared()).toBe(true);
+  });
+
   test("reports shallow ingress fields changed by Velay-managed URL writes", () => {
     writeConfig({
       ingress: {

--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -15,6 +15,14 @@ import { getLogger } from "./logger.js";
 const log = getLogger("config-file-watcher");
 
 const DEBOUNCE_MS = 500;
+const FALLBACK_POLL_MS = 1_000;
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+
+type TimerApi = {
+  setInterval: (fn: () => void, delayMs: number) => IntervalHandle;
+  clearInterval: (timer: IntervalHandle) => void;
+};
 
 export type ConfigChangeEvent = {
   /** Full parsed config.json data. */
@@ -32,16 +40,27 @@ export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
 
 export class ConfigFileWatcher {
   private watcher: FSWatcher | null = null;
+  private pollTimer: IntervalHandle | null = null;
   private watchingDirectory = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSerialized: Map<string, string> = new Map();
   private lastValues: Map<string, unknown> = new Map();
   private callback: ConfigChangeCallback;
   private configPath: string;
+  private pollIntervalMs: number;
+  private timerApi: TimerApi;
 
-  constructor(callback: ConfigChangeCallback) {
+  constructor(
+    callback: ConfigChangeCallback,
+    opts?: { pollIntervalMs?: number; timerApi?: TimerApi },
+  ) {
     this.callback = callback;
     this.configPath = getConfigPath();
+    this.pollIntervalMs = opts?.pollIntervalMs ?? FALLBACK_POLL_MS;
+    this.timerApi = opts?.timerApi ?? {
+      setInterval,
+      clearInterval,
+    };
   }
 
   start(): void {
@@ -77,6 +96,8 @@ export class ConfigFileWatcher {
         "Failed to start config file watcher",
       );
     }
+
+    this.startFallbackPolling();
   }
 
   stop(): void {
@@ -84,10 +105,32 @@ export class ConfigFileWatcher {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    if (this.pollTimer) {
+      this.timerApi.clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
     if (this.watcher) {
       this.watcher.close();
       this.watcher = null;
     }
+  }
+
+  private startFallbackPolling(): void {
+    if (this.pollIntervalMs <= 0 || this.pollTimer) return;
+
+    this.pollTimer = this.timerApi.setInterval(() => {
+      this.pollOnce();
+
+      if (this.watchingDirectory && existsSync(this.configPath)) {
+        this.upgradeWatcher();
+      }
+    }, this.pollIntervalMs);
+    (this.pollTimer as { unref?: () => void }).unref?.();
+
+    log.info(
+      { intervalMs: this.pollIntervalMs },
+      "Polling config file for missed change events",
+    );
   }
 
   private scheduleCheck(): void {


### PR DESCRIPTION
## Summary
- Add a lightweight polling fallback to the gateway config watcher so config changes are observed even when fs.watch events are missed across containers or volumes.
- Cover the missed-event path with a regression test using a manual interval timer.

## Original prompt
The user had to restart their assistant after the original Twilio setup before Twilio started working. The likely issue was that Twilio setup relies on the gateway observing config changes like twilio.setupStarted and twilio.phoneNumber at runtime; restart worked because startup re-read config.json. This change makes the gateway detect those runtime config changes without requiring a restart.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->