### PR TITLE
Add Vellum repo quality Cursor skills

### DIFF
--- a/.cursor/skills/vellum-boundary-guard/SKILL.md
+++ b/.cursor/skills/vellum-boundary-guard/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: vellum-boundary-guard
+description: Check Vellum Assistant architecture and package boundaries. Use when editing imports, moving code, adding endpoints, touching assistant/gateway/client/skill boundaries, or reviewing architecture-sensitive changes.
+---
+
+# Vellum Boundary Guard
+
+## Package Import Boundaries
+
+Enforce these boundaries:
+
+- `assistant/` must not import from `gateway/` via relative paths.
+- `gateway/` must not import from `assistant/` via relative paths.
+- `assistant/` and `skills/` must not import from each other directly.
+- Runtime code must not import from `meta/`.
+- Shared cross-package logic belongs in `packages/`.
+
+For tests that need behavior from another package, mock the boundary instead of importing real handlers.
+
+## HTTP And IPC Boundaries
+
+- Public inbound HTTP endpoints belong in `gateway/`.
+- New CLI-to-assistant interactions should use Unix socket IPC through the existing IPC route pattern.
+- Events from assistant runtime code should use the assistant event hub rather than new HTTP endpoints when possible.
+
+## Security Ownership Boundaries
+
+- Gateway owns trust rules and gateway security files.
+- CES owns credential files.
+- The assistant must not read gateway-owned directories directly.
+- Clients must not read from the user's `~/.vellum` directory.
+- Secrets must not be stored in workspace files.
+
+## Skill Boundaries
+
+First-party skills run as separate processes and should communicate through supported contracts. Do not bypass skill isolation with direct relative imports.
+
+## Review Workflow
+
+1. Search changed imports and new route registrations.
+2. Identify any package-crossing dependency.
+3. Decide whether the correct home is a package-local module, a shared `packages/` module, IPC, HTTP through gateway, or a skill contract.
+4. If a violation exists, recommend the smallest boundary-preserving move.
+
+## Verification
+
+Prefer existing guard tests when available, then add focused tests for any new boundary rule or route pattern.

--- a/.cursor/skills/vellum-change-review/SKILL.md
+++ b/.cursor/skills/vellum-change-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: vellum-change-review
+description: Review Vellum Assistant code changes for correctness, repo-specific quality rules, security risks, and missing validation. Use when reviewing diffs, preparing a PR, finishing implementation work, or when the user asks for a code review, quality pass, or pre-merge check in this repository.
+---
+
+# Vellum Change Review
+
+## Review Stance
+
+Prioritize bugs, behavioral regressions, security risks, migration gaps, broken package boundaries, and missing tests. Findings come before summaries. Avoid cosmetic feedback unless it affects correctness, maintainability, or user experience.
+
+## Required Checks
+
+1. Inspect the actual diff before judging the change.
+2. Identify which packages are affected: `assistant`, `gateway`, `clients`, `cli`, `skills`, `packages`, or `meta`.
+3. Check package boundaries:
+   - `assistant` must not import from `gateway` by relative path.
+   - `gateway` must not import from `assistant` by relative path.
+   - `assistant` and `skills` must not import each other directly.
+   - Runtime code must not import from `meta`.
+4. Check persistence changes:
+   - DB schema or data changes need append-only DB migrations.
+   - Workspace path, format, or file changes need append-only workspace migrations.
+   - Migrations must be idempotent and registered.
+5. Check feature flags:
+   - New assistant flags must be declared in `meta/feature-flags/feature-flag-registry.json`.
+   - Default-disabled or rollout-only features must not ship user-facing release notes.
+   - New flags may require a companion platform PR.
+6. Check user-facing text:
+   - User-facing copy should say "assistant", not "daemon".
+   - Examples must use generic names, emails, phone numbers, and IDs.
+7. Check LLM/provider usage:
+   - LLM calls must go through the provider abstraction.
+   - Comments and logs should use provider-agnostic wording.
+8. Check tests and verification:
+   - Look for focused tests covering changed behavior.
+   - Prefer scoped `bun test path/to/test.ts`; never suggest broad `bun test`.
+   - Suggest `bunx tsc --noEmit` when type-level risk is broad.
+
+## Review Output
+
+Use this structure:
+
+```markdown
+## Findings
+- [severity] `path`: issue, impact, and concrete fix.
+
+## Open Questions
+- Any uncertainty that affects correctness or review confidence.
+
+## Verification Gaps
+- Tests or checks that still need to run.
+```
+
+If no issues are found, say that clearly and still mention residual risk or unrun checks.

--- a/.cursor/skills/vellum-feature-flag-rollout/SKILL.md
+++ b/.cursor/skills/vellum-feature-flag-rollout/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: vellum-feature-flag-rollout
+description: Guide Vellum Assistant feature flag changes and rollout hygiene. Use when adding, editing, reviewing, or documenting assistant feature flags, rollout-gated behavior, or LaunchDarkly/platform flag follow-up work.
+---
+
+# Vellum Feature Flag Rollout
+
+## Flag Rules
+
+Assistant feature flags use simple kebab-case keys and must be declared in:
+
+```text
+meta/feature-flags/feature-flag-registry.json
+```
+
+New flags require:
+
+- `scope: "assistant"`
+- a canonical kebab-case key
+- a safe default
+- tests or guard coverage when resolver behavior changes
+- a companion `vellum-assistant-platform` PR to provision the flag in Terraform
+
+## Rollout Hygiene
+
+Do not ship user-facing release notes for default-disabled or rollout-only features. `UPDATES.md` processing does not check feature flags, so flagged copy can leak into user-facing prompts.
+
+When a feature later reaches GA, add a new append-only release-note migration. Do not mutate an old no-op migration into a release-note migration.
+
+## Permission Controls V2
+
+Under `permission-controls-v2`, do not add new deterministic approval modes for assistant-owned actions beyond the conversation-scoped host computer access gate. Avoid global toggles, persistent trust-rule UI, wildcard scopes, and time-window approvals.
+
+## Review Workflow
+
+1. Confirm whether the change adds, renames, removes, or consumes a flag.
+2. Check registry declaration and key format.
+3. Check default behavior and rollout safety.
+4. Check docs, release notes, and user-facing copy for flag leaks.
+5. Check whether the platform repo needs a Terraform update.
+6. Recommend focused tests for resolver, route, UI, or behavior changes.
+
+## PR Notes
+
+Call out:
+
+- flag key
+- default state
+- rollout plan
+- companion platform PR status
+- whether release notes are intentionally omitted

--- a/.cursor/skills/vellum-migration-checklist/SKILL.md
+++ b/.cursor/skills/vellum-migration-checklist/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: vellum-migration-checklist
+description: Validate Vellum Assistant database and workspace migrations. Use when adding, editing, reviewing, or testing migrations, release-note migrations, persisted schemas, workspace file formats, or data backfills.
+---
+
+# Vellum Migration Checklist
+
+## When A Migration Is Required
+
+Use a migration for shipped interfaces and persisted data:
+
+- DB schema changes, indexes, backfills, or persisted row shape changes.
+- Workspace file renames, moves, format changes, or namespace changes.
+- Stored config or data that existing installs must keep reading.
+
+Do not delete migration files. Migrations are append-only, even when their logic becomes obsolete.
+
+## DB Migrations
+
+For DB migrations:
+
+1. Add a new file under `assistant/src/memory/migrations/`.
+2. Make it idempotent and safe to retry after interruption.
+3. Register it in the migration index or registry used by DB init.
+4. Update schema modules if the runtime schema changed.
+5. Add or update a focused `db-*migration*.test.ts` test.
+
+Check for ordering drift and never reorder existing migrations.
+
+## Workspace Migrations
+
+For workspace migrations:
+
+1. Add a new numbered file under `assistant/src/workspace/migrations/`.
+2. Append it to `WORKSPACE_MIGRATIONS` in `assistant/src/workspace/migrations/registry.ts`.
+3. Make the migration idempotent.
+4. Add or update a focused `workspace-migration-*.test.ts` test.
+
+Never reuse or reorder existing migration IDs.
+
+## Release Notes Migrations
+
+Release notes are workspace migrations that append to `UPDATES.md`.
+
+Required:
+
+- Only add release notes for GA user-facing changes.
+- Do not add release notes for default-disabled, rollout-only, or feature-flagged features.
+- Include an HTML marker such as `<!-- release-note-id:<migration-id> -->`.
+- Read `UPDATES.md` first and skip the append if the marker already exists.
+
+The runner checkpoint is not enough to prevent duplicate appends after crash or partial failure.
+
+## Verification
+
+Run the focused migration test first. Add package typecheck when migration exports, schema types, or registry wiring changed:
+
+```bash
+cd assistant && bun test src/__tests__/workspace-migration-example.test.ts
+cd assistant && bun test src/__tests__/db-example-migrations.test.ts
+cd assistant && bunx tsc --noEmit
+```
+
+Replace example paths with the actual test files related to the change.

--- a/.cursor/skills/vellum-pr-readiness/SKILL.md
+++ b/.cursor/skills/vellum-pr-readiness/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: vellum-pr-readiness
+description: Prepare Vellum Assistant branches for review by checking git hygiene, PR scope, tests, docs, migrations, Linear linking, and companion repo needs. Use before creating a pull request, splitting work into PRs, or asking whether a branch is ready.
+---
+
+# Vellum PR Readiness
+
+## Goal
+
+Confirm the branch is reviewable, scoped, and verified before opening a PR. Prefer surfacing blockers over polishing summaries.
+
+## Checklist
+
+1. Inspect `git status` and identify unrelated changes, generated artifacts, deleted files, and untracked files.
+2. Inspect staged and unstaged diffs before recommending a commit or PR.
+3. Check for secrets:
+   - Do not commit `.env`, credentials, tokens, private keys, or local workspace data.
+   - `.env.example` is allowed only for placeholder values.
+4. Check scope:
+   - If the branch is too large, suggest using `split-to-prs`.
+   - Separate unrelated UI, backend, migration, and infra changes when practical.
+5. Check required follow-ups:
+   - Migration needed for persisted data or workspace format changes.
+   - Docs needed for significant architecture, service, or data-flow changes.
+   - Companion `vellum-assistant-platform` PR needed for platform-affecting contracts or new feature flags.
+6. Check Linear conventions:
+   - Branch, commit body, and PR body should include the Linear issue ID when one exists.
+   - Use `Closes JARVIS-123` for single final PRs.
+   - Use `Part of JARVIS-123` for intermediate PRs in multi-PR plans.
+7. Check verification:
+   - Focused tests ran for changed behavior.
+   - Typecheck ran when exported contracts or cross-package types changed.
+   - Any skipped tests are explicitly called out.
+
+## PR Body Template
+
+Use this compact structure unless the user asks for another format:
+
+```markdown
+## Summary
+- ...
+
+## Test Plan
+- ...
+
+## Risk
+- ...
+```
+
+Mention migrations, feature flags, rollout state, and companion PRs when relevant.
+
+## Human Attention Comments
+
+For non-routine changes, leave a PR comment calling out review focus and risk level. Skip this for routine low-risk changes.

--- a/.cursor/skills/vellum-pr-readiness/SKILL.md
+++ b/.cursor/skills/vellum-pr-readiness/SKILL.md
@@ -17,7 +17,7 @@ Confirm the branch is reviewable, scoped, and verified before opening a PR. Pref
    - Do not commit `.env`, credentials, tokens, private keys, or local workspace data.
    - `.env.example` is allowed only for placeholder values.
 4. Check scope:
-   - If the branch is too large, suggest using `split-to-prs`.
+   - If the branch is too large, suggest splitting it into smaller, reviewable PR branches.
    - Separate unrelated UI, backend, migration, and infra changes when practical.
 5. Check required follow-ups:
    - Migration needed for persisted data or workspace format changes.

--- a/.cursor/skills/vellum-skill-authoring/SKILL.md
+++ b/.cursor/skills/vellum-skill-authoring/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: vellum-skill-authoring
+description: Author and review first-party Vellum skills in the repository. Use when editing files under skills/, assistant bundled skills, skill manifests, tool definitions, SKILL.md files, or first-party skill portability and isolation behavior.
+---
+
+# Vellum Skill Authoring
+
+## Scope
+
+Use this for Vellum runtime skills in `skills/` and bundled assistant skills, not for Cursor Agent Skills under `.cursor/skills/`.
+
+## Core Constraints
+
+- First-party skills must be portable and isolated.
+- `skills/` must not import from `assistant/`.
+- `assistant/` must not import from `skills/`.
+- Prefer skill processes and supported contracts over new daemon tool registrations.
+- Avoid secrets, real personal data, and machine-specific paths in skill docs, tests, and fixtures.
+
+## SKILL.md Quality Bar
+
+Skill instructions should be concise and operational:
+
+- State what the skill does and when to use it.
+- Prefer concrete steps over broad advice.
+- Keep user-facing terminology consistent.
+- Use generic examples only.
+- Avoid requiring hidden local state unless setup instructions create it.
+
+## Tool And Script Review
+
+When a skill adds scripts or tools:
+
+1. Verify tool input/output contracts are explicit.
+2. Check error handling and user-facing messages.
+3. Confirm scripts can run in the skill process environment.
+4. Avoid direct imports across isolation boundaries.
+5. Add focused tests for parsing, contract handling, and failure cases.
+
+## Catalog And Packaging
+
+When adding or renaming skills, check the relevant catalog, manifest, bundled registry, or packaging path used by the runtime. Do not assume a `SKILL.md` file alone makes the skill available to users.
+
+## Verification
+
+Use focused tests around the changed skill, catalog entry, proxy bridge, or bundled registry. Add typecheck when contracts or generated manifests changed.

--- a/.cursor/skills/vellum-test-selection/SKILL.md
+++ b/.cursor/skills/vellum-test-selection/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: vellum-test-selection
+description: Select focused verification commands for Vellum Assistant changes. Use when deciding what tests, typechecks, lints, or smoke checks to run after editing this repository, especially before commits and pull requests.
+---
+
+# Vellum Test Selection
+
+## Core Rule
+
+Never run unscoped `bun test` in this repository. The full suite is large and can hang or time out. Choose focused tests based on changed files, then add typechecking when the change affects shared contracts or cross-package behavior.
+
+## Setup
+
+Before any Bun command:
+
+```bash
+export PATH="$HOME/.bun/bin:$PATH"
+```
+
+Run commands from the package directory that owns the changed files, usually `assistant`, `gateway`, `cli`, or `clients/tauri`.
+
+## Selection Workflow
+
+1. List changed files and group them by package.
+2. For direct implementation/test pairs, run the matching test file.
+3. For route, protocol, migration, IPC, provider, or schema changes, run nearby tests plus a package typecheck.
+4. For shared TypeScript contracts, run tests for each consumer package that imports the contract.
+5. For Swift or macOS client changes, prefer the existing platform-specific test command if one is already used in nearby docs or terminal history.
+6. If a command is expected to be long-running, state that before running it.
+
+## Common Commands
+
+Assistant focused test:
+
+```bash
+cd assistant && bun test src/path/to/file.test.ts
+```
+
+Assistant test grep:
+
+```bash
+cd assistant && bun test src/path/to/file.test.ts --grep "case name"
+```
+
+Assistant typecheck:
+
+```bash
+cd assistant && bunx tsc --noEmit
+```
+
+Gateway focused test:
+
+```bash
+cd gateway && bun test src/path/to/file.test.ts
+```
+
+## Risk-Based Additions
+
+Add typecheck when edits touch:
+
+- exported TypeScript types or schemas
+- route request/response shapes
+- daemon/client protocols
+- migrations and registry wiring
+- package boundary imports
+- provider abstractions
+- feature flag registry or resolver code
+
+Add migration tests when edits touch:
+
+- `assistant/src/memory/migrations/`
+- `assistant/src/workspace/migrations/`
+- persisted workspace files
+- database schema modules
+
+## Reporting
+
+When proposing or running verification, explain why each command is selected and note anything intentionally skipped.

--- a/.cursor/skills/vellum-test-selection/SKILL.md
+++ b/.cursor/skills/vellum-test-selection/SKILL.md
@@ -17,7 +17,7 @@ Before any Bun command:
 export PATH="$HOME/.bun/bin:$PATH"
 ```
 
-Run commands from the package directory that owns the changed files, usually `assistant`, `gateway`, `cli`, or `clients/tauri`.
+Run commands from the package directory that owns the changed files, usually `assistant`, `gateway`, `cli`, `clients/macos`, or `clients/tauri`.
 
 ## Selection Workflow
 

--- a/.cursor/skills/vellum-user-facing-copy/SKILL.md
+++ b/.cursor/skills/vellum-user-facing-copy/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: vellum-user-facing-copy
+description: Review Vellum Assistant user-facing copy, examples, docs, CLI output, UI strings, and assistant-facing release notes. Use when editing text users may read, including README files, SKILL.md files, CLI messages, route errors, update bulletins, and client UI labels.
+---
+
+# Vellum User-Facing Copy
+
+## Terminology
+
+Use "assistant" in user-facing text. "Daemon" is an internal implementation detail and should only appear in internal code, internal comments, file paths, or architecture explanations intended for maintainers.
+
+When unsure, ask: would a user ever read this? If yes, say "assistant".
+
+## Generic Examples
+
+Never include real personal data in examples, fixtures, tests, docs, or commit messages.
+
+Use:
+
+- Names: `Alice`, `Bob`, `Example User`
+- Emails: `user@example.com`, `alice@example.org`
+- Phone numbers: `555-0100` through `555-0199`
+- IDs: `user-123`, `org-abc`, `conv-xyz`
+
+Avoid real names, personal emails, real phone numbers, account IDs, tokens, or private workspace paths.
+
+## Release Notes
+
+Release notes are processed from `UPDATES.md` and can become assistant-facing context. Keep them concise and user-relevant.
+
+Do not add release notes for feature-flagged, default-disabled, or rollout-only features. Add notes later when the feature reaches GA.
+
+## Error Messages
+
+Good user-facing errors:
+
+- explain what failed
+- avoid exposing internals or secrets
+- say what the user can do next when there is a clear action
+- use consistent product terminology
+
+Avoid stack traces, implementation-only vocabulary, and ambiguous "something went wrong" messages when a concrete cause is available.
+
+## Review Workflow
+
+1. Identify text users may read.
+2. Check terminology, privacy, and clarity.
+3. Check whether the copy implies unavailable or flagged behavior.
+4. Preserve technical precision while removing internal jargon.
+5. Recommend tests or snapshots when copy is part of a stable interface.


### PR DESCRIPTION
## Summary
- Add project-local Cursor skills for Vellum review, testing, migrations, boundaries, feature flags, PR readiness, skill authoring, and user-facing copy.
- Encode existing repo rules into reusable review checklists for future agent work.

## Test Plan
- git diff --check upstream/main...HEAD

## Risk
- Low. Documentation/instruction-only change under .cursor/skills.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->