### PR TITLE
feat(document-editor): add HTTP endpoints for document comment CRUD

### DIFF
--- a/assistant/src/runtime/routes/document-comments-routes.ts
+++ b/assistant/src/runtime/routes/document-comments-routes.ts
@@ -1,0 +1,243 @@
+/**
+ * Route handlers for document comment CRUD operations.
+ *
+ * Exposes comment management over HTTP, delegating to the store layer in
+ * `documents/document-comments-store.ts`.
+ */
+import { z } from "zod";
+
+import {
+  createComment,
+  deleteComment,
+  getComment,
+  listComments,
+  reopenComment,
+  resolveComment,
+} from "../../documents/document-comments-store.js";
+import { rawRun } from "../../memory/raw-query.js";
+import { getLogger } from "../../util/logger.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import type { RouteDefinition } from "./types.js";
+
+const log = getLogger("document-comments-routes");
+
+// ---------------------------------------------------------------------------
+// Request schemas
+// ---------------------------------------------------------------------------
+
+const listQuerySchema = z.object({
+  status: z
+    .enum(["open", "resolved", "all"])
+    .default("all")
+    .describe("Filter by comment status"),
+});
+
+const createBodySchema = z.object({
+  content: z.string().min(1).describe("Comment text content"),
+  author: z.string().optional().default("user").describe("Comment author"),
+  anchorStart: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Selection start offset"),
+  anchorEnd: z.number().nullable().optional().describe("Selection end offset"),
+  anchorText: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Anchored text snippet"),
+  parentCommentId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Parent comment ID for replies"),
+  conversationId: z.string().describe("Owning conversation ID"),
+});
+
+const updateBodySchema = z
+  .object({
+    status: z
+      .enum(["open", "resolved"])
+      .optional()
+      .describe("New comment status"),
+    content: z.string().min(1).optional().describe("Updated comment text"),
+    resolvedBy: z.string().optional().describe("Who resolved the comment"),
+  })
+  .refine((data) => data.status !== undefined || data.content !== undefined, {
+    message: "At least one of status or content must be provided",
+  });
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "listDocumentComments",
+    endpoint: "documents/:id/comments",
+    method: "GET",
+    policyKey: "documents",
+    requirePolicyEnforcement: true,
+    summary: "List comments for a document",
+    description:
+      "Return comments for a document, optionally filtered by status.",
+    tags: ["documents"],
+    queryParams: [
+      {
+        name: "status",
+        schema: { type: "string", enum: ["open", "resolved", "all"] },
+        description: "Filter by comment status (default: all)",
+      },
+    ],
+    responseBody: z.object({
+      comments: z.array(z.unknown()).describe("Comment records"),
+    }),
+    handler: ({ pathParams, queryParams }) => {
+      const parsed = listQuerySchema.safeParse(queryParams ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError(parsed.error.issues[0].message);
+      }
+      const { status } = parsed.data;
+      const comments = listComments(pathParams!.id, { status });
+      return { comments };
+    },
+  },
+
+  {
+    operationId: "createDocumentComment",
+    endpoint: "documents/:id/comments",
+    method: "POST",
+    policyKey: "documents",
+    requirePolicyEnforcement: true,
+    summary: "Create a comment on a document",
+    description: "Add a new comment to a document.",
+    tags: ["documents"],
+    requestBody: createBodySchema,
+    responseBody: z.object({
+      id: z.string(),
+      surfaceId: z.string(),
+      conversationId: z.string(),
+      author: z.string(),
+      content: z.string(),
+      status: z.string(),
+      createdAt: z.number(),
+      updatedAt: z.number(),
+    }),
+    handler: ({ pathParams, body }) => {
+      const parsed = createBodySchema.safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError(parsed.error.issues[0].message);
+      }
+      const {
+        content,
+        author,
+        anchorStart,
+        anchorEnd,
+        anchorText,
+        parentCommentId,
+        conversationId,
+      } = parsed.data;
+      const comment = createComment({
+        surfaceId: pathParams!.id,
+        conversationId,
+        author,
+        content,
+        anchorStart,
+        anchorEnd,
+        anchorText,
+        parentCommentId,
+      });
+      log.info(
+        { id: comment.id, surfaceId: pathParams!.id },
+        "Created document comment via HTTP",
+      );
+      return comment;
+    },
+  },
+
+  {
+    operationId: "updateDocumentComment",
+    endpoint: "documents/:id/comments/:commentId",
+    method: "PATCH",
+    policyKey: "documents",
+    requirePolicyEnforcement: true,
+    summary: "Update a document comment",
+    description: "Update the status or content of a comment.",
+    tags: ["documents"],
+    requestBody: updateBodySchema,
+    responseBody: z.object({
+      id: z.string(),
+      surfaceId: z.string(),
+      content: z.string(),
+      status: z.string(),
+      updatedAt: z.number(),
+    }),
+    handler: ({ pathParams, body }) => {
+      const parsed = updateBodySchema.safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError(parsed.error.issues[0].message);
+      }
+      const { status, content, resolvedBy } = parsed.data;
+      const commentId = pathParams!.commentId;
+
+      // Verify the comment exists
+      const existing = getComment(commentId);
+      if (!existing) {
+        throw new NotFoundError("Comment not found");
+      }
+
+      if (status === "resolved") {
+        resolveComment(commentId, resolvedBy ?? "user");
+      } else if (status === "open") {
+        reopenComment(commentId);
+      }
+
+      if (content !== undefined) {
+        const now = Date.now();
+        rawRun(
+          /*sql*/ `UPDATE document_comments SET content = ?, updated_at = ? WHERE id = ?`,
+          content,
+          now,
+          commentId,
+        );
+      }
+
+      const updated = getComment(commentId);
+      if (!updated) {
+        throw new NotFoundError("Comment not found after update");
+      }
+
+      log.info(
+        { id: commentId, surfaceId: pathParams!.id },
+        "Updated document comment via HTTP",
+      );
+      return updated;
+    },
+  },
+
+  {
+    operationId: "deleteDocumentComment",
+    endpoint: "documents/:id/comments/:commentId",
+    method: "DELETE",
+    policyKey: "documents",
+    requirePolicyEnforcement: true,
+    summary: "Delete a document comment",
+    description: "Permanently delete a comment.",
+    tags: ["documents"],
+    responseBody: z.object({
+      success: z.literal(true),
+    }),
+    handler: ({ pathParams }) => {
+      const commentId = pathParams!.commentId;
+      const deleted = deleteComment(commentId);
+      if (!deleted) {
+        throw new NotFoundError("Comment not found");
+      }
+      log.info(
+        { id: commentId, surfaceId: pathParams!.id },
+        "Deleted document comment via HTTP",
+      );
+      return { success: true as const };
+    },
+  },
+];

--- a/assistant/src/runtime/routes/document-comments-routes.ts
+++ b/assistant/src/runtime/routes/document-comments-routes.ts
@@ -180,9 +180,8 @@ export const ROUTES: RouteDefinition[] = [
       const { status, content, resolvedBy } = parsed.data;
       const commentId = pathParams!.commentId;
 
-      // Verify the comment exists
       const existing = getComment(commentId);
-      if (!existing) {
+      if (!existing || existing.surfaceId !== pathParams!.id) {
         throw new NotFoundError("Comment not found");
       }
 
@@ -229,10 +228,11 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ pathParams }) => {
       const commentId = pathParams!.commentId;
-      const deleted = deleteComment(commentId);
-      if (!deleted) {
+      const existing = getComment(commentId);
+      if (!existing || existing.surfaceId !== pathParams!.id) {
         throw new NotFoundError("Comment not found");
       }
+      deleteComment(commentId);
       log.info(
         { id: commentId, surfaceId: pathParams!.id },
         "Deleted document comment via HTTP",

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -49,6 +49,7 @@ import { ROUTES as DEBUG_ROUTES } from "./debug-routes.js";
 import { ROUTES as DEFER_ROUTES } from "./defer-routes.js";
 import { ROUTES as DIAGNOSTICS_ROUTES } from "./diagnostics-routes.js";
 import { ROUTES as DISK_PRESSURE_ROUTES } from "./disk-pressure-routes.js";
+import { ROUTES as DOCUMENT_COMMENT_ROUTES } from "./document-comments-routes.js";
 import { ROUTES as DOCUMENT_ROUTES } from "./documents-routes.js";
 import { ROUTES as DOMAIN_ROUTES } from "./domain-routes.js";
 import { ROUTES as EMAIL_ROUTES } from "./email-routes.js";
@@ -174,6 +175,7 @@ export const ROUTES: RouteDefinition[] = [
   ...DIAGNOSTICS_ROUTES,
   ...DISK_PRESSURE_ROUTES,
   ...DOMAIN_ROUTES,
+  ...DOCUMENT_COMMENT_ROUTES,
   ...DOCUMENT_ROUTES,
   ...EMAIL_ROUTES,
   ...EVENTS_ROUTES,


### PR DESCRIPTION
## Summary
- Adds GET/POST/PATCH/DELETE endpoints for document comments
- Includes zod request validation and policy enforcement
- Registers routes in the route index

Part of plan: doc-comments.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->