### PR TITLE
fix(ci): add codegen step to main branch web checks

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate API clients
+        run: bun run openapi-ts
+
       - name: Lint
         run: bun run lint
 


### PR DESCRIPTION
## Prompt / plan

The provider stack PR (#31099) introduced imports from generated HeyAPI clients (`@/generated/auth/client.gen.js`, `@/generated/api/client.gen.js`, etc.) and added a `bun run openapi-ts` codegen step to `pr-web.yaml`. However, the same step was not added to `ci-main-web.yaml`, causing type check failures on every push to main since #31099 merged.

Root cause: The two workflow files (`pr-web.yaml` and `ci-main-web.yaml`) share the same logical pipeline but are maintained as separate files. When the codegen step was added to one, the other was missed.

## Test plan

- CI on this PR verifies the workflow file is valid YAML
- After merge, the next push to main will trigger `ci-main-web.yaml` with the codegen step, resolving the type check failures

Link to Devin session: https://app.devin.ai/sessions/536ceadb023a4059908b0609b9833bc1
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->