### PR TITLE
docs(design-library): document JIT compilation strategy and dep requirements

### DIFF
--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -144,6 +144,10 @@ compiles on the fly. This means:
   imports through the consumer's `node_modules`. These deps are deduplicated
   at runtime by Vite — they only need to be listed for type resolution.
 
+For multi-consumer setups or when build times become a concern, consider
+the [compiled package strategy](https://turborepo.dev/docs/core-concepts/internal-packages#compiled-packages)
+instead.
+
 References:
 - [Turborepo — Internal Packages: Just-in-Time strategy](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages)
 - [Hiroki Osame — Think twice before importing package source files](https://hirok.io/posts/importing-source-files-in-dev) (tradeoffs of source imports)

--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -130,6 +130,26 @@ import { Button } from "@vellum/design-library/components/button";
 import { cn } from "@vellum/design-library/utils/cn";
 ```
 
+### Just-in-Time compilation
+
+This package uses the **Just-in-Time (JIT) internal package** strategy —
+it exports raw TypeScript source that the consuming app's bundler (Vite)
+compiles on the fly. This means:
+
+- **No build step required** — clone, `bun install`, and start developing.
+  Changes to design library components are picked up immediately by HMR.
+- **Consumer apps must list this package's dependencies** in their own
+  `package.json` (e.g. `react-markdown`, `remark-gfm`, Radix packages).
+  Because the `file:` link resolves to raw source, TypeScript resolves
+  imports through the consumer's `node_modules`. These deps are deduplicated
+  at runtime by Vite — they only need to be listed for type resolution.
+
+References:
+- [Turborepo — Internal Packages: Just-in-Time strategy](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages)
+- [Hiroki Osame — Think twice before importing package source files](https://hirok.io/posts/importing-source-files-in-dev) (tradeoffs of source imports)
+
+### Tailwind and token setup
+
 The consuming app must import the design token stylesheet and include this
 package's source in its Tailwind source scan:
 


### PR DESCRIPTION
## Prompt / plan

Document the design library's Just-in-Time (JIT) internal package strategy in the README so contributors understand why consumer apps must list the library's dependencies in their own `package.json`.

### Why

The design library exports raw TypeScript source via `file:` links — the consuming app's bundler (Vite) compiles it on the fly. This is the [JIT internal package strategy](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages). A consequence is that TypeScript resolves the library's imports through the consumer's `node_modules`, so deps like `react-markdown` and `remark-gfm` must be listed in the consumer's `package.json` even though no app code imports them directly.

Without this documentation, contributors will reasonably try to remove these "unused" deps — which breaks CI type-checking.

### Benefits

- Prevents future contributors from removing required transitive deps
- Documents the architectural decision and its tradeoffs with authoritative references
- Links to Turborepo docs and Hiroki Osame's analysis for deeper understanding

### Safety

- Documentation-only change — no code, no runtime behavior change

### Alternatives not taken

- **Compiled package strategy** (`tsc` build step): Would eliminate dep leakage but adds a mandatory build step before the app works. For an open-source repo where ease of local setup is a priority, the JIT approach is the better tradeoff. Revisit when the library grows large enough that build times or multi-consumer support justify the added complexity.

References:
- [Turborepo — Internal Packages](https://turborepo.dev/docs/core-concepts/internal-packages)
- [Hiroki Osame — Think twice before importing package source files](https://hirok.io/posts/importing-source-files-in-dev)

## Test plan

- Documentation-only change — verified markdown renders correctly by reading the file

Link to Devin session: https://app.devin.ai/sessions/ebe8eb71fe724e9c9dbfcb852edb8573
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->