### PR TITLE
Keep managed balanced profile on Anthropic

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -440,11 +440,9 @@ describe("loadConfig startup behavior", () => {
       "anthropic-personal",
     );
     // Managed profiles exist as well.
-    expect(config.llm.profiles.balanced?.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -453,9 +451,7 @@ describe("loadConfig startup behavior", () => {
       model: "claude-opus-4-7",
     });
     expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
   test("on-platform hatch seeds only managed profiles", () => {
@@ -483,11 +479,9 @@ describe("loadConfig startup behavior", () => {
     const config = loadConfig();
 
     expect(config.llm.activeProfile).toBe("balanced");
-    expect(config.llm.profiles.balanced?.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
     // No user profiles created on platform.
     expect(config.llm.profiles["custom-balanced"]).toBeUndefined();
@@ -529,10 +523,10 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed balanced profile is seeded for fireworks-managed.
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    // Managed balanced profile is seeded for anthropic-managed.
+    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
   });
 
@@ -566,9 +560,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     // On-platform: no user profiles created, active resets to managed balanced.
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
     // The old custom-balanced is preserved on disk but no longer active.
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
@@ -595,11 +589,8 @@ describe("loadConfig startup behavior", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
-      JSON.stringify(
-        { llm: { default: { provider: "openai" } } },
-        null,
-        2,
-      ) + "\n",
+      JSON.stringify({ llm: { default: { provider: "openai" } } }, null, 2) +
+        "\n",
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
@@ -623,10 +614,10 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced uses fireworks).
-    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
+    // Managed profiles are also seeded (balanced uses Anthropic).
+    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
     expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
@@ -654,11 +645,9 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "fireworks-managed",
+      "anthropic-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -685,9 +674,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Model still gets the new template value (provider-controlled).
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
     // But the user's label override is preserved across the reseed.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
   });
@@ -715,9 +702,7 @@ describe("loadConfig startup behavior", () => {
 
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
     // Model still refreshes — only label/status are user-owned.
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
   test("off-platform reseed preserves an explicit null label (user cleared it)", () => {
@@ -758,9 +743,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.profiles.balanced.label).toBe("Balanced (Managed)");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
     // Status is unset by default — must not appear as `undefined`.
     expect("status" in raw.llm.profiles.balanced).toBe(false);
   });
@@ -887,9 +870,7 @@ describe("loadConfig startup behavior", () => {
     // Off-platform hatch: user profiles are active.
     expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.model).toBe(
-      "accounts/fireworks/models/kimi-k2p6",
-    );
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -997,11 +978,8 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
-      JSON.stringify(
-        { llm: { default: { provider: "anthropic" } } },
-        null,
-        2,
-      ) + "\n",
+      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
+        "\n",
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
@@ -1045,11 +1023,8 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
-      JSON.stringify(
-        { llm: { default: { provider: "anthropic" } } },
-        null,
-        2,
-      ) + "\n",
+      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
+        "\n",
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -40,8 +40,8 @@ type ManagedProfileTemplate = Omit<
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   balanced: {
     intent: "balanced",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
+    provider: "anthropic",
+    connectionName: "anthropic-managed",
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
@@ -286,8 +286,7 @@ export function seedInferenceProfiles(
         }
       }
 
-      const provider =
-        hatchProvider as NonNullable<ProfileEntry["provider"]>;
+      const provider = hatchProvider as NonNullable<ProfileEntry["provider"]>;
       for (const [name, template] of Object.entries(USER_PROFILE_TEMPLATES)) {
         if (preservedProfileNames.has(name)) continue;
         profiles[name] = materializeProfile(


### PR DESCRIPTION
## Summary
- move the managed `balanced` inference profile back to Anthropic/Sonnet
- keep Fireworks provider support, managed connection seeding, proxy metadata, and catalog entries intact
- update config seeding tests to assert Anthropic remains the managed balanced default

## Tests
- `cd assistant && bun test src/__tests__/config-loader-backfill.test.ts`
- pre-push: `cd assistant && bunx tsc --noEmit`
- pre-push: `cd assistant && eslint src/__tests__/config-loader-backfill.test.ts src/config/seed-inference-profiles.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->