### PR TITLE
docs(AGENTS.md): clarify per-client VELLUM_ENVIRONMENT defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,8 +316,8 @@ The `VELLUM_ENVIRONMENT` environment variable identifies the runtime environment
 **macOS** (`clients/macos/build.sh`):
 - `test` => `test`
 - `release` / `release-application` => `staging` when `DISPLAY_VERSION` contains `-staging` (e.g. `0.6.0-staging.3`), otherwise `production`
-- `run` with localhost platform/web URL overrides => `local`
-- `run` => `local`
+- `run` with localhost platform/web URL overrides => `local` (this is the `vel up` path)
+- `run` (without URL overrides) => `dev`
 - all other commands => `dev`
 
 **Chrome extension** (`clients/chrome-extension/build.sh`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,13 +311,21 @@ The `VELLUM_ENVIRONMENT` environment variable identifies the runtime environment
 | `staging` | QA against staging platform before production rollout. Default for release branch builds. |
 | `production` | Full production behavior, no developer shortcuts. Set explicitly for final production releases. |
 
-**Defaults**: `build.sh` sets the value automatically when `VELLUM_ENVIRONMENT` is unset:
-- `test` command => `test`
-- `release` / `release-application` => `staging` for `*-staging*` display versions, otherwise `production`
-- `run` command => `local` (for local full-stack development, e.g. `vel up`)
-- all other local build commands (plain `build`, etc.) => `dev`
+**Defaults**: Each `build.sh` sets the value automatically when `VELLUM_ENVIRONMENT` is unset. The staging-detection logic differs by client:
 
-CI and developers can always override by exporting `VELLUM_ENVIRONMENT` before invoking the build script — the explicit value takes precedence.
+**macOS** (`clients/macos/build.sh`):
+- `test` => `test`
+- `release` / `release-application` => `staging` when `DISPLAY_VERSION` contains `-staging` (e.g. `0.6.0-staging.3`), otherwise `production`
+- `run` with localhost platform/web URL overrides => `local`
+- `run` => `local`
+- all other commands => `dev`
+
+**Chrome extension** (`clients/chrome-extension/build.sh`):
+- `release` => `production` (no in-script staging detection; CI workflows set `VELLUM_ENVIRONMENT` explicitly)
+- `run` => `local`
+- all other commands => `dev`
+
+CI and developers can always override by exporting `VELLUM_ENVIRONMENT` before invoking the build script — the explicit value takes precedence. All CI release workflows set the variable explicitly, so the in-script defaults only affect local development.
 
 **Reading the value at runtime** (Swift):
 ```swift


### PR DESCRIPTION
## Prompt / plan

The `Build Environment (VELLUM_ENVIRONMENT)` section in AGENTS.md described staging detection as a universal `build.sh` behavior — implying all clients auto-detect staging from display version strings. In practice, only the macOS build script implements this. The Chrome extension relies on CI workflows to set `VELLUM_ENVIRONMENT` explicitly.

**Why this matters:** Agents and developers reading AGENTS.md would expect `bash build.sh release` to auto-detect staging for the Chrome extension, but it always defaults to `production`. This could lead to misdiagnosed build issues or incorrect local builds. All CI release paths work correctly (they set the env explicitly), so this is a documentation accuracy issue, not a functional bug.

**What changed:**
- Split the generic "Defaults" list into per-client subsections (macOS and Chrome extension)
- Each subsection documents the actual behavior of that client's `build.sh`
- Added a note that CI workflows set `VELLUM_ENVIRONMENT` explicitly, so in-script defaults only affect local development

**Why it's safe:** Documentation-only change. No code modified.

**Alternatives considered:**
- Adding staging detection to chrome-ext `build.sh` (check `VERSION` for `-staging` suffix): Rejected because (a) Chrome extensions don't have `DISPLAY_VERSION`, (b) CI already handles this correctly, and (c) the added complexity isn't justified for a local-dev-only path.
- Leaving documentation as-is: Rejected because inaccurate docs mislead agents and developers, especially when debugging staging build behavior.

Closes LUM-1615

## Test plan

Documentation-only change — verified the updated text matches the actual behavior of:
- `clients/macos/build.sh` (lines 1069-1089: staging detection via `DISPLAY_VERSION`)
- `clients/chrome-extension/build.sh` (lines 51-59: no staging detection)
- `.github/workflows/release.yml` (line 297: CI sets `VELLUM_ENVIRONMENT` explicitly)
- `.github/workflows/build-chrome-extension.yaml` (line 80: user-selected env)
- `.github/workflows/dev-release.yaml` (line 765: hardcoded `dev`)

Link to Devin session: https://app.devin.ai/sessions/b9e71f09a98f493a92175b2c2b89d03d
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->