### PR TITLE
docs(web): add auth middleware and Zustand auth store conventions

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -26,7 +26,7 @@ Read these before making changes:
 - No `basename` on the router — `/account/*` and `/assistant/*` are explicit top-level branches
 - Routes must match the platform repo exactly during migration (no URL changes)
 - **Route protection**: uses React Router v7 [middleware](https://reactrouter.com/how-to/middleware) (`v8_middleware` future flag), not layout gate components or `useEffect` redirects. See [CONVENTIONS.md — Route protection via middleware](./CONVENTIONS.md#route-protection-via-middleware).
-- **Auth is runtime-configurable**: `requiresAuth()` controls whether middleware enforces login — true for web/iOS, false for future Electron/macOS. See [CONVENTIONS.md — Auth is optional based on runtime](./CONVENTIONS.md#auth-is-optional-based-on-runtime).
+- **Auth is optional**: controlled by `VITE_AUTH_REQUIRED` env var — `"true"` for hosted/App Store, `"false"` (default) for local dev and self-hosting. See [CONVENTIONS.md — Auth is optional](./CONVENTIONS.md#auth-is-optional--controlled-by-environment-config).
 
 ## Commands
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -25,6 +25,8 @@ Read these before making changes:
 - Route constants: `src/utils/routes.ts` — all paths are absolute browser paths
 - No `basename` on the router — `/account/*` and `/assistant/*` are explicit top-level branches
 - Routes must match the platform repo exactly during migration (no URL changes)
+- **Route protection**: uses React Router v7 [middleware](https://reactrouter.com/how-to/middleware) (`v8_middleware` future flag), not layout gate components or `useEffect` redirects. See [CONVENTIONS.md — Route protection via middleware](./CONVENTIONS.md#route-protection-via-middleware).
+- **Auth is runtime-configurable**: `requiresAuth()` controls whether middleware enforces login — true for web/iOS, false for future Electron/macOS. See [CONVENTIONS.md — Auth is optional based on runtime](./CONVENTIONS.md#auth-is-optional-based-on-runtime).
 
 ## Commands
 

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -323,6 +323,24 @@ domain means adding or removing a folder.
 
 Reference: [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)
 
+### Auth state lives in a Zustand store
+
+Auth is cross-domain shared state — used by middleware, route
+components, API interceptors, and platform bridges. It lives in a
+Zustand store (`stores/auth-store.ts`), not a React Context. This
+is critical because:
+
+- **Middleware and loaders** need auth state outside the React tree —
+  `useAuthStore.getState()` works anywhere; Context requires a
+  component.
+- **API interceptors** need to read/write auth state synchronously.
+- **Selector support** — components subscribe to only the auth slice
+  they need (e.g., `useAuthStore(s => s.isAuthenticated)`).
+
+References:
+- [Zustand — Reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
+- [React Router — Middleware](https://reactrouter.com/how-to/middleware)
+
 ### Selector patterns and `useShallow`
 
 Selectors control re-render granularity. Choose the right pattern based
@@ -532,6 +550,81 @@ themselves.
 References:
 - [React Router v7 — Data Loading](https://reactrouter.com/how-to/data-loading)
 - [React — Separating Events from Effects](https://react.dev/learn/separating-events-from-effects)
+
+### Route protection via middleware
+
+Protected routes use React Router v7
+[middleware](https://reactrouter.com/how-to/middleware) (enabled via the
+`v8_middleware`
+[future flag](https://reactrouter.com/upgrading/future#futurev8_middleware)).
+Middleware runs **before** the route component renders — no flash of
+protected content, no `useEffect`-based redirects.
+
+```ts
+createBrowserRouter([
+  // Public — no middleware
+  { path: "/account/login", Component: LoginPage },
+
+  // Protected — auth middleware gates access
+  {
+    path: "/assistant",
+    middleware: [authMiddleware],
+    Component: RootLayout,
+    children: [/* ... */],
+  },
+], {
+  future: { v8_middleware: true },
+});
+```
+
+The auth middleware reads from the Zustand auth store (via
+`.getState()` — no hook needed) and throws `redirect("/account/login")`
+when unauthenticated. User data is passed downstream via React Router's
+typed
+[`context`](https://reactrouter.com/start/data/route-object/#middleware),
+accessible in loaders and components.
+
+#### Auth is optional — controlled by environment config
+
+Authentication is **not always required.** The hosted Vellum service
+(`vellum.ai`) and the App Store iOS app enforce login. But contributors
+running the app locally (`bun run dev`) or self-hosting it can use it
+without logging in — the same way they'd use a local desktop app.
+
+A `VITE_AUTH_REQUIRED` environment variable controls enforcement.
+Hosted deployments set it to `"true"`; the default is `"false"` so
+the app works out of the box for local development and self-hosting.
+
+| Environment | `VITE_AUTH_REQUIRED` | Behavior |
+|---|---|---|
+| Hosted web (`vellum.ai`) | `"true"` | Middleware redirects to `/account/login` |
+| App Store iOS (Capacitor) | `"true"` | Same — native login flow via ASWebAuthenticationSession |
+| Local dev / self-hosted | `"false"` (default) | Middleware passes through with anonymous context |
+| Future Electron/macOS | `"false"` (default) | Same — app usable without login |
+
+```ts
+async function authMiddleware({ context }) {
+  const { isAuthenticated, user } = useAuthStore.getState();
+
+  if (!requiresAuth()) {
+    // Local/self-hosted — allow anonymous usage
+    context.set(userContext, user ?? ANONYMOUS_USER);
+    return;
+  }
+
+  if (!isAuthenticated) {
+    throw redirect("/account/login");
+  }
+
+  context.set(userContext, user);
+}
+```
+
+References:
+- [React Router — Middleware](https://reactrouter.com/how-to/middleware)
+- [React Router — Future Flags (`v8_middleware`)](https://reactrouter.com/upgrading/future#futurev8_middleware)
+- [React Router collaborator recommendation for SPA auth](https://github.com/remix-run/react-router/discussions/14697)
+- [Vite — Env Variables](https://vite.dev/guide/env-and-mode.html)
 
 ### URL-driven routing
 


### PR DESCRIPTION
## Prompt / plan

Adds conventions for auth-protected routes to `CONVENTIONS.md` and `AGENTS.md` before the auth implementation PR lands. This ensures any parallel work follows the researched patterns.

Based on independent research of:
- [React Router v7 middleware](https://reactrouter.com/how-to/middleware) (`v8_middleware` future flag)
- [React Router collaborator recommendation for SPA auth](https://github.com/remix-run/react-router/discussions/14697)
- [Zustand — reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
- [Vite — Env Variables](https://vite.dev/guide/env-and-mode.html)

### What's added

**CONVENTIONS.md:**
- "Route protection via middleware" section — documents using React Router v7 middleware (not layout gate components or `useEffect` redirects) for auth guards with `v8_middleware` future flag.
- "Auth is optional — controlled by environment config" subsection — `VITE_AUTH_REQUIRED` env var controls enforcement. Default `"false"` so the app works out of the box for local dev, self-hosting, and open-source contributors. Hosted/App Store deployments set `"true"`.
- "Auth state lives in a Zustand store" section — documents why auth uses Zustand at `stores/auth-store.ts` (middleware/loader access via `.getState()`, selector support) instead of React Context.

**AGENTS.md:**
- Routing section updated with middleware and env-config auth references.

### Why `stores/auth-store.ts` not `lib/auth/auth-store.ts`

Auth state is cross-domain shared state used by middleware, API interceptors, and platform bridges — that's app-level state per our conventions. `lib/` is for configured third-party wrappers (api-client, csrf, telemetry). App-level Zustand stores belong in `src/stores/`.

## Test plan

Docs-only change. Verified markdown renders correctly, all links resolve, and content aligns with #31160's conventions (rebased on top of it).

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka