### PR TITLE
feat(daemon): forward optional ToolActivityMetadata on tool_result events

### DIFF
--- a/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
+++ b/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests that `ToolExecutionResult.activityMetadata` plumbs through to the
+ * emitted `tool_result` server event via `handleToolResult`. The forward path
+ * is: ToolExecutionResult (set by the tool executor) → AgentEvent tool_result
+ * (emitted by the agent loop) → tool_result server message (emitted by
+ * handleToolResult to the SSE sink).
+ *
+ * Mirrors the mocked-dependency pattern used in tool-preview-lifecycle.test.ts
+ * and annotate-risk-options.test.ts.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock platform (must precede imports that read it) ─────────────────────────
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  handleToolResult,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createCollectorDeps(): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+} {
+  const events: ServerMessage[] = [];
+  const deps = {
+    ctx: {
+      conversationId: "conv-meta",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId: "req-meta",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events };
+}
+
+function primeState(state: EventHandlerState, toolUseId: string): void {
+  state.toolUseIdToName.set(toolUseId, "web_search");
+  state.toolCallTimestamps.set(toolUseId, { startedAt: Date.now() });
+  state.currentTurnToolUseIds.push(toolUseId);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("tool_result activityMetadata plumbing", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("forwards activityMetadata to the emitted tool_result event", () => {
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "toolu_meta_present";
+    primeState(state, toolUseId);
+
+    const activityMetadata: ToolActivityMetadata = {
+      webSearch: {
+        query: "x",
+        provider: "tavily",
+        resultCount: 0,
+        durationMs: 1,
+        results: [],
+      },
+    };
+
+    handleToolResult(state, deps, {
+      type: "tool_result",
+      toolUseId,
+      content: "",
+      isError: false,
+      activityMetadata,
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent).toBeDefined();
+    expect(toolResultEvent?.activityMetadata).toEqual(activityMetadata);
+  });
+
+  test("omits activityMetadata when the executor did not populate it", () => {
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "toolu_meta_absent";
+    primeState(state, toolUseId);
+
+    handleToolResult(state, deps, {
+      type: "tool_result",
+      toolUseId,
+      content: "ok",
+      isError: false,
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent).toBeDefined();
+    expect(toolResultEvent?.activityMetadata).toBeUndefined();
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/node";
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import {
   estimatePromptTokensRaw,
   estimateToolsTokens,
@@ -142,6 +143,7 @@ export type AgentEvent =
       approvalMode?: string;
       approvalReason?: string;
       riskThreshold?: string;
+      activityMetadata?: ToolActivityMetadata;
     }
   | { type: "tool_use_preview_start"; toolUseId: string; toolName: string }
   | {
@@ -371,6 +373,7 @@ export type LoopToolExecutor = (
   approvalMode?: string;
   approvalReason?: string;
   riskThreshold?: string;
+  activityMetadata?: ToolActivityMetadata;
 }>;
 
 export class AgentLoop {
@@ -1155,6 +1158,7 @@ export class AgentLoop {
             approvalMode: result.approvalMode,
             approvalReason: result.approvalReason,
             riskThreshold: result.riskThreshold,
+            activityMetadata: result.activityMetadata,
           });
         }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,13 +1,13 @@
 import * as Sentry from "@sentry/node";
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import {
   estimatePromptTokensRaw,
   estimateToolsTokens,
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { calculateMaxToolResultChars } from "../context/tool-result-truncation.js";
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { defaultEmptyResponseTerminal } from "../plugins/defaults/empty-response.js";
 import { defaultToolErrorTerminal } from "../plugins/defaults/tool-error.js";
 import { defaultToolResultTruncateTerminal } from "../plugins/defaults/tool-result-truncate.js";

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -677,6 +677,7 @@ export function handleToolResult(
     approvalMode: event.approvalMode,
     approvalReason: event.approvalReason,
     riskThreshold: event.riskThreshold,
+    activityMetadata: event.activityMetadata,
   });
 }
 
@@ -1296,6 +1297,7 @@ export async function dispatchAgentEvent(
           isError: event.isError,
           conversationId: deps.ctx.conversationId,
           toolUseId: event.toolUseId,
+          activityMetadata: undefined,
         });
         break;
       }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -2,6 +2,7 @@
 
 import type { ChannelId, InterfaceId } from "../../channels/types.js";
 import type { CommandIntent, UserMessageAttachment } from "./shared.js";
+import type { ToolActivityMetadata } from "./web-activity.js";
 
 // === Client → Server ===
 
@@ -175,6 +176,9 @@ export interface ToolResult {
   approvalReason?: string;
   /** Snapshot of the auto-approve threshold at execution time. */
   riskThreshold?: string;
+  /** Structured activity metadata for rich client rendering. Optional; old
+   *  clients that key off `result` continue to work unchanged. */
+  activityMetadata?: ToolActivityMetadata;
 }
 
 export interface ConfirmationRequest {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -14,6 +14,7 @@ import type {
 
 import type { InterfaceId } from "../channels/types.js";
 import type { CesClient } from "../credential-execution/client.js";
+import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
@@ -163,6 +164,9 @@ export interface ToolExecutionResult extends PluginToolExecutionResult {
    * approval flow transparently.
    */
   cesApprovalRequired?: ApprovalRequired;
+  /** Structured activity metadata for client rendering (web search, web fetch, etc).
+   *  Populated by daemon-internal tools; plugins must not set this. */
+  activityMetadata?: ToolActivityMetadata;
 }
 
 export type ProxyToolResolver = (


### PR DESCRIPTION
## Summary
- Add optional activityMetadata field to ToolExecutionResult (daemon-internal)
- Add optional activityMetadata field to the ToolResult wire event
- Thread activityMetadata through the AgentEvent intermediate union and the LoopToolExecutor return type
- Forward through handleToolResult and the native server_tool_complete handler (explicit undefined for now; PR 4 will populate native path)
- Test that metadata round-trips intact, absent metadata stays absent

Part of plan: web-activity-ui-data.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->