### PR TITLE
fix(health): suppress false-positive notifications for never-connected managed providers

### DIFF
--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -315,9 +315,11 @@ async function checkManagedProvider(
     const client = await VellumPlatformClient.create();
     if (!client?.platformAssistantId) return results;
 
+    // Query without a status filter so we can distinguish "never
+    // connected" (empty result) from "previously connected but now
+    // inactive" (non-empty result with no ACTIVE entries).
     const params = new URLSearchParams();
     params.set("provider", providerRow.provider);
-    params.set("status", "ACTIVE");
 
     const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
     const response = await client.fetch(path);
@@ -331,17 +333,35 @@ async function checkManagedProvider(
     }
 
     const body = (await response.json()) as unknown;
-    const connections = (
+    const allConnections = (
       Array.isArray(body)
         ? body
         : ((body as Record<string, unknown>).results ?? [])
-    ) as Array<{ id: string; account_label?: string }>;
+    ) as Array<{ id: string; account_label?: string; status?: string }>;
+
+    if (allConnections.length === 0) {
+      // No connections of any status — the user has never connected this
+      // provider. The suggested-prompts system handles prompting them to
+      // connect; this is not a health issue.
+      return results;
+    }
+
+    const connections = allConnections.filter(
+      (c) => c.status?.toUpperCase() === "ACTIVE",
+    );
 
     if (connections.length === 0) {
-      // No managed connections exist — the user has never connected this
-      // provider. The suggested-prompts system handles prompting them to
-      // connect; generating a missing_token alert here would create
-      // false-positive "reconnect" notifications.
+      // Connections exist but none are active — the user previously
+      // connected and the connection was revoked/deactivated.
+      results.push({
+        connectionId: `managed:${providerRow.provider}`,
+        provider: providerRow.provider,
+        accountInfo: allConnections[0]?.account_label ?? null,
+        status: "missing_token",
+        details: `No active managed connection for ${providerRow.provider}. Reconnect on the Vellum platform.`,
+        missingScopes: [],
+        canAutoRecover: false,
+      });
       return results;
     }
 
@@ -543,9 +563,20 @@ export async function checkAllCredentials(): Promise<CredentialHealthReport> {
   for (const providerRow of providers) {
     if (!(await isManagedProvider(providerRow))) continue;
 
-    // If the provider is in managed mode and also has BYO connections,
-    // remove the stale BYO results — managed mode takes priority.
-    if (byoProviders.has(providerRow.provider)) {
+    let managedResults: CredentialHealthResult[] = [];
+    try {
+      managedResults = await checkManagedProvider(providerRow);
+    } catch (err) {
+      log.warn(
+        { err, provider: providerRow.provider },
+        "Failed to check managed provider health",
+      );
+    }
+
+    // Only replace BYO results with managed results when the managed
+    // check returned something. If managed returned empty (user never
+    // connected via managed mode), keep any existing BYO results.
+    if (managedResults.length > 0 && byoProviders.has(providerRow.provider)) {
       const beforeLen = results.length;
       const filtered = results.filter(
         (r) => r.provider !== providerRow.provider,
@@ -555,16 +586,7 @@ export async function checkAllCredentials(): Promise<CredentialHealthReport> {
         results.push(...filtered);
       }
     }
-
-    try {
-      const managedResults = await checkManagedProvider(providerRow);
-      results.push(...managedResults);
-    } catch (err) {
-      log.warn(
-        { err, provider: providerRow.provider },
-        "Failed to check managed provider health",
-      );
-    }
+    results.push(...managedResults);
   }
 
   const unhealthy = results.filter((r) => r.status !== "healthy");

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -347,7 +347,7 @@ async function checkManagedProvider(
     }
 
     const connections = allConnections.filter(
-      (c) => c.status?.toUpperCase() === "ACTIVE",
+      (c) => (c.status ?? "ACTIVE").toUpperCase() === "ACTIVE",
     );
 
     if (connections.length === 0) {

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -338,17 +338,10 @@ async function checkManagedProvider(
     ) as Array<{ id: string; account_label?: string }>;
 
     if (connections.length === 0) {
-      // No active managed connections — report as missing so the
-      // heartbeat can notify the user.
-      results.push({
-        connectionId: `managed:${providerRow.provider}`,
-        provider: providerRow.provider,
-        accountInfo: null,
-        status: "missing_token",
-        details: `No active managed connection for ${providerRow.provider}. Reconnect on the Vellum platform.`,
-        missingScopes: [],
-        canAutoRecover: false,
-      });
+      // No managed connections exist — the user has never connected this
+      // provider. The suggested-prompts system handles prompting them to
+      // connect; generating a missing_token alert here would create
+      // false-positive "reconnect" notifications.
       return results;
     }
 


### PR DESCRIPTION
## Summary
- `checkManagedProvider()` was reporting `missing_token` when the platform returned zero active connections for a managed provider — but that's the normal state for providers the user has never set up
- This caused bogus "reconnect" notifications for every managed provider (Google, Slack, Notion, GitHub, Linear, etc.) even if the user never connected them
- Fix: return empty results instead of a synthetic `missing_token` when no connections exist — the suggested-prompts system ("Connect Gmail", "Connect Slack", etc.) already handles prompting users to connect new services

## Root cause
Introduced in PR #30728 (`feat(health): add managed provider checks`). The `connections.length === 0` branch in `checkManagedProvider()` unconditionally treated "no connections" as a health failure, without distinguishing "never connected" from "previously connected but now broken."

## Test plan
- [x] Existing credential health service tests pass (23/23)
- [x] Existing heartbeat service tests pass (79/79)
- [ ] Manual: verify that users who never set up managed providers no longer see "reconnect" notifications in the home feed
- [ ] Manual: verify that users with active managed connections still get health alerts if their connection breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->