### PR TITLE
refactor(inference): make provider/connection explicit on managed profile templates

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -18,10 +18,6 @@ import {
 
 const log = getLogger("seed-inference-profiles");
 
-const MANAGED_CONNECTION_NAME = "anthropic-managed";
-const MANAGED_PROFILE_PROVIDER: NonNullable<ProfileEntry["provider"]> =
-  "anthropic";
-
 /**
  * Template for a daemon-managed inference profile. The profile's model is
  * resolved at seed time from `PROVIDER_MODEL_INTENTS` so the catalog stays the
@@ -32,20 +28,20 @@ type ManagedProfileTemplate = Omit<
   "provider" | "model" | "provider_connection"
 > & {
   intent: ModelIntent;
-  /** Override the global MANAGED_PROFILE_PROVIDER for this template. */
-  providerOverride?: NonNullable<ProfileEntry["provider"]>;
-  /** Override the global MANAGED_CONNECTION_NAME for this template. */
-  connectionOverride?: string;
+  provider: NonNullable<ProfileEntry["provider"]>;
+  connectionName: string;
 };
 
 /**
- * Managed Anthropic profiles. Overwritten on every daemon boot so Vellum can
- * push model/config updates to customers in new releases. Platform overlays
+ * Managed profiles. Overwritten on every daemon boot so Vellum can push
+ * model/config updates to customers in new releases. Platform overlays
  * (`preserveProfileNames`) take precedence when present.
  */
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   balanced: {
     intent: "balanced",
+    provider: "fireworks",
+    connectionName: "fireworks-managed",
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
@@ -53,11 +49,11 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-    providerOverride: "fireworks",
-    connectionOverride: "fireworks-managed",
   },
   "quality-optimized": {
     intent: "quality-optimized",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
     source: "managed",
     label: "Quality",
     description: "Best results with the most capable model",
@@ -68,6 +64,8 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "cost-optimized": {
     intent: "latency-optimized",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
     source: "managed",
     label: "Speed",
     description: "Fastest responses at lower cost",
@@ -81,11 +79,15 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
 /**
  * User profile templates. Materialized at hatch time for off-platform
  * installations. Each points at the user's personal provider connection
- * (backed by their API key in CES).
+ * (backed by their API key in CES). The `provider` and `connectionName`
+ * fields are placeholders — they are overridden at hatch time with the
+ * user's chosen provider and personal connection name.
  */
 const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   "custom-balanced": {
     intent: "balanced",
+    provider: "anthropic",
+    connectionName: "",
     source: "user",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
@@ -96,6 +98,8 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "custom-quality-optimized": {
     intent: "quality-optimized",
+    provider: "anthropic",
+    connectionName: "",
     source: "user",
     label: "Quality",
     description: "Best results with the most capable model",
@@ -106,6 +110,8 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "custom-cost-optimized": {
     intent: "latency-optimized",
+    provider: "anthropic",
+    connectionName: "",
     source: "user",
     label: "Speed",
     description: "Fastest responses at lower cost",
@@ -217,14 +223,10 @@ export function seedInferenceProfiles(
     const effectiveTemplate: ManagedProfileTemplate = isByokMode
       ? { ...template, label: `${template.label} (Managed)` }
       : template;
-    const effectiveProvider =
-      template.providerOverride ?? MANAGED_PROFILE_PROVIDER;
-    const effectiveConnection =
-      template.connectionOverride ?? MANAGED_CONNECTION_NAME;
     const next = materializeProfile(
       effectiveTemplate,
-      effectiveProvider,
-      effectiveConnection,
+      template.provider,
+      template.connectionName,
     ) as Record<string, unknown>;
     if (isByokMode && options.isHatch && !previous) {
       next.status = "disabled";
@@ -357,7 +359,7 @@ function materializeProfile(
   provider: NonNullable<ProfileEntry["provider"]>,
   connectionName: string,
 ): ProfileEntry {
-  const { intent, providerOverride: _po, connectionOverride: _co, ...rest } = template;
+  const { intent, provider: _p, connectionName: _c, ...rest } = template;
   return {
     ...rest,
     provider,


### PR DESCRIPTION
## Summary
- Removes the global `MANAGED_CONNECTION_NAME` / `MANAGED_PROFILE_PROVIDER` constants and the `providerOverride` / `connectionOverride` bolt-on pattern
- Each `ManagedProfileTemplate` now directly specifies its own `provider` and `connectionName`
- No behavioral change — the materialized profiles are identical

Addresses noan's nit from #31068.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/__tests__/config-loader-backfill.test.ts` — pass
- [x] `bun test src/__tests__/managed-profile-guard.test.ts` — pass
- [x] `bun test src/__tests__/model-intents.test.ts` — pass
- [x] `bun test src/__tests__/llm-catalog-parity.test.ts` — pass
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->