### PR TITLE
feat(chat): Convert conversation-list useReducer to Zustand store

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -34,6 +34,7 @@
         "remark-gfm": "4.0.1",
         "shiki": "4.1.0",
         "tailwind-merge": "3.6.0",
+        "zustand": "5.0.13",
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "0.97.1",
@@ -1262,6 +1263,8 @@
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,7 +41,8 @@
     "react-router": "7.15.0",
     "remark-gfm": "4.0.1",
     "shiki": "4.1.0",
-    "tailwind-merge": "3.6.0"
+    "tailwind-merge": "3.6.0",
+    "zustand": "5.0.13"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.97.1",

--- a/apps/web/src/domains/chat/hooks/use-app-viewer-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-app-viewer-actions.ts
@@ -13,6 +13,8 @@
 import * as Sentry from "@sentry/react";
 import { type Dispatch, type MutableRefObject, type RefObject, useCallback, useEffect, useRef } from "react";
 
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
+
 import { toast } from "@vellum/design-library";
 import { openApp, shareApp } from "@/domains/chat/lib/apps.js";
 import { fetchDocumentContent } from "@/domains/chat/lib/documents.js";
@@ -26,7 +28,6 @@ import type {
   ViewerState,
 } from "@/domains/chat/lib/viewer-state.js";
 import type { Conversation } from "@/domains/chat/lib/api.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
 import { haptic } from "@/utils/haptics.js";
 
 import { useActiveAppPinSync } from "@/domains/chat/hooks/use-active-app-pin-sync.js";
@@ -44,7 +45,6 @@ export interface UseAppViewerActionsParams {
   isDeploying: boolean;
   pendingDeployAppId: string | null;
   dispatchViewer: Dispatch<ViewerAction>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   viewerStateRef: MutableRefObject<ViewerState>;
   lastConversationKeyRef: MutableRefObject<string | null>;
   deepLinkAppId: RefObject<string | undefined>;
@@ -89,7 +89,6 @@ export function useAppViewerActions({
   isDeploying,
   pendingDeployAppId,
   dispatchViewer,
-  dispatchConversationList,
   viewerStateRef,
   lastConversationKeyRef,
   deepLinkAppId,
@@ -100,6 +99,8 @@ export function useAppViewerActions({
   navGoForward,
   pushConversationKeyParam,
 }: UseAppViewerActionsParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
+
   // Ref-stabilize unstable callbacks so consuming useCallbacks keep stable identity.
   const switchConversationRef = useRef(switchConversation);
   switchConversationRef.current = switchConversation;

--- a/apps/web/src/domains/chat/hooks/use-attention-tracking.ts
+++ b/apps/web/src/domains/chat/hooks/use-attention-tracking.ts
@@ -1,7 +1,6 @@
 
 import * as Sentry from "@sentry/react";
 import {
-  type Dispatch,
   type MutableRefObject,
   useEffect,
   useRef,
@@ -12,7 +11,7 @@ import {
   listConversationKeysWithPendingInteractions,
   markConversationSeen,
 } from "@/domains/chat/lib/api.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type { AssistantStateKind } from "@/domains/chat/types.js";
 
 interface UseAttentionTrackingParams {
@@ -29,9 +28,6 @@ interface UseAttentionTrackingParams {
   // Refs
   conversationsRef: MutableRefObject<Conversation[]>;
   processingSnapshotsRef: MutableRefObject<Map<string, string | undefined>>;
-
-  // State setters
-  dispatchConversationList: Dispatch<ConversationListAction>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,8 +91,8 @@ export function useAttentionTracking({
   attentionKeys,
   conversationsRef,
   processingSnapshotsRef,
-  dispatchConversationList,
 }: UseAttentionTrackingParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const lastSeenOnOpenConversationKeyRef = useRef<string | null>(null);
   const initialAttentionSweepDoneRef = useRef(false);
 

--- a/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -1,8 +1,8 @@
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, type MutableRefObject, useCallback } from "react";
+import { type MutableRefObject, useCallback } from "react";
 
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import { patchConversation as _patchConversation } from "@/domains/chat/lib/conversation-list-state.js";
 import { isSlackConversation } from "@/domains/chat/lib/groupConversations.js";
 
@@ -49,18 +49,15 @@ export function resolveUnpinGroupId(
  * Conversation CRUD actions: archive, unarchive, rename, mark read/unread,
  * pin/unpin, and move between groups.
  *
- * All mutations apply an optimistic update via `dispatchConversationList`
+ * All mutations apply an optimistic update via the conversation-list store
  * before calling the API, and roll back on failure.
  *
- * @param dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Used for all optimistic state updates.
  * @returns Stable callbacks for each conversation action.
  */
 interface UseConversationActionsParams {
   assistantId: string | null;
   activeConversationKey: string | null;
   conversations: Conversation[];
-  dispatchConversationList: Dispatch<ConversationListAction>;
   refreshConversations: () => Promise<void>;
   switchConversation: (key: string) => void;
   startNewConversation: (opts?: { silent?: boolean }) => void;
@@ -71,12 +68,12 @@ export function useConversationActions({
   assistantId,
   activeConversationKey,
   conversations,
-  dispatchConversationList,
   refreshConversations,
   switchConversation,
   startNewConversation,
   prePinGroupIdsRef,
 }: UseConversationActionsParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const handleArchiveConversation = useCallback(
     async (conversation: Conversation) => {
       if (!assistantId) return;

--- a/apps/web/src/domains/chat/hooks/use-conversation-group-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-group-actions.ts
@@ -1,8 +1,8 @@
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, useCallback } from "react";
+import { useCallback } from "react";
 
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 
 import {
   type ConversationGroup,
@@ -38,24 +38,20 @@ export function patchGroup(
  * before hitting the API. On failure, create/rename roll back optimistically;
  * delete refetches the full conversation list for accuracy.
  *
- * @param dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Used for all optimistic group mutations.
  * @returns Stable callbacks: `handleCreateGroup`, `handleRenameGroup`,
  *   `handleDeleteGroup`.
  */
 interface UseConversationGroupActionsParams {
   assistantId: string | null;
-  conversationGroups: ConversationGroup[];
-  dispatchConversationList: Dispatch<ConversationListAction>;
   refreshConversations: () => Promise<void>;
 }
 
 export function useConversationGroupActions({
   assistantId,
-  conversationGroups,
-  dispatchConversationList,
   refreshConversations,
 }: UseConversationGroupActionsParams) {
+  const conversationGroups = useConversationListStore((s) => s.conversationGroups);
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const handleCreateGroup = useCallback(async () => {
     if (!assistantId) return;
     haptic.light();

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -30,7 +30,7 @@ import type { TranscriptPaginationState } from "@/domains/chat/lib/transcript/ty
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import type { DomainEvent } from "@/domains/chat/lib/turn-state-machine.js";
 import type { InteractionEvent, InteractionState } from "@/domains/chat/lib/interaction-state-machine.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type { SubagentAction } from "@/domains/chat/lib/subagent-state.js";
 import type { SubagentStatus } from "@/domains/chat/lib/event-types.js";
 
@@ -119,7 +119,6 @@ interface UseConversationHistoryParams {
   loadEpochRef: MutableRefObject<number>;
 
   // State setters
-  dispatchConversationList: Dispatch<ConversationListAction>;
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setTranscriptPagination: Dispatch<SetStateAction<Omit<TranscriptPaginationState, "items">>>;
   setIsLoadingHistory: Dispatch<SetStateAction<boolean>>;
@@ -196,7 +195,6 @@ export function useConversationHistory({
   isLoadingOlderRef,
   historyLoadedRef,
   loadEpochRef,
-  dispatchConversationList,
   setMessages,
   setTranscriptPagination,
   setIsLoadingHistory,
@@ -214,6 +212,7 @@ export function useConversationHistory({
   onDraftRestored,
   shouldSuppressGenericChatErrorNotice,
 }: UseConversationHistoryParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const transcriptPaginationRef = useRef(transcriptPagination);
   useEffect(() => {
     transcriptPaginationRef.current = transcriptPagination;

--- a/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -34,7 +34,7 @@ import type { TranscriptPaginationState } from "@/domains/chat/lib/transcript/ty
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import type { DomainEvent } from "@/domains/chat/lib/turn-state-machine.js";
 import type { InteractionEvent, InteractionState } from "@/domains/chat/lib/interaction-state-machine.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type { SubagentAction } from "@/domains/chat/lib/subagent-state.js";
 import { haptic } from "@/utils/haptics.js";
 
@@ -126,7 +126,6 @@ interface UseConversationLoaderParams {
 
   // State setters
   setAssistantId: Dispatch<SetStateAction<string | null>>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setTranscriptPagination: Dispatch<SetStateAction<Omit<TranscriptPaginationState, "items">>>;
   setIsLoadingHistory: Dispatch<SetStateAction<boolean>>;
@@ -220,7 +219,6 @@ export function useConversationLoader({
   loadEpochRef,
   pendingInitialMessageRef,
   setAssistantId,
-  dispatchConversationList,
   setMessages,
   setTranscriptPagination,
   setIsLoadingHistory,
@@ -240,6 +238,8 @@ export function useConversationLoader({
   onDraftRestored,
   shouldSuppressGenericChatErrorNotice,
 }: UseConversationLoaderParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
+
   // -------------------------------------------------------------------------
   // Internal refs
   // -------------------------------------------------------------------------
@@ -463,7 +463,6 @@ export function useConversationLoader({
     isLoadingOlderRef,
     historyLoadedRef,
     loadEpochRef,
-    dispatchConversationList,
     setMessages,
     setTranscriptPagination,
     setIsLoadingHistory,
@@ -495,7 +494,6 @@ export function useConversationLoader({
     attentionKeys,
     conversationsRef,
     processingSnapshotsRef,
-    dispatchConversationList,
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-event-stream.ts
@@ -50,7 +50,7 @@ import type {
   WebSyncRouter,
 } from "@/lib/sync/web-sync-router.js";
 
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type { DisplayMessage } from "@/domains/chat/lib/reconcile.js";
 import type { DomainEvent as TurnAction, TurnState } from "@/domains/chat/lib/turn-state-machine.js";
 import { isSending } from "@/domains/chat/lib/turn-state-machine.js";
@@ -95,7 +95,6 @@ export interface UseEventStreamParams {
   turnStateRef: MutableRefObject<TurnState>;
 
   // Conversation list
-  dispatchConversationList: Dispatch<ConversationListAction>;
   processingSnapshotsRef: MutableRefObject<Map<string, string | undefined>>;
 
   // Messages
@@ -149,7 +148,6 @@ export function useEventStream({
   reachabilityReset,
   dispatchTurn,
   turnStateRef,
-  dispatchConversationList,
   processingSnapshotsRef,
   setMessages,
   setError,
@@ -182,6 +180,7 @@ export function useEventStream({
   const dispatchTurnRef = useRef(dispatchTurn);
   dispatchTurnRef.current = dispatchTurn;
 
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const dispatchConversationListRef = useRef(dispatchConversationList);
   dispatchConversationListRef.current = dispatchConversationList;
 

--- a/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
@@ -13,6 +13,8 @@
 import * as Sentry from "@sentry/react";
 import { type Dispatch, type MutableRefObject, type SetStateAction, useCallback, useState } from "react";
 
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
+
 import {
   type AllowlistOption,
   type ConfirmationDecision,
@@ -28,7 +30,6 @@ import {
 import { addTrustRule } from "@/domains/trust-rules/api.js";
 import type { DisplayMessage } from "@/domains/chat/lib/reconcile.js";
 import type { InteractionState, InteractionEvent } from "@/domains/chat/lib/interaction-state-machine.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
 import type { DomainEvent as TurnEvent } from "@/domains/chat/lib/turn-state-machine.js";
 
 import { clearConfirmationByRequestId } from "@/domains/chat/hooks/send-message-utils.js";
@@ -76,7 +77,6 @@ export interface UseInteractionActionsParams {
   interactionState: InteractionState;
   interactionStateRef: MutableRefObject<InteractionState>;
   dispatchInteraction: Dispatch<InteractionEvent>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   dispatchTurn: Dispatch<TurnEvent>;
   setMessages: Dispatch<DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[])>;
   setError: Dispatch<ChatError | null>;
@@ -118,7 +118,6 @@ export function useInteractionActions({
   interactionState,
   interactionStateRef,
   dispatchInteraction,
-  dispatchConversationList,
   dispatchTurn,
   setMessages,
   setError,
@@ -127,6 +126,7 @@ export function useInteractionActions({
   activeConversationKeyRef,
   confirmationToolCallMapRef,
 }: UseInteractionActionsParams): UseInteractionActionsReturn {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
   const {
     pendingSecret,
     isSubmittingSecret,

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -41,7 +41,7 @@ import { newStableId } from "@/domains/chat/lib/stable-id.js";
 import { saveDismissedSurfaceIds } from "@/domains/chat/lib/dismissedSurfacesStorage.js";
 import { isSending, type TurnState, type DomainEvent } from "@/domains/chat/lib/turn-state-machine.js";
 import type { InteractionEvent } from "@/domains/chat/lib/interaction-state-machine.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type { SubagentAction } from "@/domains/chat/lib/subagent-state.js";
 import type { PreChatOnboardingContext } from "@/lib/onboarding/prechat.js";
 
@@ -108,7 +108,6 @@ interface UseSendMessageParams {
   // State setters
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setError: Dispatch<SetStateAction<ChatError | null>>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   dispatchInteraction: Dispatch<InteractionEvent>;
   setStreamRetryNonce: Dispatch<SetStateAction<number>>;
   setInput: Dispatch<SetStateAction<string>>;
@@ -155,7 +154,6 @@ export function useSendMessage({
   confirmationToolCallMapRef,
   setMessages,
   setError,
-  dispatchConversationList,
   dispatchInteraction,
   setStreamRetryNonce,
   setInput,
@@ -167,6 +165,8 @@ export function useSendMessage({
   navRemapKey,
   replaceUrl,
 }: UseSendMessageParams) {
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
+
   // -------------------------------------------------------------------------
   // Queue management (delegated to useMessageQueue)
   // -------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -170,9 +170,6 @@ interface UseStreamEventHandlerReturn {
  * Builds a `StreamHandlerContext` on each call and delegates to the
  * appropriate handler based on event type via an exhaustive switch.
  *
- * @param params.dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Passed through to handlers that update
- *   conversation state (e.g., title updates, processing key removal).
  * @returns `handleStreamEvent(event, epoch)` — call this for each SSE event.
  */
 export function useStreamEventHandler(

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -490,6 +490,7 @@ export function useStreamEventHandler(
       pendingQueuedStableIdsRef,
       requestIdToStableIdRef,
       pendingLocalDeletionsRef,
+      dispatchConversationList,
     ],
   );
 

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -10,7 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import type { InteractionEvent } from "@/domains/chat/lib/interaction-state-machine.js";
 import type { SubagentAction } from "@/domains/chat/lib/subagent-state.js";
-import type { ConversationListAction } from "@/domains/chat/lib/conversation-list-state.js";
+import { useConversationListStore } from "@/domains/chat/lib/conversation-list-state.js";
 import type {
   AssistantEvent,
   AssistantSyncChangedEvent,
@@ -104,7 +104,6 @@ export interface UseStreamEventHandlerParams {
   turnStateRef: MutableRefObject<TurnState>;
 
   // --- Processing ---
-  dispatchConversationList: Dispatch<ConversationListAction>;
   processingSnapshotsRef: MutableRefObject<
     Map<string, string | undefined>
   >;
@@ -193,7 +192,6 @@ export function useStreamEventHandler(
     needsNewBubbleRef,
     dispatchTurn,
     turnStateRef,
-    dispatchConversationList,
     processingSnapshotsRef,
     setError,
     streamRef,
@@ -233,6 +231,8 @@ export function useStreamEventHandler(
   refreshAssistantIdentityRef.current = refreshAssistantIdentity;
   const invalidateAvatarRef = useRef(invalidateAvatar);
   invalidateAvatarRef.current = invalidateAvatar;
+
+  const dispatchConversationList = useConversationListStore((s) => s.dispatch);
 
   /** Remove a conversation key from the processing set and snapshots map. */
   const clearProcessingKey = useCallback(
@@ -489,7 +489,6 @@ export function useStreamEventHandler(
       dismissedSurfaceIdsRef,
       contextWindowUsageByConversationRef,
       setContextWindowUsage,
-      dispatchConversationList,
       setCompactionCircuitOpenUntil,
       pendingQueuedStableIdsRef,
       requestIdToStableIdRef,

--- a/apps/web/src/domains/chat/lib/conversation-list-state.test.ts
+++ b/apps/web/src/domains/chat/lib/conversation-list-state.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from "bun:test";
+import { afterEach, describe, it, expect } from "bun:test";
 
 import type { Conversation, ConversationGroup } from "@/domains/chat/lib/api.js";
 import {
   type ConversationListState,
   INITIAL_CONVERSATION_LIST_STATE,
   conversationListReducer,
+  useConversationListStore,
 } from "@/domains/chat/lib/conversation-list-state.js";
 
 function makeConversation(key: string, overrides?: Partial<Conversation>): Conversation {
@@ -428,5 +429,55 @@ describe("conversationListReducer", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const next = conversationListReducer(state, { type: "UNKNOWN" } as any);
     expect(next).toBe(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zustand store
+// ---------------------------------------------------------------------------
+
+describe("useConversationListStore", () => {
+  afterEach(() => {
+    useConversationListStore.setState({
+      ...INITIAL_CONVERSATION_LIST_STATE,
+    });
+  });
+
+  it("initializes with INITIAL_CONVERSATION_LIST_STATE", () => {
+    const state = useConversationListStore.getState();
+    expect(state.conversations).toEqual([]);
+    expect(state.conversationGroups).toEqual([]);
+    expect(state.activeConversationKey).toBeNull();
+    expect(state.editingConversationKey).toBeNull();
+    expect(state.processingKeys.size).toBe(0);
+    expect(state.attentionKeys.size).toBe(0);
+  });
+
+  it("dispatch applies reducer transitions", () => {
+    const { dispatch } = useConversationListStore.getState();
+    const convs = [makeConversation("a"), makeConversation("b")];
+    dispatch({ type: "SET_CONVERSATIONS", conversations: convs });
+    expect(useConversationListStore.getState().conversations).toEqual(convs);
+  });
+
+  it("dispatch updates active key", () => {
+    const { dispatch } = useConversationListStore.getState();
+    dispatch({ type: "SET_ACTIVE_KEY", key: "conv-1" });
+    expect(useConversationListStore.getState().activeConversationKey).toBe("conv-1");
+  });
+
+  it("dispatch adds and removes processing keys", () => {
+    const { dispatch } = useConversationListStore.getState();
+    dispatch({ type: "ADD_PROCESSING_KEY", key: "p1" });
+    expect(useConversationListStore.getState().processingKeys.has("p1")).toBe(true);
+    dispatch({ type: "REMOVE_PROCESSING_KEY", key: "p1" });
+    expect(useConversationListStore.getState().processingKeys.has("p1")).toBe(false);
+  });
+
+  it("dispatch is a stable reference", () => {
+    const d1 = useConversationListStore.getState().dispatch;
+    useConversationListStore.getState().dispatch({ type: "SET_ACTIVE_KEY", key: "x" });
+    const d2 = useConversationListStore.getState().dispatch;
+    expect(d1).toBe(d2);
   });
 });

--- a/apps/web/src/domains/chat/lib/conversation-list-state.ts
+++ b/apps/web/src/domains/chat/lib/conversation-list-state.ts
@@ -1,9 +1,8 @@
 /**
- * Conversation-list state machine.
+ * Conversation-list state — Zustand store.
  *
- * Manages the sidebar / conversation-selection state as a single
- * `useReducer` with typed domain events. All state transitions go through
- * `conversationListReducer`, keeping updates atomic and testable.
+ * Manages the sidebar / conversation-selection state as a Zustand store
+ * backed by a pure reducer for atomic, testable transitions.
  *
  * **State managed:**
  * - `conversations` — the full list of conversations for the sidebar
@@ -13,11 +12,17 @@
  * - `processingKeys` — conversations with in-flight assistant responses
  * - `attentionKeys` — conversations needing user attention (pending interactions)
  *
- * Follows the same pattern as `interaction-state-machine.ts` and
- * `turn-state-machine.ts`.
+ * Consumers read state via selectors and write via `dispatch(action)`:
  *
- * @see https://react.dev/learn/extracting-state-logic-into-a-reducer
+ * ```ts
+ * const conversations = useConversationListStore((s) => s.conversations);
+ * const dispatch = useConversationListStore((s) => s.dispatch);
+ * ```
+ *
+ * @see https://zustand.docs.pmnd.rs/
  */
+
+import { create } from "zustand";
 
 import type { Conversation, ConversationGroup } from "@/domains/chat/lib/api.js";
 
@@ -35,7 +40,7 @@ export interface ConversationListState {
   attentionKeys: Set<string>;
 }
 
-/** Empty initial state — used as the `useReducer` initializer. */
+/** Empty initial state — used as the store initializer. */
 export const INITIAL_CONVERSATION_LIST_STATE: ConversationListState = {
   conversations: [],
   conversationGroups: [],
@@ -458,3 +463,22 @@ export function conversationListReducer(
       return state;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Zustand store
+// ---------------------------------------------------------------------------
+
+interface ConversationListStore extends ConversationListState {
+  dispatch: (action: ConversationListAction) => void;
+}
+
+export const useConversationListStore = create<ConversationListStore>(
+  (set) => ({
+    ...INITIAL_CONVERSATION_LIST_STATE,
+    dispatch: (action) =>
+      set((store) => {
+        const { dispatch: _, ...state } = store;
+        return conversationListReducer(state, action);
+      }),
+  }),
+);


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1622

## Why

The conversation-list sidebar state was threaded through component props via `dispatchConversationList: Dispatch<ConversationListAction>` parameters on every consumer hook. This prop-drilling pattern means any component that receives the dispatch function re-renders when the parent re-renders, even if the conversation list state it cares about hasn't changed.

Zustand's selector-based subscriptions (`useStore(selector)`) enable fine-grained re-render control — only components whose selected slice changes will re-render. This is the [recommended approach](https://zustand.docs.pmnd.rs/) for shared state that many components read but few write, which exactly matches the conversation-list pattern (sidebar reads everything, most hooks only dispatch).

## What changed

**Core store** (`conversation-list-state.ts`):
- Added `zustand` 5.0.13 as an exact dependency
- Created `useConversationListStore` wrapping the existing pure `conversationListReducer` — the reducer is unchanged and remains the single source of truth for state transitions
- The store exposes all `ConversationListState` fields plus a stable `dispatch` function

**Consumer hooks** (10 files):
- Removed `dispatchConversationList` from each hook's params interface
- Each hook now calls `useConversationListStore((s) => s.dispatch)` internally
- Hooks: `use-conversation-actions`, `use-conversation-group-actions`, `use-attention-tracking`, `use-send-message`, `use-stream-event-handler`, `use-event-stream`, `use-conversation-history`, `use-conversation-loader`, `use-app-viewer-actions`, `use-interaction-actions`

**Stream handlers** (`stream-handlers/types.ts`):
- `StreamHandlerContext.dispatchConversationList` is intentionally preserved — stream handlers are plain functions (not React hooks), so they receive dispatch via the context object. The hook that builds the context (`use-stream-event-handler`) now sources dispatch from the store.

**Tests**:
- All 31 existing reducer tests pass unchanged
- Added 5 new tests for the Zustand store: initialization, dispatch transitions, active key updates, processing key add/remove, and dispatch reference stability

## What was NOT changed and why

- **`StreamHandlerContext` keeps `dispatchConversationList`**: Stream handlers are pure functions called from within `useCallback`, not React components. They can't call hooks, so they receive dispatch via the context parameter. This is correct and testable — test helpers mock the context directly.
- **State field props (e.g. `conversations`, `processingKeys`) remain as hook params**: Some hooks receive conversation-list state values as props from their parent. Converting these to store selectors is a natural follow-up but significantly increases scope. The dispatch prop removal is the critical path — it eliminates the prop-drilling that caused unnecessary re-renders.
- **`conversationListReducer` remains exported**: The pure reducer function is still the engine behind state transitions. It's wrapped by the store's `dispatch` and directly tested. Keeping it exported preserves testability and the option to use it in non-React contexts.

## Alternatives considered

1. **React Context + `useReducer`**: Would still require a Provider component and wouldn't give selector-based bailouts without `useSyncExternalStore` wiring. Zustand provides this out of the box with less boilerplate.
2. **Converting all state reads to selectors in this PR**: Would eliminate all conversation-list prop threading, but touches many more interfaces and increases risk. Deferred to follow-up.
3. **Individual action methods instead of `dispatch`**: Zustand supports direct setter methods, but the existing discriminated-union action pattern is well-tested and the reducer switch is comprehensive. Wrapping the reducer preserves all existing test coverage.

## Safety

- The pure `conversationListReducer` is unchanged — all 31 existing tests pass
- Zustand's `dispatch` function is created once at store initialization (stable reference), so it won't trigger unnecessary re-renders or invalidate `useCallback` dependency arrays
- No behavioral changes — same actions, same state transitions, same reducer logic
- Stream handler tests continue to work because `StreamHandlerContext` is unchanged

## References

- [Zustand documentation](https://zustand.docs.pmnd.rs/)
- [Zustand — using with reducers](https://zustand.docs.pmnd.rs/guides/updating-state#using-set-with-a-function-updater)
- [React useReducer docs](https://react.dev/reference/react/useReducer) (prior pattern)

## Test plan

- `bun test src/domains/chat/lib/conversation-list-state.test.ts` — 36 tests pass (31 existing + 5 new store tests)
- `bunx tsc --noEmit` — no new type errors (only pre-existing generated-client errors)
- `bun run lint` — passes clean
- CI will run full suite

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->