### PR TITLE
Always show Doctor button in assistant connection failure dialog

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -378,7 +378,7 @@ export function ChatRouteContent({
   assistantIdentity: _assistantIdentity,
   chatPullToRefresh,
   deployToVercel,
-  doctor: doctorEnabled,
+  doctor: _doctorEnabled,
   isMobile,
   isKeyboardOpen,
   messages,
@@ -590,13 +590,13 @@ export function ChatRouteContent({
   const genericChatError = shouldShowGenericChatErrorNotice(error) && error
     ? {
         message: error.message,
-        actions: doctorEnabled ? (
+        actions: (
           <Button asChild variant="outlined" size="compact">
             <Link to={`${routes.settings.debug}?tab=doctor`}>
               Go to Doctor
             </Link>
           </Button>
-        ) : undefined,
+        ),
       }
     : null;
 

--- a/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
+++ b/apps/web/src/domains/chat/components/connecting-to-assistant.tsx
@@ -9,7 +9,6 @@ import type {
   ReachabilityState,
 } from "@/domains/assistant/use-assistant-reachability.js";
 import { MAX_ATTEMPTS } from "@/domains/assistant/use-assistant-reachability.js";
-import { useAppFeatureFlags } from "@/lib/feature-flags/app.js";
 import { routes } from "@/utils/routes.js";
 
 interface ConnectingToAssistantProps {
@@ -115,19 +114,14 @@ const FailureBody: FC<FailureBodyProps> = ({
   lastServerState,
   onRetry,
 }) => {
-  const { doctor: doctorEnabled } = useAppFeatureFlags();
   const isCrashLoop = lastServerState === "crash_loop";
 
   const title = isCrashLoop
     ? "Your assistant hit an error"
     : "Couldn't connect to your assistant";
   const description = isCrashLoop
-    ? doctorEnabled
-      ? "Your assistant reported an error while starting. Try running the Doctor to diagnose the issue. Please contact support if the problem persists."
-      : "Your assistant reported an error while starting. Please contact support if the problem persists."
-    : doctorEnabled
-      ? `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running the Doctor to diagnose the issue. Please contact support if the problem persists.`
-      : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Please contact support if the problem persists.`;
+    ? "Your assistant reported an error while starting. Try running the Doctor to diagnose the issue. Please contact support if the problem persists."
+    : `We tried ${MAX_ATTEMPTS} times over 60 seconds and still can't reach your assistant. Try running the Doctor to diagnose the issue. Please contact support if the problem persists.`;
 
   return (
     <StatusLayout
@@ -148,25 +142,15 @@ const FailureBody: FC<FailureBodyProps> = ({
           >
             Try again
           </Button>
-          {doctorEnabled ? (
-            <Button
-              asChild
-              variant="outlined"
-              data-testid="connection-go-to-doctor-button"
-            >
-              <Link to={`${routes.settings.debug}?tab=doctor`}>
-                Go to Doctor
-              </Link>
-            </Button>
-          ) : (
-            <Button
-              asChild
-              variant="outlined"
-              data-testid="connection-contact-support-button"
-            >
-              <a href="mailto:support@vellum.ai">Contact support</a>
-            </Button>
-          )}
+          <Button
+            asChild
+            variant="outlined"
+            data-testid="connection-go-to-doctor-button"
+          >
+            <Link to={`${routes.settings.debug}?tab=doctor`}>
+              Go to Doctor
+            </Link>
+          </Button>
         </>
       }
     />


### PR DESCRIPTION
Removes the `doctor` feature flag gating from UI consumers so the Doctor diagnostic tool is always available. Previously, the "Go to Doctor" button was conditionally hidden behind the `doctor` feature flag, leaving users with the flag disabled stuck with no diagnostic path when their assistant hit an error.

**Files changed:**
- `connecting-to-assistant.tsx` — always shows "Go to Doctor" button in connection failure dialog
- `chat-route-content.tsx` — Doctor button always shown in generic chat error notices

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/f75dce8c23a94f2f9843845595e89160
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->