### PR TITLE
feat(macos): add Base URL and Models fields for openai-compatible provider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -181,8 +181,9 @@ struct InferenceProfileEditor: View {
               let model = profile.model, !model.isEmpty else {
             return false
         }
-        let catalog = store.dynamicProviderModels(provider).map(\.id)
-        return !catalog.contains(model)
+        let catalogIds = store.dynamicProviderModels(provider).map(\.id)
+        let connectionIds = effectiveConnection?.models?.map(\.id) ?? []
+        return !catalogIds.contains(model) && !connectionIds.contains(model)
     }
 
     /// Combined gate for the Save button: provider must be picked AND
@@ -605,9 +606,22 @@ struct InferenceProfileEditor: View {
         return conn.name
     }
 
+    private var selectedConnection: ProviderConnection? {
+        guard let name = profile.providerConnection, !name.isEmpty else { return nil }
+        return availableConnectionsForProvider.first { $0.name == name }
+    }
+
+    private var effectiveConnection: ProviderConnection? {
+        selectedConnection ?? availableConnectionsForProvider.first
+    }
+
     private var modelField: some View {
         let provider = profile.provider ?? ""
-        let models = store.dynamicProviderModels(provider)
+        let catalogModels = store.dynamicProviderModels(provider)
+        let connectionModels: [CatalogModel] = effectiveConnection?.models?.map {
+            CatalogModel(id: $0.id, displayName: $0.displayName ?? $0.id)
+        } ?? []
+        let models = connectionModels.isEmpty ? catalogModels : connectionModels
         return labeled(
             "Model",
             accessory: {

--- a/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProvidersSheet.swift
@@ -60,6 +60,11 @@ struct ProvidersSheet: View {
         // Inline credential editing
         var apiKeyValue = ""
         var isAdvancedExpanded = false
+        // OpenAI-compatible fields
+        var baseUrl = ""
+        var connectionModels = ""
+
+        var isOpenAICompatible: Bool { provider == "openai-compatible" }
     }
 
     enum EditorState {
@@ -335,6 +340,10 @@ struct ProvidersSheet: View {
                     if case .create = editorState {
                         editorProviderField
                     }
+                    if editorDraft.isOpenAICompatible {
+                        editorBaseUrlField
+                        editorModelsField
+                    }
                     Group {
                         editorAuthTypeField
                         if editorDraft.authType == "api_key" {
@@ -497,6 +506,35 @@ struct ProvidersSheet: View {
                 selection: $editorDraft.provider,
                 options: store.providerCatalog.map { (label: $0.displayName, value: $0.id) }
             )
+        }
+    }
+
+    private var editorBaseUrlField: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Base URL")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            VTextField(
+                placeholder: "https://api.example.com/v1",
+                text: $editorDraft.baseUrl
+            )
+            .disabled(isAuthLocked)
+        }
+    }
+
+    private var editorModelsField: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Models")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+            VTextField(
+                placeholder: "model-1, model-2",
+                text: $editorDraft.connectionModels
+            )
+            .disabled(isAuthLocked)
+            Text("Comma-separated model identifiers exposed by your endpoint.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentTertiary)
         }
     }
 
@@ -847,7 +885,9 @@ struct ProvidersSheet: View {
             provider: conn.provider,
             authType: conn.auth.type,
             credential: conn.auth.credential ?? "",
-            status: conn.status
+            status: conn.status,
+            baseUrl: conn.baseUrl ?? "",
+            connectionModels: conn.models?.map(\.id).joined(separator: ", ") ?? ""
         )
         editorState = .edit(name: conn.name)
 
@@ -873,7 +913,9 @@ struct ProvidersSheet: View {
             provider: conn.provider,
             authType: conn.auth.type,
             credential: conn.auth.credential ?? "",
-            status: conn.status
+            status: conn.status,
+            baseUrl: conn.baseUrl ?? "",
+            connectionModels: conn.models?.map(\.id).joined(separator: ", ") ?? ""
         )
         editorState = .managedEdit(name: conn.name)
 
@@ -924,6 +966,8 @@ struct ProvidersSheet: View {
             editorDraft.credential = "credential/\(provider)/api_key"
         }
         editorDraft.apiKeyValue = ""
+        editorDraft.baseUrl = ""
+        editorDraft.connectionModels = ""
         // New connection starts active by convention; user can toggle off
         // before saving if they want it disabled.
         editorDraft.status = .active
@@ -988,7 +1032,9 @@ struct ProvidersSheet: View {
             name: conn.name,
             auth: conn.auth,
             status: newStatus,
-            label: .none
+            label: .none,
+            baseUrl: .none,
+            models: .none
         ) else {
             // Roll back on failure.
             if let idx = connections.firstIndex(where: { $0.name == conn.name }) {
@@ -1063,6 +1109,19 @@ struct ProvidersSheet: View {
         let label: String? = draft.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft.label.trimmingCharacters(in: .whitespacesAndNewlines)
         let status = draft.status
 
+        let baseUrlValue: String? = draft.isOpenAICompatible && !draft.baseUrl.trimmingCharacters(in: .whitespaces).isEmpty
+            ? draft.baseUrl.trimmingCharacters(in: .whitespaces)
+            : nil
+        let modelsValue: [ConnectionModel]? = {
+            guard draft.isOpenAICompatible,
+                  !draft.connectionModels.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+            let parsed = draft.connectionModels
+                .split(separator: ",")
+                .map { ConnectionModel(id: String($0).trimmingCharacters(in: .whitespaces)) }
+                .filter { !$0.id.isEmpty }
+            return parsed.isEmpty ? nil : parsed
+        }()
+
         switch editorState {
         case .create:
             let result = await client.createProviderConnection(
@@ -1070,7 +1129,9 @@ struct ProvidersSheet: View {
                 provider: draft.provider,
                 auth: auth,
                 label: label,
-                status: status
+                status: status,
+                baseUrl: baseUrlValue,
+                models: modelsValue
             )
             switch result {
             case .created(let created):
@@ -1105,7 +1166,9 @@ struct ProvidersSheet: View {
                 name: originalName,
                 auth: auth,
                 status: status,
-                label: .some(label)
+                label: .some(label),
+                baseUrl: draft.isOpenAICompatible ? .some(baseUrlValue) : .none,
+                models: draft.isOpenAICompatible ? .some(modelsValue) : .none
             ) else {
                 await refresh()
                 actionError = "Couldn't update connection. List refreshed."

--- a/clients/macos/vellum-assistantTests/Features/Settings/ProvidersSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/ProvidersSheetTests.swift
@@ -85,7 +85,9 @@ final class ProvidersSheetTests: XCTestCase {
             provider: "openai",
             auth: ProviderConnectionAuth(type: "api_key", credential: "sk-open"),
             label: nil,
-            status: nil
+            status: nil,
+            baseUrl: nil,
+            models: nil
         )
 
         XCTAssertEqual(mockClient.createCallCount, 1)
@@ -119,7 +121,9 @@ final class ProvidersSheetTests: XCTestCase {
             name: "gone",
             auth: ProviderConnectionAuth(type: "api_key", credential: "sk-x"),
             status: nil,
-            label: nil
+            label: nil,
+            baseUrl: nil,
+            models: nil
         )
         XCTAssertNil(result, "nil update signals 404; caller should refresh")
 
@@ -251,7 +255,9 @@ final class ProvidersSheetTests: XCTestCase {
             provider: "anthropic",
             auth: ProviderConnectionAuth(type: "api_key", credential: "credential/anthropic/api_key"),
             label: "Anthropic",
-            status: .active
+            status: .active,
+            baseUrl: nil,
+            models: nil
         )
 
         XCTAssertEqual(mockClient.createCallCount, 1, "Save as New must POST.")

--- a/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ProviderConnectionClientTests.swift
@@ -38,15 +38,19 @@ final class MockProviderConnectionClient: ProviderConnectionClientProtocol {
     var createAuthArg: ProviderConnectionAuth?
     var createLabelArg: String?
     var createStatusArg: ConnectionStatus?
+    var createBaseUrlArg: String?
+    var createModelsArg: [ConnectionModel]?
     var createResponse: ProviderConnectionCreateResult = .error
 
-    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?) async -> ProviderConnectionCreateResult {
+    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult {
         createCallCount += 1
         createNameArg = name
         createProviderArg = provider
         createAuthArg = auth
         createLabelArg = label
         createStatusArg = status
+        createBaseUrlArg = baseUrl
+        createModelsArg = models
         return createResponse
     }
 
@@ -56,14 +60,18 @@ final class MockProviderConnectionClient: ProviderConnectionClientProtocol {
     var updateAuthArg: ProviderConnectionAuth?
     var updateStatusArg: ConnectionStatus?
     var updateLabelArg: String??
+    var updateBaseUrlArg: String??
+    var updateModelsArg: [ConnectionModel]??
     var updateResponse: ProviderConnection? = nil
 
-    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??) async -> ProviderConnection? {
+    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection? {
         updateCallCount += 1
         updateNameArg = name
         updateAuthArg = auth
         updateStatusArg = status
         updateLabelArg = label
+        updateBaseUrlArg = baseUrl
+        updateModelsArg = models
         return updateResponse
     }
 
@@ -249,7 +257,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         let conn = makeConnection(name: "new-conn")
         mock.createResponse = .created(conn)
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "new-conn", provider: "anthropic", auth: auth, label: nil, status: nil)
+        let result = await mock.createProviderConnection(name: "new-conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
         guard case .created(let created) = result else {
             XCTFail("Expected .created result, got \(result)")
             return
@@ -267,7 +275,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // instead of a generic "please try again."
         mock.createResponse = .duplicate
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "existing", provider: "anthropic", auth: auth, label: nil, status: nil)
+        let result = await mock.createProviderConnection(name: "existing", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
         guard case .duplicate = result else {
             XCTFail("Expected .duplicate result, got \(result)")
             return
@@ -279,7 +287,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // sheet can echo it verbatim (e.g. `Invalid provider "x". Valid: ...`).
         mock.createResponse = .invalid(message: "Invalid auth configuration.")
         let auth = ProviderConnectionAuth(type: "api_key", credential: "")
-        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil)
+        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
         guard case .invalid(let message) = result else {
             XCTFail("Expected .invalid result, got \(result)")
             return
@@ -291,7 +299,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         // Catch-all for network errors, 5xx, decode failures, etc.
         mock.createResponse = .error
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-test")
-        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil)
+        let result = await mock.createProviderConnection(name: "conn", provider: "anthropic", auth: auth, label: nil, status: nil, baseUrl: nil, models: nil)
         guard case .error = result else {
             XCTFail("Expected .error result, got \(result)")
             return
@@ -304,7 +312,7 @@ final class ProviderConnectionClientTests: XCTestCase {
         let conn = makeConnection(name: "conn")
         mock.updateResponse = conn
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-new")
-        let result = await mock.updateProviderConnection(name: "conn", auth: auth, status: nil, label: nil)
+        let result = await mock.updateProviderConnection(name: "conn", auth: auth, status: nil, label: nil, baseUrl: nil, models: nil)
         XCTAssertEqual(result?.name, "conn")
         XCTAssertEqual(mock.updateNameArg, "conn")
         XCTAssertEqual(mock.updateAuthArg?.credential, "sk-new")
@@ -313,7 +321,7 @@ final class ProviderConnectionClientTests: XCTestCase {
     func testUpdateReturnsNilOn404() async {
         mock.updateResponse = nil
         let auth = ProviderConnectionAuth(type: "api_key", credential: "sk-x")
-        let result = await mock.updateProviderConnection(name: "missing", auth: auth, status: nil, label: nil)
+        let result = await mock.updateProviderConnection(name: "missing", auth: auth, status: nil, label: nil, baseUrl: nil, models: nil)
         XCTAssertNil(result)
     }
 

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -5987,6 +5987,17 @@ public enum ConnectionStatus: String, Codable, Sendable {
     case disabled
 }
 
+/// A model entry exposed by an openai-compatible provider connection.
+public struct ConnectionModel: Codable, Sendable {
+    public let id: String
+    public let displayName: String?
+
+    public init(id: String, displayName: String? = nil) {
+        self.id = id
+        self.displayName = displayName
+    }
+}
+
 /// A named provider connection stored in the assistant database.
 public struct ProviderConnection: Codable, Sendable {
     public let name: String
@@ -6003,8 +6014,12 @@ public struct ProviderConnection: Codable, Sendable {
     /// it to render the read-only badge + view-only editor and to disable
     /// the delete affordance without mirroring the canonical name list.
     public let isManaged: Bool
+    /// Base URL for openai-compatible provider connections (e.g. `https://api.example.com/v1`).
+    public let baseUrl: String?
+    /// Model entries exposed by an openai-compatible provider connection.
+    public let models: [ConnectionModel]?
 
-    public init(name: String, provider: String, auth: ProviderConnectionAuth, status: ConnectionStatus = .active, label: String? = nil, createdAt: Int, updatedAt: Int, isManaged: Bool = false) {
+    public init(name: String, provider: String, auth: ProviderConnectionAuth, status: ConnectionStatus = .active, label: String? = nil, createdAt: Int, updatedAt: Int, isManaged: Bool = false, baseUrl: String? = nil, models: [ConnectionModel]? = nil) {
         self.name = name
         self.provider = provider
         self.auth = auth
@@ -6013,6 +6028,8 @@ public struct ProviderConnection: Codable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.isManaged = isManaged
+        self.baseUrl = baseUrl
+        self.models = models
     }
 
     /// Decodes responses from daemons that predate the `status` or `isManaged`
@@ -6030,6 +6047,8 @@ public struct ProviderConnection: Codable, Sendable {
         self.createdAt = try container.decode(Int.self, forKey: .createdAt)
         self.updatedAt = try container.decode(Int.self, forKey: .updatedAt)
         self.isManaged = try container.decodeIfPresent(Bool.self, forKey: .isManaged) ?? false
+        self.baseUrl = try container.decodeIfPresent(String.self, forKey: .baseUrl)
+        self.models = try container.decodeIfPresent([ConnectionModel].self, forKey: .models)
     }
 }
 

--- a/clients/shared/Network/ProviderConnectionClient.swift
+++ b/clients/shared/Network/ProviderConnectionClient.swift
@@ -112,7 +112,7 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         if let label { body["label"] = label }
         if let status { body["status"] = status.rawValue }
         if let baseUrl { body["base_url"] = baseUrl }
-        if let models { body["models"] = models.map { ["id": $0.id, "display_name": $0.displayName as Any].compactMapValues { $0 } } }
+        if let models { body["models"] = models.map { model -> [String: Any] in var d: [String: Any] = ["id": model.id]; if let dn = model.displayName { d["displayName"] = dn }; return d } }
         do {
             let response = try await GatewayHTTPClient.post(
                 path: "inference/provider-connections",
@@ -172,7 +172,7 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         }
         if let outerModels = models {
             if let m = outerModels {
-                body["models"] = m.map { ["id": $0.id, "display_name": $0.displayName as Any].compactMapValues { $0 } }
+                body["models"] = m.map { model -> [String: Any] in var d: [String: Any] = ["id": model.id]; if let dn = model.displayName { d["displayName"] = dn }; return d }
             } else {
                 body["models"] = NSNull()
             }

--- a/clients/shared/Network/ProviderConnectionClient.swift
+++ b/clients/shared/Network/ProviderConnectionClient.swift
@@ -34,9 +34,9 @@ public protocol ProviderConnectionClientProtocol {
     func listProviderConnections(provider: String?) async -> [ProviderConnection]?
     func getProviderConnection(name: String) async -> ProviderConnection?
     /// `label` and `status` are optional extras; pass `nil` to omit from the request body.
-    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?) async -> ProviderConnectionCreateResult
+    func createProviderConnection(name: String, provider: String, auth: ProviderConnectionAuth, label: String?, status: ConnectionStatus?, baseUrl: String?, models: [ConnectionModel]?) async -> ProviderConnectionCreateResult
     /// `status`: nil = omit from body (no change). `label`: nil outer = omit; `.some(nil)` = send null (clear); `.some("v")` = set.
-    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??) async -> ProviderConnection?
+    func updateProviderConnection(name: String, auth: ProviderConnectionAuth, status: ConnectionStatus?, label: String??, baseUrl: String??, models: [ConnectionModel]??) async -> ProviderConnection?
     func deleteProviderConnection(name: String) async -> ProviderConnectionDeleteResult
 }
 
@@ -100,7 +100,9 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         provider: String,
         auth: ProviderConnectionAuth,
         label: String? = nil,
-        status: ConnectionStatus? = nil
+        status: ConnectionStatus? = nil,
+        baseUrl: String? = nil,
+        models: [ConnectionModel]? = nil
     ) async -> ProviderConnectionCreateResult {
         var body: [String: Any] = [
             "name": name,
@@ -109,6 +111,8 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         ]
         if let label { body["label"] = label }
         if let status { body["status"] = status.rawValue }
+        if let baseUrl { body["base_url"] = baseUrl }
+        if let models { body["models"] = models.map { ["id": $0.id, "display_name": $0.displayName as Any].compactMapValues { $0 } } }
         do {
             let response = try await GatewayHTTPClient.post(
                 path: "inference/provider-connections",
@@ -153,13 +157,25 @@ public struct ProviderConnectionClient: ProviderConnectionClientProtocol {
         name: String,
         auth: ProviderConnectionAuth,
         status: ConnectionStatus? = nil,
-        label: String?? = nil
+        label: String?? = nil,
+        baseUrl: String?? = nil,
+        models: [ConnectionModel]?? = nil
     ) async -> ProviderConnection? {
         let encoded = Self.encodePath(name)
         var body: [String: Any] = ["auth": Self.authDict(for: auth)]
         if let status { body["status"] = status.rawValue }
         if let outerLabel = label {
             body["label"] = outerLabel ?? NSNull()
+        }
+        if let outerBaseUrl = baseUrl {
+            body["base_url"] = outerBaseUrl ?? NSNull()
+        }
+        if let outerModels = models {
+            if let m = outerModels {
+                body["models"] = m.map { ["id": $0.id, "display_name": $0.displayName as Any].compactMapValues { $0 } }
+            } else {
+                body["models"] = NSNull()
+            }
         }
         do {
             let response = try await GatewayHTTPClient.patch(
@@ -238,7 +254,9 @@ extension ProviderConnection {
             label: label,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            isManaged: isManaged
+            isManaged: isManaged,
+            baseUrl: baseUrl,
+            models: models
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds the missing Base URL and Models input fields to the macOS provider connection editor when OpenAI-compatible is selected. Without this, the macOS app shows the openai-compatible provider in the dropdown but can't configure it (the daemon rejects creates without base_url).

- **GeneratedAPITypes.swift**: Added `ConnectionModel` struct, `baseUrl`/`models` fields to `ProviderConnection` with backward-compatible decoding
- **ProviderConnectionClient.swift**: Updated create/update to accept and send `base_url` (snake_case wire format) and `models`
- **ProvidersSheet.swift**: Added `baseUrl`/`connectionModels` to `ConnectionDraft`, Base URL + Models form fields (shown only for openai-compatible), save/reset logic
- **Tests**: Updated mock client and test call sites

Part of JARVIS-821

## Test plan

- [ ] Build macOS app, open Settings > Models & Services > Providers
- [ ] Create new connection with OpenAI-compatible provider — verify Base URL and Models fields appear
- [ ] Fill in base URL (e.g. `https://api.z.ai/api/paas/v4/`), models (e.g. `glm-4.7`), API key — verify Create succeeds
- [ ] Edit the connection — verify Base URL and Models are pre-populated
- [ ] Verify other providers (Anthropic, OpenAI, etc.) do NOT show Base URL/Models fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->