### PR TITLE
Wire camera snapshots through surface proxy resolution

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -16,6 +16,7 @@ mock.module("../config/loader.js", () => ({
 
 const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 type MockClient = {
   clientId: string;
@@ -31,8 +32,12 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
     _conversationId?: string,
     options?: unknown,
   ) => {
-    sentMessages.push(msg);
-    sentMessageOptions.push(options);
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+      sentMessageOptions.push(options);
+    }
   },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
@@ -54,6 +59,7 @@ describe("HostBashProxy", () => {
   function setup() {
     sentMessages.length = 0;
     sentMessageOptions.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockCapableClients = [];
     mockClientRegistry = new Map();
@@ -216,6 +222,34 @@ describe("HostBashProxy", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toContain("command_timeout");
+    });
+
+    test("emits action lifecycle events for host_bash execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { command: "echo lifecycle" },
+        "session-1",
+      );
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "ok\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      await resultPromise;
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
+      expect(
+        lifecycleMessages.every((m) => m.type === "action_lifecycle"),
+      ).toBe(true);
     });
   });
 

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -11,6 +11,7 @@ mock.module("../util/logger.js", () => ({
 
 /** Events published through the mock event hub. */
 let publishedEvents: unknown[] = [];
+let lifecycleEvents: Array<Record<string, unknown>> = [];
 let mockHasConnection = true;
 
 /**
@@ -49,7 +50,11 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       mockClients.find((c) => c.clientId === clientId)?.actorPrincipalId,
   },
   broadcastMessage: (msg: unknown) => {
-    publishedEvents.push(msg);
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleEvents.push(msg as Record<string, unknown>);
+    } else {
+      publishedEvents.push(msg);
+    }
   },
 }));
 
@@ -72,6 +77,7 @@ describe("HostBrowserProxy", () => {
     HostBrowserProxy.reset();
     pendingInteractions.clear();
     publishedEvents = [];
+    lifecycleEvents = [];
     mockHasConnection = true;
     mockClients = [];
     proxy = HostBrowserProxy.instance;
@@ -154,6 +160,25 @@ describe("HostBrowserProxy", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Navigation failed");
+    });
+
+    test("emits action lifecycle events for host_browser execution", async () => {
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.reload" },
+        "session-1",
+      );
+
+      const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolveResult(requestId, { content: "ok", isError: false });
+      await resultPromise;
+
+      expect(lifecycleEvents.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleEvents.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-camera-proxy.test.ts
+++ b/assistant/src/__tests__/host-camera-proxy.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sentMessages: unknown[] = [];
+const registered: Array<{ requestId: string; interaction: unknown }> = [];
+const resolvedInteractionIds: string[] = [];
+let providerCalls = 0;
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  assistantEventHub: {
+    getMostRecentClientByCapability: (cap: string) =>
+      cap === "host_camera" ? { clientId: "client-1" } : null,
+    listClientsByCapability: (cap: string) =>
+      cap === "host_camera"
+        ? [
+            {
+              clientId: "client-1",
+              capabilities: ["host_camera"],
+              actorPrincipalId: "actor-1",
+            },
+          ]
+        : [],
+    getClientById: (clientId: string) =>
+      clientId === "client-1"
+        ? { clientId, capabilities: ["host_camera"] }
+        : null,
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientId === "client-1" ? "actor-1" : undefined,
+  },
+}));
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  register: (requestId: string, interaction: unknown) => {
+    registered.push({ requestId, interaction });
+  },
+  resolve: (requestId: string) => {
+    resolvedInteractionIds.push(requestId);
+    return undefined;
+  },
+  get: () => undefined,
+  getByKind: () => [],
+  getByConversation: () => [],
+  removeByConversation: () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: () => ({
+    sendMessage: async () => {
+      providerCalls += 1;
+      return {
+        content: [
+          { type: "text", text: "A desk, a keyboard, and a mug are visible." },
+        ],
+        model: "mock",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "end",
+      };
+    },
+  }),
+  extractAllText: (response: {
+    content: Array<{ type: string; text?: string }>;
+  }) =>
+    response.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text ?? "")
+      .join(""),
+}));
+
+import { HostCameraProxy } from "../daemon/host-camera-proxy.js";
+
+describe("HostCameraProxy", () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    registered.length = 0;
+    resolvedInteractionIds.length = 0;
+    providerCalls = 0;
+  });
+
+  test("dispatches one host_camera_request and returns only the text summary", async () => {
+    const proxy = new HostCameraProxy();
+    const resultPromise = proxy.request(
+      "describe_camera_once",
+      { prompt: "What is on the desk?" },
+      "conv-1",
+      undefined,
+      "actor-1",
+    );
+
+    const requestMessage = sentMessages.find(
+      (msg) => (msg as Record<string, unknown>).type === "host_camera_request",
+    ) as Record<string, unknown>;
+    expect(requestMessage).toBeDefined();
+    expect(requestMessage.toolName).toBe("describe_camera_once");
+    expect(requestMessage.conversationId).toBe("conv-1");
+    expect(requestMessage.input).toEqual({ prompt: "What is on the desk?" });
+    expect(requestMessage.targetClientId).toBe("client-1");
+    expect(registered).toHaveLength(1);
+
+    proxy.resolve(requestMessage.requestId as string, {
+      requestId: requestMessage.requestId as string,
+      imageBase64: "raw-image-bytes",
+      mediaType: "image/jpeg",
+      width: 640,
+      height: 480,
+    });
+
+    const result = await resultPromise;
+    expect(providerCalls).toBe(1);
+    expect(result).toEqual({
+      content: "A desk, a keyboard, and a mug are visible.",
+      isError: false,
+    });
+    expect(JSON.stringify(result)).not.toContain("raw-image-bytes");
+  });
+
+  test("client errors are returned without calling the summarizer", async () => {
+    const proxy = new HostCameraProxy();
+    const resultPromise = proxy.request(
+      "describe_camera_once",
+      {},
+      "conv-1",
+      undefined,
+      "actor-1",
+    );
+    const requestMessage = sentMessages.find(
+      (msg) => (msg as Record<string, unknown>).type === "host_camera_request",
+    ) as Record<string, unknown>;
+
+    proxy.resolve(requestMessage.requestId as string, {
+      requestId: requestMessage.requestId as string,
+      error: "Camera permission denied.",
+    });
+
+    await expect(resultPromise).resolves.toEqual({
+      content: "Camera permission denied.",
+      isError: true,
+    });
+    expect(providerCalls).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/host-camera-routes.test.ts
+++ b/assistant/src/__tests__/host-camera-routes.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface PendingEntry {
+  conversationId: string;
+  kind: string;
+  targetClientId?: string;
+  targetActorPrincipalId?: string;
+}
+
+const pending = new Map<string, PendingEntry>();
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  get: (requestId: string) => pending.get(requestId),
+  resolve: (requestId: string) => {
+    const entry = pending.get(requestId);
+    if (entry) pending.delete(requestId);
+    return entry;
+  },
+}));
+
+interface FakeConversation {
+  conversationId: string;
+  hostCameraProxy?: {
+    resolve: (requestId: string, payload: unknown) => void;
+  };
+}
+
+const conversations = new Map<string, FakeConversation>();
+
+mock.module("../daemon/conversation-store.js", () => ({
+  findConversation: (id: string) => conversations.get(id),
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveActorPrincipalIdForLocalGuardian: (value: string | undefined) => value,
+}));
+
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../runtime/routes/errors.js";
+import { ROUTES } from "../runtime/routes/host-camera-routes.js";
+
+const handleHostCameraResult = ROUTES.find(
+  (r) => r.endpoint === "host-camera-result",
+)!.handler;
+
+describe("handleHostCameraResult", () => {
+  beforeEach(() => {
+    pending.clear();
+    conversations.clear();
+  });
+
+  test("forwards one-shot image payload to the conversation hostCameraProxy", async () => {
+    const requestId = "camera-req-1";
+    const conversationId = "conv-1";
+    pending.set(requestId, { conversationId, kind: "host_camera" });
+
+    const resolveCalls: Array<{ requestId: string; payload: unknown }> = [];
+    conversations.set(conversationId, {
+      conversationId,
+      hostCameraProxy: {
+        resolve(rid, payload) {
+          resolveCalls.push({ requestId: rid, payload });
+        },
+      },
+    });
+
+    const result = await handleHostCameraResult({
+      body: {
+        requestId,
+        imageBase64: "jpeg-bytes",
+        mediaType: "image/jpeg",
+        width: 640,
+        height: 480,
+      },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveCalls).toEqual([
+      {
+        requestId,
+        payload: {
+          requestId,
+          imageBase64: "jpeg-bytes",
+          mediaType: "image/jpeg",
+          width: 640,
+          height: 480,
+        },
+      },
+    ]);
+    expect(pending.has(requestId)).toBe(false);
+  });
+
+  test("forwards errors without requiring image bytes", async () => {
+    const requestId = "camera-req-error";
+    const conversationId = "conv-error";
+    pending.set(requestId, { conversationId, kind: "host_camera" });
+
+    let payload: unknown;
+    conversations.set(conversationId, {
+      conversationId,
+      hostCameraProxy: {
+        resolve(_rid, value) {
+          payload = value;
+        },
+      },
+    });
+
+    await handleHostCameraResult({
+      body: { requestId, error: "Camera permission denied." },
+    });
+
+    expect(payload).toEqual({
+      requestId,
+      error: "Camera permission denied.",
+    });
+  });
+
+  test("rejects missing request id", () => {
+    expect(() => handleHostCameraResult({ body: {} })).toThrow(BadRequestError);
+  });
+
+  test("rejects unknown pending interaction", () => {
+    expect(() =>
+      handleHostCameraResult({ body: { requestId: "missing" } }),
+    ).toThrow(NotFoundError);
+  });
+
+  test("rejects wrong pending interaction kind", () => {
+    pending.set("req", { conversationId: "conv", kind: "host_file" });
+    expect(() =>
+      handleHostCameraResult({ body: { requestId: "req" } }),
+    ).toThrow(ConflictError);
+    expect(pending.has("req")).toBe(true);
+  });
+
+  test("targeted result must come from the target client actor", () => {
+    pending.set("req", {
+      conversationId: "conv",
+      kind: "host_camera",
+      targetClientId: "client-1",
+      targetActorPrincipalId: "actor-1",
+    });
+    expect(() =>
+      handleHostCameraResult({
+        body: { requestId: "req", error: "denied" },
+        headers: {
+          "x-vellum-client-id": "client-1",
+          "x-vellum-actor-principal-id": "actor-2",
+        },
+      }),
+    ).toThrow(ForbiddenError);
+  });
+});

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 type MockClient = {
   clientId: string;
@@ -10,7 +11,13 @@ type MockClient = {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+    }
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
@@ -30,6 +37,7 @@ describe("HostCuProxy", () => {
 
   function setup(maxSteps?: number) {
     sentMessages.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockClients = [];
     pendingInteractions.clear();
@@ -145,6 +153,29 @@ describe("HostCuProxy", () => {
       setup();
       // Should not throw
       proxy.processObservation("unknown-id", { axTree: "something" });
+    });
+
+    test("emits action lifecycle events for host_cu execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+
+      const requestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.processObservation(requestId, { axTree: "ok" });
+      await resultPromise;
+
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 
 interface MockClient {
@@ -12,7 +13,13 @@ interface MockClient {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+    }
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) => {
       if (mockClients.length > 0) {
@@ -51,6 +58,7 @@ describe("HostFileProxy", () => {
 
   function setup() {
     sentMessages.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockClients = [];
     pendingInteractions.clear();
@@ -208,6 +216,30 @@ describe("HostFileProxy", () => {
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
+    });
+
+    test("emits action lifecycle events for host_file execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/lifecycle.txt" },
+        "session-1",
+      );
+
+      const requestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(requestId, {
+        content: "ok",
+        isError: false,
+      });
+      await resultPromise;
+
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -16,6 +16,7 @@ import { isHostProxyTransport } from "../daemon/message-types/conversations.js";
 describe("supportsHostProxy (runtime)", () => {
   test("no-arg form returns true for host-proxy interfaces", () => {
     expect(supportsHostProxy("macos")).toBe(true);
+    expect(supportsHostProxy("tauri")).toBe(true);
   });
 
   test("no-arg form returns false for interfaces without host-proxy support", () => {
@@ -40,13 +41,25 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("chrome-extension", "host_bash")).toBe(false);
     expect(supportsHostProxy("chrome-extension", "host_file")).toBe(false);
     expect(supportsHostProxy("chrome-extension", "host_cu")).toBe(false);
+    expect(supportsHostProxy("chrome-extension", "host_camera")).toBe(false);
   });
 
-  test("capability form grants all four capabilities to macOS including host_browser", () => {
+  test("capability form grants all desktop capabilities to macOS including host_browser", () => {
     expect(supportsHostProxy("macos", "host_bash")).toBe(true);
     expect(supportsHostProxy("macos", "host_file")).toBe(true);
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+    expect(supportsHostProxy("macos", "host_app_control")).toBe(true);
+    expect(supportsHostProxy("macos", "host_camera")).toBe(true);
+  });
+
+  test("capability form grants all capabilities to Tauri HUD", () => {
+    expect(supportsHostProxy("tauri", "host_bash")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_file")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_cu")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_app_control")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_camera")).toBe(true);
   });
 
   test("capability form rejects everything for non-host-proxy interfaces", () => {
@@ -179,6 +192,11 @@ describe("macOS host_browser capability", () => {
     // The no-arg form gates computer-use preactivation and full proxy restore.
     // macOS must still pass this check.
     expect(supportsHostProxy("macos")).toBe(true);
+  });
+
+  test("Tauri passes the no-arg host-proxy check (full HUD proxy)", () => {
+    expect(supportsHostProxy("tauri")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
   });
 
   test("non-macOS non-extension interfaces remain host_browser-ineligible", () => {

--- a/assistant/src/actions/run-action.test.ts
+++ b/assistant/src/actions/run-action.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const recordToolInvocationMock = mock(() => {});
+
+mock.module("../memory/tool-usage-store.js", () => ({
+  recordToolInvocation: recordToolInvocationMock,
+}));
+
+const { runAction } = await import("./run-action.js");
+
+describe("runAction", () => {
+  test("emits started/executing/completed lifecycle and returns result", async () => {
+    const lifecycle: string[] = [];
+    const result = await runAction({
+      actionName: "host_app_control.observe",
+      conversationId: "conv-1",
+      execute: async () => "ok",
+      onLifecycle: (event) => {
+        lifecycle.push(event.stage);
+      },
+    });
+
+    expect(result).toBe("ok");
+    expect(lifecycle).toEqual(["started", "executing", "completed"]);
+    expect(recordToolInvocationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits failed + rollback stages when execute throws", async () => {
+    const lifecycle: string[] = [];
+    const executeError = new Error("boom");
+
+    await expect(
+      runAction({
+        actionName: "host_app_control.click",
+        conversationId: "conv-2",
+        execute: async () => {
+          throw executeError;
+        },
+        rollback: async () => undefined,
+        onLifecycle: (event) => {
+          lifecycle.push(event.stage);
+        },
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(lifecycle).toEqual([
+      "started",
+      "executing",
+      "failed",
+      "rollback_started",
+      "rollback_completed",
+    ]);
+    expect(recordToolInvocationMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/actions/run-action.ts
+++ b/assistant/src/actions/run-action.ts
@@ -1,0 +1,190 @@
+import { v4 as uuid } from "uuid";
+
+import { recordToolInvocation } from "../memory/tool-usage-store.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("actions:run");
+
+export type ActionLifecycleStage =
+  | "started"
+  | "executing"
+  | "completed"
+  | "failed"
+  | "rollback_started"
+  | "rollback_completed";
+
+export interface ActionLifecycleEvent {
+  actionId: string;
+  actionName: string;
+  stage: ActionLifecycleStage;
+  ts: number;
+  conversationId?: string;
+  message?: string;
+}
+
+export interface RunActionOptions<TResult> {
+  actionName: string;
+  conversationId: string;
+  inputSummary?: string;
+  riskLevel?: "Low" | "Medium" | "High";
+  execute: () => Promise<TResult>;
+  rollback?: (ctx: { error: unknown; result?: TResult }) => Promise<void>;
+  onLifecycle?: (event: ActionLifecycleEvent) => void | Promise<void>;
+}
+
+export async function runAction<TResult>(
+  options: RunActionOptions<TResult>,
+): Promise<TResult> {
+  const actionId = uuid();
+  const startedAt = Date.now();
+  const riskLevel = options.riskLevel ?? "Medium";
+  let result: TResult | undefined;
+  let executeError: unknown;
+
+  // Fast path: when no lifecycle subscriber is attached, execute immediately
+  // so callers that synchronously inspect side effects after invocation keep
+  // existing behavior (e.g. proxy tests asserting request envelopes).
+  if (!options.onLifecycle) {
+    try {
+      result = await options.execute();
+      writeAuditLog({
+        conversationId: options.conversationId,
+        actionName: options.actionName,
+        inputSummary: options.inputSummary ?? "{}",
+        decision: "allow",
+        riskLevel,
+        resultSummary: "completed",
+        durationMs: Date.now() - startedAt,
+      });
+      return result;
+    } catch (err) {
+      executeError = err;
+      if (options.rollback) {
+        try {
+          await options.rollback({ error: err, ...(result ? { result } : {}) });
+        } catch (rollbackErr) {
+          log.warn(
+            { actionId, actionName: options.actionName, rollbackErr },
+            "Action rollback failed",
+          );
+        }
+      }
+      writeAuditLog({
+        conversationId: options.conversationId,
+        actionName: options.actionName,
+        inputSummary: options.inputSummary ?? "{}",
+        decision: "deny",
+        riskLevel,
+        resultSummary: `failed: ${errorMessage(executeError)}`,
+        durationMs: Date.now() - startedAt,
+      });
+      throw err;
+    }
+  }
+
+  const emitLifecycle = (
+    stage: ActionLifecycleStage,
+    message?: string,
+  ): void => {
+    if (!options.onLifecycle) return;
+    try {
+      const maybePromise = options.onLifecycle({
+        actionId,
+        actionName: options.actionName,
+        stage,
+        ts: Date.now(),
+        conversationId: options.conversationId,
+        ...(message ? { message } : {}),
+      });
+      if (maybePromise instanceof Promise) {
+        maybePromise.catch((err) => {
+          log.warn(
+            { actionId, actionName: options.actionName, stage, err },
+            "Action lifecycle subscriber failed (non-fatal)",
+          );
+        });
+      }
+    } catch (err) {
+      log.warn(
+        { actionId, actionName: options.actionName, stage, err },
+        "Action lifecycle subscriber failed (non-fatal)",
+      );
+    }
+  };
+
+  emitLifecycle("started");
+  emitLifecycle("executing");
+
+  try {
+    result = await options.execute();
+    emitLifecycle("completed");
+    writeAuditLog({
+      conversationId: options.conversationId,
+      actionName: options.actionName,
+      inputSummary: options.inputSummary ?? "{}",
+      decision: "allow",
+      riskLevel,
+      resultSummary: "completed",
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (err) {
+    executeError = err;
+    emitLifecycle("failed", errorMessage(err));
+    if (options.rollback) {
+      emitLifecycle("rollback_started");
+      try {
+        await options.rollback({ error: err, ...(result ? { result } : {}) });
+        emitLifecycle("rollback_completed");
+      } catch (rollbackErr) {
+        log.warn(
+          { actionId, actionName: options.actionName, rollbackErr },
+          "Action rollback failed",
+        );
+      }
+    }
+    writeAuditLog({
+      conversationId: options.conversationId,
+      actionName: options.actionName,
+      inputSummary: options.inputSummary ?? "{}",
+      decision: "deny",
+      riskLevel,
+      resultSummary: `failed: ${errorMessage(executeError)}`,
+      durationMs: Date.now() - startedAt,
+    });
+    throw err;
+  }
+}
+
+function writeAuditLog(options: {
+  conversationId: string;
+  actionName: string;
+  inputSummary: string;
+  resultSummary: string;
+  decision: "allow" | "deny";
+  riskLevel: "Low" | "Medium" | "High";
+  durationMs: number;
+}): void {
+  try {
+    recordToolInvocation({
+      conversationId: options.conversationId,
+      toolName: `action:${options.actionName}`,
+      input: options.inputSummary,
+      result: options.resultSummary,
+      decision: options.decision,
+      riskLevel: options.riskLevel,
+      durationMs: options.durationMs,
+    });
+  } catch (err) {
+    log.warn(
+      { actionName: options.actionName, err },
+      "Action audit-log write failed (non-fatal)",
+    );
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown action error";
+}

--- a/assistant/src/channels/__tests__/types.test.ts
+++ b/assistant/src/channels/__tests__/types.test.ts
@@ -80,9 +80,13 @@ describe("parseInterfaceId", () => {
 });
 
 describe("supportsHostProxy", () => {
-  // ── macOS: supports all four host proxy capabilities. ──
+  // ── Desktop clients: support all host proxy capabilities. ──
   test("macos returns true (no capability)", () => {
     expect(supportsHostProxy("macos")).toBe(true);
+  });
+
+  test("tauri returns true (no capability)", () => {
+    expect(supportsHostProxy("tauri")).toBe(true);
   });
 
   test("macos returns true for host_bash", () => {
@@ -99,6 +103,14 @@ describe("supportsHostProxy", () => {
 
   test("macos returns true for host_browser", () => {
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  });
+
+  test("tauri returns true for desktop host capabilities", () => {
+    expect(supportsHostProxy("tauri", "host_bash")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_file")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_cu")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_app_control")).toBe(true);
   });
 
   // ── chrome-extension: only host_browser. ──

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -38,6 +38,7 @@ export const INTERFACE_IDS = [
   "slack",
   "email",
   "chrome-extension",
+  "tauri",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];
@@ -84,6 +85,7 @@ export const INTERACTIVE_INTERFACES: ReadonlySet<InterfaceId> = new Set([
   "ios",
   "cli",
   "web",
+  "tauri",
 ]);
 
 export function isInteractiveInterface(id: InterfaceId): boolean {
@@ -100,7 +102,8 @@ export type HostProxyCapability =
   | "host_file"
   | "host_cu"
   | "host_browser"
-  | "host_app_control";
+  | "host_app_control"
+  | "host_camera";
 
 /**
  * Interfaces that support the full desktop host-proxy set (all five
@@ -112,7 +115,7 @@ export type HostProxyCapability =
  * below in lock-step when adding a new host-capable client (e.g. a native
  * Linux or Windows desktop).
  */
-export type HostProxyInterfaceId = "macos";
+export type HostProxyInterfaceId = "macos" | "tauri";
 
 /**
  * Whether the interface supports a host proxy capability.
@@ -137,11 +140,11 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // macOS supports all five host proxy capabilities including host_browser
-  // and host_app_control. The host_browser proxy is provisioned via the
-  // assistant event hub. When no extension is connected, browser tools fall
-  // through to cdp-inspect/local via the CDP factory's candidate chain.
-  if (id === "macos") return true;
+  // macOS and the Tauri HUD support all desktop host proxy capabilities including
+  // host_browser, host_app_control, and host_camera. The host_browser proxy is provisioned
+  // via the assistant event hub. When no extension is connected, browser tools
+  // fall through to cdp-inspect/local via the CDP factory's candidate chain.
+  if (id === "macos" || id === "tauri") return true;
   if (id === "chrome-extension" && capability === "host_browser") return true;
   return false;
 }

--- a/assistant/src/config/bundled-skills/webcam-snapshot/SKILL.md
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: webcam-snapshot
+description: Request one user-approved webcam snapshot from the connected macOS or Tauri desktop client and return a concise text summary. Use when the user explicitly asks Jarvis to look through the webcam, see what is in front of the camera, or answer a question about the current camera view.
+compatibility: "Designed for Vellum personal assistants. Requires the webcam-snapshot feature flag and a connected macOS or Tauri client."
+metadata:
+  emoji: "📷"
+  vellum:
+    display-name: "Webcam Snapshot"
+    feature-flag: "webcam-snapshot"
+    activation-hints:
+      - "User asks the assistant to look through the webcam once"
+      - "User asks what the camera can see right now"
+      - "User asks a question about the current physical scene in front of the camera"
+    avoid-when:
+      - "User wants ambient or continuous camera monitoring"
+      - "Task can be answered without camera access"
+---
+
+This skill exposes a single request-scoped host proxy tool for one webcam
+snapshot. Each use asks the desktop client for one still frame, summarizes that
+frame, and discards the raw image.
+
+## Tool
+
+Use `describe_camera_once` only when the user has explicitly asked for camera
+access or when the current task clearly requires a one-shot camera view.
+
+Pass a short `prompt` describing what to focus on, for example:
+
+```json
+{ "prompt": "Describe what is visible on the desk." }
+```
+
+The user-visible approval should be clear that Jarvis is requesting one webcam
+snapshot. Do not claim continuous camera access, recording, or persistent image
+storage.

--- a/assistant/src/config/bundled-skills/webcam-snapshot/TOOLS.json
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/TOOLS.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "describe_camera_once",
+      "description": "Request one user-approved webcam snapshot from the connected desktop client, summarize it, and discard the raw image. Use only for explicit one-shot camera requests.",
+      "category": "webcam-snapshot",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "Optional question or focus area for the snapshot summary"
+          },
+          "target_client_id": {
+            "type": "string",
+            "description": "Optional client id to target when multiple macOS/Tauri clients support host_camera"
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/describe-camera-once.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/webcam-snapshot/tools/describe-camera-once.ts
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/tools/describe-camera-once.ts
@@ -1,0 +1,12 @@
+import { forwardHostCameraProxyTool } from "../../../../tools/host-camera/skill-proxy-bridge.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardHostCameraProxyTool("describe_camera_once", input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -117,6 +117,8 @@ import * as subagentSpawn from "./bundled-skills/subagent/tools/subagent-spawn.j
 import * as subagentStatus from "./bundled-skills/subagent/tools/subagent-status.js";
 // ── transcribe ─────────────────────────────────────────────────────────────────
 import * as transcribeMedia from "./bundled-skills/transcribe/tools/transcribe-media.js";
+// ── webcam-snapshot ────────────────────────────────────────────────────────────
+import * as describeCameraOnce from "./bundled-skills/webcam-snapshot/tools/describe-camera-once.js";
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -249,4 +251,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // transcribe
   ["transcribe:tools/transcribe-media.ts", transcribeMedia],
+
+  // webcam-snapshot
+  ["webcam-snapshot:tools/describe-camera-once.ts", describeCameraOnce],
 ]);

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -29,6 +29,7 @@ import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
 import { launchConversation } from "./conversation-launch.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
+import type { HostCameraProxy } from "./host-camera-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   CardSurfaceData,
@@ -474,6 +475,8 @@ export interface SurfaceConversationContext {
   hostCuProxy?: HostCuProxy;
   /** Optional proxy for delegating per-app app-control actions to a connected desktop client. */
   hostAppControlProxy?: HostAppControlProxy;
+  /** Optional proxy for requesting a one-shot webcam snapshot from a connected desktop client. */
+  hostCameraProxy?: HostCameraProxy;
   /**
    * Setter that lets the resolver detach the conversation's app-control proxy
    * after `app_control_stop`. Disposes the existing proxy when transitioning
@@ -481,6 +484,7 @@ export interface SurfaceConversationContext {
    * rather than dispatching to a torn-down proxy.
    */
   setHostAppControlProxy?(proxy: HostAppControlProxy | undefined): void;
+  setHostCameraProxy?(proxy: HostCameraProxy | undefined): void;
   /** True when no interactive client is connected (headless / channel-only). */
   readonly hasNoClient?: boolean;
   isProcessing(): boolean;
@@ -2066,6 +2070,31 @@ export async function surfaceProxyResolver(
       inputWithTool,
       ctx.conversationId,
       signal ?? new AbortController().signal,
+    );
+  }
+
+  if (toolName === "describe_camera_once") {
+    if (!ctx.hostCameraProxy || !ctx.hostCameraProxy.isAvailable()) {
+      return {
+        content:
+          "Camera snapshot is not available — enable the `webcam-snapshot` feature flag and connect a macOS or Tauri client.",
+        isError: true,
+      };
+    }
+
+    const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
+    return ctx.hostCameraProxy.request(
+      "describe_camera_once",
+      {
+        ...(typeof input.prompt === "string" ? { prompt: input.prompt } : {}),
+        ...(typeof input.target_client_id === "string" &&
+        input.target_client_id !== ""
+          ? { target_client_id: input.target_client_id }
+          : {}),
+      },
+      ctx.conversationId,
+      signal,
+      sourceActorPrincipalId,
     );
   }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -120,6 +120,7 @@ import {
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
 import { canonicalizeTimeZone } from "./date-context.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
+import type { HostCameraProxy } from "./host-camera-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   ServerMessage,
@@ -205,6 +206,7 @@ export class Conversation {
    * @internal
    */
   hostAppControlProxy?: HostAppControlProxy;
+  /** @internal */ hostCameraProxy?: HostCameraProxy;
   /** @internal */ cesClient?: CesClient;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
@@ -759,6 +761,8 @@ export class Conversation {
     this.hostCuProxy?.dispose();
     this.hostAppControlProxy?.dispose();
     this.hostAppControlProxy = undefined;
+    this.hostCameraProxy?.dispose();
+    this.hostCameraProxy = undefined;
     // CES client is owned by DaemonServer — just drop the reference.
     // Do NOT close it here; the server manages the CES lifecycle.
     this.cesClient = undefined;
@@ -941,6 +945,13 @@ export class Conversation {
       this.hostAppControlProxy.dispose();
     }
     this.hostAppControlProxy = proxy;
+  }
+
+  setHostCameraProxy(proxy: HostCameraProxy | undefined): void {
+    if (this.hostCameraProxy && this.hostCameraProxy !== proxy) {
+      this.hostCameraProxy.dispose();
+    }
+    this.hostCameraProxy = proxy;
   }
 
   // ── Server-authoritative state signals ─────────────────────────────

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -37,10 +37,13 @@
 
 import { createHash } from "node:crypto";
 
+import { runAction } from "../actions/run-action.js";
 import type { ContentBlock } from "../providers/types.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type {
   HostAppControlInput,
   HostAppControlResultPayload,
@@ -253,12 +256,30 @@ export class HostAppControlProxy extends HostProxyBase<
     }
 
     try {
-      const payload = await this.dispatchRequest(
-        toolName,
-        input,
+      const payload = await runAction({
+        actionName: `host_app_control.${input.tool}`,
         conversationId,
-        signal,
-      );
+        inputSummary: JSON.stringify({
+          tool: input.tool,
+          app:
+            "app" in input && typeof input.app === "string" ? input.app : null,
+        }),
+        riskLevel: "Medium",
+        execute: async () =>
+          await this.dispatchRequest(toolName, input, conversationId, signal),
+        onLifecycle: (event) => {
+          const message: ActionLifecycleMessage = {
+            type: "action_lifecycle",
+            actionId: event.actionId,
+            actionName: event.actionName,
+            stage: event.stage,
+            ts: event.ts,
+            ...(event.message ? { message: event.message } : {}),
+            conversationId,
+          };
+          broadcastMessage(message, conversationId);
+        },
+      });
       return this.handleSuccess(input, payload);
     } catch (err) {
       if (err instanceof HostProxyRequestError) {

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import { getConfig } from "../config/loader.js";
 import {
   assistantEventHub,
@@ -15,6 +16,7 @@ import { formatShellOutput } from "../tools/shared/shell-output.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 
 const log = getLogger("host-bash-proxy");
 
@@ -119,92 +121,118 @@ export class HostBashProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const shellMaxTimeoutSec = getConfig().timeouts.shellMaxTimeoutSec;
-      const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
-      const proxyTimeoutSec = timeoutSec + 3;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, command: input.command },
-          "Host bash proxy request timed out",
-        );
-        const timeoutMessage = resolvedTargetClientId
-          ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
-          : "Host bash proxy timed out waiting for client response";
-        resolve(formatShellOutput("", timeoutMessage, null, true, timeoutSec));
-      }, proxyTimeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_bash_cancel",
-                  requestId,
-                  conversationId,
-                  targetClientId: resolvedTargetClientId,
-                },
-                conversationId,
-                { targetClientId: resolvedTargetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve(formatShellOutput("", "Aborted", null, false, 0));
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_bash",
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-        targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
-        metadata: { timeoutSec },
-      });
-
-      try {
-        broadcastMessage(
-          {
-            type: "host_bash_request",
-            requestId,
-            conversationId,
-            command: input.command,
-            working_dir: input.working_dir,
-            timeout_seconds: input.timeout_seconds,
-            targetClientId: resolvedTargetClientId,
-            ...(input.env && Object.keys(input.env).length > 0
-              ? { env: input.env }
-              : {}),
-          },
+    return runAction<ToolExecutionResult>({
+      actionName: "host_bash.execute",
+      conversationId,
+      inputSummary: JSON.stringify({
+        command: input.command,
+        workingDir: input.working_dir ?? null,
+        timeoutSeconds: input.timeout_seconds ?? null,
+        targetClientId: resolvedTargetClientId ?? null,
+      }),
+      riskLevel: "High",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: resolvedTargetClientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, command: input.command, err },
-          "Host bash proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const shellMaxTimeoutSec = getConfig().timeouts.shellMaxTimeoutSec;
+          const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
+          const proxyTimeoutSec = timeoutSec + 3;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, command: input.command },
+              "Host bash proxy request timed out",
+            );
+            const timeoutMessage = resolvedTargetClientId
+              ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
+              : "Host bash proxy timed out waiting for client response";
+            resolve(
+              formatShellOutput("", timeoutMessage, null, true, timeoutSec),
+            );
+          }, proxyTimeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_bash_cancel",
+                      requestId,
+                      conversationId,
+                      targetClientId: resolvedTargetClientId,
+                    },
+                    conversationId,
+                    { targetClientId: resolvedTargetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve(formatShellOutput("", "Aborted", null, false, 0));
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_bash",
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
+            metadata: { timeoutSec },
+          });
+
+          try {
+            broadcastMessage(
+              {
+                type: "host_bash_request",
+                requestId,
+                conversationId,
+                command: input.command,
+                working_dir: input.working_dir,
+                timeout_seconds: input.timeout_seconds,
+                targetClientId: resolvedTargetClientId,
+                ...(input.env && Object.keys(input.env).length > 0
+                  ? { env: input.env }
+                  : {}),
+              },
+              conversationId,
+              { targetClientId: resolvedTargetClientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, command: input.command, err },
+              "Host bash proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import type { InterfaceId } from "../channels/types.js";
 import {
   assistantEventHub,
@@ -10,6 +11,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type { HostBrowserRequest } from "./message-types/host-browser.js";
 
 /** Distributive omit that preserves union variant fields. */
@@ -120,7 +122,9 @@ export class HostBrowserProxy {
    * a valid extension transport.
    */
   hasExtensionClient(): boolean {
-    return assistantEventHub.listClientsByInterface("chrome-extension").length > 0;
+    return (
+      assistantEventHub.listClientsByInterface("chrome-extension").length > 0
+    );
   }
 
   /**
@@ -176,78 +180,106 @@ export class HostBrowserProxy {
     const targetActorPrincipalId = preferredClient?.actorPrincipalId;
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const timeoutSec = input.timeout_seconds ?? 30;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, cdpMethod: input.cdpMethod },
-          "Host browser proxy request timed out",
-        );
-        resolve({
-          content:
-            "Host browser proxy timed out waiting for extension response (check SSE connectivity and /v1/host-browser-result callback failures such as 404/401).",
-          isError: true,
-        });
-      }, timeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage({
-                type: "host_browser_cancel",
-                requestId,
-              });
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_browser",
-        targetClientId,
-        targetActorPrincipalId,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-      });
-
-      try {
-        if (!preferredClient) {
-          pendingInteractions.resolve(requestId);
-          reject(
-            new Error(
-              "host_browser send failed: no active extension connection",
-            ),
-          );
-          return;
-        }
-
-        broadcastMessage(
-          { ...input, type: "host_browser_request", requestId, conversationId },
+    return runAction<ToolExecutionResult>({
+      actionName: "host_browser.cdp_request",
+      conversationId,
+      inputSummary: JSON.stringify({
+        cdpMethod: input.cdpMethod,
+        cdpSessionId: input.cdpSessionId ?? null,
+        targetClientId: targetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: preferredClient.clientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, cdpMethod: input.cdpMethod, err },
-          "Host browser proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const timeoutSec = input.timeout_seconds ?? 30;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, cdpMethod: input.cdpMethod },
+              "Host browser proxy request timed out",
+            );
+            resolve({
+              content:
+                "Host browser proxy timed out waiting for extension response (check SSE connectivity and /v1/host-browser-result callback failures such as 404/401).",
+              isError: true,
+            });
+          }, timeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage({
+                    type: "host_browser_cancel",
+                    requestId,
+                  });
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_browser",
+            targetClientId,
+            targetActorPrincipalId,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+          });
+
+          try {
+            if (!preferredClient) {
+              pendingInteractions.resolve(requestId);
+              reject(
+                new Error(
+                  "host_browser send failed: no active extension connection",
+                ),
+              );
+              return;
+            }
+
+            broadcastMessage(
+              {
+                ...input,
+                type: "host_browser_request",
+                requestId,
+                conversationId,
+              },
+              conversationId,
+              { targetClientId: preferredClient.clientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, cdpMethod: input.cdpMethod, err },
+              "Host browser proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-camera-proxy.ts
+++ b/assistant/src/daemon/host-camera-proxy.ts
@@ -1,0 +1,230 @@
+/**
+ * Host camera proxy.
+ *
+ * Dispatches one request-scoped webcam snapshot to a connected desktop client,
+ * summarizes the returned in-memory image through the configured provider, and
+ * returns only the bounded text summary to the agent.
+ */
+
+import { runAction } from "../actions/run-action.js";
+import {
+  extractAllText,
+  getConfiguredProvider,
+} from "../providers/provider-send-message.js";
+import type { Message } from "../providers/types.js";
+import {
+  assistantEventHub,
+  broadcastMessage,
+} from "../runtime/assistant-event-hub.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
+import type { ToolExecutionResult } from "../tools/types.js";
+import { getLogger } from "../util/logger.js";
+import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
+import type {
+  HostCameraInput,
+  HostCameraResultPayload,
+} from "./message-types/host-camera.js";
+
+const log = getLogger("host-camera-proxy");
+const MAX_SUMMARY_CHARS = 1_500;
+
+export class HostCameraProxy extends HostProxyBase<
+  HostCameraInput,
+  HostCameraResultPayload
+> {
+  constructor() {
+    super({
+      capabilityName: "host_camera",
+      requestEventName: "host_camera_request",
+      cancelEventName: "host_camera_cancel",
+      resultPendingKind: "host_camera",
+      timeoutMs: 90_000,
+      disposedMessage: "Host camera proxy disposed",
+    });
+  }
+
+  async request(
+    toolName: "describe_camera_once",
+    input: HostCameraInput,
+    conversationId: string,
+    signal?: AbortSignal,
+    sourceActorPrincipalId?: string,
+  ): Promise<ToolExecutionResult> {
+    if (signal?.aborted) {
+      return { content: "Camera snapshot was aborted.", isError: true };
+    }
+
+    const resolvedTarget = this.resolveTargetClient(
+      input.target_client_id,
+      sourceActorPrincipalId,
+    );
+    if (resolvedTarget.error) return resolvedTarget.error;
+
+    return runAction<ToolExecutionResult>({
+      actionName: "host_camera.describe_once",
+      conversationId,
+      inputSummary: JSON.stringify({
+        prompt: input.prompt ?? null,
+        targetClientId: resolvedTarget.targetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
+          conversationId,
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () => {
+        try {
+          const payload = await this.dispatchRequest(
+            toolName,
+            input,
+            conversationId,
+            signal,
+            undefined,
+            resolvedTarget.targetClientId,
+          );
+          return await summarizeCameraSnapshot(payload, input.prompt, signal);
+        } catch (err) {
+          if (err instanceof HostProxyRequestError) {
+            const content =
+              err.reason === "timeout"
+                ? "Camera snapshot timed out waiting for the desktop client."
+                : err.reason === "aborted"
+                  ? "Camera snapshot was aborted."
+                  : "Camera snapshot was cancelled because the proxy was disposed.";
+            return { content, isError: true };
+          }
+          log.warn({ err }, "Host camera proxy request failed");
+          return {
+            content: err instanceof Error ? err.message : String(err),
+            isError: true,
+          };
+        }
+      },
+    });
+  }
+
+  private resolveTargetClient(
+    targetClientId: string | undefined,
+    sourceActorPrincipalId: string | undefined,
+  ): { targetClientId?: string; error?: ToolExecutionResult } {
+    if (targetClientId) {
+      const target = assistantEventHub.getClientById(targetClientId);
+      if (!target || !target.capabilities.includes("host_camera")) {
+        return {
+          error: {
+            content: `Error: client "${targetClientId}" is not connected or does not support host_camera. Run \`assistant clients list --capability host_camera\` to see available clients.`,
+            isError: true,
+          },
+        };
+      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_camera",
+      });
+      if (rejection) return { error: rejection };
+      return { targetClientId };
+    }
+
+    const resolved = pickSameUserAutoResolve({
+      hub: assistantEventHub,
+      capability: "host_camera",
+      sourceActorPrincipalId,
+    });
+    if (resolved.kind === "ambiguous") {
+      return { error: ambiguousSameUserError("host_camera") };
+    }
+    return {
+      targetClientId: resolved.kind === "match" ? resolved.clientId : undefined,
+    };
+  }
+}
+
+async function summarizeCameraSnapshot(
+  payload: HostCameraResultPayload,
+  prompt: string | undefined,
+  signal: AbortSignal | undefined,
+): Promise<ToolExecutionResult> {
+  if (payload.error) {
+    return { content: payload.error, isError: true };
+  }
+  if (!payload.imageBase64) {
+    return {
+      content:
+        "Camera snapshot failed: the desktop client did not return an image.",
+      isError: true,
+    };
+  }
+
+  const provider = await getConfiguredProvider("mainAgent");
+  if (!provider) {
+    return {
+      content:
+        "Camera snapshot failed: no configured LLM provider is available to summarize the image.",
+      isError: true,
+    };
+  }
+
+  const mediaType = payload.mediaType ?? "image/jpeg";
+  const userPrompt =
+    prompt?.trim() ||
+    "Briefly describe what is visible in this single webcam snapshot.";
+  const messages: Message[] = [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text:
+            "Summarize this one webcam snapshot for the assistant. " +
+            "Do not include identity guesses, sensitive inferences, or unrelated speculation. " +
+            `User intent: ${userPrompt}`,
+        },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data: payload.imageBase64,
+          },
+        },
+      ],
+    },
+  ];
+
+  const response = await provider.sendMessage(
+    messages,
+    [],
+    "You produce concise, privacy-aware descriptions of one-off webcam snapshots. Keep the answer under 150 words.",
+    { signal },
+  );
+  const summary = extractAllText(response).trim();
+  if (!summary) {
+    return {
+      content:
+        "Camera snapshot was captured, but the summarizer returned no text.",
+      isError: true,
+    };
+  }
+  return {
+    content:
+      summary.length > MAX_SUMMARY_CHARS
+        ? `${summary.slice(0, MAX_SUMMARY_CHARS).trimEnd()}...`
+        : summary,
+    isError: false,
+  };
+}

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -16,6 +16,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import { escapeAxTreeContent } from "../agent/loop.js";
 import { loadConfig } from "../config/loader.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -28,6 +29,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 
 const log = getLogger("host-cu-proxy");
 
@@ -190,83 +192,108 @@ export class HostCuProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      let detachAbort: () => void = () => {};
+    return runAction<ToolExecutionResult>({
+      actionName: toolName,
+      conversationId,
+      inputSummary: JSON.stringify({
+        stepNumber,
+        targetClientId: targetClientId ?? null,
+      }),
+      riskLevel: "High",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
+          conversationId,
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          let detachAbort: () => void = () => {};
 
-      const timer = setTimeout(() => {
-        this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
-        log.warn({ requestId, toolName }, "Host CU proxy request timed out");
-        resolve({
-          content: "Host CU proxy timed out waiting for client response",
-          isError: true,
-        });
-      }, REQUEST_TIMEOUT_SEC * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
+          const timer = setTimeout(() => {
             this._ownedRequests.delete(requestId);
             pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_cu_cancel",
-                  requestId,
-                  conversationId,
-                  ...(targetClientId != null ? { targetClientId } : {}),
-                },
-                conversationId,
-                { targetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
+            log.warn(
+              { requestId, toolName },
+              "Host CU proxy request timed out",
+            );
+            resolve({
+              content: "Host CU proxy timed out waiting for client response",
+              isError: true,
+            });
+          }, REQUEST_TIMEOUT_SEC * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                this._ownedRequests.delete(requestId);
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_cu_cancel",
+                      requestId,
+                      conversationId,
+                      ...(targetClientId != null ? { targetClientId } : {}),
+                    },
+                    conversationId,
+                    { targetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
           }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
 
-      this._ownedRequests.add(requestId);
+          this._ownedRequests.add(requestId);
 
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_cu",
-        targetClientId,
-        targetActorPrincipalId:
-          targetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
-            : undefined,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-      });
-
-      try {
-        broadcastMessage(
-          {
-            type: "host_cu_request",
-            requestId,
+          pendingInteractions.register(requestId, {
             conversationId,
-            toolName,
-            input,
-            stepNumber,
-            reasoning,
-            // Include in body so receiving client can verify targeted endpoint.
-            ...(targetClientId != null ? { targetClientId } : {}),
-          },
-          conversationId,
-          { targetClientId },
-        );
-      } catch (err) {
-        this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
-        log.warn({ requestId, toolName, err }, "Host CU proxy send failed");
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+            kind: "host_cu",
+            targetClientId,
+            targetActorPrincipalId:
+              targetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+                : undefined,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+          });
+
+          try {
+            broadcastMessage(
+              {
+                type: "host_cu_request",
+                requestId,
+                conversationId,
+                toolName,
+                input,
+                stepNumber,
+                reasoning,
+                // Include in body so receiving client can verify targeted endpoint.
+                ...(targetClientId != null ? { targetClientId } : {}),
+              },
+              conversationId,
+              { targetClientId },
+            );
+          } catch (err) {
+            this._ownedRequests.delete(requestId);
+            pendingInteractions.resolve(requestId);
+            log.warn({ requestId, toolName, err }, "Host CU proxy send failed");
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import {
   assistantEventHub,
   broadcastMessage,
@@ -14,6 +15,7 @@ import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type { HostFileRequest } from "./message-types/host-file.js";
 
 /** Distributive omit that preserves union variant fields. */
@@ -130,93 +132,116 @@ export class HostFileProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const timeoutSec = 30;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, operation: input.operation },
-          "Host file proxy request timed out",
-        );
-        resolve({
-          content: resolvedTargetClientId
-            ? `Host file proxy timed out waiting for response from client '${resolvedTargetClientId}'`
-            : "Host file proxy timed out waiting for client response",
-          isError: true,
-        });
-      }, timeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_file_cancel",
-                  requestId,
-                  conversationId,
-                  ...(resolvedTargetClientId != null
-                    ? { targetClientId: resolvedTargetClientId }
-                    : {}),
-                },
-                conversationId,
-                { targetClientId: resolvedTargetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_file",
-        targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-        metadata: { operation: input.operation, path: input.path },
-      });
-
-      try {
-        broadcastMessage(
-          {
-            ...input,
-            type: "host_file_request",
-            requestId,
-            conversationId,
-            // Always include in message body so the receiving client can verify
-            // which endpoint was targeted (even when auto-resolved).
-            ...(resolvedTargetClientId != null
-              ? { targetClientId: resolvedTargetClientId }
-              : {}),
-          },
+    return runAction<ToolExecutionResult>({
+      actionName: `host_file.${input.operation}`,
+      conversationId,
+      inputSummary: JSON.stringify({
+        operation: input.operation,
+        path: input.path,
+        targetClientId: resolvedTargetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: resolvedTargetClientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, operation: input.operation, err },
-          "Host file proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const timeoutSec = 30;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, operation: input.operation },
+              "Host file proxy request timed out",
+            );
+            resolve({
+              content: resolvedTargetClientId
+                ? `Host file proxy timed out waiting for response from client '${resolvedTargetClientId}'`
+                : "Host file proxy timed out waiting for client response",
+              isError: true,
+            });
+          }, timeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_file_cancel",
+                      requestId,
+                      conversationId,
+                      ...(resolvedTargetClientId != null
+                        ? { targetClientId: resolvedTargetClientId }
+                        : {}),
+                    },
+                    conversationId,
+                    { targetClientId: resolvedTargetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_file",
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+            metadata: { operation: input.operation, path: input.path },
+          });
+
+          try {
+            broadcastMessage(
+              {
+                ...input,
+                type: "host_file_request",
+                requestId,
+                conversationId,
+                // Always include in message body so the receiving client can verify
+                // which endpoint was targeted (even when auto-resolved).
+                ...(resolvedTargetClientId != null
+                  ? { targetClientId: resolvedTargetClientId }
+                  : {}),
+              },
+              conversationId,
+              { targetClientId: resolvedTargetClientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, operation: input.operation, err },
+              "Host file proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -208,6 +208,10 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
         conversationId,
         kind: this.resultPendingKind,
         ...(targetClientId != null ? { targetClientId } : {}),
+        targetActorPrincipalId:
+          targetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+            : undefined,
       });
 
       try {

--- a/assistant/src/daemon/host-proxy-preactivation.ts
+++ b/assistant/src/daemon/host-proxy-preactivation.ts
@@ -58,6 +58,7 @@ export const HOST_PROXY_SKILL_PREACTIVATIONS: ReadonlyArray<{
 }> = [
   { capability: "host_cu", skillId: "computer-use" },
   { capability: "host_app_control", skillId: "app-control" },
+  { capability: "host_camera", skillId: "webcam-snapshot" },
 ];
 
 /**

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -14,6 +14,7 @@
 
 // Re-export domain modules (all individual types remain importable)
 export * from "./message-types/acp.js";
+export * from "./message-types/actions.js";
 export * from "./message-types/apps.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
@@ -27,6 +28,7 @@ export * from "./message-types/home.js";
 export * from "./message-types/host-app-control.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
+export * from "./message-types/host-camera.js";
 export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
 export * from "./message-types/host-transfer.js";
@@ -48,6 +50,7 @@ export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
 import type { _AcpServerMessages } from "./message-types/acp.js";
+import type { _ActionsServerMessages } from "./message-types/actions.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -88,6 +91,7 @@ import type {
   _HostBrowserClientMessages,
   _HostBrowserServerMessages,
 } from "./message-types/host-browser.js";
+import type { _HostCameraServerMessages } from "./message-types/host-camera.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type { _HostTransferServerMessages } from "./message-types/host-transfer.js";
@@ -192,6 +196,7 @@ export type ServerMessage =
   | _HostAppControlServerMessages
   | _HostBashServerMessages
   | _HostBrowserServerMessages
+  | _HostCameraServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages
   | _HostTransferServerMessages
@@ -205,6 +210,7 @@ export type ServerMessage =
   | _NotificationsServerMessages
   | _UpgradesServerMessages
   | _AcpServerMessages
+  | _ActionsServerMessages
   | _DiskPressureServerMessages
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/actions.ts
+++ b/assistant/src/daemon/message-types/actions.ts
@@ -1,0 +1,26 @@
+/**
+ * Action lifecycle messages surfaced to connected clients.
+ *
+ * These events let thin clients (e.g. Tauri HUD) show host-action progress
+ * without parsing tool-specific payloads.
+ */
+
+export type ActionLifecycleStage =
+  | "started"
+  | "executing"
+  | "completed"
+  | "failed"
+  | "rollback_started"
+  | "rollback_completed";
+
+export interface ActionLifecycleMessage {
+  type: "action_lifecycle";
+  actionId: string;
+  actionName: string;
+  stage: ActionLifecycleStage;
+  ts: number;
+  message?: string;
+  conversationId?: string;
+}
+
+export type _ActionsServerMessages = ActionLifecycleMessage;

--- a/assistant/src/daemon/message-types/host-camera.ts
+++ b/assistant/src/daemon/message-types/host-camera.ts
@@ -1,0 +1,44 @@
+// Host camera proxy types.
+// Enables a request-scoped, one-shot webcam snapshot on a connected desktop
+// client. Raw image bytes return only to the awaiting proxy and are summarized
+// before the agent sees the tool result.
+
+export interface HostCameraInput {
+  /** Optional question/instruction to guide the image summary. */
+  prompt?: string;
+  /** Optional target client id when multiple desktop clients are connected. */
+  target_client_id?: string;
+}
+
+// === Server -> Client ===
+
+export interface HostCameraRequest {
+  type: "host_camera_request";
+  requestId: string;
+  conversationId: string;
+  toolName: "describe_camera_once";
+  input: HostCameraInput;
+  targetClientId?: string;
+}
+
+export interface HostCameraCancel {
+  type: "host_camera_cancel";
+  requestId: string;
+  conversationId: string;
+  targetClientId?: string;
+}
+
+// === Result payload (HTTP /v1/host-camera-result body) ===
+
+export interface HostCameraResultPayload {
+  requestId: string;
+  imageBase64?: string;
+  mediaType?: "image/jpeg" | "image/png" | "image/webp";
+  width?: number;
+  height?: number;
+  error?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostCameraServerMessages = HostCameraRequest | HostCameraCancel;

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -46,6 +46,7 @@ import {
 } from "./conversation-store.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
+import { HostCameraProxy } from "./host-camera-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 
@@ -173,6 +174,13 @@ async function prepareConversationForMessage(
     }
   } else if (!conversation.isProcessing()) {
     conversation.setHostAppControlProxy(undefined);
+  }
+  if (supportsHostProxy(resolvedInterface, "host_camera")) {
+    if (!conversation.isProcessing() || !conversation.hostCameraProxy) {
+      conversation.setHostCameraProxy(new HostCameraProxy());
+    }
+  } else if (!conversation.isProcessing()) {
+    conversation.setHostCameraProxy(undefined);
   }
   // The early `isProcessing()` throw above guarantees the conversation is
   // idle here, so preactivation is unconditional once the proxies are wired.

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -26,6 +26,7 @@ const HOST_PREFIX_TO_CAPABILITY: Record<string, HostProxyCapability> = {
   host_cu: "host_cu",
   host_browser: "host_browser",
   host_app_control: "host_app_control",
+  host_camera: "host_camera",
 };
 
 /**
@@ -619,7 +620,6 @@ function resolveCanonicalRequestSourceType(
   if (sourceChannel === "vellum") return "desktop";
   return "channel";
 }
-
 
 /**
  * Lazily load heavy dependencies and create a canonical guardian request +

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -5,8 +5,7 @@
  * Verifies that the submitting (source) actor's principal id matches the
  * actor principal id captured for the target client at SSE subscription
  * time. This is the authoritative gate that prevents cross-user
- * execution and cross-user result submission across all three host-proxy
- * capabilities (host_bash, host_file, host_cu).
+ * execution and cross-user result submission across host-proxy capabilities.
  *
  * Two entry points map onto the two control-flow styles in the codebase:
  *   - {@link enforceSameActorOrErrorResult} for proxies — returns a
@@ -46,6 +45,7 @@ export type SameActorOp =
   | "host_file"
   | "host_cu"
   | "host_browser"
+  | "host_camera"
   | "host_transfer";
 
 /**

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,13 +1,13 @@
 /**
  * In-memory tracker that maps requestId to conversation info for pending
- * confirmation, secret, host_bash, host_file, host_cu, host_browser, and
- * host_transfer interactions.
+ * confirmation, secret, host_bash, host_file, host_cu, host_browser,
+ * host_camera, and host_transfer interactions.
  *
  * All request types self-register with their full RPC lifecycle state
  * (resolve/reject callbacks, timer, abort detach):
  *
  * - Host proxies (host_bash, host_file, host_cu, host_browser,
- *   host_app_control, host_transfer): register in request(), using
+ *   host_app_control, host_camera, host_transfer): register in request(), using
  *   rpcResolve/rpcReject/timer/detachAbort/metadata.
  *
  * - Prompters (PermissionPrompter, SecretPrompter): register in prompt(),
@@ -52,12 +52,13 @@ export interface PendingInteraction {
     | "host_cu"
     | "host_browser"
     | "host_app_control"
+    | "host_camera"
     | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
-  /** When set, the host_bash request should be routed to this specific client. */
+  /** When set, the host proxy request should be routed to this specific client. */
   targetClientId?: string;
   /**
    * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
@@ -136,13 +137,13 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, host_cu, host_browser, host_app_control, and
+ * host_bash, host_file, host_cu, host_browser, host_app_control, host_camera, and
  * host_transfer interactions are intentionally skipped — they represent
  * in-flight tool executions proxied to the client, not confirmations to
  * auto-deny. Removing them would orphan the request: the client would POST to
  * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
- * /v1/host-browser-result, /v1/host-app-control-result, or
- * /v1/host-transfer-result after completing the operation, get a 404, and the
+ * /v1/host-browser-result, /v1/host-app-control-result,
+ * /v1/host-camera-result, or /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  */
 export function removeByConversation(conversationId: string): void {
@@ -155,6 +156,7 @@ export function removeByConversation(conversationId: string): void {
       interaction.kind !== "host_cu" &&
       interaction.kind !== "host_browser" &&
       interaction.kind !== "host_app_control" &&
+      interaction.kind !== "host_camera" &&
       interaction.kind !== "host_transfer" &&
       interaction.kind !== "acp_confirmation"
     ) {

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -114,6 +114,7 @@ export function handleSubscribeAssistantEvents(
     "host_file",
     "host_cu",
     "host_app_control",
+    "host_camera",
     "host_browser",
   ];
 

--- a/assistant/src/runtime/routes/host-camera-routes.ts
+++ b/assistant/src/runtime/routes/host-camera-routes.ts
@@ -1,0 +1,131 @@
+/**
+ * Route handler for host camera result submissions.
+ *
+ * Resolves pending one-shot camera snapshot requests. The raw image bytes are
+ * forwarded only to the awaiting proxy, which summarizes and discards them.
+ */
+import { z } from "zod";
+
+import { findConversation } from "../../daemon/conversation-store.js";
+import type { HostCameraResultPayload } from "../../daemon/message-types/host-camera.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+function handleHostCameraResult({ body, headers }: RouteHandlerArgs) {
+  if (!body || typeof body !== "object") {
+    throw new BadRequestError("Request body is required");
+  }
+
+  const { requestId, imageBase64, mediaType, width, height, error } =
+    body as unknown as HostCameraResultPayload;
+
+  if (!requestId || typeof requestId !== "string") {
+    throw new BadRequestError("requestId is required");
+  }
+
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    throw new NotFoundError("No pending interaction found for this requestId");
+  }
+  if (peeked.kind !== "host_camera") {
+    throw new ConflictError(
+      `Pending interaction is of kind "${peeked.kind}", expected "host_camera"`,
+    );
+  }
+
+  if (peeked.targetClientId != null) {
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId) {
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host camera request.",
+      );
+    }
+    if (submittingClientId !== peeked.targetClientId) {
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_camera",
+    });
+  }
+
+  const interaction = pendingInteractions.resolve(requestId)!;
+  const conversation = findConversation(interaction.conversationId);
+  if (!conversation) {
+    return { accepted: true };
+  }
+
+  conversation.hostCameraProxy?.resolve(requestId, {
+    requestId,
+    ...(typeof imageBase64 === "string" ? { imageBase64 } : {}),
+    ...(mediaType ? { mediaType } : {}),
+    ...(typeof width === "number" ? { width } : {}),
+    ...(typeof height === "number" ? { height } : {}),
+    ...(typeof error === "string" ? { error } : {}),
+  });
+
+  return { accepted: true };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "host_camera_result",
+    endpoint: "host-camera-result",
+    method: "POST",
+    requireGuardian: true,
+    summary: "Submit host camera snapshot result",
+    description:
+      "Resolve a pending one-shot host camera snapshot request by requestId.",
+    tags: ["host"],
+    requestBody: z.object({
+      requestId: z.string().describe("Pending camera request ID"),
+      imageBase64: z
+        .string()
+        .describe("Base64-encoded one-shot webcam image")
+        .optional(),
+      mediaType: z.enum(["image/jpeg", "image/png", "image/webp"]).optional(),
+      width: z.number().optional(),
+      height: z.number().optional(),
+      error: z.string().optional(),
+    }),
+    responseBody: z.object({
+      accepted: z.boolean(),
+    }),
+    additionalResponses: {
+      "400": {
+        description:
+          "x-vellum-client-id header is missing for a targeted host camera request.",
+      },
+      "403": {
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+      },
+      "404": {
+        description: "No pending interaction found for the given requestId.",
+      },
+      "409": {
+        description: "Pending interaction exists but is of a different kind.",
+      },
+    },
+    handler: handleHostCameraResult,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -55,6 +55,7 @@ import { ROUTES as HOME_STATE_ROUTES } from "./home-state-routes.js";
 import { ROUTES as HOST_APP_CONTROL_ROUTES } from "./host-app-control-routes.js";
 import { ROUTES as HOST_BASH_ROUTES } from "./host-bash-routes.js";
 import { ROUTES as HOST_BROWSER_ROUTES } from "./host-browser-routes.js";
+import { ROUTES as HOST_CAMERA_ROUTES } from "./host-camera-routes.js";
 import { ROUTES as HOST_CU_ROUTES } from "./host-cu-routes.js";
 import { ROUTES as HOST_FILE_ROUTES } from "./host-file-routes.js";
 import { ROUTES as HOST_TRANSFER_ROUTES } from "./host-transfer-routes.js";
@@ -157,6 +158,7 @@ export const ROUTES: RouteDefinition[] = [
   ...HOST_APP_CONTROL_ROUTES,
   ...HOST_BASH_ROUTES,
   ...HOST_BROWSER_ROUTES,
+  ...HOST_CAMERA_ROUTES,
   ...HOST_CU_ROUTES,
   ...HOST_FILE_ROUTES,
   ...HOST_TRANSFER_ROUTES,

--- a/assistant/src/tools/host-camera/skill-proxy-bridge.ts
+++ b/assistant/src/tools/host-camera/skill-proxy-bridge.ts
@@ -1,0 +1,15 @@
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export function forwardHostCameraProxyTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.proxyToolResolver) {
+    return Promise.resolve({
+      content: `Cannot execute ${toolName}: no proxy resolver available. This tool requires a connected desktop client.`,
+      isError: true,
+    });
+  }
+  return context.proxyToolResolver(toolName, input);
+}

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -8,6 +8,7 @@ public protocol HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool
     func postFileResult(_ result: HostFileResultPayload) async -> Bool
     func postCuResult(_ result: HostCuResultPayload) async -> Bool
+    func postCameraResult(_ result: HostCameraResultPayload) async -> Bool
     func postAppControlResult(_ result: HostAppControlResultPayload) async -> Bool
     func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool
     func postTransferResult(_ result: HostTransferResultPayload) async -> Bool
@@ -80,6 +81,29 @@ public struct HostProxyClient: HostProxyClientProtocol {
             return true
         } catch {
             log.error("postCuResult error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func postCameraResult(_ result: HostCameraResultPayload) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(result)
+            let timeout: TimeInterval = result.imageBase64 != nil
+                ? max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
+                : 30
+            let response = try await GatewayHTTPClient.post(
+                path: "host-camera-result",
+                body: body,
+                extraHeaders: ["X-Vellum-Client-Id": DeviceIdStore.getOrCreate()],
+                timeout: timeout
+            )
+            guard response.isSuccess else {
+                log.error("postCameraResult failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("postCameraResult error: \(error.localizedDescription)")
             return false
         }
     }


### PR DESCRIPTION
## Summary
- Route camera snapshot requests through conversation surface proxy resolution.
- Keeps the surface-side camera path separate from the core host camera bridge.

## Test Plan
- cd assistant && bun test src/__tests__/host-camera-proxy.test.ts src/__tests__/host-camera-routes.test.ts src/__tests__/host-proxy-interface.test.ts src/actions/run-action.test.ts
- cd assistant && bunx tsc --noEmit

## Risk
- Medium. Opened as draft because it depends on the host camera proxy bridge PR.

Made with [Cursor](https://cursor.com)