### PR TITLE
chore(web): remove apps/web/ CODEOWNERS + generate auth client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,10 +9,13 @@
 
 # Web app scaffold landing zone (Ashlee).
 # `apps/web/` is the future open-source home for the Vellum web app;
-# no application code lives here yet. Code-owner review keeps
-# unrelated feature work from landing in the scaffold before the
-# migration completes. See apps/web/README.md.
+# Code-owner review keeps unrelated feature work from landing in the
+# scaffold before the migration completes. See apps/web/README.md.
 apps/web/ @ashleeradka
+
+# OpenAPI specs are synced automatically from the platform repo.
+# No owner so automated PRs can auto-merge without review.
+apps/web/openapi-schemas/
 
 # Memory system (Sidd)
 assistant/src/memory/ @siddseethepalli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,16 +7,6 @@
 
 # --- Broad directory catch-alls (DRI defaults) ---
 
-# Web app scaffold landing zone (Ashlee).
-# `apps/web/` is the future open-source home for the Vellum web app;
-# Code-owner review keeps unrelated feature work from landing in the
-# scaffold before the migration completes. See apps/web/README.md.
-apps/web/ @ashleeradka
-
-# OpenAPI specs are synced automatically from the platform repo.
-# No owner so automated PRs can auto-merge without review.
-apps/web/openapi-schemas/
-
 # Memory system (Sidd)
 assistant/src/memory/ @siddseethepalli
 

--- a/apps/web/openapi-ts.config.ts
+++ b/apps/web/openapi-ts.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "@hey-api/openapi-ts";
 
-export default defineConfig({
-  input: "./openapi-schemas/platform.yaml",
-  output: "src/generated/api",
-  plugins: [
-    "@hey-api/client-fetch",
-    "@tanstack/react-query",
-  ],
-});
+export default defineConfig([
+  {
+    input: "./openapi-schemas/platform.yaml",
+    output: "src/generated/api",
+    plugins: ["@hey-api/client-fetch", "@tanstack/react-query"],
+  },
+  {
+    input: "./openapi-schemas/auth.yaml",
+    output: "src/generated/auth",
+    plugins: ["@hey-api/client-fetch"],
+  },
+]);


### PR DESCRIPTION
## Prompt / plan

Audit of the HeyAPI OpenAPI spec sync flow between platform and OSS repos revealed two issues:

1. `apps/web/` was owned by `@ashleeradka` in CODEOWNERS. When the automated `sync-openapi-to-oss` workflow creates a sync PR touching `apps/web/openapi-schemas/`, CODEOWNERS review would block auto-merge. Removed the `apps/web/` ownership entry entirely per owner request.
2. `auth.yaml` is synced from the platform but the OSS `openapi-ts.config.ts` only generated a client from `platform.yaml`, leaving the auth spec unused.

## Changes

**CODEOWNERS**: Remove the `apps/web/ @ashleeradka` entry. This unblocks automated sync PRs from auto-merging without manual review.

**openapi-ts.config.ts**: Switch from single-config to array-config format (supported by [HeyAPI v0.97+](https://heyapi.dev/openapi-ts/configuration)) and add `auth.yaml` as a second input generating to `src/generated/auth/`. The auth spec uses only `@hey-api/client-fetch` (no React Query) — matching the platform repo's convention for auth endpoints, which are used imperatively rather than through hooks.

Both generated output directories (`src/generated/api/`, `src/generated/auth/`) are covered by the existing `src/generated/` gitignore entry.

## Why this is safe

- CODEOWNERS removal is per the owner's explicit request — no other ownership is affected.
- The `openapi-ts.config.ts` change only affects local codegen output that is gitignored. No committed source code changes. Verified by running `bun run openapi-ts` — both specs generate successfully.

## Test plan

- Verified `bun run openapi-ts` generates both `src/generated/api/` (5 files) and `src/generated/auth/` (4 files)
- Verified generated output is gitignored (`git status` shows clean tree after generation)
- `bun run lint` passes
- `bun run typecheck` passes

Link to Devin session: https://app.devin.ai/sessions/04f71516c5254c1bad9feb140d03a8ed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->