### PR TITLE
feat(design-library): add PanelItem and MarqueeText components

### DIFF
--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -9,6 +9,8 @@
     ".": "./src/index.ts",
     "./tokens.css": "./src/tokens.css",
     "./components/*": "./src/components/*.tsx",
+    "./components/panel-item": "./src/components/panel-item/panel-item.tsx",
+    "./components/panel-item/marquee-text": "./src/components/panel-item/marquee-text.tsx",
     "./utils/*": "./src/utils/*.ts",
     "./utils/portal-container": "./src/utils/portal-container.tsx"
   },

--- a/packages/design-library/src/components/panel-item/marquee-text.tsx
+++ b/packages/design-library/src/components/panel-item/marquee-text.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+
+import { cn } from "../../utils/cn.js";
+
+/**
+ * Single-line text wrapper that scrolls (marquee-style) when the parent
+ * `PanelItem` row is hovered AND the text overflows its container.
+ *
+ * Colocated with `PanelItem` because it relies on the `group` /
+ * `group-hover:` mechanism established by the parent row.
+ *
+ * Renders TWO sibling spans inside the overflow container so the static
+ * (idle / reduced-motion / touch) state still gets a real ellipsis
+ * truncation:
+ *
+ * 1. Static — `truncate` element (white-space:nowrap + overflow:hidden +
+ *    text-overflow:ellipsis). Visible by default.
+ * 2. Animated — `whitespace-nowrap` block whose width can exceed the
+ *    container. Hidden by default via `invisible`.
+ *
+ * Visibility is swapped via Tailwind utility classes using built-in
+ * variants only:
+ *   - `motion-safe:group-hover:` gates BOTH the visibility swap AND the
+ *     scroll animation behind `@media (prefers-reduced-motion: no-preference)`
+ *     and `@media (hover: hover)`. Reduced-motion users keep the static
+ *     ellipsis on hover; touch-only devices are unaffected.
+ *
+ * Both siblings live in the same overflow container and have the same
+ * box dimensions, so swapping them produces no layout shift. `aria-hidden`
+ * is set on the animated sibling so screen readers see the label exactly
+ * once.
+ */
+
+interface MarqueeTextProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const SCROLL_PX_PER_SECOND = 50;
+const MIN_SCROLL_DURATION_MS = 2000;
+const SCROLL_FRACTION_OF_ITERATION = 0.8;
+
+function MarqueeText({ children, className }: MarqueeTextProps) {
+  const containerRef = useRef<HTMLSpanElement | null>(null);
+  const innerRef = useRef<HTMLSpanElement | null>(null);
+  const [overflowPx, setOverflowPx] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const inner = innerRef.current;
+    if (!container || !inner) return;
+
+    const measure = () => {
+      const overflow = inner.scrollWidth - container.clientWidth;
+      setOverflowPx(overflow > 0 ? overflow : 0);
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    observer.observe(inner);
+    return () => observer.disconnect();
+  }, [children]);
+
+  const canScroll = overflowPx > 0;
+  const scrollMs = Math.max(
+    MIN_SCROLL_DURATION_MS,
+    Math.round(((overflowPx * 2) / SCROLL_PX_PER_SECOND) * 1000),
+  );
+  const totalMs = Math.round(scrollMs / SCROLL_FRACTION_OF_ITERATION);
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn("relative min-w-0 flex-1 overflow-hidden", className)}
+    >
+      <span className="block truncate motion-safe:group-hover:invisible">
+        {children}
+      </span>
+      <span
+        ref={innerRef}
+        aria-hidden
+        className={cn(
+          "absolute top-0 left-0 invisible block whitespace-nowrap",
+          "motion-safe:group-hover:visible",
+          canScroll && "motion-safe:group-hover:animate-panelitem-marquee",
+        )}
+        style={
+          canScroll
+            ? ({
+                "--panelitem-marquee-distance": `${overflowPx}px`,
+                "--panelitem-marquee-duration": `${totalMs}ms`,
+              } as CSSProperties)
+            : undefined
+        }
+      >
+        {children}
+      </span>
+    </span>
+  );
+}
+
+export { MarqueeText, type MarqueeTextProps };

--- a/packages/design-library/src/components/panel-item/marquee-text.tsx
+++ b/packages/design-library/src/components/panel-item/marquee-text.tsx
@@ -71,6 +71,7 @@ function MarqueeText({ children, className }: MarqueeTextProps) {
 
   return (
     <span
+      data-slot="marquee-text"
       ref={containerRef}
       className={cn("relative min-w-0 flex-1 overflow-hidden", className)}
     >

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -1,0 +1,384 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { LucideIcon } from "lucide-react";
+import {
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+import { cn } from "../../utils/cn.js";
+
+import { MarqueeText } from "./marquee-text.js";
+
+/**
+ * Sidepanel / navigation row primitive. One row you can drop into a sidebar,
+ * settings nav, admin tree, menu, or any list where rows need the standard
+ * hover / active state treatment.
+ *
+ * Visual spec:
+ *
+ * - 32px tall, `rounded-[6px]`, `p-[8px]`, `gap-[8px]` between leading icon
+ *   and label.
+ * - Default: transparent background, `--content-tertiary` icon,
+ *   `--content-secondary` label, pill-styled `badge` on `--surface-base`.
+ * - Hover (CSS `:hover`): `--surface-hover` background, icon brightens to
+ *   `--content-secondary`, badge loses its pill chrome, `trailingAction`
+ *   fades in.
+ * - Active (controlled by the `active` prop, renders `aria-current="page"`):
+ *   `--surface-active` background, icon brightens to `--content-default`,
+ *   label brightens to `--content-emphasised`, badge stays pill-less,
+ *   `trailingAction` stays visible.
+ *
+ * Label typography uses the `body-medium-lighter` token (14/400/18).
+ *
+ * Supplies `role="button"` / `<a>` semantics automatically based on whether
+ * you pass `href` or `onSelect`. When neither is supplied we render a
+ * non-interactive `<div>` (useful for pure readout rows).
+ *
+ * ### `asChild` (composition pattern)
+ *
+ * Pass `asChild` to render as a caller-provided element (e.g. a React Router
+ * `<NavLink>`) while merging PanelItem's visual classes and aria attributes
+ * onto it via Radix `Slot`. The consumer provides all children; PanelItem
+ * provides the interactive state layer (hover, active, focus-ring,
+ * aria-current, `group` modifier).
+ *
+ * ### `activeVariant`
+ *
+ * Controls how the active (`aria-current="page"`) state is styled:
+ * - `"default"` — neutral `--surface-active` background,
+ *   `--content-emphasised` text. Used in the assistant sidebar.
+ * - `"branded"` — primary-tinted background, `--primary-base` text, bolder
+ *   weight. Used in settings/admin sidebars for a branded highlight.
+ */
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface PanelItemProps {
+  /** Leading icon. Omit for label-only rows (e.g. indented sub-items). */
+  icon?: LucideIcon;
+  /**
+   * Custom leading content. When provided, overrides the `icon` prop —
+   * the icon's slot is replaced by this ReactNode.
+   */
+  leadingSlot?: ReactNode;
+  /** Row label. Pass a string for the common case; ReactNode accepted. */
+  label: ReactNode;
+  /**
+   * Chevron-style icon rendered inline after the label (for sections that
+   * can collapse/expand). Part of the left cluster so it sits adjacent to
+   * the text, not at the row's trailing edge.
+   */
+  expandChevron?: LucideIcon;
+  /**
+   * Count / status chip. Pill-styled when the row is in Default state,
+   * stripped in Hover / Active — both transitions happen automatically.
+   */
+  badge?: ReactNode;
+  /**
+   * Trailing slot (commonly an ellipsis / more-options button). Hidden by
+   * default, revealed on hover, and always visible when `active`.
+   */
+  trailingAction?: ReactNode;
+  /** Selected state. Sets `aria-current="page"` automatically. */
+  active?: boolean;
+  /**
+   * Active-state color treatment.
+   * - `"default"` — neutral `--surface-active` bg, `--content-emphasised` text.
+   * - `"branded"` — primary-tinted bg, `--primary-base` text, bolder weight.
+   * @default "default"
+   */
+  activeVariant?: "default" | "branded";
+  /** Click handler for the row itself (not `trailingAction`). */
+  onSelect?: () => void;
+  /** Render as `<a href>` instead of `<button>`. */
+  href?: string;
+  /**
+   * When true, wrap the label in `MarqueeText` so an overflowing single-line
+   * label scrolls horizontally on row hover and snaps back to the start when
+   * the pointer leaves. Honors `prefers-reduced-motion`. Off by default.
+   */
+  marqueeOnHover?: boolean;
+  className?: string;
+  /** Optional accessible label override (defaults to `label` when it's a string). */
+  "aria-label"?: string;
+  /**
+   * Render as a caller-provided child element (e.g. React Router `<NavLink>`)
+   * while merging PanelItem's styling and aria attributes onto it. Uses
+   * Radix `Slot`. When true, pass exactly one child element; PanelItem's own
+   * `href` and `onSelect` props are ignored.
+   */
+  asChild?: boolean;
+  /** Children. Required when `asChild` is true; ignored otherwise. */
+  children?: ReactNode;
+  ref?: Ref<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | HTMLElement>;
+}
+
+// ---------------------------------------------------------------------------
+// Class composition
+// ---------------------------------------------------------------------------
+
+const ROW_BASE_CLASSES = [
+  "group relative",
+  "flex h-8 max-md:h-auto w-full items-center justify-between",
+  "rounded-[6px] p-[8px] max-md:py-3 gap-[4px]",
+  "text-left text-body-medium-lighter max-md:text-body-large-default",
+  "transition-colors",
+  "bg-transparent",
+  "text-[var(--content-secondary)]",
+  "hover:bg-[var(--surface-hover)]",
+  "outline-none",
+  "focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+  "cursor-pointer select-none",
+].join(" ");
+
+const ACTIVE_DEFAULT_CLASSES = [
+  "aria-[current=page]:bg-[var(--surface-active)]",
+  "aria-[current=page]:text-[var(--content-emphasised)]",
+].join(" ");
+
+const ACTIVE_BRANDED_CLASSES = [
+  "aria-[current=page]:bg-[color-mix(in_oklab,var(--primary-base)_10%,transparent)]",
+  "aria-[current=page]:text-[var(--primary-base)]",
+  // eslint-disable-next-line no-restricted-syntax
+  "aria-[current=page]:font-medium",
+].join(" ");
+
+const LEFT_CLUSTER_CLASSES = "flex min-w-0 flex-1 items-center gap-[8px]";
+
+const LEADING_ICON_BASE_CLASSES = [
+  "shrink-0",
+  "text-[var(--content-tertiary)]",
+  "group-hover:text-[var(--content-secondary)]",
+].join(" ");
+
+const ICON_ACTIVE_DEFAULT =
+  "group-aria-[current=page]:text-[var(--content-default)]";
+const ICON_ACTIVE_BRANDED =
+  "group-aria-[current=page]:text-[var(--primary-base)]";
+
+const LABEL_CLASSES = "min-w-0 flex-1 truncate";
+
+const EXPAND_CHEVRON_CLASSES =
+  "shrink-0 text-[var(--content-tertiary)]";
+
+const RIGHT_CLUSTER_CLASSES = "flex items-center gap-2 shrink-0";
+
+const BADGE_BASE_CLASSES = [
+  "inline-flex items-center justify-center shrink-0",
+  "text-label-small-default leading-none",
+  "text-[var(--content-tertiary)]",
+  "rounded-[4px] bg-[var(--surface-base)] px-[4px] py-[2px]",
+  "group-hover:bg-transparent group-hover:rounded-none",
+  "group-hover:px-0 group-hover:py-0",
+  "group-aria-[current=page]:bg-transparent group-aria-[current=page]:rounded-none",
+  "group-aria-[current=page]:px-0 group-aria-[current=page]:py-0",
+].join(" ");
+
+const TRAILING_ACTION_CLASSES = [
+  "flex items-center shrink-0",
+  "opacity-0 transition-opacity",
+  "group-hover:opacity-100",
+  "group-aria-[current=page]:opacity-100",
+].join(" ");
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+type SharedAnchorProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "children"
+>;
+type SharedButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "type"
+>;
+
+function PanelItem({
+  icon: Icon,
+  leadingSlot,
+  label,
+  expandChevron: ExpandChevron,
+  badge,
+  trailingAction,
+  active = false,
+  activeVariant = "default",
+  onSelect,
+  href,
+  marqueeOnHover = false,
+  className,
+  "aria-label": ariaLabel,
+  asChild = false,
+  children,
+  ref,
+  ...rest
+}: PanelItemProps & SharedAnchorProps & SharedButtonProps) {
+  const ariaCurrent = active ? ("page" as const) : undefined;
+  const resolvedAriaLabel =
+    ariaLabel ?? (typeof label === "string" ? label : undefined);
+
+  const iconActiveClass =
+    activeVariant === "branded" ? ICON_ACTIVE_BRANDED : ICON_ACTIVE_DEFAULT;
+
+  const leadingIcon =
+    leadingSlot !== undefined
+      ? leadingSlot
+      : Icon
+        ? <Icon size={14} aria-hidden className={cn(LEADING_ICON_BASE_CLASSES, iconActiveClass)} />
+        : null;
+
+  const labelNode = marqueeOnHover ? (
+    <MarqueeText>{label}</MarqueeText>
+  ) : (
+    <span className={LABEL_CLASSES}>{label}</span>
+  );
+
+  const expandChevronNode = ExpandChevron ? (
+    <ExpandChevron
+      size={12}
+      aria-hidden
+      className={EXPAND_CHEVRON_CLASSES}
+    />
+  ) : null;
+
+  const badgeNode =
+    badge != null ? <span className={BADGE_BASE_CLASSES}>{badge}</span> : null;
+
+  const trailingNode = trailingAction ? (
+    <span
+      className={TRAILING_ACTION_CLASSES}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {trailingAction}
+    </span>
+  ) : null;
+
+  const innerMarkup = (
+    <>
+      <span className={LEFT_CLUSTER_CLASSES}>
+        {leadingIcon}
+        {labelNode}
+        {expandChevronNode}
+      </span>
+      <span className={RIGHT_CLUSTER_CLASSES}>
+        {badgeNode}
+        {trailingNode}
+      </span>
+    </>
+  );
+
+  const activeClasses =
+    activeVariant === "branded" ? ACTIVE_BRANDED_CLASSES : ACTIVE_DEFAULT_CLASSES;
+  const rowClasses = cn(ROW_BASE_CLASSES, activeClasses, className);
+
+  // ── asChild variant ──────────────────────────────────────────────────
+  if (asChild) {
+    if (import.meta.env.DEV) {
+      if (Icon || leadingSlot || badge || trailingAction || ExpandChevron) {
+        console.warn(
+          "PanelItem: icon, leadingSlot, badge, trailingAction, and expandChevron " +
+            "are ignored when asChild is true — the consumer owns all children.",
+        );
+      }
+    }
+    return (
+      <Slot
+        data-slot="panel-item"
+        ref={ref as Ref<HTMLElement>}
+        className={rowClasses}
+        aria-current={ariaCurrent}
+        aria-label={resolvedAriaLabel}
+        {...(rest as HTMLAttributes<HTMLElement>)}
+      >
+        {children}
+      </Slot>
+    );
+  }
+
+  // ── Anchor variant ─────────────────────────────────────────────────
+  if (href) {
+    const { onClick: anchorOnClick, ...anchorProps } =
+      rest as SharedAnchorProps;
+    return (
+      <a
+        {...anchorProps}
+        data-slot="panel-item"
+        ref={ref as Ref<HTMLAnchorElement>}
+        href={href}
+        className={rowClasses}
+        aria-current={ariaCurrent}
+        aria-label={resolvedAriaLabel}
+        onClick={(event) => {
+          anchorOnClick?.(event);
+          if (!event.defaultPrevented) {
+            onSelect?.();
+          }
+        }}
+      >
+        {innerMarkup}
+      </a>
+    );
+  }
+
+  // ── Button variant ─────────────────────────────────────────────────
+  if (onSelect) {
+    const {
+      onClick: buttonOnClick,
+      onKeyDown: buttonOnKeyDown,
+      ...buttonProps
+    } = rest as SharedButtonProps;
+
+    const composedOnClick = (event: MouseEvent<HTMLButtonElement>) => {
+      buttonOnClick?.(event);
+      if (!event.defaultPrevented) {
+        onSelect();
+      }
+    };
+
+    return (
+      <button
+        {...buttonProps}
+        data-slot="panel-item"
+        ref={ref as Ref<HTMLButtonElement>}
+        type="button"
+        className={rowClasses}
+        aria-current={ariaCurrent}
+        aria-label={resolvedAriaLabel}
+        onClick={composedOnClick}
+        onKeyDown={buttonOnKeyDown}
+      >
+        {innerMarkup}
+      </button>
+    );
+  }
+
+  // ── Non-interactive fallback ────────────────────────────────────────
+  const divProps = rest as HTMLAttributes<HTMLDivElement>;
+  return (
+    <div
+      data-slot="panel-item"
+      ref={ref as Ref<HTMLDivElement>}
+      className={rowClasses}
+      aria-current={ariaCurrent}
+      aria-label={resolvedAriaLabel}
+      {...divProps}
+    >
+      {innerMarkup}
+    </div>
+  );
+}
+
+export {
+  PanelItem,
+  type PanelItemProps,
+  ROW_BASE_CLASSES,
+  ACTIVE_DEFAULT_CLASSES,
+  ACTIVE_BRANDED_CLASSES,
+};

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -132,8 +132,11 @@ const ROW_BASE_CLASSES = [
   "transition-colors",
   "bg-transparent",
   "text-[var(--content-secondary)]",
-  "hover:bg-[var(--surface-hover)]",
   "outline-none",
+].join(" ");
+
+const INTERACTIVE_CLASSES = [
+  "hover:bg-[var(--surface-hover)]",
   "focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
   "cursor-pointer select-none",
 ].join(" ");
@@ -254,7 +257,10 @@ function PanelItem({
   const trailingNode = trailingAction ? (
     <span
       className={TRAILING_ACTION_CLASSES}
-      onClick={(event) => event.stopPropagation()}
+      onClick={(event: MouseEvent<HTMLSpanElement>) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
     >
       {trailingAction}
     </span>
@@ -276,7 +282,13 @@ function PanelItem({
 
   const activeClasses =
     activeVariant === "branded" ? ACTIVE_BRANDED_CLASSES : ACTIVE_DEFAULT_CLASSES;
-  const rowClasses = cn(ROW_BASE_CLASSES, activeClasses, className);
+  const isInteractive = asChild || !!href || !!onSelect;
+  const rowClasses = cn(
+    ROW_BASE_CLASSES,
+    isInteractive && INTERACTIVE_CLASSES,
+    activeClasses,
+    className,
+  );
 
   // ── asChild variant ──────────────────────────────────────────────────
   if (asChild) {

--- a/packages/design-library/src/env.d.ts
+++ b/packages/design-library/src/env.d.ts
@@ -1,0 +1,10 @@
+/** Ambient type augmentation for `import.meta.env` in Vite-based consumers. */
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+  readonly MODE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -145,6 +145,17 @@ export {
   type DropdownMenuPosition,
   type DropdownMenuAlign,
 } from "./components/dropdown.js";
+export {
+  PanelItem,
+  ROW_BASE_CLASSES as panelItemRowBaseClasses,
+  ACTIVE_DEFAULT_CLASSES as panelItemActiveDefaultClasses,
+  ACTIVE_BRANDED_CLASSES as panelItemActiveBrandedClasses,
+  type PanelItemProps,
+} from "./components/panel-item/panel-item.js";
+export {
+  MarqueeText,
+  type MarqueeTextProps,
+} from "./components/panel-item/marquee-text.js";
 export { cn } from "./utils/cn.js";
 export {
   PortalContainerProvider,

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -404,4 +404,27 @@
   100% { opacity: 1; transform: translateY(0); }
 }
 
+/* ---------------------------------------------------------------------------
+ * PanelItem marquee — scrolls overflowing single-line labels horizontally
+ * when the parent row (`.group`) is hovered. Driven by `MarqueeText`
+ * (colocated with PanelItem). The component sets:
+ *   --panelitem-marquee-distance: <overflow>px
+ *   --panelitem-marquee-duration: <total>ms
+ * The keyframe spends 80% of its time scrolling (40% out, 40% back) and
+ * 20% paused (10% at the end, 10% at the start). Both starts and ends
+ * at translateX(0) so dropping the animation on hover-out is jump-free.
+ * --------------------------------------------------------------------------- */
+
+@utility animate-panelitem-marquee {
+  animation: panelitem-marquee var(--panelitem-marquee-duration, 4s) linear infinite;
+}
+
+@keyframes panelitem-marquee {
+  0%   { transform: translateX(0); }
+  10%  { transform: translateX(0); }
+  50%  { transform: translateX(calc(-1 * var(--panelitem-marquee-distance, 0px))); }
+  60%  { transform: translateX(calc(-1 * var(--panelitem-marquee-distance, 0px))); }
+  100% { transform: translateX(0); }
+}
+
 


### PR DESCRIPTION
## Prompt / plan

Migrates PanelItem from `vellum-assistant-platform` (`web/src/components/app/core/PanelItem/`) to the design library as a reusable navigation row primitive. This is a prerequisite for the Settings domain migration (PR 2 in the 3-PR plan: layout architecture → PanelItem → Settings domain).

PanelItem is used in ~31 files across the platform (sidebar nav, settings, command palette, contacts list, workspace tree, library view, preferences menu, admin nav) — it's a generic building block, not domain-specific.

### What changed

**`panel-item/panel-item.tsx`** — Sidepanel navigation row primitive with four rendering variants:
- **Anchor** (`href` prop) — renders `<a>`
- **Button** (`onSelect` prop) — renders `<button type="button">`
- **Composition** (`asChild` prop) — merges styles onto caller's element via Radix `Slot` (e.g. React Router `<NavLink>`)
- **Non-interactive** (neither) — renders `<div>` for readout rows

Two `activeVariant` modes: `"default"` (neutral) and `"branded"` (primary-tinted).

**`panel-item/marquee-text.tsx`** — Single-line text wrapper that scrolls horizontally on hover when content overflows. Colocated with PanelItem because it depends on the `group` / `group-hover:` mechanism.

**`tokens.css`** — `@utility animate-panelitem-marquee` + `@keyframes panelitem-marquee` for the marquee scroll animation.

**`env.d.ts`** — Ambient `ImportMeta` type augmentation so `import.meta.env.DEV` resolves in the library's `types: []` tsconfig (used for dev-only `asChild` prop-misuse warnings).

### React 19 conventions applied

| Convention | Platform (before) | Design library (after) |
|---|---|---|
| ref handling | `forwardRef<...>(function PanelItem(..., ref))` | `ref` destructured from props interface |
| root element | no `data-slot` | `data-slot="panel-item"` / `data-slot="marquee-text"` on every root |
| component form | `export const PanelItem = forwardRef(...)` | `function PanelItem(...)` declaration |
| dev guard | `process.env.NODE_ENV` | `import.meta.env.DEV` |
| `"use client"` | present | removed (pure React) |
| `cn` import | `@/lib/utils` | `../../utils/cn.js` (library-internal) |
| `React.CSSProperties` | namespace access | named import `type CSSProperties` |

### Bugs fixed during migration

1. **Trailing action anchor navigation** — `trailingAction` wrapper only called `stopPropagation()`, not `preventDefault()`. Clicking a trailing control (e.g. ellipsis menu) inside an anchor PanelItem still followed the `<a>` link. Fixed by adding `preventDefault()`.

2. **Non-interactive div inherits interactive styles** — The `<div>` fallback (no `href`/`onSelect`) inherited `cursor-pointer`, `select-none`, and `hover:bg-[...]` from shared base classes, making non-interactive rows appear clickable. Fixed by splitting `ROW_BASE_CLASSES` into base layout + `INTERACTIVE_CLASSES` applied only when the row is interactive.

### Directory structure

Combined size exceeds the 300-line single-file threshold per [AGENTS.md rule 6](packages/design-library/AGENTS.md):

```
packages/design-library/src/components/panel-item/
├── panel-item.tsx    (main component)
└── marquee-text.tsx  (colocated subcomponent)
```

### Why this is safe

- Additive only — no existing code modified beyond barrel export and package.json
- Web app typecheck passes (0 errors)
- Web app lint passes (0 errors)
- No consumers import PanelItem yet — this just makes it available for the Settings domain PR

### References

- [React 19 — ref as a prop](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop)
- [shadcn/ui v4 — data-slot convention](https://ui.shadcn.com/docs/changelog/2025-03-data-slot)
- [Radix Slot — composition pattern](https://www.radix-ui.com/primitives/docs/utilities/slot)

## Test plan

- `bun run typecheck` in `apps/web/` — 0 errors
- `bun run lint` in `apps/web/` — 0 errors
- Design library typecheck — only pre-existing peer-dep errors (React types not resolved in isolation), no new errors introduced
- Visual testing deferred to Settings domain PR which will be the first consumer

Link to Devin session: https://app.devin.ai/sessions/536ceadb023a4059908b0609b9833bc1
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->