### PR TITLE
docs(web): clarify domain architecture, Zustand store conventions, and -store.ts naming

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -13,7 +13,7 @@ Read these before making changes:
 
 - **Build**: [Vite](https://vite.dev/) + [React 19](https://react.dev/blog/2024/12/05/react-19)
 - **Routing**: [React Router v7](https://reactrouter.com/) — [data mode](https://reactrouter.com/start/modes) (`createBrowserRouter`), NOT framework mode
-- **Client state**: [Zustand](https://zustand.docs.pmnd.rs/) (migration in progress from `useReducer` + Context)
+- **Client state**: [Zustand](https://zustand.docs.pmnd.rs/) — all shared state uses Zustand stores (see [CONVENTIONS.md — State management](./CONVENTIONS.md#state-management))
 - **Server state**: [TanStack Query](https://tanstack.com/query/latest) with [HeyAPI plugin](https://heyapi.dev/openapi-ts/plugins/tanstack-query)
 - **Styling**: [Tailwind CSS v4](https://tailwindcss.com/) via `@tailwindcss/vite`
 - **Design system**: `@vellum/design-library` at [`packages/design-library/`](../../packages/design-library/)

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -268,8 +268,7 @@ so consumers can subscribe to only the slice they need:
 ```ts
 import { create } from "zustand";
 import { useShallow } from "zustand/shallow";
-import { messageReducer } from "./message-reducer.js";
-import type { MessageAction } from "./types.js";
+import type { Message } from "./types.js";
 
 // State — the data
 export interface MessageState {
@@ -277,9 +276,11 @@ export interface MessageState {
   activeThreadId: string | null;
 }
 
-// Actions — stable function refs
+// Actions — direct named functions (no dispatch/reducer)
 export interface MessageActions {
-  dispatch: (action: MessageAction) => void;
+  addMessage: (message: Message) => void;
+  setActiveThread: (threadId: string | null) => void;
+  clearMessages: () => void;
 }
 
 // Combined store type
@@ -288,7 +289,12 @@ export type MessageStore = MessageState & MessageActions;
 export const useMessageStore = create<MessageStore>()((set) => ({
   messages: [],
   activeThreadId: null,
-  dispatch: (action) => set((state) => messageReducer(state, action)),
+  addMessage: (message) =>
+    set((s) => ({ messages: [...s.messages, message] })),
+  setActiveThread: (threadId) =>
+    set({ activeThreadId: threadId }),
+  clearMessages: () =>
+    set({ messages: [], activeThreadId: null }),
 }));
 
 // Convenience hooks for common access patterns
@@ -303,7 +309,11 @@ export function useMessageState(): MessageState {
 
 export function useMessageActions(): MessageActions {
   return useMessageStore(
-    useShallow((s) => ({ dispatch: s.dispatch })),
+    useShallow((s) => ({
+      addMessage: s.addMessage,
+      setActiveThread: s.setActiveThread,
+      clearMessages: s.clearMessages,
+    })),
   );
 }
 ```

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -78,6 +78,9 @@ top-level folder for domain modules is called **`domains/`**.
 
 ```
 src/
+  stores/                          # app-level Zustand stores (cross-domain)
+    viewer-store.ts
+    sse-connected-store.ts
   domains/                         # business domain modules
     messages/                      # message lifecycle
       message-store.ts
@@ -104,8 +107,8 @@ src/
         types.ts
     interactions/                   # user-facing prompts
       interaction-store.ts
-      interaction-state-machine.ts
-      interaction-state-machine.test.ts
+      interaction-reducer.ts
+      interaction-reducer.test.ts
       types.ts
   hooks/                           # cross-domain shared hooks
     use-is-mobile.ts
@@ -138,6 +141,21 @@ represents a bounded context.
 References:
 - [Bulletproof React — Project Structure](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md)
 - [React Router — Feature Folders](https://reactrouter.com/how-to/file-route-conventions)
+
+#### Domains do not map 1:1 to routes
+
+Domains are **business capabilities**, not URL segments. A route
+composes one or more domains; a domain may be used by zero or more
+routes. `conversations/`, `interactions/`, and `subagents/` have no
+routes of their own — they are composed by page-level domains
+(`chat/`, `home/`) that do map to routes.
+
+The dependency direction is one-way:
+`shared → domains → page domains → routes`.
+
+References:
+- [Bulletproof React — Project Structure](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md) — `features/` and `app/routes/` are separate top-level folders
+- [Feature-Sliced Design — Overview](https://feature-sliced.design/docs/get-started/overview) — "pages" (routes) and "features" (capabilities) are separate layers
 
 ### How to decide where the domain split is
 
@@ -172,6 +190,7 @@ directories. If something is domain-specific, it belongs inside
 
 | Folder | Purpose | Example contents |
 |---|---|---|
+| `stores/` | App-level Zustand stores (cross-domain state) | `viewer-store.ts`, `sse-connected-store.ts` |
 | `hooks/` | Cross-domain React hooks | `use-is-mobile.ts`, `use-visible-viewport.ts`, `use-keyboard-shortcuts.ts` |
 | `utils/` | Pure utility functions | `format.ts`, `browser.ts`, `network-status.ts`, `stable-id.ts` |
 | `types/` | Shared type definitions | `window.d.ts`, `api-types.ts` |
@@ -215,9 +234,9 @@ useReducer because:
   unacceptable during streaming (messages update every ~50ms).
 - **Framework-agnostic store definitions.** Store logic is plain
   TypeScript with no React dependency — portable across environments.
-- **Existing reducers drop in unchanged.** Reducer functions
-  (`turnReducer`, `interactionReducer`, `conversationListReducer`)
-  work as Zustand actions with no modification.
+- **Pure reducer functions as store actions.** Complex state
+  transitions use reducer functions (`(state, event) => state`) inside
+  Zustand stores — testable, deterministic, no React dependency.
 
 ```ts
 // Good — component only re-renders when its slice changes
@@ -326,13 +345,18 @@ References:
 - [Zustand — Prevent rerenders with useShallow](https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow)
 - [Zustand v5 selector best practices (community discussion)](https://github.com/pmndrs/zustand/discussions/2867)
 
-### useReducer for related state within a component
+### useReducer for component-local state only
 
-When two or more pieces of state change together or have
-interdependent transitions *within a single component or hook*,
-consolidate them into a `useReducer` with typed action events.
-Reserve `useState` for independent, single-value state (a boolean
-toggle, a text input value).
+When two or more pieces of **component-local** state change together
+or have interdependent transitions, consolidate them into a
+`useReducer` with typed action events. Reserve `useState` for
+independent, single-value state (a boolean toggle, a text input
+value).
+
+**Do not use `useReducer` for state shared across components.** Shared
+state belongs in a Zustand store. If the state has complex transitions,
+use a reducer function inside the Zustand store (see
+[Reducer functions inside Zustand stores](#reducer-functions-inside-zustand-stores)).
 
 ```ts
 // Good — related state transitions are atomic and self-documenting
@@ -349,10 +373,26 @@ function.
 
 Reference: [React — Scaling Up with Reducer and Context](https://react.dev/learn/scaling-up-with-reducer-and-context)
 
-### State machine reducers
+### Reducer functions inside Zustand stores
 
-State machines (turn state, interaction state) use typed domain events,
-not raw setters.
+Complex state with interdependent transitions (turn lifecycle,
+interaction prompts) uses a **pure reducer function** wrapped by a
+Zustand store — not `useReducer`. The reducer is the same
+`(state, event) => state` pure function; the difference is how it's
+wired:
+
+```ts
+// Good — reducer inside a Zustand store (shared state)
+export const useTurnStore = create<TurnStore>()((set) => ({
+  ...INITIAL_TURN_STATE,
+  dispatch: (event) => set((state) => turnReducer(state, event)),
+}));
+
+// Avoid — useReducer for shared state (forces prop-drilling dispatch)
+const [turnState, dispatch] = useReducer(turnReducer, INITIAL_TURN_STATE);
+```
+
+The reducer pattern is correct and recommended:
 
 - **Dispatch named events** (`SHOW_SECRET`, `DISMISS_CONFIRMATION`,
   `RESET_ALL`) instead of calling multiple `setState` functions.
@@ -362,7 +402,9 @@ not raw setters.
   verify transitions with unit tests before relying on integration
   tests.
 
-Reference: [React — useReducer](https://react.dev/reference/react/useReducer)
+References:
+- [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)
+- [React — Extracting State Logic into a Reducer](https://react.dev/learn/extracting-state-logic-into-a-reducer)
 
 ---
 
@@ -476,12 +518,12 @@ References:
 - [React Router v7 — Data Loading](https://reactrouter.com/how-to/data-loading)
 - [React — Separating Events from Effects](https://react.dev/learn/separating-events-from-effects)
 
-### URL-driven routing is the target architecture
+### URL-driven routing
 
-The target architecture uses URL routing directly via React Router v7
-nested routes, eliminating custom navigation state and URL-to-state sync
-effects. Each view state maps to a route; the URL is the source of
-truth.
+The app uses React Router v7 nested routes. Each view maps to a route;
+the URL is the source of truth. Custom in-memory navigation state
+(e.g. `MainView` enums synced to URLs via effects) should be replaced
+by routes as views are ported.
 
 References:
 - [React Router — Nested Routes](https://reactrouter.com/start/framework/routing#nested-routes)

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -92,9 +92,8 @@ src/
         chat-body.tsx
     conversations/                 # conversation CRUD, grouping, selection
       conversation-store.ts
+      conversation-store.test.ts
       use-conversation-loader.ts
-      conversation-reducer.ts
-      conversation-reducer.test.ts
       types.ts
     streaming/                     # SSE transport, event parsing
       stream-store.ts
@@ -107,8 +106,7 @@ src/
         types.ts
     interactions/                   # user-facing prompts
       interaction-store.ts
-      interaction-reducer.ts
-      interaction-reducer.test.ts
+      interaction-store.test.ts
       types.ts
   hooks/                           # cross-domain shared hooks
     use-is-mobile.ts
@@ -234,9 +232,9 @@ useReducer because:
   unacceptable during streaming (messages update every ~50ms).
 - **Framework-agnostic store definitions.** Store logic is plain
   TypeScript with no React dependency — portable across environments.
-- **Pure reducer functions as store actions.** Complex state
-  transitions use reducer functions (`(state, event) => state`) inside
-  Zustand stores — testable, deterministic, no React dependency.
+- **Direct named actions.** Store actions are plain functions that
+  call `set()` — no dispatchers, no action types, no switch statements.
+  See [Zustand store conventions](#zustand-store-conventions).
 
 ```ts
 // Good — component only re-renders when its slice changes
@@ -354,9 +352,8 @@ independent, single-value state (a boolean toggle, a text input
 value).
 
 **Do not use `useReducer` for state shared across components.** Shared
-state belongs in a Zustand store. If the state has complex transitions,
-use a reducer function inside the Zustand store (see
-[Reducer functions inside Zustand stores](#reducer-functions-inside-zustand-stores)).
+state belongs in a Zustand store with direct named actions (see
+[Direct named actions, not reducers](#direct-named-actions-not-reducers)).
 
 ```ts
 // Good — related state transitions are atomic and self-documenting
@@ -373,38 +370,46 @@ function.
 
 Reference: [React — Scaling Up with Reducer and Context](https://react.dev/learn/scaling-up-with-reducer-and-context)
 
-### Reducer functions inside Zustand stores
+### Direct named actions, not reducers
 
-Complex state with interdependent transitions (turn lifecycle,
-interaction prompts) uses a **pure reducer function** wrapped by a
-Zustand store — not `useReducer`. The reducer is the same
-`(state, event) => state` pure function; the difference is how it's
-wired:
+Zustand's recommended pattern is **direct named actions** — plain
+functions on the store that call `set()`. Do not use dispatchers,
+action-type strings, or switch-case reducers. The `redux` middleware
+exists for Redux migration paths but is not the idiomatic Zustand
+approach.
 
 ```ts
-// Good — reducer inside a Zustand store (shared state)
-export const useTurnStore = create<TurnStore>()((set) => ({
-  ...INITIAL_TURN_STATE,
-  dispatch: (event) => set((state) => turnReducer(state, event)),
+// Good — Zustand-idiomatic direct actions
+export const useTurnStore = create<TurnStore>()((set, get) => ({
+  phase: "idle" as TurnPhase,
+  activeTurnId: null as string | null,
+  activeToolCallCount: 0,
+
+  startTurn: (turnId: string) =>
+    set({ phase: "thinking", activeTurnId: turnId }),
+
+  startStreaming: () =>
+    set({ phase: "streaming" }),
+
+  completeTurn: () =>
+    set({ phase: "idle", activeTurnId: null, activeToolCallCount: 0 }),
+
+  incrementToolCalls: () =>
+    set((s) => ({ activeToolCallCount: s.activeToolCallCount + 1 })),
 }));
 
-// Avoid — useReducer for shared state (forces prop-drilling dispatch)
-const [turnState, dispatch] = useReducer(turnReducer, INITIAL_TURN_STATE);
+// Avoid — reducer/dispatch pattern (Redux holdover)
+dispatch: (action) => set((state) => turnReducer(state, action))
 ```
 
-The reducer pattern is correct and recommended:
-
-- **Dispatch named events** (`SHOW_SECRET`, `DISMISS_CONFIRMATION`,
-  `RESET_ALL`) instead of calling multiple `setState` functions.
-- **Guard against stale events.** Check `requestId` matches before
-  applying updates.
-- **Test the reducer in isolation.** Reducers are pure functions —
-  verify transitions with unit tests before relying on integration
-  tests.
+Each action is independently callable, testable, and discoverable via
+the store's TypeScript interface. Consumers call
+`useTurnStore.getState().startTurn(id)` or select individual actions
+via hooks — no action-type constants or switch statements needed.
 
 References:
-- [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)
-- [React — Extracting State Logic into a Reducer](https://react.dev/learn/extracting-state-logic-into-a-reducer)
+- [Zustand — Flux-inspired practice](https://zustand.docs.pmnd.rs/learn/guides/flux-inspired-practice) — "state can be updated without dispatched actions and reducers"
+- [Zustand — Updating state](https://zustand.docs.pmnd.rs/learn/guides/updating-state)
 
 ---
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -11,7 +11,8 @@ Vellum assistant web app (chat, settings, library, docs).
   **library / data-router mode** (`createBrowserRouter` +
   `<RouterProvider>`).
 - [Zustand](https://zustand.docs.pmnd.rs/) for shared client state
-  (messages, streaming, interactions, conversations).
+  (messages, streaming, interactions, conversations). See
+  [`CONVENTIONS.md`](./CONVENTIONS.md#state-management) for store patterns.
 - [TanStack React Query](https://tanstack.com/query/latest) for server
   state (API calls, caching, mutations).
 - [HeyAPI](https://heyapi.dev/) for OpenAPI client generation with
@@ -88,6 +89,7 @@ src/
   App.tsx                    # root layout component
   main.tsx                   # entry point (createRoot, RouterProvider)
   routes.tsx                 # route tree (createBrowserRouter)
+  stores/                    # app-level Zustand stores (cross-domain)
   domains/                   # business domain modules
     messages/                # message lifecycle
     conversations/           # conversation CRUD, grouping, selection

--- a/apps/web/STYLE_GUIDE.md
+++ b/apps/web/STYLE_GUIDE.md
@@ -21,7 +21,6 @@ keeps imports predictable.
 use-send-message.ts        # hook
 message-handlers.ts         # module
 conversation-store.ts       # Zustand store
-conversation-reducer.ts     # reducer (pure function used by store)
 chat-body.tsx               # component
 stream-event-types.ts       # types
 ```

--- a/apps/web/STYLE_GUIDE.md
+++ b/apps/web/STYLE_GUIDE.md
@@ -20,7 +20,8 @@ keeps imports predictable.
 ```
 use-send-message.ts        # hook
 message-handlers.ts         # module
-conversation-reducer.ts     # reducer
+conversation-store.ts       # Zustand store
+conversation-reducer.ts     # reducer (pure function used by store)
 chat-body.tsx               # component
 stream-event-types.ts       # types
 ```
@@ -65,6 +66,7 @@ src/
   App.tsx                    # root layout component
   main.tsx                   # entry point (createRoot, RouterProvider)
   routes.tsx                 # route tree (createBrowserRouter)
+  stores/                    # app-level Zustand stores (cross-domain)
   domains/                   # business domain modules
     messages/                # message lifecycle
     conversations/           # conversation CRUD, grouping, selection


### PR DESCRIPTION
## Prompt / plan

Update CONVENTIONS.md, STYLE_GUIDE.md, AGENTS.md, and README.md to reflect the agreed-upon architecture decisions from the Zustand migration and domain restructuring work (LUM-1622). These docs changes need to land first so all subsequent work (file restructuring, Zustand conversions) aligns to the same conventions.

### Why needed

The existing docs had several inaccuracies and gaps:
- No guidance on how domains relate to routes (they don't map 1:1)
- No mention of `src/stores/` for app-level cross-domain state
- The reducer/dispatch pattern was documented as the Zustand convention, but Zustand recommends direct named actions instead
- `useReducer` guidance didn't clarify it's for component-local state only
- "Target architecture" language implied React Router v7 was a future migration (it's current)
- AGENTS.md described Zustand as "migration in progress"

### What changed

**CONVENTIONS.md:**
- Added "Domains do not map 1:1 to routes" section with refs to [Bulletproof React](https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md) and [Feature-Sliced Design](https://feature-sliced.design/docs/get-started/overview)
- Added `src/stores/` to directory tree and shared directories table for app-level Zustand stores
- Replaced "Reducer functions inside Zustand stores" with "Direct named actions, not reducers" per [Zustand's Flux-inspired practice guide](https://zustand.docs.pmnd.rs/learn/guides/flux-inspired-practice) — idiomatic Zustand uses plain action functions on the store, not dispatch/reducer
- Scoped `useReducer` guidance to component-local state only, with cross-ref to Zustand for shared state
- Removed separate reducer file references from directory tree examples (actions live in the store file)
- Changed "URL-driven routing is the target architecture" → "URL-driven routing" (present tense — migration is complete)
- Updated Zustand rationale bullet from "existing reducers drop in" to "direct named actions"

**STYLE_GUIDE.md:**
- Added `conversation-store.ts` naming example, removed separate reducer file example
- Added `stores/` to directory structure

**AGENTS.md:**
- Changed Zustand description from "migration in progress from useReducer + Context" to link to CONVENTIONS.md state management section

**README.md:**
- Added `stores/` to directory structure
- Added link to CONVENTIONS.md for store patterns

### Alternatives not taken

- **Keep reducer/dispatch pattern**: Zustand's docs explicitly show this as a Redux migration path, not the recommended approach. The [Flux-inspired practice guide](https://zustand.docs.pmnd.rs/learn/guides/flux-inspired-practice) says "state can be updated without dispatched actions and reducers" and shows direct actions as the primary pattern.
- **Embed detailed Zustand API docs inline**: Per project convention, docs should be link-heavy and lightweight — detailed explanations link to authoritative sources rather than being embedded.

### Safety

Docs-only change — no runtime code modified. All markdown links verified.

## Test plan

- Verified all internal anchor links resolve correctly
- Docs-only PR, no code changes to verify

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->