### PR TITLE
fix(document-editor): cascade delete replies when parent comment is removed

### DIFF
--- a/assistant/src/documents/document-comments-store.test.ts
+++ b/assistant/src/documents/document-comments-store.test.ts
@@ -250,6 +250,26 @@ describe("deleteComment", () => {
   test("returns false for non-existent comment", () => {
     expect(deleteComment("comment-nonexistent")).toBe(false);
   });
+
+  test("cascades to child replies", () => {
+    const parent = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Parent",
+    });
+    const reply = createComment({
+      surfaceId: SURFACE_ID,
+      conversationId: CONVERSATION_ID,
+      author: "user1",
+      content: "Reply",
+      parentCommentId: parent.id,
+    });
+
+    expect(deleteComment(parent.id)).toBe(true);
+    expect(getComment(parent.id)).toBeNull();
+    expect(getComment(reply.id)).toBeNull();
+  });
 });
 
 describe("getCommentCountForDocument", () => {

--- a/assistant/src/documents/document-comments-store.ts
+++ b/assistant/src/documents/document-comments-store.ts
@@ -202,12 +202,17 @@ export function reopenComment(id: string): boolean {
 }
 
 export function deleteComment(id: string): boolean {
+  // Delete child replies first so they are not orphaned.
+  rawRun(
+    /*sql*/ `DELETE FROM document_comments WHERE parent_comment_id = ?`,
+    id,
+  );
   const changes = rawRun(
     /*sql*/ `DELETE FROM document_comments WHERE id = ?`,
     id,
   );
   if (changes > 0) {
-    log.info({ id }, "Deleted comment");
+    log.info({ id }, "Deleted comment and its replies");
   }
   return changes > 0;
 }


### PR DESCRIPTION
## Summary
Fixes orphaned replies when a parent comment is deleted.

**Gap:** Deleting parent orphans replies
**What was expected:** Replies should be deleted with their parent
**What was found:** Only the single comment row was deleted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->