### PR TITLE
feat(document-editor): inject open document comments into assistant context

### DIFF
--- a/assistant/src/__tests__/injector-document-comments.test.ts
+++ b/assistant/src/__tests__/injector-document-comments.test.ts
@@ -1,0 +1,377 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CommentRecord } from "../documents/document-comments-store.js";
+
+let listCommentsMock = mock((..._args: unknown[]) => [] as CommentRecord[]);
+
+mock.module("../documents/document-comments-store.js", () => ({
+  listComments: (...args: unknown[]) => listCommentsMock(...args),
+}));
+
+const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
+  await import("../plugins/defaults/injectors.js");
+import type { Injector, TurnContext } from "../plugins/types.js";
+
+function findInjector(name: string): Injector {
+  const injector = defaultInjectorsPlugin.injectors?.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!injector) {
+    throw new Error(`injector '${name}' not registered`);
+  }
+  return injector;
+}
+
+function makeContext(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-test",
+    conversationId: "conv-test",
+    turnIndex: 0,
+    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<CommentRecord> = {}): CommentRecord {
+  return {
+    id: "comment-abc",
+    surfaceId: "doc-1",
+    conversationId: "conv-test",
+    author: "user",
+    content: "Fix this paragraph",
+    anchorStart: null,
+    anchorEnd: null,
+    anchorText: null,
+    parentCommentId: null,
+    status: "open",
+    resolvedBy: null,
+    resolvedAt: null,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+const injector = findInjector("document-comments");
+
+describe("document-comments injector", () => {
+  beforeEach(() => {
+    listCommentsMock = mock(() => [] as CommentRecord[]);
+  });
+
+  test("returns null when no active documents exist", async () => {
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: { mode: "full", activeDocuments: [] },
+      }),
+    );
+    expect(block).toBeNull();
+  });
+
+  test("returns null when activeDocuments is undefined", async () => {
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: { mode: "full" },
+      }),
+    );
+    expect(block).toBeNull();
+  });
+
+  test("returns null when mode is minimal", async () => {
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "minimal",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "My Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+    expect(block).toBeNull();
+  });
+
+  test("returns null when no documents have open comments", async () => {
+    listCommentsMock = mock(() => []);
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "My Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+    expect(block).toBeNull();
+  });
+
+  test("formats doc-level comments correctly", async () => {
+    listCommentsMock = mock(() => [
+      makeComment({
+        id: "comment-id1",
+        content: "This introduction needs more context",
+        anchorText: null,
+      }),
+    ]);
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "My Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.id).toBe("document-comments");
+    expect(block!.placement).toBe("prepend-user-tail");
+    expect(block!.text).toContain("(doc-level)");
+    expect(block!.text).toContain("Comment #comment-id1");
+    expect(block!.text).toContain('"This introduction needs more context"');
+  });
+
+  test("formats inline comments with anchor text", async () => {
+    listCommentsMock = mock(() => [
+      makeComment({
+        id: "comment-id2",
+        content: "Cite the research paper",
+        anchorText: "the quick brown fox",
+        anchorStart: 10,
+        anchorEnd: 29,
+      }),
+    ]);
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "My Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.text).toContain('inline, anchored to "the quick brown fox"');
+    expect(block!.text).toContain("Comment #comment-id2");
+    expect(block!.text).toContain('"Cite the research paper"');
+  });
+
+  test("mixes doc-level and inline comments for the same document", async () => {
+    listCommentsMock = mock(() => [
+      makeComment({
+        id: "comment-id1",
+        content: "This introduction needs more context",
+        anchorText: null,
+      }),
+      makeComment({
+        id: "comment-id2",
+        content: "Cite the research paper",
+        anchorText: "the quick brown fox",
+        anchorStart: 10,
+        anchorEnd: 29,
+      }),
+    ]);
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-xxx",
+              title: "Title",
+              wordCount: 200,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.text).toContain('Document: "Title" (surface_id: "doc-xxx")');
+    expect(block!.text).toContain(
+      '- Comment #comment-id1 (doc-level): "This introduction needs more context"',
+    );
+    expect(block!.text).toContain(
+      '- Comment #comment-id2 (inline, anchored to "the quick brown fox"): "Cite the research paper"',
+    );
+  });
+
+  test("respects the 10-comment cap per document", async () => {
+    const comments = Array.from({ length: 15 }, (_, i) =>
+      makeComment({
+        id: `comment-${i}`,
+        content: `Comment number ${i}`,
+        createdAt: 1000 + i,
+      }),
+    );
+    listCommentsMock = mock(() => comments);
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "Big Doc",
+              wordCount: 500,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    // The store returns ASC order; .slice(-10) takes the 10 most recent
+    for (let i = 5; i < 15; i++) {
+      expect(block!.text).toContain(`Comment #comment-${i}`);
+    }
+    // Earlier comments should be excluded
+    for (let i = 0; i < 5; i++) {
+      expect(block!.text).not.toContain(`Comment #comment-${i}`);
+    }
+  });
+
+  test("handles multiple documents with comments", async () => {
+    let callCount = 0;
+    listCommentsMock = mock(() => {
+      callCount++;
+      if (callCount === 1) {
+        return [makeComment({ id: "c1", content: "Fix typo" })];
+      }
+      return [
+        makeComment({
+          id: "c2",
+          content: "Add citation",
+          anchorText: "some text",
+          anchorStart: 0,
+          anchorEnd: 9,
+        }),
+      ];
+    });
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "Doc A",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+            {
+              surfaceId: "doc-2",
+              title: "Doc B",
+              wordCount: 200,
+              updatedAt: 2000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.text).toContain('Document: "Doc A" (surface_id: "doc-1")');
+    expect(block!.text).toContain('Document: "Doc B" (surface_id: "doc-2")');
+    expect(block!.text).toContain("Comment #c1");
+    expect(block!.text).toContain("Comment #c2");
+  });
+
+  test("skips documents with zero open comments", async () => {
+    let callCount = 0;
+    listCommentsMock = mock(() => {
+      callCount++;
+      if (callCount === 1) return [];
+      return [makeComment({ id: "c1", content: "Needs work" })];
+    });
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "Empty Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+            {
+              surfaceId: "doc-2",
+              title: "Commented Doc",
+              wordCount: 200,
+              updatedAt: 2000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.text).not.toContain("Empty Doc");
+    expect(block!.text).toContain("Commented Doc");
+  });
+
+  test("has the correct order value", () => {
+    expect(injector.order).toBe(DEFAULT_INJECTOR_ORDER.documentComments);
+    expect(injector.order).toBe(46);
+  });
+
+  test("wraps output in <document_comments> tags with instructions", async () => {
+    listCommentsMock = mock(() => [
+      makeComment({ id: "c1", content: "Fix this" }),
+    ]);
+
+    const block = await injector.produce(
+      makeContext({
+        injectionInputs: {
+          mode: "full",
+          activeDocuments: [
+            {
+              surfaceId: "doc-1",
+              title: "My Doc",
+              wordCount: 100,
+              updatedAt: 1000,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(block).not.toBeNull();
+    expect(block!.text).toMatch(/^<document_comments>/);
+    expect(block!.text).toMatch(/<\/document_comments>$/);
+    expect(block!.text).toContain("comment_resolve");
+  });
+});

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -20,6 +20,7 @@
  * | `memory-v2-static`       | 38    | after-memory-prefix     |
  * | `now-md`                 | 40    | after-memory-prefix     |
  * | `active-documents`       | 45    | prepend-user-tail       |
+ * | `document-comments`      | 46    | prepend-user-tail       |
  * | `subagent-status`        | 50    | append-user-tail        |
  * | `slack-messages`         | 60    | replace-run-messages    |
  * | `thread-focus`           | 70    | append-user-tail        |
@@ -51,6 +52,7 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { getConfig } from "../../config/loader.js";
 import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
+import { listComments } from "../../documents/document-comments-store.js";
 import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
 import { getLogger } from "../../util/logger.js";
 import { registerPlugin } from "../registry.js";
@@ -93,6 +95,7 @@ export const DEFAULT_INJECTOR_ORDER = {
   memoryV2Static: 38,
   nowMd: 40,
   activeDocuments: 45,
+  documentComments: 46,
   subagentStatus: 50,
   slackMessages: 60,
   threadFocus: 70,
@@ -457,6 +460,68 @@ const activeDocumentsInjector: Injector = {
   },
 };
 
+/** Maximum open comments surfaced per document to limit context bloat. */
+const DOCUMENT_COMMENTS_CAP = 10;
+
+/**
+ * `document-comments` injector — order 46, prepend-user-tail.
+ *
+ * Surfaces open top-level comments on active documents so the assistant
+ * knows what feedback to address. For each active document, queries the
+ * comment store for open top-level comments (capped at
+ * {@link DOCUMENT_COMMENTS_CAP} most recent per document). Inline comments
+ * include the quoted anchor text; doc-level comments are labelled as such.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `activeDocuments` has at least one entry.
+ *  - At least one document has open comments (returns null otherwise).
+ */
+const documentCommentsInjector: Injector = {
+  name: "document-comments",
+  order: DEFAULT_INJECTOR_ORDER.documentComments,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const docs = inputs.activeDocuments;
+    if (!docs || docs.length === 0) return null;
+
+    const sections: string[] = [];
+    for (const doc of docs) {
+      const comments = listComments(doc.surfaceId, {
+        status: "open",
+        topLevelOnly: true,
+      }).slice(-DOCUMENT_COMMENTS_CAP);
+      if (comments.length === 0) continue;
+
+      const lines = comments.map((c) => {
+        const label =
+          c.anchorText != null
+            ? `inline, anchored to "${c.anchorText}"`
+            : "doc-level";
+        return `- Comment #${c.id} (${label}): "${c.content}"`;
+      });
+      sections.push(
+        `Document: "${doc.title}" (surface_id: "${doc.surfaceId}")\n${lines.join("\n")}`,
+      );
+    }
+
+    if (sections.length === 0) return null;
+
+    const text = `<document_comments>
+Open comments on your documents. Address these by editing the document, then use comment_resolve to mark each resolved.
+
+${sections.join("\n\n")}
+</document_comments>`;
+    return {
+      id: "document-comments",
+      text,
+      placement: "prepend-user-tail",
+    };
+  },
+};
+
 /**
  * `subagent-status` injector — order 50, append-user-tail.
  *
@@ -591,6 +656,7 @@ export const defaultInjectorsPlugin: Plugin = {
     memoryV2StaticInjector,
     nowMdInjector,
     activeDocumentsInjector,
+    documentCommentsInjector,
     subagentStatusInjector,
     slackMessagesInjector,
     threadFocusInjector,


### PR DESCRIPTION
## Summary
- Adds documentCommentsInjector that surfaces open comments in assistant context
- Formats inline vs doc-level comments with anchor text quotes
- Caps at 10 comments per document to limit context bloat

Part of plan: doc-comments.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->