### PR TITLE
refactor(document-editor): move content update to store layer

### DIFF
--- a/assistant/src/documents/document-comments-store.ts
+++ b/assistant/src/documents/document-comments-store.ts
@@ -201,6 +201,20 @@ export function reopenComment(id: string): boolean {
   return changes > 0;
 }
 
+export function updateCommentContent(id: string, content: string): boolean {
+  const now = Date.now();
+  const changes = rawRun(
+    /*sql*/ `UPDATE document_comments SET content = ?, updated_at = ? WHERE id = ?`,
+    content,
+    now,
+    id,
+  );
+  if (changes > 0) {
+    log.info({ id }, "Updated comment content");
+  }
+  return changes > 0;
+}
+
 export function deleteComment(id: string): boolean {
   const changes = rawRun(
     /*sql*/ `DELETE FROM document_comments WHERE id = ?`,

--- a/assistant/src/runtime/routes/document-comments-routes.ts
+++ b/assistant/src/runtime/routes/document-comments-routes.ts
@@ -13,8 +13,8 @@ import {
   listComments,
   reopenComment,
   resolveComment,
+  updateCommentContent,
 } from "../../documents/document-comments-store.js";
-import { rawRun } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
@@ -192,13 +192,7 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       if (content !== undefined) {
-        const now = Date.now();
-        rawRun(
-          /*sql*/ `UPDATE document_comments SET content = ?, updated_at = ? WHERE id = ?`,
-          content,
-          now,
-          commentId,
-        );
+        updateCommentContent(commentId, content);
       }
 
       const updated = getComment(commentId);


### PR DESCRIPTION
## Summary
Moves inline SQL for comment content update to the store abstraction.

**Gap:** HTTP route bypasses store for content update
**What was expected:** All DB operations through store layer
**What was found:** rawRun called directly in route handler
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->