### PR TITLE
feat(daemon): add structured web-search and web-fetch result types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -45,6 +45,7 @@ export * from "./message-types/subagents.js";
 export * from "./message-types/surfaces.js";
 export * from "./message-types/sync.js";
 export * from "./message-types/upgrades.js";
+export * from "./message-types/web-activity.js";
 export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 

--- a/assistant/src/daemon/message-types/web-activity.ts
+++ b/assistant/src/daemon/message-types/web-activity.ts
@@ -1,0 +1,55 @@
+// Shared structured result types for web-search and web-fetch tool activity.
+//
+// These types describe live (SSE-time) metadata that producers (search/fetch
+// tool executors) emit and consumers (clients) render alongside the existing
+// `result: string` payload. Persistence to conversation history is out of
+// scope for this plan; the metadata is live-only.
+
+export type WebSearchProviderId =
+  | "anthropic-native"
+  | "brave"
+  | "perplexity"
+  | "tavily";
+
+export interface WebSearchResultItem {
+  rank: number; // 1-indexed
+  title: string;
+  url: string;
+  domain: string; // lowercased host
+  faviconUrl?: string;
+  snippet?: string; // not populated for anthropic-native (content encrypted)
+  age?: string; // Brave-only freshness hint
+  score?: number; // Tavily-only
+}
+
+export interface WebSearchMetadata {
+  query: string;
+  provider: WebSearchProviderId;
+  resultCount: number;
+  durationMs: number;
+  results: WebSearchResultItem[];
+  /** Present when search itself failed; results[] will be empty. */
+  errorMessage?: string;
+}
+
+export interface WebFetchMetadata {
+  url: string;
+  finalUrl: string;
+  status: number;
+  contentType?: string;
+  byteCount: number;
+  charCount: number;
+  truncated: boolean;
+  title?: string;
+  domain: string;
+  faviconUrl?: string;
+  redirectCount: number;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+/** Discriminated container so future tools can add their own metadata. */
+export interface ToolActivityMetadata {
+  webSearch?: WebSearchMetadata;
+  webFetch?: WebFetchMetadata;
+}


### PR DESCRIPTION
## Summary
- Add WebSearchResultItem / WebSearchMetadata / WebFetchMetadata / ToolActivityMetadata types in assistant/src/daemon/message-types/web-activity.ts
- Re-export from the message-types barrel for downstream PRs to consume

Part of plan: web-activity-ui-data.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->