### PR TITLE
docs(web): add AGENTS.md — stack, commands, routing conventions, migration rules

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,47 @@
+# Web App — Agent Instructions
+
+Applies to all code under `apps/web/`. Subordinate to [`apps/AGENTS.md`](../AGENTS.md) and root [`AGENTS.md`](../../AGENTS.md).
+
+## Conventions and style
+
+Read these before making changes:
+
+- **[`CONVENTIONS.md`](./CONVENTIONS.md)** — Architecture, code organization, state management, component patterns, framework strategy, data fetching, testing.
+- **[`STYLE_GUIDE.md`](./STYLE_GUIDE.md)** — Naming, imports, TypeScript, component authoring, formatting.
+
+## Stack
+
+- **Build**: [Vite](https://vite.dev/) + [React 19](https://react.dev/blog/2024/12/05/react-19)
+- **Routing**: [React Router v7](https://reactrouter.com/) — [data mode](https://reactrouter.com/start/modes) (`createBrowserRouter`), NOT framework mode
+- **Client state**: [Zustand](https://zustand.docs.pmnd.rs/) (migration in progress from `useReducer` + Context)
+- **Server state**: [TanStack Query](https://tanstack.com/query/latest) with [HeyAPI plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query)
+- **Styling**: [Tailwind CSS v4](https://tailwindcss.com/) via `@tailwindcss/vite`
+- **Design system**: `@vellum/design-library` at [`packages/design-library/`](../../packages/design-library/)
+- **Platform**: Web + iOS via [Capacitor](https://capacitorjs.com/) — native code paths must be preserved
+
+## Routing
+
+- Route config: `src/routes.tsx`
+- Route constants: `src/utils/routes.ts` — all paths are absolute browser paths
+- No `basename` on the router — `/account/*` and `/assistant/*` are explicit top-level branches
+- Routes must match the platform repo exactly during migration (no URL changes)
+
+## Commands
+
+```bash
+cd apps/web && bun install            # Install dependencies
+cd apps/web && bun run dev            # Vite dev server (port 3001)
+cd apps/web && bun run openapi-ts     # Generate API client from OpenAPI specs
+cd apps/web && bunx tsc --noEmit      # Type-check
+cd apps/web && bun run lint           # Lint
+cd apps/web && bun run build          # Production build
+cd apps/web && bun test src/path/to/file.test.ts  # Run specific tests
+```
+
+## Migration status
+
+This app is being migrated from [`vellum-assistant-platform/web/`](https://github.com/vellum-ai/vellum-assistant-platform). During migration:
+
+- **Faithful copy, not simplification.** Port real implementations, not stubs. All Capacitor/native code paths must be preserved.
+- **Convention compliance on arrival.** Apply this repo's naming (kebab-case), import conventions (`.js` extensions, `@/` aliases), and directory structure as code is ported.
+- **No marketing or admin pages.** Only the assistant web app and auth/identity pages are migrating.


### PR DESCRIPTION
## Prompt / plan

Add `apps/web/AGENTS.md` — a thin reference file that gives agents the essential context they need (stack, commands, routing conventions, migration rules) without duplicating the comprehensive `CONVENTIONS.md` and `STYLE_GUIDE.md` already on main.

## What this adds

- **Conventions pointers** — directs agents to read `CONVENTIONS.md` and `STYLE_GUIDE.md` before making changes
- **Stack summary** — Vite, React 19, React Router v7 (data mode via `createBrowserRouter`), Zustand, TanStack Query, Tailwind CSS v4, Capacitor
- **Routing conventions** — documents the no-basename architecture: `/account/*` (auth pages, no app chrome) and `/assistant/*` (chat app with `RootLayout` → `ChatLayout`) as explicit top-level branches
- **Dev commands** — install, dev server, codegen, typecheck, lint, build, test
- **Migration rules** — faithful copy (not stubs), convention compliance on arrival, no marketing/admin pages

## What this does NOT do

- Does not duplicate architectural conventions already in `CONVENTIONS.md`
- Does not duplicate style rules already in `STYLE_GUIDE.md`
- Does not conflict with the `lib/` and cross-domain import conventions in those files

## Dependency

Merge [PR #31141](https://github.com/vellum-ai/vellum-assistant/pull/31141) first. The routing section documents the post-#31141 architecture (no `basename`, `/account/*` and `/assistant/*` as explicit top-level branches). On `main` today, `routes.tsx` still uses `basename: "/assistant"`.

## Test plan

- Read-only documentation change
- Verified links point to correct files
- CI passes (lint, typecheck, build)

### References

- [React Router v7 data mode](https://reactrouter.com/start/modes) — documents the distinction between data mode (`createBrowserRouter`) and framework mode
- [Vite dev server](https://vite.dev/guide/) — build tool reference
- [Capacitor](https://capacitorjs.com/) — native platform bridge

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
