### PR TITLE
fix(design-library): render Notice actions on the right side of the banner

### DIFF
--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -128,7 +128,7 @@ export function Notice({
       </div>
 
       {actions ? (
-        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
       ) : null}
 
       {onDismiss ? (

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -125,8 +125,11 @@ export function Notice({
             {children}
           </Typography>
         ) : null}
-        {actions ? <div className="mt-2 flex flex-wrap gap-2">{actions}</div> : null}
       </div>
+
+      {actions ? (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      ) : null}
 
       {onDismiss ? (
         <button


### PR DESCRIPTION
Moves the Notice component's `actions` slot from below the message text to the right side of the banner, inline with the content. This makes error banners with action buttons (like "Go to Doctor") look cleaner by placing the button next to the message instead of underneath it.

## Prompt / plan
User requested the "Go to Doctor" button in the conversation-load error banner be positioned on the right side of the warning instead of below the text.

## Test plan
- `bun run typecheck` passes in `packages/design-library`
- Only one callsite uses the `actions` prop (`chat-body.tsx` for the generic chat error), so no other UI is affected

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/9ac688ce42584c01af446b9f7acad46c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->