### PR TITLE
Tighten gateway CORS handling

### DIFF
--- a/gateway/src/http/middleware/cors.test.ts
+++ b/gateway/src/http/middleware/cors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { corsHeaders, handlePreflight, resolveWebviewOrigin } from "./cors.js";
+
+function makeRequest(origin: string | null): Request {
+  const headers = new Headers();
+  if (origin !== null) headers.set("origin", origin);
+  return new Request("http://127.0.0.1:7830/v1/events", { headers });
+}
+
+describe("resolveWebviewOrigin", () => {
+  test("matches the macOS WKWebView origin", () => {
+    expect(resolveWebviewOrigin(makeRequest("https://eli.vellum.local"))).toBe(
+      "https://eli.vellum.local",
+    );
+  });
+
+  test("matches the Tauri production custom protocol origin", () => {
+    expect(resolveWebviewOrigin(makeRequest("tauri://localhost"))).toBe(
+      "tauri://localhost",
+    );
+  });
+
+  test("matches the Tauri Windows-style host", () => {
+    expect(resolveWebviewOrigin(makeRequest("http://tauri.localhost"))).toBe(
+      "http://tauri.localhost",
+    );
+  });
+
+  test("matches the Tauri dev server (any port)", () => {
+    // Tauri's default `tauri dev` port is 1420, but users can change it.
+    expect(resolveWebviewOrigin(makeRequest("http://localhost:1420"))).toBe(
+      "http://localhost:1420",
+    );
+    expect(resolveWebviewOrigin(makeRequest("http://localhost:5173"))).toBe(
+      "http://localhost:5173",
+    );
+  });
+
+  test("rejects unrelated origins", () => {
+    expect(resolveWebviewOrigin(makeRequest("https://example.com"))).toBeNull();
+    expect(
+      resolveWebviewOrigin(makeRequest("https://evil.vellum.local.attacker")),
+    ).toBeNull();
+    expect(
+      resolveWebviewOrigin(makeRequest("http://127.0.0.1:1420")),
+    ).toBeNull();
+    expect(resolveWebviewOrigin(makeRequest(null))).toBeNull();
+  });
+});
+
+describe("preflight allows SSE-required headers", () => {
+  test("Allow-Headers covers the headers the HUD SSE client sends", () => {
+    const headers = corsHeaders("tauri://localhost");
+    const allow = headers["Access-Control-Allow-Headers"] ?? "";
+    // The Tauri `GatewayEventStream` sends these on `/v1/events`. If
+    // any are missing the browser blocks the preflight and the HUD
+    // header shows "gateway offline" even though the daemon is healthy.
+    for (const required of [
+      "Authorization",
+      "Accept",
+      "X-Vellum-Interface-Id",
+      "X-Vellum-Client-Id",
+    ]) {
+      expect(allow.toLowerCase().split(/\s*,\s*/)).toContain(
+        required.toLowerCase(),
+      );
+    }
+  });
+
+  test("handlePreflight responds 204 with the matched origin", () => {
+    const response = handlePreflight("tauri://localhost");
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "tauri://localhost",
+    );
+  });
+});

--- a/gateway/src/http/middleware/cors.test.ts
+++ b/gateway/src/http/middleware/cors.test.ts
@@ -10,8 +10,8 @@ function makeRequest(origin: string | null): Request {
 
 describe("resolveWebviewOrigin", () => {
   test("matches the macOS WKWebView origin", () => {
-    expect(resolveWebviewOrigin(makeRequest("https://eli.vellum.local"))).toBe(
-      "https://eli.vellum.local",
+    expect(resolveWebviewOrigin(makeRequest("https://app1.vellum.local"))).toBe(
+      "https://app1.vellum.local",
     );
   });
 
@@ -27,13 +27,12 @@ describe("resolveWebviewOrigin", () => {
     );
   });
 
-  test("matches the Tauri dev server (any port)", () => {
-    // Tauri's default `tauri dev` port is 1420, but users can change it.
+  test("matches the Tauri dev server default ports", () => {
     expect(resolveWebviewOrigin(makeRequest("http://localhost:1420"))).toBe(
       "http://localhost:1420",
     );
-    expect(resolveWebviewOrigin(makeRequest("http://localhost:5173"))).toBe(
-      "http://localhost:5173",
+    expect(resolveWebviewOrigin(makeRequest("http://localhost:1421"))).toBe(
+      "http://localhost:1421",
     );
   });
 
@@ -44,6 +43,9 @@ describe("resolveWebviewOrigin", () => {
     ).toBeNull();
     expect(
       resolveWebviewOrigin(makeRequest("http://127.0.0.1:1420")),
+    ).toBeNull();
+    expect(
+      resolveWebviewOrigin(makeRequest("http://localhost:5173")),
     ).toBeNull();
     expect(resolveWebviewOrigin(makeRequest(null))).toBeNull();
   });

--- a/gateway/src/http/middleware/cors.ts
+++ b/gateway/src/http/middleware/cors.ts
@@ -23,14 +23,15 @@ const log = getLogger("cors");
  * with "gateway offline" in the UI.
  *
  * The loopback bearer-token check on every protected route is the
- * actual security boundary — CORS just decides which browser-managed
- * origins are allowed to read the response. Accepting `localhost`
- * here matches whatever local Tauri/dev environment the user has
- * running; an unauthenticated origin still cannot read protected
- * data because it has no token.
+ * primary security boundary, but CORS still must avoid reflecting
+ * arbitrary localhost origins because some loopback endpoints are
+ * intentionally unauthenticated in bare-metal mode.
+ *
+ * For Tauri dev we only allow the known default ports (1420 app,
+ * 1421 HMR) rather than all localhost ports.
  */
 const WEBVIEW_ORIGIN_RE =
-  /^(?:https:\/\/[a-z0-9-]+\.vellum\.local|tauri:\/\/localhost|https?:\/\/(?:tauri\.)?localhost(?::\d+)?)$/;
+  /^(?:https:\/\/[a-z0-9-]+\.vellum\.local|tauri:\/\/localhost|https?:\/\/tauri\.localhost|https?:\/\/localhost:(?:1420|1421))$/;
 
 /**
  * Methods the webview bridge may use when calling custom route handlers.

--- a/gateway/src/http/middleware/cors.ts
+++ b/gateway/src/http/middleware/cors.ts
@@ -4,14 +4,33 @@ import { getLogger } from "../../logger.js";
 const log = getLogger("cors");
 
 /**
- * Pattern matching origins from the embedded WKWebView.
+ * Pattern matching origins from a local Vellum HUD WebView.
  *
- * The macOS app loads webview content from `https://{appId}.vellum.local/`,
- * which is cross-origin relative to the local gateway at
- * `http://127.0.0.1:{port}`. Without CORS headers, the browser blocks
- * `window.vellum.fetch` requests from the webview to the gateway.
+ * Two HUD families produce cross-origin fetches against the loopback
+ * gateway and both need CORS headers reflected back:
+ *
+ *   - macOS WKWebView app — loads pages from
+ *     `https://{appId}.vellum.local/`.
+ *   - Tauri HUD — production builds use the `tauri://localhost`
+ *     custom protocol (or `http://tauri.localhost` on Windows), and
+ *     `tauri dev` loads the page from the Vite dev server at
+ *     `http://localhost:{port}`.
+ *
+ * All of these are cross-origin relative to the gateway at
+ * `http://127.0.0.1:{port}`, so the browser issues a preflight before
+ * any custom-header fetch. Without a matching CORS responder the
+ * preflight 404s and every authed call from the HUD silently fails
+ * with "gateway offline" in the UI.
+ *
+ * The loopback bearer-token check on every protected route is the
+ * actual security boundary — CORS just decides which browser-managed
+ * origins are allowed to read the response. Accepting `localhost`
+ * here matches whatever local Tauri/dev environment the user has
+ * running; an unauthenticated origin still cannot read protected
+ * data because it has no token.
  */
-const WEBVIEW_ORIGIN_RE = /^https:\/\/[a-z0-9-]+\.vellum\.local$/;
+const WEBVIEW_ORIGIN_RE =
+  /^(?:https:\/\/[a-z0-9-]+\.vellum\.local|tauri:\/\/localhost|https?:\/\/(?:tauri\.)?localhost(?::\d+)?)$/;
 
 /**
  * Methods the webview bridge may use when calling custom route handlers.
@@ -19,10 +38,14 @@ const WEBVIEW_ORIGIN_RE = /^https:\/\/[a-z0-9-]+\.vellum\.local$/;
 const ALLOWED_METHODS = "GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS";
 
 /**
- * Headers the webview bridge sends (auth + content type + org id).
+ * Headers the webview bridge sends.
+ *
+ * `Accept`, `X-Vellum-Interface-Id`, and `X-Vellum-Client-Id` are
+ * required for the Tauri HUD's SSE client (`/v1/events` opens with
+ * `Accept: text/event-stream` + interface/client identifiers).
  */
 const ALLOWED_HEADERS =
-  "Authorization, Content-Type, X-Session-Token, Vellum-Organization-Id, X-Trace-Id";
+  "Accept, Authorization, Content-Type, X-Session-Token, Vellum-Organization-Id, X-Trace-Id, X-Vellum-Interface-Id, X-Vellum-Client-Id";
 
 /**
  * Check whether the request `Origin` header matches a known Vellum Chrome


### PR DESCRIPTION
## Summary
- Expand gateway CORS matching for macOS webviews, Tauri custom protocol origins, and Tauri dev server origins.
- Ensure preflight responses allow the headers used by the HUD SSE client.

## Test Plan
- cd gateway && bun test src/http/middleware/cors.test.ts

## Risk
- Low to medium. Small gateway ingress behavior change with focused coverage.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->