### PR TITLE
fix(web): sync iframe anchor highlights after SSE comment updates

### DIFF
--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -195,7 +195,13 @@ export function DocumentViewerContainer({
    */
   const refreshComments = useCallback(async () => {
     await commentPanelRef.current?.refreshComments();
-  }, []);
+    try {
+      const comments = await fetchComments(assistantId, surfaceId);
+      syncAnchorsToIframe(comments);
+    } catch {
+      // Best-effort — anchor highlights are cosmetic
+    }
+  }, [assistantId, surfaceId, syncAnchorsToIframe]);
 
   // Expose refreshComments for external callers (e.g. SSE handler in page).
   useImperativeHandle(handleRef, () => ({ refreshComments }), [refreshComments]);


### PR DESCRIPTION
## Summary
Fixes stale anchor highlights in the editor after SSE comment events.

**Gap:** refreshComments doesn't sync anchors to iframe
**What was expected:** Anchor highlights should update when comments change via SSE
**What was found:** Only the comment panel list refreshed; iframe highlights stayed stale
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->