### PR TITLE
Scaffold and wire the Tauri HUD client

### DIFF
--- a/clients/tauri/.gitignore
+++ b/clients/tauri/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.vite/
+*.log
+.env
+.env.local
+
+# Tauri build output is excluded by src-tauri/.gitignore

--- a/clients/tauri/AGENTS.md
+++ b/clients/tauri/AGENTS.md
@@ -1,0 +1,63 @@
+# Eli HUD (Tauri client) — Agent Instructions
+
+The Tauri client is a desktop "Jarvis HUD" that talks to the local
+assistant gateway. The app's job is purely presentational + voice IO;
+all business logic lives in the daemon.
+
+## Boundaries
+
+- **Talk to the gateway, never the runtime directly.** The Tauri app
+  resolves the local gateway URL via `~/.vellum.lock.json`
+  (`resolveLocalAssistantConnection()` in `src/services/lockfile.ts`).
+  Never construct a runtime URL using port 7821 — see the top-level
+  `gateway/AGENTS.md` for the full rationale.
+- **Don't import from `assistant/` or `gateway/`.** This client is a
+  separate package; it duplicates the small wire-shape types it needs
+  (live-voice frames, SSE envelope) so the daemon and HUD can evolve
+  independently. If the wire shapes drift, the HUD becomes the
+  consumer of a versioned gateway contract — not a transitive importer.
+- **Do not access user `~/.vellum/` files beyond the lockfile.** Per
+  the top-level `clients/AGENTS.md`, clients must not read into the
+  workspace. The lockfile is the only sanctioned cross-package path.
+
+## Voice pipeline
+
+The HUD owns the live mic stream and (optionally) runs Picovoice
+Porcupine wake-word detection inside the WebView via
+`@picovoice/porcupine-web`. On wake, it opens a `/v1/live-voice`
+WebSocket to the gateway and streams 16 kHz int16 mono PCM frames as
+base64 JSON `audio` frames per `assistant/src/live-voice/protocol.ts`.
+
+When the user is silent for `voice.vad.silenceMs` (default 700ms),
+the HUD sends `ptt_release` so the daemon endpoints the turn. While
+the daemon is speaking (`tts_audio` frames arriving), any user audio
+above ~0.04 RMS triggers a barge-in via the `interrupt` frame.
+
+Push-to-talk is exposed through `useVoiceEngine().toggleListening()`
+so the command bar's "talk" button and (future) global hotkey can
+force an active turn even when the wake word is disabled.
+
+## Configuration
+
+- `PICOVOICE_ACCESS_KEY` env var is read at runtime by the Rust
+  command `picovoice_access_key`. Without it, wake-word silently
+  disables and the HUD falls back to PTT.
+- The daemon's `voice.*` config drives runtime knobs (sensitivity,
+  VAD thresholds, keyword list). Currently the HUD takes a hardcoded
+  default snapshot — when the user wires `vellum hatch --config
+  voice.alwaysOn=true`, the HUD will sync via the existing
+  config-broadcast SSE event in a future revision.
+
+## Build
+
+The Tauri shell requires Rust toolchain on the developer's machine;
+React layer builds with Bun. See `README.md` for the install dance.
+
+## What's intentionally not here
+
+- No settings UI. Users manage config via the existing macOS
+  `vellum-assistant` Settings or the CLI.
+- No multi-instance / cloud-runtime selector. Auto-discovery picks
+  the most-recently-hatched local instance.
+- No persistent transcript storage. The transcript pane is an
+  ephemeral rolling view; conversation state lives in the daemon.

--- a/clients/tauri/README.md
+++ b/clients/tauri/README.md
@@ -1,0 +1,123 @@
+# Eli HUD (Tauri client)
+
+A cinematic Jarvis-style desktop HUD for the Eli assistant. Lives
+alongside the Swift macOS client (`clients/macos/`) and Chrome
+extension (`clients/chrome-extension/`); the three clients connect to
+the same local gateway and can run concurrently.
+
+## What it does
+
+- **Listener orb** — arc-reactor centerpiece that pulses with mic
+  amplitude, color-shifts when the wake word fires, and expands while
+  Eli is speaking.
+- **Transcript pane** — rolling user/assistant feed with streaming
+  cursor while the LLM is generating.
+- **Status strip** — link state, current model, mode (idle / listening
+  / thinking / speaking), and last error.
+- **Quick command bar** — type or speak `/tasks`, `/slack`, `/quit`,
+  or arbitrary natural-language messages.
+- **Always-on voice** (opt-in) — Picovoice Porcupine wake word in the
+  WebView, with `/v1/live-voice` WebSocket to the gateway, VAD-based
+  endpointing, and barge-in cancellation of the assistant's TTS.
+
+## Prerequisites
+
+| Tool         | Version  | Notes                                                    |
+| ------------ | -------- | -------------------------------------------------------- |
+| Bun          | ≥ 1.1    | Same version pinned in repo `.tool-versions`.            |
+| Node         | ≥ 20     | Vite/TS toolchain.                                       |
+| Rust         | stable   | `rustup default stable`. Required for `tauri build/dev`. |
+| Xcode CLT    | latest   | macOS only — needed for the Tauri WebKit shell.          |
+
+If `cargo --version` fails, install Rust:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+## Install + run
+
+```bash
+cd clients/tauri
+bun install
+bun run tauri:dev
+```
+
+`tauri:dev` boots Vite, watches `src/`, and launches the Tauri shell
+window. Use the system tray icon to toggle visibility / always-on-top
+or quit.
+
+## Build
+
+```bash
+cd clients/tauri
+bun run tauri:build
+```
+
+Bundles ship into `src-tauri/target/release/bundle/`.
+
+## Hotkey
+
+- The default global hotkey is **`⌘ + ⌥ + Space`** (macOS) — the
+  Rust shell registers it via `tauri-plugin-global-shortcut`.
+- The system tray icon offers Show/Hide HUD, Toggle always-on-top,
+  Quit Eli.
+
+## Environment variables
+
+| Var                       | Required for                       | Notes                                                                                 |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| `PICOVOICE_ACCESS_KEY`    | wake-word detection                | Free tier: <https://console.picovoice.ai/>. Without it, wake word disables silently.  |
+| `LIVEKIT_URL`             | (optional) LiveKit transport       | Default `ws://localhost:7880`. Read by the daemon, not the HUD itself.                |
+| `LIVEKIT_API_KEY` / `_SECRET` | LiveKit transport (server-side) | Stored via the daemon credential store, not env-injected at runtime in production.    |
+| `DEEPGRAM_API_KEY`        | streaming STT                      | Configured in the daemon credential store. The HUD never sees this key.               |
+
+The HUD never bundles secrets. `PICOVOICE_ACCESS_KEY` is read on launch
+by the Rust command `picovoice_access_key` and only handed to
+`@picovoice/porcupine-web` if it's non-empty.
+
+## Auto-discovery
+
+On launch the HUD parses `~/.vellum.lock.json` (or `~/.vellum.lockfile.json`)
+and picks the most-recently-hatched local assistant entry. The
+`runtimeUrl` field for cloud assistants is honored verbatim; for local
+assistants the gateway port from `resources.gatewayPort` is used.
+
+## Project layout
+
+```
+clients/tauri/
+├── index.html                    Vite entrypoint with Orbitron + Share Tech Mono fonts
+├── src/
+│   ├── App.tsx                   Top-level layout
+│   ├── main.tsx                  React 19 root
+│   ├── components/               Listener orb, transcript pane, status strip, command bar
+│   ├── hooks/use-voice-engine.ts Mic/voice/transcript orchestrator
+│   ├── services/
+│   │   ├── gateway-client.ts     POST /v1/messages
+│   │   ├── gateway-events.ts     GET /v1/events SSE subscriber
+│   │   ├── live-voice-client.ts  /v1/live-voice WebSocket
+│   │   ├── lockfile.ts           ~/.vellum.lock.json discovery
+│   │   ├── mic-stream.ts         getUserMedia + 16 kHz int16 PCM resampler
+│   │   ├── tts-playback.ts       Streaming AudioContext playback
+│   │   └── wake-word-client.ts   @picovoice/porcupine-web wrapper
+│   ├── styles.css                Tailwind + scanline / hud-shell decorations
+│   └── types.ts                  Shared types
+└── src-tauri/                    Rust shell (system tray, hotkey, window management)
+```
+
+## What's NOT done
+
+- **Settings UI.** Use the existing `vellum-assistant` Settings (or
+  `assistant config set …`) to drive `voice.*` config.
+- **Multi-instance switching.** Auto-discovery takes the most-recent
+  hatched entry. To target a specific assistant, hatch only that one.
+- **Authenticated remote runtimes.** The HUD currently assumes the
+  gateway is unauthenticated (loopback only). When the user enables
+  `runtimeProxyRequireAuth`, the HUD will need to acquire and pass an
+  edge token — punted to a follow-up.
+- **Custom wake-word training.** Only the built-in Picovoice keywords
+  are wired in the default config. Users with a Picovoice Console
+  license can switch `voice.wakeWord.keywords[].source.kind` to
+  `file` and point at a `.ppn` once the daemon's wake-word config
+  surfaces this through the broadcast SSE event.

--- a/clients/tauri/bun.lock
+++ b/clients/tauri/bun.lock
@@ -1,0 +1,668 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/tauri-hud",
+      "dependencies": {
+        "@picovoice/porcupine-web": "3.0.3",
+        "@picovoice/web-voice-processor": "4.0.10",
+        "@tauri-apps/api": "2.4.0",
+        "@tauri-apps/plugin-fs": "2.4.0",
+        "@tauri-apps/plugin-global-shortcut": "2.3.0",
+        "@tauri-apps/plugin-os": "2.3.0",
+        "framer-motion": "12.23.13",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+      },
+      "devDependencies": {
+        "@tauri-apps/cli": "2.4.0",
+        "@types/react": "19.0.7",
+        "@types/react-dom": "19.0.3",
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@vitejs/plugin-react": "5.0.0",
+        "autoprefixer": "10.4.21",
+        "eslint": "9.34.0",
+        "eslint-plugin-react-hooks": "5.2.0",
+        "eslint-plugin-simple-import-sort": "12.1.1",
+        "postcss": "8.5.4",
+        "tailwindcss": "3.4.19",
+        "typescript": "5.9.3",
+        "typescript-eslint": "8.59.0",
+        "vite": "6.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.3.1", "", {}, "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA=="],
+
+    "@eslint/core": ["@eslint/core@0.15.2", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.34.0", "", {}, "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "^0.15.2", "levn": "^0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@picovoice/porcupine-web": ["@picovoice/porcupine-web@3.0.3", "", { "dependencies": { "@picovoice/web-utils": "=1.3.1" } }, "sha512-xVFR0TO0FwM/pumxMxevP550yj9JFlmJuaFgT0CHXjtsInqBrBTZHdJDoj8f5qTHZ4khffh1lW4kiPYf2g8dBQ=="],
+
+    "@picovoice/web-utils": ["@picovoice/web-utils@1.3.1", "", { "dependencies": { "commander": "^9.2.0" }, "bin": { "pvbase64": "scripts/base64.js" } }, "sha512-jcDqdULtTm+yJrnHDjg64hARup+Z4wNkYuXHNx6EM8+qZkweBq9UA6XJrHAlUkPnlkso4JWjaIKhz3x8vZcd3g=="],
+
+    "@picovoice/web-voice-processor": ["@picovoice/web-voice-processor@4.0.10", "", { "dependencies": { "@picovoice/web-utils": "=1.3.1" } }, "sha512-8ZSf0/NoNTxLrampYWKvwMLr7Uwr1dHYEqDcwaMby1vq4za/mgbKMQmv0mZSrBkkWK67lZHYb4mxJg0MQFlD4w=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.30", "", {}, "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.3", "", { "os": "android", "cpu": "arm64" }, "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.3", "", { "os": "none", "cpu": "arm64" }, "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA=="],
+
+    "@tauri-apps/api": ["@tauri-apps/api@2.4.0", "", {}, "sha512-F1zXTsmwcCp+ocg6fbzD/YL0OHeSG1eynCag1UNlX2tD5+dlXy7eRbTu9cAcscPjcR7Nix7by2wiv/+VfWUieg=="],
+
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.4.0", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.4.0", "@tauri-apps/cli-darwin-x64": "2.4.0", "@tauri-apps/cli-linux-arm-gnueabihf": "2.4.0", "@tauri-apps/cli-linux-arm64-gnu": "2.4.0", "@tauri-apps/cli-linux-arm64-musl": "2.4.0", "@tauri-apps/cli-linux-riscv64-gnu": "2.4.0", "@tauri-apps/cli-linux-x64-gnu": "2.4.0", "@tauri-apps/cli-linux-x64-musl": "2.4.0", "@tauri-apps/cli-win32-arm64-msvc": "2.4.0", "@tauri-apps/cli-win32-ia32-msvc": "2.4.0", "@tauri-apps/cli-win32-x64-msvc": "2.4.0" }, "bin": { "tauri": "tauri.js" } }, "sha512-Esg7s20tuSULd2YF3lmtMa1vF7yr5eh/TlBHXjEyrC+XSD9aBxHVoXb6oz7oKybDY9Jf9OiBa0bf2PbybcmOLA=="],
+
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MVzYrahJBgDyzUJ2gNEU8H+0oCVEucN115+CVorFnidHcJ6DtDRMCaKLkpjOZNfJyag1WQ25fu7imvZSe0mz/g=="],
+
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-/4IdbWv6IWSuBn0WVe5JkiSIP1gZhXCZRcumSsYq3ZmOlq4BqXeXT36Oig5mlDnS/2/UpNS94kd8gOA1DNdIeQ=="],
+
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.4.0", "", { "os": "linux", "cpu": "arm" }, "sha512-rOjlk3Vd6R847LXds4pOAFKUL5NVdSWlaiQvr4H9WDUwIWWoxnj7SQfpryTtElDb2wV7a0BNaOCXCpyFEAXjkw=="],
+
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-X/uCwao6R/weWT2y4f3JKJMeUsujo9H4nBMAv9RZhRsz93n9Amw9ETavAOP11pyhl57YkasvKTCRQN6FwsaoXg=="],
+
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-GhvQtrTjadW3eLSmfrSfybSqgJMZzUXC+0WqDzFovLug3a1a1go0m9QK9YGvYLkyEpTY5zRxLtwv+tbZXN4tZw=="],
+
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.4.0", "", { "os": "linux", "cpu": "none" }, "sha512-NgeNihQ9uHS/ibMWLge5VA/BgsS/g8VPSVtCp8DSPyub3bBuCy79A8V+bzNKlMOiDVrqK4vQ//FS9kSxoJOtXw=="],
+
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ebRmV2HLIVms1KlNNueQCp3OrXBv6cimU3mYEh5NbZ8dH88f2sF46dFCyPq8Qr/Zti4qPEaAArVG7RYFjfECPw=="],
+
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FOp2cBFyq5LnUr3he95Z99PQm3nCSJv2GZNeH7UqmUpeHwdcYuhBERU7C+8VDJJPR98Q5fkcoV00Pc4nw0v5KQ=="],
+
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.4.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-SVf1wDagYsaFM+mpUYKmjNveKodcUSGPEM27WmMW4Enh6aXGzTJi4IYOE3GEFOJF1BpRNscslwE1Rd064kfpcg=="],
+
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.4.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-j+fOFVeSSejk9hrUePY7bJuaYr+80xr+ftjXzxCj0CS0d2oSbq+lT8/zS514WemJk9e9yxUus+2ke/Ng17wkkQ=="],
+
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-nv84b3a8eI5Y7ksTLBKjjvtr9NOlAGGGo7OJbjKT+xZLdiPOZ0nJ2cT+4IdfnNAZ33pKJugAfuj1fBvQKeTy0w=="],
+
+    "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.4.0", "", { "dependencies": { "@tauri-apps/api": "^2.6.0" } }, "sha512-Sp8AdDcbyXyk6LD6Pmdx44SH3LPeNAvxR2TFfq/8CwqzfO1yOyV+RzT8fov0NNN7d9nvW7O7MtMAptJ42YXA5g=="],
+
+    "@tauri-apps/plugin-global-shortcut": ["@tauri-apps/plugin-global-shortcut@2.3.0", "", { "dependencies": { "@tauri-apps/api": "^2.6.0" } }, "sha512-WbAz0ElhpP+0kzQZRScdCC7UQ7OPH8PAn//fsBNu7+ywihsnVSVOg1L9YhieAtLNtAlnmFI69Yl5AGaA3ge5IQ=="],
+
+    "@tauri-apps/plugin-os": ["@tauri-apps/plugin-os@2.3.0", "", { "dependencies": { "@tauri-apps/api": "^2.6.0" } }, "sha512-dm3bDsMuUngpIQdJ1jaMkMfyQpHyDcaTIKTFaAMHoKeUd+Is3UHO2uzhElr6ZZkfytIIyQtSVnCWdW2Kc58f3g=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/react": ["@types/react@19.0.7", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA=="],
+
+    "@types/react-dom": ["@types/react-dom@19.0.3", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.0", "@typescript-eslint/types": "^8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.0", "", {}, "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.0", "@typescript-eslint/tsconfig-utils": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.0.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.30", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.28", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.352", "", {}, "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.34.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.3.1", "@eslint/core": "^0.15.2", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.34.0", "@eslint/plugin-kit": "^0.3.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
+
+    "eslint-plugin-simple-import-sort": ["eslint-plugin-simple-import-sort@12.1.1", "", { "peerDependencies": { "eslint": ">=5.0.0" } }, "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
+
+    "framer-motion": ["framer-motion@12.23.13", "", { "dependencies": { "motion-dom": "^12.23.12", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-OMF57Xh0fuTXfJQPtCieYGeU9Fam4SxqPLVz78YI7ATRFrfz8SARtqr1+qv56cX45kPFcIEfkUorVfxlOsjcUg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
+
+    "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
+
+    "postcss-js": ["postcss-js@4.1.0", "", { "dependencies": { "camelcase-css": "^2.0.1" }, "peerDependencies": { "postcss": "^8.4.21" } }, "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
+
+    "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vite": ["vite@6.4.0", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@picovoice/web-utils/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-global-shortcut/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-os/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/clients/tauri/eslint.config.mjs
+++ b/clients/tauri/eslint.config.mjs
@@ -1,0 +1,42 @@
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+import tseslint from "typescript-eslint";
+
+const baseConfig = tseslint.config(
+  {
+    ignores: ["dist/**", "src-tauri/target/**", "node_modules/**"],
+  },
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
+    rules: {
+      "simple-import-sort/imports": [
+        "error",
+        {
+          groups: [
+            ["^node:", "^bun:"],
+            ["^@?\\w"],
+            ["^\\."],
+          ],
+        },
+      ],
+      "simple-import-sort/exports": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+);
+
+export default baseConfig;

--- a/clients/tauri/index.html
+++ b/clients/tauri/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Eli HUD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;800&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="font-mono bg-transparent">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/clients/tauri/package.json
+++ b/clients/tauri/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@vellumai/tauri-hud",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json && vite build",
+    "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@picovoice/porcupine-web": "3.0.3",
+    "@picovoice/web-voice-processor": "4.0.10",
+    "@tauri-apps/api": "2.4.0",
+    "@tauri-apps/plugin-fs": "2.4.0",
+    "@tauri-apps/plugin-global-shortcut": "2.3.0",
+    "@tauri-apps/plugin-os": "2.3.0",
+    "framer-motion": "12.23.13",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "2.4.0",
+    "@types/react": "19.0.7",
+    "@types/react-dom": "19.0.3",
+    "@typescript-eslint/eslint-plugin": "8.59.0",
+    "@typescript-eslint/parser": "8.59.0",
+    "@vitejs/plugin-react": "5.0.0",
+    "autoprefixer": "10.4.21",
+    "eslint": "9.34.0",
+    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-simple-import-sort": "12.1.1",
+    "postcss": "8.5.4",
+    "tailwindcss": "3.4.19",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.59.0",
+    "vite": "6.4.0"
+  }
+}

--- a/clients/tauri/postcss.config.cjs
+++ b/clients/tauri/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/clients/tauri/src-tauri/.gitignore
+++ b/clients/tauri/src-tauri/.gitignore
@@ -1,0 +1,3 @@
+target/
+gen/
+Cargo.lock

--- a/clients/tauri/src-tauri/Cargo.toml
+++ b/clients/tauri/src-tauri/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "eli-hud"
+version = "0.1.0"
+description = "Eli — Jarvis-style HUD for the Vellum assistant"
+authors = ["Eli Project"]
+license = "MIT"
+edition = "2021"
+rust-version = "1.77"
+
+[lib]
+name = "eli_hud_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "2.0", features = [] }
+
+[dependencies]
+tauri = { version = "2.0", features = ["macos-private-api", "tray-icon"] }
+tauri-plugin-fs = "2.0"
+tauri-plugin-global-shortcut = "2.0"
+tauri-plugin-os = "2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[features]
+custom-protocol = ["tauri/custom-protocol"]

--- a/clients/tauri/src-tauri/build.rs
+++ b/clients/tauri/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/clients/tauri/src-tauri/capabilities/default.json
+++ b/clients/tauri/src-tauri/capabilities/default.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability set granted to the main HUD window.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-set-always-on-top",
+    "core:window:allow-show",
+    "core:window:allow-hide",
+    "core:window:allow-set-focus",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging",
+    "core:app:allow-app-show",
+    "core:app:allow-app-hide",
+    "fs:allow-read-text-file",
+    "fs:allow-exists",
+    {
+      "identifier": "fs:scope",
+      "allow": [
+        { "path": "$HOME/.vellum.lock.json" },
+        { "path": "$HOME/.vellum.lockfile.json" }
+      ]
+    },
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-is-registered",
+    "os:allow-platform",
+    "os:allow-version"
+  ]
+}

--- a/clients/tauri/src-tauri/icons/.gitkeep
+++ b/clients/tauri/src-tauri/icons/.gitkeep
@@ -1,0 +1,3 @@
+Icon assets live here. Run `bun run tauri icon path/to/source.png` to
+generate the full Tauri icon set (32x32, 128x128, 128x128@2x, icon.icns,
+icon.ico, icon.png) before the first `tauri build`.

--- a/clients/tauri/src-tauri/src/lib.rs
+++ b/clients/tauri/src-tauri/src/lib.rs
@@ -1,0 +1,141 @@
+//! Eli HUD Tauri shell.
+//!
+//! The Rust side is intentionally minimal: it owns the window, system
+//! tray, and global hotkey, and exposes a couple of trivial commands
+//! the React front-end calls via `invoke`. Everything else
+//! (gateway HTTP, SSE, mic capture, wake-word detection, transcript
+//! state) lives in the WebView.
+
+use serde::Serialize;
+use tauri::{
+    menu::{Menu, MenuBuilder, MenuItemBuilder},
+    tray::{TrayIconBuilder, TrayIconEvent},
+    AppHandle, Emitter, Manager,
+};
+
+#[derive(Serialize, Clone)]
+struct PlatformInfo {
+    os: String,
+    arch: String,
+    version: String,
+}
+
+#[tauri::command]
+fn platform_info() -> PlatformInfo {
+    PlatformInfo {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    }
+}
+
+#[tauri::command]
+fn toggle_main_window(app: AppHandle) -> Result<bool, String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window not found".to_string())?;
+    let visible = window.is_visible().unwrap_or(false);
+    if visible {
+        window.hide().map_err(|e| e.to_string())?;
+        Ok(false)
+    } else {
+        window.show().map_err(|e| e.to_string())?;
+        let _ = window.set_focus();
+        Ok(true)
+    }
+}
+
+#[tauri::command]
+fn set_always_on_top(app: AppHandle, on: bool) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window("main") {
+        window.set_always_on_top(on).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Read the Picovoice Porcupine access key from the environment.
+///
+/// The HUD's wake-word detector runs inside the WebView using
+/// `@picovoice/porcupine-web`, but Picovoice's terms forbid bundling
+/// the access key into a redistributable build. We resolve it at
+/// runtime from `PICOVOICE_ACCESS_KEY` so each user provides their
+/// own (free-tier) key. Returns `None` when unset; the front-end
+/// gracefully falls back to push-to-talk in that case.
+#[tauri::command]
+fn picovoice_access_key() -> Option<String> {
+    std::env::var("PICOVOICE_ACCESS_KEY").ok().filter(|v| !v.is_empty())
+}
+
+#[tauri::command]
+fn quit_app(app: AppHandle) {
+    app.exit(0);
+}
+
+fn build_tray_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    let toggle = MenuItemBuilder::with_id("toggle", "Show / Hide HUD").build(app)?;
+    let pin = MenuItemBuilder::with_id("pin", "Toggle always-on-top").build(app)?;
+    let quit = MenuItemBuilder::with_id("quit", "Quit Eli").build(app)?;
+    MenuBuilder::new(app).items(&[&toggle, &pin, &quit]).build()
+}
+
+fn install_tray(app: &AppHandle) -> tauri::Result<()> {
+    let menu = build_tray_menu(app)?;
+    let app_handle = app.clone();
+    let _tray = TrayIconBuilder::with_id("main-tray")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(move |app, event| match event.id().as_ref() {
+            "toggle" => {
+                let _ = toggle_main_window(app.clone());
+            }
+            "pin" => {
+                if let Some(window) = app.get_webview_window("main") {
+                    let pinned = window.is_always_on_top().unwrap_or(false);
+                    let _ = window.set_always_on_top(!pinned);
+                }
+            }
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(move |_tray, event| {
+            if let TrayIconEvent::Click { .. } = event {
+                let _ = toggle_main_window(app_handle.clone());
+            }
+        })
+        .build(app)?;
+    Ok(())
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_os::init())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .invoke_handler(tauri::generate_handler![
+            platform_info,
+            toggle_main_window,
+            set_always_on_top,
+            picovoice_access_key,
+            quit_app
+        ])
+        .setup(|app| {
+            let handle = app.handle().clone();
+
+            // Set up the global toggle hotkey. We register it from
+            // JavaScript via the plugin so the React layer can change
+            // the binding at runtime; the Rust side just emits an
+            // event back into the front-end.
+            if let Err(err) = install_tray(&handle) {
+                eprintln!("eli-hud: failed to install tray icon: {err}");
+            }
+
+            // Emit a one-shot event so the front-end knows the shell
+            // has finished its setup phase. Useful for showing the
+            // arc-reactor "ready" pulse.
+            let _ = handle.emit("eli://ready", ());
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running Eli HUD application");
+}

--- a/clients/tauri/src-tauri/src/main.rs
+++ b/clients/tauri/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+// Prevents additional console window on Windows in release.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    eli_hud_lib::run()
+}

--- a/clients/tauri/src-tauri/tauri.conf.json
+++ b/clients/tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://schema.tauri.app/config/2.0.0",
+  "productName": "Eli HUD",
+  "version": "0.1.0",
+  "identifier": "ai.vellum.eli.hud",
+  "build": {
+    "beforeDevCommand": "bun run dev",
+    "beforeBuildCommand": "bun run build",
+    "devUrl": "http://localhost:1420",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "macOSPrivateApi": true,
+    "windows": [
+      {
+        "label": "main",
+        "title": "Eli",
+        "width": 480,
+        "height": 720,
+        "minWidth": 360,
+        "minHeight": 480,
+        "resizable": true,
+        "transparent": true,
+        "decorations": false,
+        "alwaysOnTop": false,
+        "skipTaskbar": false,
+        "backgroundColor": "#00000000",
+        "shadow": false,
+        "fullscreen": false,
+        "visible": true
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' blob: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; img-src 'self' data: blob:; worker-src 'self' blob:"
+    },
+    "trayIcon": {
+      "id": "main-tray",
+      "iconPath": "icons/icon.png",
+      "iconAsTemplate": true,
+      "menuOnLeftClick": false,
+      "tooltip": "Eli"
+    }
+  },
+  "plugins": {
+    "fs": {
+      "scope": ["$HOME/.vellum*", "$HOME/.vellum.lock.json", "$HOME/.vellum.lockfile.json"]
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["app", "dmg"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "category": "Productivity",
+    "shortDescription": "Eli — always-on assistant HUD",
+    "longDescription": "Eli is a Jarvis-style HUD frontend for the Vellum assistant. It listens for the wake word, surfaces transcripts and assistant state, and renders a cinematic arc-reactor listener orb."
+  }
+}

--- a/clients/tauri/src/App.tsx
+++ b/clients/tauri/src/App.tsx
@@ -1,0 +1,40 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { JSX } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  ELI_DEFAULT_HOTKEY,
+  useGlobalHotkey,
+} from "./hooks/useGlobalHotkey.js";
+
+/**
+ * Scaffold App shell. The real HUD (transcript, listener orb, voice
+ * engine) lands in a follow-up commit; this placeholder verifies the
+ * Tauri runtime, global hotkey, and tray plumbing are wired before
+ * the React feature work begins.
+ */
+export function App(): JSX.Element {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    void invoke<unknown>("platform_info").then(() => setReady(true));
+  }, []);
+
+  const handleHotkey = useCallback(() => {
+    void invoke("toggle_main_window").catch(() => undefined);
+  }, []);
+
+  useGlobalHotkey(ELI_DEFAULT_HOTKEY, handleHotkey);
+
+  return (
+    <div className="hud-shell scanlines flex flex-col h-screen items-center justify-center">
+      <div className="scanline-strip" />
+      <h1 className="font-display text-3xl tracking-[0.4em] uppercase text-hud-accent">
+        eli
+      </h1>
+      <p className="mt-3 font-mono text-xs text-hud-mute tracking-widest uppercase">
+        {ready ? "shell ready · hotkey ⌘⌥space" : "booting…"}
+      </p>
+    </div>
+  );
+}

--- a/clients/tauri/src/App.tsx
+++ b/clients/tauri/src/App.tsx
@@ -1,23 +1,72 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import type { JSX } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { CommandBar } from "./components/CommandBar.js";
+import { HudListenerOrb } from "./components/HudListenerOrb.js";
+import { HudStatusStrip } from "./components/HudStatusStrip.js";
+import { TranscriptPane } from "./components/TranscriptPane.js";
+import { useVoiceEngine } from "./hooks/use-voice-engine.js";
 import {
   ELI_DEFAULT_HOTKEY,
   useGlobalHotkey,
 } from "./hooks/useGlobalHotkey.js";
+import { resolveLocalAssistantConnection } from "./services/lockfile.js";
+import type { AssistantConnection, VoiceConfigSnapshot } from "./types.js";
 
-/**
- * Scaffold App shell. The real HUD (transcript, listener orb, voice
- * engine) lands in a follow-up commit; this placeholder verifies the
- * Tauri runtime, global hotkey, and tray plumbing are wired before
- * the React feature work begins.
- */
+const DEFAULT_VOICE_CONFIG: VoiceConfigSnapshot = {
+  alwaysOn: true,
+  wakeWord: {
+    enabled: true,
+    runOnClient: true,
+    keywords: [{ label: "Jarvis" }],
+  },
+  vad: {
+    silenceMs: 700,
+    minUtteranceMs: 300,
+    maxUtteranceMs: 20_000,
+  },
+};
+
 export function App(): JSX.Element {
-  const [ready, setReady] = useState(false);
+  const [connection, setConnection] = useState<AssistantConnection | null>(
+    null,
+  );
+  const [picovoiceAccessKey, setPicovoiceAccessKey] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
-    void invoke<unknown>("platform_info").then(() => setReady(true));
+    let cancelled = false;
+    void resolveLocalAssistantConnection().then((value) => {
+      if (!cancelled) setConnection(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Pull a Picovoice access key from the Tauri runtime if the user
+  // configured `PICOVOICE_ACCESS_KEY` in the environment. The key never
+  // gets bundled — the Rust backend reads it at runtime.
+  useEffect(() => {
+    void invoke<string | null>("picovoice_access_key").then((value) => {
+      if (typeof value === "string" && value.length > 0) {
+        setPicovoiceAccessKey(value);
+      }
+    });
+  }, []);
+
+  // Drain Tauri-side events (e.g. tray actions). Reserved for future
+  // hooks; today it just observes the ready signal.
+  useEffect(() => {
+    const unlistenReady = listen<string>("eli://ready", () => {
+      // placeholder
+    });
+    return () => {
+      void unlistenReady.then((unlisten) => unlisten());
+    };
   }, []);
 
   const handleHotkey = useCallback(() => {
@@ -26,15 +75,60 @@ export function App(): JSX.Element {
 
   useGlobalHotkey(ELI_DEFAULT_HOTKEY, handleHotkey);
 
+  const voiceConfig = useMemo<VoiceConfigSnapshot>(
+    () => DEFAULT_VOICE_CONFIG,
+    [],
+  );
+
+  const engine = useVoiceEngine({
+    connection,
+    voiceConfig,
+    picovoiceAccessKey,
+  });
+
+  const listening = engine.mode === "listening" || engine.mode === "speaking";
+  const wakeWordActive =
+    voiceConfig.wakeWord.enabled && picovoiceAccessKey !== null;
+
   return (
-    <div className="hud-shell scanlines flex flex-col h-screen items-center justify-center">
+    <div className="hud-shell scanlines flex flex-col h-screen">
       <div className="scanline-strip" />
-      <h1 className="font-display text-3xl tracking-[0.4em] uppercase text-hud-accent">
-        eli
-      </h1>
-      <p className="mt-3 font-mono text-xs text-hud-mute tracking-widest uppercase">
-        {ready ? "shell ready · hotkey ⌘⌥space" : "booting…"}
-      </p>
+      <header className="flex items-center justify-between px-5 py-3 border-b border-hud-panelBorder/60 font-display text-xs tracking-[0.4em] uppercase text-hud-accent">
+        <span>eli · jarvis hud</span>
+        <span className="text-hud-mute">v0.1</span>
+      </header>
+      <main className="flex flex-1 min-h-0">
+        <section className="w-[42%] flex items-center justify-center relative">
+          <HudListenerOrb
+            amplitude={engine.amplitude}
+            mode={engine.mode}
+            listening={listening}
+            wakeWordActive={wakeWordActive}
+            onClick={() => void engine.toggleListening()}
+          />
+        </section>
+        <section className="flex-1 flex flex-col border-l border-hud-panelBorder/60 bg-hud-panel/40">
+          <TranscriptPane entries={engine.transcript} />
+          <CommandBar
+            disabled={!connection}
+            onSubmit={(text) => {
+              if (text === "/quit") {
+                void invoke("quit_app");
+                return;
+              }
+              void engine.sendText(text);
+            }}
+            onToggleListening={() => void engine.toggleListening()}
+          />
+        </section>
+      </main>
+      <HudStatusStrip
+        status={engine.connection}
+        mode={engine.mode}
+        assistantId={connection?.assistantId ?? null}
+        listening={listening}
+        wakeWordActive={wakeWordActive}
+      />
     </div>
   );
 }

--- a/clients/tauri/src/components/CommandBar.tsx
+++ b/clients/tauri/src/components/CommandBar.tsx
@@ -1,0 +1,80 @@
+import {
+  type FormEvent,
+  type JSX,
+  type KeyboardEvent,
+  useCallback,
+  useState,
+} from "react";
+
+interface CommandBarProps {
+  readonly disabled: boolean;
+  readonly onSubmit: (text: string) => void;
+  readonly onToggleListening: () => void;
+}
+
+export function CommandBar({
+  disabled,
+  onSubmit,
+  onToggleListening,
+}: CommandBarProps): JSX.Element {
+  const [value, setValue] = useState("");
+
+  const flush = useCallback(() => {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return;
+    onSubmit(trimmed);
+    setValue("");
+  }, [onSubmit, value]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      flush();
+    },
+    [flush],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        flush();
+      }
+    },
+    [flush],
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex items-center gap-3 border-t border-hud-panelBorder/60 px-4 py-2 bg-hud-panel/50"
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onToggleListening}
+        className="font-display text-[10px] tracking-[0.32em] uppercase text-hud-glow hover:text-white disabled:opacity-40 transition-colors"
+      >
+        ⏵ talk
+      </button>
+      <span className="text-hud-muted">›</span>
+      <input
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        placeholder="speak or type · /tasks · /slack · /quit"
+        className="flex-1 bg-transparent text-[13px] text-hud-accent placeholder:text-hud-muted/60 outline-none font-mono disabled:opacity-40"
+        spellCheck={false}
+        autoFocus
+      />
+      <button
+        type="submit"
+        disabled={disabled}
+        className="font-display text-[10px] tracking-[0.32em] uppercase text-hud-accent hover:text-white disabled:opacity-40 transition-colors"
+      >
+        send
+      </button>
+    </form>
+  );
+}

--- a/clients/tauri/src/components/HudListenerOrb.tsx
+++ b/clients/tauri/src/components/HudListenerOrb.tsx
@@ -1,0 +1,92 @@
+import { motion } from "framer-motion";
+import type { JSX } from "react";
+import { useMemo } from "react";
+
+import type { AssistantMode } from "../types.js";
+
+interface HudListenerOrbProps {
+  readonly mode: AssistantMode;
+  readonly amplitude: number;
+  readonly listening: boolean;
+  readonly wakeWordActive: boolean;
+  readonly onClick?: () => void;
+}
+
+const MODE_COLORS: Record<AssistantMode, { core: string; ring: string }> = {
+  idle: { core: "#5fdeff", ring: "rgba(95, 222, 255, 0.45)" },
+  listening: { core: "#48ffb1", ring: "rgba(72, 255, 177, 0.6)" },
+  thinking: { core: "#9c8aff", ring: "rgba(156, 138, 255, 0.55)" },
+  speaking: { core: "#ff9f55", ring: "rgba(255, 159, 85, 0.6)" },
+  offline: { core: "#ff4d6d", ring: "rgba(255, 77, 109, 0.45)" },
+};
+
+/**
+ * Arc-reactor centerpiece. Pulses with mic input amplitude and shifts
+ * colour based on the assistant's current mode. Click to toggle the mic
+ * session manually (push-to-talk style).
+ */
+export function HudListenerOrb({
+  mode,
+  amplitude,
+  listening,
+  wakeWordActive,
+  onClick,
+}: HudListenerOrbProps): JSX.Element {
+  const palette = MODE_COLORS[mode];
+  const level = clamp(amplitude, 0, 1);
+  const scale = 1 + level * 0.18;
+  const ringScale = 1 + level * 0.32;
+  const innerLabel = useMemo(() => {
+    if (!listening) return "ELI";
+    return wakeWordActive ? "WAKE" : "LIVE";
+  }, [listening, wakeWordActive]);
+
+  return (
+    <button
+      type="button"
+      className="no-drag relative flex h-44 w-44 items-center justify-center rounded-full"
+      onClick={onClick}
+      aria-label="Toggle microphone"
+    >
+      <motion.span
+        className="absolute h-44 w-44 rounded-full border"
+        style={{ borderColor: palette.ring }}
+        animate={{ scale: ringScale, opacity: 0.6 + level * 0.4 }}
+        transition={{ type: "spring", stiffness: 260, damping: 30 }}
+      />
+      <motion.span
+        className="absolute h-32 w-32 rounded-full"
+        style={{
+          background: `radial-gradient(circle at 50% 50%, ${palette.core}33, transparent 70%)`,
+        }}
+        animate={{ scale: ringScale * 0.95 }}
+        transition={{ type: "spring", stiffness: 200, damping: 28 }}
+      />
+      <motion.span
+        className="relative flex h-24 w-24 items-center justify-center rounded-full"
+        style={{
+          background: `radial-gradient(circle at 50% 30%, ${palette.core}, ${palette.core}55 60%, transparent 100%)`,
+          boxShadow: `0 0 24px ${palette.core}aa, 0 0 80px ${palette.core}66`,
+        }}
+        animate={{ scale }}
+        transition={{ type: "spring", stiffness: 280, damping: 24 }}
+      >
+        <span className="font-display text-[10px] tracking-[0.4em] text-black/80">
+          {innerLabel}
+        </span>
+      </motion.span>
+      {!listening ? (
+        <span className="absolute -bottom-6 font-display text-[9px] tracking-[0.4em] text-hud-mute">
+          TAP TO LISTEN
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  if (Number.isNaN(value)) return lo;
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}

--- a/clients/tauri/src/components/HudStatusStrip.tsx
+++ b/clients/tauri/src/components/HudStatusStrip.tsx
@@ -1,0 +1,75 @@
+import type { JSX } from "react";
+
+import type { AssistantMode, ConnectionStatus } from "../types.js";
+
+interface HudStatusStripProps {
+  readonly status: ConnectionStatus;
+  readonly mode: AssistantMode;
+  readonly assistantId: string | null;
+  readonly listening: boolean;
+  readonly wakeWordActive: boolean;
+}
+
+const MODE_LABEL: Record<AssistantMode, string> = {
+  idle: "STANDBY",
+  listening: "LISTENING",
+  thinking: "PROCESSING",
+  speaking: "RESPONDING",
+  offline: "OFFLINE",
+};
+
+const MODE_TONE: Record<AssistantMode, string> = {
+  idle: "text-hud-accent",
+  listening: "text-hud-ok",
+  thinking: "text-hud-accent",
+  speaking: "text-hud-warn",
+  offline: "text-hud-danger",
+};
+
+export function HudStatusStrip({
+  status,
+  mode,
+  assistantId,
+  listening,
+  wakeWordActive,
+}: HudStatusStripProps): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-2 border-t border-hud-panelBorder/50 bg-black/30 px-4 py-2 font-display text-[10px] tracking-[0.3em] text-hud-mute">
+      <div className="flex items-center gap-3">
+        <Pill label="ELI" tone="text-hud-accent" />
+        <span>{assistantId ? assistantId.slice(0, 12) : "—"}</span>
+        {status.model ? (
+          <span className="text-hud-accent">{status.model}</span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-3">
+        <span className={MODE_TONE[mode]}>{MODE_LABEL[mode]}</span>
+        <Pill
+          label={listening ? "MIC ON" : "MIC OFF"}
+          tone={listening ? "text-hud-ok" : "text-hud-mute"}
+        />
+        {wakeWordActive ? <Pill label="WAKE" tone="text-hud-warn" /> : null}
+        <Pill
+          label={status.connected ? "LINK" : "LINK?"}
+          tone={status.connected ? "text-hud-ok" : "text-hud-danger"}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Pill({
+  label,
+  tone,
+}: {
+  readonly label: string;
+  readonly tone: string;
+}): JSX.Element {
+  return (
+    <span
+      className={`rounded-sm border border-hud-panelBorder/60 px-2 py-0.5 ${tone}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/clients/tauri/src/components/TranscriptPane.tsx
+++ b/clients/tauri/src/components/TranscriptPane.tsx
@@ -1,0 +1,83 @@
+import type { JSX } from "react";
+import { useEffect, useRef } from "react";
+
+import { formatTimestamp, shortLabel } from "../lib/format.js";
+import type { TranscriptEntry } from "../types.js";
+
+interface TranscriptPaneProps {
+  readonly entries: readonly TranscriptEntry[];
+}
+
+const ROLE_LABEL: Record<TranscriptEntry["role"], string> = {
+  user: "OPERATOR",
+  assistant: "ELI",
+  system: "SYSTEM",
+};
+
+/**
+ * Rolling transcript with auto-scroll-to-bottom. Latest entry is always
+ * fully visible; older entries dim out as they drift up the pane.
+ */
+export function TranscriptPane(props: TranscriptPaneProps): JSX.Element {
+  const { entries } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, [entries]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-hud-mute">
+          Awaiting input — say &quot;Jarvis&quot; or type a command.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="hud-transcript flex h-full flex-col gap-2 overflow-y-auto px-6 py-4"
+    >
+      {entries.map((entry) => (
+        <TranscriptRow key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+function TranscriptRow({
+  entry,
+}: {
+  entry: TranscriptEntry;
+}): JSX.Element {
+  const isUser = entry.role === "user";
+  const isSystem = entry.role === "system";
+  const align = isUser ? "items-end text-right" : "items-start text-left";
+  const accent = isUser
+    ? "border-hud-accent/60 text-hud-accent"
+    : isSystem
+      ? "border-hud-warn/60 text-hud-warn"
+      : "border-hud-ok/60 text-hud-ok";
+  const partial = entry.state === "partial" ? "after:content-['▍']" : "";
+
+  return (
+    <div className={`flex flex-col ${align}`}>
+      <div
+        className={`font-display text-[9px] tracking-[0.5em] ${accent} opacity-80`}
+      >
+        {ROLE_LABEL[entry.role]} · {formatTimestamp(entry.timestamp)}
+      </div>
+      <div
+        className={`mt-1 max-w-[85%] rounded-sm border-l-2 px-3 py-2 font-mono text-sm leading-snug ${accent} ${partial}`}
+        style={{ backgroundColor: "rgba(7, 22, 33, 0.45)" }}
+      >
+        {shortLabel(entry.text, 600)}
+      </div>
+    </div>
+  );
+}

--- a/clients/tauri/src/hooks/use-voice-engine.ts
+++ b/clients/tauri/src/hooks/use-voice-engine.ts
@@ -1,0 +1,538 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { GatewayClient } from "../services/gateway-client.js";
+import {
+  type GatewayEventEnvelope,
+  GatewayEventStream,
+} from "../services/gateway-events.js";
+import {
+  LiveVoiceClient,
+  type LiveVoiceServerFrame,
+} from "../services/live-voice-client.js";
+import { MicStream } from "../services/mic-stream.js";
+import { TtsPlayback } from "../services/tts-playback.js";
+import { WakeWordClient, type WakeWordKeyword } from "../services/wake-word-client.js";
+import type {
+  AssistantConnection,
+  AssistantMode,
+  ConnectionStatus,
+  TranscriptEntry,
+  VoiceConfigSnapshot,
+} from "../types.js";
+
+interface UseVoiceEngineOptions {
+  readonly connection: AssistantConnection | null;
+  readonly voiceConfig: VoiceConfigSnapshot;
+  readonly picovoiceAccessKey: string | null;
+}
+
+interface VoiceEngineApi {
+  readonly mode: AssistantMode;
+  readonly amplitude: number;
+  readonly transcript: readonly TranscriptEntry[];
+  readonly connection: ConnectionStatus;
+  readonly sendText: (text: string) => Promise<void>;
+  readonly toggleListening: () => Promise<void>;
+  readonly cancelTts: () => void;
+}
+
+const ENTRY_TTL_MS = 5 * 60_000;
+const MAX_TRANSCRIPT_ENTRIES = 80;
+
+/**
+ * High-level voice + transcript orchestration. Manages:
+ *   - SSE subscription for assistant text deltas
+ *   - Mic capture with optional wake-word gating
+ *   - Live-voice WebSocket lifecycle (start on wake, end on silence)
+ *   - TTS playback with barge-in (cancel on user speech)
+ *
+ * Push-to-talk is exposed via {@link toggleListening} so the HUD's
+ * quick command bar / hotkey can force-open a turn even when the
+ * wake-word is disabled.
+ */
+export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
+  const { connection, voiceConfig, picovoiceAccessKey } = options;
+
+  const [mode, setMode] = useState<AssistantMode>(
+    connection ? "idle" : "offline",
+  );
+  const [amplitude, setAmplitude] = useState(0);
+  const [transcript, setTranscript] = useState<readonly TranscriptEntry[]>([]);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
+    connected: false,
+    model: null,
+    latencyMs: null,
+    lastError: null,
+  });
+
+  const micRef = useRef<MicStream | null>(null);
+  const liveVoiceRef = useRef<LiveVoiceClient | null>(null);
+  const wakeWordRef = useRef<WakeWordClient | null>(null);
+  const ttsRef = useRef<TtsPlayback | null>(null);
+  const eventStreamRef = useRef<GatewayEventStream | null>(null);
+  const partialIdsRef = useRef<{ user: string | null; assistant: string | null }>({
+    user: null,
+    assistant: null,
+  });
+  const sessionActiveRef = useRef(false);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const turnStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const gatewayClient = useMemo(
+    () => (connection ? new GatewayClient(connection) : null),
+    [connection],
+  );
+
+  const appendTranscript = useCallback(
+    (entry: Omit<TranscriptEntry, "timestamp"> & { timestamp?: number }) => {
+      const timestamp = entry.timestamp ?? Date.now();
+      setTranscript((prev) => {
+        const next = [...prev, { ...entry, timestamp }];
+        return next.slice(-MAX_TRANSCRIPT_ENTRIES);
+      });
+    },
+    [],
+  );
+
+  const updateTranscript = useCallback(
+    (id: string, mutation: (current: TranscriptEntry) => TranscriptEntry) => {
+      setTranscript((prev) => prev.map((entry) => (entry.id === id ? mutation(entry) : entry)));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!connection) {
+      setMode("offline");
+      return;
+    }
+
+    setMode("idle");
+    const stream = new GatewayEventStream(connection, {
+      onEvent: (event) => {
+        ingestEvent(event, {
+          appendTranscript,
+          updateTranscript,
+          partialIdsRef,
+          setConnectionStatus,
+        });
+      },
+      onOpen: () => {
+        setConnectionStatus((prev) => ({ ...prev, connected: true, lastError: null }));
+      },
+      onError: (err) => {
+        setConnectionStatus((prev) => ({
+          ...prev,
+          connected: false,
+          lastError: errorMessage(err),
+        }));
+      },
+    });
+    stream.start();
+    eventStreamRef.current = stream;
+    return () => {
+      stream.stop();
+      eventStreamRef.current = null;
+    };
+  }, [appendTranscript, connection, updateTranscript]);
+
+  const handleVoiceFrame = useCallback(
+    (frame: LiveVoiceServerFrame) => {
+      switch (frame.type) {
+        case "ready":
+          setMode("listening");
+          break;
+        case "stt_partial":
+          if (typeof frame.text === "string") {
+            const id = ensurePartial(partialIdsRef, "user");
+            const ts = Date.now();
+            setTranscript((prev) =>
+              upsertPartial(prev, id, "user", frame.text!, ts),
+            );
+          }
+          break;
+        case "stt_final":
+          if (typeof frame.text === "string") {
+            const id = partialIdsRef.current.user ?? cryptoId();
+            partialIdsRef.current.user = null;
+            const ts = Date.now();
+            setTranscript((prev) =>
+              upsertPartial(prev, id, "user", frame.text!, ts, "final"),
+            );
+          }
+          setMode("thinking");
+          break;
+        case "thinking":
+          setMode("thinking");
+          break;
+        case "assistant_text_delta": {
+          if (typeof frame.text !== "string") break;
+          const id = ensurePartial(partialIdsRef, "assistant");
+          const ts = Date.now();
+          setTranscript((prev) =>
+            upsertPartial(prev, id, "assistant", frame.text!, ts, "partial", true),
+          );
+          setMode("speaking");
+          break;
+        }
+        case "tts_audio":
+          if (
+            typeof frame.dataBase64 === "string" &&
+            typeof frame.mimeType === "string" &&
+            typeof frame.sampleRate === "number"
+          ) {
+            ensurePlayback(ttsRef).enqueue({
+              dataBase64: frame.dataBase64,
+              mimeType: frame.mimeType,
+              sampleRate: frame.sampleRate,
+            });
+          }
+          break;
+        case "tts_done":
+          setMode(sessionActiveRef.current ? "listening" : "idle");
+          break;
+        case "error":
+          setConnectionStatus((prev) => ({
+            ...prev,
+            lastError: frame.message ?? "Live voice error",
+          }));
+          break;
+        default:
+          break;
+      }
+    },
+    [],
+  );
+
+  const startSession = useCallback(async (): Promise<void> => {
+    if (!connection) return;
+    if (sessionActiveRef.current) return;
+
+    if (!liveVoiceRef.current) {
+      liveVoiceRef.current = new LiveVoiceClient(connection, {
+        sampleRate: 16_000,
+        onFrame: handleVoiceFrame,
+        onClose: () => {
+          sessionActiveRef.current = false;
+          setMode("idle");
+        },
+        onError: (err) =>
+          setConnectionStatus((prev) => ({ ...prev, lastError: errorMessage(err) })),
+      });
+      await liveVoiceRef.current.open();
+    }
+    liveVoiceRef.current.start();
+    sessionActiveRef.current = true;
+    setMode("listening");
+  }, [connection, handleVoiceFrame]);
+
+  const endSession = useCallback((): void => {
+    sessionActiveRef.current = false;
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
+    if (turnStartTimerRef.current) {
+      clearTimeout(turnStartTimerRef.current);
+      turnStartTimerRef.current = null;
+    }
+    liveVoiceRef.current?.pttRelease();
+    setMode("thinking");
+  }, []);
+
+  const armSilenceTimer = useCallback(() => {
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    silenceTimerRef.current = setTimeout(() => {
+      endSession();
+    }, voiceConfig.vad.silenceMs);
+  }, [endSession, voiceConfig.vad.silenceMs]);
+
+  const handleMicFrame = useCallback(
+    async (samples: Int16Array, rms: number) => {
+      if (rms > 0.04 && sessionActiveRef.current) {
+        if (mode === "speaking") {
+          ttsRef.current?.stop();
+          liveVoiceRef.current?.interrupt();
+        }
+        armSilenceTimer();
+      }
+
+      if (sessionActiveRef.current) {
+        liveVoiceRef.current?.sendAudio(samples);
+        return;
+      }
+
+      // Wake-word gating only runs when the session is closed and the
+      // user has provisioned an access key. Without a key we silently
+      // fall through to PTT-only mode.
+      if (
+        voiceConfig.alwaysOn &&
+        voiceConfig.wakeWord.enabled &&
+        wakeWordRef.current?.isActive()
+      ) {
+        await wakeWordRef.current.pushFrame(samples);
+      }
+    },
+    [armSilenceTimer, mode, voiceConfig.alwaysOn, voiceConfig.wakeWord.enabled],
+  );
+
+  // Mic / wake-word lifecycle.
+  useEffect(() => {
+    if (!connection) return;
+
+    const mic = new MicStream({
+      onFrame: (frame) => {
+        let rms = 0;
+        for (let i = 0; i < frame.length; i += 1) {
+          rms += frame[i]! * frame[i]!;
+        }
+        rms = Math.sqrt(rms / Math.max(1, frame.length)) / 0x8000;
+        void handleMicFrame(frame, rms);
+      },
+      onAmplitude: (amp) => setAmplitude(amp),
+      onError: (err) =>
+        setConnectionStatus((prev) => ({ ...prev, lastError: errorMessage(err) })),
+    });
+    micRef.current = mic;
+
+    const initWake = async (): Promise<void> => {
+      if (
+        voiceConfig.alwaysOn &&
+        voiceConfig.wakeWord.enabled &&
+        voiceConfig.wakeWord.runOnClient &&
+        picovoiceAccessKey
+      ) {
+        const keywords: WakeWordKeyword[] = voiceConfig.wakeWord.keywords.map(
+          (kw) => ({
+            label: kw.label,
+            sensitivity: 0.55,
+            source: { kind: "builtin", keyword: kw.label },
+          }),
+        );
+        const wake = new WakeWordClient({
+          accessKey: picovoiceAccessKey,
+          keywords,
+          onWake: (label) => {
+            appendTranscript({
+              id: cryptoId(),
+              role: "system",
+              text: `Wake: ${label}`,
+              state: "final",
+            });
+            void startSession();
+          },
+          onError: (err) =>
+            setConnectionStatus((prev) => ({
+              ...prev,
+              lastError: errorMessage(err),
+            })),
+        });
+        try {
+          await wake.start();
+          wakeWordRef.current = wake;
+        } catch {
+          wakeWordRef.current = null;
+        }
+      }
+    };
+
+    void mic.start().then(initWake).catch(() => undefined);
+
+    return () => {
+      void mic.stop();
+      void wakeWordRef.current?.stop();
+      wakeWordRef.current = null;
+      micRef.current = null;
+    };
+  }, [
+    appendTranscript,
+    connection,
+    handleMicFrame,
+    picovoiceAccessKey,
+    startSession,
+    voiceConfig.alwaysOn,
+    voiceConfig.wakeWord.enabled,
+    voiceConfig.wakeWord.keywords,
+    voiceConfig.wakeWord.runOnClient,
+  ]);
+
+  // Tear down live-voice + TTS on unmount.
+  useEffect(() => {
+    return () => {
+      liveVoiceRef.current?.close();
+      void ttsRef.current?.stop();
+    };
+  }, []);
+
+  const toggleListening = useCallback(async (): Promise<void> => {
+    if (!connection) return;
+    if (sessionActiveRef.current) {
+      endSession();
+      return;
+    }
+    await startSession();
+  }, [connection, endSession, startSession]);
+
+  const cancelTts = useCallback((): void => {
+    void ttsRef.current?.stop();
+    liveVoiceRef.current?.interrupt();
+    setMode(sessionActiveRef.current ? "listening" : "idle");
+  }, []);
+
+  const sendText = useCallback(
+    async (text: string): Promise<void> => {
+      if (!gatewayClient || text.trim().length === 0) return;
+      const id = cryptoId();
+      appendTranscript({
+        id,
+        role: "user",
+        text,
+        state: "final",
+      });
+      try {
+        await gatewayClient.sendMessage({ content: text });
+        setMode("thinking");
+      } catch (err) {
+        setConnectionStatus((prev) => ({
+          ...prev,
+          lastError: errorMessage(err),
+        }));
+      }
+    },
+    [appendTranscript, gatewayClient],
+  );
+
+  // Periodically prune very old entries.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const cutoff = Date.now() - ENTRY_TTL_MS;
+      setTranscript((prev) => prev.filter((entry) => entry.timestamp > cutoff));
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return {
+    mode,
+    amplitude,
+    transcript,
+    connection: connectionStatus,
+    sendText,
+    toggleListening,
+    cancelTts,
+  };
+}
+
+interface IngestContext {
+  appendTranscript: (entry: Omit<TranscriptEntry, "timestamp"> & { timestamp?: number }) => void;
+  updateTranscript: (id: string, mutation: (current: TranscriptEntry) => TranscriptEntry) => void;
+  partialIdsRef: React.MutableRefObject<{ user: string | null; assistant: string | null }>;
+  setConnectionStatus: React.Dispatch<React.SetStateAction<ConnectionStatus>>;
+}
+
+function ingestEvent(event: GatewayEventEnvelope, ctx: IngestContext): void {
+  const message = event.message;
+  if (!message) return;
+
+  switch (message.type) {
+    case "assistant_text_delta": {
+      const text = typeof message.delta === "string" ? message.delta : message.text;
+      if (typeof text !== "string") return;
+      const id = ensurePartial(ctx.partialIdsRef, "assistant");
+       
+      ctx.updateTranscript(id, (current) => ({
+        ...current,
+        text: current.text + text,
+        timestamp: Date.now(),
+      }));
+      break;
+    }
+    case "assistant_message_complete":
+    case "assistant_text_complete": {
+      const id = ctx.partialIdsRef.current.assistant;
+      if (id) {
+        ctx.updateTranscript(id, (current) => ({
+          ...current,
+          state: "final",
+        }));
+      }
+      ctx.partialIdsRef.current.assistant = null;
+      break;
+    }
+    case "user_message": {
+      if (typeof message.text === "string") {
+        ctx.appendTranscript({
+          id: cryptoId(),
+          role: "user",
+          text: message.text,
+          state: "final",
+        });
+      }
+      break;
+    }
+    case "model_changed": {
+      if (typeof message.content === "string") {
+        ctx.setConnectionStatus((prev) => ({
+          ...prev,
+          model: message.content as string,
+        }));
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function ensurePartial(
+  ref: React.MutableRefObject<{ user: string | null; assistant: string | null }>,
+  role: "user" | "assistant",
+): string {
+  const current = ref.current[role];
+  if (current) return current;
+  const id = cryptoId();
+  ref.current = { ...ref.current, [role]: id };
+  return id;
+}
+
+function upsertPartial(
+  prev: readonly TranscriptEntry[],
+  id: string,
+  role: TranscriptEntry["role"],
+  text: string,
+  timestamp: number,
+  state: TranscriptEntry["state"] = "partial",
+  append = false,
+): TranscriptEntry[] {
+  const next = [...prev];
+  const idx = next.findIndex((entry) => entry.id === id);
+  if (idx === -1) {
+    next.push({ id, role, text, state, timestamp });
+  } else {
+    const existing = next[idx]!;
+    next[idx] = {
+      ...existing,
+      text: append ? existing.text + text : text,
+      state,
+      timestamp,
+    };
+  }
+  return next.slice(-MAX_TRANSCRIPT_ENTRIES);
+}
+
+function ensurePlayback(ref: React.MutableRefObject<TtsPlayback | null>): TtsPlayback {
+  if (!ref.current) ref.current = new TtsPlayback();
+  return ref.current;
+}
+
+function cryptoId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown error";
+}

--- a/clients/tauri/src/hooks/use-voice-engine.ts
+++ b/clients/tauri/src/hooks/use-voice-engine.ts
@@ -77,6 +77,11 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
   const sessionActiveRef = useRef(false);
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const turnStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const modeRef = useRef<AssistantMode>(mode);
+
+  useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
 
   const gatewayClient = useMemo(
     () => (connection ? new GatewayClient(connection) : null),
@@ -113,6 +118,7 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
         ingestEvent(event, {
           appendTranscript,
           updateTranscript,
+          setTranscript,
           partialIdsRef,
           setConnectionStatus,
         });
@@ -219,8 +225,8 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
         onError: (err) =>
           setConnectionStatus((prev) => ({ ...prev, lastError: errorMessage(err) })),
       });
-      await liveVoiceRef.current.open();
     }
+    await liveVoiceRef.current.open();
     liveVoiceRef.current.start();
     sessionActiveRef.current = true;
     setMode("listening");
@@ -250,7 +256,7 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
   const handleMicFrame = useCallback(
     async (samples: Int16Array, rms: number) => {
       if (rms > 0.04 && sessionActiveRef.current) {
-        if (mode === "speaking") {
+        if (modeRef.current === "speaking") {
           ttsRef.current?.stop();
           liveVoiceRef.current?.interrupt();
         }
@@ -273,7 +279,7 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
         await wakeWordRef.current.pushFrame(samples);
       }
     },
-    [armSilenceTimer, mode, voiceConfig.alwaysOn, voiceConfig.wakeWord.enabled],
+    [armSilenceTimer, voiceConfig.alwaysOn, voiceConfig.wakeWord.enabled],
   );
 
   // Mic / wake-word lifecycle.
@@ -425,6 +431,7 @@ export function useVoiceEngine(options: UseVoiceEngineOptions): VoiceEngineApi {
 interface IngestContext {
   appendTranscript: (entry: Omit<TranscriptEntry, "timestamp"> & { timestamp?: number }) => void;
   updateTranscript: (id: string, mutation: (current: TranscriptEntry) => TranscriptEntry) => void;
+  setTranscript: React.Dispatch<React.SetStateAction<readonly TranscriptEntry[]>>;
   partialIdsRef: React.MutableRefObject<{ user: string | null; assistant: string | null }>;
   setConnectionStatus: React.Dispatch<React.SetStateAction<ConnectionStatus>>;
 }
@@ -438,15 +445,14 @@ function ingestEvent(event: GatewayEventEnvelope, ctx: IngestContext): void {
       const text = typeof message.delta === "string" ? message.delta : message.text;
       if (typeof text !== "string") return;
       const id = ensurePartial(ctx.partialIdsRef, "assistant");
-       
-      ctx.updateTranscript(id, (current) => ({
-        ...current,
-        text: current.text + text,
-        timestamp: Date.now(),
-      }));
+      const ts = Date.now();
+      ctx.setTranscript((prev) =>
+        upsertPartial(prev, id, "assistant", text, ts, "partial", true),
+      );
       break;
     }
     case "assistant_message_complete":
+    case "message_complete":
     case "assistant_text_complete": {
       const id = ctx.partialIdsRef.current.assistant;
       if (id) {

--- a/clients/tauri/src/hooks/useGlobalHotkey.ts
+++ b/clients/tauri/src/hooks/useGlobalHotkey.ts
@@ -1,0 +1,43 @@
+/**
+ * Cmd+Option+Space toggles the HUD window. We register through the Tauri
+ * global-shortcut plugin so the binding works even when the WebView is
+ * unfocused.
+ */
+
+import {
+  isRegistered,
+  register,
+  unregister,
+} from "@tauri-apps/plugin-global-shortcut";
+import { useEffect } from "react";
+
+const DEFAULT_ACCELERATOR = "CmdOrControl+Alt+Space";
+
+export function useGlobalHotkey(
+  accelerator: string,
+  onTrigger: () => void,
+): void {
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        if (!(await isRegistered(accelerator))) {
+          await register(accelerator, () => {
+            if (!cancelled) onTrigger();
+          });
+        }
+      } catch {
+        // Ignore — the binding is best-effort. If another app owns the
+        // accelerator we silently fall back to tray-only activation.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      void unregister(accelerator).catch(() => {
+        /* best effort */
+      });
+    };
+  }, [accelerator, onTrigger]);
+}
+
+export const ELI_DEFAULT_HOTKEY = DEFAULT_ACCELERATOR;

--- a/clients/tauri/src/lib/format.ts
+++ b/clients/tauri/src/lib/format.ts
@@ -1,0 +1,24 @@
+/**
+ * Tiny formatting helpers shared across HUD surfaces. Kept dependency
+ * free so the bundle stays small.
+ */
+
+export function formatTimestamp(ms: number): string {
+  const date = new Date(ms);
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  const ss = String(date.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+export function clamp(value: number, lo: number, hi: number): number {
+  if (Number.isNaN(value)) return lo;
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}
+
+export function shortLabel(text: string, max = 80): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}

--- a/clients/tauri/src/main.tsx
+++ b/clients/tauri/src/main.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import { App } from "./App.js";
+
+import "./styles.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("Eli HUD: missing #root element");
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/clients/tauri/src/services/gateway-client.ts
+++ b/clients/tauri/src/services/gateway-client.ts
@@ -1,0 +1,53 @@
+import type { AssistantConnection } from "../types.js";
+
+export interface SendMessageOptions {
+  readonly content: string;
+  readonly conversationKey?: string;
+  readonly slashCommand?: string;
+  readonly clientTimezone?: string;
+}
+
+/**
+ * Minimal HTTP client for the gateway-fronted assistant API. Mirrors the
+ * shape of `POST /v1/messages` from the daemon — see
+ * `assistant/src/runtime/routes/conversation-routes.ts` for the canonical
+ * schema. We intentionally only model the fields the HUD uses; the
+ * daemon ignores unknown body fields.
+ */
+export class GatewayClient {
+  constructor(private readonly connection: AssistantConnection) {}
+
+  async sendMessage(options: SendMessageOptions): Promise<void> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Vellum-Interface-Id": "tauri",
+    };
+    if (this.connection.bearerToken) {
+      headers["Authorization"] = `Bearer ${this.connection.bearerToken}`;
+    }
+
+    const body = {
+      content: options.content,
+      ...(options.conversationKey
+        ? { conversationKey: options.conversationKey }
+        : {}),
+      ...(options.slashCommand ? { slashCommand: options.slashCommand } : {}),
+      clientTimezone:
+        options.clientTimezone ??
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+
+    const response = await fetch(`${this.connection.httpBaseUrl}/v1/messages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok && response.status !== 202) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `POST /v1/messages failed: ${response.status} ${text || response.statusText}`,
+      );
+    }
+  }
+}

--- a/clients/tauri/src/services/gateway-events.ts
+++ b/clients/tauri/src/services/gateway-events.ts
@@ -1,0 +1,139 @@
+import type { AssistantConnection } from "../types.js";
+
+/**
+ * Loose shape of the messages the daemon publishes over `GET /v1/events`.
+ * The daemon's `ServerMessage` discriminated union has dozens of arms;
+ * the HUD only needs a handful, so we model the rest as `Record<string,
+ * unknown>` and let consumers narrow on the discriminator.
+ */
+export interface GatewayServerMessage {
+  readonly type: string;
+  readonly conversationId?: string;
+  readonly text?: string;
+  readonly delta?: string;
+  readonly content?: string;
+  readonly role?: "user" | "assistant" | "system";
+  readonly messageId?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface GatewayEventEnvelope {
+  readonly conversationId?: string;
+  readonly message?: GatewayServerMessage;
+}
+
+export interface GatewayEventStreamHandlers {
+  onEvent(event: GatewayEventEnvelope): void;
+  onOpen?(): void;
+  onError?(error: unknown): void;
+}
+
+const RECONNECT_BACKOFF_MS = [500, 1_000, 2_000, 4_000, 8_000] as const;
+const SSE_INTERFACE_ID = "tauri";
+
+export class GatewayEventStream {
+  private readonly connection: AssistantConnection;
+  private readonly handlers: GatewayEventStreamHandlers;
+  private abort: AbortController | null = null;
+  private retryAttempt = 0;
+  private stopped = false;
+
+  constructor(
+    connection: AssistantConnection,
+    handlers: GatewayEventStreamHandlers,
+  ) {
+    this.connection = connection;
+    this.handlers = handlers;
+  }
+
+  start(): void {
+    if (this.stopped) return;
+    void this.connectLoop();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abort?.abort();
+    this.abort = null;
+  }
+
+  private async connectLoop(): Promise<void> {
+    while (!this.stopped) {
+      try {
+        await this.connectOnce();
+        this.retryAttempt = 0;
+      } catch (error) {
+        if (this.stopped) return;
+        this.handlers.onError?.(error);
+        const delay =
+          RECONNECT_BACKOFF_MS[
+            Math.min(this.retryAttempt, RECONNECT_BACKOFF_MS.length - 1)
+          ];
+        this.retryAttempt += 1;
+        await sleep(delay);
+      }
+    }
+  }
+
+  private async connectOnce(): Promise<void> {
+    this.abort = new AbortController();
+    const headers: Record<string, string> = {
+      Accept: "text/event-stream",
+      "X-Vellum-Interface-Id": SSE_INTERFACE_ID,
+    };
+    if (this.connection.bearerToken) {
+      headers["Authorization"] = `Bearer ${this.connection.bearerToken}`;
+    }
+
+    const url = `${this.connection.httpBaseUrl}/v1/events`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: this.abort.signal,
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`SSE connect failed: ${response.status}`);
+    }
+
+    this.handlers.onOpen?.();
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (!this.stopped) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split("\n\n");
+        buffer = frames.pop() ?? "";
+        for (const frame of frames) {
+          this.processFrame(frame);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private processFrame(frame: string): void {
+    for (const line of frame.split("\n")) {
+      if (!line.startsWith("data: ")) continue;
+      const payload = line.slice(6);
+      try {
+        const parsed = JSON.parse(payload) as GatewayEventEnvelope;
+        this.handlers.onEvent(parsed);
+      } catch {
+        // Heartbeats and malformed frames are silently dropped.
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/clients/tauri/src/services/live-voice-client.ts
+++ b/clients/tauri/src/services/live-voice-client.ts
@@ -1,0 +1,187 @@
+import type { AssistantConnection } from "../types.js";
+
+/**
+ * Subset of the assistant's live-voice protocol that the HUD speaks.
+ * The full protocol lives at `assistant/src/live-voice/protocol.ts` —
+ * we duplicate the wire shape rather than importing it because the
+ * Tauri app is its own TypeScript project and does not link against
+ * the daemon source.
+ */
+export type LiveVoiceClientFrame =
+  | {
+      readonly type: "start";
+      readonly conversationId?: string;
+      readonly audio: {
+        readonly mimeType: "audio/pcm";
+        readonly sampleRate: number;
+        readonly channels: 1;
+      };
+    }
+  | { readonly type: "audio"; readonly dataBase64: string }
+  | { readonly type: "ptt_release" }
+  | { readonly type: "interrupt" }
+  | { readonly type: "end" };
+
+export interface LiveVoiceServerFrame {
+  readonly type: string;
+  readonly seq?: number;
+  readonly text?: string;
+  readonly turnId?: string;
+  readonly mimeType?: string;
+  readonly sampleRate?: number;
+  readonly dataBase64?: string;
+  readonly conversationId?: string;
+  readonly sessionId?: string;
+  readonly code?: string;
+  readonly message?: string;
+}
+
+export interface LiveVoiceClientOptions {
+  readonly sampleRate: number;
+  readonly conversationKey?: string;
+  readonly onFrame: (frame: LiveVoiceServerFrame) => void;
+  readonly onOpen?: () => void;
+  readonly onClose?: (event: CloseEvent) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export class LiveVoiceClient {
+  private readonly connection: AssistantConnection;
+  private readonly options: LiveVoiceClientOptions;
+  private socket: WebSocket | null = null;
+  private started = false;
+
+  constructor(
+    connection: AssistantConnection,
+    options: LiveVoiceClientOptions,
+  ) {
+    this.connection = connection;
+    this.options = options;
+  }
+
+  /** Opens the underlying WebSocket. Resolves once the start frame is sent. */
+  async open(): Promise<void> {
+    if (this.socket) return;
+
+    const url = this.connection.bearerToken
+      ? `${this.connection.wsBaseUrl}/v1/live-voice?token=${encodeURIComponent(this.connection.bearerToken)}`
+      : `${this.connection.wsBaseUrl}/v1/live-voice`;
+
+    this.socket = new WebSocket(url);
+    this.socket.binaryType = "arraybuffer";
+
+    await new Promise<void>((resolve, reject) => {
+      if (!this.socket) {
+        reject(new Error("Socket missing after construction"));
+        return;
+      }
+      this.socket.addEventListener("open", () => {
+        this.options.onOpen?.();
+        resolve();
+      }, { once: true });
+      this.socket.addEventListener("error", (event) => {
+        this.options.onError?.(event);
+        reject(new Error("WebSocket error during open"));
+      }, { once: true });
+    });
+
+    this.socket.addEventListener("message", (event) => {
+      this.handleMessage(event.data);
+    });
+
+    this.socket.addEventListener("close", (event) => {
+      this.options.onClose?.(event);
+      this.socket = null;
+      this.started = false;
+    });
+  }
+
+  /**
+   * Send the live-voice `start` frame. Call this once after the wake word
+   * has been detected (or PTT pressed) — the daemon only opens an
+   * active turn after receiving a `start` frame.
+   */
+  start(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error("LiveVoiceClient.start() requires an open socket");
+    }
+    if (this.started) return;
+    const frame: LiveVoiceClientFrame = {
+      type: "start",
+      ...(this.options.conversationKey
+        ? { conversationId: this.options.conversationKey }
+        : {}),
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: this.options.sampleRate,
+        channels: 1,
+      },
+    };
+    this.sendJson(frame);
+    this.started = true;
+  }
+
+  /** Push raw int16 PCM samples. Encodes to base64 for the JSON frame. */
+  sendAudio(samples: Int16Array): void {
+    if (!this.started) return;
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    const dataBase64 = encodeInt16ToBase64(samples);
+    this.sendJson({ type: "audio", dataBase64 });
+  }
+
+  /** Tell the daemon the user is done speaking. */
+  pttRelease(): void {
+    if (!this.started) return;
+    this.sendJson({ type: "ptt_release" });
+  }
+
+  /** Cancel current TTS playback / interrupt the assistant. */
+  interrupt(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    this.sendJson({ type: "interrupt" });
+  }
+
+  end(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    this.sendJson({ type: "end" });
+    this.started = false;
+  }
+
+  close(): void {
+    this.socket?.close();
+    this.socket = null;
+    this.started = false;
+  }
+
+  private sendJson(frame: LiveVoiceClientFrame): void {
+    this.socket?.send(JSON.stringify(frame));
+  }
+
+  private handleMessage(data: ArrayBuffer | string): void {
+    if (typeof data !== "string") return;
+    try {
+      const parsed = JSON.parse(data) as LiveVoiceServerFrame;
+      this.options.onFrame(parsed);
+    } catch (err) {
+      this.options.onError?.(err);
+    }
+  }
+}
+
+const BASE64_CHUNK_SAMPLES = 4096;
+
+function encodeInt16ToBase64(samples: Int16Array): string {
+  // Encode int16 little-endian PCM into base64. The byte buffer must be a
+  // contiguous Uint8Array view to read raw bytes for btoa-style encoding.
+  const bytes = new Uint8Array(
+    samples.buffer,
+    samples.byteOffset,
+    samples.byteLength,
+  );
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += BASE64_CHUNK_SAMPLES) {
+    const slice = bytes.subarray(i, i + BASE64_CHUNK_SAMPLES);
+    binary += String.fromCharCode(...slice);
+  }
+  return btoa(binary);
+}

--- a/clients/tauri/src/services/lockfile.ts
+++ b/clients/tauri/src/services/lockfile.ts
@@ -92,9 +92,12 @@ function parseLockfile(raw: string): Lockfile | null {
 function pickEntry(
   assistants: LockfileAssistantEntry[],
 ): LockfileAssistantEntry | null {
-  if (assistants.length === 0) return null;
+  const localAssistants = assistants.filter(
+    (entry) => (entry.cloud ?? "local").toLowerCase() === "local",
+  );
+  if (localAssistants.length === 0) return null;
   // Most-recently-hatched wins (string comparison is fine for ISO-8601).
-  return assistants.reduce<LockfileAssistantEntry | null>((best, current) => {
+  return localAssistants.reduce<LockfileAssistantEntry | null>((best, current) => {
     if (!best) return current;
     const bestStamp = best.hatchedAt ?? "";
     const currentStamp = current.hatchedAt ?? "";

--- a/clients/tauri/src/services/lockfile.ts
+++ b/clients/tauri/src/services/lockfile.ts
@@ -1,0 +1,134 @@
+import { homeDir } from "@tauri-apps/api/path";
+import { exists, readTextFile } from "@tauri-apps/plugin-fs";
+
+import type { AssistantConnection } from "../types.js";
+
+interface LockfileAssistantEntry {
+  readonly assistantId?: string;
+  readonly hatchedAt?: string;
+  readonly cloud?: string;
+  readonly runtimeUrl?: string;
+  readonly resources?: {
+    readonly gatewayPort?: number;
+  };
+}
+
+interface Lockfile {
+  readonly assistants?: LockfileAssistantEntry[];
+}
+
+const LOCKFILE_NAMES = [".vellum.lock.json", ".vellum.lockfile.json"] as const;
+const DEFAULT_GATEWAY_PORT = 7830;
+
+/**
+ * Resolve the local assistant's connection info by reading the standard
+ * Vellum lockfile candidates from `$HOME`. Returns `null` when no usable
+ * lockfile entry is present so the caller can render an "offline" state
+ * instead of throwing.
+ */
+export async function resolveLocalAssistantConnection(): Promise<AssistantConnection | null> {
+  const home = await homeDir();
+
+  for (const name of LOCKFILE_NAMES) {
+    const path = joinPath(home, name);
+    if (!(await safeExists(path))) continue;
+
+    const raw = await safeReadText(path);
+    if (!raw) continue;
+
+    const parsed = parseLockfile(raw);
+    if (!parsed) continue;
+
+    const entry = pickEntry(parsed.assistants ?? []);
+    if (!entry) continue;
+
+    const runtime = pickRuntimeUrl(entry);
+    if (!runtime) continue;
+
+    return {
+      httpBaseUrl: runtime.httpBaseUrl,
+      wsBaseUrl: runtime.wsBaseUrl,
+      bearerToken: null,
+      assistantId: entry.assistantId ?? "self",
+    };
+  }
+
+  return null;
+}
+
+function joinPath(base: string, file: string): string {
+  if (base.endsWith("/")) return `${base}${file}`;
+  return `${base}/${file}`;
+}
+
+async function safeExists(path: string): Promise<boolean> {
+  try {
+    return await exists(path);
+  } catch {
+    return false;
+  }
+}
+
+async function safeReadText(path: string): Promise<string | null> {
+  try {
+    return await readTextFile(path);
+  } catch {
+    return null;
+  }
+}
+
+function parseLockfile(raw: string): Lockfile | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (typeof value === "object" && value !== null) {
+      return value as Lockfile;
+    }
+  } catch {
+    // ignore malformed lockfile and fall through to next candidate
+  }
+  return null;
+}
+
+function pickEntry(
+  assistants: LockfileAssistantEntry[],
+): LockfileAssistantEntry | null {
+  if (assistants.length === 0) return null;
+  // Most-recently-hatched wins (string comparison is fine for ISO-8601).
+  return assistants.reduce<LockfileAssistantEntry | null>((best, current) => {
+    if (!best) return current;
+    const bestStamp = best.hatchedAt ?? "";
+    const currentStamp = current.hatchedAt ?? "";
+    return currentStamp > bestStamp ? current : best;
+  }, null);
+}
+
+interface ResolvedRuntime {
+  readonly httpBaseUrl: string;
+  readonly wsBaseUrl: string;
+}
+
+function pickRuntimeUrl(entry: LockfileAssistantEntry): ResolvedRuntime | null {
+  const cloud = (entry.cloud ?? "local").toLowerCase();
+  if (cloud !== "local" && entry.runtimeUrl) {
+    return splitRuntimeUrl(entry.runtimeUrl);
+  }
+
+  const port = entry.resources?.gatewayPort ?? DEFAULT_GATEWAY_PORT;
+  return {
+    httpBaseUrl: `http://127.0.0.1:${port}`,
+    wsBaseUrl: `ws://127.0.0.1:${port}`,
+  };
+}
+
+function splitRuntimeUrl(rawUrl: string): ResolvedRuntime | null {
+  try {
+    const url = new URL(rawUrl);
+    const httpProto = url.protocol === "https:" ? "https:" : "http:";
+    const wsProto = url.protocol === "https:" ? "wss:" : "ws:";
+    const httpBaseUrl = `${httpProto}//${url.host}`.replace(/\/+$/, "");
+    const wsBaseUrl = `${wsProto}//${url.host}`.replace(/\/+$/, "");
+    return { httpBaseUrl, wsBaseUrl };
+  } catch {
+    return null;
+  }
+}

--- a/clients/tauri/src/services/mic-stream.ts
+++ b/clients/tauri/src/services/mic-stream.ts
@@ -160,11 +160,11 @@ function downsampleFloat32(
   }
 
   const ratio = sourceRate / targetRate;
-  const outputLength = Math.floor((input.length - state.remainder) / ratio);
+  const outputLength = Math.floor((input.length + state.remainder) / ratio);
   const output = new Float32Array(Math.max(0, outputLength));
 
   let outputIndex = 0;
-  let inputIndex = state.remainder;
+  let inputIndex = -state.remainder;
   while (outputIndex < outputLength) {
     const lower = Math.floor(inputIndex);
     const upper = Math.min(lower + 1, input.length - 1);

--- a/clients/tauri/src/services/mic-stream.ts
+++ b/clients/tauri/src/services/mic-stream.ts
@@ -1,0 +1,180 @@
+/**
+ * Browser-native mic capture for the Tauri WebView. Uses
+ * `navigator.mediaDevices.getUserMedia` + an `AudioWorklet` (or
+ * `ScriptProcessorNode` fallback) to hand back 16 kHz mono PCM frames.
+ *
+ * The HUD currently stays inside the Tauri WebView for audio capture
+ * because:
+ *   - Tauri 2's official plugin set does not yet ship `tauri-plugin-mic`
+ *     for desktop (only mobile).
+ *   - WebRTC / `getUserMedia` is widely supported on macOS WebKit and
+ *     Linux WebKitGTK and gives us the lowest-friction path.
+ *
+ * The amplitude callback is a coarse RMS estimate the listener orb
+ * reads to drive its pulse animation.
+ */
+
+const TARGET_SAMPLE_RATE = 16_000;
+const TARGET_FRAME_SAMPLES = 512;
+
+export interface MicStreamHandlers {
+  /** Called with int16 PCM frames at {@link TARGET_SAMPLE_RATE}. */
+  onFrame(frame: Int16Array): void;
+  /** RMS amplitude in [0, 1]. Cheap to compute; emitted every frame. */
+  onAmplitude?(amplitude: number): void;
+  onError?(error: unknown): void;
+}
+
+interface ResampleState {
+  remainder: number;
+}
+
+export class MicStream {
+  private readonly handlers: MicStreamHandlers;
+  private audioContext: AudioContext | null = null;
+  private mediaStream: MediaStream | null = null;
+  private workletNode: ScriptProcessorNode | AudioWorkletNode | null = null;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private resample: ResampleState = { remainder: 0 };
+  private outputBuffer: number[] = [];
+  private running = false;
+
+  constructor(handlers: MicStreamHandlers) {
+    this.handlers = handlers;
+  }
+
+  get sampleRate(): number {
+    return TARGET_SAMPLE_RATE;
+  }
+
+  get frameSamples(): number {
+    return TARGET_FRAME_SAMPLES;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+        video: false,
+      });
+
+      this.audioContext = new AudioContext();
+      this.source = this.audioContext.createMediaStreamSource(this.mediaStream);
+
+      // ScriptProcessorNode is deprecated but still works in every modern
+      // engine and avoids the worklet bundle complexity we don't need yet.
+      const processor = this.audioContext.createScriptProcessor(2048, 1, 1);
+      processor.onaudioprocess = (event) => {
+        const channel = event.inputBuffer.getChannelData(0);
+        this.handleFloatFrame(channel, this.audioContext!.sampleRate);
+      };
+      this.source.connect(processor);
+      processor.connect(this.audioContext.destination);
+      this.workletNode = processor;
+    } catch (err) {
+      this.running = false;
+      this.handlers.onError?.(err);
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+    try {
+      if (this.workletNode && "disconnect" in this.workletNode) {
+        this.workletNode.disconnect();
+      }
+      this.source?.disconnect();
+      await this.audioContext?.close();
+      this.mediaStream?.getTracks().forEach((track) => {
+        track.stop();
+      });
+    } catch (err) {
+      this.handlers.onError?.(err);
+    } finally {
+      this.workletNode = null;
+      this.source = null;
+      this.mediaStream = null;
+      this.audioContext = null;
+      this.outputBuffer.length = 0;
+      this.resample = { remainder: 0 };
+    }
+  }
+
+  private handleFloatFrame(input: Float32Array, sourceRate: number): void {
+    if (!this.running) return;
+
+    const downsampled = downsampleFloat32(
+      input,
+      sourceRate,
+      TARGET_SAMPLE_RATE,
+      this.resample,
+    );
+
+    let rms = 0;
+    for (let i = 0; i < downsampled.length; i += 1) {
+      rms += downsampled[i]! * downsampled[i]!;
+    }
+    rms = Math.sqrt(rms / Math.max(1, downsampled.length));
+    this.handlers.onAmplitude?.(Math.min(1, rms * 4));
+
+    for (let i = 0; i < downsampled.length; i += 1) {
+      this.outputBuffer.push(downsampled[i]!);
+    }
+
+    while (this.outputBuffer.length >= TARGET_FRAME_SAMPLES) {
+      const slice = this.outputBuffer.splice(0, TARGET_FRAME_SAMPLES);
+      const int16 = new Int16Array(TARGET_FRAME_SAMPLES);
+      for (let i = 0; i < TARGET_FRAME_SAMPLES; i += 1) {
+        const sample = Math.max(-1, Math.min(1, slice[i]!));
+        int16[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+      }
+      this.handlers.onFrame(int16);
+    }
+  }
+}
+
+/**
+ * Naive linear-interpolation downsampler. Adequate for wake-word
+ * detection (Picovoice's own examples ship the same approach) and
+ * STT transport — the daemon's STT layer applies its own resampling
+ * if the source rate drifts.
+ */
+function downsampleFloat32(
+  input: Float32Array,
+  sourceRate: number,
+  targetRate: number,
+  state: ResampleState,
+): Float32Array {
+  if (sourceRate === targetRate) {
+    return input;
+  }
+
+  const ratio = sourceRate / targetRate;
+  const outputLength = Math.floor((input.length - state.remainder) / ratio);
+  const output = new Float32Array(Math.max(0, outputLength));
+
+  let outputIndex = 0;
+  let inputIndex = state.remainder;
+  while (outputIndex < outputLength) {
+    const lower = Math.floor(inputIndex);
+    const upper = Math.min(lower + 1, input.length - 1);
+    const fraction = inputIndex - lower;
+    output[outputIndex] =
+      input[lower]! * (1 - fraction) + input[upper]! * fraction;
+    outputIndex += 1;
+    inputIndex += ratio;
+  }
+
+  state.remainder = inputIndex - input.length;
+  return output;
+}

--- a/clients/tauri/src/services/tts-playback.ts
+++ b/clients/tauri/src/services/tts-playback.ts
@@ -1,0 +1,108 @@
+/**
+ * Streaming TTS playback for the HUD. The daemon sends `tts_audio`
+ * frames (base64-encoded PCM or MP3 chunks) as the LLM streams; we
+ * decode each chunk and queue it onto an `AudioContext` so playback
+ * starts before the full utterance is synthesized.
+ *
+ * The implementation is deliberately conservative: PCM-int16 chunks
+ * are decoded inline; non-PCM payloads (e.g. MP3 from the system-TTS
+ * fallback) are passed through `decodeAudioData` which is async but
+ * still gap-free if the chunks arrive faster than realtime.
+ */
+
+export interface TtsChunk {
+  readonly mimeType: string;
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export class TtsPlayback {
+  private context: AudioContext | null = null;
+  private nextStartTime = 0;
+
+  enqueue(chunk: TtsChunk): void {
+    const context = this.ensureContext();
+    void this.scheduleChunk(context, chunk);
+  }
+
+  async stop(): Promise<void> {
+    this.nextStartTime = 0;
+    if (!this.context) return;
+    try {
+      await this.context.close();
+    } catch {
+      // already closed
+    }
+    this.context = null;
+  }
+
+  private ensureContext(): AudioContext {
+    if (!this.context) {
+      this.context = new AudioContext();
+      this.nextStartTime = this.context.currentTime;
+    }
+    return this.context;
+  }
+
+  private async scheduleChunk(
+    context: AudioContext,
+    chunk: TtsChunk,
+  ): Promise<void> {
+    try {
+      const buffer = await this.decodeChunk(context, chunk);
+      const source = context.createBufferSource();
+      source.buffer = buffer;
+      source.connect(context.destination);
+      const startAt = Math.max(this.nextStartTime, context.currentTime);
+      source.start(startAt);
+      this.nextStartTime = startAt + buffer.duration;
+    } catch {
+      // Swallow decode errors — the live-voice pipeline emits a
+      // `tts_done` either way and the HUD will fall back to text.
+    }
+  }
+
+  private async decodeChunk(
+    context: AudioContext,
+    chunk: TtsChunk,
+  ): Promise<AudioBuffer> {
+    const bytes = base64ToBytes(chunk.dataBase64);
+
+    if (
+      chunk.mimeType === "audio/pcm" ||
+      chunk.mimeType === "audio/L16" ||
+      chunk.mimeType === "audio/wav"
+    ) {
+      return decodeInt16Pcm(context, bytes, chunk.sampleRate);
+    }
+
+    const copy = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(copy).set(bytes);
+    return await context.decodeAudioData(copy);
+  }
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function decodeInt16Pcm(
+  context: AudioContext,
+  bytes: Uint8Array,
+  sampleRate: number,
+): AudioBuffer {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const sampleCount = Math.floor(bytes.byteLength / 2);
+  const buffer = context.createBuffer(1, sampleCount, sampleRate);
+  const channel = buffer.getChannelData(0);
+  for (let i = 0; i < sampleCount; i += 1) {
+    const sample = view.getInt16(i * 2, true);
+    channel[i] = sample / 0x8000;
+  }
+  return buffer;
+}

--- a/clients/tauri/src/services/wake-word-client.ts
+++ b/clients/tauri/src/services/wake-word-client.ts
@@ -1,0 +1,147 @@
+/**
+ * Client-side wake-word detection using `@picovoice/porcupine-web`.
+ *
+ * The HUD owns the always-on mic stream and runs Porcupine in-process
+ * inside the WebView so we don't have to ship raw audio to the daemon
+ * 24/7. When wake fires, the HUD opens a live-voice WebSocket to the
+ * gateway and starts forwarding 16 kHz PCM frames; the daemon-side
+ * detector at `assistant/src/voice/wake-word/` exists for a future
+ * server-side detection mode.
+ *
+ * Lazily imports the Picovoice SDK so the rest of the app still
+ * type-checks without the access key configured.
+ */
+
+export interface WakeWordKeyword {
+  readonly label: string;
+  readonly source:
+    | { readonly kind: "builtin"; readonly keyword: string }
+    | { readonly kind: "file"; readonly path: string };
+  readonly sensitivity: number;
+}
+
+export interface WakeWordClientOptions {
+  readonly accessKey: string;
+  readonly keywords: readonly WakeWordKeyword[];
+  readonly modelPath?: string;
+  readonly onWake: (label: string) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+interface PorcupineWorkerModule {
+  readonly PorcupineWorker: {
+    create(
+      accessKey: string,
+      keywords: unknown,
+      detectionCallback: (detection: { readonly label: string }) => void,
+      model: { readonly publicPath: string },
+    ): Promise<PorcupineWorkerInstance>;
+  };
+  readonly BuiltInKeyword: Record<string, unknown>;
+}
+
+interface PorcupineWorkerInstance {
+  process(samples: Int16Array): Promise<void>;
+  release(): Promise<void>;
+}
+
+const DEFAULT_MODEL_PATH = "/porcupine_params.pv";
+
+let cachedPorcupineImport: Promise<PorcupineWorkerModule> | null = null;
+
+async function loadPorcupineModule(): Promise<PorcupineWorkerModule> {
+  if (cachedPorcupineImport) return cachedPorcupineImport;
+  // String-literal dynamic import keeps the dependency optional — the
+  // module is only needed when wake-word is enabled in config. We
+  // launder through `unknown` because the published `.d.ts` ships a
+  // richer surface than the small subset we exercise.
+  cachedPorcupineImport = (
+    import(/* @vite-ignore */ "@picovoice/porcupine-web") as Promise<unknown>
+  ).then((mod) => mod as PorcupineWorkerModule);
+  return cachedPorcupineImport;
+}
+
+export class WakeWordClient {
+  private readonly options: WakeWordClientOptions;
+  private worker: PorcupineWorkerInstance | null = null;
+  private active = false;
+
+  constructor(options: WakeWordClientOptions) {
+    this.options = options;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async start(): Promise<void> {
+    if (this.active) return;
+    if (this.options.keywords.length === 0) {
+      throw new Error("Wake-word client requires at least one keyword");
+    }
+
+    try {
+      const mod = await loadPorcupineModule();
+      const keywords = this.options.keywords.map((entry) => {
+        if (entry.source.kind === "builtin") {
+          const builtin = mod.BuiltInKeyword[normalizeBuiltinKey(entry.source.keyword)];
+          if (!builtin) {
+            throw new Error(
+              `Unknown built-in Porcupine keyword: ${entry.source.keyword}`,
+            );
+          }
+          return {
+            builtin,
+            label: entry.label,
+            sensitivity: entry.sensitivity,
+          };
+        }
+        return {
+          publicPath: entry.source.path,
+          label: entry.label,
+          sensitivity: entry.sensitivity,
+        };
+      });
+
+      this.worker = await mod.PorcupineWorker.create(
+        this.options.accessKey,
+        keywords,
+        (detection) => {
+          this.options.onWake(detection.label);
+        },
+        { publicPath: this.options.modelPath ?? DEFAULT_MODEL_PATH },
+      );
+      this.active = true;
+    } catch (err) {
+      this.options.onError?.(err);
+      throw err;
+    }
+  }
+
+  async pushFrame(samples: Int16Array): Promise<void> {
+    if (!this.active || !this.worker) return;
+    try {
+      await this.worker.process(samples);
+    } catch (err) {
+      this.options.onError?.(err);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.active) return;
+    this.active = false;
+    try {
+      await this.worker?.release();
+    } catch (err) {
+      this.options.onError?.(err);
+    }
+    this.worker = null;
+  }
+}
+
+function normalizeBuiltinKey(label: string): string {
+  // Picovoice exports keys like "Jarvis", "HeySiri", "OkGoogle".
+  return label
+    .replace(/(?:^|\s|-)([a-z])/g, (_match, ch: string) => ch.toUpperCase())
+    .replace(/\s+/g, "");
+}

--- a/clients/tauri/src/styles.css
+++ b/clients/tauri/src/styles.css
@@ -1,0 +1,89 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  overflow: hidden;
+  user-select: none;
+}
+
+body {
+  font-family: "Share Tech Mono", ui-monospace, monospace;
+  color: theme("colors.hud.accent");
+}
+
+.hud-shell {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(95, 222, 255, 0.18),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 50% 100%,
+      rgba(0, 30, 60, 0.85),
+      transparent 60%
+    ),
+    linear-gradient(180deg, rgba(2, 6, 12, 0.92), rgba(2, 6, 12, 0.96));
+  border-radius: 18px;
+  border: 1px solid theme("colors.hud.panelBorder");
+  box-shadow: theme("boxShadow.panel");
+  overflow: hidden;
+  -webkit-app-region: drag;
+}
+
+.hud-shell button,
+.hud-shell input,
+.hud-shell textarea,
+.hud-shell .no-drag {
+  -webkit-app-region: no-drag;
+}
+
+.scanlines::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(95, 222, 255, 0.02) 0,
+    rgba(95, 222, 255, 0.02) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  pointer-events: none;
+}
+
+.scanline-strip {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 8%;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(95, 222, 255, 0.18),
+    transparent
+  );
+  animation: scanline 6s linear infinite;
+  pointer-events: none;
+}
+
+.font-display {
+  font-family: "Orbitron", sans-serif;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}

--- a/clients/tauri/src/types.ts
+++ b/clients/tauri/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types for the Eli HUD client. Keep this file framework-free
+ * so it can be imported by both React components and plain services.
+ */
+
+export type AssistantMode =
+  | "idle"
+  | "listening"
+  | "thinking"
+  | "speaking"
+  | "offline";
+
+export interface TranscriptEntry {
+  readonly id: string;
+  readonly role: "user" | "assistant" | "system";
+  readonly text: string;
+  /** Wall-clock timestamp in ms. */
+  readonly timestamp: number;
+  /**
+   * `partial` entries can still be amended; `final` entries are
+   * immutable. Used to drive cursor-blink styling on streaming output.
+   */
+  readonly state: "partial" | "final";
+}
+
+export interface AssistantConnection {
+  /** Daemon HTTP base URL, e.g. `http://localhost:7821`. */
+  readonly httpBaseUrl: string;
+  /** WebSocket base URL, e.g. `ws://localhost:7821`. */
+  readonly wsBaseUrl: string;
+  /** Bearer token if the daemon requires auth, otherwise `null`. */
+  readonly bearerToken: string | null;
+  /** Unique identifier for the active assistant ("self" for local). */
+  readonly assistantId: string;
+}
+
+export interface VoiceConfigSnapshot {
+  readonly alwaysOn: boolean;
+  readonly wakeWord: {
+    readonly enabled: boolean;
+    readonly keywords: readonly { readonly label: string }[];
+    readonly runOnClient: boolean;
+  };
+  readonly vad: {
+    readonly silenceMs: number;
+    readonly minUtteranceMs: number;
+    readonly maxUtteranceMs: number;
+  };
+}
+
+export interface ConnectionStatus {
+  readonly connected: boolean;
+  readonly model: string | null;
+  readonly latencyMs: number | null;
+  readonly lastError: string | null;
+}

--- a/clients/tauri/tailwind.config.ts
+++ b/clients/tauri/tailwind.config.ts
@@ -1,0 +1,51 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ['"Orbitron"', "sans-serif"],
+        mono: ['"Share Tech Mono"', "ui-monospace", "monospace"],
+      },
+      colors: {
+        hud: {
+          bg: "#04080d",
+          panel: "rgba(7, 18, 28, 0.78)",
+          panelBorder: "rgba(95, 222, 255, 0.18)",
+          accent: "#5fdeff",
+          accentDim: "rgba(95, 222, 255, 0.45)",
+          glow: "#aef0ff",
+          warn: "#ff9f55",
+          danger: "#ff4d6d",
+          ok: "#48ffb1",
+          mute: "rgba(140, 180, 200, 0.55)",
+          muted: "rgba(140, 180, 200, 0.55)",
+        },
+      },
+      boxShadow: {
+        arcReactor:
+          "0 0 24px rgba(95, 222, 255, 0.55), 0 0 80px rgba(95, 222, 255, 0.25)",
+        panel:
+          "0 16px 80px rgba(0, 0, 0, 0.55), inset 0 0 0 1px rgba(95, 222, 255, 0.18)",
+      },
+      keyframes: {
+        scanline: {
+          "0%": { transform: "translateY(-100%)" },
+          "100%": { transform: "translateY(100%)" },
+        },
+        pulseRing: {
+          "0%, 100%": { transform: "scale(1)", opacity: "0.65" },
+          "50%": { transform: "scale(1.08)", opacity: "1" },
+        },
+      },
+      animation: {
+        scanline: "scanline 6s linear infinite",
+        pulseRing: "pulseRing 2.4s ease-in-out infinite",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/clients/tauri/tsconfig.json
+++ b/clients/tauri/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/clients/tauri/tsconfig.node.json
+++ b/clients/tauri/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/clients/tauri/vite.config.ts
+++ b/clients/tauri/vite.config.ts
@@ -1,0 +1,29 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+const host = process.env.TAURI_DEV_HOST;
+
+export default defineConfig(async () => ({
+  plugins: [react()],
+  clearScreen: false,
+  server: {
+    port: 1420,
+    strictPort: true,
+    host: host || false,
+    hmr: host
+      ? {
+          protocol: "ws",
+          host,
+          port: 1421,
+        }
+      : undefined,
+    watch: {
+      ignored: ["**/src-tauri/**"],
+    },
+  },
+  build: {
+    target: "esnext",
+    minify: "esbuild",
+    sourcemap: true,
+  },
+}));


### PR DESCRIPTION
## Summary
- Scaffold the Tauri 2 HUD client package and app shell.
- Wire core voice, transcript, listener orb, lockfile, gateway, and playback plumbing.

## Test Plan
- cd clients/tauri && bun run typecheck

## Risk
- Medium. Large new client surface, but mostly isolated under clients/tauri.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->