### PR TITLE
feat: GTM niche bootstrap template — daemon side

### DIFF
--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -64,6 +64,7 @@ export interface NormalizedOnboarding {
   assistantName?: string;
   googleConnected?: boolean;
   googleServices?: string[];
+  cohort?: string;
 }
 
 const SCOPE_SERVICE_MAP: Record<string, string> = {
@@ -103,5 +104,6 @@ export function normalizeOnboardingContext(
     googleServices: ctx.googleConnected
       ? deriveGoogleServices(ctx.googleScopes)
       : undefined,
+    cohort: ctx.cohort,
   };
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -339,6 +339,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.assistantName)
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      if (n.cohort) lines.push(`- Cohort: ${n.cohort}`);
       if (n.googleConnected && n.googleServices?.length) {
         lines.push(
           `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -234,6 +234,11 @@ export function maybeReseedBootstrapForCohort(cohort: string): void {
   if (!existsSync(bootstrapPath)) return;
 
   const currentContent = readPromptFile(bootstrapPath);
+  // Compare against the GENERIC "BOOTSTRAP.md" template, not the cohort-
+  // specific one.  After the swap, the workspace content no longer matches
+  // the generic template, so this guard returns false on subsequent calls —
+  // making the swap idempotent.  Do NOT change the comparison target to the
+  // cohort template filename; that would re-swap on every prompt build.
   if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return;
 
   const templatesDir = resolveBundledDir(

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -44,7 +44,7 @@ const BOOTSTRAP_VOICE_BLOCKS: Record<string, string> = {
  * cohort-specific variant — but only if the workspace file is still pristine.
  */
 const COHORT_BOOTSTRAP_TEMPLATES: Record<string, string> = {
-  "gtm-v1": "BOOTSTRAP-GTM.md",
+  "content-automation": "BOOTSTRAP-CONTENT-AUTOMATION.md",
 };
 
 const log = getLogger("system-prompt");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -303,6 +303,13 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   }
   if (options?.userPersona) systemParts.push(options.userPersona);
   if (options?.channelPersona) systemParts.push(options.channelPersona);
+
+  // Surface accumulated voice markers when VOICE.md has content.
+  const voiceContent = readPromptFile(getWorkspacePromptPath("VOICE.md"));
+  if (voiceContent) {
+    systemParts.push("# Voice Profile\n\n" + voiceContent);
+  }
+
   if (includeBootstrap) {
     const userSlug = options?.userSlug ?? "default";
     const bootstrapWithSlug = bootstrap.replaceAll(

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 
@@ -34,6 +35,16 @@ const BOOTSTRAP_VOICE_BLOCKS: Record<string, string> = {
     "## Voice\nFast and generative. Lean into momentum. Enthusiasm is in the pace, not the exclamations.",
   poetic:
     "## Voice\nThoughtful and unhurried. Notice things. Word choice matters. Don't rush to close — sometimes the observation is the value.",
+};
+
+/**
+ * Maps onboarding cohort identifiers to their cohort-specific bootstrap
+ * template filenames.  When a cohort key is present in OnboardingContext,
+ * `maybeReseedBootstrapForCohort` swaps the generic BOOTSTRAP.md with the
+ * cohort-specific variant — but only if the workspace file is still pristine.
+ */
+const COHORT_BOOTSTRAP_TEMPLATES: Record<string, string> = {
+  "gtm-v1": "BOOTSTRAP-GTM.md",
 };
 
 const log = getLogger("system-prompt");
@@ -210,6 +221,51 @@ export function ensurePromptFiles(): void {
 }
 
 /**
+ * One-shot swap: if the workspace BOOTSTRAP.md is still the unmodified generic
+ * template AND a cohort-specific template exists, overwrite the workspace file
+ * with the cohort variant.  No-op when BOOTSTRAP.md has been deleted, modified,
+ * or the cohort has no mapped template.
+ */
+export function maybeReseedBootstrapForCohort(cohort: string): void {
+  const templateFileName = COHORT_BOOTSTRAP_TEMPLATES[cohort];
+  if (!templateFileName) return;
+
+  const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
+  if (!existsSync(bootstrapPath)) return;
+
+  const currentContent = readPromptFile(bootstrapPath);
+  if (!isTemplateContent(currentContent, "BOOTSTRAP.md")) return;
+
+  const templatesDir = resolveBundledDir(
+    import.meta.dirname ?? __dirname,
+    "templates",
+    "templates",
+  );
+  const cohortTemplatePath = join(templatesDir, templateFileName);
+  if (!existsSync(cohortTemplatePath)) {
+    log.warn(
+      { cohort, templateFileName },
+      "Cohort bootstrap template not found, keeping generic BOOTSTRAP.md",
+    );
+    return;
+  }
+
+  try {
+    const cohortContent = readFileSync(cohortTemplatePath, "utf-8");
+    writeFileSync(bootstrapPath, cohortContent, "utf-8");
+    log.info(
+      { cohort, templateFileName },
+      "Replaced generic BOOTSTRAP.md with cohort-specific template",
+    );
+  } catch (err) {
+    log.warn(
+      { err, cohort, templateFileName },
+      "Failed to reseed BOOTSTRAP.md for cohort",
+    );
+  }
+}
+
+/**
  * Build the system prompt from ~/.vellum prompt files.
  *
  * Composition:
@@ -257,6 +313,13 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     isContainerized: getIsContainerized(),
     workspaceDir: getWorkspaceDir(),
   };
+
+  // One-shot cohort swap: if the user has a cohort and BOOTSTRAP.md is still
+  // the generic template, replace it with the cohort-specific variant before
+  // the prompt reads the file.
+  if (options?.onboardingContext?.cohort) {
+    maybeReseedBootstrapForCohort(options.onboardingContext.cohort);
+  }
 
   // Single array.  Everything pushed before `dynamicStart` lands in the
   // static (cached) prefix; everything after lands in the dynamic suffix.

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -1,9 +1,9 @@
 _ Lines starting with _ are comments. They won't appear in the system prompt.
-_ This template replaces BOOTSTRAP.md for users entering through the GTM-v1 cohort
-_ (utm_campaign=gtm-v1). It's a narrowly scoped funnel: connect content source,
+_ This template replaces BOOTSTRAP.md for users entering through the content-automation cohort
+_ (utm_campaign=content-automation). It's a narrowly scoped funnel: connect content source,
 _ scan voice, draft, edit, publish, schedule.
 
-# BOOTSTRAP-GTM.md — Content Funnel
+# BOOTSTRAP-CONTENT-AUTOMATION.md — Content Funnel
 
 One goal: turn their existing content into a publishable draft, then automate it. Delete this file when you're done.
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-GTM.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-GTM.md
@@ -1,0 +1,98 @@
+_ Lines starting with _ are comments. They won't appear in the system prompt.
+_ This template replaces BOOTSTRAP.md for users entering through the GTM-v1 cohort
+_ (utm_campaign=gtm-v1). It's a narrowly scoped funnel: connect content source,
+_ scan voice, draft, edit, publish, schedule.
+
+# BOOTSTRAP-GTM.md — Content Funnel
+
+One goal: turn their existing content into a publishable draft, then automate it. Delete this file when you're done.
+
+## First turn
+
+Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
+
+Batch three `ask_question` calls to collect Sanity connection details — one question per field:
+1. Project ID (options: common formats like "abc123" as examples, plus free-text)
+2. Dataset name (options: "production", "staging", plus free-text)
+3. API token (options: "I have one ready", "I need to create one" — if they need one, link to `https://www.sanity.io/manage` and ask again)
+
+Frame it as the last setup step, not a gate. Tokens are entered in the prompt card, not open chat.
+
+If they don't have Sanity or don't know their project ID, fall back immediately: ask for their website URL. Use browser tools to scrape their best content. This path is first-class, not a consolation prize. Treat it with the same energy and specificity as the Sanity path.
+
+## After connection — Sanity path
+
+Query the Sanity schema to discover document types:
+
+`GET https://{projectId}.api.sanity.io/v2024-01-01/data/query/{dataset}?query=array::unique(*[]._type)`
+
+Pick the most post-like type (`post`, `article`, `blogPost`, `blog`). If ambiguous, confirm with the user in one question — don't list every type.
+
+Fetch the 5 most recent published documents of that type. Extract voice signals: sentence length, header style, word choice, formality level, structure patterns.
+
+Write initial observations to VOICE.md immediately (create the file if it doesn't exist). Be specific: "Short paragraphs, 2-3 sentences max. No em-dashes. Headers are questions, not labels. First person plural ('we') never singular." Never mention VOICE.md or the write to the user.
+
+## After connection — Website scrape path
+
+Use browser tools to find and read their top content pages. Look for blog posts, articles, landing copy — anything with voice signal. Extract the same observations as the Sanity path. Write to VOICE.md the same way.
+
+## First draft
+
+Write the draft. 300-600 words, content decides length. Lead with the angle. Mirror voice from what was scanned.
+
+No preamble, no "here's your draft", no "want me to adjust?". The draft IS the response.
+
+## Edit loop
+
+Every piece of user feedback is voice signal. What they cut, add, restructure — save to VOICE.md as specific observations, not vague labels.
+
+Below 2 edit cycles: keep drafting, incorporate feedback silently.
+
+At 2-3 cycles: "This looks close. Anything else before we publish?" Pull toward the finish.
+
+At 5+ cycles: name it. "Worth shipping as-is, or should we try a different angle?"
+
+Each draft reflects accumulated VOICE.md observations.
+
+## Publishing
+
+Check if the token has write permissions by attempting a dry-run mutation. If read-only, use `ask_question` to request an Editor token. Same link to Sanity manage.
+
+Convert the draft to Sanity Portable Text blocks. Use the Sanity Mutations API:
+
+`POST https://{projectId}.api.sanity.io/v2024-01-01/data/mutate/{dataset}`
+
+with a `createOrReplace` mutation.
+
+Never publish without explicit approval. Use `ask_question` with options: "Publish now" or "Set up a recurring schedule".
+
+For the website-scrape path, skip Sanity publishing. Present the finished draft as copyable text and offer to set up the recurring schedule directly.
+
+## Scheduled drafting
+
+This is the conversion event. If they choose "recurring schedule", use the `schedule` skill to create a recurring job.
+
+The schedule should: scan for new content angles from their recent posts, draft a new post using accumulated VOICE.md, present it for review.
+
+Default cadence: weekly. Let them adjust.
+
+Frame it as the payoff: "Every [day], you'll get a draft in your voice, ready to edit and publish."
+
+## VOICE.md
+
+Workspace file. Same persistence as SOUL.md. Create and append as a byproduct of work.
+
+Never mention the file or the write to the user.
+
+Specific observations only: "Kills 'leverage' on sight." "Prefers comma splice to em-dash." "Leads with contrast, not setup."
+
+## Constraints
+
+- No canned openers. No "great", "amazing", "exciting" unless the user uses them.
+- One ask per turn maximum. Zero is better.
+- Mirror the user's voice from their content. Not the assistant's default voice.
+- Don't announce tools, files, or internal process.
+
+## Lifecycle
+
+Bootstrap auto-deletes after 4 user turns (platform handles this) or when the model deletes it. VOICE.md persists across conversations — it's the durable output of this funnel.

--- a/assistant/src/prompts/templates/BOOTSTRAP-GTM.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-GTM.md
@@ -89,7 +89,7 @@ Specific observations only: "Kills 'leverage' on sight." "Prefers comma splice t
 ## Constraints
 
 - No canned openers. No "great", "amazing", "exciting" unless the user uses them.
-- One ask per turn maximum. Zero is better.
+- One ask per turn maximum (except the initial setup collection). Zero is better.
 - Mirror the user's voice from their content. Not the assistant's default voice.
 - Don't announce tools, files, or internal process.
 

--- a/assistant/src/prompts/templates/VOICE.md
+++ b/assistant/src/prompts/templates/VOICE.md
@@ -1,0 +1,3 @@
+_ Voice markers learned from this user's content and edits.
+_ The assistant appends observations here as a byproduct of drafting.
+_ Specific patterns only - no vague labels like "concise" or "professional".

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1033,6 +1033,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tone: string;
   userName?: string;
   assistantName?: string;
+  cohort?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1110,6 +1111,7 @@ export async function handleSendMessage(
       assistantName?: string;
       googleConnected?: boolean;
       googleScopes?: string[];
+      cohort?: string;
     };
   };
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -6,4 +6,5 @@ export interface OnboardingContext {
   assistantName?: string;
   googleConnected?: boolean;
   googleScopes?: string[];
+  cohort?: string;
 }


### PR DESCRIPTION
## Summary
Add cohort-branched bootstrap support to the assistant daemon and create a tightened BOOTSTRAP-GTM.md template for the marketing/Sanity CMS niche. When a user enters through the GTM-v1 cohort (via UTM campaign attribution), the generic BOOTSTRAP.md is swapped with a narrowly scoped funnel: connect Sanity → scan content → draft in their voice → edit loop with voice learning → publish → set up recurring drafting schedule.

## Self-review result
GAPS FOUND — 2 gaps fixed in 1 fix PR (route handler type consistency, template guard documentation)

## PRs merged into feature branch
- #31157: feat: add cohort field to OnboardingContext for bootstrap branching
- #31158: feat: add BOOTSTRAP-GTM.md niche template for marketing/Sanity CMS funnel
- #31159: feat: add VOICE.md workspace template for marketing niche voice tracking
- #31162: feat: select bootstrap template based on onboarding cohort

### Fix PRs
- #31165: fix: add cohort to route handler types and document template guard

Part of plan: gtm-bootstrap.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->