### PR TITLE
fix: add cohort to route handler types and document template guard

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -234,6 +234,11 @@ export function maybeReseedBootstrapForCohort(cohort: string): void {
   if (!existsSync(bootstrapPath)) return;
 
   const currentContent = readPromptFile(bootstrapPath);
+  // Compare against the GENERIC "BOOTSTRAP.md" template, not the cohort-
+  // specific one.  After the swap, the workspace content no longer matches
+  // the generic template, so this guard returns false on subsequent calls —
+  // making the swap idempotent.  Do NOT change the comparison target to the
+  // cohort template filename; that would re-swap on every prompt build.
   if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return;
 
   const templatesDir = resolveBundledDir(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1033,6 +1033,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tone: string;
   userName?: string;
   assistantName?: string;
+  cohort?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1110,6 +1111,7 @@ export async function handleSendMessage(
       assistantName?: string;
       googleConnected?: boolean;
       googleScopes?: string[];
+      cohort?: string;
     };
   };
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for gtm-bootstrap.md.

**Gap 1:** Add `cohort?: string` to `handleSendMessage` body type and `persistOnboardingArtifacts` parameter type for consistency with OnboardingContext.
**Gap 2:** Add inline comment on `isTemplateContent` guard in `maybeReseedBootstrapForCohort` to prevent future maintainers from changing the comparison target.