### PR TITLE
feat: add VOICE.md workspace template for marketing niche voice tracking

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -303,6 +303,13 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   }
   if (options?.userPersona) systemParts.push(options.userPersona);
   if (options?.channelPersona) systemParts.push(options.channelPersona);
+
+  // Surface accumulated voice markers when VOICE.md has content.
+  const voiceContent = readPromptFile(getWorkspacePromptPath("VOICE.md"));
+  if (voiceContent) {
+    systemParts.push("# Voice Profile\n\n" + voiceContent);
+  }
+
   if (includeBootstrap) {
     const userSlug = options?.userSlug ?? "default";
     const bootstrapWithSlug = bootstrap.replaceAll(

--- a/assistant/src/prompts/templates/VOICE.md
+++ b/assistant/src/prompts/templates/VOICE.md
@@ -1,0 +1,3 @@
+_ Voice markers learned from this user's content and edits.
+_ The assistant appends observations here as a byproduct of drafting.
+_ Specific patterns only - no vague labels like "concise" or "professional".


### PR DESCRIPTION
## Summary
- Create VOICE.md template with comment-only scaffold for voice marker tracking
- Surface VOICE.md content in system prompt under Voice Profile header when present
- No impact on existing prompt behavior when VOICE.md is absent

Part of plan: gtm-bootstrap.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->