### PR TITLE
feat(document-editor): add document comment SSE message types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -22,6 +22,7 @@ export * from "./message-types/contacts.js";
 export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
 export * from "./message-types/disk-pressure.js";
+export * from "./message-types/document-comments.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/home.js";
@@ -76,6 +77,7 @@ import type {
   _DiagnosticsServerMessages,
 } from "./message-types/diagnostics.js";
 import type { _DiskPressureServerMessages } from "./message-types/disk-pressure.js";
+import type { _DocumentCommentsServerMessages } from "./message-types/document-comments.js";
 import type {
   _DocumentsClientMessages,
   _DocumentsServerMessages,
@@ -192,6 +194,7 @@ export type ServerMessage =
   | _BrowserServerMessages
   | _SubagentsServerMessages
   | _DocumentsServerMessages
+  | _DocumentCommentsServerMessages
   | _GuardianActionsServerMessages
   | _SyncInvalidationServerMessages
   | _HomeServerMessages

--- a/assistant/src/daemon/message-types/document-comments.ts
+++ b/assistant/src/daemon/message-types/document-comments.ts
@@ -1,0 +1,50 @@
+// Document comment event types (Server → Client).
+
+export interface DocumentCommentCreated {
+  type: "document_comment_created";
+  conversationId: string;
+  surfaceId: string;
+  comment: {
+    id: string;
+    surfaceId: string;
+    author: string;
+    content: string;
+    anchorStart?: number;
+    anchorEnd?: number;
+    anchorText?: string;
+    parentCommentId?: string;
+    status: string;
+    createdAt: number;
+    updatedAt: number;
+  };
+}
+
+export interface DocumentCommentResolved {
+  type: "document_comment_resolved";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+  resolvedBy: string;
+}
+
+export interface DocumentCommentReopened {
+  type: "document_comment_reopened";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+}
+
+export interface DocumentCommentDeleted {
+  type: "document_comment_deleted";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+}
+
+// --- Domain-level union alias (consumed by the barrel file) ---
+
+export type _DocumentCommentsServerMessages =
+  | DocumentCommentCreated
+  | DocumentCommentResolved
+  | DocumentCommentReopened
+  | DocumentCommentDeleted;


### PR DESCRIPTION
## Summary
- Defines four SSE message types for document comment events (created, resolved, reopened, deleted)
- Exports domain union alias and adds to ServerMessage union in message-protocol.ts

Part of plan: doc-comments.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->