### PR TITLE
feat(document-editor): add comment_list, comment_resolve, and comment_reply tools

### DIFF
--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -101,6 +101,72 @@
       },
       "executor": "tools/document-delete.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "comment_list",
+      "description": "List open comments on a document. Returns all unresolved comments with their content, anchor text, and thread context so you can address user feedback.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          }
+        },
+        "required": ["surface_id"]
+      },
+      "executor": "tools/comment-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "comment_resolve",
+      "description": "Mark a comment as resolved after you have addressed the feedback. Use this after editing the document to satisfy the comment.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "comment_id": {
+            "type": "string",
+            "description": "The comment ID to resolve"
+          }
+        },
+        "required": ["surface_id", "comment_id"]
+      },
+      "executor": "tools/comment-resolve.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "comment_reply",
+      "description": "Reply to a comment thread. Use this to ask clarifying questions or explain your approach before or after making changes.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "comment_id": {
+            "type": "string",
+            "description": "The parent comment ID to reply to"
+          },
+          "content": {
+            "type": "string",
+            "description": "Reply text"
+          }
+        },
+        "required": ["surface_id", "comment_id", "content"]
+      },
+      "executor": "tools/comment-reply.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/document-editor/tools/comment-list.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/comment-list.ts
@@ -1,0 +1,12 @@
+import { executeCommentList } from "../../../../tools/document/document-comment-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeCommentList(input, context);
+}

--- a/assistant/src/config/bundled-skills/document-editor/tools/comment-reply.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/comment-reply.ts
@@ -1,0 +1,12 @@
+import { executeCommentReply } from "../../../../tools/document/document-comment-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeCommentReply(input, context);
+}

--- a/assistant/src/config/bundled-skills/document-editor/tools/comment-resolve.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/comment-resolve.ts
@@ -1,0 +1,12 @@
+import { executeCommentResolve } from "../../../../tools/document/document-comment-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeCommentResolve(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -51,6 +51,9 @@ import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js"
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document-editor ───────────────────────────────────────────────────────────
+import * as commentList from "./bundled-skills/document-editor/tools/comment-list.js";
+import * as commentReply from "./bundled-skills/document-editor/tools/comment-reply.js";
+import * as commentResolve from "./bundled-skills/document-editor/tools/comment-resolve.js";
 import * as documentCreate from "./bundled-skills/document-editor/tools/document-create.js";
 import * as documentDelete from "./bundled-skills/document-editor/tools/document-delete.js";
 import * as documentList from "./bundled-skills/document-editor/tools/document-list.js";
@@ -170,6 +173,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/google-contacts.ts", googleContacts],
 
   // document-editor
+  ["document-editor:tools/comment-list.ts", commentList],
+  ["document-editor:tools/comment-reply.ts", commentReply],
+  ["document-editor:tools/comment-resolve.ts", commentResolve],
   ["document-editor:tools/document-create.ts", documentCreate],
   ["document-editor:tools/document-delete.ts", documentDelete],
   ["document-editor:tools/document-list.ts", documentList],

--- a/assistant/src/tools/document/document-comment-tool.test.ts
+++ b/assistant/src/tools/document/document-comment-tool.test.ts
@@ -319,7 +319,8 @@ describe("executeCommentReply", () => {
     // Verify SSE event
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe("document_comment_created");
-    const eventComment = (sent[0] as { comment: { id: string } }).comment;
+    const eventComment = (sent[0] as unknown as { comment: { id: string } })
+      .comment;
     expect(eventComment.id).toBe(body.comment.id);
   });
 

--- a/assistant/src/tools/document/document-comment-tool.test.ts
+++ b/assistant/src/tools/document/document-comment-tool.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import {
+  createComment,
+  getComment,
+  listComments,
+} from "../../documents/document-comments-store.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { rawRun, resetTestTables } from "../../memory/raw-query.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+import {
+  executeCommentList,
+  executeCommentReply,
+  executeCommentResolve,
+} from "./document-comment-tool.js";
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SURFACE_ID = "doc-comment-tool-test";
+const CONVERSATION_ID = "conv-comment-tool";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: CONVERSATION_ID,
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function seedDocument(
+  surfaceId: string = SURFACE_ID,
+  conversationId: string = CONVERSATION_ID,
+): void {
+  const now = Date.now();
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)`,
+    conversationId,
+    now,
+    now,
+  );
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
+     VALUES (?, ?, 'Test Doc', 'body', 2, ?, ?)`,
+    surfaceId,
+    conversationId,
+    now,
+    now,
+  );
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    surfaceId,
+    conversationId,
+    now,
+  );
+}
+
+beforeEach(() => {
+  resetTestTables(
+    "document_comments",
+    "document_conversations",
+    "documents",
+    "conversations",
+  );
+  seedDocument();
+});
+
+// ---------------------------------------------------------------------------
+// comment_list
+// ---------------------------------------------------------------------------
+
+describe("executeCommentList", () => {
+  test("returns only open comments", () => {
+    const c1 = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Open comment",
+    });
+    const c2 = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Resolved comment",
+    });
+    // Resolve one directly via the store
+    rawRun(
+      /*sql*/ `UPDATE document_comments SET status = 'resolved', resolved_by = 'user1', resolved_at = ? WHERE id = ?`,
+      Date.now(),
+      c2.id,
+    );
+
+    const result = executeCommentList(
+      { surface_id: SURFACE_ID },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{
+      success: boolean;
+      comments: Array<{ id: string; content: string }>;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.comments).toHaveLength(1);
+    expect(body.comments[0].id).toBe(c1.id);
+    expect(body.comments[0].content).toBe("Open comment");
+  });
+
+  test("includes anchor and thread metadata", () => {
+    const parent = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Fix this",
+      anchorStart: 5,
+      anchorEnd: 10,
+      anchorText: "hello",
+    });
+    createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "assistant",
+      content: "Will do",
+      parentCommentId: parent.id,
+    });
+
+    const result = executeCommentList(
+      { surface_id: SURFACE_ID },
+      makeContext(),
+    );
+    const body = parseResult<{
+      comments: Array<{
+        anchor_start: number | null;
+        anchor_end: number | null;
+        anchor_text: string | null;
+        parent_comment_id: string | null;
+      }>;
+    }>(result);
+
+    expect(body.comments).toHaveLength(2);
+    expect(body.comments[0].anchor_start).toBe(5);
+    expect(body.comments[0].anchor_end).toBe(10);
+    expect(body.comments[0].anchor_text).toBe("hello");
+    expect(body.comments[0].parent_comment_id).toBeNull();
+    expect(body.comments[1].parent_comment_id).toBe(parent.id);
+  });
+
+  test("blocks access for non-privileged actors on other conversations", () => {
+    seedDocument("doc-other", "conv-other");
+    createComment({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      author: "user1",
+      content: "Secret feedback",
+    });
+
+    const result = executeCommentList(
+      { surface_id: "doc-other" },
+      makeContext({ conversationId: CONVERSATION_ID }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parseResult<{ error: string }>(result).error).toBe(
+      "Document not found",
+    );
+  });
+
+  test("allows guardian access to comments on any document", () => {
+    seedDocument("doc-other", "conv-other");
+    createComment({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      author: "user1",
+      content: "Cross-conv comment",
+    });
+
+    const result = executeCommentList(
+      { surface_id: "doc-other" },
+      makeContext({ trustClass: "guardian" }),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ comments: Array<{ content: string }> }>(result);
+    expect(body.comments).toHaveLength(1);
+    expect(body.comments[0].content).toBe("Cross-conv comment");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comment_resolve
+// ---------------------------------------------------------------------------
+
+describe("executeCommentResolve", () => {
+  test("resolves a comment with resolved_by: 'assistant' and emits SSE event", () => {
+    const c = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Fix this",
+    });
+
+    const sent: Array<{ type: string; [key: string]: unknown }> = [];
+    const result = executeCommentResolve(
+      { surface_id: SURFACE_ID, comment_id: c.id },
+      makeContext({ sendToClient: (msg) => sent.push(msg) }),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ success: boolean; comment_id: string }>(result);
+    expect(body.success).toBe(true);
+    expect(body.comment_id).toBe(c.id);
+
+    // Verify the DB was updated
+    const fetched = getComment(c.id);
+    expect(fetched!.status).toBe("resolved");
+    expect(fetched!.resolvedBy).toBe("assistant");
+
+    // Verify SSE event
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe("document_comment_resolved");
+    expect(sent[0].commentId).toBe(c.id);
+    expect(sent[0].resolvedBy).toBe("assistant");
+  });
+
+  test("returns error for non-existent comment", () => {
+    const result = executeCommentResolve(
+      { surface_id: SURFACE_ID, comment_id: "comment-nonexistent" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parseResult<{ error: string }>(result).error).toBe(
+      "Comment not found",
+    );
+  });
+
+  test("blocks cross-conversation resolve for non-privileged actors", () => {
+    seedDocument("doc-other", "conv-other");
+    const c = createComment({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      author: "user1",
+      content: "Cannot resolve this",
+    });
+
+    const result = executeCommentResolve(
+      { surface_id: "doc-other", comment_id: c.id },
+      makeContext({ conversationId: CONVERSATION_ID }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parseResult<{ error: string }>(result).error).toBe(
+      "Document not found",
+    );
+    // Comment should remain open
+    expect(getComment(c.id)!.status).toBe("open");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comment_reply
+// ---------------------------------------------------------------------------
+
+describe("executeCommentReply", () => {
+  test("creates a reply with parent_comment_id and author: 'assistant'", () => {
+    const parent = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Please explain",
+    });
+
+    const sent: Array<{ type: string; [key: string]: unknown }> = [];
+    const result = executeCommentReply(
+      {
+        surface_id: SURFACE_ID,
+        comment_id: parent.id,
+        content: "Here is my explanation",
+      },
+      makeContext({ sendToClient: (msg) => sent.push(msg) }),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{
+      success: boolean;
+      comment: {
+        id: string;
+        author: string;
+        content: string;
+        parent_comment_id: string;
+      };
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.comment.author).toBe("assistant");
+    expect(body.comment.content).toBe("Here is my explanation");
+    expect(body.comment.parent_comment_id).toBe(parent.id);
+
+    // Verify persisted in DB
+    const fetched = getComment(body.comment.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.author).toBe("assistant");
+    expect(fetched!.parentCommentId).toBe(parent.id);
+
+    // Verify SSE event
+    expect(sent).toHaveLength(1);
+    expect(sent[0].type).toBe("document_comment_created");
+    const eventComment = (sent[0] as { comment: { id: string } }).comment;
+    expect(eventComment.id).toBe(body.comment.id);
+  });
+
+  test("blocks cross-conversation reply for non-privileged actors", () => {
+    seedDocument("doc-other", "conv-other");
+    const parent = createComment({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      author: "user1",
+      content: "Feedback on other doc",
+    });
+
+    const result = executeCommentReply(
+      {
+        surface_id: "doc-other",
+        comment_id: parent.id,
+        content: "Sneaky reply",
+      },
+      makeContext({ conversationId: CONVERSATION_ID }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(parseResult<{ error: string }>(result).error).toBe(
+      "Document not found",
+    );
+    // No reply should exist
+    const comments = listComments("doc-other");
+    expect(comments).toHaveLength(1);
+  });
+
+  test("works without sendToClient (no SSE emission)", () => {
+    const parent = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Question",
+    });
+
+    const result = executeCommentReply(
+      {
+        surface_id: SURFACE_ID,
+        comment_id: parent.id,
+        content: "Answer",
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{
+      success: boolean;
+      comment: { content: string };
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.comment.content).toBe("Answer");
+  });
+});

--- a/assistant/src/tools/document/document-comment-tool.ts
+++ b/assistant/src/tools/document/document-comment-tool.ts
@@ -1,0 +1,141 @@
+import {
+  createComment,
+  listComments,
+  resolveComment,
+} from "../../documents/document-comments-store.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+import { canAccessDocument, documentNotFound } from "./document-tool.js";
+
+// ── Exported execute functions ─────────────────────────────────────────
+
+export function executeCommentList(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  const comments = listComments(surfaceId, { status: "open" });
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: surfaceId,
+      comments: comments.map((c) => ({
+        id: c.id,
+        author: c.author,
+        content: c.content,
+        anchor_start: c.anchorStart,
+        anchor_end: c.anchorEnd,
+        anchor_text: c.anchorText,
+        parent_comment_id: c.parentCommentId,
+        status: c.status,
+        created_at: c.createdAt,
+        updated_at: c.updatedAt,
+      })),
+    }),
+    isError: false,
+  };
+}
+
+export function executeCommentResolve(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const commentId = input.comment_id as string;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  const resolved = resolveComment(commentId, "assistant");
+  if (!resolved) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        comment_id: commentId,
+        error: "Comment not found",
+      }),
+      isError: true,
+    };
+  }
+
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "document_comment_resolved",
+      conversationId: context.conversationId,
+      surfaceId,
+      commentId,
+      resolvedBy: "assistant",
+    });
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      comment_id: commentId,
+      message: "Comment resolved",
+    }),
+    isError: false,
+  };
+}
+
+export function executeCommentReply(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const commentId = input.comment_id as string;
+  const content = input.content as string;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  const reply = createComment({
+    surfaceId,
+    conversationId: context.conversationId,
+    author: "assistant",
+    content,
+    parentCommentId: commentId,
+  });
+
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "document_comment_created",
+      conversationId: context.conversationId,
+      surfaceId,
+      comment: {
+        id: reply.id,
+        surfaceId: reply.surfaceId,
+        author: reply.author,
+        content: reply.content,
+        parentCommentId: reply.parentCommentId,
+        status: reply.status,
+        createdAt: reply.createdAt,
+        updatedAt: reply.updatedAt,
+      },
+    });
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      comment: {
+        id: reply.id,
+        surface_id: reply.surfaceId,
+        author: reply.author,
+        content: reply.content,
+        parent_comment_id: reply.parentCommentId,
+        status: reply.status,
+        created_at: reply.createdAt,
+        updated_at: reply.updatedAt,
+      },
+    }),
+    isError: false,
+  };
+}

--- a/assistant/src/tools/document/document-comment-tool.ts
+++ b/assistant/src/tools/document/document-comment-tool.ts
@@ -1,5 +1,6 @@
 import {
   createComment,
+  getComment,
   listComments,
   resolveComment,
 } from "../../documents/document-comments-store.js";
@@ -52,8 +53,8 @@ export function executeCommentResolve(
     return documentNotFound(surfaceId);
   }
 
-  const resolved = resolveComment(commentId, "assistant");
-  if (!resolved) {
+  const existing = getComment(commentId);
+  if (!existing || existing.surfaceId !== surfaceId) {
     return {
       content: JSON.stringify({
         success: false,
@@ -63,6 +64,8 @@ export function executeCommentResolve(
       isError: true,
     };
   }
+
+  resolveComment(commentId, "assistant");
 
   if (context.sendToClient) {
     context.sendToClient({
@@ -94,6 +97,18 @@ export function executeCommentReply(
 
   if (!canAccessDocument(surfaceId, context)) {
     return documentNotFound(surfaceId);
+  }
+
+  const parent = getComment(commentId);
+  if (!parent || parent.surfaceId !== surfaceId) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        comment_id: commentId,
+        error: "Parent comment not found on this document",
+      }),
+      isError: true,
+    };
   }
 
   const reply = createComment({

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -17,7 +17,7 @@ function isPrivilegedDocumentActor(context: ToolContext): boolean {
   );
 }
 
-function documentNotFound(surfaceId: string): ToolExecutionResult {
+export function documentNotFound(surfaceId: string): ToolExecutionResult {
   return {
     content: JSON.stringify({
       success: false,
@@ -28,7 +28,10 @@ function documentNotFound(surfaceId: string): ToolExecutionResult {
   };
 }
 
-function canAccessDocument(surfaceId: string, context: ToolContext): boolean {
+export function canAccessDocument(
+  surfaceId: string,
+  context: ToolContext,
+): boolean {
   return (
     isPrivilegedDocumentActor(context) ||
     isDocumentAssociatedWithConversation(surfaceId, context.conversationId)


### PR DESCRIPTION
## Summary
- Adds three assistant tools: comment_list, comment_resolve, comment_reply
- Implements executor functions with access control and SSE event emission
- Registers tools in document-editor TOOLS.json with thin wrapper executors

Part of plan: doc-comments.md (PR 5 of 11)