### PR TITLE
feat(web): handle document comment SSE events

### DIFF
--- a/apps/web/src/domains/chat/lib/document-comment-events.test.ts
+++ b/apps/web/src/domains/chat/lib/document-comment-events.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { DocumentComment } from "@/domains/chat/lib/document-comments.js";
+import {
+  type CommentStateMap,
+  type DocumentCommentCreatedEvent,
+  type DocumentCommentDeletedEvent,
+  type DocumentCommentEventCallbacks,
+  type DocumentCommentReopenedEvent,
+  type DocumentCommentResolvedEvent,
+  handleDocumentCommentCreated,
+  handleDocumentCommentDeleted,
+  handleDocumentCommentReopened,
+  handleDocumentCommentResolved,
+} from "@/domains/chat/lib/document-comment-events.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(
+  entries?: [string, DocumentComment[]][],
+): CommentStateMap {
+  return new Map(entries ?? []);
+}
+
+function makeCallbacks(): DocumentCommentEventCallbacks & {
+  calls: string[];
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    onCommentsChanged: mock((surfaceId: string) => {
+      calls.push(surfaceId);
+    }),
+  };
+}
+
+function makeComment(overrides?: Partial<DocumentComment>): DocumentComment {
+  return {
+    id: "c1",
+    surfaceId: "doc-1",
+    conversationId: "conv-1",
+    author: "user",
+    content: "A comment",
+    anchorStart: null,
+    anchorEnd: null,
+    anchorText: null,
+    parentCommentId: null,
+    status: "open",
+    resolvedBy: null,
+    resolvedAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleDocumentCommentCreated
+// ---------------------------------------------------------------------------
+
+describe("handleDocumentCommentCreated", () => {
+  test("adds comment to empty state map", () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const event: DocumentCommentCreatedEvent = {
+      type: "document_comment_created",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      comment: {
+        id: "c1",
+        surfaceId: "doc-1",
+        author: "user",
+        content: "First comment",
+        anchorStart: 0,
+        anchorEnd: 10,
+        anchorText: "hello",
+        status: "open",
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+
+    handleDocumentCommentCreated(event, state, cb);
+
+    const comments = state.get("doc-1")!;
+    expect(comments).toHaveLength(1);
+    expect(comments[0]!.id).toBe("c1");
+    expect(comments[0]!.content).toBe("First comment");
+    expect(comments[0]!.anchorStart).toBe(0);
+    expect(comments[0]!.anchorEnd).toBe(10);
+    expect(comments[0]!.anchorText).toBe("hello");
+    expect(comments[0]!.conversationId).toBe("conv-1");
+    expect(comments[0]!.author).toBe("user");
+    expect(cb.calls).toEqual(["doc-1"]);
+  });
+
+  test("appends to existing comments for same surface", () => {
+    const existing = makeComment({ id: "c0" });
+    const state = makeState([["doc-1", [existing]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentCreatedEvent = {
+      type: "document_comment_created",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      comment: {
+        id: "c1",
+        surfaceId: "doc-1",
+        author: "assistant",
+        content: "Second comment",
+        status: "open",
+        createdAt: 2000,
+        updatedAt: 2000,
+      },
+    };
+
+    handleDocumentCommentCreated(event, state, cb);
+
+    const comments = state.get("doc-1")!;
+    expect(comments).toHaveLength(2);
+    expect(comments[0]!.id).toBe("c0");
+    expect(comments[1]!.id).toBe("c1");
+    expect(comments[1]!.author).toBe("assistant");
+  });
+
+  test("normalizes optional fields to null", () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const event: DocumentCommentCreatedEvent = {
+      type: "document_comment_created",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      comment: {
+        id: "c1",
+        surfaceId: "doc-1",
+        author: "user",
+        content: "No anchor",
+        status: "open",
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+
+    handleDocumentCommentCreated(event, state, cb);
+
+    const comment = state.get("doc-1")![0]!;
+    expect(comment.anchorStart).toBeNull();
+    expect(comment.anchorEnd).toBeNull();
+    expect(comment.anchorText).toBeNull();
+    expect(comment.parentCommentId).toBeNull();
+    expect(comment.resolvedBy).toBeNull();
+    expect(comment.resolvedAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDocumentCommentResolved
+// ---------------------------------------------------------------------------
+
+describe("handleDocumentCommentResolved", () => {
+  test("updates comment status to resolved", () => {
+    const comment = makeComment({ id: "c1", status: "open" });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentResolvedEvent = {
+      type: "document_comment_resolved",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+      resolvedBy: "user-123",
+    };
+
+    handleDocumentCommentResolved(event, state, cb);
+
+    expect(comment.status).toBe("resolved");
+    expect(comment.resolvedBy).toBe("user-123");
+    expect(comment.resolvedAt).toBeGreaterThan(0);
+    expect(cb.calls).toEqual(["doc-1"]);
+  });
+
+  test("no-ops when surface has no comments", () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const event: DocumentCommentResolvedEvent = {
+      type: "document_comment_resolved",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+      resolvedBy: "user-123",
+    };
+
+    handleDocumentCommentResolved(event, state, cb);
+
+    expect(cb.calls).toHaveLength(0);
+  });
+
+  test("no-ops when comment id not found", () => {
+    const comment = makeComment({ id: "c2" });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentResolvedEvent = {
+      type: "document_comment_resolved",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c999",
+      resolvedBy: "user-123",
+    };
+
+    handleDocumentCommentResolved(event, state, cb);
+
+    expect(comment.status).toBe("open");
+    expect(cb.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDocumentCommentReopened
+// ---------------------------------------------------------------------------
+
+describe("handleDocumentCommentReopened", () => {
+  test("updates comment status to open", () => {
+    const comment = makeComment({
+      id: "c1",
+      status: "resolved",
+      resolvedBy: "user-123",
+      resolvedAt: 2000,
+    });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentReopenedEvent = {
+      type: "document_comment_reopened",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+    };
+
+    handleDocumentCommentReopened(event, state, cb);
+
+    expect(comment.status).toBe("open");
+    expect(comment.resolvedBy).toBeNull();
+    expect(comment.resolvedAt).toBeNull();
+    expect(cb.calls).toEqual(["doc-1"]);
+  });
+
+  test("no-ops when surface has no comments", () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const event: DocumentCommentReopenedEvent = {
+      type: "document_comment_reopened",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+    };
+
+    handleDocumentCommentReopened(event, state, cb);
+
+    expect(cb.calls).toHaveLength(0);
+  });
+
+  test("no-ops when comment id not found", () => {
+    const comment = makeComment({ id: "c2", status: "resolved" });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentReopenedEvent = {
+      type: "document_comment_reopened",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c999",
+    };
+
+    handleDocumentCommentReopened(event, state, cb);
+
+    expect(comment.status).toBe("resolved");
+    expect(cb.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDocumentCommentDeleted
+// ---------------------------------------------------------------------------
+
+describe("handleDocumentCommentDeleted", () => {
+  test("removes comment from state", () => {
+    const comment = makeComment({ id: "c1" });
+    const other = makeComment({ id: "c2" });
+    const state = makeState([["doc-1", [comment, other]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentDeletedEvent = {
+      type: "document_comment_deleted",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+    };
+
+    handleDocumentCommentDeleted(event, state, cb);
+
+    const comments = state.get("doc-1")!;
+    expect(comments).toHaveLength(1);
+    expect(comments[0]!.id).toBe("c2");
+    expect(cb.calls).toEqual(["doc-1"]);
+  });
+
+  test("removes surface entry when last comment is deleted", () => {
+    const comment = makeComment({ id: "c1" });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentDeletedEvent = {
+      type: "document_comment_deleted",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+    };
+
+    handleDocumentCommentDeleted(event, state, cb);
+
+    expect(state.has("doc-1")).toBe(false);
+    expect(cb.calls).toEqual(["doc-1"]);
+  });
+
+  test("no-ops when surface has no comments", () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const event: DocumentCommentDeletedEvent = {
+      type: "document_comment_deleted",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c1",
+    };
+
+    handleDocumentCommentDeleted(event, state, cb);
+
+    expect(cb.calls).toHaveLength(0);
+  });
+
+  test("no-ops when comment id not found", () => {
+    const comment = makeComment({ id: "c2" });
+    const state = makeState([["doc-1", [comment]]]);
+    const cb = makeCallbacks();
+    const event: DocumentCommentDeletedEvent = {
+      type: "document_comment_deleted",
+      conversationId: "conv-1",
+      surfaceId: "doc-1",
+      commentId: "c999",
+    };
+
+    handleDocumentCommentDeleted(event, state, cb);
+
+    const comments = state.get("doc-1")!;
+    expect(comments).toHaveLength(1);
+    expect(cb.calls).toHaveLength(0);
+  });
+});

--- a/apps/web/src/domains/chat/lib/document-comment-events.ts
+++ b/apps/web/src/domains/chat/lib/document-comment-events.ts
@@ -116,6 +116,7 @@ export function handleDocumentCommentCreated(
 ): void {
   const comment = toDocumentComment(event);
   const existing = state.get(event.surfaceId) ?? [];
+  if (existing.some((c) => c.id === comment.id)) return;
   existing.push(comment);
   state.set(event.surfaceId, existing);
   callbacks.onCommentsChanged(event.surfaceId);

--- a/apps/web/src/domains/chat/lib/document-comment-events.ts
+++ b/apps/web/src/domains/chat/lib/document-comment-events.ts
@@ -1,0 +1,177 @@
+/**
+ * SSE event handlers for document comment lifecycle events.
+ *
+ * Each handler is a pure function that accepts a typed event payload and a
+ * callback for signalling state changes. PR 10 (viewer integration) will
+ * wire these into the main SSE stream processor.
+ */
+
+import type { DocumentComment } from "@/domains/chat/lib/document-comments.js";
+
+// ---------------------------------------------------------------------------
+// SSE event shapes — mirrors daemon message-types/document-comments.ts
+// ---------------------------------------------------------------------------
+
+export interface DocumentCommentCreatedEvent {
+  type: "document_comment_created";
+  conversationId: string;
+  surfaceId: string;
+  comment: {
+    id: string;
+    surfaceId: string;
+    author: string;
+    content: string;
+    anchorStart?: number;
+    anchorEnd?: number;
+    anchorText?: string;
+    parentCommentId?: string;
+    status: string;
+    createdAt: number;
+    updatedAt: number;
+  };
+}
+
+export interface DocumentCommentResolvedEvent {
+  type: "document_comment_resolved";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+  resolvedBy: string;
+}
+
+export interface DocumentCommentReopenedEvent {
+  type: "document_comment_reopened";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+}
+
+export interface DocumentCommentDeletedEvent {
+  type: "document_comment_deleted";
+  conversationId: string;
+  surfaceId: string;
+  commentId: string;
+}
+
+export type DocumentCommentEvent =
+  | DocumentCommentCreatedEvent
+  | DocumentCommentResolvedEvent
+  | DocumentCommentReopenedEvent
+  | DocumentCommentDeletedEvent;
+
+// ---------------------------------------------------------------------------
+// Callbacks
+// ---------------------------------------------------------------------------
+
+export interface DocumentCommentEventCallbacks {
+  /** Notify the comment panel that the comment list for a surface changed. */
+  onCommentsChanged: (surfaceId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// State container
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutable map of surfaceId -> comments. Handlers mutate this structure
+ * in-place so the caller can maintain a single shared reference.
+ */
+export type CommentStateMap = Map<string, DocumentComment[]>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDocumentComment(
+  event: DocumentCommentCreatedEvent,
+): DocumentComment {
+  const c = event.comment;
+  return {
+    id: c.id,
+    surfaceId: c.surfaceId,
+    conversationId: event.conversationId,
+    author: c.author === "assistant" ? "assistant" : "user",
+    content: c.content,
+    anchorStart: c.anchorStart ?? null,
+    anchorEnd: c.anchorEnd ?? null,
+    anchorText: c.anchorText ?? null,
+    parentCommentId: c.parentCommentId ?? null,
+    status: c.status === "resolved" ? "resolved" : "open",
+    resolvedBy: null,
+    resolvedAt: null,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+/** Add a newly created comment to local state. */
+export function handleDocumentCommentCreated(
+  event: DocumentCommentCreatedEvent,
+  state: CommentStateMap,
+  callbacks: DocumentCommentEventCallbacks,
+): void {
+  const comment = toDocumentComment(event);
+  const existing = state.get(event.surfaceId) ?? [];
+  existing.push(comment);
+  state.set(event.surfaceId, existing);
+  callbacks.onCommentsChanged(event.surfaceId);
+}
+
+/** Mark a comment as resolved in local state. */
+export function handleDocumentCommentResolved(
+  event: DocumentCommentResolvedEvent,
+  state: CommentStateMap,
+  callbacks: DocumentCommentEventCallbacks,
+): void {
+  const comments = state.get(event.surfaceId);
+  if (!comments) return;
+
+  const target = comments.find((c) => c.id === event.commentId);
+  if (!target) return;
+
+  target.status = "resolved";
+  target.resolvedBy = event.resolvedBy;
+  target.resolvedAt = Date.now();
+  callbacks.onCommentsChanged(event.surfaceId);
+}
+
+/** Mark a comment as open (re-opened) in local state. */
+export function handleDocumentCommentReopened(
+  event: DocumentCommentReopenedEvent,
+  state: CommentStateMap,
+  callbacks: DocumentCommentEventCallbacks,
+): void {
+  const comments = state.get(event.surfaceId);
+  if (!comments) return;
+
+  const target = comments.find((c) => c.id === event.commentId);
+  if (!target) return;
+
+  target.status = "open";
+  target.resolvedBy = null;
+  target.resolvedAt = null;
+  callbacks.onCommentsChanged(event.surfaceId);
+}
+
+/** Remove a comment from local state. */
+export function handleDocumentCommentDeleted(
+  event: DocumentCommentDeletedEvent,
+  state: CommentStateMap,
+  callbacks: DocumentCommentEventCallbacks,
+): void {
+  const comments = state.get(event.surfaceId);
+  if (!comments) return;
+
+  const idx = comments.findIndex((c) => c.id === event.commentId);
+  if (idx === -1) return;
+
+  comments.splice(idx, 1);
+  if (comments.length === 0) {
+    state.delete(event.surfaceId);
+  }
+  callbacks.onCommentsChanged(event.surfaceId);
+}


### PR DESCRIPTION
## Summary
- Implements four SSE event handlers for document comment lifecycle
- Handlers are pure functions that accept event data and state update callbacks
- Adds tests verifying correct state mutations for each event type

Part of plan: doc-comments.md (PR 9 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->