### PR TITLE
Add perception and personal knowledge memory spine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Root .env — sourced automatically by clients/macos/build.sh
-# Copy to .env and fill in values. This file is gitignored.
+# Copy to .env or .env.local and fill in values. These files are gitignored.
 # Existing environment variables take precedence over values here.
 
 # --- Sentry (crash reporting) ---
@@ -21,3 +21,7 @@ PROXY_ALLOWED_HOSTS=*.vellum.ai
 # Defaults to https://www.vellum.ai/docs. Must be a parseable absolute http(s) URL with no
 # query or fragment, otherwise the override is ignored and the default is used.
 # VELLUM_DOCS_BASE_URL=https://staging.vellum.ai/docs
+
+# --- LLM providers ---
+# Store real keys in .env.local or the assistant key store, never in this example file.
+OPENAI_API_KEY=

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -16,6 +16,7 @@ mock.module("../config/loader.js", () => ({
 
 const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 type MockClient = {
   clientId: string;
@@ -31,8 +32,12 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
     _conversationId?: string,
     options?: unknown,
   ) => {
-    sentMessages.push(msg);
-    sentMessageOptions.push(options);
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+      sentMessageOptions.push(options);
+    }
   },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
@@ -54,6 +59,7 @@ describe("HostBashProxy", () => {
   function setup() {
     sentMessages.length = 0;
     sentMessageOptions.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockCapableClients = [];
     mockClientRegistry = new Map();
@@ -216,6 +222,34 @@ describe("HostBashProxy", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toContain("command_timeout");
+    });
+
+    test("emits action lifecycle events for host_bash execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { command: "echo lifecycle" },
+        "session-1",
+      );
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "ok\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      await resultPromise;
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
+      expect(
+        lifecycleMessages.every((m) => m.type === "action_lifecycle"),
+      ).toBe(true);
     });
   });
 

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -11,6 +11,7 @@ mock.module("../util/logger.js", () => ({
 
 /** Events published through the mock event hub. */
 let publishedEvents: unknown[] = [];
+let lifecycleEvents: Array<Record<string, unknown>> = [];
 let mockHasConnection = true;
 
 /**
@@ -49,7 +50,11 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       mockClients.find((c) => c.clientId === clientId)?.actorPrincipalId,
   },
   broadcastMessage: (msg: unknown) => {
-    publishedEvents.push(msg);
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleEvents.push(msg as Record<string, unknown>);
+    } else {
+      publishedEvents.push(msg);
+    }
   },
 }));
 
@@ -72,6 +77,7 @@ describe("HostBrowserProxy", () => {
     HostBrowserProxy.reset();
     pendingInteractions.clear();
     publishedEvents = [];
+    lifecycleEvents = [];
     mockHasConnection = true;
     mockClients = [];
     proxy = HostBrowserProxy.instance;
@@ -154,6 +160,25 @@ describe("HostBrowserProxy", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Navigation failed");
+    });
+
+    test("emits action lifecycle events for host_browser execution", async () => {
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.reload" },
+        "session-1",
+      );
+
+      const requestId = (getPublishedMessages()[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolveResult(requestId, { content: "ok", isError: false });
+      await resultPromise;
+
+      expect(lifecycleEvents.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleEvents.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-camera-proxy.test.ts
+++ b/assistant/src/__tests__/host-camera-proxy.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sentMessages: unknown[] = [];
+const registered: Array<{ requestId: string; interaction: unknown }> = [];
+const resolvedInteractionIds: string[] = [];
+let providerCalls = 0;
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  assistantEventHub: {
+    getMostRecentClientByCapability: (cap: string) =>
+      cap === "host_camera" ? { clientId: "client-1" } : null,
+    listClientsByCapability: (cap: string) =>
+      cap === "host_camera"
+        ? [
+            {
+              clientId: "client-1",
+              capabilities: ["host_camera"],
+              actorPrincipalId: "actor-1",
+            },
+          ]
+        : [],
+    getClientById: (clientId: string) =>
+      clientId === "client-1"
+        ? { clientId, capabilities: ["host_camera"] }
+        : null,
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientId === "client-1" ? "actor-1" : undefined,
+  },
+}));
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  register: (requestId: string, interaction: unknown) => {
+    registered.push({ requestId, interaction });
+  },
+  resolve: (requestId: string) => {
+    resolvedInteractionIds.push(requestId);
+    return undefined;
+  },
+  get: () => undefined,
+  getByKind: () => [],
+  getByConversation: () => [],
+  removeByConversation: () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: () => ({
+    sendMessage: async () => {
+      providerCalls += 1;
+      return {
+        content: [
+          { type: "text", text: "A desk, a keyboard, and a mug are visible." },
+        ],
+        model: "mock",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "end",
+      };
+    },
+  }),
+  extractAllText: (response: {
+    content: Array<{ type: string; text?: string }>;
+  }) =>
+    response.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text ?? "")
+      .join(""),
+}));
+
+import { HostCameraProxy } from "../daemon/host-camera-proxy.js";
+
+describe("HostCameraProxy", () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    registered.length = 0;
+    resolvedInteractionIds.length = 0;
+    providerCalls = 0;
+  });
+
+  test("dispatches one host_camera_request and returns only the text summary", async () => {
+    const proxy = new HostCameraProxy();
+    const resultPromise = proxy.request(
+      "describe_camera_once",
+      { prompt: "What is on the desk?" },
+      "conv-1",
+      undefined,
+      "actor-1",
+    );
+
+    const requestMessage = sentMessages.find(
+      (msg) => (msg as Record<string, unknown>).type === "host_camera_request",
+    ) as Record<string, unknown>;
+    expect(requestMessage).toBeDefined();
+    expect(requestMessage.toolName).toBe("describe_camera_once");
+    expect(requestMessage.conversationId).toBe("conv-1");
+    expect(requestMessage.input).toEqual({ prompt: "What is on the desk?" });
+    expect(requestMessage.targetClientId).toBe("client-1");
+    expect(registered).toHaveLength(1);
+
+    proxy.resolve(requestMessage.requestId as string, {
+      requestId: requestMessage.requestId as string,
+      imageBase64: "raw-image-bytes",
+      mediaType: "image/jpeg",
+      width: 640,
+      height: 480,
+    });
+
+    const result = await resultPromise;
+    expect(providerCalls).toBe(1);
+    expect(result).toEqual({
+      content: "A desk, a keyboard, and a mug are visible.",
+      isError: false,
+    });
+    expect(JSON.stringify(result)).not.toContain("raw-image-bytes");
+  });
+
+  test("client errors are returned without calling the summarizer", async () => {
+    const proxy = new HostCameraProxy();
+    const resultPromise = proxy.request(
+      "describe_camera_once",
+      {},
+      "conv-1",
+      undefined,
+      "actor-1",
+    );
+    const requestMessage = sentMessages.find(
+      (msg) => (msg as Record<string, unknown>).type === "host_camera_request",
+    ) as Record<string, unknown>;
+
+    proxy.resolve(requestMessage.requestId as string, {
+      requestId: requestMessage.requestId as string,
+      error: "Camera permission denied.",
+    });
+
+    await expect(resultPromise).resolves.toEqual({
+      content: "Camera permission denied.",
+      isError: true,
+    });
+    expect(providerCalls).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/host-camera-routes.test.ts
+++ b/assistant/src/__tests__/host-camera-routes.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface PendingEntry {
+  conversationId: string;
+  kind: string;
+  targetClientId?: string;
+  targetActorPrincipalId?: string;
+}
+
+const pending = new Map<string, PendingEntry>();
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  get: (requestId: string) => pending.get(requestId),
+  resolve: (requestId: string) => {
+    const entry = pending.get(requestId);
+    if (entry) pending.delete(requestId);
+    return entry;
+  },
+}));
+
+interface FakeConversation {
+  conversationId: string;
+  hostCameraProxy?: {
+    resolve: (requestId: string, payload: unknown) => void;
+  };
+}
+
+const conversations = new Map<string, FakeConversation>();
+
+mock.module("../daemon/conversation-store.js", () => ({
+  findConversation: (id: string) => conversations.get(id),
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveActorPrincipalIdForLocalGuardian: (value: string | undefined) => value,
+}));
+
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../runtime/routes/errors.js";
+import { ROUTES } from "../runtime/routes/host-camera-routes.js";
+
+const handleHostCameraResult = ROUTES.find(
+  (r) => r.endpoint === "host-camera-result",
+)!.handler;
+
+describe("handleHostCameraResult", () => {
+  beforeEach(() => {
+    pending.clear();
+    conversations.clear();
+  });
+
+  test("forwards one-shot image payload to the conversation hostCameraProxy", async () => {
+    const requestId = "camera-req-1";
+    const conversationId = "conv-1";
+    pending.set(requestId, { conversationId, kind: "host_camera" });
+
+    const resolveCalls: Array<{ requestId: string; payload: unknown }> = [];
+    conversations.set(conversationId, {
+      conversationId,
+      hostCameraProxy: {
+        resolve(rid, payload) {
+          resolveCalls.push({ requestId: rid, payload });
+        },
+      },
+    });
+
+    const result = await handleHostCameraResult({
+      body: {
+        requestId,
+        imageBase64: "jpeg-bytes",
+        mediaType: "image/jpeg",
+        width: 640,
+        height: 480,
+      },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveCalls).toEqual([
+      {
+        requestId,
+        payload: {
+          requestId,
+          imageBase64: "jpeg-bytes",
+          mediaType: "image/jpeg",
+          width: 640,
+          height: 480,
+        },
+      },
+    ]);
+    expect(pending.has(requestId)).toBe(false);
+  });
+
+  test("forwards errors without requiring image bytes", async () => {
+    const requestId = "camera-req-error";
+    const conversationId = "conv-error";
+    pending.set(requestId, { conversationId, kind: "host_camera" });
+
+    let payload: unknown;
+    conversations.set(conversationId, {
+      conversationId,
+      hostCameraProxy: {
+        resolve(_rid, value) {
+          payload = value;
+        },
+      },
+    });
+
+    await handleHostCameraResult({
+      body: { requestId, error: "Camera permission denied." },
+    });
+
+    expect(payload).toEqual({
+      requestId,
+      error: "Camera permission denied.",
+    });
+  });
+
+  test("rejects missing request id", () => {
+    expect(() => handleHostCameraResult({ body: {} })).toThrow(BadRequestError);
+  });
+
+  test("rejects unknown pending interaction", () => {
+    expect(() =>
+      handleHostCameraResult({ body: { requestId: "missing" } }),
+    ).toThrow(NotFoundError);
+  });
+
+  test("rejects wrong pending interaction kind", () => {
+    pending.set("req", { conversationId: "conv", kind: "host_file" });
+    expect(() =>
+      handleHostCameraResult({ body: { requestId: "req" } }),
+    ).toThrow(ConflictError);
+    expect(pending.has("req")).toBe(true);
+  });
+
+  test("targeted result must come from the target client actor", () => {
+    pending.set("req", {
+      conversationId: "conv",
+      kind: "host_camera",
+      targetClientId: "client-1",
+      targetActorPrincipalId: "actor-1",
+    });
+    expect(() =>
+      handleHostCameraResult({
+        body: { requestId: "req", error: "denied" },
+        headers: {
+          "x-vellum-client-id": "client-1",
+          "x-vellum-actor-principal-id": "actor-2",
+        },
+      }),
+    ).toThrow(ForbiddenError);
+  });
+});

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 type MockClient = {
   clientId: string;
@@ -10,7 +11,13 @@ type MockClient = {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+    }
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
@@ -30,6 +37,7 @@ describe("HostCuProxy", () => {
 
   function setup(maxSteps?: number) {
     sentMessages.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockClients = [];
     pendingInteractions.clear();
@@ -145,6 +153,29 @@ describe("HostCuProxy", () => {
       setup();
       // Should not throw
       proxy.processObservation("unknown-id", { axTree: "something" });
+    });
+
+    test("emits action lifecycle events for host_cu execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+
+      const requestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.processObservation(requestId, { axTree: "ok" });
+      await resultPromise;
+
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
+const lifecycleMessages: Array<Record<string, unknown>> = [];
 let mockHasClient = false;
 
 interface MockClient {
@@ -12,7 +13,13 @@ interface MockClient {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    if ((msg as { type?: string }).type === "action_lifecycle") {
+      lifecycleMessages.push(msg as Record<string, unknown>);
+    } else {
+      sentMessages.push(msg);
+    }
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) => {
       if (mockClients.length > 0) {
@@ -51,6 +58,7 @@ describe("HostFileProxy", () => {
 
   function setup() {
     sentMessages.length = 0;
+    lifecycleMessages.length = 0;
     mockHasClient = false;
     mockClients = [];
     pendingInteractions.clear();
@@ -208,6 +216,30 @@ describe("HostFileProxy", () => {
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
+    });
+
+    test("emits action lifecycle events for host_file execution", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/lifecycle.txt" },
+        "session-1",
+      );
+
+      const requestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(requestId, {
+        content: "ok",
+        isError: false,
+      });
+      await resultPromise;
+
+      expect(lifecycleMessages.length).toBeGreaterThanOrEqual(3);
+      expect(lifecycleMessages.map((m) => m.stage)).toEqual([
+        "started",
+        "executing",
+        "completed",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -16,6 +16,7 @@ import { isHostProxyTransport } from "../daemon/message-types/conversations.js";
 describe("supportsHostProxy (runtime)", () => {
   test("no-arg form returns true for host-proxy interfaces", () => {
     expect(supportsHostProxy("macos")).toBe(true);
+    expect(supportsHostProxy("tauri")).toBe(true);
   });
 
   test("no-arg form returns false for interfaces without host-proxy support", () => {
@@ -40,13 +41,25 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("chrome-extension", "host_bash")).toBe(false);
     expect(supportsHostProxy("chrome-extension", "host_file")).toBe(false);
     expect(supportsHostProxy("chrome-extension", "host_cu")).toBe(false);
+    expect(supportsHostProxy("chrome-extension", "host_camera")).toBe(false);
   });
 
-  test("capability form grants all four capabilities to macOS including host_browser", () => {
+  test("capability form grants all desktop capabilities to macOS including host_browser", () => {
     expect(supportsHostProxy("macos", "host_bash")).toBe(true);
     expect(supportsHostProxy("macos", "host_file")).toBe(true);
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+    expect(supportsHostProxy("macos", "host_app_control")).toBe(true);
+    expect(supportsHostProxy("macos", "host_camera")).toBe(true);
+  });
+
+  test("capability form grants all capabilities to Tauri HUD", () => {
+    expect(supportsHostProxy("tauri", "host_bash")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_file")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_cu")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_app_control")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_camera")).toBe(true);
   });
 
   test("capability form rejects everything for non-host-proxy interfaces", () => {
@@ -179,6 +192,11 @@ describe("macOS host_browser capability", () => {
     // The no-arg form gates computer-use preactivation and full proxy restore.
     // macOS must still pass this check.
     expect(supportsHostProxy("macos")).toBe(true);
+  });
+
+  test("Tauri passes the no-arg host-proxy check (full HUD proxy)", () => {
+    expect(supportsHostProxy("tauri")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
   });
 
   test("non-macOS non-extension interfaces remain host_browser-ineligible", () => {

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -4,10 +4,11 @@
  *
  * Covers:
  *
- * 1. The ten default injectors registered by `defaultInjectorsPlugin` come
+ * 1. The default injectors registered by `defaultInjectorsPlugin` come
  *    back from `getInjectors()` in the documented order
  *    (disk-pressure-warning → workspace-context → unified-turn-context →
- *    pkb-context → pkb-reminder → memory-v2-static → now-md →
+ *    pkb-context → pkb-reminder → memory-v2-static →
+ *    perception-memory-context → now-md →
  *    subagent-status → slack-messages → thread-focus).
  * 2. A third-party-registered injector at `order: 25` slots between
  *    `unified-turn-context` (order 20) and `pkb` (order 30), proving the
@@ -42,12 +43,10 @@ mock.module("../config/loader.js", () => ({
   },
 }));
 
-const { applyRuntimeInjections, composeInjectorChain } = await import(
-  "../daemon/conversation-runtime-assembly.js"
-);
-const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } = await import(
-  "../plugins/defaults/injectors.js"
-);
+const { applyRuntimeInjections, composeInjectorChain } =
+  await import("../daemon/conversation-runtime-assembly.js");
+const { DEFAULT_INJECTOR_ORDER, defaultInjectorsPlugin } =
+  await import("../plugins/defaults/injectors.js");
 import {
   getInjectors,
   registerPlugin,
@@ -91,7 +90,7 @@ describe("injector chain", () => {
     resetPluginRegistryForTests();
   });
 
-  test("defaultInjectorsPlugin registers the ten defaults in the documented order", () => {
+  test("defaultInjectorsPlugin registers defaults in the documented order", () => {
     registerPlugin(defaultInjectorsPlugin);
 
     const names = getInjectors().map((i) => i.name);
@@ -102,7 +101,9 @@ describe("injector chain", () => {
       "pkb-context",
       "pkb-reminder",
       "memory-v2-static",
+      "perception-memory-context",
       "now-md",
+      "active-plan",
       "subagent-status",
       "slack-messages",
       "thread-focus",
@@ -127,7 +128,11 @@ describe("injector chain", () => {
     expect(byName.get("memory-v2-static")).toBe(
       DEFAULT_INJECTOR_ORDER.memoryV2Static,
     );
+    expect(byName.get("perception-memory-context")).toBe(
+      DEFAULT_INJECTOR_ORDER.perceptionMemory,
+    );
     expect(byName.get("now-md")).toBe(DEFAULT_INJECTOR_ORDER.nowMd);
+    expect(byName.get("active-plan")).toBe(DEFAULT_INJECTOR_ORDER.activePlan);
     expect(byName.get("subagent-status")).toBe(
       DEFAULT_INJECTOR_ORDER.subagentStatus,
     );
@@ -158,7 +163,9 @@ describe("injector chain", () => {
       "pkb-context", // 30
       "pkb-reminder", // 35
       "memory-v2-static", // 38
+      "perception-memory-context", // 39
       "now-md", // 40
+      "active-plan", // 45
       "subagent-status", // 50
       "slack-messages", // 60
       "thread-focus", // 70
@@ -166,7 +173,7 @@ describe("injector chain", () => {
   });
 
   test("composeInjectorChain returns empty string when every injector opts out", async () => {
-    // The default chain is the golden-path: all ten defaults return `null`
+    // The default chain is the golden-path: all defaults return `null`
     // on an empty turn context, so the composed block is an empty string.
     registerPlugin(defaultInjectorsPlugin);
 
@@ -345,6 +352,8 @@ describe("injector chain", () => {
       "<turn_context>\ncurrent_time: 2026-04-22\ninterface: macos\n</turn_context>";
     const pkbContent = "essentials of the project";
     const nowContent = "Current focus: shipping G2.1";
+    const activePlanContext =
+      "Goal: Ship focused slice\nCurrent step: Run tests";
     const subagentBlock =
       '<active_subagents>\n- [running] "worker" (sub-1) | elapsed: 5s\n</active_subagents>';
 
@@ -355,6 +364,7 @@ describe("injector chain", () => {
       pkbContext: pkbContent,
       pkbActive: false, // disable reminder-branch to keep the snapshot small
       nowScratchpad: nowContent,
+      activePlanContext,
       subagentStatusBlock: subagentBlock,
     });
 
@@ -375,8 +385,11 @@ describe("injector chain", () => {
     );
     expect(texts[3]).toBe(`<knowledge_base>\n${pkbContent}\n</knowledge_base>`);
     expect(texts[4]).toBe("What next?"); // user's typed text
-    expect(texts[5]).toBe(subagentBlock); // append order 50
-    expect(texts).toHaveLength(6);
+    expect(texts[5]).toBe(
+      `<active_plan>\n${activePlanContext}\n</active_plan>`,
+    );
+    expect(texts[6]).toBe(subagentBlock); // append order 50
+    expect(texts).toHaveLength(7);
 
     // Block metadata captures for DB persistence — one field per default
     // injector whose output the loader rehydrates from message metadata.

--- a/assistant/src/__tests__/llm-callsite-catalog.test.ts
+++ b/assistant/src/__tests__/llm-callsite-catalog.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { getLLMCallSiteLabel } from "../config/llm-callsite-catalog.js";
-import { CALL_SITE_CATALOG } from "../config/schemas/call-site-catalog.js";
+import {
+  CALL_SITE_CATALOG,
+  CALL_SITE_TIERS,
+} from "../config/schemas/call-site-catalog.js";
 import { LLMCallSiteEnum } from "../config/schemas/llm.js";
 
 describe("LLM call-site catalog", () => {
@@ -30,5 +33,12 @@ describe("LLM call-site catalog", () => {
 
   test("returns the raw ID for unknown call sites", () => {
     expect(getLLMCallSiteLabel("unknownCallSite")).toBe("unknownCallSite");
+  });
+
+  test("assigns every call site to a declared tier", () => {
+    const tierIds = new Set(CALL_SITE_TIERS.map((tier) => tier.id));
+    for (const site of CALL_SITE_CATALOG) {
+      expect(tierIds.has(site.tier)).toBe(true);
+    }
   });
 });

--- a/assistant/src/__tests__/perception-memory-injector.test.ts
+++ b/assistant/src/__tests__/perception-memory-injector.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the `perception-memory-context` runtime injector.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { defaultInjectorsPlugin } from "../plugins/defaults/injectors.js";
+import type { Injector, TurnContext } from "../plugins/types.js";
+
+function findInjector(name: string): Injector {
+  const injector = defaultInjectorsPlugin.injectors?.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!injector) {
+    throw new Error(`injector '${name}' not registered`);
+  }
+  return injector;
+}
+
+function makeContext(overrides: Partial<TurnContext> = {}): TurnContext {
+  return {
+    requestId: "req-test",
+    conversationId: "conv-test",
+    turnIndex: 0,
+    trust: { sourceChannel: "vellum", trustClass: "guardian" },
+    ...overrides,
+  };
+}
+
+const injector = findInjector("perception-memory-context");
+
+describe("perception-memory-context injector", () => {
+  test("returns null when context is missing", async () => {
+    const ctx = makeContext({ injectionInputs: {} });
+    expect(await injector.produce(ctx)).toBeNull();
+  });
+
+  test("returns null in minimal mode", async () => {
+    const ctx = makeContext({
+      injectionInputs: {
+        mode: "minimal",
+        perceptionMemoryContext: "### Recent perceived episodes\n- test",
+      },
+    });
+    expect(await injector.produce(ctx)).toBeNull();
+  });
+
+  test("wraps context with after-memory-prefix placement", async () => {
+    const content = "### Recent perceived episodes\n- Edited runtime routes.";
+    const ctx = makeContext({
+      injectionInputs: { perceptionMemoryContext: content },
+    });
+    const block = await injector.produce(ctx);
+    expect(block).not.toBeNull();
+    expect(block!.id).toBe("perception-memory-context");
+    expect(block!.placement).toBe("after-memory-prefix");
+    expect(block!.text).toBe(
+      `<perception_memory>\n${content}\n</perception_memory>`,
+    );
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-072-seed-perception-callsite.test.ts
+++ b/assistant/src/__tests__/workspace-migration-072-seed-perception-callsite.test.ts
@@ -1,0 +1,161 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { seedPerceptionCallsiteMigration } from "../workspace/migrations/072-seed-perception-callsite.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-072-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath(), JSON.stringify(data, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath(), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("072-seed-perception-callsite migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(seedPerceptionCallsiteMigration.id).toBe(
+      "072-seed-perception-callsite",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "072-seed-perception-callsite",
+    );
+  });
+
+  test("fresh config seeds explicit Anthropic cheap defaults", () => {
+    expect(existsSync(configPath())).toBe(false);
+
+    seedPerceptionCallsiteMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.perception).toEqual({
+      provider: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 1024,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 8_000 },
+    });
+  });
+
+  test("uses matching cost-optimized profile when present", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-sonnet-4-6" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+
+    seedPerceptionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.perception).toEqual({
+      profile: "cost-optimized",
+      maxTokens: 1024,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 8_000 },
+    });
+  });
+
+  test("preserves explicit user model selection unchanged", () => {
+    const perception = {
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      effort: "medium",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 32_000 },
+    };
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: { perception },
+      },
+    });
+
+    seedPerceptionCallsiteMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.perception).toEqual(perception);
+  });
+
+  test("resolved perception config uses cheap bounded defaults", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          effort: "high",
+          thinking: { enabled: true, streamThinking: true },
+          contextWindow: { maxInputTokens: 200_000 },
+        },
+      },
+    });
+
+    seedPerceptionCallsiteMigration.run(workspaceDir);
+
+    const onDisk = readConfig() as { llm: unknown };
+    const parsed = LLMSchema.parse(onDisk.llm);
+    const resolved = resolveCallSiteConfig("perception", parsed);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.maxTokens).toBe(1024);
+    expect(resolved.effort).toBe("low");
+    expect(resolved.temperature).toBe(0);
+    expect(resolved.thinking).toEqual({
+      enabled: false,
+      streamThinking: false,
+    });
+    expect(resolved.contextWindow.maxInputTokens).toBe(8_000);
+  });
+});

--- a/assistant/src/actions/run-action.test.ts
+++ b/assistant/src/actions/run-action.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const recordToolInvocationMock = mock(() => {});
+
+mock.module("../memory/tool-usage-store.js", () => ({
+  recordToolInvocation: recordToolInvocationMock,
+}));
+
+const { runAction } = await import("./run-action.js");
+
+describe("runAction", () => {
+  test("emits started/executing/completed lifecycle and returns result", async () => {
+    const lifecycle: string[] = [];
+    const result = await runAction({
+      actionName: "host_app_control.observe",
+      conversationId: "conv-1",
+      execute: async () => "ok",
+      onLifecycle: (event) => {
+        lifecycle.push(event.stage);
+      },
+    });
+
+    expect(result).toBe("ok");
+    expect(lifecycle).toEqual(["started", "executing", "completed"]);
+    expect(recordToolInvocationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits failed + rollback stages when execute throws", async () => {
+    const lifecycle: string[] = [];
+    const executeError = new Error("boom");
+
+    await expect(
+      runAction({
+        actionName: "host_app_control.click",
+        conversationId: "conv-2",
+        execute: async () => {
+          throw executeError;
+        },
+        rollback: async () => undefined,
+        onLifecycle: (event) => {
+          lifecycle.push(event.stage);
+        },
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(lifecycle).toEqual([
+      "started",
+      "executing",
+      "failed",
+      "rollback_started",
+      "rollback_completed",
+    ]);
+    expect(recordToolInvocationMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/assistant/src/actions/run-action.ts
+++ b/assistant/src/actions/run-action.ts
@@ -1,0 +1,190 @@
+import { v4 as uuid } from "uuid";
+
+import { recordToolInvocation } from "../memory/tool-usage-store.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("actions:run");
+
+export type ActionLifecycleStage =
+  | "started"
+  | "executing"
+  | "completed"
+  | "failed"
+  | "rollback_started"
+  | "rollback_completed";
+
+export interface ActionLifecycleEvent {
+  actionId: string;
+  actionName: string;
+  stage: ActionLifecycleStage;
+  ts: number;
+  conversationId?: string;
+  message?: string;
+}
+
+export interface RunActionOptions<TResult> {
+  actionName: string;
+  conversationId: string;
+  inputSummary?: string;
+  riskLevel?: "Low" | "Medium" | "High";
+  execute: () => Promise<TResult>;
+  rollback?: (ctx: { error: unknown; result?: TResult }) => Promise<void>;
+  onLifecycle?: (event: ActionLifecycleEvent) => void | Promise<void>;
+}
+
+export async function runAction<TResult>(
+  options: RunActionOptions<TResult>,
+): Promise<TResult> {
+  const actionId = uuid();
+  const startedAt = Date.now();
+  const riskLevel = options.riskLevel ?? "Medium";
+  let result: TResult | undefined;
+  let executeError: unknown;
+
+  // Fast path: when no lifecycle subscriber is attached, execute immediately
+  // so callers that synchronously inspect side effects after invocation keep
+  // existing behavior (e.g. proxy tests asserting request envelopes).
+  if (!options.onLifecycle) {
+    try {
+      result = await options.execute();
+      writeAuditLog({
+        conversationId: options.conversationId,
+        actionName: options.actionName,
+        inputSummary: options.inputSummary ?? "{}",
+        decision: "allow",
+        riskLevel,
+        resultSummary: "completed",
+        durationMs: Date.now() - startedAt,
+      });
+      return result;
+    } catch (err) {
+      executeError = err;
+      if (options.rollback) {
+        try {
+          await options.rollback({ error: err, ...(result ? { result } : {}) });
+        } catch (rollbackErr) {
+          log.warn(
+            { actionId, actionName: options.actionName, rollbackErr },
+            "Action rollback failed",
+          );
+        }
+      }
+      writeAuditLog({
+        conversationId: options.conversationId,
+        actionName: options.actionName,
+        inputSummary: options.inputSummary ?? "{}",
+        decision: "deny",
+        riskLevel,
+        resultSummary: `failed: ${errorMessage(executeError)}`,
+        durationMs: Date.now() - startedAt,
+      });
+      throw err;
+    }
+  }
+
+  const emitLifecycle = (
+    stage: ActionLifecycleStage,
+    message?: string,
+  ): void => {
+    if (!options.onLifecycle) return;
+    try {
+      const maybePromise = options.onLifecycle({
+        actionId,
+        actionName: options.actionName,
+        stage,
+        ts: Date.now(),
+        conversationId: options.conversationId,
+        ...(message ? { message } : {}),
+      });
+      if (maybePromise instanceof Promise) {
+        maybePromise.catch((err) => {
+          log.warn(
+            { actionId, actionName: options.actionName, stage, err },
+            "Action lifecycle subscriber failed (non-fatal)",
+          );
+        });
+      }
+    } catch (err) {
+      log.warn(
+        { actionId, actionName: options.actionName, stage, err },
+        "Action lifecycle subscriber failed (non-fatal)",
+      );
+    }
+  };
+
+  emitLifecycle("started");
+  emitLifecycle("executing");
+
+  try {
+    result = await options.execute();
+    emitLifecycle("completed");
+    writeAuditLog({
+      conversationId: options.conversationId,
+      actionName: options.actionName,
+      inputSummary: options.inputSummary ?? "{}",
+      decision: "allow",
+      riskLevel,
+      resultSummary: "completed",
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (err) {
+    executeError = err;
+    emitLifecycle("failed", errorMessage(err));
+    if (options.rollback) {
+      emitLifecycle("rollback_started");
+      try {
+        await options.rollback({ error: err, ...(result ? { result } : {}) });
+        emitLifecycle("rollback_completed");
+      } catch (rollbackErr) {
+        log.warn(
+          { actionId, actionName: options.actionName, rollbackErr },
+          "Action rollback failed",
+        );
+      }
+    }
+    writeAuditLog({
+      conversationId: options.conversationId,
+      actionName: options.actionName,
+      inputSummary: options.inputSummary ?? "{}",
+      decision: "deny",
+      riskLevel,
+      resultSummary: `failed: ${errorMessage(executeError)}`,
+      durationMs: Date.now() - startedAt,
+    });
+    throw err;
+  }
+}
+
+function writeAuditLog(options: {
+  conversationId: string;
+  actionName: string;
+  inputSummary: string;
+  resultSummary: string;
+  decision: "allow" | "deny";
+  riskLevel: "Low" | "Medium" | "High";
+  durationMs: number;
+}): void {
+  try {
+    recordToolInvocation({
+      conversationId: options.conversationId,
+      toolName: `action:${options.actionName}`,
+      input: options.inputSummary,
+      result: options.resultSummary,
+      decision: options.decision,
+      riskLevel: options.riskLevel,
+      durationMs: options.durationMs,
+    });
+  } catch (err) {
+    log.warn(
+      { actionName: options.actionName, err },
+      "Action audit-log write failed (non-fatal)",
+    );
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown action error";
+}

--- a/assistant/src/agent/preference-feedback.test.ts
+++ b/assistant/src/agent/preference-feedback.test.ts
@@ -1,0 +1,201 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  listPkbPreferences,
+  upsertPkbPreference,
+} from "../memory/personal-knowledge-store.js";
+import type { Provider, ProviderResponse } from "../providers/types.js";
+import { runPreferenceFeedback } from "./preference-feedback.js";
+
+function mockProvider(responseText: string): Provider {
+  return {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [{ type: "text", text: responseText }],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+describe("runPreferenceFeedback", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("short-circuits when memory-maturation flag is disabled", async () => {
+    const result = await runPreferenceFeedback(
+      { userText: "make it shorter", assistantText: "ok." },
+      { isEnabled: () => false },
+    );
+    expect(result.applied).toBe(false);
+    expect(result.reinforced).toEqual([]);
+    expect(result.contradicted).toEqual([]);
+    expect(result.inferred).toEqual([]);
+  });
+
+  test("reinforces an existing preference", async () => {
+    upsertPkbPreference({
+      key: "communication-style",
+      value: "concise",
+      signal: "positive",
+    });
+
+    const result = await runPreferenceFeedback(
+      { userText: "thanks, keep replies short", assistantText: "Got it." },
+      {
+        isEnabled: () => true,
+        getProvider: async () =>
+          mockProvider(
+            JSON.stringify({
+              reinforced: [{ key: "communication-style" }],
+              contradicted: [],
+              inferred: [],
+            }),
+          ),
+      },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.reinforced).toEqual(["communication-style"]);
+
+    const [row] = listPkbPreferences({});
+    expect(row?.positiveCount).toBe(2);
+    expect(row?.lastReinforcedAt).toBeGreaterThan(0);
+  });
+
+  test("contradicts and overwrites an existing preference value", async () => {
+    upsertPkbPreference({
+      key: "communication-style",
+      value: "concise",
+      signal: "positive",
+    });
+
+    const result = await runPreferenceFeedback(
+      {
+        userText: "actually give me more detail going forward",
+        assistantText: "Will do — fuller answers from here on.",
+      },
+      {
+        isEnabled: () => true,
+        getProvider: async () =>
+          mockProvider(
+            JSON.stringify({
+              reinforced: [],
+              contradicted: [{ key: "communication-style", value: "detailed" }],
+              inferred: [],
+            }),
+          ),
+      },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.contradicted).toEqual(["communication-style"]);
+
+    const [row] = listPkbPreferences({});
+    expect(row?.value).toBe("detailed");
+    expect(row?.negativeCount).toBe(1);
+    expect(row?.positiveCount).toBe(1);
+    expect(row?.lastContradictedAt).toBeGreaterThan(0);
+  });
+
+  test("records inferred new preferences only when key is unseen", async () => {
+    upsertPkbPreference({
+      key: "tone",
+      value: "warm",
+      signal: "positive",
+    });
+
+    const result = await runPreferenceFeedback(
+      {
+        userText: "I prefer metric units, please",
+        assistantText: "Switching to metric.",
+      },
+      {
+        isEnabled: () => true,
+        getProvider: async () =>
+          mockProvider(
+            JSON.stringify({
+              reinforced: [],
+              contradicted: [],
+              inferred: [
+                { key: "units", value: "metric" },
+                { key: "tone", value: "ignored — already present" },
+              ],
+            }),
+          ),
+      },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.inferred).toEqual([{ key: "units", value: "metric" }]);
+    const rows = listPkbPreferences({});
+    const keys = rows.map((r) => r.key);
+    expect(keys).toContain("units");
+    expect(keys).toContain("tone");
+  });
+
+  test("returns empty when the provider is missing", async () => {
+    const result = await runPreferenceFeedback(
+      { userText: "hi", assistantText: "hello" },
+      { isEnabled: () => true, getProvider: async () => null },
+    );
+    expect(result.applied).toBe(false);
+  });
+
+  test("returns empty when the LLM response is malformed", async () => {
+    upsertPkbPreference({
+      key: "communication-style",
+      value: "concise",
+      signal: "positive",
+    });
+    const result = await runPreferenceFeedback(
+      { userText: "hi", assistantText: "hello" },
+      {
+        isEnabled: () => true,
+        getProvider: async () => mockProvider("not json"),
+      },
+    );
+    expect(result.applied).toBe(false);
+    expect(result.contradicted).toEqual([]);
+  });
+
+  test("skips inferred keys that already exist", async () => {
+    upsertPkbPreference({
+      key: "language",
+      value: "english",
+      signal: "positive",
+    });
+
+    const result = await runPreferenceFeedback(
+      { userText: "switch to spanish", assistantText: "ok" },
+      {
+        isEnabled: () => true,
+        getProvider: async () =>
+          mockProvider(
+            JSON.stringify({
+              reinforced: [],
+              contradicted: [],
+              inferred: [{ key: "language", value: "spanish" }],
+            }),
+          ),
+      },
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.inferred).toEqual([]);
+  });
+});

--- a/assistant/src/agent/preference-feedback.ts
+++ b/assistant/src/agent/preference-feedback.ts
@@ -1,0 +1,280 @@
+/**
+ * Post-turn preference-feedback observer.
+ *
+ * After each assistant turn, the observer classifies the just-completed
+ * exchange and reinforces or contradicts learned preferences. Judgement is
+ * model-mediated per the "Assistant-Driven Judgement" rule — we do not
+ * pattern-match user text to infer preference signals.
+ *
+ * Feature-flag gated by `memory-maturation`. When disabled the observer
+ * short-circuits before any LLM call, so callers can safely invoke it on
+ * every turn without coordinating the flag check at the call site.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import {
+  listPkbPreferences,
+  type PreferenceSignal,
+  upsertPkbPreference,
+} from "../memory/personal-knowledge-store.js";
+import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import type { Provider } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("preference-feedback");
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface PreferenceFeedbackTurn {
+  /**
+   * The user's latest message (already-sanitised plain text). Pass a short
+   * excerpt — the observer caps the payload size on its own.
+   */
+  userText: string;
+  /**
+   * The assistant's latest reply (already-sanitised plain text). Empty/null
+   * skips the observer.
+   */
+  assistantText: string;
+  /** Optional scope override; defaults to the PKB default scope. */
+  scopeId?: string;
+}
+
+export interface PreferenceFeedbackResult {
+  /** True when the observer made at least one PKB write. */
+  applied: boolean;
+  /** Preference keys reinforced as a `positive` signal. */
+  reinforced: string[];
+  /** Preference keys flipped as a `negative` signal. */
+  contradicted: string[];
+  /** Newly inferred preferences (key/value). */
+  inferred: Array<{ key: string; value: string }>;
+}
+
+export interface PreferenceFeedbackOptions {
+  /** Override provider resolution for tests. */
+  getProvider?: () => Promise<Provider | null>;
+  /** Override flag resolution for tests. */
+  isEnabled?: () => boolean;
+  /** Hard timeout for the LLM call, defaults to 8s. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const MAX_PREFERENCES_IN_PROMPT = 25;
+const MAX_USER_TEXT_LEN = 1_000;
+const MAX_ASSISTANT_TEXT_LEN = 1_000;
+
+const PREFERENCE_FEEDBACK_PROMPT = `You are the assistant's preference-learning subsystem.
+
+You are given:
+- A list of preferences the assistant currently believes about the user (key + value).
+- The most recent user message and assistant reply.
+
+Your job is to identify whether any preferences were reinforced or contradicted in this exchange, and whether any *new* preferences are clearly stated by the user.
+
+Rules:
+- Only act on explicit or clearly implied signal from the user. Do not speculate.
+- "reinforced": the user behaved consistently with the stored value (e.g. asked for concise output when "communication-style" = "concise").
+- "contradicted": the user contradicted the stored value (e.g. asked for verbose output when stored value is "concise"). Include the new value the user prefers in 'value'.
+- "inferred": brand-new preferences clearly stated by the user this turn.
+- Reuse existing keys when possible. Use kebab-case for new keys.
+
+Return ONLY valid JSON, no prose. Schema:
+{
+  "reinforced": [{"key": "..."}],
+  "contradicted": [{"key": "...", "value": "..."}],
+  "inferred": [{"key": "...", "value": "..."}]
+}
+
+If nothing applies, return: {"reinforced": [], "contradicted": [], "inferred": []}`;
+
+const FeedbackDecisionSchema = z.object({
+  reinforced: z
+    .array(z.object({ key: z.string().min(1).max(120) }))
+    .max(20)
+    .default([]),
+  contradicted: z
+    .array(
+      z.object({
+        key: z.string().min(1).max(120),
+        value: z.string().min(1).max(400),
+      }),
+    )
+    .max(20)
+    .default([]),
+  inferred: z
+    .array(
+      z.object({
+        key: z.string().min(1).max(120),
+        value: z.string().min(1).max(400),
+      }),
+    )
+    .max(20)
+    .default([]),
+});
+
+const EMPTY_RESULT: PreferenceFeedbackResult = {
+  applied: false,
+  reinforced: [],
+  contradicted: [],
+  inferred: [],
+};
+
+export async function runPreferenceFeedback(
+  turn: PreferenceFeedbackTurn,
+  options: PreferenceFeedbackOptions = {},
+): Promise<PreferenceFeedbackResult> {
+  const isEnabled =
+    options.isEnabled ??
+    (() => isAssistantFeatureFlagEnabled("memory-maturation", getConfig()));
+  if (!isEnabled()) return EMPTY_RESULT;
+
+  const userText = clipText(turn.userText, MAX_USER_TEXT_LEN);
+  const assistantText = clipText(turn.assistantText, MAX_ASSISTANT_TEXT_LEN);
+  if (!userText || !assistantText) return EMPTY_RESULT;
+
+  const provider = await (options.getProvider
+    ? options.getProvider()
+    : getConfiguredProvider("preferenceFeedback"));
+  if (!provider) return EMPTY_RESULT;
+
+  const stored = listPkbPreferences({
+    scopeId: turn.scopeId,
+    limit: MAX_PREFERENCES_IN_PROMPT,
+  });
+  const storedSummary = stored.map((row) => ({
+    key: row.key,
+    value: row.value,
+  }));
+
+  const prompt = JSON.stringify(
+    {
+      stored: storedSummary,
+      userText,
+      assistantText,
+    },
+    null,
+    2,
+  );
+
+  let decoded: z.infer<typeof FeedbackDecisionSchema>;
+  try {
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: prompt }] }],
+      undefined,
+      PREFERENCE_FEEDBACK_PROMPT,
+      {
+        signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+        config: { callSite: "preferenceFeedback", max_tokens: 384 },
+      },
+    );
+    const text = response.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+    const parsedJson = parseJsonObjectFromText(text);
+    const parsed = FeedbackDecisionSchema.safeParse(parsedJson);
+    if (!parsed.success) {
+      log.debug({ issues: parsed.error.issues }, "feedback decision malformed");
+      return EMPTY_RESULT;
+    }
+    decoded = parsed.data;
+  } catch (err) {
+    log.debug({ err }, "preference feedback classification failed");
+    return EMPTY_RESULT;
+  }
+
+  const knownKeys = new Set(stored.map((row) => row.key));
+  const reinforced: string[] = [];
+  const contradicted: string[] = [];
+  const inferred: Array<{ key: string; value: string }> = [];
+
+  for (const entry of decoded.reinforced) {
+    if (!knownKeys.has(entry.key)) continue;
+    const existing = stored.find((row) => row.key === entry.key);
+    if (!existing) continue;
+    try {
+      upsertPkbPreference({
+        scopeId: turn.scopeId,
+        key: entry.key,
+        value: existing.value,
+        learnedFrom: "preference-feedback",
+        signal: "positive",
+      });
+      reinforced.push(entry.key);
+    } catch (err) {
+      log.warn({ err, key: entry.key }, "failed to reinforce preference");
+    }
+  }
+
+  for (const entry of decoded.contradicted) {
+    if (!knownKeys.has(entry.key)) continue;
+    try {
+      upsertPkbPreference({
+        scopeId: turn.scopeId,
+        key: entry.key,
+        value: entry.value,
+        learnedFrom: "preference-feedback",
+        signal: "negative" as PreferenceSignal,
+      });
+      contradicted.push(entry.key);
+    } catch (err) {
+      log.warn({ err, key: entry.key }, "failed to contradict preference");
+    }
+  }
+
+  for (const entry of decoded.inferred) {
+    if (knownKeys.has(entry.key)) continue;
+    try {
+      upsertPkbPreference({
+        scopeId: turn.scopeId,
+        key: entry.key,
+        value: entry.value,
+        learnedFrom: "preference-feedback",
+        signal: "positive",
+      });
+      inferred.push({ key: entry.key, value: entry.value });
+    } catch (err) {
+      log.warn({ err, key: entry.key }, "failed to record inferred preference");
+    }
+  }
+
+  const applied = reinforced.length + contradicted.length + inferred.length > 0;
+  return { applied, reinforced, contradicted, inferred };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clipText(value: string | undefined, limit: number): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  if (trimmed.length <= limit) return trimmed;
+  return trimmed.slice(0, limit);
+}
+
+function parseJsonObjectFromText(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    const objectMatch = candidate.match(/\{[\s\S]*\}/);
+    if (!objectMatch) return null;
+    try {
+      return JSON.parse(objectMatch[0]);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/assistant/src/channels/__tests__/types.test.ts
+++ b/assistant/src/channels/__tests__/types.test.ts
@@ -80,9 +80,13 @@ describe("parseInterfaceId", () => {
 });
 
 describe("supportsHostProxy", () => {
-  // ── macOS: supports all four host proxy capabilities. ──
+  // ── Desktop clients: support all host proxy capabilities. ──
   test("macos returns true (no capability)", () => {
     expect(supportsHostProxy("macos")).toBe(true);
+  });
+
+  test("tauri returns true (no capability)", () => {
+    expect(supportsHostProxy("tauri")).toBe(true);
   });
 
   test("macos returns true for host_bash", () => {
@@ -99,6 +103,14 @@ describe("supportsHostProxy", () => {
 
   test("macos returns true for host_browser", () => {
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  });
+
+  test("tauri returns true for desktop host capabilities", () => {
+    expect(supportsHostProxy("tauri", "host_bash")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_file")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_cu")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_browser")).toBe(true);
+    expect(supportsHostProxy("tauri", "host_app_control")).toBe(true);
   });
 
   // ── chrome-extension: only host_browser. ──

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -38,6 +38,7 @@ export const INTERFACE_IDS = [
   "slack",
   "email",
   "chrome-extension",
+  "tauri",
 ] as const;
 
 export type InterfaceId = (typeof INTERFACE_IDS)[number];
@@ -84,6 +85,7 @@ export const INTERACTIVE_INTERFACES: ReadonlySet<InterfaceId> = new Set([
   "ios",
   "cli",
   "web",
+  "tauri",
 ]);
 
 export function isInteractiveInterface(id: InterfaceId): boolean {
@@ -100,7 +102,8 @@ export type HostProxyCapability =
   | "host_file"
   | "host_cu"
   | "host_browser"
-  | "host_app_control";
+  | "host_app_control"
+  | "host_camera";
 
 /**
  * Interfaces that support the full desktop host-proxy set (all five
@@ -112,7 +115,7 @@ export type HostProxyCapability =
  * below in lock-step when adding a new host-capable client (e.g. a native
  * Linux or Windows desktop).
  */
-export type HostProxyInterfaceId = "macos";
+export type HostProxyInterfaceId = "macos" | "tauri";
 
 /**
  * Whether the interface supports a host proxy capability.
@@ -137,11 +140,11 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // macOS supports all five host proxy capabilities including host_browser
-  // and host_app_control. The host_browser proxy is provisioned via the
-  // assistant event hub. When no extension is connected, browser tools fall
-  // through to cdp-inspect/local via the CDP factory's candidate chain.
-  if (id === "macos") return true;
+  // macOS and the Tauri HUD support all desktop host proxy capabilities including
+  // host_browser, host_app_control, and host_camera. The host_browser proxy is provisioned
+  // via the assistant event hub. When no extension is connected, browser tools
+  // fall through to cdp-inspect/local via the CDP factory's candidate chain.
+  if (id === "macos" || id === "tauri") return true;
   if (id === "chrome-extension" && capability === "host_browser") return true;
   return false;
 }

--- a/assistant/src/config/bundled-skills/perception/SKILL.md
+++ b/assistant/src/config/bundled-skills/perception/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: perception
+description: Query the assistant's recent ambient perception context, such as active app and window changes, to answer questions like what the user was working on moments ago. Use when the user asks about recent activity, context, focus, or what was happening on their computer.
+compatibility: "Designed for Vellum personal assistants. Requires the assistant's perception feature flag and a connected local desktop client."
+metadata:
+  emoji: "👁️"
+  vellum:
+    display-name: "Perception"
+    activation-hints:
+      - "User asks what they were just doing or working on"
+      - "User asks about recent computer context, app focus, or window changes"
+      - "User asks the assistant to use ambient context from the desktop"
+    avoid-when:
+      - "The user asks about conversation history rather than host context"
+      - "The task requires screenshots, OCR, or audio context; Phase 1 only exposes active app/window events"
+featureFlag: perception
+---
+
+## Overview
+
+Use this skill to inspect the assistant's recent **structured perception context**.
+The context is memory-only and now includes:
+
+- `app_focus_changed` — active app and redacted window title changes.
+- Interpreted perception signals such as `task_detected`, `meeting_started`,
+  and `code_edited` (when emitted by the local interpreter).
+- Phase 5 personal-knowledge read surfaces (entities, episodes, preferences)
+  populated by relevance-gated perception summaries.
+
+Raw screenshots, audio, OCR, URLs, process ids, and file paths are intentionally not available through this skill.
+
+## Query Recent Context
+
+Use the bundled script. The assistant injects `$INTERNAL_GATEWAY_BASE_URL`, so
+do not hardcode localhost or ask the user to export a runtime URL.
+
+```bash
+bun ./skills/perception/scripts/recent-context.ts --window-ms 300000 --limit 20
+```
+
+Options:
+
+- `--window-ms <ms>`: only return events received within the last N milliseconds.
+- `--limit <n>`: maximum number of events, most recent first.
+- `--kind app_focus_changed`: restrict to one perception event kind.
+- `--runtime-url <url>`: override the gateway URL when explicitly needed.
+- `--token <jwt>`: override the bearer token.
+
+The script calls `GET /v1/perception/recent`. If perception is disabled or not yet started, the response is:
+
+```json
+{ "enabled": false, "entries": [] }
+```
+
+## Query Personal Knowledge (Phase 5)
+
+Use the bundled script to read personal-knowledge snapshots inferred from
+relevance-scored perception events.
+
+```bash
+bun ./skills/perception/scripts/personal-knowledge.ts --mode entities --query "typescript" --limit 10
+```
+
+Other modes:
+
+```bash
+bun ./skills/perception/scripts/personal-knowledge.ts --mode episodes --limit 20
+bun ./skills/perception/scripts/personal-knowledge.ts --mode preferences --limit 20
+```
+
+Options:
+
+- `--mode entities|episodes|preferences`: selects PKB endpoint.
+- `--query <text>`: required for `--mode entities`.
+- `--limit <n>`: maximum rows returned.
+- `--runtime-url <url>`: override the gateway URL when explicitly needed.
+- `--token <jwt>`: override the bearer token.
+
+These map to:
+
+- `GET /v1/personal-knowledge/entities`
+- `GET /v1/personal-knowledge/episodes`
+- `GET /v1/personal-knowledge/preferences`
+
+## Response Interpretation
+
+When answering the user:
+
+1. State the time window you inspected.
+2. Summarize app/window changes in plain language.
+3. Be explicit when the buffer is empty or disabled.
+4. Do not infer sensitive details from redacted titles.
+5. Do not claim access to screenshots, audio, or exact document paths in Phase 1.
+
+## Security Rules
+
+- Treat perception context as local, privacy-sensitive data.
+- Do not ask the user for tokens or secrets in chat. Use the runtime-provided environment when available.
+- Do not attempt host actions from this skill. This skill is read-only.
+- If the output says `enabled: false`, tell the user perception is not enabled instead of trying to bypass the gate.

--- a/assistant/src/config/bundled-skills/perception/scripts/personal-knowledge.ts
+++ b/assistant/src/config/bundled-skills/perception/scripts/personal-knowledge.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env bun
+
+import { createHmac, randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface Args {
+  runtimeUrl?: string;
+  token?: string;
+  mode?: string;
+  query?: string;
+  limit?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (!arg.startsWith("--")) continue;
+    if (next == null || next.startsWith("--")) {
+      throw new Error(`${arg} requires a value`);
+    }
+    i += 1;
+    switch (arg) {
+      case "--runtime-url":
+        args.runtimeUrl = next;
+        break;
+      case "--token":
+        args.token = next;
+        break;
+      case "--mode":
+        args.mode = next;
+        break;
+      case "--query":
+        args.query = next;
+        break;
+      case "--limit":
+        args.limit = next;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function envValue(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function runtimeUrl(args: Args): string {
+  const value =
+    args.runtimeUrl ??
+    envValue(
+      "INTERNAL_GATEWAY_BASE_URL",
+      "VELLUM_RUNTIME_URL",
+      "ASSISTANT_RUNTIME_URL",
+      "RUNTIME_URL",
+    );
+  if (!value) {
+    throw new Error(
+      "Missing gateway URL. Run inside the assistant skill environment or pass --runtime-url.",
+    );
+  }
+  return value.replace(/\/+$/, "");
+}
+
+const CURRENT_POLICY_EPOCH = 1;
+const DAEMON_PORT_FALLBACK = "7821";
+
+function token(args: Args): string | undefined {
+  return (
+    args.token ??
+    envValue("VELLUM_AUTH_TOKEN", "ASSISTANT_AUTH_TOKEN", "VELLUM_JWT")
+  );
+}
+
+function resolveMode(mode?: string): "entities" | "episodes" | "preferences" {
+  if (!mode) {
+    throw new Error(
+      "Missing --mode. Expected one of: entities, episodes, preferences.",
+    );
+  }
+  if (mode === "entities" || mode === "episodes" || mode === "preferences") {
+    return mode;
+  }
+  throw new Error(`Unsupported --mode value: ${mode}`);
+}
+
+function buildUrl(baseUrl: string, args: Args): string {
+  const mode = resolveMode(args.mode);
+  const url = new URL(`${baseUrl}/v1/personal-knowledge/${mode}`);
+  if (args.limit) url.searchParams.set("limit", args.limit);
+  if (mode === "entities") {
+    if (!args.query || args.query.trim().length === 0) {
+      throw new Error("--query is required when --mode entities");
+    }
+    url.searchParams.set("query", args.query.trim());
+  }
+  return url.toString();
+}
+
+async function requestPersonalKnowledge(
+  baseUrl: string,
+  args: Args,
+  authToken?: string,
+): Promise<{ ok: boolean; status: number; text: string }> {
+  const headers: HeadersInit = authToken
+    ? { Authorization: `Bearer ${authToken}` }
+    : {};
+  const response = await fetch(buildUrl(baseUrl, args), { headers });
+  const text = await response.text();
+  return { ok: response.ok, status: response.status, text };
+}
+
+function base64urlEncodeJson(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function mintLocalGatewayIngressToken(): string | undefined {
+  const workspaceDir = envValue("VELLUM_WORKSPACE_DIR");
+  if (!workspaceDir) return undefined;
+
+  const keyPath = join(workspaceDir, "deprecated", "actor-token-signing-key");
+  if (!existsSync(keyPath)) return undefined;
+
+  let key: Buffer;
+  try {
+    key = readFileSync(keyPath);
+  } catch {
+    return undefined;
+  }
+
+  if (key.length !== 32) return undefined;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64urlEncodeJson({ alg: "HS256", typ: "JWT" });
+  const payload = base64urlEncodeJson({
+    iss: "vellum-auth",
+    aud: "vellum-daemon",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_ingress_v1",
+    exp: now + 60,
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    iat: now,
+    jti: randomBytes(16).toString("hex"),
+  });
+  const signature = createHmac("sha256", key)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+function deriveRuntimeUrlFromGateway(baseUrl: string): string | undefined {
+  try {
+    const url = new URL(baseUrl);
+    if (url.port === "7830") {
+      url.port = DAEMON_PORT_FALLBACK;
+      return url.toString().replace(/\/+$/, "");
+    }
+  } catch {
+    // no-op
+  }
+  return undefined;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const baseUrl = runtimeUrl(args);
+  const explicitToken = token(args);
+
+  const firstAttempt = await requestPersonalKnowledge(
+    baseUrl,
+    args,
+    explicitToken,
+  );
+  if (firstAttempt.ok) {
+    try {
+      console.log(JSON.stringify(JSON.parse(firstAttempt.text), null, 2));
+    } catch {
+      console.log(firstAttempt.text);
+    }
+    return;
+  }
+
+  if (!explicitToken && firstAttempt.status === 401) {
+    const fallbackToken = mintLocalGatewayIngressToken();
+    const runtimeBaseUrl = deriveRuntimeUrlFromGateway(baseUrl);
+    if (fallbackToken && runtimeBaseUrl) {
+      const secondAttempt = await requestPersonalKnowledge(
+        runtimeBaseUrl,
+        args,
+        fallbackToken,
+      );
+      if (secondAttempt.ok) {
+        try {
+          console.log(JSON.stringify(JSON.parse(secondAttempt.text), null, 2));
+        } catch {
+          console.log(secondAttempt.text);
+        }
+        return;
+      }
+    }
+  }
+
+  throw new Error(
+    `GET personal-knowledge route failed (${firstAttempt.status}): ${firstAttempt.text}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/assistant/src/config/bundled-skills/perception/scripts/recent-context.ts
+++ b/assistant/src/config/bundled-skills/perception/scripts/recent-context.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+
+import { createHmac, randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface Args {
+  runtimeUrl?: string;
+  token?: string;
+  windowMs?: string;
+  limit?: string;
+  kind?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (!arg.startsWith("--")) continue;
+    if (next == null || next.startsWith("--")) {
+      throw new Error(`${arg} requires a value`);
+    }
+    i += 1;
+    switch (arg) {
+      case "--runtime-url":
+        args.runtimeUrl = next;
+        break;
+      case "--token":
+        args.token = next;
+        break;
+      case "--window-ms":
+        args.windowMs = next;
+        break;
+      case "--limit":
+        args.limit = next;
+        break;
+      case "--kind":
+        args.kind = next;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function envValue(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function runtimeUrl(args: Args): string {
+  const value =
+    args.runtimeUrl ??
+    envValue(
+      "INTERNAL_GATEWAY_BASE_URL",
+      "VELLUM_RUNTIME_URL",
+      "ASSISTANT_RUNTIME_URL",
+      "RUNTIME_URL",
+    );
+  if (!value) {
+    throw new Error(
+      "Missing gateway URL. Run inside the assistant skill environment or pass --runtime-url.",
+    );
+  }
+  return value.replace(/\/+$/, "");
+}
+
+const CURRENT_POLICY_EPOCH = 1;
+const DAEMON_PORT_FALLBACK = "7821";
+
+function token(args: Args): string | undefined {
+  return (
+    args.token ??
+    envValue("VELLUM_AUTH_TOKEN", "ASSISTANT_AUTH_TOKEN", "VELLUM_JWT")
+  );
+}
+
+function buildUrl(baseUrl: string, args: Args): string {
+  const url = new URL(`${baseUrl}/v1/perception/recent`);
+  if (args.windowMs) url.searchParams.set("windowMs", args.windowMs);
+  if (args.limit) url.searchParams.set("limit", args.limit);
+  if (args.kind) url.searchParams.set("kind", args.kind);
+  return url.toString();
+}
+
+async function requestRecent(
+  baseUrl: string,
+  args: Args,
+  authToken?: string,
+): Promise<{ ok: boolean; status: number; text: string }> {
+  const headers: HeadersInit = authToken
+    ? { Authorization: `Bearer ${authToken}` }
+    : {};
+  const response = await fetch(buildUrl(baseUrl, args), { headers });
+  const text = await response.text();
+  return { ok: response.ok, status: response.status, text };
+}
+
+function base64urlEncodeJson(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function mintLocalGatewayIngressToken(): string | undefined {
+  const workspaceDir = envValue("VELLUM_WORKSPACE_DIR");
+  if (!workspaceDir) return undefined;
+
+  const keyPath = join(workspaceDir, "deprecated", "actor-token-signing-key");
+  if (!existsSync(keyPath)) return undefined;
+
+  let key: Buffer;
+  try {
+    key = readFileSync(keyPath);
+  } catch {
+    return undefined;
+  }
+
+  if (key.length !== 32) return undefined;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64urlEncodeJson({ alg: "HS256", typ: "JWT" });
+  const payload = base64urlEncodeJson({
+    iss: "vellum-auth",
+    aud: "vellum-daemon",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_ingress_v1",
+    exp: now + 60,
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    iat: now,
+    jti: randomBytes(16).toString("hex"),
+  });
+  const signature = createHmac("sha256", key)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+function deriveRuntimeUrlFromGateway(baseUrl: string): string | undefined {
+  try {
+    const url = new URL(baseUrl);
+    if (url.port === "7830") {
+      url.port = DAEMON_PORT_FALLBACK;
+      return url.toString().replace(/\/+$/, "");
+    }
+  } catch {
+    // no-op
+  }
+  return undefined;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const baseUrl = runtimeUrl(args);
+  const explicitToken = token(args);
+
+  const firstAttempt = await requestRecent(baseUrl, args, explicitToken);
+  if (firstAttempt.ok) {
+    try {
+      console.log(JSON.stringify(JSON.parse(firstAttempt.text), null, 2));
+    } catch {
+      console.log(firstAttempt.text);
+    }
+    return;
+  }
+
+  if (!explicitToken && firstAttempt.status === 401) {
+    const fallbackToken = mintLocalGatewayIngressToken();
+    const runtimeBaseUrl = deriveRuntimeUrlFromGateway(baseUrl);
+    if (fallbackToken && runtimeBaseUrl) {
+      const secondAttempt = await requestRecent(
+        runtimeBaseUrl,
+        args,
+        fallbackToken,
+      );
+      if (secondAttempt.ok) {
+        try {
+          console.log(JSON.stringify(JSON.parse(secondAttempt.text), null, 2));
+        } catch {
+          console.log(secondAttempt.text);
+        }
+        return;
+      }
+    }
+  }
+
+  throw new Error(
+    `GET /v1/perception/recent failed (${firstAttempt.status}): ${firstAttempt.text}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/assistant/src/config/bundled-skills/webcam-snapshot/SKILL.md
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: webcam-snapshot
+description: Request one user-approved webcam snapshot from the connected macOS or Tauri desktop client and return a concise text summary. Use when the user explicitly asks Jarvis to look through the webcam, see what is in front of the camera, or answer a question about the current camera view.
+compatibility: "Designed for Vellum personal assistants. Requires the webcam-snapshot feature flag and a connected macOS or Tauri client."
+metadata:
+  emoji: "📷"
+  vellum:
+    display-name: "Webcam Snapshot"
+    feature-flag: "webcam-snapshot"
+    activation-hints:
+      - "User asks the assistant to look through the webcam once"
+      - "User asks what the camera can see right now"
+      - "User asks a question about the current physical scene in front of the camera"
+    avoid-when:
+      - "User wants ambient or continuous camera monitoring"
+      - "Task can be answered without camera access"
+---
+
+This skill exposes a single request-scoped host proxy tool for one webcam
+snapshot. Each use asks the desktop client for one still frame, summarizes that
+frame, and discards the raw image.
+
+## Tool
+
+Use `describe_camera_once` only when the user has explicitly asked for camera
+access or when the current task clearly requires a one-shot camera view.
+
+Pass a short `prompt` describing what to focus on, for example:
+
+```json
+{ "prompt": "Describe what is visible on the desk." }
+```
+
+The user-visible approval should be clear that Jarvis is requesting one webcam
+snapshot. Do not claim continuous camera access, recording, or persistent image
+storage.

--- a/assistant/src/config/bundled-skills/webcam-snapshot/TOOLS.json
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/TOOLS.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "describe_camera_once",
+      "description": "Request one user-approved webcam snapshot from the connected desktop client, summarize it, and discard the raw image. Use only for explicit one-shot camera requests.",
+      "category": "webcam-snapshot",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "Optional question or focus area for the snapshot summary"
+          },
+          "target_client_id": {
+            "type": "string",
+            "description": "Optional client id to target when multiple macOS/Tauri clients support host_camera"
+          }
+        },
+        "required": []
+      },
+      "executor": "tools/describe-camera-once.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/webcam-snapshot/tools/describe-camera-once.ts
+++ b/assistant/src/config/bundled-skills/webcam-snapshot/tools/describe-camera-once.ts
@@ -1,0 +1,12 @@
+import { forwardHostCameraProxyTool } from "../../../../tools/host-camera/skill-proxy-bridge.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardHostCameraProxyTool("describe_camera_once", input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -117,6 +117,8 @@ import * as subagentSpawn from "./bundled-skills/subagent/tools/subagent-spawn.j
 import * as subagentStatus from "./bundled-skills/subagent/tools/subagent-status.js";
 // ── transcribe ─────────────────────────────────────────────────────────────────
 import * as transcribeMedia from "./bundled-skills/transcribe/tools/transcribe-media.js";
+// ── webcam-snapshot ────────────────────────────────────────────────────────────
+import * as describeCameraOnce from "./bundled-skills/webcam-snapshot/tools/describe-camera-once.js";
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -249,4 +251,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // transcribe
   ["transcribe:tools/transcribe-media.ts", transcribeMedia],
+
+  // webcam-snapshot
+  ["webcam-snapshot:tools/describe-camera-once.ts", describeCameraOnce],
 ]);

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -11,6 +11,26 @@ export const CALL_SITE_DOMAINS = [
 
 export type CallSiteDomainId = (typeof CALL_SITE_DOMAINS)[number]["id"];
 
+export const CALL_SITE_TIERS = [
+  {
+    id: "perception",
+    displayName: "Perception",
+    description: "Fast signal interpretation and lightweight classification.",
+  },
+  {
+    id: "reflex",
+    displayName: "Reflex",
+    description: "Low-latency decisions and UI copy generation.",
+  },
+  {
+    id: "deliberation",
+    displayName: "Deliberation",
+    description: "Deep reasoning, planning, and long-form synthesis.",
+  },
+] as const;
+
+export type CallSiteTierId = (typeof CALL_SITE_TIERS)[number]["id"];
+
 export interface CallSiteDomainEntry {
   id: CallSiteDomainId;
   displayName: string;
@@ -21,6 +41,7 @@ export interface CallSiteEntry {
   displayName: string;
   description: string;
   domain: CallSiteDomainId;
+  tier: CallSiteTierId;
 }
 
 /**
@@ -36,6 +57,57 @@ type CatalogRecord = {
     domain: CallSiteDomainId;
   };
 };
+
+function resolveCallSiteTier(id: LLMCallSite): CallSiteTierId {
+  switch (id) {
+    case "perception":
+    case "preferenceFeedback":
+    case "interactionClassifier":
+    case "meetConsentMonitor":
+      return "perception";
+    case "conversationStarters":
+    case "conversationTitle":
+    case "commitMessage":
+    case "emptyStateGreeting":
+    case "notificationDecision":
+    case "preferenceExtraction":
+    case "guardianQuestionCopy":
+    case "approvalCopy":
+    case "feedEventCopy":
+    case "trustRuleSuggestion":
+    case "styleAnalyzer":
+    case "inviteInstructionGenerator":
+    case "skillCategoryInference":
+    case "meetChatOpportunity":
+      return "reflex";
+    case "mainAgent":
+    case "subagentSpawn":
+    case "heartbeatAgent":
+    case "filingAgent":
+    case "compactionAgent":
+    case "analyzeConversation":
+    case "callAgent":
+    case "memoryExtraction":
+    case "memoryConsolidation":
+    case "memoryRetrieval":
+    case "memoryV2Migration":
+    case "memoryV2Sweep":
+    case "recall":
+    case "narrativeRefinement":
+    case "patternScan":
+    case "conversationSummarization":
+    case "identityIntro":
+    case "approvalConversation":
+    case "inference":
+    case "proactiveArtifactDecision":
+    case "proactiveArtifactBuild":
+      return "deliberation";
+    default: {
+      const exhaustive: never = id;
+      return exhaustive;
+    }
+  }
+}
 
 const CATALOG_RECORD: CatalogRecord = {
   // agentLoop
@@ -278,8 +350,27 @@ const CATALOG_RECORD: CatalogRecord = {
       "Builds the personalized artifact in a background conversation with tool access.",
     domain: "agentLoop",
   },
+  perception: {
+    id: "perception",
+    displayName: "Perception Interpreter",
+    description:
+      "Interprets ambient perception signals into higher-level structured events.",
+    domain: "agentLoop",
+  },
+  preferenceFeedback: {
+    id: "preferenceFeedback",
+    displayName: "Preference Feedback Observer",
+    description:
+      "Classifies just-completed conversation turns for preference reinforcements or contradictions so the personal-knowledge base learns from real use.",
+    domain: "memory",
+  },
 };
 
 // Source of truth for call-site display metadata. API responses and usage
 // display paths should reuse this catalog instead of defining separate labels.
-export const CALL_SITE_CATALOG: CallSiteEntry[] = Object.values(CATALOG_RECORD);
+export const CALL_SITE_CATALOG: CallSiteEntry[] = Object.values(
+  CATALOG_RECORD,
+).map((entry) => ({
+  ...entry,
+  tier: resolveCallSiteTier(entry.id),
+}));

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -19,6 +19,7 @@ const LLMProvider = z.enum([
   "gemini",
   "ollama",
   "fireworks",
+  "minimax",
   "openrouter",
 ]);
 type LLMProvider = z.infer<typeof LLMProvider>;
@@ -72,6 +73,8 @@ export const LLMCallSiteEnum = z.enum([
   "trustRuleSuggestion",
   "proactiveArtifactDecision",
   "proactiveArtifactBuild",
+  "perception",
+  "preferenceFeedback",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -77,6 +77,7 @@ import {
   readMemoryV2StaticContent,
   shouldLoadMemoryV2Static,
 } from "../memory/v2/static-context.js";
+import { buildPerceptionKnowledgeContext } from "../perception/personal-knowledge-context.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { defaultCompactionTerminal } from "../plugins/defaults/compaction.js";
 import { defaultHistoryRepairTerminal } from "../plugins/defaults/history-repair.js";
@@ -1439,6 +1440,13 @@ export async function runAgentLoopImpl(
       ? readMemoryV2StaticContent()
       : null;
     const memoryV2Static = currentMemoryV2Static;
+    const perceptionMemoryContext = shouldLoadMemoryV2Static({
+      shouldInjectNowAndPkb,
+      sourceChannel: ctx.trustContext?.sourceChannel,
+      isTrustedActor,
+    })
+      ? buildPerceptionKnowledgeContext()
+      : null;
 
     // PKB relevance-hint inputs. Resolved once per turn and reused across
     // re-injections so post-compaction rebuilds pick up fresh hints against
@@ -1537,6 +1545,7 @@ export async function runAgentLoopImpl(
       pkbRoot,
       pkbWorkingDir: pkbActive ? ctx.workingDir : undefined,
       memoryV2Static,
+      perceptionMemoryContext,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
@@ -1823,6 +1832,7 @@ export async function runAgentLoopImpl(
             ...injectionOpts,
             ...(stepCompacted && { pkbContext: currentPkbContent }),
             ...(stepCompacted && { memoryV2Static: currentMemoryV2Static }),
+            ...(stepCompacted && { perceptionMemoryContext }),
             ...(stepCompacted && { nowScratchpad: currentNowContent }),
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext
@@ -2136,6 +2146,7 @@ export async function runAgentLoopImpl(
         ...injectionOpts,
         pkbContext: currentPkbContent,
         memoryV2Static: currentMemoryV2Static,
+        perceptionMemoryContext,
         nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
           ? ctx.workspaceTopLevelContext
@@ -2390,6 +2401,9 @@ export async function runAgentLoopImpl(
           ...injectionOpts,
           pkbContext: currentPkbContent,
           memoryV2Static: convergenceStripped ? currentMemoryV2Static : null,
+          perceptionMemoryContext: convergenceStripped
+            ? perceptionMemoryContext
+            : null,
           nowScratchpad: convergenceStripped ? currentNowContent : null,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
@@ -2552,6 +2566,9 @@ export async function runAgentLoopImpl(
             ...injectionOpts,
             pkbContext: currentPkbContent,
             memoryV2Static: convergenceStripped ? currentMemoryV2Static : null,
+            perceptionMemoryContext: convergenceStripped
+              ? perceptionMemoryContext
+              : null,
             nowScratchpad: convergenceStripped ? currentNowContent : null,
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1660,6 +1660,8 @@ const RUNTIME_INJECTION_PREFIXES = [
   // variant that may linger in in-flight histories during a rolling deploy.
   "<NOW.md Always keep this up to date",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
+  "<perception_memory>",
+  "<active_plan>",
   "<knowledge_base>",
   "<pkb>", // backward-compat: strip legacy tag from pre-rename history
   "<system_reminder>",
@@ -1946,6 +1948,14 @@ export interface RuntimeInjectionOptions {
    * original user message.
    */
   memoryV2Static?: string | null;
+  /**
+   * Compact snapshot derived from perception-backed personal knowledge
+   * (episodes/entities/preferences). The `perception-memory-context`
+   * injector wraps this in `<perception_memory>` and places it after the
+   * memory prefix on full-mode turns.
+   */
+  perceptionMemoryContext?: string | null;
+  activePlanContext?: string | null;
   nowScratchpad?: string | null;
   subagentStatusBlock?: string | null;
   isNonInteractive?: boolean;
@@ -2028,6 +2038,8 @@ function buildTurnInjectionInputs(
     pkbRoot: options.pkbRoot,
     pkbWorkingDir: options.pkbWorkingDir,
     memoryV2Static: options.memoryV2Static,
+    perceptionMemoryContext: options.perceptionMemoryContext,
+    activePlanContext: options.activePlanContext,
     nowScratchpad: options.nowScratchpad,
     subagentStatusBlock: options.subagentStatusBlock,
     channelCapabilities: options.channelCapabilities,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -120,6 +120,7 @@ import {
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
 import { canonicalizeTimeZone } from "./date-context.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
+import type { HostCameraProxy } from "./host-camera-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   ServerMessage,
@@ -205,6 +206,7 @@ export class Conversation {
    * @internal
    */
   hostAppControlProxy?: HostAppControlProxy;
+  /** @internal */ hostCameraProxy?: HostCameraProxy;
   /** @internal */ cesClient?: CesClient;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
@@ -759,6 +761,8 @@ export class Conversation {
     this.hostCuProxy?.dispose();
     this.hostAppControlProxy?.dispose();
     this.hostAppControlProxy = undefined;
+    this.hostCameraProxy?.dispose();
+    this.hostCameraProxy = undefined;
     // CES client is owned by DaemonServer — just drop the reference.
     // Do NOT close it here; the server manages the CES lifecycle.
     this.cesClient = undefined;
@@ -941,6 +945,13 @@ export class Conversation {
       this.hostAppControlProxy.dispose();
     }
     this.hostAppControlProxy = proxy;
+  }
+
+  setHostCameraProxy(proxy: HostCameraProxy | undefined): void {
+    if (this.hostCameraProxy && this.hostCameraProxy !== proxy) {
+      this.hostCameraProxy.dispose();
+    }
+    this.hostCameraProxy = proxy;
   }
 
   // ── Server-authoritative state signals ─────────────────────────────

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -37,10 +37,13 @@
 
 import { createHash } from "node:crypto";
 
+import { runAction } from "../actions/run-action.js";
 import type { ContentBlock } from "../providers/types.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type {
   HostAppControlInput,
   HostAppControlResultPayload,
@@ -253,12 +256,30 @@ export class HostAppControlProxy extends HostProxyBase<
     }
 
     try {
-      const payload = await this.dispatchRequest(
-        toolName,
-        input,
+      const payload = await runAction({
+        actionName: `host_app_control.${input.tool}`,
         conversationId,
-        signal,
-      );
+        inputSummary: JSON.stringify({
+          tool: input.tool,
+          app:
+            "app" in input && typeof input.app === "string" ? input.app : null,
+        }),
+        riskLevel: "Medium",
+        execute: async () =>
+          await this.dispatchRequest(toolName, input, conversationId, signal),
+        onLifecycle: (event) => {
+          const message: ActionLifecycleMessage = {
+            type: "action_lifecycle",
+            actionId: event.actionId,
+            actionName: event.actionName,
+            stage: event.stage,
+            ts: event.ts,
+            ...(event.message ? { message: event.message } : {}),
+            conversationId,
+          };
+          broadcastMessage(message, conversationId);
+        },
+      });
       return this.handleSuccess(input, payload);
     } catch (err) {
       if (err instanceof HostProxyRequestError) {

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import { getConfig } from "../config/loader.js";
 import {
   assistantEventHub,
@@ -15,6 +16,7 @@ import { formatShellOutput } from "../tools/shared/shell-output.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 
 const log = getLogger("host-bash-proxy");
 
@@ -119,92 +121,118 @@ export class HostBashProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const shellMaxTimeoutSec = getConfig().timeouts.shellMaxTimeoutSec;
-      const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
-      const proxyTimeoutSec = timeoutSec + 3;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, command: input.command },
-          "Host bash proxy request timed out",
-        );
-        const timeoutMessage = resolvedTargetClientId
-          ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
-          : "Host bash proxy timed out waiting for client response";
-        resolve(formatShellOutput("", timeoutMessage, null, true, timeoutSec));
-      }, proxyTimeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_bash_cancel",
-                  requestId,
-                  conversationId,
-                  targetClientId: resolvedTargetClientId,
-                },
-                conversationId,
-                { targetClientId: resolvedTargetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve(formatShellOutput("", "Aborted", null, false, 0));
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_bash",
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-        targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
-        metadata: { timeoutSec },
-      });
-
-      try {
-        broadcastMessage(
-          {
-            type: "host_bash_request",
-            requestId,
-            conversationId,
-            command: input.command,
-            working_dir: input.working_dir,
-            timeout_seconds: input.timeout_seconds,
-            targetClientId: resolvedTargetClientId,
-            ...(input.env && Object.keys(input.env).length > 0
-              ? { env: input.env }
-              : {}),
-          },
+    return runAction<ToolExecutionResult>({
+      actionName: "host_bash.execute",
+      conversationId,
+      inputSummary: JSON.stringify({
+        command: input.command,
+        workingDir: input.working_dir ?? null,
+        timeoutSeconds: input.timeout_seconds ?? null,
+        targetClientId: resolvedTargetClientId ?? null,
+      }),
+      riskLevel: "High",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: resolvedTargetClientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, command: input.command, err },
-          "Host bash proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const shellMaxTimeoutSec = getConfig().timeouts.shellMaxTimeoutSec;
+          const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
+          const proxyTimeoutSec = timeoutSec + 3;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, command: input.command },
+              "Host bash proxy request timed out",
+            );
+            const timeoutMessage = resolvedTargetClientId
+              ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
+              : "Host bash proxy timed out waiting for client response";
+            resolve(
+              formatShellOutput("", timeoutMessage, null, true, timeoutSec),
+            );
+          }, proxyTimeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_bash_cancel",
+                      requestId,
+                      conversationId,
+                      targetClientId: resolvedTargetClientId,
+                    },
+                    conversationId,
+                    { targetClientId: resolvedTargetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve(formatShellOutput("", "Aborted", null, false, 0));
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_bash",
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
+            metadata: { timeoutSec },
+          });
+
+          try {
+            broadcastMessage(
+              {
+                type: "host_bash_request",
+                requestId,
+                conversationId,
+                command: input.command,
+                working_dir: input.working_dir,
+                timeout_seconds: input.timeout_seconds,
+                targetClientId: resolvedTargetClientId,
+                ...(input.env && Object.keys(input.env).length > 0
+                  ? { env: input.env }
+                  : {}),
+              },
+              conversationId,
+              { targetClientId: resolvedTargetClientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, command: input.command, err },
+              "Host bash proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import type { InterfaceId } from "../channels/types.js";
 import {
   assistantEventHub,
@@ -10,6 +11,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type { HostBrowserRequest } from "./message-types/host-browser.js";
 
 /** Distributive omit that preserves union variant fields. */
@@ -120,7 +122,9 @@ export class HostBrowserProxy {
    * a valid extension transport.
    */
   hasExtensionClient(): boolean {
-    return assistantEventHub.listClientsByInterface("chrome-extension").length > 0;
+    return (
+      assistantEventHub.listClientsByInterface("chrome-extension").length > 0
+    );
   }
 
   /**
@@ -176,78 +180,106 @@ export class HostBrowserProxy {
     const targetActorPrincipalId = preferredClient?.actorPrincipalId;
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const timeoutSec = input.timeout_seconds ?? 30;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, cdpMethod: input.cdpMethod },
-          "Host browser proxy request timed out",
-        );
-        resolve({
-          content:
-            "Host browser proxy timed out waiting for extension response (check SSE connectivity and /v1/host-browser-result callback failures such as 404/401).",
-          isError: true,
-        });
-      }, timeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage({
-                type: "host_browser_cancel",
-                requestId,
-              });
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_browser",
-        targetClientId,
-        targetActorPrincipalId,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-      });
-
-      try {
-        if (!preferredClient) {
-          pendingInteractions.resolve(requestId);
-          reject(
-            new Error(
-              "host_browser send failed: no active extension connection",
-            ),
-          );
-          return;
-        }
-
-        broadcastMessage(
-          { ...input, type: "host_browser_request", requestId, conversationId },
+    return runAction<ToolExecutionResult>({
+      actionName: "host_browser.cdp_request",
+      conversationId,
+      inputSummary: JSON.stringify({
+        cdpMethod: input.cdpMethod,
+        cdpSessionId: input.cdpSessionId ?? null,
+        targetClientId: targetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: preferredClient.clientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, cdpMethod: input.cdpMethod, err },
-          "Host browser proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const timeoutSec = input.timeout_seconds ?? 30;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, cdpMethod: input.cdpMethod },
+              "Host browser proxy request timed out",
+            );
+            resolve({
+              content:
+                "Host browser proxy timed out waiting for extension response (check SSE connectivity and /v1/host-browser-result callback failures such as 404/401).",
+              isError: true,
+            });
+          }, timeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage({
+                    type: "host_browser_cancel",
+                    requestId,
+                  });
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_browser",
+            targetClientId,
+            targetActorPrincipalId,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+          });
+
+          try {
+            if (!preferredClient) {
+              pendingInteractions.resolve(requestId);
+              reject(
+                new Error(
+                  "host_browser send failed: no active extension connection",
+                ),
+              );
+              return;
+            }
+
+            broadcastMessage(
+              {
+                ...input,
+                type: "host_browser_request",
+                requestId,
+                conversationId,
+              },
+              conversationId,
+              { targetClientId: preferredClient.clientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, cdpMethod: input.cdpMethod, err },
+              "Host browser proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-camera-proxy.ts
+++ b/assistant/src/daemon/host-camera-proxy.ts
@@ -1,0 +1,230 @@
+/**
+ * Host camera proxy.
+ *
+ * Dispatches one request-scoped webcam snapshot to a connected desktop client,
+ * summarizes the returned in-memory image through the configured provider, and
+ * returns only the bounded text summary to the agent.
+ */
+
+import { runAction } from "../actions/run-action.js";
+import {
+  extractAllText,
+  getConfiguredProvider,
+} from "../providers/provider-send-message.js";
+import type { Message } from "../providers/types.js";
+import {
+  assistantEventHub,
+  broadcastMessage,
+} from "../runtime/assistant-event-hub.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
+import type { ToolExecutionResult } from "../tools/types.js";
+import { getLogger } from "../util/logger.js";
+import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
+import type {
+  HostCameraInput,
+  HostCameraResultPayload,
+} from "./message-types/host-camera.js";
+
+const log = getLogger("host-camera-proxy");
+const MAX_SUMMARY_CHARS = 1_500;
+
+export class HostCameraProxy extends HostProxyBase<
+  HostCameraInput,
+  HostCameraResultPayload
+> {
+  constructor() {
+    super({
+      capabilityName: "host_camera",
+      requestEventName: "host_camera_request",
+      cancelEventName: "host_camera_cancel",
+      resultPendingKind: "host_camera",
+      timeoutMs: 90_000,
+      disposedMessage: "Host camera proxy disposed",
+    });
+  }
+
+  async request(
+    toolName: "describe_camera_once",
+    input: HostCameraInput,
+    conversationId: string,
+    signal?: AbortSignal,
+    sourceActorPrincipalId?: string,
+  ): Promise<ToolExecutionResult> {
+    if (signal?.aborted) {
+      return { content: "Camera snapshot was aborted.", isError: true };
+    }
+
+    const resolvedTarget = this.resolveTargetClient(
+      input.target_client_id,
+      sourceActorPrincipalId,
+    );
+    if (resolvedTarget.error) return resolvedTarget.error;
+
+    return runAction<ToolExecutionResult>({
+      actionName: "host_camera.describe_once",
+      conversationId,
+      inputSummary: JSON.stringify({
+        prompt: input.prompt ?? null,
+        targetClientId: resolvedTarget.targetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
+          conversationId,
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () => {
+        try {
+          const payload = await this.dispatchRequest(
+            toolName,
+            input,
+            conversationId,
+            signal,
+            undefined,
+            resolvedTarget.targetClientId,
+          );
+          return await summarizeCameraSnapshot(payload, input.prompt, signal);
+        } catch (err) {
+          if (err instanceof HostProxyRequestError) {
+            const content =
+              err.reason === "timeout"
+                ? "Camera snapshot timed out waiting for the desktop client."
+                : err.reason === "aborted"
+                  ? "Camera snapshot was aborted."
+                  : "Camera snapshot was cancelled because the proxy was disposed.";
+            return { content, isError: true };
+          }
+          log.warn({ err }, "Host camera proxy request failed");
+          return {
+            content: err instanceof Error ? err.message : String(err),
+            isError: true,
+          };
+        }
+      },
+    });
+  }
+
+  private resolveTargetClient(
+    targetClientId: string | undefined,
+    sourceActorPrincipalId: string | undefined,
+  ): { targetClientId?: string; error?: ToolExecutionResult } {
+    if (targetClientId) {
+      const target = assistantEventHub.getClientById(targetClientId);
+      if (!target || !target.capabilities.includes("host_camera")) {
+        return {
+          error: {
+            content: `Error: client "${targetClientId}" is not connected or does not support host_camera. Run \`assistant clients list --capability host_camera\` to see available clients.`,
+            isError: true,
+          },
+        };
+      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_camera",
+      });
+      if (rejection) return { error: rejection };
+      return { targetClientId };
+    }
+
+    const resolved = pickSameUserAutoResolve({
+      hub: assistantEventHub,
+      capability: "host_camera",
+      sourceActorPrincipalId,
+    });
+    if (resolved.kind === "ambiguous") {
+      return { error: ambiguousSameUserError("host_camera") };
+    }
+    return {
+      targetClientId: resolved.kind === "match" ? resolved.clientId : undefined,
+    };
+  }
+}
+
+async function summarizeCameraSnapshot(
+  payload: HostCameraResultPayload,
+  prompt: string | undefined,
+  signal: AbortSignal | undefined,
+): Promise<ToolExecutionResult> {
+  if (payload.error) {
+    return { content: payload.error, isError: true };
+  }
+  if (!payload.imageBase64) {
+    return {
+      content:
+        "Camera snapshot failed: the desktop client did not return an image.",
+      isError: true,
+    };
+  }
+
+  const provider = await getConfiguredProvider("mainAgent");
+  if (!provider) {
+    return {
+      content:
+        "Camera snapshot failed: no configured LLM provider is available to summarize the image.",
+      isError: true,
+    };
+  }
+
+  const mediaType = payload.mediaType ?? "image/jpeg";
+  const userPrompt =
+    prompt?.trim() ||
+    "Briefly describe what is visible in this single webcam snapshot.";
+  const messages: Message[] = [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text:
+            "Summarize this one webcam snapshot for the assistant. " +
+            "Do not include identity guesses, sensitive inferences, or unrelated speculation. " +
+            `User intent: ${userPrompt}`,
+        },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data: payload.imageBase64,
+          },
+        },
+      ],
+    },
+  ];
+
+  const response = await provider.sendMessage(
+    messages,
+    [],
+    "You produce concise, privacy-aware descriptions of one-off webcam snapshots. Keep the answer under 150 words.",
+    { signal },
+  );
+  const summary = extractAllText(response).trim();
+  if (!summary) {
+    return {
+      content:
+        "Camera snapshot was captured, but the summarizer returned no text.",
+      isError: true,
+    };
+  }
+  return {
+    content:
+      summary.length > MAX_SUMMARY_CHARS
+        ? `${summary.slice(0, MAX_SUMMARY_CHARS).trimEnd()}...`
+        : summary,
+    isError: false,
+  };
+}

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -16,6 +16,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import { escapeAxTreeContent } from "../agent/loop.js";
 import { loadConfig } from "../config/loader.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -28,6 +29,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 
 const log = getLogger("host-cu-proxy");
 
@@ -190,83 +192,108 @@ export class HostCuProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      let detachAbort: () => void = () => {};
+    return runAction<ToolExecutionResult>({
+      actionName: toolName,
+      conversationId,
+      inputSummary: JSON.stringify({
+        stepNumber,
+        targetClientId: targetClientId ?? null,
+      }),
+      riskLevel: "High",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
+          conversationId,
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          let detachAbort: () => void = () => {};
 
-      const timer = setTimeout(() => {
-        this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
-        log.warn({ requestId, toolName }, "Host CU proxy request timed out");
-        resolve({
-          content: "Host CU proxy timed out waiting for client response",
-          isError: true,
-        });
-      }, REQUEST_TIMEOUT_SEC * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
+          const timer = setTimeout(() => {
             this._ownedRequests.delete(requestId);
             pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_cu_cancel",
-                  requestId,
-                  conversationId,
-                  ...(targetClientId != null ? { targetClientId } : {}),
-                },
-                conversationId,
-                { targetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
+            log.warn(
+              { requestId, toolName },
+              "Host CU proxy request timed out",
+            );
+            resolve({
+              content: "Host CU proxy timed out waiting for client response",
+              isError: true,
+            });
+          }, REQUEST_TIMEOUT_SEC * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                this._ownedRequests.delete(requestId);
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_cu_cancel",
+                      requestId,
+                      conversationId,
+                      ...(targetClientId != null ? { targetClientId } : {}),
+                    },
+                    conversationId,
+                    { targetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
           }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
 
-      this._ownedRequests.add(requestId);
+          this._ownedRequests.add(requestId);
 
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_cu",
-        targetClientId,
-        targetActorPrincipalId:
-          targetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
-            : undefined,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-      });
-
-      try {
-        broadcastMessage(
-          {
-            type: "host_cu_request",
-            requestId,
+          pendingInteractions.register(requestId, {
             conversationId,
-            toolName,
-            input,
-            stepNumber,
-            reasoning,
-            // Include in body so receiving client can verify targeted endpoint.
-            ...(targetClientId != null ? { targetClientId } : {}),
-          },
-          conversationId,
-          { targetClientId },
-        );
-      } catch (err) {
-        this._ownedRequests.delete(requestId);
-        pendingInteractions.resolve(requestId);
-        log.warn({ requestId, toolName, err }, "Host CU proxy send failed");
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+            kind: "host_cu",
+            targetClientId,
+            targetActorPrincipalId:
+              targetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+                : undefined,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+          });
+
+          try {
+            broadcastMessage(
+              {
+                type: "host_cu_request",
+                requestId,
+                conversationId,
+                toolName,
+                input,
+                stepNumber,
+                reasoning,
+                // Include in body so receiving client can verify targeted endpoint.
+                ...(targetClientId != null ? { targetClientId } : {}),
+              },
+              conversationId,
+              { targetClientId },
+            );
+          } catch (err) {
+            this._ownedRequests.delete(requestId);
+            pendingInteractions.resolve(requestId);
+            log.warn({ requestId, toolName, err }, "Host CU proxy send failed");
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { runAction } from "../actions/run-action.js";
 import {
   assistantEventHub,
   broadcastMessage,
@@ -14,6 +15,7 @@ import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import type { ActionLifecycleMessage } from "./message-types/actions.js";
 import type { HostFileRequest } from "./message-types/host-file.js";
 
 /** Distributive omit that preserves union variant fields. */
@@ -130,93 +132,116 @@ export class HostFileProxy {
 
     const requestId = uuid();
 
-    return new Promise<ToolExecutionResult>((resolve, reject) => {
-      const timeoutSec = 30;
-
-      let detachAbort: () => void = () => {};
-
-      const timer = setTimeout(() => {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, operation: input.operation },
-          "Host file proxy request timed out",
-        );
-        resolve({
-          content: resolvedTargetClientId
-            ? `Host file proxy timed out waiting for response from client '${resolvedTargetClientId}'`
-            : "Host file proxy timed out waiting for client response",
-          isError: true,
-        });
-      }, timeoutSec * 1000);
-
-      if (signal) {
-        const onAbort = () => {
-          if (pendingInteractions.get(requestId)) {
-            pendingInteractions.resolve(requestId);
-            try {
-              broadcastMessage(
-                {
-                  type: "host_file_cancel",
-                  requestId,
-                  conversationId,
-                  ...(resolvedTargetClientId != null
-                    ? { targetClientId: resolvedTargetClientId }
-                    : {}),
-                },
-                conversationId,
-                { targetClientId: resolvedTargetClientId },
-              );
-            } catch {
-              // Best-effort cancel notification
-            }
-            resolve({ content: "Aborted", isError: true });
-          }
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () => signal.removeEventListener("abort", onAbort);
-      }
-
-      pendingInteractions.register(requestId, {
-        conversationId,
-        kind: "host_file",
-        targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
-        rpcResolve: resolve as (v: unknown) => void,
-        rpcReject: reject,
-        timer,
-        detachAbort,
-        metadata: { operation: input.operation, path: input.path },
-      });
-
-      try {
-        broadcastMessage(
-          {
-            ...input,
-            type: "host_file_request",
-            requestId,
-            conversationId,
-            // Always include in message body so the receiving client can verify
-            // which endpoint was targeted (even when auto-resolved).
-            ...(resolvedTargetClientId != null
-              ? { targetClientId: resolvedTargetClientId }
-              : {}),
-          },
+    return runAction<ToolExecutionResult>({
+      actionName: `host_file.${input.operation}`,
+      conversationId,
+      inputSummary: JSON.stringify({
+        operation: input.operation,
+        path: input.path,
+        targetClientId: resolvedTargetClientId ?? null,
+      }),
+      riskLevel: "Medium",
+      onLifecycle: (event) => {
+        const message: ActionLifecycleMessage = {
+          type: "action_lifecycle",
+          actionId: event.actionId,
+          actionName: event.actionName,
+          stage: event.stage,
+          ts: event.ts,
+          ...(event.message ? { message: event.message } : {}),
           conversationId,
-          { targetClientId: resolvedTargetClientId },
-        );
-      } catch (err) {
-        pendingInteractions.resolve(requestId);
-        log.warn(
-          { requestId, operation: input.operation, err },
-          "Host file proxy send failed",
-        );
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+        };
+        broadcastMessage(message, conversationId);
+      },
+      execute: async () =>
+        await new Promise<ToolExecutionResult>((resolve, reject) => {
+          const timeoutSec = 30;
+
+          let detachAbort: () => void = () => {};
+
+          const timer = setTimeout(() => {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, operation: input.operation },
+              "Host file proxy request timed out",
+            );
+            resolve({
+              content: resolvedTargetClientId
+                ? `Host file proxy timed out waiting for response from client '${resolvedTargetClientId}'`
+                : "Host file proxy timed out waiting for client response",
+              isError: true,
+            });
+          }, timeoutSec * 1000);
+
+          if (signal) {
+            const onAbort = () => {
+              if (pendingInteractions.get(requestId)) {
+                pendingInteractions.resolve(requestId);
+                try {
+                  broadcastMessage(
+                    {
+                      type: "host_file_cancel",
+                      requestId,
+                      conversationId,
+                      ...(resolvedTargetClientId != null
+                        ? { targetClientId: resolvedTargetClientId }
+                        : {}),
+                    },
+                    conversationId,
+                    { targetClientId: resolvedTargetClientId },
+                  );
+                } catch {
+                  // Best-effort cancel notification
+                }
+                resolve({ content: "Aborted", isError: true });
+              }
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", onAbort);
+          }
+
+          pendingInteractions.register(requestId, {
+            conversationId,
+            kind: "host_file",
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
+            rpcResolve: resolve as (v: unknown) => void,
+            rpcReject: reject,
+            timer,
+            detachAbort,
+            metadata: { operation: input.operation, path: input.path },
+          });
+
+          try {
+            broadcastMessage(
+              {
+                ...input,
+                type: "host_file_request",
+                requestId,
+                conversationId,
+                // Always include in message body so the receiving client can verify
+                // which endpoint was targeted (even when auto-resolved).
+                ...(resolvedTargetClientId != null
+                  ? { targetClientId: resolvedTargetClientId }
+                  : {}),
+              },
+              conversationId,
+              { targetClientId: resolvedTargetClientId },
+            );
+          } catch (err) {
+            pendingInteractions.resolve(requestId);
+            log.warn(
+              { requestId, operation: input.operation, err },
+              "Host file proxy send failed",
+            );
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
     });
   }
 

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -208,6 +208,10 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
         conversationId,
         kind: this.resultPendingKind,
         ...(targetClientId != null ? { targetClientId } : {}),
+        targetActorPrincipalId:
+          targetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+            : undefined,
       });
 
       try {

--- a/assistant/src/daemon/host-proxy-preactivation.ts
+++ b/assistant/src/daemon/host-proxy-preactivation.ts
@@ -58,6 +58,7 @@ export const HOST_PROXY_SKILL_PREACTIVATIONS: ReadonlyArray<{
 }> = [
   { capability: "host_cu", skillId: "computer-use" },
   { capability: "host_app_control", skillId: "app-control" },
+  { capability: "host_camera", skillId: "webcam-snapshot" },
 ];
 
 /**

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -57,6 +57,7 @@ import {
 } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
+import { startPerception } from "../perception/startup.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
 import { backfillGuardIfNeeded } from "../proactive-artifact/index.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -323,9 +324,21 @@ export async function runDaemon(): Promise<void> {
     // so a slow or unreachable gateway doesn't delay daemon startup (the
     // IPC call has a 3s connect + 5s call timeout that would otherwise
     // stall the critical path).
-    void initFeatureFlagOverrides().catch((err) =>
-      log.warn({ err }, "Background feature flag init failed"),
-    );
+    void initFeatureFlagOverrides()
+      .then(() => {
+        // Perception startup is flag-gated and idempotent. Retrying after
+        // async override hydration closes the startup race where the initial
+        // call to startPerception() can observe only registry defaults.
+        try {
+          startPerception();
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to start perception spine after feature-flag init",
+          );
+        }
+      })
+      .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 
     maybeSeedMemoryV2Skills(loadConfig());
 
@@ -996,6 +1009,18 @@ export async function runDaemon(): Promise<void> {
       log.warn(
         { err },
         "Failed to start home feed scheduler — continuing startup",
+      );
+    }
+
+    // Perception spine: ambient context buffer fed by perception.* events on
+    // the assistant event hub. Gated by the `perception` feature flag and a
+    // safe no-op when off. See `docs/jarvis-roadmap.md`.
+    try {
+      startPerception();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to start perception spine — continuing startup",
       );
     }
 

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -14,6 +14,7 @@
 
 // Re-export domain modules (all individual types remain importable)
 export * from "./message-types/acp.js";
+export * from "./message-types/actions.js";
 export * from "./message-types/apps.js";
 export * from "./message-types/browser.js";
 export * from "./message-types/computer-use.js";
@@ -27,6 +28,7 @@ export * from "./message-types/home.js";
 export * from "./message-types/host-app-control.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
+export * from "./message-types/host-camera.js";
 export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
 export * from "./message-types/host-transfer.js";
@@ -48,6 +50,7 @@ export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
 import type { _AcpServerMessages } from "./message-types/acp.js";
+import type { _ActionsServerMessages } from "./message-types/actions.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -88,6 +91,7 @@ import type {
   _HostBrowserClientMessages,
   _HostBrowserServerMessages,
 } from "./message-types/host-browser.js";
+import type { _HostCameraServerMessages } from "./message-types/host-camera.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type { _HostTransferServerMessages } from "./message-types/host-transfer.js";
@@ -192,6 +196,7 @@ export type ServerMessage =
   | _HostAppControlServerMessages
   | _HostBashServerMessages
   | _HostBrowserServerMessages
+  | _HostCameraServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages
   | _HostTransferServerMessages
@@ -205,6 +210,7 @@ export type ServerMessage =
   | _NotificationsServerMessages
   | _UpgradesServerMessages
   | _AcpServerMessages
+  | _ActionsServerMessages
   | _DiskPressureServerMessages
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/actions.ts
+++ b/assistant/src/daemon/message-types/actions.ts
@@ -1,0 +1,26 @@
+/**
+ * Action lifecycle messages surfaced to connected clients.
+ *
+ * These events let thin clients (e.g. Tauri HUD) show host-action progress
+ * without parsing tool-specific payloads.
+ */
+
+export type ActionLifecycleStage =
+  | "started"
+  | "executing"
+  | "completed"
+  | "failed"
+  | "rollback_started"
+  | "rollback_completed";
+
+export interface ActionLifecycleMessage {
+  type: "action_lifecycle";
+  actionId: string;
+  actionName: string;
+  stage: ActionLifecycleStage;
+  ts: number;
+  message?: string;
+  conversationId?: string;
+}
+
+export type _ActionsServerMessages = ActionLifecycleMessage;

--- a/assistant/src/daemon/message-types/host-camera.ts
+++ b/assistant/src/daemon/message-types/host-camera.ts
@@ -1,0 +1,44 @@
+// Host camera proxy types.
+// Enables a request-scoped, one-shot webcam snapshot on a connected desktop
+// client. Raw image bytes return only to the awaiting proxy and are summarized
+// before the agent sees the tool result.
+
+export interface HostCameraInput {
+  /** Optional question/instruction to guide the image summary. */
+  prompt?: string;
+  /** Optional target client id when multiple desktop clients are connected. */
+  target_client_id?: string;
+}
+
+// === Server -> Client ===
+
+export interface HostCameraRequest {
+  type: "host_camera_request";
+  requestId: string;
+  conversationId: string;
+  toolName: "describe_camera_once";
+  input: HostCameraInput;
+  targetClientId?: string;
+}
+
+export interface HostCameraCancel {
+  type: "host_camera_cancel";
+  requestId: string;
+  conversationId: string;
+  targetClientId?: string;
+}
+
+// === Result payload (HTTP /v1/host-camera-result body) ===
+
+export interface HostCameraResultPayload {
+  requestId: string;
+  imageBase64?: string;
+  mediaType?: "image/jpeg" | "image/png" | "image/webp";
+  width?: number;
+  height?: number;
+  error?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostCameraServerMessages = HostCameraRequest | HostCameraCancel;

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -46,6 +46,7 @@ import {
 } from "./conversation-store.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
+import { HostCameraProxy } from "./host-camera-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 
@@ -173,6 +174,13 @@ async function prepareConversationForMessage(
     }
   } else if (!conversation.isProcessing()) {
     conversation.setHostAppControlProxy(undefined);
+  }
+  if (supportsHostProxy(resolvedInterface, "host_camera")) {
+    if (!conversation.isProcessing() || !conversation.hostCameraProxy) {
+      conversation.setHostCameraProxy(new HostCameraProxy());
+    }
+  } else if (!conversation.isProcessing()) {
+    conversation.setHostCameraProxy(undefined);
   }
   // The early `isProcessing()` throw above guarantees the conversation is
   // idle here, so preactivation is unconditional once the proxies are wired.

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -5,6 +5,7 @@ import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { McpServerManager } from "../mcp/manager.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
+import { stopPerception } from "../perception/startup.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
 import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
@@ -120,6 +121,11 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     cleanupShellOutputTempFiles();
     deps.scheduler.stop();
     deps.feedScheduler?.stop();
+    try {
+      stopPerception();
+    } catch (err) {
+      log.warn({ err }, "Perception shutdown failed (non-fatal)");
+    }
     deps.getMemoryWorker()?.stop();
 
     if (deps.mcpManager) {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -133,6 +133,9 @@ import {
   migrateOAuthProvidersScopeSeparator,
   migrateOAuthProvidersTokenAuthMethodDefault,
   migrateOAuthProvidersTokenExchangeBodyFormat,
+  migratePerceptionConsentGrants,
+  migratePkbEntityEpisodeTables,
+  migratePkbQualityFields,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
@@ -410,6 +413,9 @@ export function initializeDb(): void {
     },
     migrateScheduleRetryPolicy,
     migrateTraceEventsCreatedAtIndex,
+    migratePkbEntityEpisodeTables,
+    migratePkbQualityFields,
+    migratePerceptionConsentGrants,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -42,7 +42,8 @@ export type MemoryJobType =
   | "memory_v2_consolidate"
   | "memory_v2_migrate"
   | "memory_v2_reembed"
-  | "memory_v2_activation_recompute";
+  | "memory_v2_activation_recompute"
+  | "pkb_decay";
 
 export const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,3 +1,4 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import {
@@ -67,6 +68,7 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "./jobs-store.js";
+import { runPkbDecayPass } from "./pkb-decay.js";
 import { QdrantCircuitOpenError } from "./qdrant-circuit-breaker.js";
 import {
   memoryV2ActivationRecomputeJob,
@@ -355,6 +357,11 @@ function graphDecayJob(job: MemoryJob): void {
   log.info({ jobId: job.id, ...result }, "Graph decay tick complete");
 }
 
+function pkbDecayJob(job: MemoryJob): void {
+  const result = runPkbDecayPass();
+  log.info({ jobId: job.id, ...result }, "PKB decay tick complete");
+}
+
 async function graphConsolidateJob(
   job: MemoryJob,
   config: AssistantConfig,
@@ -555,6 +562,9 @@ async function processJob(
     case "memory_v2_activation_recompute":
       await memoryV2ActivationRecomputeJob(job, config);
       return;
+    case "pkb_decay":
+      pkbDecayJob(job);
+      return;
 
     default: {
       const rawType = (job as { type: string }).type;
@@ -614,6 +624,7 @@ const GRAPH_DECAY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const GRAPH_CONSOLIDATE_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const GRAPH_PATTERN_SCAN_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
 const GRAPH_NARRATIVE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+const PKB_DECAY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
 export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   decay: "graph_maintenance:decay:last_run",
@@ -621,6 +632,7 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   patternScan: "graph_maintenance:pattern_scan:last_run",
   narrative: "graph_maintenance:narrative:last_run",
   memoryV2Consolidate: "memory_v2_consolidate_last_run",
+  pkbDecay: "pkb_maintenance:decay:last_run",
 } as const;
 
 /**
@@ -689,6 +701,15 @@ export function maybeEnqueueGraphMaintenanceJobs(
     const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);
     if (nowMs - lastRun >= intervalMs) {
       enqueueMemoryJob(jobType, {});
+      setMemoryCheckpoint(key, String(nowMs));
+    }
+  }
+
+  if (isAssistantFeatureFlagEnabled("memory-maturation", config)) {
+    const key = GRAPH_MAINTENANCE_CHECKPOINTS.pkbDecay;
+    const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);
+    if (nowMs - lastRun >= PKB_DECAY_INTERVAL_MS) {
+      enqueueMemoryJob("pkb_decay", {});
       setMemoryCheckpoint(key, String(nowMs));
     }
   }

--- a/assistant/src/memory/migrations/240-pkb-entity-episode-tables.ts
+++ b/assistant/src/memory/migrations/240-pkb-entity-episode-tables.ts
@@ -1,0 +1,87 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Phase 5 kickoff: normalized personal-knowledge storage.
+ *
+ * Adds:
+ * - pkb_entities
+ * - pkb_episodes
+ * - pkb_preferences
+ *
+ * Uses IF NOT EXISTS for idempotency.
+ */
+export function migratePkbEntityEpisodeTables(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS pkb_entities (
+      id              TEXT PRIMARY KEY,
+      scope_id        TEXT NOT NULL DEFAULT 'default',
+      entity_type     TEXT NOT NULL,
+      canonical_name  TEXT NOT NULL,
+      aliases_json    TEXT NOT NULL DEFAULT '[]',
+      attributes_json TEXT NOT NULL DEFAULT '{}',
+      confidence      REAL NOT NULL DEFAULT 0.5,
+      first_seen_at   INTEGER NOT NULL,
+      last_seen_at    INTEGER NOT NULL,
+      created_at      INTEGER NOT NULL,
+      updated_at      INTEGER NOT NULL
+    )
+  `);
+  raw.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pkb_entities_scope_type_name
+      ON pkb_entities(scope_id, entity_type, canonical_name)
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_pkb_entities_scope_updated
+      ON pkb_entities(scope_id, updated_at)
+  `);
+
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS pkb_episodes (
+      id                      TEXT PRIMARY KEY,
+      scope_id                TEXT NOT NULL DEFAULT 'default',
+      entity_id               TEXT REFERENCES pkb_entities(id) ON DELETE SET NULL,
+      summary                 TEXT NOT NULL,
+      details_json            TEXT NOT NULL DEFAULT '{}',
+      happened_at             INTEGER NOT NULL,
+      salience                REAL NOT NULL DEFAULT 0.5,
+      source_conversation_id  TEXT,
+      created_at              INTEGER NOT NULL
+    )
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_pkb_episodes_scope_happened
+      ON pkb_episodes(scope_id, happened_at)
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_pkb_episodes_scope_salience
+      ON pkb_episodes(scope_id, salience)
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_pkb_episodes_entity
+      ON pkb_episodes(entity_id)
+  `);
+
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS pkb_preferences (
+      id           TEXT PRIMARY KEY,
+      scope_id     TEXT NOT NULL DEFAULT 'default',
+      key          TEXT NOT NULL,
+      value        TEXT NOT NULL,
+      confidence   REAL NOT NULL DEFAULT 0.5,
+      learned_from TEXT NOT NULL DEFAULT 'inferred',
+      created_at   INTEGER NOT NULL,
+      updated_at   INTEGER NOT NULL
+    )
+  `);
+  raw.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pkb_preferences_scope_key
+      ON pkb_preferences(scope_id, key)
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_pkb_preferences_scope_updated
+      ON pkb_preferences(scope_id, updated_at)
+  `);
+}

--- a/assistant/src/memory/migrations/242-pkb-quality-fields.ts
+++ b/assistant/src/memory/migrations/242-pkb-quality-fields.ts
@@ -1,0 +1,118 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_pkb_quality_fields_v1";
+
+/**
+ * Memory Maturation MVP — Phase 10B.
+ *
+ * Extends the Phase 5 PKB tables with the columns needed for confidence /
+ * provenance / decay management and idempotent episode writes.
+ *
+ * `pkb_entities`:
+ *   - `evidence_count` — number of times the entity has been reinforced.
+ *   - `last_reinforced_at` — distinct from `last_seen_at`; bumped only on
+ *     a true reinforcement event.
+ *   - `provenance_json` — append-only list of source descriptors
+ *     ({ sourceKind, sourceEventId, observedAt, contribution }), capped
+ *     by the writer.
+ *
+ * `pkb_preferences`:
+ *   - `evidence_count`, `positive_count`, `negative_count` — counter-based
+ *     confidence (beta-mean of positive/(positive+negative)).
+ *   - `last_reinforced_at`, `last_contradicted_at` — recency anchors for
+ *     decay + feedback observability.
+ *
+ * `pkb_episodes`:
+ *   - `idempotency_key` — optional; partial unique index lets callers
+ *     pass `${sourceEventId}:${interpretedKind}` and get an idempotent
+ *     insert without affecting the existing unkeyed writes.
+ */
+export function migratePkbQualityFields(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    if (!tableHasColumn(database, "pkb_entities", "evidence_count")) {
+      raw.exec(
+        `ALTER TABLE pkb_entities ADD COLUMN evidence_count INTEGER NOT NULL DEFAULT 1`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_entities", "last_reinforced_at")) {
+      raw.exec(
+        `ALTER TABLE pkb_entities ADD COLUMN last_reinforced_at INTEGER`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_entities", "provenance_json")) {
+      raw.exec(
+        `ALTER TABLE pkb_entities ADD COLUMN provenance_json TEXT NOT NULL DEFAULT '[]'`,
+      );
+    }
+
+    if (!tableHasColumn(database, "pkb_preferences", "evidence_count")) {
+      raw.exec(
+        `ALTER TABLE pkb_preferences ADD COLUMN evidence_count INTEGER NOT NULL DEFAULT 1`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_preferences", "positive_count")) {
+      raw.exec(
+        `ALTER TABLE pkb_preferences ADD COLUMN positive_count INTEGER NOT NULL DEFAULT 1`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_preferences", "negative_count")) {
+      raw.exec(
+        `ALTER TABLE pkb_preferences ADD COLUMN negative_count INTEGER NOT NULL DEFAULT 0`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_preferences", "last_reinforced_at")) {
+      raw.exec(
+        `ALTER TABLE pkb_preferences ADD COLUMN last_reinforced_at INTEGER`,
+      );
+    }
+    if (!tableHasColumn(database, "pkb_preferences", "last_contradicted_at")) {
+      raw.exec(
+        `ALTER TABLE pkb_preferences ADD COLUMN last_contradicted_at INTEGER`,
+      );
+    }
+
+    if (!tableHasColumn(database, "pkb_episodes", "idempotency_key")) {
+      raw.exec(`ALTER TABLE pkb_episodes ADD COLUMN idempotency_key TEXT`);
+    }
+    raw.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_pkb_episodes_scope_idempotency
+        ON pkb_episodes(scope_id, idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+    `);
+  });
+}
+
+export function downPkbQualityFields(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(`DROP INDEX IF EXISTS idx_pkb_episodes_scope_idempotency`);
+  // SQLite supports DROP COLUMN since 3.35; the codebase already relies on
+  // it via the other ALTER TABLE down migrations.
+  if (tableHasColumn(database, "pkb_episodes", "idempotency_key")) {
+    raw.exec(`ALTER TABLE pkb_episodes DROP COLUMN idempotency_key`);
+  }
+  for (const col of [
+    "last_contradicted_at",
+    "last_reinforced_at",
+    "negative_count",
+    "positive_count",
+    "evidence_count",
+  ]) {
+    if (tableHasColumn(database, "pkb_preferences", col)) {
+      raw.exec(`ALTER TABLE pkb_preferences DROP COLUMN ${col}`);
+    }
+  }
+  for (const col of [
+    "provenance_json",
+    "last_reinforced_at",
+    "evidence_count",
+  ]) {
+    if (tableHasColumn(database, "pkb_entities", col)) {
+      raw.exec(`ALTER TABLE pkb_entities DROP COLUMN ${col}`);
+    }
+  }
+}

--- a/assistant/src/memory/migrations/243-perception-consent-grants.ts
+++ b/assistant/src/memory/migrations/243-perception-consent-grants.ts
@@ -1,0 +1,44 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Multimodal Perception MVP — Phase 10C.
+ *
+ * Adds `perception_consent_grants` to back the per-conversation consent
+ * gate for sensitive perception event kinds (`screen_snapshot`,
+ * `audio_excerpt`). One row per (scope_id, conversation_id, event_kind);
+ * tracks when the grant was issued, when it expires, and when it was
+ * revoked.
+ *
+ * Wired through the existing `confirmation_request` → `POST /v1/confirm`
+ * flow (no new approval primitive). On `allow_conversation`, the route
+ * inserts a row here; subsequent publish-route calls for the same triple
+ * short-circuit. On `deny` / `always_deny`, no row is written and the
+ * publish route rejects with `{ accepted: false, reason: "consent_required" }`.
+ *
+ * Uses IF NOT EXISTS for idempotency.
+ */
+export function migratePerceptionConsentGrants(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS perception_consent_grants (
+      id              TEXT PRIMARY KEY,
+      scope_id        TEXT NOT NULL DEFAULT 'default',
+      conversation_id TEXT NOT NULL,
+      event_kind      TEXT NOT NULL,
+      granted_at      INTEGER NOT NULL,
+      expires_at      INTEGER,
+      revoked_at      INTEGER,
+      created_at      INTEGER NOT NULL
+    )
+  `);
+  raw.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_perception_consent_grants_triple
+      ON perception_consent_grants(scope_id, conversation_id, event_kind)
+  `);
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_perception_consent_grants_expires
+      ON perception_consent_grants(expires_at)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -201,6 +201,12 @@ export {
 } from "./237-heartbeat-runs.js";
 export { migrateScheduleRetryPolicy } from "./238-schedule-retry-policy.js";
 export { migrateTraceEventsCreatedAtIndex } from "./239-trace-events-created-at-index.js";
+export { migratePkbEntityEpisodeTables } from "./240-pkb-entity-episode-tables.js";
+export {
+  downPkbQualityFields,
+  migratePkbQualityFields,
+} from "./242-pkb-quality-fields.js";
+export { migratePerceptionConsentGrants } from "./243-perception-consent-grants.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -48,6 +48,7 @@ import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
 import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
+import { downPkbQualityFields } from "./242-pkb-quality-fields.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -411,6 +412,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
     down: downHeartbeatRuns,
+  },
+  {
+    key: "migration_pkb_quality_fields_v1",
+    version: 48,
+    description:
+      "Add evidence_count / provenance / decay anchor columns to pkb_entities and pkb_preferences, plus idempotency_key on pkb_episodes — Memory Maturation MVP",
+    down: downPkbQualityFields,
   },
 ];
 

--- a/assistant/src/memory/personal-knowledge-store.test.ts
+++ b/assistant/src/memory/personal-knowledge-store.test.ts
@@ -1,0 +1,212 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import {
+  findPkbEntities,
+  listPkbPreferences,
+  listRecentPkbEntities,
+  listRecentPkbEpisodes,
+  recordPkbEpisode,
+  scorePkbEntities,
+  upsertPkbEntity,
+  upsertPkbPreference,
+} from "./personal-knowledge-store.js";
+
+describe("personal-knowledge-store", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("upsertPkbEntity merges aliases/attributes and counter-weights confidence", () => {
+    const first = upsertPkbEntity({
+      entityType: "person",
+      canonicalName: "Alice",
+      aliases: ["Al"],
+      attributes: { team: "platform" },
+      confidence: 0.4,
+    });
+    const second = upsertPkbEntity({
+      entityType: "person",
+      canonicalName: "alice",
+      aliases: ["A."],
+      attributes: { role: "engineer" },
+      confidence: 0.9,
+    });
+
+    expect(first.id).toBe(second.id);
+    // Counter-weighted mean: (1 * 0.4 + 0.9) / 2 = 0.65
+    expect(second.confidence).toBeCloseTo(0.65, 5);
+    expect(second.evidenceCount).toBe(2);
+    expect(second.aliasesJson).toContain("Al");
+    expect(second.aliasesJson).toContain("A.");
+    expect(second.attributesJson).toContain("platform");
+    expect(second.attributesJson).toContain("engineer");
+  });
+
+  test("findPkbEntities searches canonical names and aliases", () => {
+    upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "jarvis hud",
+      aliases: ["hud"],
+    });
+    upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "meeting bot",
+      aliases: ["bots"],
+    });
+
+    const byName = findPkbEntities({ query: "jarvis", limit: 10 });
+    const byAlias = findPkbEntities({ query: "hud", limit: 10 });
+
+    expect(byName).toHaveLength(1);
+    expect(byAlias).toHaveLength(1);
+    expect(byAlias[0]?.canonicalName).toBe("jarvis hud");
+  });
+
+  test("listRecentPkbEntities returns newest entities first", () => {
+    upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "older",
+      confidence: 0.5,
+    });
+    upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "newer",
+      confidence: 0.7,
+    });
+
+    const recent = listRecentPkbEntities({ limit: 2 });
+    expect(recent).toHaveLength(2);
+    expect(recent[0]?.canonicalName).toBe("newer");
+    expect(recent[1]?.canonicalName).toBe("older");
+  });
+
+  test("recordPkbEpisode stores episode and lists newest first", () => {
+    const older = recordPkbEpisode({
+      summary: "older episode",
+      happenedAt: 1000,
+      salience: 0.2,
+    });
+    const newer = recordPkbEpisode({
+      summary: "newer episode",
+      happenedAt: 2000,
+      salience: 0.9,
+    });
+
+    const episodes = listRecentPkbEpisodes({ limit: 10 });
+    expect(episodes.map((e) => e.id)).toEqual([newer.id, older.id]);
+  });
+
+  test("upsertPkbPreference reinforces with positive signal (default)", () => {
+    const first = upsertPkbPreference({
+      key: "coding.style",
+      value: "concise",
+      confidence: 0.4,
+    });
+    const second = upsertPkbPreference({
+      key: "coding.style",
+      value: "concise",
+      learnedFrom: "conversation",
+    });
+
+    expect(first.id).toBe(second.id);
+    // Two positive observations → beta-mean = 2/(2+0) = 1.0
+    expect(second.confidence).toBe(1);
+    expect(second.positiveCount).toBe(2);
+    expect(second.negativeCount).toBe(0);
+    expect(second.evidenceCount).toBe(2);
+
+    const prefs = listPkbPreferences({ limit: 10 });
+    expect(prefs).toHaveLength(1);
+  });
+
+  test("upsertPkbPreference contradicted signal overwrites value and bumps negative counter", () => {
+    upsertPkbPreference({
+      key: "coding.style",
+      value: "concise",
+      confidence: 0.4,
+    });
+    const contradicted = upsertPkbPreference({
+      key: "coding.style",
+      value: "detailed",
+      signal: "negative",
+    });
+    // 1 positive, 1 negative → 1/(1+1) = 0.5
+    expect(contradicted.confidence).toBeCloseTo(0.5, 5);
+    expect(contradicted.value).toBe("detailed");
+    expect(contradicted.negativeCount).toBe(1);
+    expect(contradicted.lastContradictedAt).not.toBeNull();
+  });
+
+  test("recordPkbEpisode is idempotent on idempotencyKey", () => {
+    const a = recordPkbEpisode({
+      summary: "first",
+      idempotencyKey: "src-1:task_detected",
+    });
+    const b = recordPkbEpisode({
+      summary: "second (should be ignored)",
+      idempotencyKey: "src-1:task_detected",
+    });
+    expect(a.id).toBe(b.id);
+    expect(b.summary).toBe("first");
+    expect(listRecentPkbEpisodes({ limit: 10 })).toHaveLength(1);
+  });
+
+  test("scorePkbEntities ranks recent reinforced entities highest", () => {
+    const now = Date.now();
+    const stale = upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "stale entity",
+      confidence: 0.9,
+    });
+    // Push the stale entity's reinforcement anchor far into the past.
+    const sqlite = getSqlite();
+    sqlite.run(
+      `UPDATE pkb_entities SET last_reinforced_at = ?, last_seen_at = ? WHERE id = ?`,
+      [
+        now - 60 * 24 * 60 * 60 * 1000,
+        now - 60 * 24 * 60 * 60 * 1000,
+        stale.id,
+      ],
+    );
+    const fresh = upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "fresh entity",
+      confidence: 0.5,
+    });
+    const scored = scorePkbEntities({ now, limit: 10 });
+    expect(scored[0]!.entity.id).toBe(fresh.id);
+    expect(scored[1]!.entity.id).toBe(stale.id);
+  });
+
+  test("entity provenance is appended and capped", () => {
+    let last: ReturnType<typeof upsertPkbEntity> | undefined;
+    for (let i = 0; i < 25; i += 1) {
+      last = upsertPkbEntity({
+        entityType: "project",
+        canonicalName: "repeatedly reinforced",
+        confidence: 0.6,
+        provenance: {
+          source: "perception",
+          sourceEventId: `evt-${i}`,
+          observedAt: 1000 + i,
+        },
+      });
+    }
+    const provenance = JSON.parse(last!.provenanceJson) as Array<{
+      sourceEventId: string;
+    }>;
+    expect(provenance).toHaveLength(20);
+    expect(provenance.at(-1)?.sourceEventId).toBe("evt-24");
+    expect(last!.evidenceCount).toBe(25);
+  });
+});

--- a/assistant/src/memory/personal-knowledge-store.ts
+++ b/assistant/src/memory/personal-knowledge-store.ts
@@ -1,0 +1,507 @@
+import { and, desc, eq, like, or, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db-connection.js";
+import { pkbEntities, pkbEpisodes, pkbPreferences } from "./schema.js";
+
+export interface UpsertPkbEntityInput {
+  scopeId?: string;
+  entityType: string;
+  canonicalName: string;
+  aliases?: string[];
+  attributes?: Record<string, unknown>;
+  confidence?: number;
+  /** Optional provenance entry appended on every upsert. */
+  provenance?: PkbProvenanceEntry;
+  /** When true, treat this upsert as a reinforcement (bump counter + last_reinforced_at). Defaults to true. */
+  reinforce?: boolean;
+}
+
+export interface PkbProvenanceEntry {
+  source: string;
+  sourceEventId?: string;
+  observedAt: number;
+  /** Optional human-readable note for audit. */
+  note?: string;
+}
+
+export interface RecordPkbEpisodeInput {
+  scopeId?: string;
+  entityId?: string;
+  summary: string;
+  details?: Record<string, unknown>;
+  happenedAt?: number;
+  salience?: number;
+  sourceConversationId?: string;
+  /**
+   * If set and another row exists for (scope_id, idempotency_key), the
+   * existing row is returned unchanged. Recommended for perception
+   * writers: pass `${sourceEventId}:${interpretedKind}`.
+   */
+  idempotencyKey?: string;
+}
+
+export type PreferenceSignal = "positive" | "negative";
+
+export interface UpsertPkbPreferenceInput {
+  scopeId?: string;
+  key: string;
+  value: string;
+  confidence?: number;
+  learnedFrom?: string;
+  /** Direction of the new evidence. Defaults to `positive`. */
+  signal?: PreferenceSignal;
+}
+
+const DEFAULT_SCOPE = "default";
+const MAX_PROVENANCE_ENTRIES = 20;
+
+export function upsertPkbEntity(input: UpsertPkbEntityInput) {
+  const db = getDb();
+  const now = Date.now();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const entityType = input.entityType.trim();
+  const canonicalName = normalizeEntityName(input.canonicalName);
+  const aliases = dedupeAliases(input.aliases ?? [], canonicalName);
+  const confidence = clamp01(input.confidence ?? 0.6);
+  const reinforce = input.reinforce ?? true;
+
+  const existing = db
+    .select()
+    .from(pkbEntities)
+    .where(
+      and(
+        eq(pkbEntities.scopeId, scopeId),
+        eq(pkbEntities.entityType, entityType),
+        eq(pkbEntities.canonicalName, canonicalName),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    const mergedAliases = dedupeAliases(
+      [
+        ...safeJsonStringArray(existing.aliasesJson),
+        ...aliases,
+        existing.canonicalName,
+      ],
+      existing.canonicalName,
+    );
+    const mergedAttributes = {
+      ...safeJsonObject(existing.attributesJson),
+      ...(input.attributes ?? {}),
+    };
+    const evidenceCount = existing.evidenceCount ?? 1;
+    // Counter-weighted mean — every reinforcement pulls confidence toward
+    // the incoming observation but in proportion to the existing evidence.
+    const mergedConfidence = reinforce
+      ? clamp01(
+          (evidenceCount * existing.confidence + confidence) /
+            (evidenceCount + 1),
+        )
+      : Math.max(existing.confidence, confidence);
+    const newEvidenceCount = reinforce ? evidenceCount + 1 : evidenceCount;
+    const mergedProvenance = appendProvenance(
+      safeJsonProvenance(existing.provenanceJson ?? "[]"),
+      input.provenance,
+    );
+
+    db.update(pkbEntities)
+      .set({
+        aliasesJson: JSON.stringify(mergedAliases),
+        attributesJson: JSON.stringify(mergedAttributes),
+        confidence: mergedConfidence,
+        lastSeenAt: now,
+        updatedAt: now,
+        evidenceCount: newEvidenceCount,
+        ...(reinforce ? { lastReinforcedAt: now } : {}),
+        provenanceJson: JSON.stringify(mergedProvenance),
+      })
+      .where(eq(pkbEntities.id, existing.id))
+      .run();
+    return db
+      .select()
+      .from(pkbEntities)
+      .where(eq(pkbEntities.id, existing.id))
+      .get()!;
+  }
+
+  const id = uuid();
+  const initialProvenance = input.provenance ? [input.provenance] : [];
+  db.insert(pkbEntities)
+    .values({
+      id,
+      scopeId,
+      entityType,
+      canonicalName,
+      aliasesJson: JSON.stringify(aliases),
+      attributesJson: JSON.stringify(input.attributes ?? {}),
+      confidence,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      createdAt: now,
+      updatedAt: now,
+      evidenceCount: 1,
+      lastReinforcedAt: now,
+      provenanceJson: JSON.stringify(initialProvenance),
+    })
+    .run();
+
+  return db.select().from(pkbEntities).where(eq(pkbEntities.id, id)).get()!;
+}
+
+export function findPkbEntities(input: {
+  scopeId?: string;
+  query: string;
+  limit?: number;
+}) {
+  const db = getDb();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const needle = `%${input.query.trim().toLowerCase()}%`;
+  const limit = Math.max(1, Math.min(input.limit ?? 10, 100));
+
+  return db
+    .select()
+    .from(pkbEntities)
+    .where(
+      and(
+        eq(pkbEntities.scopeId, scopeId),
+        or(
+          like(sql`lower(${pkbEntities.canonicalName})`, needle),
+          like(sql`lower(${pkbEntities.aliasesJson})`, needle),
+        ),
+      ),
+    )
+    .orderBy(desc(pkbEntities.lastSeenAt))
+    .limit(limit)
+    .all();
+}
+
+export function listRecentPkbEntities(input: {
+  scopeId?: string;
+  limit?: number;
+}) {
+  const db = getDb();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const limit = Math.max(1, Math.min(input.limit ?? 20, 100));
+  return db
+    .select()
+    .from(pkbEntities)
+    .where(eq(pkbEntities.scopeId, scopeId))
+    .orderBy(desc(pkbEntities.updatedAt))
+    .limit(limit)
+    .all();
+}
+
+export function recordPkbEpisode(input: RecordPkbEpisodeInput) {
+  const db = getDb();
+  const now = Date.now();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const idempotencyKey = input.idempotencyKey?.trim() || undefined;
+
+  if (idempotencyKey) {
+    const existing = db
+      .select()
+      .from(pkbEpisodes)
+      .where(
+        and(
+          eq(pkbEpisodes.scopeId, scopeId),
+          eq(pkbEpisodes.idempotencyKey, idempotencyKey),
+        ),
+      )
+      .get();
+    if (existing) return existing;
+  }
+
+  const id = uuid();
+  db.insert(pkbEpisodes)
+    .values({
+      id,
+      scopeId,
+      entityId: input.entityId,
+      summary: input.summary.trim(),
+      detailsJson: JSON.stringify(input.details ?? {}),
+      happenedAt: input.happenedAt ?? now,
+      salience: clamp01(input.salience ?? 0.5),
+      sourceConversationId: input.sourceConversationId,
+      createdAt: now,
+      idempotencyKey: idempotencyKey ?? null,
+    })
+    .run();
+  return db.select().from(pkbEpisodes).where(eq(pkbEpisodes.id, id)).get()!;
+}
+
+export function listRecentPkbEpisodes(input: {
+  scopeId?: string;
+  limit?: number;
+}) {
+  const db = getDb();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const limit = Math.max(1, Math.min(input.limit ?? 20, 100));
+  return db
+    .select()
+    .from(pkbEpisodes)
+    .where(eq(pkbEpisodes.scopeId, scopeId))
+    .orderBy(desc(pkbEpisodes.happenedAt), desc(pkbEpisodes.createdAt))
+    .limit(limit)
+    .all();
+}
+
+export function upsertPkbPreference(input: UpsertPkbPreferenceInput) {
+  const db = getDb();
+  const now = Date.now();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const key = input.key.trim();
+  const value = input.value.trim();
+  const learnedFrom = input.learnedFrom?.trim() || "inferred";
+  const signal: PreferenceSignal = input.signal ?? "positive";
+
+  const existing = db
+    .select()
+    .from(pkbPreferences)
+    .where(
+      and(eq(pkbPreferences.scopeId, scopeId), eq(pkbPreferences.key, key)),
+    )
+    .get();
+
+  if (existing) {
+    const positive =
+      (existing.positiveCount ?? 1) + (signal === "positive" ? 1 : 0);
+    const negative =
+      (existing.negativeCount ?? 0) + (signal === "negative" ? 1 : 0);
+    const evidence = (existing.evidenceCount ?? 1) + 1;
+    // Beta-mean estimator — Laplace-smoothed positive ratio.
+    const confidence = clamp01(positive / Math.max(1, positive + negative));
+    db.update(pkbPreferences)
+      .set({
+        // On a contradiction, overwrite the stored value with the new
+        // (negative) signal's value so the most recent observed value
+        // wins. On reinforcement, the value already matches.
+        value: signal === "negative" ? value : existing.value,
+        confidence,
+        learnedFrom,
+        updatedAt: now,
+        evidenceCount: evidence,
+        positiveCount: positive,
+        negativeCount: negative,
+        ...(signal === "positive" ? { lastReinforcedAt: now } : {}),
+        ...(signal === "negative" ? { lastContradictedAt: now } : {}),
+      })
+      .where(eq(pkbPreferences.id, existing.id))
+      .run();
+    return db
+      .select()
+      .from(pkbPreferences)
+      .where(eq(pkbPreferences.id, existing.id))
+      .get()!;
+  }
+
+  const id = uuid();
+  const initialConfidence = clamp01(input.confidence ?? 0.6);
+  db.insert(pkbPreferences)
+    .values({
+      id,
+      scopeId,
+      key,
+      value,
+      confidence: initialConfidence,
+      learnedFrom,
+      createdAt: now,
+      updatedAt: now,
+      evidenceCount: 1,
+      positiveCount: signal === "positive" ? 1 : 0,
+      negativeCount: signal === "negative" ? 1 : 0,
+      ...(signal === "positive" ? { lastReinforcedAt: now } : {}),
+      ...(signal === "negative" ? { lastContradictedAt: now } : {}),
+    })
+    .run();
+  return db
+    .select()
+    .from(pkbPreferences)
+    .where(eq(pkbPreferences.id, id))
+    .get()!;
+}
+
+export function listPkbPreferences(input: {
+  scopeId?: string;
+  limit?: number;
+}) {
+  const db = getDb();
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE;
+  const limit = Math.max(1, Math.min(input.limit ?? 50, 200));
+  return db
+    .select()
+    .from(pkbPreferences)
+    .where(eq(pkbPreferences.scopeId, scopeId))
+    .orderBy(desc(pkbPreferences.confidence), desc(pkbPreferences.updatedAt))
+    .limit(limit)
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Scoring helpers — used by the perception-context formatter and the
+// memory-maturation feature flag's selection logic.
+//
+// Score = w_conf * confidence
+//       + w_recent * exp(-Δt / τ)
+//       + w_evidence * log(1 + evidence_count)
+//
+// All weights are positive; τ controls how aggressively recency decays.
+// ---------------------------------------------------------------------------
+
+export interface ScoringOptions {
+  scopeId?: string;
+  limit?: number;
+  now?: number;
+  weights?: {
+    confidence?: number;
+    recency?: number;
+    evidence?: number;
+  };
+  /** Recency time constant in milliseconds. Default 14 days. */
+  halfLifeMs?: number;
+}
+
+export interface ScoredEntity {
+  entity: ReturnType<typeof listRecentPkbEntities>[number];
+  score: number;
+}
+
+export interface ScoredPreference {
+  preference: ReturnType<typeof listPkbPreferences>[number];
+  score: number;
+}
+
+const DEFAULT_WEIGHTS = { confidence: 0.5, recency: 0.3, evidence: 0.2 };
+const DEFAULT_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1_000;
+
+export function scorePkbEntities(
+  input: { query?: string } & ScoringOptions = {},
+): ScoredEntity[] {
+  const now = input.now ?? Date.now();
+  const weights = { ...DEFAULT_WEIGHTS, ...(input.weights ?? {}) };
+  const halfLife = Math.max(1, input.halfLifeMs ?? DEFAULT_HALF_LIFE_MS);
+  const limit = Math.max(1, Math.min(input.limit ?? 20, 200));
+
+  const rows = input.query
+    ? findPkbEntities({
+        scopeId: input.scopeId,
+        query: input.query,
+        limit: limit * 3,
+      })
+    : listRecentPkbEntities({ scopeId: input.scopeId, limit: limit * 3 });
+
+  const scored: ScoredEntity[] = rows.map((entity) => {
+    const anchor = entity.lastReinforcedAt ?? entity.lastSeenAt;
+    const dt = Math.max(0, now - anchor);
+    const recency = Math.exp(-dt / halfLife);
+    const evidence = Math.log1p(entity.evidenceCount ?? 1);
+    const score =
+      weights.confidence * entity.confidence +
+      weights.recency * recency +
+      weights.evidence * evidence;
+    return { entity, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit);
+}
+
+export function scorePkbPreferences(
+  input: ScoringOptions = {},
+): ScoredPreference[] {
+  const now = input.now ?? Date.now();
+  const weights = { ...DEFAULT_WEIGHTS, ...(input.weights ?? {}) };
+  const halfLife = Math.max(1, input.halfLifeMs ?? DEFAULT_HALF_LIFE_MS);
+  const limit = Math.max(1, Math.min(input.limit ?? 20, 200));
+
+  const rows = listPkbPreferences({
+    scopeId: input.scopeId,
+    limit: limit * 3,
+  });
+  const scored: ScoredPreference[] = rows.map((preference) => {
+    const anchor = preference.lastReinforcedAt ?? preference.updatedAt;
+    const dt = Math.max(0, now - anchor);
+    const recency = Math.exp(-dt / halfLife);
+    const evidence = Math.log1p(preference.evidenceCount ?? 1);
+    const score =
+      weights.confidence * preference.confidence +
+      weights.recency * recency +
+      weights.evidence * evidence;
+    return { preference, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function normalizeEntityName(name: string): string {
+  return name.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function dedupeAliases(aliases: string[], canonicalName: string): string[] {
+  const out = new Set<string>();
+  for (const alias of aliases) {
+    const normalized = alias.trim().replace(/\s+/g, " ");
+    if (!normalized) continue;
+    if (normalized.toLowerCase() === canonicalName.toLowerCase()) continue;
+    out.add(normalized);
+  }
+  return Array.from(out.values()).slice(0, 50);
+}
+
+function safeJsonStringArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+function safeJsonObject(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function safeJsonProvenance(value: string): PkbProvenanceEntry[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is PkbProvenanceEntry => {
+      if (!v || typeof v !== "object") return false;
+      const entry = v as Record<string, unknown>;
+      return (
+        typeof entry.source === "string" && typeof entry.observedAt === "number"
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+function appendProvenance(
+  existing: PkbProvenanceEntry[],
+  entry: PkbProvenanceEntry | undefined,
+): PkbProvenanceEntry[] {
+  if (!entry) return existing.slice(-MAX_PROVENANCE_ENTRIES);
+  const next = [...existing, entry];
+  return next.slice(-MAX_PROVENANCE_ENTRIES);
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/assistant/src/memory/pkb-decay.test.ts
+++ b/assistant/src/memory/pkb-decay.test.ts
@@ -1,0 +1,125 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import {
+  listPkbPreferences,
+  listRecentPkbEntities,
+  upsertPkbEntity,
+  upsertPkbPreference,
+} from "./personal-knowledge-store.js";
+import { runPkbDecayPass } from "./pkb-decay.js";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1_000;
+
+describe("runPkbDecayPass", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("no-op when there are no rows", () => {
+    const metrics = runPkbDecayPass({ now: Date.now() });
+    expect(metrics.entitiesScanned).toBe(0);
+    expect(metrics.entitiesUpdated).toBe(0);
+    expect(metrics.preferencesScanned).toBe(0);
+    expect(metrics.preferencesUpdated).toBe(0);
+  });
+
+  test("decays entity confidence by half-life from last_reinforced_at", () => {
+    const t0 = Date.UTC(2026, 0, 1);
+    const inserted = upsertPkbEntity({
+      entityType: "person",
+      canonicalName: "Alice",
+      confidence: 0.8,
+    });
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE pkb_entities SET last_reinforced_at = ? WHERE id = ?", [
+      t0,
+      inserted.id,
+    ]);
+
+    const halfLifeDays = 10;
+    const metrics = runPkbDecayPass({
+      now: t0 + halfLifeDays * ONE_DAY_MS,
+      entityHalfLifeDays: halfLifeDays,
+    });
+
+    expect(metrics.entitiesScanned).toBe(1);
+    expect(metrics.entitiesUpdated).toBe(1);
+
+    const rows = listRecentPkbEntities({ limit: 1 });
+    expect(rows[0]?.confidence).toBeCloseTo(0.4, 5);
+  });
+
+  test("decays preferences using preference half-life", () => {
+    const t0 = Date.UTC(2026, 0, 1);
+    const pref = upsertPkbPreference({
+      key: "writing-style",
+      value: "concise",
+      confidence: 0.9,
+      signal: "positive",
+    });
+    const sqlite = getSqlite();
+    sqlite.run(
+      "UPDATE pkb_preferences SET last_reinforced_at = ?, confidence = ? WHERE id = ?",
+      [t0, 0.9, pref.id],
+    );
+
+    const metrics = runPkbDecayPass({
+      now: t0 + 15 * ONE_DAY_MS,
+      preferenceHalfLifeDays: 15,
+    });
+
+    expect(metrics.preferencesScanned).toBe(1);
+    expect(metrics.preferencesUpdated).toBe(1);
+
+    const [updated] = listPkbPreferences({});
+    expect(updated?.confidence).toBeCloseTo(0.45, 5);
+  });
+
+  test("respects floor and does not push confidence to zero", () => {
+    const t0 = Date.UTC(2026, 0, 1);
+    const inserted = upsertPkbEntity({
+      entityType: "person",
+      canonicalName: "Bob",
+      confidence: 0.07,
+    });
+    const sqlite = getSqlite();
+    sqlite.run("UPDATE pkb_entities SET last_reinforced_at = ? WHERE id = ?", [
+      t0,
+      inserted.id,
+    ]);
+
+    const metrics = runPkbDecayPass({
+      now: t0 + 1_000 * ONE_DAY_MS,
+      entityHalfLifeDays: 30,
+      confidenceFloor: 0.05,
+    });
+    expect(metrics.entitiesUpdated).toBe(1);
+    const rows = listRecentPkbEntities({ limit: 1 });
+    expect(rows[0]?.confidence).toBe(0.05);
+  });
+
+  test("skips rows already below the floor", () => {
+    const t0 = Date.UTC(2026, 0, 1);
+    upsertPkbEntity({
+      entityType: "person",
+      canonicalName: "Carol",
+      confidence: 0.03,
+    });
+    const metrics = runPkbDecayPass({
+      now: t0 + 100 * ONE_DAY_MS,
+      confidenceFloor: 0.05,
+    });
+    expect(metrics.entitiesScanned).toBe(0);
+    expect(metrics.entitiesUpdated).toBe(0);
+  });
+});

--- a/assistant/src/memory/pkb-decay.ts
+++ b/assistant/src/memory/pkb-decay.ts
@@ -1,0 +1,142 @@
+/**
+ * Hourly decay worker for the personal-knowledge base.
+ *
+ * Anchors decay on `last_reinforced_at` (entities + preferences). The
+ * mathematical model is an exponential half-life: confidence multiplied
+ * by `0.5 ** (elapsedDays / halfLifeDays)` each tick. The worker writes
+ * the decayed value back so future scoring reads from a stored truth
+ * rather than an ephemeral derivation.
+ *
+ * No LLM calls — purely mathematical. Mirrors the pattern in
+ * `assistant/src/memory/graph/decay.ts`.
+ *
+ * The worker is feature-flagged: callers wire it into the scheduler
+ * only when `memory-maturation` is enabled.
+ */
+
+import { eq, gt } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db-connection.js";
+import { pkbEntities, pkbPreferences } from "./schema.js";
+
+const log = getLogger("pkb-decay");
+
+export interface DecayOptions {
+  /** Reference clock, defaults to `Date.now()`. */
+  now?: number;
+  /** Confidence half-life in days. Default 30 days. */
+  entityHalfLifeDays?: number;
+  /** Confidence half-life in days for preferences. Default 45 days. */
+  preferenceHalfLifeDays?: number;
+  /**
+   * Floor below which we stop decaying — keeps low-confidence rows from
+   * asymptotically chasing zero forever. Default 0.05.
+   */
+  confidenceFloor?: number;
+}
+
+export interface DecayMetrics {
+  entitiesScanned: number;
+  entitiesUpdated: number;
+  preferencesScanned: number;
+  preferencesUpdated: number;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * Run one decay pass. Safe to invoke at startup and on every cron tick.
+ * Never throws — degrades to a structured log on unexpected errors.
+ */
+export function runPkbDecayPass(options: DecayOptions = {}): DecayMetrics {
+  const now = options.now ?? Date.now();
+  const entityHalfLifeDays = clampPositive(options.entityHalfLifeDays ?? 30);
+  const prefHalfLifeDays = clampPositive(options.preferenceHalfLifeDays ?? 45);
+  const floor = Math.max(0, Math.min(0.99, options.confidenceFloor ?? 0.05));
+
+  let entitiesScanned = 0;
+  let entitiesUpdated = 0;
+  let preferencesScanned = 0;
+  let preferencesUpdated = 0;
+
+  try {
+    const db = getDb();
+
+    const entityRows = db
+      .select({
+        id: pkbEntities.id,
+        confidence: pkbEntities.confidence,
+        lastReinforcedAt: pkbEntities.lastReinforcedAt,
+        lastSeenAt: pkbEntities.lastSeenAt,
+      })
+      .from(pkbEntities)
+      .where(gt(pkbEntities.confidence, floor))
+      .all();
+    entitiesScanned = entityRows.length;
+
+    for (const row of entityRows) {
+      const anchor = row.lastReinforcedAt ?? row.lastSeenAt;
+      if (anchor >= now) continue;
+      const elapsedDays = (now - anchor) / ONE_DAY_MS;
+      const decayFactor = Math.pow(0.5, elapsedDays / entityHalfLifeDays);
+      const decayed = Math.max(floor, row.confidence * decayFactor);
+      if (Math.abs(decayed - row.confidence) < 1e-6) continue;
+      db.update(pkbEntities)
+        .set({ confidence: decayed, updatedAt: now })
+        .where(eq(pkbEntities.id, row.id))
+        .run();
+      entitiesUpdated += 1;
+    }
+
+    const prefRows = db
+      .select({
+        id: pkbPreferences.id,
+        confidence: pkbPreferences.confidence,
+        lastReinforcedAt: pkbPreferences.lastReinforcedAt,
+        updatedAt: pkbPreferences.updatedAt,
+      })
+      .from(pkbPreferences)
+      .where(gt(pkbPreferences.confidence, floor))
+      .all();
+    preferencesScanned = prefRows.length;
+
+    for (const row of prefRows) {
+      const anchor = row.lastReinforcedAt ?? row.updatedAt;
+      if (anchor >= now) continue;
+      const elapsedDays = (now - anchor) / ONE_DAY_MS;
+      const decayFactor = Math.pow(0.5, elapsedDays / prefHalfLifeDays);
+      const decayed = Math.max(floor, row.confidence * decayFactor);
+      if (Math.abs(decayed - row.confidence) < 1e-6) continue;
+      db.update(pkbPreferences)
+        .set({ confidence: decayed, updatedAt: now })
+        .where(eq(pkbPreferences.id, row.id))
+        .run();
+      preferencesUpdated += 1;
+    }
+  } catch (err) {
+    log.warn({ err }, "pkb decay pass failed");
+  }
+
+  log.debug(
+    {
+      entitiesScanned,
+      entitiesUpdated,
+      preferencesScanned,
+      preferencesUpdated,
+    },
+    "pkb decay pass complete",
+  );
+
+  return {
+    entitiesScanned,
+    entitiesUpdated,
+    preferencesScanned,
+    preferencesUpdated,
+  };
+}
+
+function clampPositive(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  return value;
+}

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -8,4 +8,6 @@ export * from "./memory-core.js";
 export * from "./memory-graph.js";
 export * from "./notifications.js";
 export * from "./oauth.js";
+export * from "./perception-consent.js";
+export * from "./personal-knowledge.js";
 export * from "./tasks.js";

--- a/assistant/src/memory/schema/perception-consent.ts
+++ b/assistant/src/memory/schema/perception-consent.ts
@@ -1,0 +1,40 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+/**
+ * Per-conversation consent grants for sensitive perception event kinds
+ * (`screen_snapshot`, `audio_excerpt`).
+ *
+ * Issued via the existing `confirmation_request` → `POST /v1/confirm` flow
+ * with `selectedScope: "conversation"`. Subsequent publish-route calls for
+ * the same (scope_id, conversation_id, event_kind) triple short-circuit.
+ */
+export const perceptionConsentGrants = sqliteTable(
+  "perception_consent_grants",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    conversationId: text("conversation_id").notNull(),
+    eventKind: text("event_kind").notNull(),
+    grantedAt: integer("granted_at").notNull(),
+    expiresAt: integer("expires_at"),
+    revokedAt: integer("revoked_at"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_perception_consent_grants_triple").on(
+      table.scopeId,
+      table.conversationId,
+      table.eventKind,
+    ),
+    index("idx_perception_consent_grants_expires").on(table.expiresAt),
+  ],
+);
+
+export type PerceptionConsentGrantRow =
+  typeof perceptionConsentGrants.$inferSelect;

--- a/assistant/src/memory/schema/personal-knowledge.ts
+++ b/assistant/src/memory/schema/personal-knowledge.ts
@@ -1,0 +1,91 @@
+import {
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const pkbEntities = sqliteTable(
+  "pkb_entities",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    entityType: text("entity_type").notNull(),
+    canonicalName: text("canonical_name").notNull(),
+    aliasesJson: text("aliases_json").notNull().default("[]"),
+    attributesJson: text("attributes_json").notNull().default("{}"),
+    confidence: real("confidence").notNull().default(0.5),
+    firstSeenAt: integer("first_seen_at").notNull(),
+    lastSeenAt: integer("last_seen_at").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+    // Added in migration 242 (Memory Maturation MVP).
+    evidenceCount: integer("evidence_count").notNull().default(1),
+    lastReinforcedAt: integer("last_reinforced_at"),
+    provenanceJson: text("provenance_json").notNull().default("[]"),
+  },
+  (table) => [
+    uniqueIndex("idx_pkb_entities_scope_type_name").on(
+      table.scopeId,
+      table.entityType,
+      table.canonicalName,
+    ),
+    index("idx_pkb_entities_scope_updated").on(table.scopeId, table.updatedAt),
+  ],
+);
+
+export const pkbEpisodes = sqliteTable(
+  "pkb_episodes",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    entityId: text("entity_id").references(() => pkbEntities.id, {
+      onDelete: "set null",
+    }),
+    summary: text("summary").notNull(),
+    detailsJson: text("details_json").notNull().default("{}"),
+    happenedAt: integer("happened_at").notNull(),
+    salience: real("salience").notNull().default(0.5),
+    sourceConversationId: text("source_conversation_id"),
+    createdAt: integer("created_at").notNull(),
+    // Added in migration 242 (Memory Maturation MVP).
+    idempotencyKey: text("idempotency_key"),
+  },
+  (table) => [
+    index("idx_pkb_episodes_scope_happened").on(
+      table.scopeId,
+      table.happenedAt,
+    ),
+    index("idx_pkb_episodes_scope_salience").on(table.scopeId, table.salience),
+    index("idx_pkb_episodes_entity").on(table.entityId),
+  ],
+);
+
+export const pkbPreferences = sqliteTable(
+  "pkb_preferences",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    confidence: real("confidence").notNull().default(0.5),
+    learnedFrom: text("learned_from").notNull().default("inferred"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+    // Added in migration 242 (Memory Maturation MVP).
+    evidenceCount: integer("evidence_count").notNull().default(1),
+    positiveCount: integer("positive_count").notNull().default(1),
+    negativeCount: integer("negative_count").notNull().default(0),
+    lastReinforcedAt: integer("last_reinforced_at"),
+    lastContradictedAt: integer("last_contradicted_at"),
+  },
+  (table) => [
+    uniqueIndex("idx_pkb_preferences_scope_key").on(table.scopeId, table.key),
+    index("idx_pkb_preferences_scope_updated").on(
+      table.scopeId,
+      table.updatedAt,
+    ),
+  ],
+);

--- a/assistant/src/perception/consent-grants.test.ts
+++ b/assistant/src/perception/consent-grants.test.ts
@@ -1,0 +1,173 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  getActivePerceptionConsent,
+  hasActivePerceptionConsent,
+  listPerceptionConsentGrantsForConversation,
+  recordPerceptionConsentGrant,
+  revokePerceptionConsentGrant,
+} from "./consent-grants.js";
+
+describe("perception consent grants", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM perception_consent_grants");
+  });
+
+  test("no grant by default", () => {
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-1",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(false);
+  });
+
+  test("granted lookup returns the grant", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    const grant = getActivePerceptionConsent({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    expect(grant?.eventKind).toBe("audio_excerpt");
+    expect(grant?.conversationId).toBe("conv-1");
+    expect(grant?.revokedAt).toBeNull();
+  });
+
+  test("expired grants are not active", () => {
+    const past = Date.now() - 10_000;
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+      expiresAt: past,
+    });
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-1",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(false);
+  });
+
+  test("revocation makes grant inactive", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-1",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(true);
+
+    const result = revokePerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    expect(result).toBe("active");
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-1",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(false);
+  });
+
+  test("repeated revocation returns already_revoked", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    revokePerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    const result = revokePerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    expect(result).toBe("already_revoked");
+  });
+
+  test("revocation of unknown grant returns not_found", () => {
+    const result = revokePerceptionConsentGrant({
+      conversationId: "conv-2",
+      eventKind: "screen_snapshot",
+    });
+    expect(result).toBe("not_found");
+  });
+
+  test("re-granting restores an active grant", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    revokePerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    const grant = getActivePerceptionConsent({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    expect(grant).not.toBeNull();
+    expect(grant?.revokedAt).toBeNull();
+  });
+
+  test("grants are scoped per (conversation, eventKind)", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-A",
+      eventKind: "screen_snapshot",
+    });
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-A",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(true);
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-A",
+        eventKind: "audio_excerpt",
+      }),
+    ).toBe(false);
+    expect(
+      hasActivePerceptionConsent({
+        conversationId: "conv-B",
+        eventKind: "screen_snapshot",
+      }),
+    ).toBe(false);
+  });
+
+  test("listGrantsForConversation returns the conversation's grants", () => {
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "screen_snapshot",
+    });
+    recordPerceptionConsentGrant({
+      conversationId: "conv-1",
+      eventKind: "audio_excerpt",
+    });
+    const grants = listPerceptionConsentGrantsForConversation("conv-1");
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => g.eventKind).sort()).toEqual([
+      "audio_excerpt",
+      "screen_snapshot",
+    ]);
+  });
+});

--- a/assistant/src/perception/consent-grants.ts
+++ b/assistant/src/perception/consent-grants.ts
@@ -1,0 +1,231 @@
+/**
+ * Per-conversation consent grants for sensitive perception event kinds.
+ *
+ * The `screen_snapshot` and `audio_excerpt` event kinds carry information the
+ * user almost certainly did not intend to feed into the assistant's reasoning
+ * loop without an explicit affirmation. We gate them on a
+ * `perception_consent_grants` row scoped to
+ * `(scope_id, conversation_id, event_kind)`.
+ *
+ * The grant lifecycle:
+ *
+ * 1. A producer attempts to publish a gated event.
+ * 2. If a non-revoked, non-expired grant exists, the event is accepted.
+ * 3. If no grant exists, the route rejects with `consent_required`. The
+ *    caller is responsible for issuing a `confirmation_request` with
+ *    `selectedScope: "conversation"` via the existing pending-interactions
+ *    flow; on approval the caller records the grant via {@link recordPerceptionConsentGrant}.
+ *
+ * This file owns the persistence layer only — it does not start the
+ * confirmation flow itself, so we do not invent a new approval primitive.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../memory/db-connection.js";
+import { perceptionConsentGrants } from "../memory/schema/perception-consent.js";
+
+export type PerceptionConsentEventKind = "screen_snapshot" | "audio_excerpt";
+
+const DEFAULT_SCOPE_ID = "default";
+
+export interface PerceptionConsentLookup {
+  scopeId?: string;
+  conversationId: string;
+  eventKind: PerceptionConsentEventKind;
+  /** Reference clock. Defaults to `Date.now()`. */
+  now?: number;
+}
+
+export interface PerceptionConsentGrantInput extends PerceptionConsentLookup {
+  /** Optional explicit expiry. Omit for "until revoked". */
+  expiresAt?: number;
+}
+
+export interface PerceptionConsentGrant {
+  id: string;
+  scopeId: string;
+  conversationId: string;
+  eventKind: PerceptionConsentEventKind;
+  grantedAt: number;
+  expiresAt: number | null;
+  revokedAt: number | null;
+  createdAt: number;
+}
+
+function rowToGrant(row: {
+  id: string;
+  scopeId: string;
+  conversationId: string;
+  eventKind: string;
+  grantedAt: number;
+  expiresAt: number | null;
+  revokedAt: number | null;
+  createdAt: number;
+}): PerceptionConsentGrant {
+  return {
+    id: row.id,
+    scopeId: row.scopeId,
+    conversationId: row.conversationId,
+    eventKind: row.eventKind as PerceptionConsentEventKind,
+    grantedAt: row.grantedAt,
+    expiresAt: row.expiresAt,
+    revokedAt: row.revokedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Return true when there is a live (non-revoked, non-expired) grant for the
+ * `(scopeId, conversationId, eventKind)` triple.
+ */
+export function hasActivePerceptionConsent(
+  lookup: PerceptionConsentLookup,
+): boolean {
+  return getActivePerceptionConsent(lookup) !== null;
+}
+
+export function getActivePerceptionConsent(
+  lookup: PerceptionConsentLookup,
+): PerceptionConsentGrant | null {
+  const scopeId = lookup.scopeId ?? DEFAULT_SCOPE_ID;
+  const now = lookup.now ?? Date.now();
+
+  const db = getDb();
+  const row = db
+    .select()
+    .from(perceptionConsentGrants)
+    .where(
+      and(
+        eq(perceptionConsentGrants.scopeId, scopeId),
+        eq(perceptionConsentGrants.conversationId, lookup.conversationId),
+        eq(perceptionConsentGrants.eventKind, lookup.eventKind),
+      ),
+    )
+    .get();
+  if (!row) return null;
+  if (row.revokedAt !== null && row.revokedAt <= now) return null;
+  if (row.expiresAt !== null && row.expiresAt <= now) return null;
+  return rowToGrant(row);
+}
+
+/**
+ * Idempotent upsert of a consent grant. Re-running with the same triple
+ * refreshes `grantedAt` and clears any prior revocation, preserving the row's
+ * id so callers can link audit events.
+ */
+export function recordPerceptionConsentGrant(
+  input: PerceptionConsentGrantInput,
+): PerceptionConsentGrant {
+  const scopeId = input.scopeId ?? DEFAULT_SCOPE_ID;
+  const now = input.now ?? Date.now();
+  const expiresAt =
+    typeof input.expiresAt === "number" ? input.expiresAt : null;
+
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(perceptionConsentGrants)
+    .where(
+      and(
+        eq(perceptionConsentGrants.scopeId, scopeId),
+        eq(perceptionConsentGrants.conversationId, input.conversationId),
+        eq(perceptionConsentGrants.eventKind, input.eventKind),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    db.update(perceptionConsentGrants)
+      .set({
+        grantedAt: now,
+        expiresAt,
+        revokedAt: null,
+      })
+      .where(eq(perceptionConsentGrants.id, existing.id))
+      .run();
+    return rowToGrant({
+      ...existing,
+      grantedAt: now,
+      expiresAt,
+      revokedAt: null,
+    });
+  }
+
+  const id = uuid();
+  db.insert(perceptionConsentGrants)
+    .values({
+      id,
+      scopeId,
+      conversationId: input.conversationId,
+      eventKind: input.eventKind,
+      grantedAt: now,
+      expiresAt,
+      revokedAt: null,
+      createdAt: now,
+    })
+    .run();
+
+  return {
+    id,
+    scopeId,
+    conversationId: input.conversationId,
+    eventKind: input.eventKind,
+    grantedAt: now,
+    expiresAt,
+    revokedAt: null,
+    createdAt: now,
+  };
+}
+
+/**
+ * Mark the grant for `(scopeId, conversationId, eventKind)` as revoked. No-op
+ * when no row exists. Returns the previous state (`active`, `already_revoked`,
+ * or `not_found`).
+ */
+export function revokePerceptionConsentGrant(
+  lookup: PerceptionConsentLookup,
+): "active" | "already_revoked" | "not_found" {
+  const scopeId = lookup.scopeId ?? DEFAULT_SCOPE_ID;
+  const now = lookup.now ?? Date.now();
+
+  const db = getDb();
+  const row = db
+    .select()
+    .from(perceptionConsentGrants)
+    .where(
+      and(
+        eq(perceptionConsentGrants.scopeId, scopeId),
+        eq(perceptionConsentGrants.conversationId, lookup.conversationId),
+        eq(perceptionConsentGrants.eventKind, lookup.eventKind),
+      ),
+    )
+    .get();
+  if (!row) return "not_found";
+  if (row.revokedAt !== null) return "already_revoked";
+  db.update(perceptionConsentGrants)
+    .set({ revokedAt: now })
+    .where(eq(perceptionConsentGrants.id, row.id))
+    .run();
+  return "active";
+}
+
+/** List all grants for a conversation, useful for debugging UIs and tests. */
+export function listPerceptionConsentGrantsForConversation(
+  conversationId: string,
+  scopeId: string = DEFAULT_SCOPE_ID,
+): PerceptionConsentGrant[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(perceptionConsentGrants)
+    .where(
+      and(
+        eq(perceptionConsentGrants.scopeId, scopeId),
+        eq(perceptionConsentGrants.conversationId, conversationId),
+      ),
+    )
+    .all();
+  return rows.map(rowToGrant);
+}

--- a/assistant/src/perception/context-buffer.test.ts
+++ b/assistant/src/perception/context-buffer.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { ContextBuffer } from "./context-buffer.js";
+import {
+  type PerceptionEvent,
+  perceptionEventType,
+} from "./perception-event.js";
+
+function makeEvent(
+  overrides: Partial<
+    Extract<PerceptionEvent["payload"], { kind: "app_focus_changed" }>
+  > = {},
+): PerceptionEvent {
+  return {
+    eventId: `evt-${Math.random().toString(36).slice(2, 10)}`,
+    ts: new Date().toISOString(),
+    source: { module: "test", version: "0" },
+    payload: {
+      kind: "app_focus_changed",
+      appId: "com.apple.Safari",
+      appName: "Safari",
+      windowTitle: "Example",
+      redacted: false,
+      ...overrides,
+    },
+  };
+}
+
+function appNameOf(event: PerceptionEvent): string | null {
+  return event.payload.kind === "app_focus_changed"
+    ? event.payload.appName
+    : null;
+}
+
+function envelope(event: PerceptionEvent): {
+  id: string;
+  emittedAt: string;
+  message: { type: string; perception: PerceptionEvent };
+} {
+  return {
+    id: event.eventId,
+    emittedAt: event.ts,
+    message: {
+      type: perceptionEventType(event.payload.kind),
+      perception: event,
+    },
+  };
+}
+
+describe("ContextBuffer.ingest", () => {
+  test("stores valid perception events most-recent-first", () => {
+    let now = new Date("2026-01-01T00:00:00Z").getTime();
+    const buf = new ContextBuffer({ now: () => new Date(now) });
+
+    buf.ingest(envelope(makeEvent({ appName: "First" })));
+    now += 1000;
+    buf.ingest(envelope(makeEvent({ appName: "Second" })));
+
+    const recent = buf.recent();
+    expect(recent).toHaveLength(2);
+    expect(appNameOf(recent[0]!.event)).toBe("Second");
+    expect(appNameOf(recent[1]!.event)).toBe("First");
+  });
+
+  test("ignores non-perception events", () => {
+    const buf = new ContextBuffer();
+    buf.ingest({ id: "x", emittedAt: "now", message: { type: "pong" } });
+    buf.ingest({});
+    buf.ingest(null);
+    expect(buf.size()).toBe(0);
+  });
+
+  test("rejects malformed perception payloads without throwing", () => {
+    const buf = new ContextBuffer();
+    buf.ingest({
+      id: "x",
+      emittedAt: "now",
+      message: {
+        type: "perception.app_focus_changed",
+        perception: { junk: 1 },
+      },
+    });
+    expect(buf.size()).toBe(0);
+  });
+
+  test("evicts oldest when over capacity", () => {
+    const buf = new ContextBuffer({ maxEntries: 2 });
+    buf.ingest(envelope(makeEvent({ appName: "A" })));
+    buf.ingest(envelope(makeEvent({ appName: "B" })));
+    buf.ingest(envelope(makeEvent({ appName: "C" })));
+    expect(buf.size()).toBe(2);
+    const recent = buf.recent();
+    expect(recent.map((e) => appNameOf(e.event))).toEqual(["C", "B"]);
+  });
+
+  test("expires entries past TTL", () => {
+    let now = new Date("2026-01-01T00:00:00Z").getTime();
+    const buf = new ContextBuffer({ ttlMs: 1000, now: () => new Date(now) });
+
+    buf.ingest(envelope(makeEvent({ appName: "old" })));
+    now += 5000;
+    buf.ingest(envelope(makeEvent({ appName: "new" })));
+
+    const recent = buf.recent();
+    expect(recent).toHaveLength(1);
+    expect(appNameOf(recent[0]!.event)).toBe("new");
+  });
+});
+
+describe("ContextBuffer.recent filters", () => {
+  test("windowMs limits to events received within window", () => {
+    let now = new Date("2026-01-01T00:00:00Z").getTime();
+    const buf = new ContextBuffer({
+      ttlMs: 60_000,
+      now: () => new Date(now),
+    });
+
+    buf.ingest(envelope(makeEvent({ appName: "old" })));
+    now += 30_000;
+    buf.ingest(envelope(makeEvent({ appName: "fresh" })));
+
+    const recent = buf.recent({ windowMs: 5_000 });
+    expect(recent).toHaveLength(1);
+    expect(appNameOf(recent[0]!.event)).toBe("fresh");
+  });
+
+  test("limit caps result size", () => {
+    const buf = new ContextBuffer();
+    for (let i = 0; i < 5; i += 1) {
+      buf.ingest(envelope(makeEvent({ appName: `app-${i}` })));
+    }
+    expect(buf.recent({ limit: 2 })).toHaveLength(2);
+  });
+
+  test("kind filter narrows to one perception kind", () => {
+    const buf = new ContextBuffer();
+    buf.ingest(envelope(makeEvent()));
+    expect(buf.recent({ kind: "app_focus_changed" })).toHaveLength(1);
+  });
+});
+
+describe("ContextBuffer.attach", () => {
+  test("subscribes to a hub and ingests published perception events", async () => {
+    const hub = new AssistantEventHub();
+    const buf = new ContextBuffer();
+    buf.attach(hub);
+
+    const event = makeEvent({ appName: "Safari" });
+    await hub.publish(
+      envelope(event) as unknown as Parameters<typeof hub.publish>[0],
+    );
+
+    const recent = buf.recent();
+    expect(recent).toHaveLength(1);
+    expect(appNameOf(recent[0]!.event)).toBe("Safari");
+  });
+
+  test("attach is idempotent", () => {
+    const hub = new AssistantEventHub();
+    const buf = new ContextBuffer();
+    const first = buf.attach(hub);
+    const second = buf.attach(hub);
+    expect(first).toBe(second);
+  });
+
+  test("detach unsubscribes so later publishes are dropped", async () => {
+    const hub = new AssistantEventHub();
+    const buf = new ContextBuffer();
+    buf.attach(hub);
+    buf.detach();
+
+    await hub.publish(
+      envelope(makeEvent()) as unknown as Parameters<typeof hub.publish>[0],
+    );
+
+    expect(buf.size()).toBe(0);
+  });
+});

--- a/assistant/src/perception/context-buffer.ts
+++ b/assistant/src/perception/context-buffer.ts
@@ -1,0 +1,211 @@
+/**
+ * Daemon-side ring buffer of perception events.
+ *
+ * The buffer subscribes to {@link AssistantEventHub} as a process-typed
+ * subscriber, recognises events whose outer `message.type` begins with
+ * `perception.`, validates them against the perception schema, and stores
+ * the parsed payload + receive time.
+ *
+ * Memory-only by design. Entries are evicted when:
+ *   - the buffer is at capacity (oldest pruned on insert), or
+ *   - a stored entry has aged past `ttlMs` (pruned lazily on insert/query).
+ *
+ * Phase 1 ships only as the storage layer; the agent-facing query path
+ * (`getRecentContext`) is added in a follow-up via a skill IPC route, so
+ * this module intentionally exposes no global accessors.
+ *
+ * Roadmap: `docs/jarvis-roadmap.md`.
+ */
+
+import type {
+  AssistantEventHub,
+  AssistantEventSubscription,
+} from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import {
+  parsePerceptionEvent,
+  PERCEPTION_EVENT_TYPE_PREFIX,
+  type PerceptionEvent,
+  type PerceptionEventKind,
+} from "./perception-event.js";
+
+const log = getLogger("perception-context-buffer");
+
+const DEFAULT_MAX_ENTRIES = 512;
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+export interface BufferedPerceptionEvent {
+  /** When the daemon received the event (not when the producer captured it). */
+  readonly receivedAt: Date;
+  /** The validated payload. */
+  readonly event: PerceptionEvent;
+}
+
+export interface ContextBufferOptions {
+  /** Maximum entries retained; oldest pruned on overflow. */
+  readonly maxEntries?: number;
+  /** Per-entry max age in milliseconds; pruned lazily. */
+  readonly ttlMs?: number;
+  /** Clock override for tests. */
+  readonly now?: () => Date;
+}
+
+export interface RecentQuery {
+  /** Only return entries received within the last N ms. */
+  readonly windowMs?: number;
+  /** Cap the number of returned entries (most recent first). */
+  readonly limit?: number;
+  /** Restrict to a specific perception kind. */
+  readonly kind?: PerceptionEventKind;
+}
+
+/**
+ * In-memory ring of perception events. One instance per daemon process.
+ *
+ * Not thread-safe across workers; the daemon is single-process for this
+ * data path.
+ */
+export class ContextBuffer {
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => Date;
+  private readonly entries: BufferedPerceptionEvent[] = [];
+  private subscription: AssistantEventSubscription | null = null;
+
+  constructor(options: ContextBufferOptions = {}) {
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? (() => new Date());
+    if (this.maxEntries < 1) {
+      throw new RangeError("ContextBuffer.maxEntries must be >= 1");
+    }
+    if (this.ttlMs < 1) {
+      throw new RangeError("ContextBuffer.ttlMs must be >= 1ms");
+    }
+  }
+
+  /**
+   * Subscribe to the hub. Idempotent. Returns the existing subscription if
+   * already attached so the caller does not need to track state.
+   */
+  attach(hub: AssistantEventHub): AssistantEventSubscription {
+    if (this.subscription) return this.subscription;
+    this.subscription = hub.subscribe({
+      type: "process",
+      callback: (event) => this.ingest(event),
+    });
+    return this.subscription;
+  }
+
+  detach(): void {
+    this.subscription?.dispose();
+    this.subscription = null;
+  }
+
+  /**
+   * Validate and store an event if it's a perception event. Non-perception
+   * events are silently ignored. Malformed perception events are logged and
+   * dropped; we never throw out of an event-pipeline handler.
+   */
+  ingest(event: unknown): void {
+    const type = getEventType(event);
+    if (!type || !type.startsWith(`${PERCEPTION_EVENT_TYPE_PREFIX}.`)) return;
+
+    const message = getEventMessage(event);
+    if (!message) return;
+    const candidate = extractPerceptionPayload(message);
+
+    let parsed;
+    try {
+      parsed = parsePerceptionEvent(candidate);
+    } catch (err) {
+      log.warn(
+        { err, type },
+        "dropping perception event that failed schema validation",
+      );
+      return;
+    }
+
+    const receivedAt = this.now();
+    this.entries.push({ receivedAt, event: parsed });
+    this.pruneExpired(receivedAt);
+    while (this.entries.length > this.maxEntries) {
+      this.entries.shift();
+    }
+  }
+
+  /**
+   * Return entries most-recent-first, after applying TTL and the optional
+   * `windowMs` / `limit` / `kind` filters.
+   */
+  recent(query: RecentQuery = {}): BufferedPerceptionEvent[] {
+    const now = this.now();
+    this.pruneExpired(now);
+
+    const earliest =
+      query.windowMs != null ? now.getTime() - query.windowMs : -Infinity;
+    const out: BufferedPerceptionEvent[] = [];
+    for (let i = this.entries.length - 1; i >= 0; i -= 1) {
+      const entry = this.entries[i];
+      if (!entry) continue;
+      if (entry.receivedAt.getTime() < earliest) break;
+      if (query.kind && entry.event.payload.kind !== query.kind) continue;
+      out.push(entry);
+      if (query.limit != null && out.length >= query.limit) break;
+    }
+    return out;
+  }
+
+  size(): number {
+    return this.entries.length;
+  }
+
+  clear(): void {
+    this.entries.length = 0;
+  }
+
+  private pruneExpired(now: Date): void {
+    const cutoff = now.getTime() - this.ttlMs;
+    while (this.entries.length > 0) {
+      const first = this.entries[0];
+      if (!first) break;
+      if (first.receivedAt.getTime() >= cutoff) break;
+      this.entries.shift();
+    }
+  }
+}
+
+/**
+ * Read the `message.type` field off an `AssistantEvent`-shaped value without
+ * importing the discriminated union (which doesn't include perception types).
+ */
+function getEventType(event: unknown): string | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  const type = (message as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function getEventMessage(event: unknown): Record<string, unknown> | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  return message as Record<string, unknown>;
+}
+
+/**
+ * Pull a `PerceptionEvent`-shaped object out of the AssistantEvent's
+ * `message`. We accept either an explicitly-nested `{ perception: ... }`
+ * shape or a flattened message where the perception fields sit alongside
+ * the outer `type`, so producers can choose either style.
+ */
+function extractPerceptionPayload(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  const nested = message.perception;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return message;
+}

--- a/assistant/src/perception/feature-gate.ts
+++ b/assistant/src/perception/feature-gate.ts
@@ -1,0 +1,15 @@
+/**
+ * Feature-gate predicate for the perception spine.
+ *
+ * Centralised so every call site (startup, route handlers, future tools)
+ * uses the same flag key.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+export const PERCEPTION_FLAG = "perception" as const;
+
+export function isPerceptionEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(PERCEPTION_FLAG, config);
+}

--- a/assistant/src/perception/interpreter.test.ts
+++ b/assistant/src/perception/interpreter.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Provider } from "../providers/types.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { PerceptionInterpreter } from "./interpreter.js";
+
+function makeProvider(replyText: string): Provider {
+  return {
+    name: "test-provider",
+    async sendMessage() {
+      return {
+        content: [{ type: "text", text: replyText }],
+        model: "test-model",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "stop",
+      };
+    },
+  };
+}
+
+function appFocusMessage() {
+  return {
+    type: "perception.app_focus_changed",
+    perception: {
+      eventId: "focus-1",
+      ts: "2026-05-15T04:00:00.000Z",
+      source: { module: "skills/perception" },
+      payload: {
+        kind: "app_focus_changed",
+        appId: "com.microsoft.VSCode",
+        appName: "Visual Studio Code",
+        windowTitle: "Debug user@example.com in https://example.com",
+        redacted: false,
+      },
+    },
+  };
+}
+
+describe("PerceptionInterpreter", () => {
+  test("publishes task_detected for high-confidence app focus interpretation", async () => {
+    const hub = new AssistantEventHub();
+    const seen: Array<Record<string, unknown>> = [];
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (type === "perception.task_detected") {
+          seen.push(event as unknown as Record<string, unknown>);
+        }
+      },
+    });
+
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            emit: true,
+            label: "Debugging API auth issue",
+            summary:
+              "User is debugging user@example.com while testing https://example.com",
+            confidence: 0.92,
+          }),
+        ),
+      now: () => new Date("2026-05-15T04:00:05.000Z"),
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-1",
+      emittedAt: "2026-05-15T04:00:00.000Z",
+      message: appFocusMessage(),
+    } as never);
+
+    expect(seen).toHaveLength(1);
+    const message = (seen[0] as { message: Record<string, unknown> }).message;
+    const perception = message.perception as {
+      payload: {
+        kind: string;
+        label: string;
+        summary: string;
+        confidence: number;
+      };
+    };
+    expect(perception.payload.kind).toBe("task_detected");
+    expect(perception.payload.label).toBe("Debugging API auth issue");
+    expect(perception.payload.summary).toContain("[redacted-email]");
+    expect(perception.payload.summary).toContain("[redacted-url]");
+    expect(perception.payload.confidence).toBe(0.92);
+
+    interpreter.detach();
+    sink.dispose();
+  });
+
+  test("does not publish when interpreter decides emit=false", async () => {
+    const hub = new AssistantEventHub();
+    let count = 0;
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (type === "perception.task_detected") count += 1;
+      },
+    });
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () => makeProvider(JSON.stringify({ emit: false })),
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-2",
+      emittedAt: "2026-05-15T04:00:00.000Z",
+      message: appFocusMessage(),
+    } as never);
+
+    expect(count).toBe(0);
+    interpreter.detach();
+    sink.dispose();
+  });
+
+  test("publishes meeting_started with normalized platform", async () => {
+    const hub = new AssistantEventHub();
+    const seenTypes: string[] = [];
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (typeof type === "string" && type.startsWith("perception.")) {
+          seenTypes.push(type);
+        }
+      },
+    });
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            emit: true,
+            kind: "meeting_started",
+            summary: "Joined standup at https://meet.google.com/xyz",
+            confidence: 0.88,
+            platform: "google-meet",
+          }),
+        ),
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-3",
+      emittedAt: "2026-05-15T04:00:00.000Z",
+      message: appFocusMessage(),
+    } as never);
+
+    expect(seenTypes).toContain("perception.meeting_started");
+    interpreter.detach();
+    sink.dispose();
+  });
+
+  test("drops low-confidence interpretation", async () => {
+    const hub = new AssistantEventHub();
+    let emitted = false;
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (type === "perception.code_edited") emitted = true;
+      },
+    });
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            emit: true,
+            kind: "code_edited",
+            summary: "Editing TypeScript files in Eli",
+            confidence: 0.2,
+          }),
+        ),
+      minConfidence: 0.5,
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-4",
+      emittedAt: "2026-05-15T04:00:00.000Z",
+      message: appFocusMessage(),
+    } as never);
+
+    expect(emitted).toBe(false);
+    interpreter.detach();
+    sink.dispose();
+  });
+
+  test("redacts token-like and account-id-like strings from interpreted output", async () => {
+    const hub = new AssistantEventHub();
+    const seen: Array<Record<string, unknown>> = [];
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (type === "perception.task_detected") {
+          seen.push(event as unknown as Record<string, unknown>);
+        }
+      },
+    });
+
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            emit: true,
+            label: "Investigate tokenabc123456",
+            summary:
+              "Check apiKey=sk_live_ABCDEF123456 for account-12345 and user_67890",
+            confidence: 0.9,
+          }),
+        ),
+      now: () => new Date("2026-05-15T04:00:05.000Z"),
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-5",
+      emittedAt: "2026-05-15T04:00:00.000Z",
+      message: appFocusMessage(),
+    } as never);
+
+    expect(seen).toHaveLength(1);
+    const message = (seen[0] as { message: Record<string, unknown> }).message;
+    const perception = message.perception as {
+      payload: { label: string; summary: string };
+    };
+    expect(perception.payload.label).toContain("[redacted-secret]");
+    expect(perception.payload.summary).toContain("[redacted-secret]");
+    expect(perception.payload.summary).toContain("[redacted-account-id]");
+    expect(perception.payload.summary).not.toContain("sk_live_ABCDEF123456");
+
+    interpreter.detach();
+    sink.dispose();
+  });
+
+  test("debounces rapid duplicate app focus signals", async () => {
+    const hub = new AssistantEventHub();
+    let providerCalls = 0;
+    let nowMs = Date.parse("2026-05-15T04:00:00.000Z");
+
+    const interpreter = new PerceptionInterpreter({
+      getProvider: async () => ({
+        name: "test-provider",
+        async sendMessage() {
+          providerCalls += 1;
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  emit: true,
+                  label: "Coding",
+                  summary: "Editing code",
+                  confidence: 0.9,
+                }),
+              },
+            ],
+            model: "test-model",
+            usage: { inputTokens: 1, outputTokens: 1 },
+            stopReason: "stop",
+          };
+        },
+      }),
+      now: () => new Date(nowMs),
+      debounceMs: 2_000,
+    });
+    interpreter.attach(hub);
+
+    await hub.publish({
+      id: "in-6",
+      emittedAt: new Date(nowMs).toISOString(),
+      message: appFocusMessage(),
+    } as never);
+
+    nowMs += 500; // within debounce window
+    await hub.publish({
+      id: "in-7",
+      emittedAt: new Date(nowMs).toISOString(),
+      message: appFocusMessage(),
+    } as never);
+
+    nowMs += 3_000; // outside debounce window
+    await hub.publish({
+      id: "in-8",
+      emittedAt: new Date(nowMs).toISOString(),
+      message: appFocusMessage(),
+    } as never);
+
+    expect(providerCalls).toBe(2);
+    interpreter.detach();
+  });
+});

--- a/assistant/src/perception/interpreter.ts
+++ b/assistant/src/perception/interpreter.ts
@@ -1,0 +1,398 @@
+import { z } from "zod";
+
+import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import type { Provider } from "../providers/types.js";
+import type {
+  AssistantEventHub,
+  AssistantEventSubscription,
+} from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type AppFocusChangedPayload,
+  type MeetingStartedPayload,
+  parsePerceptionEvent,
+  PERCEPTION_EVENT_TYPE_PREFIX,
+  type PerceptionEvent,
+  perceptionEventType,
+} from "./perception-event.js";
+import { sanitizeOptional, sanitizeText } from "./sanitization.js";
+
+const log = getLogger("perception-interpreter");
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MIN_CONFIDENCE = 0.5;
+const DEFAULT_DEBOUNCE_MS = 2_000;
+
+const InterpretedKindSchema = z.enum([
+  "task_detected",
+  "meeting_started",
+  "code_edited",
+]);
+
+const InterpreterDecisionSchema = z.object({
+  emit: z.boolean(),
+  kind: InterpretedKindSchema.optional(),
+  label: z.string().min(1).max(120).optional(),
+  summary: z.string().min(1).max(320).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  platform: z
+    .enum(["zoom", "google-meet", "teams", "slack-huddle", "other"])
+    .optional(),
+  workspaceHint: z.string().max(120).optional(),
+  languageHint: z.string().max(40).optional(),
+});
+
+const PERCEPTION_INTERPRETER_PROMPT = `You interpret local desktop context into structured task signals.
+Return strict JSON only with this schema:
+{
+  "emit": boolean,
+  "kind"?: "task_detected" | "meeting_started" | "code_edited",
+  "label"?: string,
+  "summary"?: string,
+  "confidence"?: number,
+  "platform"?: "zoom" | "google-meet" | "teams" | "slack-huddle" | "other",
+  "workspaceHint"?: string,
+  "languageHint"?: string
+}
+
+Rules:
+- Focus only on the provided app and redacted window title.
+- Do NOT include emails, URLs, phone numbers, API keys, account IDs, or other sensitive identifiers.
+- If the signal is too weak or generic, return {"emit":false}.
+- Use "meeting_started" when the signal strongly indicates an active meeting.
+- Use "code_edited" when the signal strongly indicates active coding/editing.
+- Use "task_detected" for all other meaningful task signals.
+- If emitting, keep label concise (<= 120 chars) and summary short (<= 320 chars).
+- confidence must be between 0 and 1.
+- Include optional fields only when strongly supported.
+- Output JSON only.`;
+
+type InterpretedEmission =
+  | {
+      kind: "task_detected";
+      label: string;
+      summary: string;
+      confidence: number;
+    }
+  | {
+      kind: "meeting_started";
+      summary: string;
+      confidence: number;
+      platform?: MeetingStartedPayload["platform"];
+    }
+  | {
+      kind: "code_edited";
+      summary: string;
+      confidence: number;
+      workspaceHint?: string;
+      languageHint?: string;
+    };
+
+export interface PerceptionInterpreterOptions {
+  getProvider?: () => Promise<Provider | null>;
+  now?: () => Date;
+  timeoutMs?: number;
+  minConfidence?: number;
+  debounceMs?: number;
+}
+
+export class PerceptionInterpreter {
+  private readonly getProvider: () => Promise<Provider | null>;
+  private readonly now: () => Date;
+  private readonly timeoutMs: number;
+  private readonly minConfidence: number;
+  private readonly debounceMs: number;
+  private readonly lastInterpretationByFocusKey = new Map<string, number>();
+  private subscription: AssistantEventSubscription | null = null;
+  private hub: AssistantEventHub | null = null;
+
+  constructor(options: PerceptionInterpreterOptions = {}) {
+    this.getProvider =
+      options.getProvider ?? (() => getConfiguredProvider("perception"));
+    this.now = options.now ?? (() => new Date());
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.minConfidence = options.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+    this.debounceMs = Math.max(0, options.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+  }
+
+  attach(hub: AssistantEventHub): AssistantEventSubscription {
+    if (this.subscription) return this.subscription;
+    this.hub = hub;
+    this.subscription = hub.subscribe({
+      type: "process",
+      callback: async (event) => {
+        await this.ingest(event);
+      },
+    });
+    return this.subscription;
+  }
+
+  detach(): void {
+    this.subscription?.dispose();
+    this.subscription = null;
+    this.hub = null;
+    this.lastInterpretationByFocusKey.clear();
+  }
+
+  async ingest(event: unknown): Promise<void> {
+    const type = getEventType(event);
+    if (!type || !type.startsWith(`${PERCEPTION_EVENT_TYPE_PREFIX}.`)) return;
+
+    const message = getEventMessage(event);
+    if (!message) return;
+    const candidate = extractPerceptionPayload(message);
+
+    let parsed: PerceptionEvent;
+    try {
+      parsed = parsePerceptionEvent(candidate);
+    } catch {
+      return;
+    }
+
+    if (parsed.payload.kind !== "app_focus_changed") return;
+    const appFocusEvent = parsed as PerceptionEvent & {
+      payload: AppFocusChangedPayload;
+    };
+    if (this.shouldDebounce(appFocusEvent)) return;
+
+    const inferred = await this.interpretAppFocus(appFocusEvent);
+    if (!inferred) return;
+
+    await this.publishInterpretedEvent(parsed, inferred);
+  }
+
+  private async interpretAppFocus(
+    event: PerceptionEvent & { payload: AppFocusChangedPayload },
+  ): Promise<InterpretedEmission | null> {
+    try {
+      const provider = await this.getProvider();
+      if (!provider) return null;
+
+      const redactedTitle = sanitizeForPrompt(event.payload.windowTitle);
+      const userInput = JSON.stringify(
+        {
+          eventId: event.eventId,
+          timestamp: event.ts,
+          appId: sanitizeForPrompt(event.payload.appId),
+          appName: sanitizeForPrompt(event.payload.appName),
+          windowTitle: event.payload.redacted ? "" : redactedTitle,
+          titleRedactedAtSource: event.payload.redacted,
+        },
+        null,
+        2,
+      );
+
+      const response = await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: userInput }] }],
+        undefined,
+        PERCEPTION_INTERPRETER_PROMPT,
+        {
+          signal: AbortSignal.timeout(this.timeoutMs),
+          config: { callSite: "perception" },
+        },
+      );
+      const text = response.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n")
+        .trim();
+      if (text.length === 0) return null;
+
+      const parsedDecision = InterpreterDecisionSchema.safeParse(
+        parseJsonObjectFromText(text),
+      );
+      if (!parsedDecision.success) return null;
+      if (!parsedDecision.data.emit) return null;
+
+      const confidence = parsedDecision.data.confidence ?? 0.5;
+      if (confidence < this.minConfidence) return null;
+
+      const kind = parsedDecision.data.kind ?? "task_detected";
+      const summary = sanitizeForEmission(parsedDecision.data.summary ?? "");
+      if (!summary) return null;
+
+      if (kind === "meeting_started") {
+        return {
+          kind,
+          summary,
+          confidence,
+          platform: parsedDecision.data.platform,
+        };
+      }
+
+      if (kind === "code_edited") {
+        return {
+          kind,
+          summary,
+          confidence,
+          workspaceHint: sanitizeForOptionalField(
+            parsedDecision.data.workspaceHint,
+            120,
+          ),
+          languageHint: sanitizeForOptionalField(
+            parsedDecision.data.languageHint,
+            40,
+          ),
+        };
+      }
+
+      const label = sanitizeForEmission(parsedDecision.data.label ?? "").slice(
+        0,
+        120,
+      );
+      if (!label) return null;
+      return {
+        kind: "task_detected",
+        label,
+        summary,
+        confidence,
+      };
+    } catch (err) {
+      log.debug({ err }, "perception interpretation failed");
+      return null;
+    }
+  }
+
+  private async publishInterpretedEvent(
+    source: PerceptionEvent,
+    inferred: InterpretedEmission,
+  ): Promise<void> {
+    if (!this.hub) return;
+    const now = this.now();
+    const eventPrefix =
+      inferred.kind === "meeting_started"
+        ? "meeting"
+        : inferred.kind === "code_edited"
+          ? "code"
+          : "task";
+    const payload = buildInterpretedPayload(source.eventId, inferred);
+    const perception = {
+      eventId: `${eventPrefix}-${source.eventId}-${now.getTime()}`,
+      ts: now.toISOString(),
+      source: { module: "assistant/perception-interpreter" },
+      payload,
+    };
+
+    await this.hub.publish({
+      id: perception.eventId,
+      emittedAt: now.toISOString(),
+      message: {
+        type: perceptionEventType(payload.kind),
+        perception,
+      },
+    } as never);
+  }
+
+  private shouldDebounce(
+    event: PerceptionEvent & { payload: AppFocusChangedPayload },
+  ): boolean {
+    if (this.debounceMs <= 0) return false;
+    const nowMs = this.now().getTime();
+    const focusKey = `${event.payload.appId}|${event.payload.windowTitle}`;
+    const priorMs = this.lastInterpretationByFocusKey.get(focusKey);
+    this.lastInterpretationByFocusKey.set(focusKey, nowMs);
+
+    if (priorMs == null) return false;
+    return nowMs - priorMs < this.debounceMs;
+  }
+}
+
+function buildInterpretedPayload(
+  sourceEventId: string,
+  inferred: InterpretedEmission,
+) {
+  if (inferred.kind === "meeting_started") {
+    return {
+      kind: "meeting_started" as const,
+      summary: inferred.summary,
+      confidence: inferred.confidence,
+      sourceEventId,
+      ...(inferred.platform ? { platform: inferred.platform } : {}),
+    };
+  }
+
+  if (inferred.kind === "code_edited") {
+    return {
+      kind: "code_edited" as const,
+      summary: inferred.summary,
+      confidence: inferred.confidence,
+      sourceEventId,
+      ...(inferred.workspaceHint
+        ? { workspaceHint: inferred.workspaceHint }
+        : {}),
+      ...(inferred.languageHint ? { languageHint: inferred.languageHint } : {}),
+    };
+  }
+
+  return {
+    kind: "task_detected" as const,
+    label: inferred.label,
+    summary: inferred.summary,
+    confidence: inferred.confidence,
+    sourceEventId,
+  };
+}
+
+function parseJsonObjectFromText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // continue with fenced/object extraction fallback
+  }
+
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) {
+    try {
+      return JSON.parse(fenced[1].trim());
+    } catch {
+      // ignore
+    }
+  }
+
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    return JSON.parse(text.slice(start, end + 1));
+  }
+  throw new Error("missing JSON object");
+}
+
+function sanitizeForPrompt(value: string): string {
+  return sanitizeText(value, 256);
+}
+
+function sanitizeForOptionalField(
+  value: string | undefined,
+  maxLength: number,
+): string | undefined {
+  return sanitizeOptional(value, maxLength);
+}
+
+function sanitizeForEmission(value: string): string {
+  return sanitizeText(value, 320);
+}
+
+function getEventType(event: unknown): string | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  const type = (message as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function getEventMessage(event: unknown): Record<string, unknown> | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  return message as Record<string, unknown>;
+}
+
+function extractPerceptionPayload(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  const nested = message.perception;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return message;
+}

--- a/assistant/src/perception/perception-event.test.ts
+++ b/assistant/src/perception/perception-event.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parsePerceptionEvent,
+  PERCEPTION_EVENT_KINDS,
+} from "./perception-event.js";
+
+const baseEnvelope = {
+  eventId: "evt-1",
+  ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+  source: { module: "test" },
+};
+
+describe("perception-event schemas", () => {
+  test("PERCEPTION_EVENT_KINDS contains the new multimodal kinds", () => {
+    expect(PERCEPTION_EVENT_KINDS).toContain("screen_snapshot");
+    expect(PERCEPTION_EVENT_KINDS).toContain("audio_excerpt");
+  });
+
+  test("parses a valid screen_snapshot payload", () => {
+    const parsed = parsePerceptionEvent({
+      ...baseEnvelope,
+      payload: {
+        kind: "screen_snapshot",
+        conversationId: "conv-1",
+        appId: "com.apple.Safari",
+        appName: "Safari",
+        windowTitle: "Window",
+        ocrTextRedacted: "hello world",
+        redacted: false,
+        captureMethod: "ocr",
+        confidence: 0.5,
+      },
+    });
+    expect(parsed.payload.kind).toBe("screen_snapshot");
+  });
+
+  test("rejects screen_snapshot missing conversationId", () => {
+    expect(() =>
+      parsePerceptionEvent({
+        ...baseEnvelope,
+        payload: {
+          kind: "screen_snapshot",
+          appId: "com.apple.Safari",
+          appName: "Safari",
+          windowTitle: "Window",
+          ocrTextRedacted: "ok",
+          redacted: false,
+          captureMethod: "ocr",
+          confidence: 0.5,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects screen_snapshot with oversize ocrTextRedacted", () => {
+    expect(() =>
+      parsePerceptionEvent({
+        ...baseEnvelope,
+        payload: {
+          kind: "screen_snapshot",
+          conversationId: "conv-1",
+          appId: "com.apple.Safari",
+          appName: "Safari",
+          windowTitle: "Window",
+          ocrTextRedacted: "a".repeat(2049),
+          redacted: false,
+          captureMethod: "ocr",
+          confidence: 0.5,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects screen_snapshot with invalid captureMethod", () => {
+    expect(() =>
+      parsePerceptionEvent({
+        ...baseEnvelope,
+        payload: {
+          kind: "screen_snapshot",
+          conversationId: "conv-1",
+          appId: "com.apple.Safari",
+          appName: "Safari",
+          windowTitle: "Window",
+          ocrTextRedacted: "ok",
+          redacted: false,
+          captureMethod: "screenshot",
+          confidence: 0.5,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("parses a valid audio_excerpt payload", () => {
+    const parsed = parsePerceptionEvent({
+      ...baseEnvelope,
+      payload: {
+        kind: "audio_excerpt",
+        conversationId: "conv-1",
+        sessionId: "sess-1",
+        turnId: "turn-1",
+        transcriptRedacted: "hello",
+        confidence: 0.9,
+        language: "en-US",
+      },
+    });
+    expect(parsed.payload.kind).toBe("audio_excerpt");
+  });
+
+  test("rejects audio_excerpt with oversize transcriptRedacted", () => {
+    expect(() =>
+      parsePerceptionEvent({
+        ...baseEnvelope,
+        payload: {
+          kind: "audio_excerpt",
+          conversationId: "conv-1",
+          sessionId: "sess-1",
+          turnId: "turn-1",
+          transcriptRedacted: "x".repeat(1025),
+          confidence: 0.9,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects audio_excerpt with out-of-range confidence", () => {
+    expect(() =>
+      parsePerceptionEvent({
+        ...baseEnvelope,
+        payload: {
+          kind: "audio_excerpt",
+          conversationId: "conv-1",
+          sessionId: "sess-1",
+          turnId: "turn-1",
+          transcriptRedacted: "hi",
+          confidence: 1.2,
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/perception/perception-event.ts
+++ b/assistant/src/perception/perception-event.ts
@@ -1,0 +1,322 @@
+/**
+ * Perception event contract.
+ *
+ * Perception is the daemon's continuous, low-cost stream of "what is the user
+ * doing right now". Raw frames (screenshots, audio, full OCR text) never leave
+ * the originating process — only the structured events declared here cross the
+ * IPC boundary into `assistantEventHub`.
+ *
+ * Producers: the `skills/perception/` skill is the canonical publisher;
+ * additional skills may emit perception events as long as they respect the
+ * privacy gate (no raw frames, redacted text, blocklist enforced upstream).
+ *
+ * Consumers: the in-process `ContextBuffer` (memory-only ring), the relevance
+ * scorer, and the proactive trigger. None of these are allowed to read raw
+ * frame data because the contract does not transport it.
+ *
+ * Roadmap: `docs/jarvis-roadmap.md`.
+ */
+
+import { z } from "zod";
+
+/**
+ * The kinds of perception signals the daemon understands.
+ *
+ * Phase 1 ships `app_focus_changed` only. Later phases add screenshot-derived,
+ * audio-derived, and editor-derived signals — each new kind must update this
+ * union AND add a corresponding payload schema in {@link PerceptionPayload}.
+ */
+export const PERCEPTION_EVENT_KINDS = [
+  "app_focus_changed",
+  "task_detected",
+  "meeting_started",
+  "code_edited",
+  "relevance_scored",
+  "screen_snapshot",
+  "audio_excerpt",
+] as const;
+
+export type PerceptionEventKind = (typeof PERCEPTION_EVENT_KINDS)[number];
+
+/**
+ * Source process that produced the event. Used for audit + debugging; not
+ * for trust decisions (trust comes from the skill IPC handshake, not from
+ * a field in the payload).
+ */
+export const PerceptionSourceSchema = z.object({
+  /** Skill or module identifier, e.g. `"skills/perception"`. */
+  module: z.string().min(1).max(128),
+  /** Optional version/build tag for triage. */
+  version: z.string().max(64).optional(),
+});
+
+export type PerceptionSource = z.infer<typeof PerceptionSourceSchema>;
+
+/**
+ * `app_focus_changed` — the user switched focus to a different app or window.
+ *
+ * Privacy: window titles often contain document names. The producer must run
+ * its blocklist + redaction pass before emitting. The contract intentionally
+ * does NOT carry process ids, file paths, or URLs — those are higher-trust
+ * signals that need their own gated kind.
+ */
+export const AppFocusChangedPayloadSchema = z.object({
+  kind: z.literal("app_focus_changed"),
+  /** Bundle id or platform-native app identifier, e.g. `com.apple.Safari`. */
+  appId: z.string().min(1).max(256),
+  /** Human-readable app name as the OS reports it. */
+  appName: z.string().min(1).max(256),
+  /** Redacted window title. Empty string when unavailable or fully redacted. */
+  windowTitle: z.string().max(512),
+  /** Whether the window title was redacted by the producer. */
+  redacted: z.boolean(),
+});
+
+export type AppFocusChangedPayload = z.infer<
+  typeof AppFocusChangedPayloadSchema
+>;
+
+/**
+ * `task_detected` — interpreted, higher-level task signal inferred from raw
+ * focus changes by the local perception interpreter.
+ *
+ * Privacy: this is a distilled summary and must never include direct secrets
+ * (emails, full tokens, phone numbers, exact account IDs). Producers should
+ * redact/normalize before emitting.
+ */
+export const TaskDetectedPayloadSchema = z.object({
+  kind: z.literal("task_detected"),
+  /** Short task label suitable for downstream routing/scoring. */
+  label: z.string().min(1).max(120),
+  /** User-facing, redacted summary of what the user appears to be doing. */
+  summary: z.string().max(320),
+  /** Confidence score in [0, 1]. */
+  confidence: z.number().min(0).max(1),
+  /** Source perception event id that triggered this interpretation. */
+  sourceEventId: z.string().min(1).max(128),
+});
+
+export type TaskDetectedPayload = z.infer<typeof TaskDetectedPayloadSchema>;
+
+/**
+ * `meeting_started` — interpreted signal that the user appears to have entered
+ * a live meeting context.
+ */
+export const MeetingStartedPayloadSchema = z.object({
+  kind: z.literal("meeting_started"),
+  /** Redacted user-facing summary. */
+  summary: z.string().max(320),
+  /** Confidence score in [0, 1]. */
+  confidence: z.number().min(0).max(1),
+  /** Source perception event id that triggered this interpretation. */
+  sourceEventId: z.string().min(1).max(128),
+  /** Best-effort meeting platform classification. */
+  platform: z
+    .enum(["zoom", "google-meet", "teams", "slack-huddle", "other"])
+    .optional(),
+});
+
+export type MeetingStartedPayload = z.infer<typeof MeetingStartedPayloadSchema>;
+
+/**
+ * `code_edited` — interpreted signal that the user appears to be actively
+ * editing code.
+ */
+export const CodeEditedPayloadSchema = z.object({
+  kind: z.literal("code_edited"),
+  /** Redacted user-facing summary. */
+  summary: z.string().max(320),
+  /** Confidence score in [0, 1]. */
+  confidence: z.number().min(0).max(1),
+  /** Source perception event id that triggered this interpretation. */
+  sourceEventId: z.string().min(1).max(128),
+  /** Optional coarse workspace/project hint when available. */
+  workspaceHint: z.string().max(120).optional(),
+  /** Optional language hint, e.g. "TypeScript". */
+  languageHint: z.string().max(40).optional(),
+});
+
+export type CodeEditedPayload = z.infer<typeof CodeEditedPayloadSchema>;
+
+export const RelevanceDecisionSchema = z.enum([
+  "ignore",
+  "remember",
+  "maybe-act",
+  "act-now",
+]);
+
+export type RelevanceDecision = z.infer<typeof RelevanceDecisionSchema>;
+
+export const RelevanceUrgencySchema = z.enum(["low", "medium", "high"]);
+
+export type RelevanceUrgency = z.infer<typeof RelevanceUrgencySchema>;
+
+/**
+ * `relevance_scored` — canonical output from the Phase 3 relevance gate.
+ *
+ * Captures the scorer's decision for one interpreted event, including whether
+ * an `act-now` decision actually triggered a proactive wake or was blocked by
+ * interruption budget.
+ */
+export const RelevanceScoredPayloadSchema = z.object({
+  kind: z.literal("relevance_scored"),
+  /** Perception event id that was scored by the relevance gate. */
+  sourceEventId: z.string().min(1).max(128),
+  /** Interpreted source event kind that was scored. */
+  sourceKind: z.enum(["task_detected", "meeting_started", "code_edited"]),
+  /** Relevance decision class from the scorer. */
+  decision: RelevanceDecisionSchema,
+  /** Relative urgency used for budget + trigger policy. */
+  urgency: RelevanceUrgencySchema,
+  /** Redacted short explanation for audit/debugging. */
+  reason: z.string().max(240).optional(),
+  /**
+   * True when an `act-now` decision actually invoked the proactive wake path.
+   * False for all non-act-now decisions and budget-blocked/skipped outcomes.
+   */
+  triggeredWake: z.boolean(),
+  /** True when an `act-now` decision was blocked by the hourly budget. */
+  blockedByBudget: z.boolean(),
+  /** Background conversation id used for wake, when one was invoked. */
+  wakeConversationId: z.string().min(1).max(128).optional(),
+});
+
+export type RelevanceScoredPayload = z.infer<
+  typeof RelevanceScoredPayloadSchema
+>;
+
+/**
+ * `screen_snapshot` — sanitized OCR / accessibility-tree summary captured from
+ * the user's screen by an on-device producer (e.g. macOS WatchSession).
+ *
+ * Privacy: raw images NEVER cross IPC. The producer runs OCR and any
+ * accessibility-tree extraction locally, applies its blocklist + redaction
+ * pass, and emits the truncated structured fields declared here. The hard
+ * 2048-character cap on `ocrTextRedacted` is enforced both by schema and by
+ * the route-level sanitizer.
+ *
+ * This kind is gated by the `perception-screen-snapshot` feature flag AND by
+ * a per-conversation `perception_consent_grants` row — both must be present
+ * for the daemon to accept the event.
+ */
+export const ScreenSnapshotPayloadSchema = z.object({
+  kind: z.literal("screen_snapshot"),
+  /**
+   * Conversation that the publisher associates the snapshot with. The
+   * `perception_consent_grants` table is keyed on this id; the route rejects
+   * with `consent_required` when no active grant exists for the triple.
+   */
+  conversationId: z.string().min(1).max(128),
+  /** Bundle id of the captured foreground app. */
+  appId: z.string().min(1).max(256),
+  /** Human-readable app name. */
+  appName: z.string().min(1).max(256),
+  /** Redacted window title (empty if redacted/unavailable). */
+  windowTitle: z.string().max(512),
+  /**
+   * Redacted, truncated text extracted from the screen. Capped at 2048
+   * characters to bound prompt impact. Producers are expected to truncate
+   * upstream; the route sanitizer enforces the cap defensively.
+   */
+  ocrTextRedacted: z.string().max(2048),
+  /** Whether any redaction took place. */
+  redacted: z.boolean(),
+  /** How the producer extracted text from the screen. */
+  captureMethod: z.enum(["ax", "ocr"]),
+  /** Producer-reported confidence in the extraction, in [0, 1]. */
+  confidence: z.number().min(0).max(1),
+});
+
+export type ScreenSnapshotPayload = z.infer<typeof ScreenSnapshotPayloadSchema>;
+
+/**
+ * `audio_excerpt` — a sanitized excerpt of a finalized speech-to-text turn
+ * captured by the live-voice session.
+ *
+ * Privacy: raw audio NEVER crosses IPC. Only the redacted transcript text is
+ * forwarded into the perception spine, capped at 1024 characters.
+ *
+ * This kind is gated by the `perception-audio-excerpt` feature flag AND by a
+ * per-conversation `perception_consent_grants` row.
+ */
+export const AudioExcerptPayloadSchema = z.object({
+  kind: z.literal("audio_excerpt"),
+  /**
+   * Conversation that the publisher associates the excerpt with. The
+   * `perception_consent_grants` table is keyed on this id; the route rejects
+   * with `consent_required` when no active grant exists for the triple.
+   */
+  conversationId: z.string().min(1).max(128),
+  /** Live-voice session id that produced the excerpt. */
+  sessionId: z.string().min(1).max(128),
+  /** Stable id for the conversational turn the excerpt belongs to. */
+  turnId: z.string().min(1).max(128),
+  /**
+   * Redacted, truncated finalized STT transcript. Bounded at 1024 characters
+   * (schema + route sanitizer both enforce).
+   */
+  transcriptRedacted: z.string().max(1024),
+  /** Optional BCP-47 language tag, e.g. "en-US". */
+  language: z.string().max(20).optional(),
+  /** Producer-reported confidence in the STT result, in [0, 1]. */
+  confidence: z.number().min(0).max(1),
+});
+
+export type AudioExcerptPayload = z.infer<typeof AudioExcerptPayloadSchema>;
+
+/**
+ * Discriminated union of all perception payload shapes. Extend here when
+ * adding a new kind; the union name `kind` is the discriminator.
+ */
+export const PerceptionPayloadSchema = z.discriminatedUnion("kind", [
+  AppFocusChangedPayloadSchema,
+  TaskDetectedPayloadSchema,
+  MeetingStartedPayloadSchema,
+  CodeEditedPayloadSchema,
+  RelevanceScoredPayloadSchema,
+  ScreenSnapshotPayloadSchema,
+  AudioExcerptPayloadSchema,
+]);
+
+export type PerceptionPayload = z.infer<typeof PerceptionPayloadSchema>;
+
+/**
+ * The full envelope published to `assistantEventHub`.
+ *
+ * `ts` is the producer's wall-clock at capture time. The hub also stamps its
+ * own receive time on the outer `AssistantEvent` — they may diverge if the
+ * producer batches.
+ */
+export const PerceptionEventSchema = z.object({
+  /** Monotonic, opaque event id assigned by the producer. */
+  eventId: z.string().min(1).max(128),
+  /** ISO-8601 timestamp at capture time. */
+  ts: z.string().datetime(),
+  source: PerceptionSourceSchema,
+  payload: PerceptionPayloadSchema,
+});
+
+export type PerceptionEvent = z.infer<typeof PerceptionEventSchema>;
+
+/**
+ * Tag used by `assistantEventHub` consumers to filter for the perception
+ * family. Producers MUST set this on the outer `AssistantEvent.type` so
+ * subscribers can subscribe without parsing the payload.
+ *
+ * Concrete event types nest the kind, e.g. `perception.app_focus_changed`,
+ * so consumers can subscribe coarsely (`perception.*`) or precisely.
+ */
+export const PERCEPTION_EVENT_TYPE_PREFIX = "perception" as const;
+
+export function perceptionEventType(kind: PerceptionEventKind): string {
+  return `${PERCEPTION_EVENT_TYPE_PREFIX}.${kind}`;
+}
+
+/**
+ * Parse + validate an unknown payload as a perception event. Producers and
+ * consumers both call this at the trust boundary to avoid leaking malformed
+ * input into the in-process consumers.
+ */
+export function parsePerceptionEvent(input: unknown): PerceptionEvent {
+  return PerceptionEventSchema.parse(input);
+}

--- a/assistant/src/perception/personal-knowledge-context.test.ts
+++ b/assistant/src/perception/personal-knowledge-context.test.ts
@@ -1,0 +1,53 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  recordPkbEpisode,
+  upsertPkbEntity,
+  upsertPkbPreference,
+} from "../memory/personal-knowledge-store.js";
+import { buildPerceptionKnowledgeContext } from "./personal-knowledge-context.js";
+
+describe("buildPerceptionKnowledgeContext", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("returns null when no PKB perception rows exist", () => {
+    expect(buildPerceptionKnowledgeContext()).toBeNull();
+  });
+
+  test("renders episodes, entities, and preferences sections", () => {
+    upsertPkbEntity({
+      entityType: "workspace",
+      canonicalName: "eli",
+      confidence: 0.91,
+    });
+    recordPkbEpisode({
+      summary: "Edited perception runtime routes and tests.",
+      salience: 0.8,
+    });
+    upsertPkbPreference({
+      key: "coding.language.preferred",
+      value: "TypeScript",
+      confidence: 0.92,
+      learnedFrom: "perception",
+    });
+
+    const block = buildPerceptionKnowledgeContext();
+    expect(block).toContain("### Recent perceived episodes");
+    expect(block).toContain("### Active perceived entities");
+    expect(block).toContain("### Learned preferences");
+    expect(block).toContain("workspace: eli");
+    expect(block).toContain("coding.language.preferred = TypeScript");
+  });
+});

--- a/assistant/src/perception/personal-knowledge-context.ts
+++ b/assistant/src/perception/personal-knowledge-context.ts
@@ -1,0 +1,116 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import {
+  listPkbPreferences,
+  listRecentPkbEntities,
+  listRecentPkbEpisodes,
+  scorePkbEntities,
+  scorePkbPreferences,
+} from "../memory/personal-knowledge-store.js";
+
+const DEFAULT_SCOPE_ID = "default";
+const DEFAULT_ENTITY_LIMIT = 5;
+const DEFAULT_EPISODE_LIMIT = 5;
+const DEFAULT_PREFERENCE_LIMIT = 5;
+const MAX_SECTION_TEXT = 180;
+
+export function buildPerceptionKnowledgeContext(options?: {
+  scopeId?: string;
+  entityLimit?: number;
+  episodeLimit?: number;
+  preferenceLimit?: number;
+}): string | null {
+  const scopeId = options?.scopeId ?? DEFAULT_SCOPE_ID;
+  const entityLimit = clampLimit(
+    options?.entityLimit,
+    DEFAULT_ENTITY_LIMIT,
+    20,
+  );
+  const episodeLimit = clampLimit(
+    options?.episodeLimit,
+    DEFAULT_EPISODE_LIMIT,
+    20,
+  );
+  const preferenceLimit = clampLimit(
+    options?.preferenceLimit,
+    DEFAULT_PREFERENCE_LIMIT,
+    20,
+  );
+
+  // When memory-maturation is enabled, switch from "most recent" selection to
+  // scoring-based selection so high-decay items naturally fall out of the
+  // prompt block. The episode list stays recency-ordered — scoring would
+  // require an additional confidence/decay signal we don't track on episodes
+  // yet, and the existing recency order already provides what the prompt
+  // needs.
+  const maturationEnabled = isAssistantFeatureFlagEnabled(
+    "memory-maturation",
+    getConfig(),
+  );
+
+  const entities = maturationEnabled
+    ? scorePkbEntities({ scopeId, limit: entityLimit }).map((s) => s.entity)
+    : listRecentPkbEntities({ scopeId, limit: entityLimit });
+  const episodes = listRecentPkbEpisodes({ scopeId, limit: episodeLimit });
+  const preferences = maturationEnabled
+    ? scorePkbPreferences({ scopeId, limit: preferenceLimit }).map(
+        (s) => s.preference,
+      )
+    : listPkbPreferences({ scopeId, limit: preferenceLimit });
+
+  if (
+    entities.length === 0 &&
+    episodes.length === 0 &&
+    preferences.length === 0
+  ) {
+    return null;
+  }
+
+  const sections: string[] = [];
+
+  if (episodes.length > 0) {
+    sections.push(
+      "### Recent perceived episodes",
+      ...episodes.map((episode) => `- ${trimText(episode.summary)}`),
+    );
+  }
+
+  if (entities.length > 0) {
+    sections.push(
+      "### Active perceived entities",
+      ...entities.map(
+        (entity) =>
+          `- ${entity.entityType}: ${trimText(entity.canonicalName)} (confidence ${entity.confidence.toFixed(2)})`,
+      ),
+    );
+  }
+
+  if (preferences.length > 0) {
+    sections.push(
+      "### Learned preferences",
+      ...preferences.map(
+        (pref) =>
+          `- ${pref.key} = ${trimText(pref.value)} (confidence ${pref.confidence.toFixed(2)})`,
+      ),
+    );
+  }
+
+  return sections.join("\n");
+}
+
+function trimText(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_SECTION_TEXT) return normalized;
+  return `${normalized.slice(0, MAX_SECTION_TEXT - 1)}…`;
+}
+
+function clampLimit(
+  value: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  const raw = Number.isFinite(value) ? Math.trunc(value!) : fallback;
+  if (raw < 1) return 1;
+  if (raw > max) return max;
+  return raw;
+}

--- a/assistant/src/perception/personal-knowledge-writer.test.ts
+++ b/assistant/src/perception/personal-knowledge-writer.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import {
+  listPkbPreferences,
+  listRecentPkbEpisodes,
+} from "../memory/personal-knowledge-store.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { perceptionEventType } from "./perception-event.js";
+import { PersonalKnowledgeWriter } from "./personal-knowledge-writer.js";
+
+describe("PersonalKnowledgeWriter", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("persists episode + preference when relevance says remember", async () => {
+    const hub = new AssistantEventHub();
+    const writer = new PersonalKnowledgeWriter();
+    writer.attach(hub);
+
+    const interpretedId = "evt-code-1";
+    await hub.publish({
+      id: interpretedId,
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: perceptionEventType("code_edited"),
+        perception: {
+          eventId: interpretedId,
+          ts: new Date().toISOString(),
+          source: { module: "test" },
+          payload: {
+            kind: "code_edited",
+            summary: "Edited assistant runtime routes.",
+            confidence: 0.92,
+            sourceEventId: "evt-focus-1",
+            workspaceHint: "eli",
+            languageHint: "TypeScript",
+          },
+        },
+      },
+    } as never);
+
+    await hub.publish({
+      id: "evt-rel-1",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: perceptionEventType("relevance_scored"),
+        perception: {
+          eventId: "evt-rel-1",
+          ts: new Date().toISOString(),
+          source: { module: "test" },
+          payload: {
+            kind: "relevance_scored",
+            sourceEventId: interpretedId,
+            sourceKind: "code_edited",
+            decision: "remember",
+            urgency: "low",
+            triggeredWake: false,
+            blockedByBudget: false,
+          },
+        },
+      },
+    } as never);
+
+    const episodes = listRecentPkbEpisodes({ limit: 10 });
+    const preferences = listPkbPreferences({ limit: 10 });
+
+    expect(episodes).toHaveLength(1);
+    expect(episodes[0]?.summary).toContain("Edited assistant runtime routes");
+    expect(preferences).toHaveLength(1);
+    expect(preferences[0]?.key).toBe("coding.language.preferred");
+    expect(preferences[0]?.value).toBe("TypeScript");
+
+    writer.detach();
+  });
+
+  test("ignores relevance ignore decisions", async () => {
+    const hub = new AssistantEventHub();
+    const writer = new PersonalKnowledgeWriter();
+    writer.attach(hub);
+
+    const interpretedId = "evt-task-1";
+    await hub.publish({
+      id: interpretedId,
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: perceptionEventType("task_detected"),
+        perception: {
+          eventId: interpretedId,
+          ts: new Date().toISOString(),
+          source: { module: "test" },
+          payload: {
+            kind: "task_detected",
+            label: "Refactor tests",
+            summary: "Refactoring route tests",
+            confidence: 0.8,
+            sourceEventId: "evt-focus-2",
+          },
+        },
+      },
+    } as never);
+
+    await hub.publish({
+      id: "evt-rel-2",
+      emittedAt: new Date().toISOString(),
+      message: {
+        type: perceptionEventType("relevance_scored"),
+        perception: {
+          eventId: "evt-rel-2",
+          ts: new Date().toISOString(),
+          source: { module: "test" },
+          payload: {
+            kind: "relevance_scored",
+            sourceEventId: interpretedId,
+            sourceKind: "task_detected",
+            decision: "ignore",
+            urgency: "low",
+            triggeredWake: false,
+            blockedByBudget: false,
+          },
+        },
+      },
+    } as never);
+
+    expect(listRecentPkbEpisodes({ limit: 10 })).toHaveLength(0);
+    writer.detach();
+  });
+});

--- a/assistant/src/perception/personal-knowledge-writer.ts
+++ b/assistant/src/perception/personal-knowledge-writer.ts
@@ -1,0 +1,282 @@
+import {
+  recordPkbEpisode,
+  upsertPkbEntity,
+  upsertPkbPreference,
+} from "../memory/personal-knowledge-store.js";
+import type {
+  AssistantEventHub,
+  AssistantEventSubscription,
+} from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type CodeEditedPayload,
+  type MeetingStartedPayload,
+  parsePerceptionEvent,
+  PERCEPTION_EVENT_TYPE_PREFIX,
+  type PerceptionEvent,
+  type TaskDetectedPayload,
+} from "./perception-event.js";
+
+const log = getLogger("perception-pkb-writer");
+
+const SOURCE_CACHE_TTL_MS = 10 * 60 * 1000;
+const SOURCE_CACHE_MAX = 1000;
+const DEFAULT_SCOPE_ID = "default";
+
+type InterpretedPayload =
+  | TaskDetectedPayload
+  | MeetingStartedPayload
+  | CodeEditedPayload;
+
+interface CachedInterpreted {
+  event: PerceptionEvent;
+  storedAtMs: number;
+}
+
+export class PersonalKnowledgeWriter {
+  private subscription: AssistantEventSubscription | null = null;
+  private interpretedByEventId = new Map<string, CachedInterpreted>();
+
+  attach(hub: AssistantEventHub): AssistantEventSubscription {
+    if (this.subscription) return this.subscription;
+    this.subscription = hub.subscribe({
+      type: "process",
+      callback: async (event) => {
+        try {
+          await this.ingest(event);
+        } catch (err) {
+          log.warn({ err }, "personal knowledge writer ingest failed");
+        }
+      },
+    });
+    return this.subscription;
+  }
+
+  detach(): void {
+    this.subscription?.dispose();
+    this.subscription = null;
+    this.interpretedByEventId.clear();
+  }
+
+  async ingest(event: unknown): Promise<void> {
+    const type = getEventType(event);
+    if (!type || !type.startsWith(`${PERCEPTION_EVENT_TYPE_PREFIX}.`)) return;
+
+    const message = getEventMessage(event);
+    if (!message) return;
+
+    const candidate = extractPerceptionPayload(message);
+    let parsed: PerceptionEvent;
+    try {
+      parsed = parsePerceptionEvent(candidate);
+    } catch {
+      return;
+    }
+
+    this.pruneSourceCache();
+
+    switch (parsed.payload.kind) {
+      case "task_detected":
+      case "meeting_started":
+      case "code_edited":
+        this.cacheInterpreted(parsed);
+        return;
+      case "relevance_scored":
+        await this.persistRelevantDecision(parsed);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private cacheInterpreted(event: PerceptionEvent): void {
+    this.interpretedByEventId.set(event.eventId, {
+      event,
+      storedAtMs: Date.now(),
+    });
+    if (this.interpretedByEventId.size <= SOURCE_CACHE_MAX) return;
+    const oldest = this.interpretedByEventId.keys().next().value as
+      | string
+      | undefined;
+    if (oldest) this.interpretedByEventId.delete(oldest);
+  }
+
+  private async persistRelevantDecision(event: PerceptionEvent): Promise<void> {
+    if (event.payload.kind !== "relevance_scored") return;
+    if (event.payload.decision === "ignore") return;
+
+    const source = this.interpretedByEventId.get(
+      event.payload.sourceEventId,
+    )?.event;
+    if (!source) return;
+
+    const interpreted = source.payload as InterpretedPayload;
+    const observedAt = Date.parse(source.ts) || Date.now();
+    const provenance = {
+      source: "perception",
+      sourceEventId: source.eventId,
+      observedAt,
+    };
+    const { entityId, episodeSummary } = this.ensureEntityAndEpisodeSummary(
+      interpreted,
+      provenance,
+    );
+
+    recordPkbEpisode({
+      scopeId: DEFAULT_SCOPE_ID,
+      entityId,
+      summary: episodeSummary,
+      details: {
+        sourceEventId: source.eventId,
+        relevanceEventId: event.eventId,
+        relevanceDecision: event.payload.decision,
+        relevanceUrgency: event.payload.urgency,
+        relevanceReason: event.payload.reason,
+        sourceKind: interpreted.kind,
+      },
+      happenedAt: observedAt,
+      salience: salienceForDecision(
+        event.payload.decision,
+        event.payload.urgency,
+      ),
+      sourceConversationId: event.payload.wakeConversationId,
+      idempotencyKey: `${source.eventId}:${interpreted.kind}`,
+    });
+
+    this.learnPreference(interpreted);
+  }
+
+  private ensureEntityAndEpisodeSummary(
+    interpreted: InterpretedPayload,
+    provenance: { source: string; sourceEventId: string; observedAt: number },
+  ): {
+    entityId?: string;
+    episodeSummary: string;
+  } {
+    switch (interpreted.kind) {
+      case "task_detected": {
+        const entity = upsertPkbEntity({
+          scopeId: DEFAULT_SCOPE_ID,
+          entityType: "task",
+          canonicalName: interpreted.label,
+          aliases: [],
+          attributes: { summary: interpreted.summary },
+          confidence: interpreted.confidence,
+          provenance,
+        });
+        return {
+          entityId: entity.id,
+          episodeSummary: interpreted.summary || interpreted.label,
+        };
+      }
+      case "meeting_started": {
+        const name = interpreted.platform ?? "meeting";
+        const entity = upsertPkbEntity({
+          scopeId: DEFAULT_SCOPE_ID,
+          entityType: "meeting-platform",
+          canonicalName: name,
+          aliases: [],
+          attributes: { summary: interpreted.summary },
+          confidence: interpreted.confidence,
+          provenance,
+        });
+        return { entityId: entity.id, episodeSummary: interpreted.summary };
+      }
+      case "code_edited": {
+        const workspace = interpreted.workspaceHint?.trim();
+        if (workspace) {
+          const entity = upsertPkbEntity({
+            scopeId: DEFAULT_SCOPE_ID,
+            entityType: "workspace",
+            canonicalName: workspace,
+            aliases: interpreted.languageHint ? [interpreted.languageHint] : [],
+            attributes: { summary: interpreted.summary },
+            confidence: interpreted.confidence,
+            provenance,
+          });
+          return { entityId: entity.id, episodeSummary: interpreted.summary };
+        }
+        const language = interpreted.languageHint?.trim();
+        if (language) {
+          const entity = upsertPkbEntity({
+            scopeId: DEFAULT_SCOPE_ID,
+            entityType: "language",
+            canonicalName: language,
+            aliases: [],
+            attributes: { summary: interpreted.summary },
+            confidence: interpreted.confidence,
+            provenance,
+          });
+          return { entityId: entity.id, episodeSummary: interpreted.summary };
+        }
+        return { episodeSummary: interpreted.summary };
+      }
+    }
+  }
+
+  private learnPreference(interpreted: InterpretedPayload): void {
+    if (interpreted.kind === "code_edited" && interpreted.languageHint) {
+      upsertPkbPreference({
+        scopeId: DEFAULT_SCOPE_ID,
+        key: "coding.language.preferred",
+        value: interpreted.languageHint,
+        confidence: interpreted.confidence,
+        learnedFrom: "perception",
+      });
+    }
+    if (interpreted.kind === "meeting_started" && interpreted.platform) {
+      upsertPkbPreference({
+        scopeId: DEFAULT_SCOPE_ID,
+        key: "meeting.platform.preferred",
+        value: interpreted.platform,
+        confidence: interpreted.confidence,
+        learnedFrom: "perception",
+      });
+    }
+  }
+
+  private pruneSourceCache(): void {
+    const cutoff = Date.now() - SOURCE_CACHE_TTL_MS;
+    for (const [id, item] of this.interpretedByEventId.entries()) {
+      if (item.storedAtMs < cutoff) {
+        this.interpretedByEventId.delete(id);
+      }
+    }
+  }
+}
+
+function salienceForDecision(
+  decision: "remember" | "maybe-act" | "act-now",
+  urgency: "low" | "medium" | "high",
+): number {
+  const base =
+    decision === "act-now" ? 0.9 : decision === "maybe-act" ? 0.7 : 0.5;
+  const urgencyBoost =
+    urgency === "high" ? 0.1 : urgency === "medium" ? 0.05 : 0;
+  return Math.max(0, Math.min(1, base + urgencyBoost));
+}
+
+function getEventType(event: unknown): string | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  const type = (message as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function getEventMessage(event: unknown): Record<string, unknown> | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  return message as Record<string, unknown>;
+}
+
+function extractPerceptionPayload(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  const nested = message.perception;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return message;
+}

--- a/assistant/src/perception/relevance-gate.test.ts
+++ b/assistant/src/perception/relevance-gate.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Provider } from "../providers/types.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { PerceptionRelevanceGate } from "./relevance-gate.js";
+
+function makeProvider(replyText: string): Provider {
+  return {
+    name: "test-provider",
+    async sendMessage() {
+      return {
+        content: [{ type: "text", text: replyText }],
+        model: "test-model",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "stop",
+      };
+    },
+  };
+}
+
+function makeTaskDetectedEvent(eventId = "task-1") {
+  return {
+    message: {
+      type: "perception.task_detected",
+      perception: {
+        eventId,
+        ts: "2026-05-15T05:00:00.000Z",
+        source: { module: "skills/perception" },
+        payload: {
+          kind: "task_detected",
+          label: "Debugging auth",
+          summary: "User is debugging authentication issues",
+          confidence: 0.92,
+          sourceEventId: "focus-123",
+        },
+      },
+    },
+  };
+}
+
+function envelope(event: ReturnType<typeof makeTaskDetectedEvent>) {
+  return {
+    id: "inbound-evt",
+    emittedAt: "2026-05-15T05:00:00.000Z",
+    message: event.message,
+  };
+}
+
+describe("PerceptionRelevanceGate", () => {
+  test("invokes wake on act-now decision when within budget", async () => {
+    const checkpoints = new Map<string, string>();
+    const wakeCalls: Array<{ conversationId: string; hint: string }> = [];
+
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "act-now",
+            urgency: "medium",
+            reason: "Time-sensitive opportunity.",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+      wakeAgent: async ({ conversationId, hint }) => {
+        wakeCalls.push({ conversationId, hint });
+        return { invoked: true, producedToolCalls: false };
+      },
+      bootstrapConversation: () => ({ id: "conv-1" }),
+      getCheckpoint: (key) => checkpoints.get(key) ?? null,
+      setCheckpoint: (key, value) => {
+        checkpoints.set(key, value);
+      },
+    });
+
+    await gate.ingest(makeTaskDetectedEvent());
+
+    expect(wakeCalls).toHaveLength(1);
+    const recorded = checkpoints.get("perception:act-now:hourly-timestamps");
+    expect(recorded).not.toBeUndefined();
+    expect(JSON.parse(recorded ?? "[]")).toHaveLength(1);
+  });
+
+  test("blocks medium urgency act-now when hourly budget is exhausted", async () => {
+    const checkpoints = new Map<string, string>();
+    checkpoints.set(
+      "perception:act-now:hourly-timestamps",
+      JSON.stringify([Date.parse("2026-05-15T04:40:00.000Z")]),
+    );
+    let wakeCount = 0;
+
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "act-now",
+            urgency: "medium",
+            reason: "Would be useful but not urgent.",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+      hourlyActNowBudget: 1,
+      wakeAgent: async () => {
+        wakeCount += 1;
+        return { invoked: true, producedToolCalls: false };
+      },
+      bootstrapConversation: () => ({ id: "conv-2" }),
+      getCheckpoint: (key) => checkpoints.get(key) ?? null,
+      setCheckpoint: (key, value) => {
+        checkpoints.set(key, value);
+      },
+    });
+
+    await gate.ingest(makeTaskDetectedEvent("task-2"));
+
+    expect(wakeCount).toBe(0);
+  });
+
+  test("high urgency act-now bypasses hourly budget", async () => {
+    const checkpoints = new Map<string, string>();
+    checkpoints.set(
+      "perception:act-now:hourly-timestamps",
+      JSON.stringify([
+        Date.parse("2026-05-15T04:20:00.000Z"),
+        Date.parse("2026-05-15T04:40:00.000Z"),
+      ]),
+    );
+    let wakeCount = 0;
+
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "act-now",
+            urgency: "high",
+            reason: "Immediate meeting context change.",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+      hourlyActNowBudget: 1,
+      wakeAgent: async () => {
+        wakeCount += 1;
+        return { invoked: true, producedToolCalls: false };
+      },
+      bootstrapConversation: () => ({ id: "conv-3" }),
+      getCheckpoint: (key) => checkpoints.get(key) ?? null,
+      setCheckpoint: (key, value) => {
+        checkpoints.set(key, value);
+      },
+    });
+
+    await gate.ingest(makeTaskDetectedEvent("task-3"));
+
+    expect(wakeCount).toBe(1);
+  });
+
+  test("rolls back budget and cleans conversation when wake is not invoked", async () => {
+    const checkpoints = new Map<string, string>();
+    const deleted: string[] = [];
+
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "act-now",
+            urgency: "medium",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+      wakeAgent: async () => ({ invoked: false, producedToolCalls: false }),
+      bootstrapConversation: () => ({ id: "conv-4" }),
+      deleteConversation: (conversationId) => {
+        deleted.push(conversationId);
+      },
+      getCheckpoint: (key) => checkpoints.get(key) ?? null,
+      setCheckpoint: (key, value) => {
+        checkpoints.set(key, value);
+      },
+    });
+
+    await gate.ingest(makeTaskDetectedEvent("task-4"));
+
+    expect(deleted).toEqual(["conv-4"]);
+    const recorded = checkpoints.get("perception:act-now:hourly-timestamps");
+    expect(JSON.parse(recorded ?? "[]")).toHaveLength(0);
+  });
+
+  test("publishes relevance_scored event for downstream consumers", async () => {
+    const hub = new AssistantEventHub();
+    const seen: Array<Record<string, unknown>> = [];
+    const sink = hub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string }).type;
+        if (type === "perception.relevance_scored") {
+          seen.push(event as unknown as Record<string, unknown>);
+        }
+      },
+    });
+
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "remember",
+            urgency: "low",
+            reason: "Useful context to retain.",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+    });
+    gate.attach(hub);
+
+    await hub.publish(envelope(makeTaskDetectedEvent("task-audit")) as never);
+
+    expect(seen).toHaveLength(1);
+    const msg = seen[0]!.message as {
+      perception: {
+        payload: {
+          kind: string;
+          decision: string;
+          sourceEventId: string;
+          triggeredWake: boolean;
+          blockedByBudget: boolean;
+        };
+      };
+    };
+    expect(msg.perception.payload.kind).toBe("relevance_scored");
+    expect(msg.perception.payload.decision).toBe("remember");
+    expect(msg.perception.payload.sourceEventId).toBe("task-audit");
+    expect(msg.perception.payload.triggeredWake).toBe(false);
+    expect(msg.perception.payload.blockedByBudget).toBe(false);
+
+    gate.detach();
+    sink.dispose();
+  });
+
+  test("redacts sensitive strings in reason and proactive wake hint", async () => {
+    const checkpoints = new Map<string, string>();
+    const wakeCalls: Array<{ conversationId: string; hint: string }> = [];
+    const gate = new PerceptionRelevanceGate({
+      getProvider: async () =>
+        makeProvider(
+          JSON.stringify({
+            decision: "act-now",
+            urgency: "high",
+            reason:
+              "User user_abc123 entered https://example.com with apiKey=sk_live_ABCDEF123456",
+          }),
+        ),
+      now: () => new Date("2026-05-15T05:00:10.000Z"),
+      wakeAgent: async ({ conversationId, hint }) => {
+        wakeCalls.push({ conversationId, hint });
+        return { invoked: true, producedToolCalls: false };
+      },
+      bootstrapConversation: () => ({ id: "conv-9" }),
+      getCheckpoint: (key) => checkpoints.get(key) ?? null,
+      setCheckpoint: (key, value) => {
+        checkpoints.set(key, value);
+      },
+    });
+
+    await gate.ingest(
+      envelope({
+        message: {
+          type: "perception.task_detected",
+          perception: {
+            eventId: "task-redact",
+            ts: "2026-05-15T05:00:00.000Z",
+            source: { module: "skills/perception" },
+            payload: {
+              kind: "task_detected",
+              label: "Account follow-up",
+              summary:
+                "Investigate token=tok_123456789 and account-12345 at https://internal.example",
+              confidence: 0.95,
+              sourceEventId: "focus-redact",
+            },
+          },
+        },
+      } as ReturnType<typeof makeTaskDetectedEvent>),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    const hint = wakeCalls[0]!.hint;
+    expect(hint).toContain("[redacted-url]");
+    expect(hint).toContain("[redacted-secret]");
+    expect(hint).toContain("[redacted-account-id]");
+    expect(hint).not.toContain("tok_123456789");
+    expect(hint).not.toContain("account-12345");
+  });
+});

--- a/assistant/src/perception/relevance-gate.ts
+++ b/assistant/src/perception/relevance-gate.ts
@@ -1,0 +1,456 @@
+import { z } from "zod";
+
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../memory/checkpoints.js";
+import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { deleteConversation } from "../memory/conversation-crud.js";
+import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import type { Provider } from "../providers/types.js";
+import {
+  wakeAgentForOpportunity,
+  type WakeResult,
+} from "../runtime/agent-wake.js";
+import type {
+  AssistantEventHub,
+  AssistantEventSubscription,
+} from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import {
+  parsePerceptionEvent,
+  PERCEPTION_EVENT_TYPE_PREFIX,
+  type PerceptionEvent,
+  perceptionEventType,
+  type RelevanceDecision as RelevanceDecisionKind,
+  type RelevanceUrgency,
+} from "./perception-event.js";
+import { sanitizeOptional, sanitizeText } from "./sanitization.js";
+
+const log = getLogger("perception-relevance-gate");
+
+const ACT_NOW_BUDGET_KEY = "perception:act-now:hourly-timestamps";
+const DEFAULT_HOURLY_ACT_NOW_BUDGET = 2;
+const HOUR_MS = 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+const RelevanceDecisionSchema = z.object({
+  decision: z.enum(["ignore", "remember", "maybe-act", "act-now"]),
+  urgency: z.enum(["low", "medium", "high"]).optional(),
+  reason: z.string().max(240).optional(),
+});
+
+const RELEVANCE_PROMPT = `Classify one interpreted perception event.
+Return strict JSON only:
+{"decision":"ignore"|"remember"|"maybe-act"|"act-now","urgency":"low"|"medium"|"high","reason":"..."}
+
+Policy:
+- Use "ignore" for low-signal/noisy events.
+- Use "remember" for useful context that should be retained but no immediate action.
+- Use "maybe-act" for potentially actionable signals that should wait for more context.
+- Use "act-now" only when immediate proactive follow-up is likely valuable.
+- "high" urgency is rare and only for time-sensitive opportunities.
+- Never include secrets, URLs, emails, phone numbers, or account IDs in reason.
+- Output JSON only.`;
+
+type InterpretedKind = "task_detected" | "meeting_started" | "code_edited";
+
+export interface RelevanceDecision {
+  decision: RelevanceDecisionKind;
+  urgency: RelevanceUrgency;
+  reason?: string;
+}
+
+interface ActNowOutcome {
+  triggeredWake: boolean;
+  blockedByBudget: boolean;
+  wakeConversationId?: string;
+}
+
+export interface PerceptionRelevanceGateOptions {
+  getProvider?: () => Promise<Provider | null>;
+  now?: () => Date;
+  hourlyActNowBudget?: number;
+  timeoutMs?: number;
+  wakeAgent?: (opts: {
+    conversationId: string;
+    hint: string;
+    source: string;
+  }) => Promise<WakeResult>;
+  bootstrapConversation?: () => { id: string };
+  deleteConversation?: (conversationId: string) => void;
+  getCheckpoint?: (key: string) => string | null;
+  setCheckpoint?: (key: string, value: string) => void;
+}
+
+export class PerceptionRelevanceGate {
+  private readonly getProvider: () => Promise<Provider | null>;
+  private readonly now: () => Date;
+  private readonly hourlyActNowBudget: number;
+  private readonly timeoutMs: number;
+  private readonly wakeAgent: (opts: {
+    conversationId: string;
+    hint: string;
+    source: string;
+  }) => Promise<WakeResult>;
+  private readonly bootstrapConversation: () => { id: string };
+  private readonly deleteConversation: (conversationId: string) => void;
+  private readonly getCheckpoint: (key: string) => string | null;
+  private readonly setCheckpoint: (key: string, value: string) => void;
+  private subscription: AssistantEventSubscription | null = null;
+  private hub: AssistantEventHub | null = null;
+
+  constructor(options: PerceptionRelevanceGateOptions = {}) {
+    this.getProvider =
+      options.getProvider ?? (() => getConfiguredProvider("perception"));
+    this.now = options.now ?? (() => new Date());
+    this.hourlyActNowBudget =
+      options.hourlyActNowBudget ?? DEFAULT_HOURLY_ACT_NOW_BUDGET;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.wakeAgent =
+      options.wakeAgent ??
+      ((opts) =>
+        wakeAgentForOpportunity({
+          conversationId: opts.conversationId,
+          hint: opts.hint,
+          source: opts.source,
+        }));
+    this.bootstrapConversation =
+      options.bootstrapConversation ??
+      (() =>
+        bootstrapConversation({
+          conversationType: "background",
+          source: "perception_proactive",
+          origin: "watcher",
+          systemHint: "Perception proactive check",
+          groupId: "system:background",
+        }));
+    this.deleteConversation = options.deleteConversation ?? deleteConversation;
+    this.getCheckpoint = options.getCheckpoint ?? getMemoryCheckpoint;
+    this.setCheckpoint = options.setCheckpoint ?? setMemoryCheckpoint;
+  }
+
+  attach(hub: AssistantEventHub): AssistantEventSubscription {
+    if (this.subscription) return this.subscription;
+    this.hub = hub;
+    this.subscription = hub.subscribe({
+      type: "process",
+      callback: async (event) => {
+        try {
+          await this.ingest(event);
+        } catch (err) {
+          log.warn({ err }, "relevance gate ingest failed");
+        }
+      },
+    });
+    return this.subscription;
+  }
+
+  detach(): void {
+    this.subscription?.dispose();
+    this.subscription = null;
+    this.hub = null;
+  }
+
+  async ingest(event: unknown): Promise<void> {
+    const type = getEventType(event);
+    if (!type || !type.startsWith(`${PERCEPTION_EVENT_TYPE_PREFIX}.`)) return;
+
+    const message = getEventMessage(event);
+    if (!message) return;
+    const candidate = extractPerceptionPayload(message);
+
+    let parsed: PerceptionEvent;
+    try {
+      parsed = parsePerceptionEvent(candidate);
+    } catch {
+      return;
+    }
+
+    if (!isInterpretedKind(parsed.payload.kind)) return;
+
+    const decision = await this.classify(parsed);
+    const outcome: ActNowOutcome =
+      decision.decision === "act-now"
+        ? await this.maybeTriggerActNow(parsed, decision)
+        : { triggeredWake: false, blockedByBudget: false };
+    await this.emitDecisionEvent(parsed, decision, outcome);
+  }
+
+  private async classify(event: PerceptionEvent): Promise<RelevanceDecision> {
+    const provider = await this.getProvider();
+    if (!provider) return fallbackDecision(event);
+
+    const prompt = JSON.stringify(
+      {
+        eventId: event.eventId,
+        ts: event.ts,
+        kind: event.payload.kind,
+        payload: event.payload,
+      },
+      null,
+      2,
+    );
+
+    try {
+      const response = await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: prompt }] }],
+        undefined,
+        RELEVANCE_PROMPT,
+        {
+          signal: AbortSignal.timeout(this.timeoutMs),
+          config: { callSite: "perception", max_tokens: 256 },
+        },
+      );
+      const text = response.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n")
+        .trim();
+      const parsed = RelevanceDecisionSchema.safeParse(
+        parseJsonObjectFromText(text),
+      );
+      if (!parsed.success) return fallbackDecision(event);
+      return {
+        decision: parsed.data.decision,
+        urgency: parsed.data.urgency ?? "low",
+        reason: sanitizeReason(parsed.data.reason),
+      };
+    } catch (err) {
+      log.debug({ err }, "relevance classification failed");
+      return fallbackDecision(event);
+    }
+  }
+
+  private async maybeTriggerActNow(
+    event: PerceptionEvent,
+    decision: RelevanceDecision,
+  ): Promise<ActNowOutcome> {
+    const nowMs = this.now().getTime();
+    const prior = this.readRecentActNowTimestamps(nowMs);
+    if (
+      decision.urgency !== "high" &&
+      prior.length >= this.hourlyActNowBudget
+    ) {
+      log.info(
+        {
+          eventId: event.eventId,
+          kind: event.payload.kind,
+          hourlyActNowBudget: this.hourlyActNowBudget,
+        },
+        "act-now skipped due to hourly interruption budget",
+      );
+      this.writeActNowTimestamps(prior);
+      return { triggeredWake: false, blockedByBudget: true };
+    }
+
+    const conversation = this.bootstrapConversation();
+    const current = [...prior, nowMs];
+    this.writeActNowTimestamps(current);
+
+    const hint = buildActNowHint(event, decision);
+    const wake = await this.wakeAgent({
+      conversationId: conversation.id,
+      hint,
+      source: "perception_proactive",
+    });
+
+    if (!wake.invoked) {
+      // Roll back budget consumption for failed wake attempts.
+      this.writeActNowTimestamps(prior);
+      try {
+        this.deleteConversation(conversation.id);
+      } catch (err) {
+        log.warn({ err, conversationId: conversation.id }, "failed cleanup");
+      }
+      return { triggeredWake: false, blockedByBudget: false };
+    }
+
+    log.info(
+      {
+        eventId: event.eventId,
+        kind: event.payload.kind,
+        urgency: decision.urgency,
+        conversationId: conversation.id,
+      },
+      "act-now proactive wake invoked",
+    );
+    return {
+      triggeredWake: true,
+      blockedByBudget: false,
+      wakeConversationId: conversation.id,
+    };
+  }
+
+  private async emitDecisionEvent(
+    sourceEvent: PerceptionEvent,
+    decision: RelevanceDecision,
+    outcome: ActNowOutcome,
+  ): Promise<void> {
+    if (!this.hub) return;
+
+    const emittedAt = this.now().toISOString();
+    const eventId = `relevance-${sourceEvent.eventId}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    const perceptionEvent: PerceptionEvent = {
+      eventId,
+      ts: emittedAt,
+      source: {
+        module: "assistant/perception-relevance-gate",
+      },
+      payload: {
+        kind: "relevance_scored",
+        sourceEventId: sourceEvent.eventId,
+        sourceKind: sourceEvent.payload.kind as InterpretedKind,
+        decision: decision.decision,
+        urgency: decision.urgency,
+        reason: decision.reason,
+        triggeredWake: outcome.triggeredWake,
+        blockedByBudget: outcome.blockedByBudget,
+        wakeConversationId: outcome.wakeConversationId,
+      },
+    };
+
+    try {
+      await this.hub.publish({
+        id: eventId,
+        emittedAt,
+        message: {
+          type: perceptionEventType("relevance_scored"),
+          perception: perceptionEvent,
+        },
+      } as never);
+    } catch (err) {
+      log.warn({ err, eventId }, "failed to publish relevance_scored event");
+    }
+  }
+
+  private readRecentActNowTimestamps(nowMs: number): number[] {
+    const raw = this.getCheckpoint(ACT_NOW_BUDGET_KEY);
+    if (!raw) return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    const cutoff = nowMs - HOUR_MS;
+    return parsed
+      .map((value) => (typeof value === "number" ? value : Number.NaN))
+      .filter((value) => Number.isFinite(value) && value >= cutoff);
+  }
+
+  private writeActNowTimestamps(timestamps: number[]): void {
+    this.setCheckpoint(ACT_NOW_BUDGET_KEY, JSON.stringify(timestamps));
+  }
+}
+
+function parseJsonObjectFromText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // continue with extraction fallback
+  }
+
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) {
+    return JSON.parse(fenced[1].trim());
+  }
+
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    return JSON.parse(text.slice(start, end + 1));
+  }
+  throw new Error("missing JSON object");
+}
+
+function sanitizeReason(reason: string | undefined): string | undefined {
+  return sanitizeOptional(reason, 240);
+}
+
+function fallbackDecision(event: PerceptionEvent): RelevanceDecision {
+  if (
+    event.payload.kind === "meeting_started" &&
+    event.payload.confidence >= 0.9
+  ) {
+    return {
+      decision: "act-now",
+      urgency: "high",
+      reason: "High-confidence meeting transition detected.",
+    };
+  }
+  if (
+    event.payload.kind === "task_detected" &&
+    event.payload.confidence >= 0.85
+  ) {
+    return {
+      decision: "maybe-act",
+      urgency: "medium",
+      reason: "Potentially actionable task context.",
+    };
+  }
+  if (event.payload.kind === "code_edited" && event.payload.confidence >= 0.8) {
+    return {
+      decision: "remember",
+      urgency: "low",
+      reason: "Useful coding context for future turns.",
+    };
+  }
+  return { decision: "ignore", urgency: "low", reason: "Low-signal context." };
+}
+
+function buildActNowHint(
+  event: PerceptionEvent,
+  decision: RelevanceDecision,
+): string {
+  const payloadText = sanitizeHintText(JSON.stringify(event.payload));
+  return `Perception triggered an act-now opportunity.
+
+Event kind: ${event.payload.kind}
+Event id: ${event.eventId}
+Urgency: ${decision.urgency}
+Reason: ${decision.reason ?? "not provided"}
+Payload (redacted): ${payloadText}
+
+Decide whether a proactive outreach is appropriate right now. If yes, produce a concise, high-signal proactive message. If not, do a silent no-op.`;
+}
+
+function sanitizeHintText(value: string): string {
+  return sanitizeText(value, 500);
+}
+
+function isInterpretedKind(kind: string): kind is InterpretedKind {
+  return (
+    kind === "task_detected" ||
+    kind === "meeting_started" ||
+    kind === "code_edited"
+  );
+}
+
+function getEventType(event: unknown): string | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  const type = (message as { type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function getEventMessage(event: unknown): Record<string, unknown> | undefined {
+  if (!event || typeof event !== "object") return undefined;
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  return message as Record<string, unknown>;
+}
+
+function extractPerceptionPayload(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  const nested = message.perception;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return message;
+}

--- a/assistant/src/perception/sanitization.ts
+++ b/assistant/src/perception/sanitization.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared redaction utilities for perception payloads.
+ *
+ * Single source of truth for the patterns used by:
+ *   - `PerceptionInterpreter` when sanitizing LLM-produced text
+ *   - `PerceptionRelevanceGate` when sanitizing reason + proactive wake hints
+ *   - HTTP publish-route defense-in-depth on caller-provided fields
+ *
+ * The producer is always expected to redact at capture time, but every
+ * crossing of a process boundary re-applies these patterns so a buggy or
+ * compromised producer can never leak raw secrets into the daemon's event
+ * hub, memory buffer, or persisted memory.
+ */
+
+const REDACTION_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  {
+    pattern: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+    replacement: "[redacted-email]",
+  },
+  {
+    pattern: /\bhttps?:\/\/\S+/gi,
+    replacement: "[redacted-url]",
+  },
+  {
+    pattern: /\+?\d[\d()\-\s]{7,}\d/g,
+    replacement: "[redacted-phone]",
+  },
+  {
+    pattern:
+      /\b(?:api[_-]?key|token|secret|passwd|password)[=:]?[A-Za-z0-9._-]{8,}\b/gi,
+    replacement: "[redacted-secret]",
+  },
+  {
+    pattern:
+      /\b(?:acct|account|user|org|workspace|team|project)[_-]?[A-Za-z0-9]{3,}\b/gi,
+    replacement: "[redacted-account-id]",
+  },
+];
+
+/**
+ * Apply the canonical redaction patterns and collapse whitespace.
+ *
+ * `maxLength` truncates the result to a per-call-site safe budget. Callers
+ * should pick a budget that matches the schema constraint they emit into
+ * (e.g. 320 for `summary`, 240 for relevance `reason`).
+ */
+export function sanitizeText(value: string, maxLength: number): string {
+  let result = value;
+  for (const { pattern, replacement } of REDACTION_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result.replace(/\s+/g, " ").trim().slice(0, maxLength);
+}
+
+/** Same as `sanitizeText` but preserves `undefined` for missing fields. */
+export function sanitizeOptional(
+  value: string | undefined,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const cleaned = sanitizeText(value, maxLength);
+  return cleaned.length > 0 ? cleaned : undefined;
+}

--- a/assistant/src/perception/startup.ts
+++ b/assistant/src/perception/startup.ts
@@ -1,0 +1,90 @@
+/**
+ * Perception spine startup.
+ *
+ * Creates the process-wide `ContextBuffer` and attaches it to the shared
+ * `assistantEventHub` when the `perception` feature flag is on. A no-op
+ * when the flag is off, so calling this unconditionally from daemon
+ * startup is safe.
+ *
+ * Per the daemon-startup philosophy (see `assistant/AGENTS.md`), this
+ * module must never throw. Failures are logged and the perception buffer
+ * is left null, so the rest of the daemon keeps running.
+ *
+ * Roadmap: `docs/jarvis-roadmap.md`.
+ */
+
+import { getConfig } from "../config/loader.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import { ContextBuffer } from "./context-buffer.js";
+import { isPerceptionEnabled } from "./feature-gate.js";
+import { PerceptionInterpreter } from "./interpreter.js";
+import { PersonalKnowledgeWriter } from "./personal-knowledge-writer.js";
+import { PerceptionRelevanceGate } from "./relevance-gate.js";
+
+const log = getLogger("perception-startup");
+
+let active: ContextBuffer | null = null;
+let activeInterpreter: PerceptionInterpreter | null = null;
+let activeRelevanceGate: PerceptionRelevanceGate | null = null;
+let activePersonalKnowledgeWriter: PersonalKnowledgeWriter | null = null;
+
+/**
+ * Initialise the perception spine. Safe to call multiple times; subsequent
+ * calls are no-ops once the buffer is attached.
+ */
+export function startPerception(): void {
+  if (active) return;
+  try {
+    const config = getConfig();
+    if (!isPerceptionEnabled(config)) {
+      log.debug("perception flag off; skipping startup");
+      return;
+    }
+  } catch (err) {
+    log.warn({ err }, "failed to read config; perception not started");
+    return;
+  }
+
+  try {
+    const buffer = new ContextBuffer();
+    buffer.attach(assistantEventHub);
+    active = buffer;
+    const interpreter = new PerceptionInterpreter();
+    interpreter.attach(assistantEventHub);
+    activeInterpreter = interpreter;
+    const relevanceGate = new PerceptionRelevanceGate();
+    relevanceGate.attach(assistantEventHub);
+    activeRelevanceGate = relevanceGate;
+    const personalKnowledgeWriter = new PersonalKnowledgeWriter();
+    personalKnowledgeWriter.attach(assistantEventHub);
+    activePersonalKnowledgeWriter = personalKnowledgeWriter;
+    log.info("perception spine started");
+  } catch (err) {
+    log.warn({ err }, "perception spine failed to start");
+  }
+}
+
+/**
+ * Return the active perception buffer, or `null` if the feature is off or
+ * startup hasn't run yet. Consumers (future IPC routes, tools) must handle
+ * the null case rather than assume the buffer exists.
+ */
+export function getPerceptionBuffer(): ContextBuffer | null {
+  return active;
+}
+
+/**
+ * Tear down the perception spine. Used by tests and shutdown handlers.
+ */
+export function stopPerception(): void {
+  activePersonalKnowledgeWriter?.detach();
+  activePersonalKnowledgeWriter = null;
+  activeRelevanceGate?.detach();
+  activeRelevanceGate = null;
+  activeInterpreter?.detach();
+  activeInterpreter = null;
+  if (!active) return;
+  active.detach();
+  active = null;
+}

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -18,7 +18,9 @@
  * | `pkb-context`            | 30    | after-memory-prefix     |
  * | `pkb-reminder`           | 35    | after-memory-prefix     |
  * | `memory-v2-static`       | 38    | after-memory-prefix     |
+ * | `perception-memory`      | 39    | after-memory-prefix     |
  * | `now-md`                 | 40    | after-memory-prefix     |
+ * | `active-plan`            | 45    | append-user-tail        |
  * | `subagent-status`        | 50    | append-user-tail        |
  * | `slack-messages`         | 60    | replace-run-messages    |
  * | `thread-focus`           | 70    | append-user-tail        |
@@ -90,7 +92,9 @@ export const DEFAULT_INJECTOR_ORDER = {
   pkbContext: 30,
   pkbReminder: 35,
   memoryV2Static: 38,
+  perceptionMemory: 39,
   nowMd: 40,
+  activePlan: 45,
   subagentStatus: 50,
   slackMessages: 60,
   threadFocus: 70,
@@ -384,6 +388,37 @@ const memoryV2StaticInjector: Injector = {
 };
 
 /**
+ * `perception-memory-context` injector — order 39, after-memory-prefix.
+ *
+ * Injects a compact perception-derived PKB snapshot (episodes/entities/
+ * preferences) as `<perception_memory>...</perception_memory>`.
+ *
+ * Gating:
+ *  - `mode === "full"`.
+ *  - `perceptionMemoryContext` is a non-null, non-empty string.
+ */
+const perceptionMemoryContextInjector: Injector = {
+  name: "perception-memory-context",
+  order: DEFAULT_INJECTOR_ORDER.perceptionMemory,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const content = inputs.perceptionMemoryContext;
+    if (!content) return null;
+    const escaped = content.replace(
+      /<\/perception_memory\s*>/gi,
+      "&lt;/perception_memory&gt;",
+    );
+    return {
+      id: "perception-memory-context",
+      text: `<perception_memory>\n${escaped}\n</perception_memory>`,
+      placement: "after-memory-prefix",
+    };
+  },
+};
+
+/**
  * Wrap the static memory content in `<memory>...</memory>`. Escapes any
  * closing `</memory>` inside the content so authored memory files cannot
  * accidentally break out of the wrapper.
@@ -418,6 +453,27 @@ const nowMdInjector: Injector = {
       id: "now-md",
       text,
       placement: "after-memory-prefix",
+    };
+  },
+};
+
+const activePlanInjector: Injector = {
+  name: "active-plan",
+  order: DEFAULT_INJECTOR_ORDER.activePlan,
+  async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+    const inputs = readInjectionInputs(ctx);
+    const mode = inputs.mode ?? "full";
+    if (mode !== "full") return null;
+    const content = inputs.activePlanContext;
+    if (!content) return null;
+    const escaped = content.replace(
+      /<\/active_plan\s*>/gi,
+      "&lt;/active_plan&gt;",
+    );
+    return {
+      id: "active-plan",
+      text: `<active_plan>\n${escaped}\n</active_plan>`,
+      placement: "append-user-tail",
     };
   },
 };
@@ -557,7 +613,9 @@ export const defaultInjectorsPlugin: Plugin = {
     pkbContextInjector,
     pkbReminderInjector,
     memoryV2StaticInjector,
+    perceptionMemoryContextInjector,
     nowMdInjector,
+    activePlanInjector,
     subagentStatusInjector,
     slackMessagesInjector,
     threadFocusInjector,

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -825,6 +825,13 @@ export interface TurnInjectionInputs {
    * the user message.
    */
   readonly memoryV2Static?: string | null;
+  /**
+   * Perception-derived personal-knowledge snapshot (episodes/entities/
+   * preferences) to inject as compact planning context. Null/undefined skips.
+   */
+  readonly perceptionMemoryContext?: string | null;
+  /** Active confirmed task-plan context for this conversation. */
+  readonly activePlanContext?: string | null;
   /** NOW.md scratchpad content or null to skip. */
   readonly nowScratchpad?: string | null;
   /** Pre-built `<active_subagents>` block or null to skip. */

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -26,6 +26,7 @@ const HOST_PREFIX_TO_CAPABILITY: Record<string, HostProxyCapability> = {
   host_cu: "host_cu",
   host_browser: "host_browser",
   host_app_control: "host_app_control",
+  host_camera: "host_camera",
 };
 
 /**
@@ -619,7 +620,6 @@ function resolveCanonicalRequestSourceType(
   if (sourceChannel === "vellum") return "desktop";
   return "channel";
 }
-
 
 /**
  * Lazily load heavy dependencies and create a canonical guardian request +

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -5,8 +5,7 @@
  * Verifies that the submitting (source) actor's principal id matches the
  * actor principal id captured for the target client at SSE subscription
  * time. This is the authoritative gate that prevents cross-user
- * execution and cross-user result submission across all three host-proxy
- * capabilities (host_bash, host_file, host_cu).
+ * execution and cross-user result submission across host-proxy capabilities.
  *
  * Two entry points map onto the two control-flow styles in the codebase:
  *   - {@link enforceSameActorOrErrorResult} for proxies — returns a
@@ -46,6 +45,7 @@ export type SameActorOp =
   | "host_file"
   | "host_cu"
   | "host_browser"
+  | "host_camera"
   | "host_transfer";
 
 /**

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,13 +1,13 @@
 /**
  * In-memory tracker that maps requestId to conversation info for pending
- * confirmation, secret, host_bash, host_file, host_cu, host_browser, and
- * host_transfer interactions.
+ * confirmation, secret, host_bash, host_file, host_cu, host_browser,
+ * host_camera, and host_transfer interactions.
  *
  * All request types self-register with their full RPC lifecycle state
  * (resolve/reject callbacks, timer, abort detach):
  *
  * - Host proxies (host_bash, host_file, host_cu, host_browser,
- *   host_app_control, host_transfer): register in request(), using
+ *   host_app_control, host_camera, host_transfer): register in request(), using
  *   rpcResolve/rpcReject/timer/detachAbort/metadata.
  *
  * - Prompters (PermissionPrompter, SecretPrompter): register in prompt(),
@@ -52,12 +52,13 @@ export interface PendingInteraction {
     | "host_cu"
     | "host_browser"
     | "host_app_control"
+    | "host_camera"
     | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
-  /** When set, the host_bash request should be routed to this specific client. */
+  /** When set, the host proxy request should be routed to this specific client. */
   targetClientId?: string;
   /**
    * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
@@ -136,13 +137,13 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, host_cu, host_browser, host_app_control, and
+ * host_bash, host_file, host_cu, host_browser, host_app_control, host_camera, and
  * host_transfer interactions are intentionally skipped — they represent
  * in-flight tool executions proxied to the client, not confirmations to
  * auto-deny. Removing them would orphan the request: the client would POST to
  * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
- * /v1/host-browser-result, /v1/host-app-control-result, or
- * /v1/host-transfer-result after completing the operation, get a 404, and the
+ * /v1/host-browser-result, /v1/host-app-control-result,
+ * /v1/host-camera-result, or /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  */
 export function removeByConversation(conversationId: string): void {
@@ -155,6 +156,7 @@ export function removeByConversation(conversationId: string): void {
       interaction.kind !== "host_cu" &&
       interaction.kind !== "host_browser" &&
       interaction.kind !== "host_app_control" &&
+      interaction.kind !== "host_camera" &&
       interaction.kind !== "host_transfer" &&
       interaction.kind !== "acp_confirmation"
     ) {

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -114,6 +114,7 @@ export function handleSubscribeAssistantEvents(
     "host_file",
     "host_cu",
     "host_app_control",
+    "host_camera",
     "host_browser",
   ];
 

--- a/assistant/src/runtime/routes/host-camera-routes.ts
+++ b/assistant/src/runtime/routes/host-camera-routes.ts
@@ -1,0 +1,131 @@
+/**
+ * Route handler for host camera result submissions.
+ *
+ * Resolves pending one-shot camera snapshot requests. The raw image bytes are
+ * forwarded only to the awaiting proxy, which summarizes and discards them.
+ */
+import { z } from "zod";
+
+import { findConversation } from "../../daemon/conversation-store.js";
+import type { HostCameraResultPayload } from "../../daemon/message-types/host-camera.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+function handleHostCameraResult({ body, headers }: RouteHandlerArgs) {
+  if (!body || typeof body !== "object") {
+    throw new BadRequestError("Request body is required");
+  }
+
+  const { requestId, imageBase64, mediaType, width, height, error } =
+    body as unknown as HostCameraResultPayload;
+
+  if (!requestId || typeof requestId !== "string") {
+    throw new BadRequestError("requestId is required");
+  }
+
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    throw new NotFoundError("No pending interaction found for this requestId");
+  }
+  if (peeked.kind !== "host_camera") {
+    throw new ConflictError(
+      `Pending interaction is of kind "${peeked.kind}", expected "host_camera"`,
+    );
+  }
+
+  if (peeked.targetClientId != null) {
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId) {
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host camera request.",
+      );
+    }
+    if (submittingClientId !== peeked.targetClientId) {
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_camera",
+    });
+  }
+
+  const interaction = pendingInteractions.resolve(requestId)!;
+  const conversation = findConversation(interaction.conversationId);
+  if (!conversation) {
+    return { accepted: true };
+  }
+
+  conversation.hostCameraProxy?.resolve(requestId, {
+    requestId,
+    ...(typeof imageBase64 === "string" ? { imageBase64 } : {}),
+    ...(mediaType ? { mediaType } : {}),
+    ...(typeof width === "number" ? { width } : {}),
+    ...(typeof height === "number" ? { height } : {}),
+    ...(typeof error === "string" ? { error } : {}),
+  });
+
+  return { accepted: true };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "host_camera_result",
+    endpoint: "host-camera-result",
+    method: "POST",
+    requireGuardian: true,
+    summary: "Submit host camera snapshot result",
+    description:
+      "Resolve a pending one-shot host camera snapshot request by requestId.",
+    tags: ["host"],
+    requestBody: z.object({
+      requestId: z.string().describe("Pending camera request ID"),
+      imageBase64: z
+        .string()
+        .describe("Base64-encoded one-shot webcam image")
+        .optional(),
+      mediaType: z.enum(["image/jpeg", "image/png", "image/webp"]).optional(),
+      width: z.number().optional(),
+      height: z.number().optional(),
+      error: z.string().optional(),
+    }),
+    responseBody: z.object({
+      accepted: z.boolean(),
+    }),
+    additionalResponses: {
+      "400": {
+        description:
+          "x-vellum-client-id header is missing for a targeted host camera request.",
+      },
+      "403": {
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+      },
+      "404": {
+        description: "No pending interaction found for the given requestId.",
+      },
+      "409": {
+        description: "Pending interaction exists but is of a different kind.",
+      },
+    },
+    handler: handleHostCameraResult,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -55,6 +55,7 @@ import { ROUTES as HOME_STATE_ROUTES } from "./home-state-routes.js";
 import { ROUTES as HOST_APP_CONTROL_ROUTES } from "./host-app-control-routes.js";
 import { ROUTES as HOST_BASH_ROUTES } from "./host-bash-routes.js";
 import { ROUTES as HOST_BROWSER_ROUTES } from "./host-browser-routes.js";
+import { ROUTES as HOST_CAMERA_ROUTES } from "./host-camera-routes.js";
 import { ROUTES as HOST_CU_ROUTES } from "./host-cu-routes.js";
 import { ROUTES as HOST_FILE_ROUTES } from "./host-file-routes.js";
 import { ROUTES as HOST_TRANSFER_ROUTES } from "./host-transfer-routes.js";
@@ -157,6 +158,7 @@ export const ROUTES: RouteDefinition[] = [
   ...HOST_APP_CONTROL_ROUTES,
   ...HOST_BASH_ROUTES,
   ...HOST_BROWSER_ROUTES,
+  ...HOST_CAMERA_ROUTES,
   ...HOST_CU_ROUTES,
   ...HOST_FILE_ROUTES,
   ...HOST_TRANSFER_ROUTES,

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -79,6 +79,8 @@ import { ROUTES as NOTIFICATION_ROUTES } from "./notification-routes.js";
 import { ROUTES as OAUTH_APPS_ROUTES } from "./oauth-apps.js";
 import { ROUTES as OAUTH_CONNECT_ROUTES } from "./oauth-connect-routes.js";
 import { ROUTES as OAUTH_PROVIDERS_ROUTES } from "./oauth-providers.js";
+import { ROUTES as PERCEPTION_ROUTES } from "./perception-routes.js";
+import { ROUTES as PERSONAL_KNOWLEDGE_ROUTES } from "./personal-knowledge-routes.js";
 import { ROUTES as PLAYGROUND_ROUTES } from "./playground/index.js";
 import { ROUTES as PROFILER_ROUTES } from "./profiler-routes.js";
 import { ROUTES as PS_ROUTES } from "./ps-routes.js";
@@ -177,6 +179,8 @@ export const ROUTES: RouteDefinition[] = [
   ...NOTIFICATION_ROUTES,
   ...OAUTH_APPS_ROUTES,
   ...OAUTH_PROVIDERS_ROUTES,
+  ...PERCEPTION_ROUTES,
+  ...PERSONAL_KNOWLEDGE_ROUTES,
   ...PLAYGROUND_ROUTES,
   ...PROFILER_ROUTES,
   ...PS_ROUTES,

--- a/assistant/src/runtime/routes/perception-http-smoke.test.ts
+++ b/assistant/src/runtime/routes/perception-http-smoke.test.ts
@@ -1,0 +1,116 @@
+/**
+ * HTTP smoke test for the Phase 1 perception vertical slice.
+ *
+ * This exercises the same runtime routes the gateway proxies for the Tauri HUD:
+ * POST one `app_focus_changed` event, then read it back from the in-memory
+ * buffer via GET /v1/perception/recent.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../../config/assistant-feature-flags.js";
+import { startPerception, stopPerception } from "../../perception/startup.js";
+import { mintToken } from "../auth/token-service.js";
+import { RuntimeHttpServer } from "../http-server.js";
+
+const TEST_JWT = mintToken({
+  aud: "vellum-daemon",
+  sub: "actor:self:test",
+  scope_profile: "actor_client_v1",
+  policy_epoch: 1,
+  ttlSeconds: 3600,
+});
+
+const AUTH_HEADERS = {
+  Authorization: `Bearer ${TEST_JWT}`,
+  "Content-Type": "application/json",
+};
+
+const event = {
+  eventId: "evt-http-smoke",
+  ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+  source: { module: "test-http" },
+  payload: {
+    kind: "app_focus_changed",
+    appId: "com.apple.Terminal",
+    appName: "Terminal",
+    windowTitle: "Eli - perception smoke",
+    redacted: false,
+  },
+};
+
+describe("perception HTTP smoke", () => {
+  let server: RuntimeHttpServer | null = null;
+  let port = 0;
+
+  beforeEach(async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+    server = new RuntimeHttpServer({ port: 0 });
+    await server.start();
+    port = server.actualPort;
+  });
+
+  afterEach(async () => {
+    await server?.stop();
+    server = null;
+    stopPerception();
+    clearFeatureFlagOverridesCache();
+  });
+
+  test("publishes and reads back recent perception context over HTTP", async () => {
+    const publish = await fetch(
+      `http://127.0.0.1:${port}/v1/perception/publish`,
+      {
+        method: "POST",
+        headers: AUTH_HEADERS,
+        body: JSON.stringify(event),
+      },
+    );
+    expect(publish.status).toBe(200);
+    await expect(publish.json()).resolves.toEqual({ accepted: true });
+
+    const recent = await fetch(
+      `http://127.0.0.1:${port}/v1/perception/recent?limit=1`,
+      {
+        headers: { Authorization: `Bearer ${TEST_JWT}` },
+      },
+    );
+    expect(recent.status).toBe(200);
+    const body = (await recent.json()) as {
+      enabled: boolean;
+      entries: Array<{ event: typeof event }>;
+    };
+    expect(body.enabled).toBe(true);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0]?.event).toMatchObject({
+      eventId: "evt-http-smoke",
+      payload: {
+        kind: "app_focus_changed",
+        appName: "Terminal",
+        windowTitle: "Eli - perception smoke",
+      },
+    });
+  });
+});

--- a/assistant/src/runtime/routes/perception-routes.test.ts
+++ b/assistant/src/runtime/routes/perception-routes.test.ts
@@ -1,0 +1,343 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../../config/assistant-feature-flags.js";
+import { getSqlite, resetDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { recordPerceptionConsentGrant } from "../../perception/consent-grants.js";
+import { startPerception, stopPerception } from "../../perception/startup.js";
+import { ROUTES } from "./perception-routes.js";
+
+const recentRoute = ROUTES.find(
+  (route) => route.operationId === "perception_recent",
+);
+const publishRoute = ROUTES.find(
+  (route) => route.operationId === "perception_publish",
+);
+
+if (!recentRoute || !publishRoute) {
+  throw new Error("perception routes are not registered");
+}
+
+const validEvent = {
+  eventId: "evt-test",
+  ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+  source: { module: "test" },
+  payload: {
+    kind: "app_focus_changed",
+    appId: "com.apple.Safari",
+    appName: "Safari",
+    windowTitle: "Example",
+    redacted: false,
+  },
+};
+
+describe("perception routes", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM perception_consent_grants");
+  });
+
+  afterEach(() => {
+    stopPerception();
+    clearFeatureFlagOverridesCache();
+  });
+
+  test("recent route reports disabled when the buffer is not started", () => {
+    const result = recentRoute.handler({ queryParams: {} });
+    expect(result).toEqual({ enabled: false, entries: [] });
+  });
+
+  test("recent route accepts documented query params", () => {
+    const result = recentRoute.handler({
+      queryParams: {
+        windowMs: "300000",
+        limit: "20",
+        kind: "app_focus_changed",
+      },
+    });
+    expect(result).toEqual({ enabled: false, entries: [] });
+  });
+
+  test("recent route rejects invalid query params", () => {
+    expect(() =>
+      recentRoute.handler({
+        queryParams: {
+          limit: "0",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("publish route validates events and reports disabled when off", async () => {
+    await expect(publishRoute.handler({ body: validEvent })).resolves.toEqual({
+      accepted: false,
+      reason: "disabled",
+    });
+  });
+
+  test("publish route rejects malformed events", async () => {
+    await expect(
+      publishRoute.handler({ body: { junk: true } }),
+    ).rejects.toThrow();
+  });
+
+  test("publish route stores events when perception is enabled", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    await expect(publishRoute.handler({ body: validEvent })).resolves.toEqual({
+      accepted: true,
+    });
+
+    const result = recentRoute.handler({ queryParams: { limit: "1" } });
+    expect(result).toMatchObject({
+      enabled: true,
+      entries: [
+        {
+          event: {
+            eventId: "evt-test",
+            payload: {
+              kind: "app_focus_changed",
+              appName: "Safari",
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("publish route accepts and redacts screen_snapshot events when consent granted", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+    recordPerceptionConsentGrant({
+      conversationId: "conv-screen",
+      eventKind: "screen_snapshot",
+    });
+
+    const event = {
+      eventId: "evt-screen",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "screen_snapshot",
+        conversationId: "conv-screen",
+        appId: "com.apple.Safari",
+        appName: "Safari",
+        windowTitle: "Doc",
+        ocrTextRedacted:
+          "Project notes: contact user@example.com for apiKey=sk_live_TOPSECRET via https://internal.example.com",
+        redacted: false,
+        captureMethod: "ocr",
+        confidence: 0.8,
+      },
+    };
+
+    await expect(publishRoute.handler({ body: event })).resolves.toEqual({
+      accepted: true,
+    });
+
+    const result = recentRoute.handler({
+      queryParams: { kind: "screen_snapshot", limit: "1" },
+    }) as {
+      enabled: boolean;
+      entries: Array<{
+        event: { payload: { ocrTextRedacted: string } };
+      }>;
+    };
+    const stored = result.entries[0]!.event.payload.ocrTextRedacted;
+    expect(stored).toContain("[redacted-email]");
+    expect(stored).toContain("[redacted-secret]");
+    expect(stored).toContain("[redacted-url]");
+    expect(stored).not.toContain("user@example.com");
+    expect(stored).not.toContain("sk_live_TOPSECRET");
+    expect(stored).not.toContain("https://internal.example.com");
+  });
+
+  test("publish route rejects screen_snapshot when consent missing", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    const event = {
+      eventId: "evt-screen-no-consent",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "screen_snapshot",
+        conversationId: "conv-no-consent",
+        appId: "com.apple.Safari",
+        appName: "Safari",
+        windowTitle: "Doc",
+        ocrTextRedacted: "harmless text",
+        redacted: false,
+        captureMethod: "ocr",
+        confidence: 0.8,
+      },
+    };
+
+    await expect(publishRoute.handler({ body: event })).resolves.toEqual({
+      accepted: false,
+      reason: "consent_required",
+    });
+  });
+
+  test("publish route accepts and redacts audio_excerpt events when consent granted", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+    recordPerceptionConsentGrant({
+      conversationId: "conv-audio",
+      eventKind: "audio_excerpt",
+    });
+
+    const event = {
+      eventId: "evt-audio",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "audio_excerpt",
+        conversationId: "conv-audio",
+        sessionId: "sess-1",
+        turnId: "turn-1",
+        transcriptRedacted:
+          "Send the apiKey=sk_live_AUDIO123 to user@example.com",
+        confidence: 0.9,
+        language: "en-US",
+      },
+    };
+
+    await expect(publishRoute.handler({ body: event })).resolves.toEqual({
+      accepted: true,
+    });
+
+    const result = recentRoute.handler({
+      queryParams: { kind: "audio_excerpt", limit: "1" },
+    }) as {
+      enabled: boolean;
+      entries: Array<{
+        event: { payload: { transcriptRedacted: string } };
+      }>;
+    };
+    const stored = result.entries[0]!.event.payload.transcriptRedacted;
+    expect(stored).toContain("[redacted-email]");
+    expect(stored).toContain("[redacted-secret]");
+    expect(stored).not.toContain("sk_live_AUDIO123");
+    expect(stored).not.toContain("user@example.com");
+  });
+
+  test("publish route rejects audio_excerpt when consent missing", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    const event = {
+      eventId: "evt-audio-no-consent",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "audio_excerpt",
+        conversationId: "conv-no-consent",
+        sessionId: "sess-1",
+        turnId: "turn-1",
+        transcriptRedacted: "hello",
+        confidence: 0.9,
+      },
+    };
+    await expect(publishRoute.handler({ body: event })).resolves.toEqual({
+      accepted: false,
+      reason: "consent_required",
+    });
+  });
+
+  test("publish route rejects screen_snapshot exceeding the 2048 char cap", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    const event = {
+      eventId: "evt-screen-too-big",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "screen_snapshot",
+        conversationId: "conv-big",
+        appId: "com.apple.Safari",
+        appName: "Safari",
+        windowTitle: "Doc",
+        ocrTextRedacted: "a".repeat(2049),
+        redacted: false,
+        captureMethod: "ocr",
+        confidence: 0.8,
+      },
+    };
+    await expect(publishRoute.handler({ body: event })).rejects.toThrow();
+  });
+
+  test("publish route rejects audio_excerpt exceeding the 1024 char cap", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    const event = {
+      eventId: "evt-audio-too-big",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "audio_excerpt",
+        conversationId: "conv-big-audio",
+        sessionId: "sess-1",
+        turnId: "turn-1",
+        transcriptRedacted: "x".repeat(1025),
+        confidence: 0.9,
+      },
+    };
+    await expect(publishRoute.handler({ body: event })).rejects.toThrow();
+  });
+
+  test("publish route redacts sensitive strings as defense-in-depth", async () => {
+    _setOverridesForTesting({ perception: true });
+    startPerception();
+
+    const dirtyEvent = {
+      eventId: "evt-dirty",
+      ts: new Date("2026-01-01T00:00:00Z").toISOString(),
+      source: { module: "test" },
+      payload: {
+        kind: "app_focus_changed",
+        appId: "com.apple.Safari",
+        appName: "Safari",
+        windowTitle:
+          "Inbox - user@example.com - apiKey=sk_live_ABCDEF123456 - https://internal.example.com",
+        redacted: false,
+      },
+    };
+
+    await expect(publishRoute.handler({ body: dirtyEvent })).resolves.toEqual({
+      accepted: true,
+    });
+
+    const result = recentRoute.handler({ queryParams: { limit: "1" } }) as {
+      enabled: boolean;
+      entries: Array<{
+        event: { payload: { windowTitle: string } };
+      }>;
+    };
+    const stored = result.entries[0]!.event.payload.windowTitle;
+    expect(stored).toContain("[redacted-email]");
+    expect(stored).toContain("[redacted-secret]");
+    expect(stored).toContain("[redacted-url]");
+    expect(stored).not.toContain("user@example.com");
+    expect(stored).not.toContain("sk_live_ABCDEF123456");
+    expect(stored).not.toContain("https://internal.example.com");
+  });
+});

--- a/assistant/src/runtime/routes/perception-routes.ts
+++ b/assistant/src/runtime/routes/perception-routes.ts
@@ -1,0 +1,239 @@
+/**
+ * Read-only perception routes.
+ *
+ * These routes expose the daemon-side, memory-only `ContextBuffer` to
+ * internal clients and first-party skills. They do not start perception,
+ * mutate memory, or request host access.
+ */
+
+import { z } from "zod";
+
+import {
+  hasActivePerceptionConsent,
+  type PerceptionConsentEventKind,
+} from "../../perception/consent-grants.js";
+import {
+  PERCEPTION_EVENT_KINDS,
+  type PerceptionEvent,
+  type PerceptionEventKind,
+  PerceptionEventSchema,
+  perceptionEventType,
+} from "../../perception/perception-event.js";
+import {
+  sanitizeOptional,
+  sanitizeText,
+} from "../../perception/sanitization.js";
+import { getPerceptionBuffer } from "../../perception/startup.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const CONSENT_GATED_KINDS = new Set<PerceptionEventKind>([
+  "screen_snapshot",
+  "audio_excerpt",
+]);
+
+function isConsentGatedKind(
+  kind: PerceptionEventKind,
+): kind is PerceptionConsentEventKind {
+  return CONSENT_GATED_KINDS.has(kind);
+}
+
+/**
+ * Defense-in-depth: scrub user-visible string fields on caller-provided
+ * perception payloads before they cross into the event hub or context buffer.
+ *
+ * The producer (Tauri/macOS capture skill) is the primary redactor, but we
+ * never trust a caller's claim that text is already redacted — Phase 9
+ * invariant: "no raw secrets". A buggy or compromised client cannot leak
+ * unredacted text past this route.
+ */
+function sanitizeIncomingPerceptionEvent(
+  event: PerceptionEvent,
+): PerceptionEvent {
+  const payload = event.payload;
+  switch (payload.kind) {
+    case "app_focus_changed":
+      return {
+        ...event,
+        payload: {
+          ...payload,
+          appId: sanitizeText(payload.appId, 256),
+          appName: sanitizeText(payload.appName, 256),
+          windowTitle: sanitizeText(payload.windowTitle, 512),
+        },
+      };
+    case "task_detected":
+      return {
+        ...event,
+        payload: {
+          ...payload,
+          label: sanitizeText(payload.label, 120),
+          summary: sanitizeText(payload.summary, 320),
+        },
+      };
+    case "meeting_started":
+      return {
+        ...event,
+        payload: { ...payload, summary: sanitizeText(payload.summary, 320) },
+      };
+    case "code_edited":
+      return {
+        ...event,
+        payload: {
+          ...payload,
+          summary: sanitizeText(payload.summary, 320),
+          workspaceHint: sanitizeOptional(payload.workspaceHint, 120),
+          languageHint: sanitizeOptional(payload.languageHint, 40),
+        },
+      };
+    case "relevance_scored":
+      return {
+        ...event,
+        payload: { ...payload, reason: sanitizeOptional(payload.reason, 240) },
+      };
+    case "screen_snapshot":
+      return {
+        ...event,
+        payload: {
+          ...payload,
+          appId: sanitizeText(payload.appId, 256),
+          appName: sanitizeText(payload.appName, 256),
+          windowTitle: sanitizeText(payload.windowTitle, 512),
+          ocrTextRedacted: sanitizeText(payload.ocrTextRedacted, 2048),
+        },
+      };
+    case "audio_excerpt":
+      return {
+        ...event,
+        payload: {
+          ...payload,
+          sessionId: sanitizeText(payload.sessionId, 128),
+          turnId: sanitizeText(payload.turnId, 128),
+          transcriptRedacted: sanitizeText(payload.transcriptRedacted, 1024),
+          language: sanitizeOptional(payload.language, 20),
+        },
+      };
+  }
+}
+
+const RecentPerceptionQuerySchema = z.object({
+  windowMs: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().positive().max(200).optional(),
+  kind: z.enum(PERCEPTION_EVENT_KINDS).optional(),
+});
+
+const BufferedPerceptionEventSchema = z.object({
+  receivedAt: z.string().datetime(),
+  event: PerceptionEventSchema,
+});
+
+const RecentPerceptionResponseSchema = z.object({
+  enabled: z.boolean(),
+  entries: z.array(BufferedPerceptionEventSchema),
+});
+
+const PublishPerceptionResponseSchema = z.object({
+  accepted: z.boolean(),
+  reason: z.enum(["disabled", "consent_required"]).optional(),
+});
+
+function handleRecentPerception({ queryParams = {} }: RouteHandlerArgs) {
+  const query = RecentPerceptionQuerySchema.parse(queryParams);
+  const buffer = getPerceptionBuffer();
+  if (!buffer) {
+    return { enabled: false, entries: [] };
+  }
+
+  const entries = buffer.recent({
+    windowMs: query.windowMs,
+    limit: query.limit,
+    kind: query.kind as PerceptionEventKind | undefined,
+  });
+
+  return {
+    enabled: true,
+    entries: entries.map((entry) => ({
+      receivedAt: entry.receivedAt.toISOString(),
+      event: entry.event,
+    })),
+  };
+}
+
+async function handlePublishPerception({ body = {} }: RouteHandlerArgs) {
+  const parsed = PerceptionEventSchema.parse(body);
+  const buffer = getPerceptionBuffer();
+  if (!buffer) {
+    return { accepted: false, reason: "disabled" as const };
+  }
+
+  const perception = sanitizeIncomingPerceptionEvent(parsed);
+
+  if (isConsentGatedKind(perception.payload.kind)) {
+    const conversationId = (perception.payload as { conversationId: string })
+      .conversationId;
+    const allowed = hasActivePerceptionConsent({
+      conversationId,
+      eventKind: perception.payload.kind,
+    });
+    if (!allowed) {
+      return { accepted: false, reason: "consent_required" as const };
+    }
+  }
+
+  await assistantEventHub.publish({
+    id: perception.eventId,
+    emittedAt: new Date().toISOString(),
+    message: {
+      type: perceptionEventType(perception.payload.kind),
+      perception,
+    },
+  } as never);
+
+  return { accepted: true };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "perception_recent",
+    endpoint: "perception/recent",
+    method: "GET",
+    handler: handleRecentPerception,
+    summary: "List recent perception events",
+    description:
+      "Read recent structured perception events from the daemon's memory-only buffer. Returns an empty result when perception is disabled.",
+    tags: ["perception"],
+    queryParams: [
+      {
+        name: "windowMs",
+        type: "integer",
+        description: "Only return events received within the last N ms.",
+      },
+      {
+        name: "limit",
+        type: "integer",
+        description: "Maximum number of events to return, most recent first.",
+      },
+      {
+        name: "kind",
+        schema: {
+          type: "string",
+          enum: [...PERCEPTION_EVENT_KINDS],
+        },
+        description: "Restrict results to a perception event kind.",
+      },
+    ],
+    responseBody: RecentPerceptionResponseSchema,
+  },
+  {
+    operationId: "perception_publish",
+    endpoint: "perception/publish",
+    method: "POST",
+    handler: handlePublishPerception,
+    summary: "Publish a perception event",
+    description:
+      "Validate and publish one structured perception event into the assistant event hub. Returns accepted=false when perception is disabled.",
+    tags: ["perception"],
+    requestBody: PerceptionEventSchema,
+    responseBody: PublishPerceptionResponseSchema,
+  },
+];

--- a/assistant/src/runtime/routes/personal-knowledge-routes.test.ts
+++ b/assistant/src/runtime/routes/personal-knowledge-routes.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import {
+  recordPkbEpisode,
+  upsertPkbEntity,
+  upsertPkbPreference,
+} from "../../memory/personal-knowledge-store.js";
+import { ROUTES } from "./personal-knowledge-routes.js";
+
+const entitiesRoute = ROUTES.find(
+  (route) => route.operationId === "personal_knowledge_entities",
+);
+const episodesRoute = ROUTES.find(
+  (route) => route.operationId === "personal_knowledge_episodes",
+);
+const preferencesRoute = ROUTES.find(
+  (route) => route.operationId === "personal_knowledge_preferences",
+);
+
+if (!entitiesRoute || !episodesRoute || !preferencesRoute) {
+  throw new Error("personal knowledge routes are not registered");
+}
+
+describe("personal knowledge routes", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM pkb_episodes");
+    sqlite.run("DELETE FROM pkb_preferences");
+    sqlite.run("DELETE FROM pkb_entities");
+  });
+
+  test("entities route searches canonical names and aliases", () => {
+    upsertPkbEntity({
+      entityType: "project",
+      canonicalName: "jarvis roadmap",
+      aliases: ["roadmap"],
+    });
+
+    const result = entitiesRoute.handler({ queryParams: { query: "roadmap" } });
+    expect((result as { entries: unknown[] }).entries).toHaveLength(1);
+  });
+
+  test("episodes route returns recent episodes", () => {
+    recordPkbEpisode({ summary: "older", happenedAt: 1000 });
+    recordPkbEpisode({ summary: "newer", happenedAt: 2000 });
+
+    const result = episodesRoute.handler({ queryParams: { limit: "1" } }) as {
+      entries: Array<{ summary: string }>;
+    };
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]?.summary).toBe("newer");
+  });
+
+  test("preferences route returns learned preferences", () => {
+    upsertPkbPreference({
+      key: "coding.language.preferred",
+      value: "TypeScript",
+      confidence: 0.9,
+      learnedFrom: "perception",
+    });
+
+    const result = preferencesRoute.handler({
+      queryParams: { limit: "10" },
+    }) as { entries: Array<{ key: string; value: string }> };
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      key: "coding.language.preferred",
+      value: "TypeScript",
+    });
+  });
+});

--- a/assistant/src/runtime/routes/personal-knowledge-routes.ts
+++ b/assistant/src/runtime/routes/personal-knowledge-routes.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+
+import {
+  findPkbEntities,
+  listPkbPreferences,
+  listRecentPkbEpisodes,
+} from "../../memory/personal-knowledge-store.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const EntitiesQuerySchema = z.object({
+  query: z.string().min(1),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+});
+
+const EpisodesQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+});
+
+const PreferencesQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(200).optional(),
+});
+
+function handlePkbEntities({ queryParams = {} }: RouteHandlerArgs) {
+  const query = EntitiesQuerySchema.parse(queryParams);
+  return {
+    entries: findPkbEntities({
+      query: query.query,
+      ...(query.limit ? { limit: query.limit } : {}),
+    }),
+  };
+}
+
+function handlePkbEpisodes({ queryParams = {} }: RouteHandlerArgs) {
+  const query = EpisodesQuerySchema.parse(queryParams);
+  return {
+    entries: listRecentPkbEpisodes({
+      ...(query.limit ? { limit: query.limit } : {}),
+    }),
+  };
+}
+
+function handlePkbPreferences({ queryParams = {} }: RouteHandlerArgs) {
+  const query = PreferencesQuerySchema.parse(queryParams);
+  return {
+    entries: listPkbPreferences({
+      ...(query.limit ? { limit: query.limit } : {}),
+    }),
+  };
+}
+
+const PkbEntitySchema = z.object({
+  id: z.string(),
+  scopeId: z.string(),
+  entityType: z.string(),
+  canonicalName: z.string(),
+  aliasesJson: z.string(),
+  attributesJson: z.string(),
+  confidence: z.number(),
+  firstSeenAt: z.number(),
+  lastSeenAt: z.number(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+const PkbEpisodeSchema = z.object({
+  id: z.string(),
+  scopeId: z.string(),
+  entityId: z.string().nullable(),
+  summary: z.string(),
+  detailsJson: z.string(),
+  happenedAt: z.number(),
+  salience: z.number(),
+  sourceConversationId: z.string().nullable(),
+  createdAt: z.number(),
+});
+
+const PkbPreferenceSchema = z.object({
+  id: z.string(),
+  scopeId: z.string(),
+  key: z.string(),
+  value: z.string(),
+  confidence: z.number(),
+  learnedFrom: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "personal_knowledge_entities",
+    endpoint: "personal-knowledge/entities",
+    method: "GET",
+    summary: "Search personal knowledge entities",
+    description:
+      "Search entity records learned from perception and conversations.",
+    tags: ["memory", "personal-knowledge"],
+    queryParams: [
+      {
+        name: "query",
+        type: "string",
+        required: true,
+        description: "Case-insensitive search string for names and aliases.",
+      },
+      {
+        name: "limit",
+        type: "integer",
+        description: "Maximum number of entities to return (default 10).",
+      },
+    ],
+    responseBody: z.object({ entries: z.array(PkbEntitySchema) }),
+    handler: handlePkbEntities,
+  },
+  {
+    operationId: "personal_knowledge_episodes",
+    endpoint: "personal-knowledge/episodes",
+    method: "GET",
+    summary: "List recent personal knowledge episodes",
+    description:
+      "Return most recent episodic memory entries written by the PKB writer.",
+    tags: ["memory", "personal-knowledge"],
+    queryParams: [
+      {
+        name: "limit",
+        type: "integer",
+        description: "Maximum number of episodes to return (default 20).",
+      },
+    ],
+    responseBody: z.object({ entries: z.array(PkbEpisodeSchema) }),
+    handler: handlePkbEpisodes,
+  },
+  {
+    operationId: "personal_knowledge_preferences",
+    endpoint: "personal-knowledge/preferences",
+    method: "GET",
+    summary: "List learned preference signals",
+    description:
+      "Return implicit preference records inferred from recurring behavior.",
+    tags: ["memory", "personal-knowledge"],
+    queryParams: [
+      {
+        name: "limit",
+        type: "integer",
+        description: "Maximum number of preferences to return (default 50).",
+      },
+    ],
+    responseBody: z.object({ entries: z.array(PkbPreferenceSchema) }),
+    handler: handlePkbPreferences,
+  },
+];

--- a/assistant/src/tools/host-camera/skill-proxy-bridge.ts
+++ b/assistant/src/tools/host-camera/skill-proxy-bridge.ts
@@ -1,0 +1,15 @@
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export function forwardHostCameraProxyTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.proxyToolResolver) {
+    return Promise.resolve({
+      content: `Cannot execute ${toolName}: no proxy resolver available. This tool requires a connected desktop client.`,
+      isError: true,
+    });
+  }
+  return context.proxyToolResolver(toolName, input);
+}

--- a/assistant/src/workspace/migrations/072-seed-perception-callsite.ts
+++ b/assistant/src/workspace/migrations/072-seed-perception-callsite.ts
@@ -1,0 +1,148 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed a cheap, bounded default for the `perception` LLM call site.
+ *
+ * The local perception interpreter is a frequent background path and should
+ * never inherit heavyweight chat defaults (`mainAgent` profile/model/effort).
+ * This migration sets low-cost defaults while preserving explicit user intent:
+ *
+ * - If `llm.callSites.perception` already has `profile`, `provider`, or `model`,
+ *   leave it unchanged.
+ * - Otherwise prefer `profile: "cost-optimized"` when that profile matches the
+ *   workspace default provider; fall back to provider+cheap-model mapping.
+ * - Seed bounded leaves only when absent.
+ */
+export const seedPerceptionCallsiteMigration: WorkspaceMigration = {
+  id: "072-seed-perception-callsite",
+  description: "Seed cost-optimized defaults for the perception LLM call site",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    const configExisted = existsSync(configPath);
+
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const defaultBlock = readObject(llm.default);
+    const provider = readString(defaultBlock?.provider) ?? "anthropic";
+    const cheapModel = resolveCheapModel(provider);
+    if (cheapModel === undefined) return;
+
+    const callSites = readObject(llm.callSites) ?? {};
+    const existing = readObject(callSites.perception) ?? {};
+    if (hasExplicitModelSelection(existing)) return;
+
+    const seeded: Record<string, unknown> = { ...existing };
+    let changed = false;
+
+    const profiles = readObject(llm.profiles) ?? {};
+    const costProfile = readObject(profiles["cost-optimized"]);
+    if (readString(costProfile?.provider) === provider) {
+      seeded.profile = "cost-optimized";
+    } else {
+      seeded.provider = provider;
+      seeded.model = cheapModel;
+    }
+    changed = true;
+
+    changed = seedMissingLeaf(seeded, "maxTokens", 1024) || changed;
+    changed = seedMissingLeaf(seeded, "effort", "low") || changed;
+    changed = seedMissingLeaf(seeded, "temperature", 0) || changed;
+
+    const thinking = readObject(seeded.thinking) ?? {};
+    const seededThinking = { ...thinking };
+    const thinkingEnabledChanged = seedMissingLeaf(
+      seededThinking,
+      "enabled",
+      false,
+    );
+    const thinkingStreamChanged = seedMissingLeaf(
+      seededThinking,
+      "streamThinking",
+      false,
+    );
+    if (thinkingEnabledChanged || thinkingStreamChanged) {
+      seeded.thinking = seededThinking;
+      changed = true;
+    }
+
+    const contextWindow = readObject(seeded.contextWindow) ?? {};
+    const seededContextWindow = { ...contextWindow };
+    const contextChanged = seedMissingLeaf(
+      seededContextWindow,
+      "maxInputTokens",
+      8_000,
+    );
+    if (contextChanged) {
+      seeded.contextWindow = seededContextWindow;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    callSites.perception = seeded;
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: perception should not silently regress to expensive defaults.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const CHEAP_MODELS_BY_PROVIDER: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-5.4-nano",
+  gemini: "gemini-3-flash",
+  ollama: "llama3.2",
+  fireworks: "accounts/fireworks/models/kimi-k2p5",
+  openrouter: "anthropic/claude-haiku-4.5",
+  minimax: "abab6.5s-chat",
+};
+
+function resolveCheapModel(provider: string): string | undefined {
+  return CHEAP_MODELS_BY_PROVIDER[provider];
+}
+
+function hasExplicitModelSelection(value: Record<string, unknown>): boolean {
+  return "profile" in value || "provider" in value || "model" in value;
+}
+
+function seedMissingLeaf(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean {
+  if (key in target) return false;
+  target[key] = value;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/073-seed-preference-feedback-callsite.ts
+++ b/assistant/src/workspace/migrations/073-seed-preference-feedback-callsite.ts
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed a cheap, bounded default for the `preferenceFeedback` LLM call site.
+ *
+ * The post-turn preference-feedback observer runs once per assistant turn and
+ * should never inherit heavyweight chat defaults. Mirrors the seeding logic
+ * used by `072-seed-perception-callsite.ts`:
+ *
+ * - If `llm.callSites.preferenceFeedback` already has `profile`, `provider`,
+ *   or `model`, leave it unchanged.
+ * - Otherwise prefer `profile: "cost-optimized"` when that profile matches the
+ *   workspace default provider; fall back to provider+cheap-model mapping.
+ * - Seed bounded leaves only when absent.
+ */
+export const seedPreferenceFeedbackCallsiteMigration: WorkspaceMigration = {
+  id: "073-seed-preference-feedback-callsite",
+  description:
+    "Seed cost-optimized defaults for the preferenceFeedback LLM call site",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown> = {};
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const defaultBlock = readObject(llm.default);
+    const provider = readString(defaultBlock?.provider) ?? "anthropic";
+    const cheapModel = resolveCheapModel(provider);
+    if (cheapModel === undefined) return;
+
+    const callSites = readObject(llm.callSites) ?? {};
+    const existing = readObject(callSites.preferenceFeedback) ?? {};
+    if (hasExplicitModelSelection(existing)) return;
+
+    const seeded: Record<string, unknown> = { ...existing };
+    let changed = false;
+
+    const profiles = readObject(llm.profiles) ?? {};
+    const costProfile = readObject(profiles["cost-optimized"]);
+    if (readString(costProfile?.provider) === provider) {
+      seeded.profile = "cost-optimized";
+    } else {
+      seeded.provider = provider;
+      seeded.model = cheapModel;
+    }
+    changed = true;
+
+    changed = seedMissingLeaf(seeded, "maxTokens", 512) || changed;
+    changed = seedMissingLeaf(seeded, "effort", "low") || changed;
+    changed = seedMissingLeaf(seeded, "temperature", 0) || changed;
+
+    const thinking = readObject(seeded.thinking) ?? {};
+    const seededThinking = { ...thinking };
+    const thinkingEnabledChanged = seedMissingLeaf(
+      seededThinking,
+      "enabled",
+      false,
+    );
+    const thinkingStreamChanged = seedMissingLeaf(
+      seededThinking,
+      "streamThinking",
+      false,
+    );
+    if (thinkingEnabledChanged || thinkingStreamChanged) {
+      seeded.thinking = seededThinking;
+      changed = true;
+    }
+
+    const contextWindow = readObject(seeded.contextWindow) ?? {};
+    const seededContextWindow = { ...contextWindow };
+    const contextChanged = seedMissingLeaf(
+      seededContextWindow,
+      "maxInputTokens",
+      4_000,
+    );
+    if (contextChanged) {
+      seeded.contextWindow = seededContextWindow;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    callSites.preferenceFeedback = seeded;
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: feedback observer should not silently regress to expensive defaults.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const CHEAP_MODELS_BY_PROVIDER: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-5.4-nano",
+  gemini: "gemini-3-flash",
+  ollama: "llama3.2",
+  fireworks: "accounts/fireworks/models/kimi-k2p5",
+  openrouter: "anthropic/claude-haiku-4.5",
+  minimax: "abab6.5s-chat",
+};
+
+function resolveCheapModel(provider: string): string | undefined {
+  return CHEAP_MODELS_BY_PROVIDER[provider];
+}
+
+function hasExplicitModelSelection(value: Record<string, unknown>): boolean {
+  return "profile" in value || "provider" in value || "model" in value;
+}
+
+function seedMissingLeaf(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean {
+  if (key in target) return false;
+  target[key] = value;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -69,6 +69,8 @@ import { releaseNotesLocalTimezoneMigration } from "./068-release-notes-local-ti
 import { seedOnboardingThreadsMigration } from "./069-seed-onboarding-threads.js";
 import { memoryV2SummarySchemaRebuildMigration } from "./070-memory-v2-summary-schema-rebuild.js";
 import { removeSafeStorageReleaseNoteMigration } from "./071-remove-safe-storage-release-note.js";
+import { seedPerceptionCallsiteMigration } from "./072-seed-perception-callsite.js";
+import { seedPreferenceFeedbackCallsiteMigration } from "./073-seed-preference-feedback-callsite.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -149,4 +151,6 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedOnboardingThreadsMigration,
   memoryV2SummarySchemaRebuildMigration,
   removeSafeStorageReleaseNoteMigration,
+  seedPerceptionCallsiteMigration,
+  seedPreferenceFeedbackCallsiteMigration,
 ];

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -8,6 +8,7 @@ public protocol HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool
     func postFileResult(_ result: HostFileResultPayload) async -> Bool
     func postCuResult(_ result: HostCuResultPayload) async -> Bool
+    func postCameraResult(_ result: HostCameraResultPayload) async -> Bool
     func postAppControlResult(_ result: HostAppControlResultPayload) async -> Bool
     func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool
     func postTransferResult(_ result: HostTransferResultPayload) async -> Bool
@@ -80,6 +81,29 @@ public struct HostProxyClient: HostProxyClientProtocol {
             return true
         } catch {
             log.error("postCuResult error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func postCameraResult(_ result: HostCameraResultPayload) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(result)
+            let timeout: TimeInterval = result.imageBase64 != nil
+                ? max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
+                : 30
+            let response = try await GatewayHTTPClient.post(
+                path: "host-camera-result",
+                body: body,
+                extraHeaders: ["X-Vellum-Client-Id": DeviceIdStore.getOrCreate()],
+                timeout: timeout
+            )
+            guard response.isSuccess else {
+                log.error("postCameraResult failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("postCameraResult error: \(error.localizedDescription)")
             return false
         }
     }

--- a/docs/jarvis-roadmap.md
+++ b/docs/jarvis-roadmap.md
@@ -1,0 +1,1034 @@
+# JARVIS Roadmap
+
+> Living document. Every meaningful step ships an update at the bottom in the
+> **Progress Log**. Old entries are never rewritten — only superseded by new
+> entries.
+
+## North star
+
+A locally-trusted assistant that:
+
+1. **Perceives** what is happening on the user's machine continuously.
+2. **Judges** what is worth remembering, surfacing, or acting on.
+3. **Acts** through narrow, audited, permissioned host capabilities.
+4. **Speaks** at human cadence with full context awareness.
+5. **Remembers** people, projects, and preferences over time.
+
+Differentiator vs. an "open Claw"-style demo: every host capability is scoped,
+default-off, approval-gated, and audited. Security is the moat, not an
+afterthought.
+
+## Capability gap analysis
+
+| Capability | Today | Target |
+|---|---|---|
+| Ambient perception (screen, audio, app, editor) | Nothing continuous | Local low-cost stream, structured signals, on-device privacy gate |
+| Local interpreter (cheap brain) | None | Skill-isolated process emitting `perception.*` events |
+| Signal bus / relevance gate | `assistantEventHub` exists | Extended with perception event family + relevance scoring |
+| Proactive trigger | `wakeAgentForOpportunity` exists for bulletins | Hooked to perception signals with interruption budget |
+| Action reliability | Host proxy paths exist | Standard wrapper: precondition → capture → do → verify → rollback |
+| Personal knowledge layer | Qdrant + db memory | Entities, episodes, learned preferences |
+| Multi-tier model orchestration | Call-site profiles exist | Perception / reflex / main / deliberation tiers populated |
+| Voice fusion | Live voice in progress | Perception context injected into voice session |
+| Security: capabilities, approvals, audit | Trust rules + CES exist | Per-capability default-off + ephemeral grants + audit on every host action |
+
+## Architecture target
+
+```
+[Eyes/Ears on device]  ->  [Local perception model]  ->  [Signal bus]
+                                                            |
+                                              [Relevance + privacy gate]
+                                                            |
+                              +-----------------------------+-----------------------------+
+                              |                             |                             |
+                       [Memory writer]            [Proactive trigger]           [On-demand agent]
+                                                            |                             |
+                                                            +--------------+--------------+
+                                                                           |
+                                                              [Policy / approval gate]
+                                                                           |
+                                                                  [Host proxy tools]
+                                                                           |
+                                                              [Verification + rollback]
+```
+
+Sensitive data never leaves the device unredacted. Only **structured events**
+cross the daemon boundary; raw frames stay in the perception process's local
+ring buffer and are dropped on TTL.
+
+## Phases
+
+Phases are ordered by leverage, not by ease. Each one has a vertical-slice
+exit criterion that proves the spine works end-to-end before we widen it.
+
+### Phase 1 — Perception spine (vertical slice)
+Goal: prove the full loop with the minimum useful set of signals.
+
+**Exit criterion:** ask the assistant "what was I working on five minutes
+ago?" and get a correct answer derived from perception events, not chat
+history.
+
+Scope:
+- Event contract in `assistant/src/perception/perception-event.ts`.
+- Daemon-side `ContextBuffer` ring (in-memory, TTL'd) subscribed to
+  `perception.*` events on `assistantEventHub`.
+- `getRecentContext()` tool exposed to the main agent.
+- Tauri client emits two signals: active app + window title (no screenshots
+  this round).
+- New skill `skills/perception/` (process) that consumes Tauri pushes and
+  republishes typed events via the existing `host.events.publish` IPC.
+- Feature flag `perception` in the assistant feature flag registry, default
+  off.
+- Blocklist enforced at the source (Tauri) before any signal crosses IPC.
+
+Out of scope for this phase: screenshots, OCR, audio context, editor
+context, proactive triggers, knowledge graph. Those land in later phases.
+
+### Phase 2 — Local interpreter
+- [x] Cheap LLM call site `llm.callSites.perception` resolved through existing
+  resolver.
+- [x] Frame → event extractor (e.g. `task_detected`, `meeting_started`,
+  `code_edited`).
+- [x] PII redaction before publish.
+
+### Phase 3 — Relevance + proactive trigger
+- [x] Relevance scorer (tiny model) classifies events into ignore /
+  remember / maybe-act / act-now.
+- [x] `act-now` hooks into `wakeAgentForOpportunity` (the same path
+  `UPDATES.md` already uses).
+- [x] Per-hour interruption budget; high-urgency override.
+
+### Phase 4 — Execution reliability wrapper
+- `assistant/src/actions/run-action.ts` standard wrapper.
+- HUD status strip fed from action lifecycle events.
+- Audit log entry per action.
+
+### Phase 5 — Personal knowledge layer
+- Workspace migration adds entity / episode tables.
+- Writers in memory module, readers exposed as agent tools.
+- Implicit preference learning.
+
+### Phase 6 — Voice fusion
+- Perception context injected as system input on the live-voice session.
+- Voice can hand off mid-utterance to the action wrapper.
+
+### Phase 7 — Multi-tier model orchestration polish
+- [x] Populate perception / reflex / deliberation tiers explicitly.
+- [x] Document tier responsibilities and expose them in config API responses.
+
+### Phase 8 — Multi-device handoff
+- [x] Single coherent session across desktop, browser extension, mobile.
+  - Shared default handoff key unifies local first-party interfaces.
+  - Client wiring now explicitly adopts/restores this key in local desktop/HUD
+    send paths and pre-send normalization.
+
+### Phase 9 — Continuous security hardening
+- [x] Capability declarations, ephemeral grants, audit rotation, redaction
+  guard tests. Runs alongside every phase, not last.
+  - Added guard coverage around handoff key scoping and non-local isolation.
+  - Expanded perception redaction guards for token/account-id patterns in
+    both emitted events and proactive hint paths.
+
+### Phase 10 — Jarvis vertical-slice MVPs (in flight)
+
+Three coordinated MVPs landing in parallel. Each phase ships behind a
+default-off feature flag with its own migration set and guard tests.
+
+#### Phase 10A — Autonomous execution engine
+
+- [x] Migration 241: `plans`, `plan_steps`, `plan_step_runs` (shape mirrors
+  `schedule_jobs/_runs` so the crash-recovery template translates).
+- [x] Store API at `assistant/src/plans/plan-store.ts` — idempotent on
+  `(plan_id, step.order, attempt)`.
+- [x] Runner at `assistant/src/plans/run-plan.ts` — stepwise dispatcher,
+  each step wrapped with `runAction` for uniform audit + lifecycle, plus
+  `plan_lifecycle` + `plan_step_lifecycle` client broadcasts via
+  `assistant/src/daemon/message-types/plans.ts`.
+- [x] Crash recovery at `assistant/src/plans/recovery.ts`; called from
+  `assistant/src/daemon/lifecycle.ts` after schedule recovery, before the
+  main agent loop boots.
+- [x] HTTP/IPC routes at `assistant/src/runtime/routes/plan-routes.ts`:
+  `GET /v1/plans`, `GET /v1/plans/:id`, `POST /v1/plans/:id/cancel`.
+- [x] Feature flag `autonomous-execution` (default off) +
+  `skills/plans/SKILL.md` + `skills/plans/scripts/plan-control.ts`.
+
+#### Phase 10B — Memory maturation
+
+- [x] Migration 242 — `evidence_count` / `provenance_json` /
+  `last_reinforced_at` on `pkb_entities`; counter columns
+  (`evidence_count`, `positive_count`, `negative_count`,
+  `last_reinforced_at`, `last_contradicted_at`) on `pkb_preferences`;
+  `idempotency_key` partial-unique on `pkb_episodes`.
+- [x] Store API rewrite: counter-weighted entity confidence, signed
+  preference merges, idempotent episode writes, `scorePkb*` helpers.
+- [x] Hourly `pkb-decay` worker + post-turn `preference-feedback`
+  observer + new `preferenceFeedback` LLM call-site (workspace
+  migration 073).
+- [x] `personal-knowledge-context.ts` switched to scoring-based
+  selection; feature flag `memory-maturation`.
+
+#### Phase 10C — Multimodal perception
+
+- [x] Migration 243 — `perception_consent_grants` table backs the
+  per-conversation gate without inventing a new approval primitive.
+- [x] `screen_snapshot` + `audio_excerpt` payload schemas in
+  `assistant/src/perception/perception-event.ts`; defense-in-depth
+  sanitizer extension in `perception-routes.ts`.
+- [x] Live-voice `stt_final` publishes `audio_excerpt`; macOS
+  `WatchSession.swift` publishes `screen_snapshot` alongside the legacy
+  `watch_observation` path.
+- [x] Consent flow wired through the new `consent-grants.ts` store; the
+  daemon reuses the existing `confirmation_request` → `POST /v1/confirm`
+  (`allow_conversation`) path to populate it. Routes reject with
+  `consent_required` when missing.
+- [x] Feature flags `perception-screen-snapshot` +
+  `perception-audio-excerpt`, both default off. Tauri Rust screen
+  capture explicitly deferred to MVP+1.
+
+## Phase 1 work plan (active)
+
+Concrete tasks, in order. Status icons: `[ ]` pending, `[~]` in flight,
+`[x]` done.
+
+- [x] Roadmap doc (this file) + progress log scaffold.
+- [x] Draft typed perception event contract
+  (`assistant/src/perception/perception-event.ts`).
+- [x] Add `ContextBuffer` ring with TTL and `recent({ window })` query.
+- [x] Wire `ContextBuffer` to subscribe to `perception.*` on
+  `assistantEventHub` (`attach()` method).
+- [x] Add `perception` flag to
+  `meta/feature-flags/feature-flag-registry.json` (scope: assistant,
+  default off) + sync to bundled copies.
+- [x] Add startup module (`perception/startup.ts`) that creates the
+  singleton when the flag is on; safe no-op otherwise.
+- [x] Tests: ingest happy path + ignore non-perception + drop malformed
+  + capacity eviction + TTL expiry + `windowMs`/`limit`/`kind` filters
+  + hub attach/detach idempotency.
+- [x] Call `startPerception()` from the daemon lifecycle startup sequence.
+- [x] Add `GET /v1/perception/recent` shared route that proxies to
+  `getPerceptionBuffer().recent(...)` and returns disabled/empty when
+  the flag is off or startup has not attached the buffer.
+- [x] Add `skills/perception/` scaffold and bundled
+  `scripts/recent-context.ts` wrapper around the route. No new non-skill
+  tool registrations — daemon hosts the data, skill hosts the surface.
+- [x] Tests: route disabled state + documented query params + invalid
+  query rejection.
+- [x] Add authenticated `POST /v1/perception/publish` route for client
+  producers.
+- [x] Tauri: active app + window title sampler, behind blocklist,
+  pushing to the daemon publish route.
+- [x] Add HTTP smoke test for the Phase 1 vertical slice:
+  POST perception event -> GET recent context.
+- [x] Update progress log with vertical-slice demo proof.
+
+## Security invariants (do not violate)
+
+1. Every new capability is **declared in the feature flag registry** and
+   defaults off.
+2. Raw screen / audio frames **never** leave the device, even with the
+   flag on. Only structured events cross IPC.
+3. **Blocklist is enforced at capture time**, not on publish. If 1Password
+   is focused, no signal is captured at all.
+4. The perception process must not be able to call host action tools — it
+   only publishes events.
+5. Every host action goes through the action wrapper (Phase 4) with audit
+   log entry, regardless of who requested it.
+6. Approval prompts are **ephemeral**, scoped to a task/conversation, and
+   logged.
+
+## Open questions
+
+- Do we want perception events persisted to disk at all, or memory-only?
+  Initial answer: memory-only ring, plus optional rollups into the memory
+  module after relevance scoring. Revisit when Phase 5 lands.
+- Where does the perception skill live in Docker mode? It has no role
+  there until we add a Docker-mode capture channel. For now, perception
+  is **bare-metal only**, gated by an additional runtime check.
+- How do we represent "user is in a meeting" vs the meet-join skill's
+  own state? Coordinate later; perception will emit a coarse signal and
+  defer to meet-join for ground truth.
+
+---
+
+## Progress Log
+
+Newest entries at the top. Every entry includes date, phase, what
+shipped, and what's next. Never edit old entries — append new ones.
+
+### 2026-05-17 — Phase 10C landed: Multimodal Perception MVP
+
+- Two new perception event kinds added to
+  `assistant/src/perception/perception-event.ts`:
+  - `screen_snapshot` — bundle/app id + window title + redacted, truncated
+    OCR/AX text (≤2048 chars) + `captureMethod: 'ax' | 'ocr'` + confidence
+    in `[0, 1]`. Each payload also carries the producer's
+    `conversationId` so the consent gate is unambiguous.
+  - `audio_excerpt` — session/turn ids + redacted, truncated STT
+    transcript (≤1024 chars) + optional BCP-47 language tag + confidence.
+    Also carries `conversationId`.
+  Both kinds were added to the discriminated union; TypeScript's
+  exhaustive `switch` checks immediately surfaced every downstream
+  consumer that had to update.
+- Defense-in-depth sanitizer extended in
+  `assistant/src/runtime/routes/perception-routes.ts`: caller-supplied
+  text fields for both kinds are scrubbed via `sanitizeText` /
+  `sanitizeOptional` before they enter the hub. Guard tests assert
+  emails, secrets, and URLs are redacted.
+- Per-conversation consent flow lands as
+  `assistant/src/perception/consent-grants.ts`:
+  - `hasActivePerceptionConsent`, `getActivePerceptionConsent`,
+    `recordPerceptionConsentGrant`, `revokePerceptionConsentGrant`,
+    `listPerceptionConsentGrantsForConversation`.
+  - Idempotent on `(scope_id, conversation_id, event_kind)`; re-granting
+    clears prior revocation, expiry is honoured, revocation returns
+    `active` / `already_revoked` / `not_found`.
+  - The publish route rejects `screen_snapshot` / `audio_excerpt` with
+    `{ accepted: false, reason: "consent_required" }` when no live grant
+    exists. We reuse the existing `confirmation_request` →
+    `POST /v1/confirm` (`selectedScope: "conversation"`) flow to issue
+    grants — no new approval primitive.
+- Producers wired:
+  - `assistant/src/live-voice/live-voice-session.ts` publishes
+    `perception.audio_excerpt` in the `final` branch of
+    `handleTranscriberEvent` once `perception` + `perception-audio-excerpt`
+    are on AND a consent grant is active. Best-effort: failures here are
+    logged at `warn` and never block the live-voice session.
+  - `clients/macos/vellum-assistant/Ambient/WatchSession.swift` POSTs a
+    `screen_snapshot` perception event alongside the legacy
+    `watch_observation` path. Truncates OCR text to the schema's 2048-char
+    budget, uses `ISO8601DateFormatter` for `ts`, and reuses the existing
+    `GatewayHTTPClient` transport via a new
+    `ComputerUseClient.sendScreenSnapshotPerception` method.
+- Feature flags `perception-screen-snapshot` and
+  `perception-audio-excerpt` in the registry, both `defaultEnabled: false`.
+  The existing `perception` master switch remains the top-level gate.
+- Tests:
+  - `assistant/src/perception/perception-event.test.ts` — schema
+    happy/sad paths for both new kinds, including missing `conversationId`,
+    oversize text, and out-of-range confidence.
+  - `assistant/src/perception/consent-grants.test.ts` — grant lifecycle
+    (record / revoke / re-grant), expiry, scoping by `(conversationId,
+    eventKind)`.
+  - `assistant/src/runtime/routes/perception-routes.test.ts` extended
+    with redaction guards for both kinds, `consent_required` rejection
+    paths, and length-cap rejections.
+  - `assistant/src/live-voice/__tests__/live-voice-stt.test.ts` extended
+    with publish-on-final tests for flag-on+consent-on / flag-on+no-consent
+    / flag-off paths.
+- Out of scope (explicitly deferred): Tauri Rust screen capture, OS-level
+  `NSScreenCaptureUsageDescription` Info.plist additions, and any UI for
+  managing consent grants. The plan callout — "Tauri Rust capture deferred
+  to MVP+1" — is the canonical reference.
+
+### 2026-05-17 — Phase 10B landed: Memory Maturation MVP
+
+- PKB store API hardened around real-use signal:
+  - `upsertPkbEntity` now keeps an `evidence_count`, refreshes
+    `last_reinforced_at`, appends provenance (capped at 20 entries) and
+    replaces the old `Math.max(confidence, incoming)` merge with a
+    counter-weighted mean `(evidence*confidence + incoming) / (evidence+1)`.
+  - `upsertPkbPreference` takes a `signal: 'positive' | 'negative'` and
+    derives confidence from a Laplace-smoothed beta mean
+    `positive / (positive + negative + 1)`. Contradictory signals overwrite
+    the stored value while keeping the historical counters.
+  - `recordPkbEpisode` accepts an optional `idempotencyKey` and short-circuits
+    when one is already on file; the perception writer passes
+    `${sourceEventId}:${interpreted.kind}` so retries no longer double-write.
+  - New `scorePkbEntities` / `scorePkbPreferences` helpers combine confidence,
+    decay-anchored recency, and `log1p(evidence_count)` so high-decay items
+    drop out of context naturally.
+- Hourly decay worker `assistant/src/memory/pkb-decay.ts`:
+  - Exponential half-life applied to confidence (`0.5 ** (Δdays / halfLife)`).
+  - Half-lives default to 30 days for entities and 45 days for preferences,
+    floor at `0.05` so we don't asymptotically chase zero forever.
+  - Registered as a new `pkb_decay` `MemoryJobType` and scheduled from
+    `maybeEnqueueGraphMaintenanceJobs` only when `memory-maturation` is on.
+- Post-turn preference-feedback observer at
+  `assistant/src/agent/preference-feedback.ts`:
+  - Short-circuits when `memory-maturation` is disabled — safe to call on every
+    turn regardless of flag state.
+  - Calls the new `preferenceFeedback` LLM call-site via the standard
+    provider abstraction, then routes `reinforced` / `contradicted` /
+    `inferred` decisions into `upsertPkbPreference` with the right signal.
+  - Judgement is model-mediated per the "Assistant-Driven Judgement" rule.
+- New `preferenceFeedback` LLM call-site declared in
+  `assistant/src/config/schemas/llm.ts` and seeded with cost-optimised
+  defaults by workspace migration `073-seed-preference-feedback-callsite.ts`.
+- `personal-knowledge-context.ts` switches to scoring-based entity / preference
+  selection when `memory-maturation` is enabled; the legacy recency-only path
+  remains as the fallback.
+- Feature flag `memory-maturation` is added to the registry (default off);
+  the store-API changes ship unconditionally (additive, backwards-compatible).
+- Tests:
+  - `assistant/src/memory/pkb-decay.test.ts` — half-life math, floor clamp,
+    skip-below-floor, no-op on empty DB.
+  - `assistant/src/agent/preference-feedback.test.ts` — flag short-circuit,
+    reinforce, contradict, infer-new-key, malformed response, missing provider.
+  - `assistant/src/memory/personal-knowledge-store.test.ts` — extended with
+    idempotency, counter-merge, provenance capping, and scoring.
+
+Next: 10C (multimodal perception) lands the `screen_snapshot` / `audio_excerpt`
+payloads on top of the existing `perception_consent_grants` table.
+
+### 2026-05-17 — Phase 10A landed: Autonomous Execution Engine MVP
+
+- New durable plan storage at `assistant/src/plans/`:
+  - `plan-store.ts` — CRUD over `plans` / `plan_steps` / `plan_step_runs`,
+    idempotent on `(plan_id, step.order, attempt)`.
+  - `run-plan.ts` — stepwise driver; each step wrapped with `runAction` so
+    audit and lifecycle stay uniform with one-shot host actions. Broadcasts
+    `plan_lifecycle` + `plan_step_lifecycle` messages through new
+    `assistant/src/daemon/message-types/plans.ts`.
+  - `recovery.ts` — `recoverStalePlans()` patterned on
+    `recoverStaleSchedules`. Called from `daemon/lifecycle.ts` after
+    schedule recovery, before the main agent loop boots.
+- Migration `241-plan-execution-tables.ts` adds the three tables;
+  registered in `db-init.ts` migration steps + `migrations/index.ts`.
+- Drizzle schema in `assistant/src/memory/schema/plans.ts`.
+- Read + cancel surface:
+  - `assistant/src/runtime/routes/plan-routes.ts` exposes `GET /v1/plans`,
+    `GET /v1/plans/:id`, `POST /v1/plans/:id/cancel`.
+  - `skills/plans/SKILL.md` + `scripts/plan-control.ts` give the agent a
+    skill-mediated control surface (no new registered tool, per
+    `assistant/src/tools/AGENTS.md`).
+- Feature flag `autonomous-execution` added to the registry (default off).
+- Tests:
+  - `assistant/src/__tests__/db-jarvis-vertical-slice-migrations.test.ts`
+    — covers all three Phase 10 migrations (241/242/243) + idempotent re-run.
+  - `assistant/src/plans/plan-store.test.ts` — CRUD, ordering, attempt
+    monotonicity, recovery, terminal-state semantics.
+  - `assistant/src/plans/run-plan.test.ts` — happy/sad/throws/cancel paths.
+  - `assistant/src/plans/recovery.test.ts` — crash → resume round-trip.
+  - `assistant/src/runtime/routes/plan-routes.test.ts` — list/get/cancel.
+- Migrations 242 (PKB quality fields) and 243 (perception consent grants)
+  also ship in this PR so subsequent phases stack cleanly. Their store-API
+  and producer wiring land in 10B / 10C.
+
+### 2026-05-17 — Follow-up hardening: host-proxy lifecycle + tier consumption + debounce
+
+- Phase 4 reliability wrapper normalization expanded:
+  - `runAction(...)` now wraps execution in all remaining host proxies:
+    - `assistant/src/daemon/host-bash-proxy.ts`
+    - `assistant/src/daemon/host-cu-proxy.ts`
+    - `assistant/src/daemon/host-file-proxy.ts`
+    - `assistant/src/daemon/host-browser-proxy.ts`
+  - Each proxy now emits `action_lifecycle` messages (`started`, `executing`,
+    `completed` / `failed`) to the conversation stream via
+    `broadcastMessage(...)` using `ActionLifecycleMessage`.
+  - Added lifecycle emission coverage in proxy tests:
+    - `assistant/src/__tests__/host-bash-proxy.test.ts`
+    - `assistant/src/__tests__/host-cu-proxy.test.ts`
+    - `assistant/src/__tests__/host-file-proxy.test.ts`
+    - `assistant/src/__tests__/host-browser-proxy.test.ts`
+- Phase 7 tier metadata consumption expanded on Apple shared client:
+  - `clients/shared/Network/SettingsClient.swift` now decodes:
+    - `tiers: [CallSiteCatalogTier]` on catalog response
+    - `tier: String` on each call-site entry.
+- Perception hot-path performance improvement:
+  - Added rapid duplicate app-focus debounce in
+    `assistant/src/perception/interpreter.ts` with configurable
+    `debounceMs` (default `2000ms`) keyed by `(appId, windowTitle)`.
+  - Added regression test:
+    - `assistant/src/perception/interpreter.test.ts`:
+      `debounces rapid duplicate app focus signals`.
+- Verification:
+  - `cd assistant && bun run lint -- --fix`
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/__tests__/host-bash-proxy.test.ts`
+  - `cd assistant && bun test src/__tests__/host-cu-proxy.test.ts`
+  - `cd assistant && bun test src/__tests__/host-file-proxy.test.ts`
+  - `cd assistant && bun test src/__tests__/host-browser-proxy.test.ts`
+  - `cd assistant && bun test src/perception/interpreter.test.ts`
+- Notes:
+  - Proxy tests continue to log expected non-fatal
+    `tool_invocations`-table warnings in isolated unit environments; this does
+    not affect assertion outcomes.
+
+### 2026-05-17 — Full audit: defense-in-depth + dedup of redaction logic
+
+- Audit run (typecheck, lint, targeted + boundary + redaction tests):
+  - `bunx tsc --noEmit` clean on assistant and clients/tauri.
+  - `bun run lint` clean after autofix + removal of unused
+    `findPkbEntities` import in
+    `assistant/src/perception/personal-knowledge-writer.ts`.
+  - 92 targeted perception / handoff / PKB / call-site tests pass.
+  - Boundary + redaction guards (skill-isolation, gateway-only,
+    persistence-secret-redaction, secret-prompt-log-hygiene,
+    host-proxy-interface, assistant-event-hub) pass when isolated.
+    `secret-prompt-log-hygiene` shows test-isolation flakiness only when
+    co-run with `host-proxy-interface` — pre-existing, unrelated to this
+    work.
+- Phase 9 defense-in-depth strengthened:
+  - Introduced shared sanitizer
+    `assistant/src/perception/sanitization.ts` as the single source of
+    truth for redaction patterns (email, URL, phone, secret/token,
+    account-id) and length budget.
+  - Refactored `perception/interpreter.ts` and `perception/relevance-gate.ts`
+    to import the shared sanitizer instead of inlining the regex set.
+  - Added defense-in-depth on
+    `POST /v1/perception/publish`: incoming payloads are re-sanitized
+    server-side per `kind` before reaching the event hub / ContextBuffer,
+    so a buggy/compromised producer cannot leak raw secrets past the
+    daemon trust boundary.
+  - New guard test:
+    `perception routes > publish route redacts sensitive strings as
+    defense-in-depth` in
+    `assistant/src/runtime/routes/perception-routes.test.ts`.
+- Known open items surfaced by the audit (deferred, not regressions):
+  - Phase 4 invariant is only adopted by `host-app-control-proxy`; other
+    host proxies (`host-bash`, `host-cu`, `host-file`, `host-browser`)
+    still bypass `runAction`. Should be normalized via a follow-up phase.
+  - Tier metadata on `/v1/llm/call-sites` is producer-only; Swift
+    `CallSiteCatalogResponse` does not yet decode `tiers` / `tier`.
+  - `assistantEventHub.publish` fans out subscribers sequentially.
+    Switching to bounded parallel fanout would reduce perception ingest
+    latency once volume grows.
+  - PKB entity search uses `LIKE %x%` over `aliases_json`; would benefit
+    from a normalized alias table or FTS index when entity count grows.
+
+### 2026-05-17 — Phase 9 complete: redaction guard expansion
+
+- Hardened perception redaction logic to cover additional sensitive shapes:
+  - token/secret/api-key/password-like values
+  - account-id-like identifiers (`account-...`, `user_...`, `org-...`, etc.)
+  - existing email/URL/phone protections remain intact.
+- Applied the expanded redaction to:
+  - interpreted perception emission sanitization:
+    `assistant/src/perception/interpreter.ts`
+  - relevance reason normalization + proactive wake hint payload formatting:
+    `assistant/src/perception/relevance-gate.ts`
+- Added guard tests to prevent regression:
+  - `assistant/src/perception/interpreter.test.ts`
+    - asserts token/account-id redaction in emitted `task_detected` fields.
+  - `assistant/src/perception/relevance-gate.test.ts`
+    - asserts sensitive strings are redacted in both classifier reason and
+      act-now wake hints.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/interpreter.test.ts src/perception/relevance-gate.test.ts`
+- Next: continue ongoing security maintenance via normal PR hygiene (new
+  capability surfaces must include equivalent redaction + guard tests).
+
+### 2026-05-17 — Phase 8 complete: explicit handoff-key client wiring
+
+- Extended cross-interface handoff validation:
+  - `assistant/src/__tests__/send-endpoint-busy.test.ts` now verifies that
+    local first-party interfaces (`macos`, `ios`, `web`, `chrome-extension`,
+    `tauri`) converge on a single default handoff conversation when
+    `conversationKey` is omitted.
+- Added explicit local handoff constants/helpers in shared client code:
+  - `clients/shared/Network/ConversationHandoff.swift`
+  - `normalizeConversationKey(...)` now defaults blank/missing keys to
+    `default:vellum:handoff`.
+- Wired handoff-key restore/adoption in desktop client setup and send paths:
+  - `clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift`
+    now binds local connection ownership to the shared handoff key.
+  - `clients/shared/Network/MessageClient.swift` and
+    `clients/shared/Network/BtwClient.swift` normalize empty keys to the
+    shared handoff key before POST.
+  - `clients/tauri/src/services/gateway-client.ts` now explicitly includes
+    `conversationKey: "default:vellum:handoff"` when none is provided.
+- Added regression coverage in macOS client tests:
+  - `clients/macos/vellum-assistantTests/MessageClientTimezoneTests.swift`
+    now verifies fallback to `ConversationHandoff.defaultLocalConversationKey`.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/__tests__/send-endpoint-busy.test.ts`
+  - `cd clients && swift test --filter MessageClientTimezoneTests`
+  - `cd clients/tauri && bunx tsc --noEmit`
+- Next: continue Phase 9 hardening in parallel (capability boundary and
+  redaction guard expansion).
+
+### 2026-05-17 — Phase 7 complete + Phase 8/9 handoff hardening
+
+- Added explicit call-site model tiers (`perception`, `reflex`, `deliberation`)
+  and exported tier metadata for clients:
+  - `assistant/src/config/schemas/call-site-catalog.ts`
+  - `assistant/src/runtime/routes/llm-call-sites-routes.ts`
+- Added tests that enforce every call site maps to a declared tier:
+  - `assistant/src/__tests__/llm-callsite-catalog.test.ts`
+  - `assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts`
+- Added shared multi-device default conversation handoff logic for first-party
+  local interfaces (`macos`, `ios`, `web`, `chrome-extension`, `tauri`):
+  - `assistant/src/runtime/conversation-handoff.ts`
+  - wired into `assistant/src/runtime/routes/conversation-routes.ts`
+  - wired into live voice fallback mapping in
+    `assistant/src/runtime/http-server.ts`
+  - mirrored default key in `clients/tauri/src/services/live-voice-client.ts`
+- Security hardening coverage:
+  - `assistant/src/runtime/__tests__/conversation-handoff.test.ts` verifies
+    non-local channel isolation and no CLI merge into shared handoff key.
+  - Updated `assistant/src/__tests__/send-endpoint-busy.test.ts` to assert
+    shared handoff-key behavior.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/runtime/__tests__/conversation-handoff.test.ts src/runtime/routes/__tests__/llm-call-sites-routes.test.ts src/__tests__/llm-callsite-catalog.test.ts src/__tests__/send-endpoint-busy.test.ts`
+- Next in Phase 8: wire explicit handoff-key adoption/restore behavior in iOS
+  and browser extension clients, then add cross-interface integration coverage.
+
+### 2026-05-17 — Phase 6 progress: spoken action lifecycle cues
+
+- Wired action lifecycle events through the voice bridge callback surface:
+  - `assistant/src/calls/voice-session-bridge.ts`
+  - `VoiceTurnCallbacks` now includes `action_lifecycle`, and `startVoiceTurn`
+    forwards `action_lifecycle` daemon messages to voice clients.
+- Added live-voice lifecycle cue handling:
+  - `assistant/src/live-voice/live-voice-session.ts`
+  - when an in-flight voice turn receives lifecycle stages
+    (`started`/`executing`/`completed`/`failed`/`rollback_*`), the session now:
+    - emits short conversational status deltas (e.g. "Working on ..."),
+    - feeds the same cue text into TTS buffering for spoken progress updates,
+    - dedupes repeated stage announcements per action ID.
+- Added targeted tests:
+  - `assistant/src/__tests__/voice-session-bridge.test.ts`
+    - verifies `action_lifecycle` forwarding to callbacks.
+  - `assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts`
+    - verifies lifecycle events become assistant status deltas in live voice.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/live-voice/__tests__/live-voice-agent-turn.test.ts src/__tests__/voice-session-bridge.test.ts`
+- Next in Phase 6: add client-visible live-voice status surface plumbing for
+  these lifecycle cues (dedicated frame/UI affordance rather than text delta).
+
+### 2026-05-15 — Phase 6 kickoff: live-voice perception fusion
+
+- Wired perception-memory context into live voice turn grounding:
+  - `assistant/src/live-voice/live-voice-session.ts` now builds each
+    `voiceControlPrompt` as:
+    - base live-voice prompt, plus
+    - `<perception_memory>...</perception_memory>` when recent PKB context is
+      available.
+- Added dependency seam for deterministic tests:
+  - `LiveVoiceSessionOptions.getPerceptionMemoryContext?: () => string | null`
+  - defaults to `buildPerceptionKnowledgeContext()` with safe fallback to
+    `null` on any retrieval failure.
+- Added test coverage:
+  - `assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts`
+    validates prompt injection for a synthetic perception-memory payload.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/live-voice/__tests__/live-voice-agent-turn.test.ts src/perception/personal-knowledge-context.test.ts`
+- Next in Phase 6: route live voice action/tool handoffs through richer
+  lifecycle-aware feedback so spoken replies can confirm in-progress host
+  actions with the same reliability cues as HUD text mode.
+
+### 2026-05-15 — Phase 5 complete: main-agent PKB context injection
+
+- Added a pre-turn perception-memory context formatter:
+  - `assistant/src/perception/personal-knowledge-context.ts`
+  - renders compact sections from PKB rows (`episodes`, `entities`,
+    `preferences`) with bounded per-line length.
+- Added PKB listing helper:
+  - `listRecentPkbEntities(...)` in
+    `assistant/src/memory/personal-knowledge-store.ts`.
+- Wired main-agent runtime injection:
+  - `assistant/src/daemon/conversation-agent-loop.ts` now builds
+    `perceptionMemoryContext` on full-mode trusted turns and threads it into
+    all re-injection paths (normal, overflow/compaction, convergence, fallback).
+  - `assistant/src/daemon/conversation-runtime-assembly.ts` + plugin types now
+    carry `perceptionMemoryContext` as a first-class injection input.
+  - `assistant/src/plugins/defaults/injectors.ts` adds
+    `perception-memory-context` (order `39`) that emits
+    `<perception_memory>...</perception_memory>` after memory-prefix blocks.
+- Safety and lifecycle:
+  - context is gated with the same trusted-actor/remote-channel logic used by
+    memory-v2 static injection.
+  - `<perception_memory>` added to compaction strip prefixes so re-assembly does
+    not duplicate stale snapshots.
+- Added/updated verification:
+  - `assistant/src/perception/personal-knowledge-context.test.ts`
+  - `assistant/src/__tests__/perception-memory-injector.test.ts`
+  - updated `assistant/src/__tests__/injector-chain.test.ts`
+  - updated `assistant/src/memory/personal-knowledge-store.test.ts`
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/personal-knowledge-context.test.ts src/perception/personal-knowledge-writer.test.ts src/memory/personal-knowledge-store.test.ts src/__tests__/injector-chain.test.ts src/__tests__/perception-memory-injector.test.ts`
+- Next phase (Phase 6): voice fusion — feed this same perception-memory snapshot
+  into live voice session grounding so spoken responses inherit current task
+  context without waiting for chat turns.
+
+### 2026-05-15 — Phase 5 skill bridge: PKB query script
+
+- Extended the first-party `skills/perception` skill so the main agent can read
+  PKB data through a bundled script, not just daemon internals.
+- Added `skills/perception/scripts/personal-knowledge.ts`:
+  - supports `--mode entities|episodes|preferences`,
+  - supports `--query` for entity lookup and optional `--limit`,
+  - uses the same injected-auth + local fallback token strategy as
+    `recent-context.ts` for local/dev reliability.
+- Updated `skills/perception/SKILL.md` to document:
+  - the new Phase 5 personal-knowledge read surface,
+  - command examples for entities/episodes/preferences,
+  - endpoint mapping to `/v1/personal-knowledge/*`.
+- Next in Phase 5: consume PKB outputs directly in main-agent planning prompts
+  (e.g., short pre-turn memory retrieval policy + prompt context formatting).
+
+### 2026-05-15 — Phase 5 wiring: relevance -> PKB + query routes
+
+- Wired a new perception-side PKB writer:
+  - `assistant/src/perception/personal-knowledge-writer.ts`
+  - Subscribes to perception events, caches interpreted events
+    (`task_detected` / `meeting_started` / `code_edited`), and on
+    `relevance_scored` with decision `remember` / `maybe-act` / `act-now`,
+    persists:
+    - entities (`pkb_entities`) with confidence,
+    - episodes (`pkb_episodes`) with salience derived from decision+urgency,
+    - lightweight learned preferences (`pkb_preferences`) for repeated patterns.
+- Integrated writer into perception lifecycle:
+  - `assistant/src/perception/startup.ts` now starts/stops the writer alongside
+    `ContextBuffer`, interpreter, and relevance gate.
+- Added read surface for agent/query clients:
+  - `assistant/src/runtime/routes/personal-knowledge-routes.ts`
+  - new endpoints:
+    - `GET /v1/personal-knowledge/entities`
+    - `GET /v1/personal-knowledge/episodes`
+    - `GET /v1/personal-knowledge/preferences`
+  - route registration updated in `assistant/src/runtime/routes/index.ts`.
+- Added targeted verification coverage:
+  - `assistant/src/perception/personal-knowledge-writer.test.ts`
+  - `assistant/src/runtime/routes/personal-knowledge-routes.test.ts`
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/personal-knowledge-writer.test.ts src/runtime/routes/personal-knowledge-routes.test.ts src/memory/personal-knowledge-store.test.ts`
+- Next in Phase 5: expose these PKB reads through a first-party skill interface
+  so the main agent can consume them as explicit memory context in planning.
+
+### 2026-05-15 — Phase 5 kickoff: personal knowledge storage spine
+
+- Added normalized PKB tables (DB migration `240`):
+  - `pkb_entities`: canonical entities with aliases/attributes and confidence.
+  - `pkb_episodes`: timestamped episodic observations linked to entities.
+  - `pkb_preferences`: implicit preference key/value records with confidence.
+- Wired migration into startup init path:
+  - `assistant/src/memory/migrations/240-pkb-entity-episode-tables.ts`
+  - exports + `initializeDb()` migration step list updated.
+- Added typed schema exports:
+  - `assistant/src/memory/schema/personal-knowledge.ts`
+  - re-exported from schema index.
+- Added writer/reader memory module:
+  - `assistant/src/memory/personal-knowledge-store.ts`
+  - `upsertPkbEntity`, `findPkbEntities`, `recordPkbEpisode`,
+    `listRecentPkbEpisodes`, `upsertPkbPreference`, `listPkbPreferences`.
+- Added unit coverage:
+  - `assistant/src/memory/personal-knowledge-store.test.ts`
+  - covers entity merge/upsert behavior, alias/canonical lookup, episode
+    ordering, and preference upsert semantics.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/memory/personal-knowledge-store.test.ts`
+- Next in Phase 5: connect perception/relevance outputs to PKB writers and add
+  a small read surface for the main agent to query entities/episodes directly.
+
+### 2026-05-15 — Phase 4 kickoff: action wrapper + lifecycle feed
+
+- Added a reusable execution wrapper:
+  - `assistant/src/actions/run-action.ts` introduces a standard action flow with
+    lifecycle stages (`started`, `executing`, `completed`, `failed`,
+    `rollback_*`) and optional rollback handling.
+  - Every wrapped action now writes an audit entry through the existing
+    `tool_invocations` store (`toolName: action:<actionName>`), including
+    decision, risk level, and duration.
+- Added a typed server message for action lifecycle events:
+  - `assistant/src/daemon/message-types/actions.ts`
+  - integrated into the aggregate daemon protocol union.
+- Wired host app-control through the wrapper as the first adopter:
+  - `HostAppControlProxy.request(...)` now runs inside `runAction(...)`.
+  - Emits `action_lifecycle` messages via `broadcastMessage(...)` so connected
+    clients can show progress.
+- HUD status strip feed:
+  - Tauri `HostProxyClient` now consumes `action_lifecycle` events and maps
+    them into status-strip action/error text.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/actions/run-action.test.ts`
+  - `cd clients/tauri && bunx tsc --noEmit`
+- Next in Phase 4: adopt the wrapper for the other host proxies and add richer
+  per-action status badges (not just text) in the HUD strip.
+
+### 2026-05-15 — Phase 3 complete
+
+- Added explicit relevance decision event stream:
+  - `perception.relevance_scored` now emits for every interpreted event scored
+    by the relevance gate (`ignore` / `remember` / `maybe-act` / `act-now`).
+  - Payload includes source event link, urgency, redacted reason, and trigger
+    outcome fields (`triggeredWake`, `blockedByBudget`, `wakeConversationId`).
+- Relevance gate now emits an auditable canonical decision signal even when no
+  proactive wake occurs, so memory writers and other downstream jobs can consume
+  one uniform stream.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/interpreter.test.ts src/perception/relevance-gate.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts`
+    (16 passing tests)
+- Phase 3 status: **done**. Next work moves to Phase 4 (execution reliability
+  wrapper + lifecycle/audit events).
+
+### 2026-05-15 — Phase 3 kickoff: relevance gate + proactive wake wiring
+
+- Added `PerceptionRelevanceGate`
+  (`assistant/src/perception/relevance-gate.ts`).
+  - Consumes interpreted perception events (`task_detected`,
+    `meeting_started`, `code_edited`) from `assistantEventHub`.
+  - Uses a tiny LLM classification pass (`callSite: perception`) to map each
+    event to one of: `ignore`, `remember`, `maybe-act`, `act-now`.
+  - Applies bounded output validation (`zod`) and conservative fallback
+    decisions when model output is missing/invalid.
+- Wired `act-now` to `wakeAgentForOpportunity` via a background conversation
+  bootstrap path (`source: perception_proactive`), matching the same generic
+  wake mechanism used by other subsystem opportunities.
+- Added per-hour interruption budget enforcement for `act-now`:
+  - Stores rolling wake timestamps in memory checkpoints
+    (`perception:act-now:hourly-timestamps`).
+  - Enforces a default hourly cap for non-high urgency opportunities.
+  - Supports high-urgency override while still recording budget state.
+  - Rolls back budget consumption if wake invocation fails and cleans up orphan
+    background conversations.
+- Startup wiring:
+  - `startPerception()` now attaches `PerceptionRelevanceGate` alongside
+    `ContextBuffer` and `PerceptionInterpreter`.
+  - `stopPerception()` detaches the relevance gate for clean shutdown/tests.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/interpreter.test.ts src/perception/relevance-gate.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts`
+    (15 passing tests)
+- Next in Phase 3: add an explicit relevance/audit event stream for
+  ignore/remember/maybe-act decisions so downstream memory writers can consume
+  the same gate outputs.
+
+### 2026-05-15 — Phase 2 complete
+
+- Seeded workspace migration `072-seed-perception-callsite` so the
+  perception interpreter reliably uses a cheap, bounded call-site default
+  instead of inheriting heavyweight chat defaults.
+  - Preserves explicit user-owned `profile`/`provider`/`model` selections.
+  - Seeds low-cost defaults (`maxTokens`, low effort, no thinking, bounded
+    context window) when unset.
+- Added migration regression tests:
+  - `assistant/src/__tests__/workspace-migration-072-seed-perception-callsite.test.ts`
+- Phase 2 checklist is now fully complete:
+  - dedicated `perception` call-site exists and is seeded
+  - local interpreter emits structured `task_detected` /
+    `meeting_started` / `code_edited` events
+  - interpreted payloads are redacted before publish
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/__tests__/workspace-migration-072-seed-perception-callsite.test.ts src/perception/interpreter.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts`
+    (16 passing tests)
+- Next: begin Phase 3 (relevance scoring + proactive trigger/budget wiring).
+
+### 2026-05-15 — Phase 2: taxonomy expansion
+
+- Expanded interpreted perception taxonomy beyond generic `task_detected`.
+  - Added `meeting_started` and `code_edited` event kinds to the perception
+    contract.
+  - Kept all interpreted payloads bounded and source-linked with
+    `sourceEventId` for auditability.
+- Upgraded `PerceptionInterpreter` output contract and prompt to select among:
+  `task_detected`, `meeting_started`, and `code_edited`.
+  - Added optional structured fields where relevant (`platform`,
+    `workspaceHint`, `languageHint`).
+  - Preserved confidence gating and defensive redaction on all emitted text.
+- Added tests for:
+  - meeting classification publish path (`perception.meeting_started`)
+  - low-confidence suppression
+  - existing task-detected and route smoke coverage remained green.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/context-buffer.test.ts src/perception/interpreter.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts`
+    (22 passing tests)
+- Next in Phase 2: fold in lightweight temporal context (previous focus event)
+  for better stability and add explicit PII-shape regression fixtures.
+
+### 2026-05-15 — Phase 2 kickoff: local interpreter spine
+
+- Added a dedicated `llm.callSites.perception` call-site so perception
+  interpretation can be tuned independently from the main agent profile.
+- Introduced `PerceptionInterpreter`
+  (`assistant/src/perception/interpreter.ts`).
+  - Subscribes to `perception.*` events.
+  - Consumes `app_focus_changed` inputs.
+  - Calls the configured provider through the new `perception` call-site.
+  - Emits interpreted `perception.task_detected` events when confidence is
+    high enough.
+- Extended the perception contract with `task_detected`.
+  - Added payload schema: `label`, `summary`, `confidence`, `sourceEventId`.
+  - Kept strict bounds so downstream consumers get typed, bounded data.
+- Added defensive redaction in the interpreter before prompt input and before
+  emitting interpreted events (emails/URLs/phone-like strings scrubbed).
+- Wired interpreter lifecycle into perception startup/shutdown alongside the
+  existing `ContextBuffer`.
+- Verification:
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/perception/context-buffer.test.ts src/perception/interpreter.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts`
+    (20 passing tests)
+- Next in Phase 2: improve extraction taxonomy (`meeting.started`,
+  `code.edited`, etc.) and add stronger redaction coverage tests.
+
+### 2026-05-15 — Phase 1 complete: vertical slice proven
+
+- Closed the last Phase 1 gap: recorded end-to-end proof and marked the
+  work-plan checklist complete.
+- Fixed a startup race that could keep perception disabled even when
+  `perception: true` was set in gateway overrides.
+  - Root cause: `startPerception()` ran before async
+    `initFeatureFlagOverrides()` hydration completed, so the first
+    flag read could fall back to registry defaults (`perception=false`).
+  - Fix: after background feature-flag init resolves, lifecycle now
+    retries `startPerception()` (idempotent + safe no-op when already started).
+- Verification:
+  - Runtime smoke on a live local assistant:
+    - `POST /v1/perception/publish` -> `{"accepted":true}`
+    - `bun ./skills/perception/scripts/recent-context.ts --window-ms 300000 --limit 5`
+      returned `enabled: true` with the newly published
+      `app_focus_changed` event (`appName: "Visual Studio Code"`).
+  - `cd assistant && bunx tsc --noEmit`
+  - `cd assistant && bun test src/runtime/routes/perception-http-smoke.test.ts src/runtime/routes/perception-routes.test.ts src/perception/context-buffer.test.ts`
+    (18 passing tests)
+- Phase 1 status: **done**. Next work moves to Phase 2 (local interpreter).
+
+### 2026-05-14 — Voice: xAI streaming TTS wired
+
+- Upgraded the existing `xai` TTS provider from REST-only synthesis to
+  live streaming synthesis via `wss://api.x.ai/v1/tts`.
+  - Live voice can now use the configured `xai` provider because it
+    advertises `supportsStreaming: true`.
+  - The streaming path requests 16 kHz PCM when live voice asks for
+    `outputFormat: "pcm"`, matching the downstream live audio pipeline.
+  - API keys stay server-side in the secure credential store under
+    `credential/xai/api_key`; the desktop client never sees the key.
+- Verification:
+  - `bun test src/tts/__tests__/provider-adapters.test.ts src/tts/__tests__/provider-catalog.test.ts src/tts/__tests__/provider-catalog-consistency.test.ts`
+    passes 87 tests.
+  - `bunx tsc --noEmit` clean in `assistant/`.
+- Next: store an xAI API key, switch `services.tts.provider` to `xai`,
+  and run a live voice smoke test with the HUD.
+
+### 2026-05-14 — Phase 1: Tauri active-window producer
+
+- `POST /v1/perception/publish` added.
+  - Validates one `PerceptionEvent`.
+  - Publishes to `assistantEventHub` only when the perception buffer is
+    active.
+  - Returns `{ accepted: false, reason: "disabled" }` when the flag is
+    off or startup has not attached the buffer.
+- Tauri Rust command `active_window_context` added.
+  - macOS-only via `osascript` / System Events.
+  - Returns `null` for blocked apps before the title crosses into
+    JavaScript.
+  - Blocks 1Password, Keychain Access, and System Settings/Preferences.
+  - Redacts title when it contains sensitive terms like private
+    browsing/incognito/password/login/bank/payment/checkout.
+- Tauri React service `PerceptionClient` added.
+  - Samples every 5 seconds.
+  - Dedupes unchanged app/title signatures.
+  - Posts structured `app_focus_changed` events to
+    `/v1/perception/publish`.
+  - Marks a signature as delivered only after the daemon returns
+    `accepted: true`, so enabling perception after the HUD is already
+    open still sends the current focus state.
+  - Best-effort: failures do not affect voice, host proxy, or the HUD.
+- Verification:
+  - `bunx tsc --noEmit` clean in `assistant/`.
+  - `bun test src/runtime/routes/perception-routes.test.ts src/perception/context-buffer.test.ts`
+    passes 17 tests, including the enabled publish/readback path.
+  - `bun run typecheck` clean in `clients/tauri/`.
+  - `bun run lint` clean in `clients/tauri/`.
+  - `bun test src/__tests__/gateway-only-guard.test.ts` clean after
+    removing a stale Tauri comment that referenced the direct runtime
+    port instead of the gateway-fronted URL.
+  - `cargo fmt --check` could not run because `cargo` is not installed
+    in this environment.
+- Next: run the HUD with the `perception` flag enabled and verify the
+  end-to-end query: "what was I working on five minutes ago?"
+
+### 2026-05-14 — Phase 1: HTTP vertical-slice smoke
+
+- Added `assistant/src/runtime/routes/perception-http-smoke.test.ts`.
+  - Forces the `perception` flag on in test.
+  - Starts the real `RuntimeHttpServer` on an ephemeral port.
+  - Posts an `app_focus_changed` event to `/v1/perception/publish`.
+  - Reads it back from `/v1/perception/recent?limit=1`.
+- Verification:
+  - `bun test src/runtime/routes/perception-http-smoke.test.ts src/runtime/routes/perception-routes.test.ts src/perception/context-buffer.test.ts`
+    passes 18 tests.
+  - `bunx tsc --noEmit` clean in `assistant/`.
+- Remaining manual smoke: run the Tauri shell with the `perception` flag
+  enabled and ask the assistant what the user was working on recently.
+
+### 2026-05-14 — Phase 1: read surface and startup wiring
+
+- Perception now starts from daemon lifecycle startup via
+  `startPerception()` and detaches during graceful shutdown via
+  `stopPerception()`.
+- `GET /v1/perception/recent` added as a shared route
+  (`assistant/src/runtime/routes/perception-routes.ts`).
+  - Query params: `windowMs`, `limit`, `kind`.
+  - Returns `{ enabled: false, entries: [] }` when perception is off or
+    not started.
+  - Shared route means HTTP clients and IPC callers use the same handler.
+- `skills/perception/` added.
+  - `SKILL.md` documents activation, security boundaries, and Phase 1
+    limits.
+  - `scripts/recent-context.ts` wraps the route for skill use.
+  - `skills/catalog.json` includes the skill.
+- Route tests added:
+  `assistant/src/runtime/routes/perception-routes.test.ts`.
+- Verification:
+  - `bunx tsc --noEmit` clean in `assistant/`.
+  - `bun test src/runtime/routes/perception-routes.test.ts src/perception/context-buffer.test.ts`
+    passes 14 tests.
+- Next: Tauri active-app/window-title sampler plus a publish route for
+  producer events. This is the first host-facing piece and must enforce
+  blocklist/redaction before emitting.
+
+### 2026-05-14 — Phase 1: daemon-side spine assembled
+
+- `ContextBuffer` ring shipped
+  (`assistant/src/perception/context-buffer.ts`).
+  - Memory-only, capacity-bounded (default 512), TTL-bounded
+    (default 30 min).
+  - `attach(hub)` subscribes as a `process`-typed subscriber, ignores
+    non-perception events, drops malformed perception payloads with a
+    warn log rather than throwing.
+  - `recent({ windowMs, limit, kind })` returns most-recent-first.
+  - 11 unit tests, all green.
+- Feature flag `perception` added to the registry
+  (`meta/feature-flags/feature-flag-registry.json`), default off, scope
+  `assistant`. Bundled copies synced via
+  `meta/feature-flags/sync-bundled-copies.ts`.
+- Gate helper `perception/feature-gate.ts` exports `isPerceptionEnabled`
+  so every call site reads the flag through one path.
+- Startup module `perception/startup.ts` creates the singleton,
+  attaches it to `assistantEventHub`, and is a safe no-op when the flag
+  is off — matches the daemon-never-blocks-startup rule.
+- **Not yet called from `daemon/main.ts`** — that's the next commit so
+  the wiring lands once the IPC surface for skills is also in place.
+- Decision: per `assistant/src/tools/AGENTS.md`, perception's agent
+  surface (`getRecentContext`) will live as a **skill tool**, not a new
+  daemon tool registration. The daemon hosts the buffer; a forthcoming
+  `skills/perception/` will expose the read-only query through skill
+  IPC and forward to `getPerceptionBuffer()`.
+- Next: skill scaffold + IPC route, then daemon-main wiring, then the
+  Tauri sampler.
+
+### 2026-05-14 — Phase 1: event contract landed
+
+- `assistant/src/perception/perception-event.ts` shipped.
+  - Zod-validated discriminated union, `app_focus_changed` payload only.
+  - Producers must call `parsePerceptionEvent()` at the trust boundary;
+    consumers MUST NOT trust raw input.
+  - Event topic uses `perception.<kind>` so subscribers can filter
+    without parsing the payload.
+- Typecheck clean across the assistant package.
+- Next: `ContextBuffer` ring (memory-only, TTL-driven) wired to
+  `assistantEventHub` subscriptions on `perception.*`. Then surface
+  `getRecentContext` as a tool the main agent can call.
+
+### 2026-05-14 — Phase 1 kickoff
+
+- Roadmap doc created (`docs/jarvis-roadmap.md`).
+- Capability gap, target architecture, and 9-phase plan committed.
+- Phase 1 vertical-slice scope locked: signals = active app + window
+  title only; screenshots / OCR / audio / editor context deferred.
+- Security invariants enumerated.
+- Next: draft typed perception event contract and land the daemon-side
+  `ContextBuffer` so Tauri has a concrete target to publish to.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -280,6 +280,54 @@
       "label": "Pro Plan Adjust",
       "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings → Billing tab.",
       "defaultEnabled": false
+    },
+    {
+      "id": "perception",
+      "scope": "assistant",
+      "key": "perception",
+      "label": "Perception",
+      "description": "Enable the ambient perception spine: assistant-side context buffer that records structured perception events (e.g. active app/window changes) and exposes them to the assistant for time-aware recall. Phase 1 vertical slice; client capture is bare-metal only.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "perception-screen-snapshot",
+      "scope": "assistant",
+      "key": "perception-screen-snapshot",
+      "label": "Perception: Screen Snapshot",
+      "description": "Sub-flag of perception. Allow on-device screen OCR results to flow through the perception spine as `screen_snapshot` events. Raw images never cross IPC; only redacted OCR text. Requires per-conversation consent via the existing confirmation flow.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "perception-audio-excerpt",
+      "scope": "assistant",
+      "key": "perception-audio-excerpt",
+      "label": "Perception: Audio Excerpt",
+      "description": "Sub-flag of perception. Publish redacted excerpts of the live-voice STT transcript stream as `audio_excerpt` events so the assistant can reason over spoken context. Requires per-conversation consent.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "webcam-snapshot",
+      "scope": "assistant",
+      "key": "webcam-snapshot",
+      "label": "Webcam Snapshot",
+      "description": "Enable the on-demand webcam snapshot skill. Each use requests one desktop camera frame, summarizes it through the configured LLM path, and discards the raw image.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "autonomous-execution",
+      "scope": "assistant",
+      "key": "autonomous-execution",
+      "label": "Autonomous Execution",
+      "description": "Enable the autonomous execution engine: durable multi-step plans persisted in plans/plan_steps/plan_step_runs, with crash recovery and lifecycle broadcasts. Plans skill exposes inspection + cancellation.",
+      "defaultEnabled": false
+    },
+    {
+      "id": "memory-maturation",
+      "scope": "assistant",
+      "key": "memory-maturation",
+      "label": "Memory Maturation",
+      "description": "Enable counter-weighted PKB confidence, idempotent episode writes, the hourly PKB decay job, and the post-turn preference-feedback observer. Store-API changes ship unconditionally.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add perception event ingestion, context buffering, consent grants, relevance/interpreter flow, and PKB storage/context wiring.
- Add DB and workspace migrations plus route coverage for perception and personal knowledge APIs.

## Test Plan
- cd assistant && bun test src/__tests__/workspace-migration-072-seed-perception-callsite.test.ts src/__tests__/perception-memory-injector.test.ts src/memory/personal-knowledge-store.test.ts src/memory/pkb-decay.test.ts src/perception/consent-grants.test.ts src/perception/context-buffer.test.ts src/perception/interpreter.test.ts src/perception/perception-event.test.ts src/perception/personal-knowledge-context.test.ts src/perception/personal-knowledge-writer.test.ts src/perception/relevance-gate.test.ts src/runtime/routes/perception-routes.test.ts src/runtime/routes/personal-knowledge-routes.test.ts src/runtime/routes/perception-http-smoke.test.ts
- cd assistant && bunx tsc --noEmit

## Risk
- High. New persistence, migrations, runtime routes, and feature-flagged perception behavior. Draft because it depends on the host camera bridge baseline.

Made with [Cursor](https://cursor.com)