### PR TITLE
[codex] Fix quality profile switch during app builds

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -219,6 +219,50 @@ describe("AgentLoop", () => {
     expect(calls[1].options?.config?.overrideProfile).toBe("quality-optimized");
   });
 
+  test("re-resolves max input tokens before truncating tool results", async () => {
+    const toolCallId = "tool-1";
+    const toolOutput = "x".repeat(2_500);
+    const { provider, calls } = createMockProvider([
+      toolUseResponse(toolCallId, "read_file", { path: "/tmp/test.txt" }),
+      textResponse("File contents received."),
+    ]);
+
+    let maxInputTokens = 1_000;
+    const toolExecutor = async () => {
+      maxInputTokens = 10_000;
+      return { content: toolOutput, isError: false };
+    };
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    await loop.run(
+      [userMessage],
+      collectEvents([]),
+      undefined,
+      "req-1",
+      undefined,
+      "mainAgent",
+      undefined,
+      undefined,
+      1_000,
+      undefined,
+      () => maxInputTokens,
+    );
+
+    const secondCallMessages = calls[1].messages;
+    const lastMsg = secondCallMessages[secondCallMessages.length - 1];
+    const toolResultBlock = lastMsg.content.find(
+      (b): b is Extract<ContentBlock, { type: "tool_result" }> =>
+        b.type === "tool_result",
+    );
+    expect(toolResultBlock?.content).toBe(toolOutput);
+  });
+
   // 3. Multi-turn tool loop
   test("supports multi-turn tool execution", async () => {
     const { provider, calls } = createMockProvider([

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -181,6 +181,44 @@ describe("AgentLoop", () => {
     ]);
   });
 
+  test("re-resolves override profile before each provider call", async () => {
+    const toolCallId = "tool-1";
+    const { provider, calls } = createMockProvider([
+      toolUseResponse(toolCallId, "read_file", { path: "/tmp/test.txt" }),
+      textResponse("File contents received."),
+    ]);
+
+    let overrideProfile: string | undefined;
+    const toolExecutor = async () => {
+      overrideProfile = "quality-optimized";
+      return { content: "ok", isError: false };
+    };
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      {},
+      dummyTools,
+      toolExecutor,
+    );
+
+    await loop.run(
+      [userMessage],
+      collectEvents([]),
+      undefined,
+      "req-1",
+      undefined,
+      "mainAgent",
+      undefined,
+      undefined,
+      undefined,
+      () => overrideProfile,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].options?.config?.overrideProfile).toBeUndefined();
+    expect(calls[1].options?.config?.overrideProfile).toBe("quality-optimized");
+  });
+
   // 3. Multi-turn tool loop
   test("supports multi-turn tool execution", async () => {
     const { provider, calls } = createMockProvider([
@@ -469,7 +507,6 @@ describe("AgentLoop", () => {
         .isError,
     ).toBe(false);
   });
-
 
   // 9. Tool executor error results are forwarded correctly
   test("forwards tool error results to provider", async () => {
@@ -1767,7 +1804,9 @@ describe("AgentLoop", () => {
     ]);
 
     // message_complete emitted for tool_use response + retry text response (not the empty one)
-    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    const messageCompletes = events.filter(
+      (e) => e.type === "message_complete",
+    );
     expect(messageCompletes).toHaveLength(2);
   });
 
@@ -1883,7 +1922,9 @@ describe("AgentLoop", () => {
     expect(calls).toHaveLength(3);
 
     // message_complete: tool_use response + final empty response (retry exhausted)
-    const messageCompletes = events.filter((e) => e.type === "message_complete");
+    const messageCompletes = events.filter(
+      (e) => e.type === "message_complete",
+    );
     expect(messageCompletes).toHaveLength(2);
 
     // The last assistant message in history is the empty one

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -204,6 +204,28 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(lastStreamParams!.thinking).toEqual({ type: "disabled" });
   });
 
+  test("drops unsigned thinking blocks from prior assistant messages", async () => {
+    await provider.sendMessage([
+      userMsg("Hi"),
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "non-native reasoning", signature: "" },
+          { type: "text", text: "I can help." },
+        ],
+      },
+      userMsg("Continue"),
+    ]);
+
+    const messages = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string; thinking?: string }>;
+    }>;
+    const assistant = messages.find((message) => message.role === "assistant");
+
+    expect(assistant?.content).toEqual([{ type: "text", text: "I can help." }]);
+  });
+
   test("splits system prompt into two cache blocks on boundary marker", async () => {
     const staticBlock = "You are a helpful assistant.";
     const dynamicBlock = "User workspace files here.";

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -350,11 +350,15 @@ import {
 
 // Captures every positional argument the loop passes to `agentLoop.run`.
 // The 8th positional argument is the per-turn `overrideProfile`, which is
-// what these tests assert on.
+// what most tests assert on. The 10th positional argument re-resolves that
+// profile between provider calls.
 interface CapturedAgentLoopRun {
   callSite: LLMCallSite | undefined;
   overrideProfile: string | undefined;
+  resolvedOverrideProfile: string | undefined;
 }
+
+let mutateBeforeResolveOverrideProfile: (() => void) | undefined;
 
 function makeCtx(
   captured: CapturedAgentLoopRun[],
@@ -371,8 +375,15 @@ function makeCtx(
     callSite?: LLMCallSite,
     _turnContext?: unknown,
     overrideProfile?: string,
+    _effectiveMaxInputTokens?: number,
+    resolveOverrideProfile?: () => string | undefined,
   ): Promise<Message[]> => {
-    captured.push({ callSite, overrideProfile });
+    mutateBeforeResolveOverrideProfile?.();
+    captured.push({
+      callSite,
+      overrideProfile,
+      resolvedOverrideProfile: resolveOverrideProfile?.(),
+    });
     return [
       ...messages,
       {
@@ -511,6 +522,7 @@ beforeEach(() => {
     totalEstimatedCost: 0,
     title: null,
   };
+  mutateBeforeResolveOverrideProfile = undefined;
   resetPluginRegistryAndRegisterDefaults();
 });
 
@@ -630,5 +642,35 @@ describe("runAgentLoopImpl — per-conversation inferenceProfile", () => {
     for (const call of captured) {
       expect(call.overrideProfile).toBe("fast");
     }
+  });
+
+  test("re-resolves inferenceProfile when a tool changes it mid-turn", async () => {
+    mockConversationRow = {
+      id: "conv-1",
+      conversationType: "standard",
+      inferenceProfile: null,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      title: null,
+    };
+    mutateBeforeResolveOverrideProfile = () => {
+      mockConversationRow = {
+        ...mockConversationRow!,
+        inferenceProfile: "quality-optimized",
+      };
+    };
+
+    const captured: CapturedAgentLoopRun[] = [];
+    const ctx = makeCtx(captured);
+
+    await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0].overrideProfile).toBeUndefined();
+    expect(captured[0].resolvedOverrideProfile).toBe("quality-optimized");
+    expect(ctx.currentTurnOverrideProfile).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -78,7 +78,11 @@ mock.module("../config/loader.js", () => ({
           },
         },
       },
-      profiles: {},
+      profiles: {
+        "quality-optimized": {
+          contextWindow: { maxInputTokens: 50000 },
+        },
+      },
       callSites: {},
       pricingOverrides: [],
     },
@@ -350,12 +354,13 @@ import {
 
 // Captures every positional argument the loop passes to `agentLoop.run`.
 // The 8th positional argument is the per-turn `overrideProfile`, which is
-// what most tests assert on. The 10th positional argument re-resolves that
-// profile between provider calls.
+// what most tests assert on. The 10th and 11th positional arguments re-resolve
+// that profile and its max-token budget between provider calls.
 interface CapturedAgentLoopRun {
   callSite: LLMCallSite | undefined;
   overrideProfile: string | undefined;
   resolvedOverrideProfile: string | undefined;
+  resolvedEffectiveMaxInputTokens: number | undefined;
 }
 
 let mutateBeforeResolveOverrideProfile: (() => void) | undefined;
@@ -377,12 +382,14 @@ function makeCtx(
     overrideProfile?: string,
     _effectiveMaxInputTokens?: number,
     resolveOverrideProfile?: () => string | undefined,
+    resolveEffectiveMaxInputTokens?: () => number | undefined,
   ): Promise<Message[]> => {
     mutateBeforeResolveOverrideProfile?.();
     captured.push({
       callSite,
       overrideProfile,
       resolvedOverrideProfile: resolveOverrideProfile?.(),
+      resolvedEffectiveMaxInputTokens: resolveEffectiveMaxInputTokens?.(),
     });
     return [
       ...messages,
@@ -671,6 +678,7 @@ describe("runAgentLoopImpl — per-conversation inferenceProfile", () => {
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0].overrideProfile).toBeUndefined();
     expect(captured[0].resolvedOverrideProfile).toBe("quality-optimized");
+    expect(captured[0].resolvedEffectiveMaxInputTokens).toBe(50000);
     expect(ctx.currentTurnOverrideProfile).toBeUndefined();
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -459,6 +459,7 @@ export class AgentLoop {
     overrideProfile?: string,
     effectiveMaxInputTokens?: number,
     resolveOverrideProfile?: () => string | undefined,
+    resolveEffectiveMaxInputTokens?: () => number | undefined,
   ): Promise<Message[]> {
     const history = [...messages];
     const initialHistoryLength = messages.length;
@@ -1085,7 +1086,10 @@ export class AgentLoop {
         // truncation strategy (e.g. a summariser) while the default
         // middleware preserves the historical tail-drop behaviour.
         const contextWindowTokens =
-          effectiveMaxInputTokens ?? this.config.maxInputTokens ?? 180_000;
+          resolveEffectiveMaxInputTokens?.() ??
+          effectiveMaxInputTokens ??
+          this.config.maxInputTokens ??
+          180_000;
         const maxChars = calculateMaxToolResultChars(contextWindowTokens);
         const truncateMiddlewares = getMiddlewaresFor("toolResultTruncate");
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -458,6 +458,7 @@ export class AgentLoop {
      */
     overrideProfile?: string,
     effectiveMaxInputTokens?: number,
+    resolveOverrideProfile?: () => string | undefined,
   ): Promise<Message[]> {
     const history = [...messages];
     const initialHistoryLength = messages.length;
@@ -580,9 +581,14 @@ export class AgentLoop {
         // `activeProfile` and any call-site named profile. Threading it on
         // every send (rather than once at construction) keeps subagents that
         // share an `AgentLoop` instance but ought to inherit a different
-        // profile correct — and matches how `callSite` is plumbed.
-        if (overrideProfile) {
-          providerConfig.overrideProfile = overrideProfile;
+        // profile correct — and matches how `callSite` is plumbed. The
+        // optional resolver lets a turn observe an explicitly confirmed
+        // profile-session switch before the next model call.
+        const effectiveOverrideProfile = resolveOverrideProfile
+          ? resolveOverrideProfile()
+          : overrideProfile;
+        if (effectiveOverrideProfile) {
+          providerConfig.overrideProfile = effectiveOverrideProfile;
         }
 
         // Rate-limit consecutive LLM calls to prevent spin when tools return instantly

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -127,10 +127,10 @@ App building is design-heavy judgment work — color palettes, layout decisions,
 assistant inference session list
 ```
 
-If no session is active, check the current default profile:
+If no session is active, check the current active profile:
 
 ```
-assistant config get llm.default.profile
+assistant config get llm.activeProfile
 ```
 
 If the profile is already `quality-optimized`, skip the rest of this step and proceed to Step 1.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -27,6 +27,7 @@ import type {
 } from "../channels/types.js";
 import {
   contextWindowConfigFromEffective,
+  type EffectiveContextWindow,
   resolveEffectiveContextWindow,
 } from "../config/llm-context-resolution.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
@@ -703,35 +704,36 @@ export async function runAgentLoopImpl(
     callSite: turnCallSite,
     overrideProfile: turnOverrideProfile ?? undefined,
   });
-  const turnContextWindowConfig = contextWindowConfigFromEffective(
+  let currentEffectiveContextWindow: EffectiveContextWindow =
+    effectiveContextWindow;
+  let currentContextWindowConfig = contextWindowConfigFromEffective(
     resolveCallSiteConfig(turnCallSite, config.llm, {
       overrideProfile: turnOverrideProfile ?? undefined,
     }).contextWindow,
-    effectiveContextWindow,
+    currentEffectiveContextWindow,
   );
   const contextWindowManager =
     ctx.contextWindowManager as ContextWindowManager & {
       updateConfig?: (config: ContextWindowConfig) => void;
     };
-  contextWindowManager.updateConfig?.(turnContextWindowConfig);
+  contextWindowManager.updateConfig?.(currentContextWindowConfig);
 
   let appliedOverrideProfile = turnOverrideProfile;
-  const resolveCurrentOverrideProfile = (): string | undefined => {
+  const refreshCurrentProfileState = (): string | undefined => {
     const currentOverrideProfile = readCurrentOverrideProfile();
     if (currentOverrideProfile !== appliedOverrideProfile) {
-      const latestEffectiveContextWindow = resolveEffectiveContextWindow({
+      currentEffectiveContextWindow = resolveEffectiveContextWindow({
         llm: config.llm,
         callSite: turnCallSite,
         overrideProfile: currentOverrideProfile,
       });
-      contextWindowManager.updateConfig?.(
-        contextWindowConfigFromEffective(
-          resolveCallSiteConfig(turnCallSite, config.llm, {
-            overrideProfile: currentOverrideProfile,
-          }).contextWindow,
-          latestEffectiveContextWindow,
-        ),
+      currentContextWindowConfig = contextWindowConfigFromEffective(
+        resolveCallSiteConfig(turnCallSite, config.llm, {
+          overrideProfile: currentOverrideProfile,
+        }).contextWindow,
+        currentEffectiveContextWindow,
       );
+      contextWindowManager.updateConfig?.(currentContextWindowConfig);
       appliedOverrideProfile = currentOverrideProfile;
       rlog.info(
         { overrideProfile: currentOverrideProfile ?? null },
@@ -740,6 +742,34 @@ export async function runAgentLoopImpl(
     }
     ctx.currentTurnOverrideProfile = currentOverrideProfile;
     return currentOverrideProfile;
+  };
+  const resolveCurrentOverrideProfile = (): string | undefined =>
+    refreshCurrentProfileState();
+  const resolveCurrentMaxInputTokens = (): number => {
+    refreshCurrentProfileState();
+    return currentEffectiveContextWindow.maxInputTokens;
+  };
+  const resolveCurrentContextWindowConfig = (): ContextWindowConfig => {
+    refreshCurrentProfileState();
+    return currentContextWindowConfig;
+  };
+  const resolveCurrentContextBudget = (): {
+    overflowRecovery: EffectiveContextWindow["overflowRecovery"];
+    providerMaxTokens: number;
+    preflightBudget: number;
+  } => {
+    refreshCurrentProfileState();
+    const overflowRecovery = currentEffectiveContextWindow.overflowRecovery;
+    const providerMaxTokens = currentEffectiveContextWindow.maxInputTokens;
+    const baseSafetyMargin = overflowRecovery.safetyMarginRatio;
+    const messageCount = ctx.messages.length;
+    const safetyMargin =
+      messageCount > 50 ? Math.max(baseSafetyMargin, 0.15) : baseSafetyMargin;
+    return {
+      overflowRecovery,
+      providerMaxTokens,
+      preflightBudget: Math.floor(providerMaxTokens * (1 - safetyMargin)),
+    };
   };
 
   // Initial value for `createToolExecutor` to read into
@@ -1118,7 +1148,7 @@ export async function runAgentLoopImpl(
       precomputedEstimate: compactCheck.estimatedTokens,
       conversationOriginChannel:
         getConversationOriginChannel(ctx.conversationId) ?? undefined,
-      overrideProfile: turnOverrideProfile ?? null,
+      overrideProfile: resolveCurrentOverrideProfile() ?? null,
     };
     let compacted: Awaited<
       ReturnType<typeof ctx.contextWindowManager.maybeCompact>
@@ -1731,15 +1761,9 @@ export async function runAgentLoopImpl(
     // After runtime injections are applied, estimate the prompt token count
     // and proactively invoke the reducer if already above budget. This avoids
     // a wasted provider round-trip that would just fail with context_too_large.
-    const overflowRecovery = effectiveContextWindow.overflowRecovery;
-    const providerMaxTokens = effectiveContextWindow.maxInputTokens;
-    // Widen safety margin for large conversations where estimation error
-    // compounds across many messages with tool results.
-    const baseSafetyMargin = overflowRecovery.safetyMarginRatio;
-    const messageCount = ctx.messages.length;
-    const safetyMargin =
-      messageCount > 50 ? Math.max(baseSafetyMargin, 0.15) : baseSafetyMargin;
-    const preflightBudget = Math.floor(providerMaxTokens * (1 - safetyMargin));
+    const initialContextBudget = resolveCurrentContextBudget();
+    const overflowRecovery = initialContextBudget.overflowRecovery;
+    const preflightBudget = initialContextBudget.preflightBudget;
     let reducerState: ReducerState | undefined;
 
     const toolTokenBudget = ctx.agentLoop.getToolTokenBudget(runMessages);
@@ -1816,10 +1840,10 @@ export async function runAgentLoopImpl(
         runMessages,
         systemPrompt: ctx.systemPrompt,
         providerName: estimationProviderName,
-        contextWindow: turnContextWindowConfig,
+        contextWindow: resolveCurrentContextWindowConfig(),
         preflightBudget,
         toolTokenBudget,
-        maxAttempts: overflowRecovery.maxAttempts,
+        maxAttempts: resolveCurrentContextBudget().overflowRecovery.maxAttempts,
         abortSignal: abortController.signal,
         compactFn: async (msgs, signal, opts) => {
           // Route the reducer's forced-compaction tier through the
@@ -1849,7 +1873,7 @@ export async function runAgentLoopImpl(
                 signal,
                 options: {
                   ...(opts ?? {}),
-                  overrideProfile: turnOverrideProfile ?? null,
+                  overrideProfile: resolveCurrentOverrideProfile() ?? null,
                 },
               },
               buildPluginTurnContext(ctx, reqId),
@@ -2120,7 +2144,8 @@ export async function runAgentLoopImpl(
       // yield if we're approaching the preflight budget. This lets the
       // conversation-agent-loop run compaction before the provider rejects.
       if (overflowRecovery.enabled) {
-        const midLoopThreshold = preflightBudget * 0.85;
+        const midLoopThreshold =
+          resolveCurrentContextBudget().preflightBudget * 0.85;
         const estimated = await runTokenEstimatePipeline(checkpoint.history);
         if (estimated > midLoopThreshold) {
           rlog.warn(
@@ -2156,8 +2181,9 @@ export async function runAgentLoopImpl(
       turnCallSite,
       loopTurnCtx,
       turnOverrideProfile,
-      effectiveContextWindow.maxInputTokens,
+      resolveCurrentMaxInputTokens(),
       resolveCurrentOverrideProfile,
+      resolveCurrentMaxInputTokens,
     );
 
     rlog.info(
@@ -2174,7 +2200,8 @@ export async function runAgentLoopImpl(
     let midLoopCompactAttempts = 0;
     while (
       yieldedForBudget &&
-      midLoopCompactAttempts < overflowRecovery.maxAttempts &&
+      midLoopCompactAttempts <
+        resolveCurrentContextBudget().overflowRecovery.maxAttempts &&
       !state.contextTooLargeDetected &&
       !abortController.signal.aborted
     ) {
@@ -2221,10 +2248,11 @@ export async function runAgentLoopImpl(
             options: {
               lastCompactedAt: ctx.contextCompactedAt ?? undefined,
               force: true,
-              targetInputTokensOverride: preflightBudget,
+              targetInputTokensOverride:
+                resolveCurrentContextBudget().preflightBudget,
               conversationOriginChannel:
                 getConversationOriginChannel(ctx.conversationId) ?? undefined,
-              overrideProfile: turnOverrideProfile ?? null,
+              overrideProfile: resolveCurrentOverrideProfile() ?? null,
             },
           },
           buildPluginTurnContext(ctx, reqId),
@@ -2310,8 +2338,9 @@ export async function runAgentLoopImpl(
         turnCallSite,
         loopTurnCtx,
         turnOverrideProfile,
-        effectiveContextWindow.maxInputTokens,
+        resolveCurrentMaxInputTokens(),
         resolveCurrentOverrideProfile,
+        resolveCurrentMaxInputTokens,
       );
     }
 
@@ -2325,7 +2354,8 @@ export async function runAgentLoopImpl(
         {
           phase: "mid-loop-compact",
           midLoopCompactAttempts,
-          maxAttempts: overflowRecovery.maxAttempts,
+          maxAttempts:
+            resolveCurrentContextBudget().overflowRecovery.maxAttempts,
         },
         "Mid-loop compaction exhausted all attempts — escalating to convergence loop",
       );
@@ -2368,8 +2398,9 @@ export async function runAgentLoopImpl(
         turnCallSite,
         loopTurnCtx,
         turnOverrideProfile,
-        effectiveContextWindow.maxInputTokens,
+        resolveCurrentMaxInputTokens(),
         resolveCurrentOverrideProfile,
+        resolveCurrentMaxInputTokens,
       );
 
       if (state.orderingErrorDetected) {
@@ -2438,8 +2469,9 @@ export async function runAgentLoopImpl(
         turnCallSite,
         loopTurnCtx,
         turnOverrideProfile,
-        effectiveContextWindow.maxInputTokens,
+        resolveCurrentMaxInputTokens(),
         resolveCurrentOverrideProfile,
+        resolveCurrentMaxInputTokens,
       );
       if (state.imageTooLargeDetected) {
         rlog.error(
@@ -2510,18 +2542,21 @@ export async function runAgentLoopImpl(
           toolTokenBudget,
         },
       );
-      let correctedTarget = preflightBudget;
+      const convergenceBudget = resolveCurrentContextBudget();
+      let correctedTarget = convergenceBudget.preflightBudget;
       if (actualTokens && estimatedTokensAtOverflow > 0) {
         const estimationErrorRatio = actualTokens / estimatedTokensAtOverflow;
         if (estimationErrorRatio > 1.0) {
-          correctedTarget = Math.floor(preflightBudget / estimationErrorRatio);
+          correctedTarget = Math.floor(
+            convergenceBudget.preflightBudget / estimationErrorRatio,
+          );
           rlog.warn(
             {
               phase: "convergence",
               actualTokens,
               estimatedTokens: estimatedTokensAtOverflow,
               estimationErrorRatio: estimationErrorRatio.toFixed(2),
-              preflightBudget,
+              preflightBudget: convergenceBudget.preflightBudget,
               correctedTarget,
             },
             "Adjusting compaction target based on observed estimation error",
@@ -2546,11 +2581,11 @@ export async function runAgentLoopImpl(
             systemPrompt: ctx.systemPrompt,
             tools: undefined,
             compaction: emergencyConfig,
-            maxInputTokens: effectiveContextWindow.maxInputTokens,
+            maxInputTokens: resolveCurrentMaxInputTokens(),
             previousEstimatedInputTokens: estimatedTokensAtOverflow,
             force: true,
             signal: abortController.signal,
-            overrideProfile: turnOverrideProfile ?? null,
+            overrideProfile: resolveCurrentOverrideProfile() ?? null,
             nonPersistedPrefixCount:
               ctx.contextWindowManager.nonPersistedPrefixCount,
           });
@@ -2588,7 +2623,7 @@ export async function runAgentLoopImpl(
       }
 
       let convergenceAttempts = 0;
-      const maxAttempts = overflowRecovery.maxAttempts;
+      const maxAttempts = convergenceBudget.overflowRecovery.maxAttempts;
 
       while (
         state.contextTooLargeDetected &&
@@ -2617,7 +2652,7 @@ export async function runAgentLoopImpl(
           {
             providerName: estimationProviderName,
             systemPrompt: ctx.systemPrompt,
-            contextWindow: turnContextWindowConfig,
+            contextWindow: resolveCurrentContextWindowConfig(),
             targetTokens: correctedTarget,
             toolTokenBudget,
           },
@@ -2625,7 +2660,7 @@ export async function runAgentLoopImpl(
           (msgs, signal, opts) =>
             ctx.contextWindowManager.maybeCompact(msgs, signal!, {
               ...(opts ?? {}),
-              overrideProfile: turnOverrideProfile ?? null,
+              overrideProfile: resolveCurrentOverrideProfile() ?? null,
             }),
           abortController.signal,
         );
@@ -2701,8 +2736,9 @@ export async function runAgentLoopImpl(
           turnCallSite,
           loopTurnCtx,
           turnOverrideProfile,
-          effectiveContextWindow.maxInputTokens,
+          resolveCurrentMaxInputTokens(),
           resolveCurrentOverrideProfile,
+          resolveCurrentMaxInputTokens,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -2780,7 +2816,7 @@ export async function runAgentLoopImpl(
                   force: true,
                   minKeepRecentUserTurns: 0,
                   targetInputTokensOverride: correctedTarget,
-                  overrideProfile: turnOverrideProfile ?? null,
+                  overrideProfile: resolveCurrentOverrideProfile() ?? null,
                 },
               },
               buildPluginTurnContext(ctx, reqId),
@@ -2863,8 +2899,9 @@ export async function runAgentLoopImpl(
             turnCallSite,
             loopTurnCtx,
             turnOverrideProfile,
-            effectiveContextWindow.maxInputTokens,
+            resolveCurrentMaxInputTokens(),
             resolveCurrentOverrideProfile,
+            resolveCurrentMaxInputTokens,
           );
         }
         // action === "fail_gracefully" falls through to the final error below
@@ -3074,11 +3111,11 @@ export async function runAgentLoopImpl(
       state.exchangeLlmCallCount,
       {
         tokens: state.lastCallInputTokens,
-        maxTokens: effectiveContextWindow.maxInputTokens,
+        maxTokens: resolveCurrentMaxInputTokens(),
       },
       {
         callSite: turnCallSite,
-        overrideProfile: turnOverrideProfile ?? null,
+        overrideProfile: resolveCurrentOverrideProfile() ?? null,
       },
     );
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -520,12 +520,11 @@ export interface AgentLoopConversationContext {
   /** Per-turn snapshot of channelCapabilities, frozen at message-processing start. */
   currentTurnChannelCapabilities?: ChannelCapabilities;
   /**
-   * Per-turn snapshot of the resolved inference-profile override. Read by
+   * Current inference-profile override for this turn. Read by
    * `createToolExecutor` so `ToolContext.overrideProfile` carries the same
-   * profile the agent loop is sending to the provider. Without this, a tool
-   * that spawns nested subagents (e.g. `subagent_spawn`) cannot recover the
-   * override from a row read because the in-flight subagent's own row never
-   * had `inferenceProfile` set.
+   * profile the agent loop is sending to the provider. Refreshed between
+   * model calls so an explicitly confirmed profile session opened mid-turn
+   * is inherited by later tool executions and nested subagents.
    */
   currentTurnOverrideProfile?: string;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
@@ -690,6 +689,10 @@ export async function runAgentLoopImpl(
   // spawned subagent's background conversation) wins over the row read
   // so the agent loop's own background-skip rule doesn't zero out an
   // explicitly inherited override.
+  const readCurrentOverrideProfile = (): string | undefined =>
+    options?.overrideProfile ??
+    getConversationOverrideProfileFromRow(getConversation(ctx.conversationId));
+
   const turnOverrideProfile =
     options?.overrideProfile ??
     getConversationOverrideProfileFromRow(turnStartConversation);
@@ -706,15 +709,43 @@ export async function runAgentLoopImpl(
     }).contextWindow,
     effectiveContextWindow,
   );
-  (
+  const contextWindowManager =
     ctx.contextWindowManager as ContextWindowManager & {
       updateConfig?: (config: ContextWindowConfig) => void;
-    }
-  ).updateConfig?.(turnContextWindowConfig);
+    };
+  contextWindowManager.updateConfig?.(turnContextWindowConfig);
 
-  // Snapshot for `createToolExecutor` to read into `ToolContext.overrideProfile`
-  // — see field doc on `AgentLoopConversationContext` for why the tool needs
-  // it (nested subagent spawns can't recover the override from a row read).
+  let appliedOverrideProfile = turnOverrideProfile;
+  const resolveCurrentOverrideProfile = (): string | undefined => {
+    const currentOverrideProfile = readCurrentOverrideProfile();
+    if (currentOverrideProfile !== appliedOverrideProfile) {
+      const latestEffectiveContextWindow = resolveEffectiveContextWindow({
+        llm: config.llm,
+        callSite: turnCallSite,
+        overrideProfile: currentOverrideProfile,
+      });
+      contextWindowManager.updateConfig?.(
+        contextWindowConfigFromEffective(
+          resolveCallSiteConfig(turnCallSite, config.llm, {
+            overrideProfile: currentOverrideProfile,
+          }).contextWindow,
+          latestEffectiveContextWindow,
+        ),
+      );
+      appliedOverrideProfile = currentOverrideProfile;
+      rlog.info(
+        { overrideProfile: currentOverrideProfile ?? null },
+        "Turn inference profile changed mid-loop",
+      );
+    }
+    ctx.currentTurnOverrideProfile = currentOverrideProfile;
+    return currentOverrideProfile;
+  };
+
+  // Initial value for `createToolExecutor` to read into
+  // `ToolContext.overrideProfile`. `resolveCurrentOverrideProfile` refreshes
+  // this between model calls so a confirmed profile session opened by a tool
+  // applies to later tool executions and nested subagents in the same turn.
   ctx.currentTurnOverrideProfile = turnOverrideProfile;
 
   // Capture the turn channel context *before* any awaits so a second
@@ -2126,6 +2157,7 @@ export async function runAgentLoopImpl(
       loopTurnCtx,
       turnOverrideProfile,
       effectiveContextWindow.maxInputTokens,
+      resolveCurrentOverrideProfile,
     );
 
     rlog.info(
@@ -2279,6 +2311,7 @@ export async function runAgentLoopImpl(
         loopTurnCtx,
         turnOverrideProfile,
         effectiveContextWindow.maxInputTokens,
+        resolveCurrentOverrideProfile,
       );
     }
 
@@ -2336,6 +2369,7 @@ export async function runAgentLoopImpl(
         loopTurnCtx,
         turnOverrideProfile,
         effectiveContextWindow.maxInputTokens,
+        resolveCurrentOverrideProfile,
       );
 
       if (state.orderingErrorDetected) {
@@ -2405,6 +2439,7 @@ export async function runAgentLoopImpl(
         loopTurnCtx,
         turnOverrideProfile,
         effectiveContextWindow.maxInputTokens,
+        resolveCurrentOverrideProfile,
       );
       if (state.imageTooLargeDetected) {
         rlog.error(
@@ -2667,6 +2702,7 @@ export async function runAgentLoopImpl(
           loopTurnCtx,
           turnOverrideProfile,
           effectiveContextWindow.maxInputTokens,
+          resolveCurrentOverrideProfile,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -2828,6 +2864,7 @@ export async function runAgentLoopImpl(
             loopTurnCtx,
             turnOverrideProfile,
             effectiveContextWindow.maxInputTokens,
+            resolveCurrentOverrideProfile,
           );
         }
         // action === "fail_gracefully" falls through to the final error below

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -927,8 +927,9 @@ export class AnthropicProvider implements Provider {
 
       // Thinking blocks are stripped at rest by DB migration 209 so
       // historical messages are clean when loaded. Within a turn,
-      // assistant messages have original thinking with valid signatures
-      // — the API accepts them. No provider-side stripping needed.
+      // Anthropic-native assistant messages have original thinking with
+      // valid signatures — the API accepts them. Non-Anthropic providers can
+      // emit unsigned thinking blocks, which `toAnthropicBlockSafe` drops.
 
       sentMessages = ensureToolPairing(
         repairOrphanedServerToolBlocks(formatted),
@@ -1544,6 +1545,9 @@ export class AnthropicProvider implements Provider {
       case "text":
         return { type: "text", text: block.text };
       case "thinking":
+        if (!block.signature) {
+          return null;
+        }
         return {
           type: "thinking",
           thinking: block.thinking,


### PR DESCRIPTION
## Summary

Fixes app-builder turns where the user confirms switching to `quality-optimized`, but the current build continues on the profile that was active at turn start.

## Root Cause

`runAgentLoopImpl` snapshotted the conversation inference profile at turn start and passed that same override through the full agent loop. The app-builder skill could successfully ask for confirmation and open a `quality-optimized` inference session mid-turn, but later provider calls in the same build turn still used the stale override.

## Changes

- Re-resolve the conversation inference profile before each provider call so confirmed mid-turn session changes apply immediately.
- Refresh the turn context-window config when the effective profile changes mid-loop.
- Update app-builder preflight docs to check `llm.activeProfile` instead of `llm.default.profile`.
- Drop unsigned thinking blocks before sending prior assistant messages to Anthropic, avoiding provider-switch signature errors.
- Add regressions for mid-turn profile re-resolution and unsigned thinking sanitization.

## Validation

- `bun test src/__tests__/conversation-agent-loop-inference-profile.test.ts`
- `bun test src/__tests__/agent-loop.test.ts`
- `bun test src/__tests__/anthropic-provider.test.ts`
- `bunx tsc --noEmit`
- commit hook: Prettier, lint, typecheck
- pre-push hook: typecheck and lint