### PR TITLE
docs(AGENTS.md): add self-contained client build script guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,7 @@ let env = ProcessInfo.processInfo.environment["VELLUM_ENVIRONMENT"] ?? "producti
 - Use `VELLUM_ENVIRONMENT` for behavior that varies by deployment target (e.g. local image builds, telemetry sampling, API base URLs).
 - Do **not** use it as a substitute for feature flags — flags gate features per-user/org, environments gate per-deployment.
 - Do **not** check for `DEBUG` / `RELEASE` compiler flags (`#if DEBUG`) when the distinction is really about deployment environment. A debug build pointed at staging is still `staging`, not `local`.
+- Client `build.sh` scripts must be **self-contained** — install their own dependencies (e.g. `bun install --frozen-lockfile`) before building. Do not rely on `setup.sh`, `vel up`, or CI workflows to pre-install client dependencies. This ensures the build works regardless of invocation path.
 
 ## Sentry & Linear Integration
 


### PR DESCRIPTION
## Prompt / plan

Adds a prevention guideline from the root cause analysis of the chrome extension build failure (LUM-1614, PR #31091).

**Why this is needed:** The chrome extension's `build.sh` didn't install its own dependencies — it relied on CI workflows having explicit `bun install` steps. This meant `vel up` and standalone `build.sh` invocations failed with missing React types while CI passed. The pattern can recur any time a new client is added to the monorepo.

**What changed:** Added one bullet to the Build Environment Guidelines section: client `build.sh` scripts must be self-contained and install their own dependencies before building.

**Why it's safe:** Documentation-only change. Codifies the pattern already established by `clients/macos/build.sh` (which has multiple `bun install` calls) and now `clients/chrome-extension/build.sh` (fixed in PR #31091).

**Alternatives considered:**
- Adding this as a standalone section: Rejected — it's a single guideline that fits naturally in the existing Build Environment Guidelines list.
- Adding enforcement via CI lint: Considered but deferred — a documentation guideline is sufficient for now since new clients are rare.

Closes LUM-1616

## Test plan

Documentation-only change — verified the guideline text is accurate and consistent with the self-contained build patterns in `clients/macos/build.sh` and `clients/chrome-extension/build.sh`.

Link to Devin session: https://app.devin.ai/sessions/b9e71f09a98f493a92175b2c2b89d03d
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->