### PR TITLE
[v2] Expand live voice streaming and TTS runtime handling

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -939,11 +939,40 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     });
     expect(res2.status).toBe(202);
 
-    // Both should have resolved to the same default conversation key
-    // ("default:vellum:macos"), which maps to the same conversationId.
-    const mapping = getConversationByKey("default:vellum:macos");
+    // Both should resolve to the shared local handoff key, which allows
+    // first-party local interfaces to continue one conversation across devices.
+    const mapping = getConversationByKey("default:vellum:handoff");
     expect(mapping).not.toBeNull();
     expect(mapping!.conversationId).toBeTruthy();
+
+    await stopServer();
+  });
+
+  test("local first-party interfaces without conversationKey share one handoff conversation", async () => {
+    await startServer(() => makeCompletingConversation());
+
+    const interfaces = ["macos", "ios", "web", "chrome-extension", "tauri"];
+    for (const iface of interfaces) {
+      const res = await fetch(messagesUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          content: `hello-from-${iface}`,
+          sourceChannel: "vellum",
+          interface: iface,
+        }),
+      });
+      expect(res.status).toBe(202);
+    }
+
+    const handoff = getConversationByKey("default:vellum:handoff");
+    expect(handoff).not.toBeNull();
+
+    // Legacy interface-scoped defaults are no longer used for first-party
+    // local interfaces when conversationKey is omitted.
+    expect(getConversationByKey("default:vellum:macos")).toBeNull();
+    expect(getConversationByKey("default:vellum:tauri")).toBeNull();
+    expect(getConversationByKey("default:vellum:web")).toBeNull();
 
     await stopServer();
   });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -566,6 +566,47 @@ describe("voice-session-bridge", () => {
     });
   });
 
+  test("startVoiceTurn forwards action lifecycle events to callbacks", async () => {
+    const conversation = createConversation(
+      "voice bridge action lifecycle test",
+    );
+    const events: ServerMessage[] = [
+      {
+        type: "action_lifecycle",
+        actionId: "action-1",
+        actionName: "host_app_control",
+        stage: "executing",
+        ts: Date.now(),
+        conversationId: conversation.id,
+      },
+      { type: "message_complete", conversationId: conversation.id },
+    ];
+    const session = makeStreamingSession(events);
+    injectDeps(() => session);
+
+    const lifecycleEvents: Array<
+      Extract<ServerMessage, { type: "action_lifecycle" }>
+    > = [];
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: "do the action",
+      isInbound: true,
+      callbacks: {
+        action_lifecycle: (msg) => lifecycleEvents.push(msg),
+      },
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lifecycleEvents).toHaveLength(1);
+    expect(lifecycleEvents[0]).toMatchObject({
+      actionId: "action-1",
+      stage: "executing",
+    });
+  });
+
   test("startVoiceTurn passes guardian context to the session", async () => {
     const conversation = createConversation(
       "voice bridge guardian context test",

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -88,6 +88,9 @@ export interface VoiceRunEventSink {
   ): void;
   onError(message: string): void;
   onToolUse(toolName: string, input: Record<string, unknown>): void;
+  onActionLifecycle(
+    msg: Extract<ServerMessage, { type: "action_lifecycle" }>,
+  ): void;
 }
 
 export interface VoiceTurnCallbacks {
@@ -102,6 +105,9 @@ export interface VoiceTurnCallbacks {
   ) => void;
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;
+  action_lifecycle?: (
+    msg: Extract<ServerMessage, { type: "action_lifecycle" }>,
+  ) => void;
 }
 
 export interface VoiceTurnOptions {
@@ -309,6 +315,9 @@ export async function startVoiceTurn(
     },
     onToolUse: (toolName, input) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
+    },
+    onActionLifecycle: (msg) => {
+      opts.callbacks?.action_lifecycle?.(msg);
     },
   };
 
@@ -582,6 +591,8 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input);
+          } else if (msg.type === "action_lifecycle") {
+            eventSink.onActionLifecycle(msg);
           }
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -90,6 +90,7 @@ function createSessionHarness(
     startVoiceTurn?: LiveVoiceTurnStarter;
     createTurnId?: () => string;
     emitMetrics?: boolean;
+    getPerceptionMemoryContext?: () => string | null;
   } = {},
 ) {
   const transcriber =
@@ -108,6 +109,7 @@ function createSessionHarness(
     startVoiceTurn,
     createTurnId: options.createTurnId ?? (() => "live-turn-1"),
     emitMetrics: options.emitMetrics ?? false,
+    getPerceptionMemoryContext: options.getPerceptionMemoryContext,
   });
 
   return { frames, session, startVoiceTurn, transcriber };
@@ -179,6 +181,9 @@ describe("LiveVoiceSession assistant turn", () => {
       isInbound: true,
     });
     expect(voiceTurnOptions?.signal).toBeInstanceOf(AbortSignal);
+    expect(voiceTurnOptions?.voiceControlPrompt).toContain(
+      "You are speaking in a local live voice session. Keep replies brief and conversational.",
+    );
     expect(frames.map((frame) => frame.type)).toEqual([
       "ready",
       "stt_final",
@@ -203,6 +208,72 @@ describe("LiveVoiceSession assistant turn", () => {
     expect(frames[6]).toMatchObject({
       type: "tts_done",
       turnId: "live-turn-1",
+    });
+  });
+
+  test("injects perception memory context into the live voice control prompt", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { session, transcriber } = createSessionHarness({
+      startVoiceTurn,
+      getPerceptionMemoryContext: () =>
+        "### Recent perceived episodes\n- Edited runtime routes.",
+    });
+
+    await session.start();
+    transcriber.emit({ type: "final", text: "hello" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => startVoiceTurn.mock.calls.length > 0);
+
+    const voiceTurnOptions = startVoiceTurn.mock.calls[0]?.[0];
+    expect(voiceTurnOptions?.voiceControlPrompt).toContain(
+      "<perception_memory>",
+    );
+    expect(voiceTurnOptions?.voiceControlPrompt).toContain(
+      "Edited runtime routes.",
+    );
+  });
+
+  test("turns action lifecycle updates into assistant speech cues", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.action_lifecycle?.({
+        type: "action_lifecycle",
+        actionId: "action-1",
+        actionName: "host_app_control",
+        stage: "executing",
+        ts: Date.now(),
+        conversationId: options.conversationId,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-123",
+      });
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { frames, session, transcriber } = createSessionHarness({
+      startVoiceTurn,
+    });
+
+    await session.start();
+    transcriber.emit({ type: "final", text: "hello" });
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(frames[4]).toMatchObject({
+      type: "assistant_text_delta",
+      text: "Working on host app control. ",
     });
   });
 
@@ -285,6 +356,7 @@ describe("LiveVoiceSession assistant turn", () => {
       "ready",
       "stt_final",
       "metrics",
+      "tts_done",
     ]);
   });
 
@@ -304,10 +376,14 @@ describe("LiveVoiceSession assistant turn", () => {
 
     await session.start();
     await session.handleClientFrame({ type: "ptt_release" });
-    await waitForFrameCount(frames, 2);
+    await waitForFrameCount(frames, 3);
 
     expect(startVoiceTurn).not.toHaveBeenCalled();
-    expect(frames.map((frame) => frame.type)).toEqual(["ready", "stt_final"]);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "tts_done",
+    ]);
   });
 
   test("falls back to the session id when start omits a conversation id", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -1,6 +1,23 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../../config/assistant-feature-flags.js";
+import { getSqlite, resetDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { recordPerceptionConsentGrant } from "../../perception/consent-grants.js";
+import { PERCEPTION_EVENT_TYPE_PREFIX } from "../../perception/perception-event.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -100,6 +117,129 @@ function createSessionWithTranscriber(
 }
 
 describe("LiveVoiceSession STT", () => {
+  beforeAll(() => {
+    resetDb();
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const sqlite = getSqlite();
+    sqlite.run("DELETE FROM perception_consent_grants");
+  });
+
+  afterEach(() => {
+    clearFeatureFlagOverridesCache();
+  });
+
+  test("publishes audio_excerpt perception event when sub-flag is on and consent granted", async () => {
+    _setOverridesForTesting({
+      perception: true,
+      "perception-audio-excerpt": true,
+    });
+    recordPerceptionConsentGrant({
+      conversationId: "conversation-123",
+      eventKind: "audio_excerpt",
+    });
+
+    const events: unknown[] = [];
+    const sub = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string } | undefined)?.type;
+        if (type?.startsWith(`${PERCEPTION_EVENT_TYPE_PREFIX}.`)) {
+          events.push(event);
+        }
+      },
+    });
+
+    try {
+      const { session, transcriber } = createSessionWithTranscriber();
+      await session.start();
+      transcriber.emit({ type: "final", text: "remember the meeting at 4pm" });
+      await session.handleClientFrame({ type: "ptt_release" });
+
+      const audioEvents = events.filter((e) => {
+        const type = ((e as { message?: { type?: string } }).message ?? {})
+          .type;
+        return type === `${PERCEPTION_EVENT_TYPE_PREFIX}.audio_excerpt`;
+      });
+      expect(audioEvents.length).toBeGreaterThanOrEqual(1);
+      const message = (audioEvents[0] as { message: unknown }).message as {
+        perception: {
+          payload: {
+            kind: string;
+            transcriptRedacted: string;
+            sessionId: string;
+          };
+        };
+      };
+      expect(message.perception.payload.kind).toBe("audio_excerpt");
+      expect(message.perception.payload.transcriptRedacted).toBe(
+        "remember the meeting at 4pm",
+      );
+      expect(message.perception.payload.sessionId).toBe("session-123");
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("does not publish audio_excerpt when consent is missing", async () => {
+    _setOverridesForTesting({
+      perception: true,
+      "perception-audio-excerpt": true,
+    });
+    // Intentionally no consent grant recorded.
+
+    const audioEvents: unknown[] = [];
+    const sub = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string } | undefined)?.type;
+        if (type === `${PERCEPTION_EVENT_TYPE_PREFIX}.audio_excerpt`) {
+          audioEvents.push(event);
+        }
+      },
+    });
+
+    try {
+      const { session, transcriber } = createSessionWithTranscriber();
+      await session.start();
+      transcriber.emit({ type: "final", text: "no consent here" });
+      await session.handleClientFrame({ type: "ptt_release" });
+      expect(audioEvents).toEqual([]);
+    } finally {
+      sub.dispose();
+    }
+  });
+
+  test("does not publish audio_excerpt when sub-flag is off", async () => {
+    _setOverridesForTesting({
+      perception: true,
+      "perception-audio-excerpt": false,
+    });
+
+    const audioEvents: unknown[] = [];
+    const sub = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        const type = (event.message as { type?: string } | undefined)?.type;
+        if (type === `${PERCEPTION_EVENT_TYPE_PREFIX}.audio_excerpt`) {
+          audioEvents.push(event);
+        }
+      },
+    });
+
+    try {
+      const { session, transcriber } = createSessionWithTranscriber();
+      await session.start();
+      transcriber.emit({ type: "final", text: "hi" });
+      await session.handleClientFrame({ type: "ptt_release" });
+      expect(audioEvents).toEqual([]);
+    } finally {
+      sub.dispose();
+    }
+  });
+
   test("resolves streaming STT through the injected resolver and sends ready", async () => {
     const { frames, resolver, session, transcriber } =
       createSessionWithTranscriber();
@@ -149,7 +289,7 @@ describe("LiveVoiceSession STT", () => {
     expect(session.finalTranscriptText).toBe("hello world final transcript");
   });
 
-  test("treats ptt_release as end-of-utterance and rejects later audio", async () => {
+  test("treats ptt_release as end-of-utterance and drops later audio", async () => {
     const { frames, session, transcriber } = createSessionWithTranscriber();
 
     await session.start();
@@ -163,20 +303,7 @@ describe("LiveVoiceSession STT", () => {
 
     expect(transcriber.stopped).toBe(true);
     expect(transcriber.audioChunks.map((chunk) => [...chunk])).toEqual([[1]]);
-    expect(frames.filter((frame) => frame.type === "error")).toEqual([
-      {
-        type: "error",
-        seq: 4,
-        code: "invalid_audio_payload",
-        message: "Live voice audio received after push-to-talk release.",
-      },
-      {
-        type: "error",
-        seq: 5,
-        code: "invalid_audio_payload",
-        message: "Live voice audio received after push-to-talk release.",
-      },
-    ]);
+    expect(frames.filter((frame) => frame.type === "error")).toEqual([]);
   });
 
   test("returns a readable error frame when streaming STT is unavailable", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5,15 +5,24 @@ import type {
   VoiceTurnHandle,
   VoiceTurnOptions,
 } from "../calls/voice-session-bridge.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import type { ActionLifecycleMessage } from "../daemon/message-types/actions.js";
+import { hasActivePerceptionConsent } from "../perception/consent-grants.js";
+import { perceptionEventType } from "../perception/perception-event.js";
+import { buildPerceptionKnowledgeContext } from "../perception/personal-knowledge-context.js";
+import { sanitizeText } from "../perception/sanitization.js";
 import {
   listProviderIds,
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../stt/types.js";
+import { getLogger } from "../util/logger.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -33,6 +42,8 @@ import {
 import type {
   LiveVoiceTtsOptions,
   LiveVoiceTtsResult,
+  LiveVoiceTtsSession,
+  LiveVoiceTtsSessionOptions,
 } from "./live-voice-tts.js";
 import {
   type LiveVoiceClientFrame,
@@ -49,9 +60,23 @@ type LiveVoiceSessionState =
   | "failed"
   | "closed";
 
+const log = getLogger("live-voice");
+
 const LIVE_VOICE_TTS_SEGMENT_CHAR_THRESHOLD = 180;
 const SENTENCE_ENDING_PUNCTUATION = new Set([".", "!", "?"]);
 const TRAILING_SENTENCE_PUNCTUATION = new Set(['"', "'", ")", "]"]);
+
+function resolveLiveVoiceSourceChannel(
+  sourceChannel: string | undefined,
+): "vellum" {
+  return sourceChannel === "vellum" ? sourceChannel : "vellum";
+}
+
+function resolveLiveVoiceSourceInterface(
+  sourceInterface: string | undefined,
+): "macos" | "tauri" {
+  return sourceInterface === "tauri" ? sourceInterface : "macos";
+}
 
 export type LiveVoiceStreamingTranscriberResolver = (
   options: ResolveStreamingTranscriberOptions,
@@ -64,6 +89,22 @@ export type LiveVoiceTurnStarter = (
 export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
 ) => Promise<LiveVoiceTtsResult>;
+
+/**
+ * Opens a persistent multi-utterance streaming TTS session. Live-voice
+ * prefers this path when the configured provider supports it (currently
+ * xAI) because it amortises the WebSocket handshake across every text
+ * delta in the turn — eliminating the per-segment latency the streamer
+ * path otherwise pays.
+ *
+ * The function is expected to throw a `LiveVoiceTtsError` with code
+ * `LIVE_VOICE_TTS_STREAMING_UNAVAILABLE` when the provider can't open a
+ * session; callers should treat that as a soft fallback signal and revert
+ * to per-segment `streamTtsAudio` for the remainder of the turn.
+ */
+export type LiveVoiceTtsSessionOpener = (
+  options: LiveVoiceTtsSessionOptions,
+) => Promise<LiveVoiceTtsSession>;
 
 export interface LiveVoiceSessionArchiveAudioInput {
   messageId?: string | null;
@@ -87,10 +128,24 @@ export interface LiveVoiceSessionOptions {
   resolveTranscriber?: LiveVoiceStreamingTranscriberResolver;
   startVoiceTurn?: LiveVoiceTurnStarter;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
+  /**
+   * Optional persistent-session TTS opener. When provided, the session
+   * runs in "stream-as-you-speak" mode: every assistant text delta is
+   * forwarded to the open session as-is and the provider (e.g. xAI)
+   * streams audio chunks back as it produces them — bypassing the
+   * sentence-segmentation buffer entirely. The session is finalized at
+   * `message_complete` and closed on abort/error.
+   *
+   * If the opener throws `LIVE_VOICE_TTS_STREAMING_UNAVAILABLE` (provider
+   * does not support sessions), the session silently falls back to the
+   * per-segment `streamTtsAudio` path for that turn.
+   */
+  openTtsStreamingSession?: LiveVoiceTtsSessionOpener | null;
   archiveAudio?: LiveVoiceSessionAudioArchiver | null;
   emitMetrics?: boolean;
   metricsClock?: LiveVoiceMetricsClock;
   createTurnId?: () => string;
+  getPerceptionMemoryContext?: () => string | null;
 }
 
 interface ActiveAssistantTurn {
@@ -103,12 +158,24 @@ interface ActiveAssistantTurn {
   finalized: boolean;
   ttsBuffer: string;
   ttsQueue: Promise<void>;
+  /**
+   * Lazy persistent TTS session promise. `null` when no opener is
+   * configured. Resolves to a session when streaming-session mode is in
+   * use, or `null` when the opener bailed (e.g. provider doesn't support
+   * sessions) and we've fallen back to per-segment mode.
+   */
+  ttsSessionPromise: Promise<LiveVoiceTtsSession | null> | null;
+  /** Pending tts_audio frames written from the session's chunk callback. */
+  ttsSessionAudioFrames: Promise<void>;
+  /** True once the session has been finalized or aborted. */
+  ttsSessionFinalized: boolean;
   userMessageId: string | null;
   assistantMessageId: string | null;
   userAudioChunks: Buffer[];
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+  announcedActionLifecycleStages: Set<string>;
 }
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
@@ -116,10 +183,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
   private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
   private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
+  private readonly openTtsStreamingSession: LiveVoiceTtsSessionOpener | null;
   private readonly archiveAudio: LiveVoiceSessionAudioArchiver | null;
   private readonly emitMetrics: boolean;
   private readonly metrics: LiveVoiceMetricsCollector;
   private readonly createTurnId: () => string;
+  private readonly getPerceptionMemoryContext: () => string | null;
   private readonly conversationId: string;
   private state: LiveVoiceSessionState = "initializing";
   private transcriber: StreamingTranscriber | null = null;
@@ -133,7 +202,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private currentUserAudioChunks: Buffer[] = [];
   private metricsTurnStarted = false;
   private metricsTurnFinished = false;
+  private terminalTurnFrameSent = false;
   private sessionEndMetricsEmitted = false;
+  /**
+   * Probed once during `start()` and frozen for the rest of the session.
+   * `true` means the active TTS provider advertised support for persistent
+   * streaming sessions AND `openTtsStreamingSession` was wired — every
+   * assistant turn in this session will use the session-mode pipeline.
+   * `false` keeps the session on the per-segment `streamTtsAudio` path.
+   *
+   * Probing eagerly here (rather than lazily on the first delta) avoids
+   * the queue race condition that would arise from mixing session-mode and
+   * segment-mode work within the same turn.
+   */
+  private ttsStreamingSessionsSupported = false;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -144,9 +226,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
     this.startVoiceTurn = options.startVoiceTurn ?? null;
     this.streamTtsAudio = options.streamTtsAudio ?? null;
+    this.openTtsStreamingSession = options.openTtsStreamingSession ?? null;
     this.archiveAudio = options.archiveAudio ?? null;
     this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
+    this.getPerceptionMemoryContext =
+      options.getPerceptionMemoryContext ?? defaultPerceptionMemoryContext;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
     this.metrics = new LiveVoiceMetricsCollector({
@@ -187,6 +272,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         this.transcriber = null;
         return;
       }
+
+      // Streaming-session support is settled at session-create time by the
+      // caller (factory wires the opener iff the configured provider
+      // advertises capability). A non-null opener means we're committed to
+      // session-mode for every assistant turn in this session.
+      this.ttsStreamingSessionsSupported = Boolean(
+        this.openTtsStreamingSession,
+      );
 
       this.state = "active";
       this.metrics.markReady();
@@ -253,7 +346,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.state === "utterance_released" ||
       this.state === "transcriber_closed"
     ) {
-      await this.sendAudioAfterReleaseError();
+      // Browser mic pipelines can deliver a few late frames after the client
+      // sends `ptt_release`. The utterance boundary is already fixed, so drop
+      // them silently rather than flooding the HUD with recoverable errors.
       return;
     }
 
@@ -336,6 +431,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }
         this.markFinalTranscript();
         await this.sendFrame({ type: "stt_final", text: event.text });
+        await this.publishAudioExcerpt(transcript);
         await this.startAssistantTurnIfReady();
         return;
       }
@@ -384,6 +480,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const content = this.finalTranscriptText.trim();
     if (content.length === 0) {
       await this.finalizePendingTurn("empty_transcript");
+      await this.sendTerminalTurnFrame();
       return;
     }
 
@@ -402,11 +499,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       finalized: false,
       ttsBuffer: "",
       ttsQueue: Promise.resolve(),
+      ttsSessionPromise: null,
+      ttsSessionAudioFrames: Promise.resolve(),
+      ttsSessionFinalized: false,
       userMessageId: this.currentUserMessageId,
       assistantMessageId: null,
       userAudioChunks: this.currentUserAudioChunks,
       assistantAudioChunks: [],
       assistantAudioMimeType: "audio/pcm",
+      announcedActionLifecycleStages: new Set<string>(),
     };
 
     await this.sendFrame({ type: "thinking", turnId });
@@ -416,12 +517,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       const handle = await this.startVoiceTurn({
         conversationId: this.conversationId,
         voiceSessionId: this.context.sessionId,
-        userMessageChannel: "vellum",
-        assistantMessageChannel: "vellum",
-        userMessageInterface: "macos",
-        assistantMessageInterface: "macos",
-        voiceControlPrompt:
-          "You are speaking in a local live voice session. Keep replies brief and conversational.",
+        userMessageChannel: resolveLiveVoiceSourceChannel(
+          this.context.startFrame.sourceChannel,
+        ),
+        assistantMessageChannel: resolveLiveVoiceSourceChannel(
+          this.context.startFrame.sourceChannel,
+        ),
+        userMessageInterface: resolveLiveVoiceSourceInterface(
+          this.context.startFrame.sourceInterface,
+        ),
+        assistantMessageInterface: resolveLiveVoiceSourceInterface(
+          this.context.startFrame.sourceInterface,
+        ),
+        voiceControlPrompt: buildLiveVoiceControlPrompt(
+          this.getPerceptionMemoryContext(),
+        ),
         approvalMode: "local-live-voice",
         content,
         isInbound: true,
@@ -468,6 +578,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             if (activeTurn?.token !== token) return;
             activeTurn.assistantMessageId = messageId;
           },
+          action_lifecycle: (msg) => {
+            if (!this.isActiveAssistantTurn(token)) return;
+            void this.handleActionLifecycleUpdate(token, msg);
+          },
         },
         onError: (message) => {
           if (!this.isActiveAssistantTurn(token)) return;
@@ -510,6 +624,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
+  private async handleActionLifecycleUpdate(
+    token: symbol,
+    msg: ActionLifecycleMessage,
+  ): Promise<void> {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token || activeTurn.assistantCompleted) return;
+    const lifecycleKey = `${msg.actionId}:${msg.stage}`;
+    if (activeTurn.announcedActionLifecycleStages.has(lifecycleKey)) return;
+    activeTurn.announcedActionLifecycleStages.add(lifecycleKey);
+
+    const cue = actionLifecycleCue(msg);
+    if (!cue) return;
+
+    await this.sendFrame(
+      {
+        type: "assistant_text_delta",
+        text: cue,
+      },
+      () => this.isForwardingAssistantText(token),
+    );
+    this.bufferAssistantTextForTts(token, cue);
+  }
+
   private async cancelAssistantTurn(reason: string): Promise<void> {
     const turn = this.activeAssistantTurn;
     if (!turn) {
@@ -520,6 +657,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.activeAssistantTurn = null;
     turn.abortController.abort();
     turn.handle?.abort();
+    // Best-effort: if a streaming TTS session was opened for this turn,
+    // tear it down so the upstream WebSocket releases promptly. The session
+    // already listens to abortController.signal but closing explicitly here
+    // avoids relying on signal-handler ordering.
+    if (turn.ttsSessionPromise) {
+      void turn.ttsSessionPromise.then(async (session) => {
+        if (!session) return;
+        try {
+          await session.close();
+        } catch {
+          // ignore close errors during cancellation
+        }
+      });
+    }
     await this.finalizeAssistantTurn(turn, "cancelled", reason);
   }
 
@@ -552,11 +703,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private bufferAssistantTextForTts(token: symbol, text: string): void {
-    if (!this.streamTtsAudio || text.length === 0) return;
+    if (text.length === 0) return;
 
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token || activeTurn.assistantCompleted) return;
 
+    // Streaming-session mode: forward every delta into a single persistent
+    // session for this turn. xAI handles segmentation/synthesis pacing
+    // itself, so we don't need to buffer up sentence boundaries.
+    if (this.ttsStreamingSessionsSupported && this.openTtsStreamingSession) {
+      this.appendTextToTtsStreamingSession(token, text);
+      return;
+    }
+
+    if (!this.streamTtsAudio) return;
     activeTurn.ttsBuffer += text;
     this.flushTtsBuffer(token, false);
   }
@@ -564,6 +724,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private completeTtsForTurn(token: symbol): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) return;
+
+    // Streaming-session mode: finalize the active session, then signal the
+    // client. The session emits its terminal audio chunk via the existing
+    // chunk pipeline so playback finishes naturally.
+    if (this.ttsStreamingSessionsSupported && this.openTtsStreamingSession) {
+      this.finalizeTtsStreamingSessionForTurn(token);
+      return;
+    }
 
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
@@ -595,6 +763,187 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
         }
       });
+  }
+
+  /**
+   * Lazy-open the persistent TTS session for this turn (if not already
+   * open) and append the delta. The session-mode opener is only wired in
+   * the factory when the configured provider advertises session support,
+   * so any open failure here is a hard error (network/auth) and we surface
+   * it as an error frame to the client.
+   */
+  private appendTextToTtsStreamingSession(token: symbol, text: string): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) return;
+
+    if (!activeTurn.ttsSessionPromise) {
+      activeTurn.ttsSessionPromise = this.openLiveVoiceTtsSessionForTurn(
+        token,
+        activeTurn,
+      );
+    }
+
+    const sessionPromise = activeTurn.ttsSessionPromise;
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(async () => {
+        let session: LiveVoiceTtsSession | null = null;
+        try {
+          session = await sessionPromise;
+        } catch (err) {
+          log.warn(
+            { message: errorMessage(err) },
+            "Live voice TTS streaming-session open failed",
+          );
+          if (!this.isForwardingTts(token)) return;
+          await this.sendFrame(
+            {
+              type: "error",
+              code: LiveVoiceProtocolErrorCode.InvalidField,
+              message: `Live voice TTS failed: ${errorMessage(err)}`,
+            },
+            () => this.isForwardingTts(token),
+          );
+          return;
+        }
+        if (!session) return;
+
+        const currentTurn = this.activeAssistantTurn;
+        if (
+          currentTurn?.token !== token ||
+          currentTurn.abortController.signal.aborted ||
+          currentTurn.ttsSessionFinalized
+        ) {
+          return;
+        }
+
+        try {
+          await session.appendText(text);
+        } catch (err) {
+          log.warn(
+            { textLength: text.length, message: errorMessage(err) },
+            "Live voice TTS streaming-session appendText failed",
+          );
+          if (!this.isForwardingTts(token)) return;
+          await this.sendFrame(
+            {
+              type: "error",
+              code: LiveVoiceProtocolErrorCode.InvalidField,
+              message: `Live voice TTS failed: ${errorMessage(err)}`,
+            },
+            () => this.isForwardingTts(token),
+          );
+        }
+      });
+  }
+
+  /**
+   * Finalize the streaming TTS session for `token`'s turn, wait for the
+   * provider to emit its terminal audio chunk, then send `tts_done`.
+   */
+  private finalizeTtsStreamingSessionForTurn(token: symbol): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) return;
+
+    const sessionPromise = activeTurn.ttsSessionPromise;
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(async () => {
+        const currentTurn = this.activeAssistantTurn;
+        if (currentTurn?.token !== token || currentTurn.ttsDone) return;
+
+        let session: LiveVoiceTtsSession | null = null;
+        if (sessionPromise) {
+          try {
+            session = await sessionPromise;
+          } catch {
+            // appendText path already surfaced the error frame; here we
+            // just continue to send tts_done so the client can clean up.
+            session = null;
+          }
+        }
+
+        if (session && !currentTurn.ttsSessionFinalized) {
+          currentTurn.ttsSessionFinalized = true;
+          try {
+            await session.finalize();
+          } catch (err) {
+            log.warn(
+              { message: errorMessage(err) },
+              "Live voice TTS streaming-session finalize failed",
+            );
+          }
+          await currentTurn.ttsSessionAudioFrames;
+          try {
+            await session.close();
+          } catch {
+            // ignore close errors
+          }
+        }
+
+        currentTurn.ttsDone = true;
+        await this.finalizeAssistantTurn(
+          currentTurn,
+          "completed",
+          "completed",
+          {
+            clearActive: false,
+          },
+        );
+        await this.sendFrame(
+          { type: "tts_done", turnId: currentTurn.turnId },
+          () =>
+            this.activeAssistantTurn?.token === token &&
+            currentTurn.finalized &&
+            !this.isClosed,
+        );
+
+        if (this.activeAssistantTurn?.token === token) {
+          if (currentTurn.handle && currentTurn.finalized) {
+            this.activeAssistantTurn = null;
+          }
+        }
+      });
+  }
+
+  /**
+   * Open a live-voice TTS streaming session for the given turn. Errors
+   * propagate up to the queue chain that called this method — the caller
+   * surfaces them as a client-facing error frame.
+   */
+  private async openLiveVoiceTtsSessionForTurn(
+    token: symbol,
+    activeTurn: ActiveAssistantTurn,
+  ): Promise<LiveVoiceTtsSession | null> {
+    if (!this.openTtsStreamingSession) return null;
+    return await this.openTtsStreamingSession({
+      signal: activeTurn.abortController.signal,
+      outputFormat: "pcm",
+      sampleRate: this.context.startFrame.audio.sampleRate,
+      onAudioChunk: (chunk) => {
+        if (!this.isForwardingTts(token)) return;
+        const liveTurn = this.activeAssistantTurn;
+        if (liveTurn?.token !== token) return;
+        liveTurn.assistantAudioChunks.push(
+          Buffer.from(chunk.dataBase64, "base64"),
+        );
+        liveTurn.assistantAudioMimeType = chunk.contentType;
+        liveTurn.assistantAudioSampleRate = chunk.sampleRate;
+        this.metrics.markFirstTtsAudio(liveTurn.turnId);
+        liveTurn.ttsSessionAudioFrames = liveTurn.ttsSessionAudioFrames.then(
+          () =>
+            this.sendFrame(
+              {
+                type: "tts_audio",
+                mimeType: chunk.contentType,
+                sampleRate: chunk.sampleRate,
+                dataBase64: chunk.dataBase64,
+              },
+              () => this.isForwardingTts(token),
+            ),
+        );
+      },
+    });
   }
 
   private flushTtsBuffer(token: symbol, force: boolean): void {
@@ -665,6 +1014,35 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           });
           await ttsAudioFrames;
         } catch (err) {
+          // The catch path used to be silent on the daemon side — the only
+          // signal was the `error` frame sent to the client. That made
+          // diagnosing provider auth/config/network failures impossible
+          // without attaching a debugger. Log the full error here so the
+          // failure mode is visible in the assistant log alongside the
+          // user-facing error frame.
+          const errAsAny = err as Error & {
+            code?: unknown;
+            statusCode?: unknown;
+            cause?: unknown;
+          };
+          log.warn(
+            {
+              segmentLength: segment.length,
+              errorName: errAsAny?.name,
+              errorCode:
+                typeof errAsAny?.code === "string" ? errAsAny.code : undefined,
+              statusCode:
+                typeof errAsAny?.statusCode === "number"
+                  ? errAsAny.statusCode
+                  : undefined,
+              cause:
+                errAsAny?.cause instanceof Error
+                  ? errAsAny.cause.message
+                  : undefined,
+              message: errorMessage(err),
+            },
+            "Live voice TTS segment synthesis failed",
+          );
           if (!this.isForwardingTts(token)) return;
           await this.sendFrame(
             {
@@ -734,6 +1112,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       assistantAudioMimeType: "audio/pcm",
     });
     await this.finishMetricsTurn("cancelled", reason, turnId);
+  }
+
+  private async sendTerminalTurnFrame(): Promise<void> {
+    const turnId = this.currentTurnId;
+    if (!turnId || this.terminalTurnFrameSent || this.isClosed) return;
+    this.terminalTurnFrameSent = true;
+    await this.sendFrame({ type: "tts_done", turnId });
   }
 
   private async finalizeAssistantTurn(
@@ -930,14 +1315,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     throw new LiveVoiceSessionStartupError(message);
   }
 
-  private async sendAudioAfterReleaseError(): Promise<void> {
-    await this.sendFrame({
-      type: "error",
-      code: LiveVoiceProtocolErrorCode.InvalidAudioPayload,
-      message: "Live voice audio received after push-to-talk release.",
-    });
-  }
-
   private async sendFrame(
     frame: LiveVoiceServerFramePayload,
     shouldSend: () => boolean = () => true,
@@ -959,6 +1336,74 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.outboundFrames.catch(() => {});
   }
 
+  /**
+   * Best-effort publish of a finalised STT turn as a `perception.audio_excerpt`
+   * event so the assistant can reason over spoken context.
+   *
+   * Gated by:
+   * - The master `perception` flag (must be on for any perception event).
+   * - The sub-flag `perception-audio-excerpt` (default off).
+   * - A per-conversation `perception_consent_grants` row — that gate lands in
+   *   phase 4C and reuses the existing `confirmation_request` flow; until it
+   *   lands, the feature flag is the only gate. Failures here never bubble
+   *   back to the live-voice session.
+   */
+  private async publishAudioExcerpt(transcript: string): Promise<void> {
+    try {
+      if (transcript.length === 0) return;
+      const config = getConfig();
+      if (!isAssistantFeatureFlagEnabled("perception", config)) return;
+      if (!isAssistantFeatureFlagEnabled("perception-audio-excerpt", config)) {
+        return;
+      }
+
+      if (
+        !hasActivePerceptionConsent({
+          conversationId: this.conversationId,
+          eventKind: "audio_excerpt",
+        })
+      ) {
+        return;
+      }
+
+      const sanitized = sanitizeText(transcript, 1024);
+      if (sanitized.length === 0) return;
+
+      const eventId = `audio-excerpt:${this.context.sessionId}:${randomUUID()}`;
+      const ts = new Date().toISOString();
+
+      await assistantEventHub.publish({
+        id: eventId,
+        emittedAt: ts,
+        message: {
+          type: perceptionEventType("audio_excerpt"),
+          perception: {
+            eventId,
+            ts,
+            source: { module: "live-voice" },
+            payload: {
+              kind: "audio_excerpt",
+              conversationId: this.conversationId,
+              sessionId: this.context.sessionId,
+              turnId: this.conversationId,
+              transcriptRedacted: sanitized,
+              confidence: 1,
+            },
+          },
+        },
+      } as never);
+    } catch (err) {
+      log.warn(
+        {
+          err,
+          sessionId: this.context.sessionId,
+          conversationId: this.conversationId,
+        },
+        "failed to publish audio_excerpt perception event",
+      );
+    }
+  }
+
   private get isClosed(): boolean {
     return this.state === "closed";
   }
@@ -975,6 +1420,12 @@ export function createLiveVoiceSession(
       options.streamTtsAudio === undefined
         ? defaultStreamLiveVoiceTtsAudio
         : options.streamTtsAudio,
+    // The session-mode opener is OPT-IN. Production wiring (http-server)
+    // probes provider capability synchronously and passes
+    // `defaultOpenLiveVoiceTtsStreamingSession` when supported. Tests that
+    // don't pass `openTtsStreamingSession` get null and stay on the
+    // legacy per-segment path — preserving prior test behaviour.
+    openTtsStreamingSession: options.openTtsStreamingSession ?? null,
     archiveAudio:
       options.archiveAudio === undefined
         ? defaultArchiveLiveVoiceAudio
@@ -1003,6 +1454,20 @@ async function defaultStreamLiveVoiceTtsAudio(
 ): Promise<LiveVoiceTtsResult> {
   const { streamLiveVoiceTtsAudio } = await import("./live-voice-tts.js");
   return streamLiveVoiceTtsAudio(options);
+}
+
+/**
+ * Exported so production callers (`http-server.ts`) can wire it after a
+ * provider-capability probe. Tests that use `createLiveVoiceSession`
+ * directly without passing `openTtsStreamingSession` continue to get the
+ * legacy per-segment path.
+ */
+export async function defaultOpenLiveVoiceTtsStreamingSession(
+  options: LiveVoiceTtsSessionOptions,
+): Promise<LiveVoiceTtsSession> {
+  const { openLiveVoiceTtsStreamingSession } =
+    await import("./live-voice-tts.js");
+  return openLiveVoiceTtsStreamingSession(options);
 }
 
 async function defaultArchiveLiveVoiceAudio(
@@ -1141,4 +1606,52 @@ function stopTranscriberBestEffort(
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function buildLiveVoiceControlPrompt(
+  perceptionMemoryContext: string | null,
+): string {
+  const basePrompt =
+    "You are speaking in a local live voice session. Keep replies brief and conversational.";
+  if (!perceptionMemoryContext || perceptionMemoryContext.trim().length === 0) {
+    return basePrompt;
+  }
+  const escaped = perceptionMemoryContext.replace(
+    /<\/perception_memory\s*>/gi,
+    "&lt;/perception_memory&gt;",
+  );
+  return `${basePrompt}\n\n<perception_memory>\n${escaped}\n</perception_memory>`;
+}
+
+function defaultPerceptionMemoryContext(): string | null {
+  try {
+    return buildPerceptionKnowledgeContext();
+  } catch {
+    return null;
+  }
+}
+
+function actionLifecycleCue(msg: ActionLifecycleMessage): string | null {
+  const label = friendlyActionName(msg.actionName);
+  switch (msg.stage) {
+    case "started":
+      return `Starting ${label}. `;
+    case "executing":
+      return `Working on ${label}. `;
+    case "completed":
+      return `${label} complete. `;
+    case "failed":
+      return `${label} failed. `;
+    case "rollback_started":
+      return `Rolling back ${label}. `;
+    case "rollback_completed":
+      return `Rollback complete for ${label}. `;
+    default:
+      return null;
+  }
+}
+
+function friendlyActionName(actionName: string): string {
+  const normalized = actionName.replace(/[_-]+/g, " ").trim();
+  return normalized.length > 0 ? normalized : "action";
 }

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -3,6 +3,7 @@ import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import type {
   TtsProvider,
   TtsProviderId,
+  TtsStreamingSession,
   TtsSynthesisRequest,
   TtsUseCase,
 } from "../tts/types.js";
@@ -126,6 +127,144 @@ export async function streamLiveVoiceTtsAudio(
   } catch (err) {
     throw normalizeProviderError(err, providerId);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Persistent streaming sessions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for opening a persistent streaming TTS session for live voice.
+ *
+ * Sessions exist so callers can feed assistant text deltas to a single
+ * long-lived transport (typically a WebSocket) instead of opening a fresh
+ * connection per speakable segment. That eliminates ~300-500ms of handshake
+ * latency per segment for providers that support it (currently xAI).
+ */
+export interface LiveVoiceTtsSessionOptions {
+  voiceId?: string;
+  signal?: AbortSignal;
+  useCase?: TtsUseCase;
+  outputFormat?: TtsSynthesisRequest["outputFormat"];
+  sampleRate?: number;
+  config?: LiveVoiceTtsConfig;
+  onAudioChunk: (chunk: LiveVoiceTtsAudioChunk) => void;
+}
+
+/**
+ * Live-voice-friendly façade over {@link TtsStreamingSession}. The chunk
+ * callback receives audio in the same `LiveVoiceTtsAudioChunk` shape as the
+ * one-shot `streamLiveVoiceTtsAudio` path so downstream framing code is
+ * identical regardless of which mode is in use.
+ */
+export interface LiveVoiceTtsSession {
+  readonly provider: TtsProviderId;
+  readonly contentType: string;
+  readonly sampleRate: number;
+  appendText(text: string): Promise<void>;
+  finalize(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export type LiveVoiceTtsSessionOpener = (
+  options: LiveVoiceTtsSessionOptions,
+) => Promise<LiveVoiceTtsSession>;
+
+/**
+ * Open a persistent streaming TTS session against the configured provider.
+ * Throws {@link LiveVoiceTtsError} with code `LIVE_VOICE_TTS_STREAMING_UNAVAILABLE`
+ * if the active provider doesn't support session-mode streaming — callers
+ * should fall back to per-segment `streamLiveVoiceTtsAudio` in that case.
+ */
+export async function openLiveVoiceTtsStreamingSession(
+  options: LiveVoiceTtsSessionOptions,
+): Promise<LiveVoiceTtsSession> {
+  const { provider, providerId, providerConfig } =
+    await resolveLiveVoiceStreamingTtsProvider(options.config);
+
+  if (
+    !provider.capabilities.supportsStreamingSessions ||
+    typeof provider.openStreamingSession !== "function"
+  ) {
+    throw new LiveVoiceTtsError(
+      "LIVE_VOICE_TTS_STREAMING_UNAVAILABLE",
+      `TTS provider "${providerId}" does not support persistent streaming sessions.`,
+      { provider: providerId },
+    );
+  }
+
+  const sampleRate = resolveSampleRate(options.sampleRate, providerConfig);
+  const chunkContentType = resolveChunkContentType(
+    provider,
+    providerConfig,
+    options.outputFormat,
+  );
+  const canStreamChunks = isRawPcmContentType(chunkContentType);
+
+  if (!canStreamChunks) {
+    // Non-PCM session output isn't currently routed to clients chunk-by-chunk
+    // — the live-voice WebSocket frame format assumes audio/pcm. Bail out
+    // early so callers can fall back to the buffered per-segment path.
+    throw new LiveVoiceTtsError(
+      "LIVE_VOICE_TTS_STREAMING_UNAVAILABLE",
+      `TTS provider "${providerId}" does not produce raw PCM output required by streaming-session mode.`,
+      { provider: providerId },
+    );
+  }
+
+  const emitAudioFrame = (audio: Uint8Array): void => {
+    if (audio.byteLength === 0) return;
+    options.onAudioChunk({
+      type: "tts_audio",
+      contentType: chunkContentType,
+      sampleRate,
+      dataBase64: Buffer.from(audio).toString("base64"),
+    });
+  };
+
+  let providerSession: TtsStreamingSession;
+  try {
+    providerSession = await provider.openStreamingSession({
+      useCase: options.useCase ?? "phone-call",
+      voiceId: options.voiceId,
+      outputFormat: options.outputFormat,
+      signal: options.signal,
+      onChunk: (chunk) => emitAudioFrame(chunk),
+    });
+  } catch (err) {
+    throw normalizeProviderError(err, providerId);
+  }
+
+  let closed = false;
+  return {
+    provider: providerId,
+    contentType: chunkContentType,
+    sampleRate,
+    async appendText(text: string): Promise<void> {
+      if (closed) return;
+      try {
+        await providerSession.appendText(text);
+      } catch (err) {
+        throw normalizeProviderError(err, providerId);
+      }
+    },
+    async finalize(): Promise<void> {
+      try {
+        await providerSession.finalize();
+      } catch (err) {
+        throw normalizeProviderError(err, providerId);
+      }
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      try {
+        await providerSession.close();
+      } catch {
+        // close errors are swallowed — the caller is already on a shutdown path
+      }
+    },
+  };
 }
 
 async function resolveLiveVoiceStreamingTtsProvider(

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -56,6 +56,8 @@ export interface LiveVoiceAudioConfig {
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
+  readonly sourceChannel?: string;
+  readonly sourceInterface?: string;
   readonly audio: LiveVoiceAudioConfig;
 }
 
@@ -356,6 +358,22 @@ function validateStartFrame(
       "start",
     );
   }
+  if ("sourceChannel" in value && !isNonEmptyString(value.sourceChannel)) {
+    return protocolError(
+      "invalid_field",
+      "start frame field sourceChannel must be a non-empty string",
+      "sourceChannel",
+      "start",
+    );
+  }
+  if ("sourceInterface" in value && !isNonEmptyString(value.sourceInterface)) {
+    return protocolError(
+      "invalid_field",
+      "start frame field sourceInterface must be a non-empty string",
+      "sourceInterface",
+      "start",
+    );
+  }
 
   return {
     ok: true,
@@ -363,6 +381,12 @@ function validateStartFrame(
       type: "start",
       ...(typeof value.conversationId === "string"
         ? { conversationId: value.conversationId }
+        : {}),
+      ...(typeof value.sourceChannel === "string"
+        ? { sourceChannel: value.sourceChannel }
+        : {}),
+      ...(typeof value.sourceInterface === "string"
+        ? { sourceInterface: value.sourceInterface }
         : {}),
       audio: audioConfig.frame,
     },

--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.test.ts
@@ -45,7 +45,7 @@ function mockWhisperResponses(
  */
 function createTranscriberWithMock(
   responses: Array<{ text?: string } | { error: Error }>,
-  options?: { pollIntervalMs?: number },
+  options?: { pollIntervalMs?: number; minPcmPollDurationMs?: number },
 ): {
   transcriber: OpenAIWhisperStreamingTranscriber;
   transcribeFn: ReturnType<typeof mock>;
@@ -54,6 +54,10 @@ function createTranscriberWithMock(
   const { transcribeFn, calls } = mockWhisperResponses(responses);
   const transcriber = new OpenAIWhisperStreamingTranscriber(TEST_API_KEY, {
     pollIntervalMs: options?.pollIntervalMs ?? 10,
+    // Disable the PCM short-audio defer in tests so the existing
+    // micro-buffer fixtures still trigger polls. The hallucination
+    // mitigation is exercised in dedicated tests below.
+    minPcmPollDurationMs: options?.minPcmPollDurationMs ?? 0,
   });
 
   // Replace the internal transcribeAccumulated method with our mock.
@@ -384,6 +388,51 @@ describe("OpenAIWhisperStreamingTranscriber", () => {
       const errors = events.filter((e) => e.type === "error");
       expect(errors.length).toBeGreaterThanOrEqual(1);
     });
+
+    test("too-short Whisper poll input is ignored without an error event", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        {
+          error: new Error(
+            'Whisper API error (400): {"error":{"message":"Audio file is too short. Minimum audio length is 0.1 seconds.","type":"invalid_request_error","param":"file","code":"audio_too_short","seconds":0}}',
+          ),
+        },
+        { text: "recovered" },
+        { text: "recovered final" },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("too-short"), "audio/webm");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(events.filter((e) => e.type === "error")).toEqual([]);
+
+      transcriber.sendAudio(Buffer.from("real-audio"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(events.some((e) => e.type === "final")).toBe(true);
+    });
+
+    test("too-short Whisper final input closes as silence without an error event", async () => {
+      const { transcriber } = createTranscriberWithMock([
+        {
+          error: new Error(
+            'Whisper API error (400): {"error":{"message":"Audio file is too short. Minimum audio length is 0.1 seconds.","type":"invalid_request_error","param":"file","code":"audio_too_short","seconds":0}}',
+          ),
+        },
+      ]);
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("too-short"), "audio/webm");
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(events.filter((e) => e.type === "error")).toEqual([]);
+      expect(events.filter((e) => e.type === "final")).toEqual([
+        { type: "final", text: "" },
+      ]);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -559,6 +608,90 @@ describe("OpenAIWhisperStreamingTranscriber", () => {
       for (const call of calls) {
         expect(call.mimeType).toBe("audio/webm");
       }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Hallucination mitigation: defer first poll on very short PCM
+  // -----------------------------------------------------------------------
+
+  describe("short-audio hallucination mitigation", () => {
+    test("defers Whisper calls until enough PCM has accumulated", async () => {
+      const { transcriber, transcribeFn } = createTranscriberWithMock(
+        [{ text: "Hello there" }, { text: "Hello there friend" }],
+        {
+          pollIntervalMs: 10,
+          // Realistic threshold — 16 kHz mono PCM16, 500 ms = 16000 bytes.
+          minPcmPollDurationMs: 500,
+        },
+      );
+      const events = collectEvents(transcriber);
+
+      // Tiny PCM buffer: 32 bytes ≈ 1 ms at 16 kHz mono PCM16. Far below
+      // the 500 ms threshold, so the transcriber should not call the API.
+      transcriber.sendAudio(Buffer.alloc(32), "audio/pcm");
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      expect(transcribeFn).not.toHaveBeenCalled();
+      expect(events.filter((e) => e.type === "partial")).toEqual([]);
+
+      // Add a chunk that pushes us comfortably past the threshold:
+      // 32_000 bytes = 1 s at 16 kHz mono PCM16.
+      transcriber.sendAudio(Buffer.alloc(32_000), "audio/pcm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(
+        events.filter((e) => e.type === "partial").length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    test("does not defer non-PCM audio (compressed durations unknown)", async () => {
+      const { transcriber, transcribeFn } = createTranscriberWithMock(
+        [{ text: "compressed result" }],
+        {
+          pollIntervalMs: 10,
+          minPcmPollDurationMs: 5_000, // would defer forever if applied
+        },
+      );
+      const events = collectEvents(transcriber);
+
+      transcriber.sendAudio(Buffer.from("webm-chunk"), "audio/webm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
+
+      expect(transcribeFn).toHaveBeenCalled();
+    });
+
+    test("threshold only applies before the first partial", async () => {
+      const { transcriber, transcribeFn } = createTranscriberWithMock(
+        [{ text: "first partial" }, { text: "first partial extended" }],
+        {
+          pollIntervalMs: 10,
+          minPcmPollDurationMs: 200,
+        },
+      );
+      const events = collectEvents(transcriber);
+
+      // 6_400 bytes = 200 ms at 16 kHz mono PCM16.
+      transcriber.sendAudio(Buffer.alloc(6_400), "audio/pcm");
+      await waitFor(() => events.some((e) => e.type === "partial"));
+
+      const callsAfterFirstPartial = transcribeFn.mock.calls.length;
+
+      // Tiny follow-up — should still be polled because we are past the
+      // initial hallucination window now that we have a partial.
+      transcriber.sendAudio(Buffer.alloc(32), "audio/pcm");
+      await waitFor(
+        () => transcribeFn.mock.calls.length > callsAfterFirstPartial,
+      );
+
+      transcriber.stop();
+      await waitFor(() => events.some((e) => e.type === "closed"));
     });
   });
 });

--- a/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper-stream.ts
@@ -78,6 +78,22 @@ const DEFAULT_PCM_SAMPLE_RATE = 16_000;
  */
 const DEFAULT_PCM_CHANNELS = 1;
 
+/**
+ * Minimum accumulated PCM duration (ms) before the first incremental
+ * poll is sent to Whisper. `whisper-1` reliably hallucinates training-set
+ * phrases ("Thank you.", "Thanks for watching.", "Goodbye.") when given
+ * <1 s of audio — see `isLikelyWhisperHallucination` for the canonical
+ * list and OpenAI's published guidance.
+ *
+ * Deferring the first poll lets enough real signal accumulate that the
+ * model has a chance to transcribe actual speech instead of guessing.
+ * Subsequent polls have plenty of context, so they are not gated.
+ *
+ * Only applies when the input MIME type is `audio/pcm` (the only format
+ * for which we can cheaply compute duration from byte length).
+ */
+const DEFAULT_MIN_PCM_POLL_DURATION_MS = 1_000;
+
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
@@ -89,6 +105,12 @@ export interface OpenAIWhisperStreamOptions {
   pcmSampleRate?: number;
   /** PCM channel count when receiving `audio/pcm` input (default: 1). */
   pcmChannels?: number;
+  /**
+   * Minimum accumulated PCM duration (ms) before the first poll fires.
+   * Tests can set this to 0 to keep their existing semantics.
+   * Defaults to {@link DEFAULT_MIN_PCM_POLL_DURATION_MS}.
+   */
+  minPcmPollDurationMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,6 +125,7 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
   private readonly pollIntervalMs: number;
   private readonly pcmSampleRate: number;
   private readonly pcmChannels: number;
+  private readonly minPcmPollDurationMs: number;
 
   /** Accumulated audio chunks across the entire session. */
   private audioChunks: Buffer[] = [];
@@ -136,6 +159,8 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
     this.pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
     this.pcmSampleRate = options.pcmSampleRate ?? DEFAULT_PCM_SAMPLE_RATE;
     this.pcmChannels = options.pcmChannels ?? DEFAULT_PCM_CHANNELS;
+    this.minPcmPollDurationMs =
+      options.minPcmPollDurationMs ?? DEFAULT_MIN_PCM_POLL_DURATION_MS;
   }
 
   // -----------------------------------------------------------------------
@@ -162,6 +187,7 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
       );
     }
     if (this.stopped) return;
+    if (audio.byteLength === 0) return;
 
     this.audioChunks.push(audio);
     this.audioMimeType = mimeType;
@@ -221,6 +247,22 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
   private async doPoll(): Promise<void> {
     if (this.stopped || this.polling || !this.audioDirty) return;
 
+    // Whisper-1 hallucinates canonical phrases ("Thank you.",
+    // "Thanks for watching.", "Goodbye.") on very short audio. Defer
+    // the first poll until we have enough PCM accumulated to give the
+    // model real context. `audioDirty` stays true so the next sendAudio
+    // reschedules; we only update `lastPollTime` so the rescheduled
+    // poll respects the standard interval rather than firing
+    // immediately.
+    if (this.shouldDeferPollForShortAudio()) {
+      log.debug(
+        { durationMs: this.accumulatedPcmDurationMs() },
+        "Deferring Whisper poll until enough audio has accumulated",
+      );
+      this.lastPollTime = Date.now();
+      return;
+    }
+
     this.polling = true;
     this.audioDirty = false;
 
@@ -258,6 +300,11 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
         this.emit({ type: "partial", text });
       }
     } catch (err) {
+      if (isWhisperAudioTooShortError(err)) {
+        log.debug({ error: err }, "Ignoring too-short Whisper poll input");
+        return;
+      }
+
       // Transient errors during polling are non-fatal — the final
       // request on stop() will capture the complete audio.
       log.warn({ error: err }, "Incremental poll request failed");
@@ -304,6 +351,15 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
         this.emit({ type: "final", text: this.lastEmittedText });
       }
     } catch (err) {
+      if (isWhisperAudioTooShortError(err)) {
+        log.info(
+          { error: err },
+          "Treating too-short Whisper final input as silence",
+        );
+        this.emit({ type: "final", text: this.lastEmittedText });
+        return;
+      }
+
       log.error({ error: err }, "Final transcription request failed");
       const message = err instanceof Error ? err.message : String(err);
       this.emit({ type: "error", category: "provider-error", message });
@@ -363,6 +419,39 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
     return base === "audio/pcm";
   }
 
+  /**
+   * Accumulated PCM audio duration in milliseconds, derived from the
+   * total byte length of the buffered chunks and the configured PCM
+   * sample rate / channel count. Returns 0 for non-PCM inputs since we
+   * can't cheaply compute compressed-frame durations.
+   */
+  private accumulatedPcmDurationMs(): number {
+    if (!this.isPcmMimeType(this.audioMimeType)) return 0;
+    const bytesPerSecond = this.pcmSampleRate * this.pcmChannels * 2;
+    if (bytesPerSecond <= 0) return 0;
+    let totalBytes = 0;
+    for (const chunk of this.audioChunks) {
+      totalBytes += chunk.byteLength;
+    }
+    return (totalBytes / bytesPerSecond) * 1000;
+  }
+
+  /**
+   * Returns true when we should bail out of the current poll attempt
+   * because there is not yet enough audio accumulated for Whisper to
+   * transcribe reliably without hallucinating.
+   *
+   * The threshold is bypassed once a partial has already been emitted,
+   * since by then we are past the hallucination-prone first window and
+   * need lower-latency incremental updates for the UI.
+   */
+  private shouldDeferPollForShortAudio(): boolean {
+    if (this.minPcmPollDurationMs <= 0) return false;
+    if (this.lastEmittedText.length > 0) return false;
+    if (!this.isPcmMimeType(this.audioMimeType)) return false;
+    return this.accumulatedPcmDurationMs() < this.minPcmPollDurationMs;
+  }
+
   // -----------------------------------------------------------------------
   // Event emission
   // -----------------------------------------------------------------------
@@ -378,4 +467,13 @@ export class OpenAIWhisperStreamingTranscriber implements StreamingTranscriber {
       );
     }
   }
+}
+
+function isWhisperAudioTooShortError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Audio file is too short") ||
+    message.includes("Minimum audio length") ||
+    /"duration"\s*:\s*0/.test(message)
+  );
 }

--- a/assistant/src/providers/speech-to-text/openai-whisper.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { OpenAIWhisperProvider } from "./openai-whisper.js";
+import {
+  isLikelyWhisperHallucination,
+  OpenAIWhisperProvider,
+  whisperTranscribe,
+} from "./openai-whisper.js";
 
 const TEST_API_KEY = "sk-test-key-for-unit-tests";
 
@@ -150,5 +154,110 @@ describe("OpenAIWhisperProvider", () => {
       const bodyPart = msg.replace("Whisper API error (500): ", "");
       expect(bodyPart.length).toBeLessThanOrEqual(300);
     }
+  });
+
+  test("sends hallucination-mitigation params (language, temperature, prompt) by default", async () => {
+    let capturedBody: FormData | undefined;
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as FormData;
+      return new Response(JSON.stringify({ text: "real speech" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    await provider.transcribe(Buffer.from("audio"), "audio/wav");
+
+    expect(capturedBody?.get("language")).toBe("en");
+    expect(capturedBody?.get("temperature")).toBe("0");
+    expect(typeof capturedBody?.get("prompt")).toBe("string");
+    expect((capturedBody?.get("prompt") as string).length).toBeGreaterThan(0);
+  });
+
+  test("filters known Whisper hallucinations on isolated short transcripts", async () => {
+    for (const phrase of [
+      "Thank you.",
+      "thanks for watching",
+      "Goodbye!",
+      "Bye-bye",
+      "Please subscribe",
+    ]) {
+      globalThis.fetch = (async () => {
+        return new Response(JSON.stringify({ text: phrase }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as unknown as typeof fetch;
+
+      const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+      const result = await provider.transcribe(
+        Buffer.from("silence"),
+        "audio/wav",
+      );
+
+      expect(result.text).toBe("");
+    }
+  });
+
+  test("preserves longer transcripts that happen to contain a flagged phrase", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          text: "Thank you, but I actually wanted to ask about the weather.",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("real audio"),
+      "audio/wav",
+    );
+
+    expect(result.text).toContain("weather");
+  });
+
+  test("hallucination filter can be disabled per call", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ text: "Thank you." }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await whisperTranscribe(
+      TEST_API_KEY,
+      Buffer.from("audio"),
+      "audio/wav",
+      undefined,
+      { filterHallucinations: false },
+    );
+
+    expect(result).toBe("Thank you.");
+  });
+
+  test("isLikelyWhisperHallucination heuristic", () => {
+    expect(isLikelyWhisperHallucination("Thank you.")).toBe(true);
+    expect(isLikelyWhisperHallucination("THANKS FOR WATCHING!")).toBe(true);
+    expect(isLikelyWhisperHallucination("Goodbye.")).toBe(true);
+    expect(isLikelyWhisperHallucination("bye")).toBe(true);
+    expect(isLikelyWhisperHallucination("you")).toBe(true);
+    expect(isLikelyWhisperHallucination("")).toBe(false);
+    expect(isLikelyWhisperHallucination("Hello, how are you today?")).toBe(
+      false,
+    );
+    expect(
+      isLikelyWhisperHallucination(
+        "Thanks for watching, but actually I have a question.",
+      ),
+    ).toBe(false);
   });
 });

--- a/assistant/src/providers/speech-to-text/openai-whisper.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.ts
@@ -4,6 +4,123 @@ const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 /**
+ * Default conversational priming prompt. The Whisper API treats `prompt`
+ * as a soft bias on the decoder's token distribution. Anchoring the model
+ * in a "live voice assistant" context discourages the well-known YouTube
+ * caption hallucinations ("Thank you for watching", "Please subscribe",
+ * "Goodbye.") that `whisper-1` produces on short or low-energy audio.
+ *
+ * Must be in the same language as the configured `language` param.
+ */
+const DEFAULT_WHISPER_PROMPT =
+  "The user is having a natural conversation with their voice assistant. " +
+  "They may pause, hesitate, or speak softly.";
+
+/**
+ * Phrases `whisper-1` confidently emits when the audio is silent,
+ * near-silent, or too short to transcribe. These are training-set
+ * artifacts (overwhelmingly YouTube boilerplate). When the entire
+ * trimmed transcript matches one of these phrases we treat it as
+ * silence rather than letting it propagate downstream.
+ *
+ * The list is intentionally narrow: only single utterances that have
+ * no plausible meaning in a one-on-one voice-assistant turn. Phrases
+ * like "thank you" can be legitimate when they appear inside a longer
+ * sentence, so the filter only fires on short, exact, isolated matches.
+ */
+const KNOWN_WHISPER_HALLUCINATION_PHRASES = new Set([
+  "thank you",
+  "thank you.",
+  "thank you!",
+  "thanks",
+  "thanks.",
+  "thanks!",
+  "thank you for watching",
+  "thanks for watching",
+  "thanks for watching!",
+  "thank you so much for watching",
+  "thank you for watching this video",
+  "thank you for your time",
+  "thank you for listening",
+  "thanks for listening",
+  "see you next time",
+  "see you in the next video",
+  "see you next video",
+  "bye",
+  "bye.",
+  "bye!",
+  "bye bye",
+  "bye-bye",
+  "goodbye",
+  "goodbye.",
+  "goodbye!",
+  "please subscribe",
+  "subscribe to my channel",
+  "like and subscribe",
+  "like, share, and subscribe",
+  "you",
+  "yeah",
+  "okay",
+  "ok",
+  ".",
+]);
+
+/**
+ * Upper bound on transcript length that's eligible for the hallucination
+ * filter. Anything longer is treated as real speech even if it begins
+ * with a hallucinated phrase, since the model probably attached real
+ * content to it.
+ */
+const HALLUCINATION_MAX_LEN = 64;
+
+export interface WhisperTranscribeOptions {
+  /**
+   * BCP-47 / ISO-639-1 language hint passed to Whisper. Pinning the
+   * language avoids the model's language-detection step, which is a
+   * significant hallucination source on short clips. Pass `null` to
+   * omit the parameter and let Whisper auto-detect.
+   */
+  language?: string | null;
+  /**
+   * Sampling temperature. Whisper defaults to 0; we mirror that
+   * explicitly so the encoder is fully deterministic.
+   */
+  temperature?: number;
+  /**
+   * Soft decoder bias. Pass `null` to omit. Must be in the same
+   * language as `language`.
+   */
+  prompt?: string | null;
+  /**
+   * When true (the default), known-hallucination phrases that comprise
+   * the entire transcript are converted to empty strings.
+   */
+  filterHallucinations?: boolean;
+}
+
+/**
+ * Returns true when `text` looks like a Whisper hallucination of
+ * silence/noise rather than real user speech.
+ *
+ * Exported for tests and for callers that want to apply the filter
+ * outside the transcribe path (e.g. across a session-level cache).
+ */
+export function isLikelyWhisperHallucination(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > HALLUCINATION_MAX_LEN) return false;
+  // Normalize to a comparable form: lowercase, collapse whitespace,
+  // strip leading/trailing punctuation. We keep an inner-punctuation
+  // preserving variant too so "Thank you." and "Thank you" both match.
+  const lower = trimmed.toLowerCase();
+  if (KNOWN_WHISPER_HALLUCINATION_PHRASES.has(lower)) return true;
+  const stripped = lower
+    .replace(/^[\s.!?,;:'"\-]+/u, "")
+    .replace(/[\s.!?,;:'"\-]+$/u, "");
+  return KNOWN_WHISPER_HALLUCINATION_PHRASES.has(stripped);
+}
+
+/**
  * Derive a filename extension from a MIME type so the Whisper API can detect
  * the audio format. Falls back to "audio" when the MIME type is unrecognised.
  */
@@ -30,7 +147,11 @@ function extensionFromMime(mimeType: string): string {
  * Shared between the batch provider and the streaming adapter to avoid
  * duplicating request construction logic.
  */
-function buildWhisperFormData(audio: Buffer, mimeType: string): FormData {
+function buildWhisperFormData(
+  audio: Buffer,
+  mimeType: string,
+  options: WhisperTranscribeOptions,
+): FormData {
   const ext = extensionFromMime(mimeType);
 
   const formData = new FormData();
@@ -40,6 +161,20 @@ function buildWhisperFormData(audio: Buffer, mimeType: string): FormData {
     `audio.${ext}`,
   );
   formData.append("model", "whisper-1");
+
+  const language = options.language === undefined ? "en" : options.language;
+  if (language !== null) {
+    formData.append("language", language);
+  }
+
+  const temperature = options.temperature ?? 0;
+  formData.append("temperature", String(temperature));
+
+  const prompt =
+    options.prompt === undefined ? DEFAULT_WHISPER_PROMPT : options.prompt;
+  if (prompt !== null && prompt.length > 0) {
+    formData.append("prompt", prompt);
+  }
 
   return formData;
 }
@@ -54,8 +189,9 @@ export async function whisperTranscribe(
   audio: Buffer,
   mimeType: string,
   signal?: AbortSignal,
+  options: WhisperTranscribeOptions = {},
 ): Promise<string> {
-  const formData = buildWhisperFormData(audio, mimeType);
+  const formData = buildWhisperFormData(audio, mimeType, options);
 
   const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
 
@@ -74,7 +210,16 @@ export async function whisperTranscribe(
   }
 
   const result = (await response.json()) as { text?: string };
-  return result.text?.trim() ?? "";
+  const text = result.text?.trim() ?? "";
+
+  if (
+    options.filterHallucinations !== false &&
+    isLikelyWhisperHallucination(text)
+  ) {
+    return "";
+  }
+
+  return text;
 }
 
 export class OpenAIWhisperProvider {

--- a/assistant/src/runtime/__tests__/conversation-handoff.test.ts
+++ b/assistant/src/runtime/__tests__/conversation-handoff.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDefaultConversationKey } from "../conversation-handoff.js";
+
+describe("resolveDefaultConversationKey", () => {
+  test("uses shared handoff key for local first-party vellum interfaces", () => {
+    expect(resolveDefaultConversationKey("vellum", "macos")).toBe(
+      "default:vellum:handoff",
+    );
+    expect(resolveDefaultConversationKey("vellum", "ios")).toBe(
+      "default:vellum:handoff",
+    );
+    expect(resolveDefaultConversationKey("vellum", "chrome-extension")).toBe(
+      "default:vellum:handoff",
+    );
+  });
+
+  test("keeps interface-scoped defaults for non-local channels", () => {
+    expect(resolveDefaultConversationKey("slack", "slack")).toBe(
+      "default:slack:slack",
+    );
+    expect(resolveDefaultConversationKey("telegram", "telegram")).toBe(
+      "default:telegram:telegram",
+    );
+  });
+
+  test("does not merge CLI into the shared handoff key", () => {
+    expect(resolveDefaultConversationKey("vellum", "cli")).toBe(
+      "default:vellum:cli",
+    );
+  });
+});

--- a/assistant/src/runtime/conversation-handoff.ts
+++ b/assistant/src/runtime/conversation-handoff.ts
@@ -1,0 +1,29 @@
+import type { ChannelId, InterfaceId } from "../channels/types.js";
+
+/**
+ * Desktop/browser/mobile local interfaces should share one default thread so
+ * users can pick up the same conversation across devices without manually
+ * passing a conversation key.
+ */
+const SHARED_LOCAL_HANDOFF_INTERFACES: ReadonlySet<InterfaceId> = new Set([
+  "macos",
+  "ios",
+  "web",
+  "chrome-extension",
+  "tauri",
+]);
+
+const SHARED_LOCAL_HANDOFF_KEY = "default:vellum:handoff";
+
+export function resolveDefaultConversationKey(
+  sourceChannel: ChannelId,
+  sourceInterface: InterfaceId,
+): string {
+  if (
+    sourceChannel === "vellum" &&
+    SHARED_LOCAL_HANDOFF_INTERFACES.has(sourceInterface)
+  ) {
+    return SHARED_LOCAL_HANDOFF_KEY;
+  }
+  return `default:${sourceChannel}:${sourceInterface}`;
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -25,30 +25,43 @@ import {
   handleStatusCallback,
   handleVoiceWebhook,
 } from "../calls/twilio-routes.js";
+import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { isHttpAuthDisabled } from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { processMessage } from "../daemon/process-message.js";
-import { createLiveVoiceSession } from "../live-voice/live-voice-session.js";
-import { LiveVoiceSessionManager } from "../live-voice/live-voice-session-manager.js";
+import {
+  createLiveVoiceSession,
+  defaultOpenLiveVoiceTtsStreamingSession,
+  type LiveVoiceTtsSessionOpener,
+} from "../live-voice/live-voice-session.js";
+import {
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionManager,
+} from "../live-voice/live-voice-session-manager.js";
 import {
   type LiveVoiceClientFrame,
+  type LiveVoiceClientStartFrame,
   type LiveVoiceProtocolError,
   LiveVoiceProtocolErrorCode,
   type LiveVoiceServerFrame,
   parseLiveVoiceBinaryAudioFrame,
   parseLiveVoiceClientTextFrame,
 } from "../live-voice/protocol.js";
+import { getOrCreateConversation as getOrCreateConversationMapping } from "../memory/conversation-key-store.js";
 import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import {
   activeSttStreamSessions,
   SttStreamSession,
 } from "../stt/stt-stream-session.js";
+import { getTtsProvider } from "../tts/provider-registry.js";
+import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { authenticateRequest } from "./auth/middleware.js";
 import { parseSub } from "./auth/subject.js";
 import { verifyToken } from "./auth/token-service.js";
 import { sweepFailedEvents } from "./channel-retry-sweep.js";
+import { resolveDefaultConversationKey } from "./conversation-handoff.js";
 import { httpError, type HttpErrorCode } from "./http-errors.js";
 import { HttpRouter } from "./http-router.js";
 import {
@@ -152,6 +165,58 @@ interface LiveVoiceWebSocketData {
   lastSeq: number;
 }
 
+/**
+ * Synchronously check whether the configured TTS provider supports the
+ * persistent multi-utterance streaming-session API. Used to opt the live
+ * voice path into low-latency session-mode (currently xAI) without
+ * paying per-segment WebSocket handshake overhead. Any failure (provider
+ * not registered, config malformed) falls back to the legacy per-segment
+ * path by returning `null`.
+ */
+function resolveTtsStreamingSessionOpener(): LiveVoiceTtsSessionOpener | null {
+  try {
+    const { provider: providerId } = resolveTtsConfig(getConfig());
+    const provider = getTtsProvider(providerId);
+    if (
+      provider.capabilities.supportsStreamingSessions &&
+      typeof provider.openStreamingSession === "function"
+    ) {
+      return defaultOpenLiveVoiceTtsStreamingSession;
+    }
+  } catch {
+    // fall through to null — caller defaults to per-segment mode
+  }
+  return null;
+}
+
+function resolveLiveVoiceConversationContext(
+  context: LiveVoiceSessionFactoryContext,
+): LiveVoiceSessionFactoryContext {
+  const parsedSourceChannel = parseChannelId(context.startFrame.sourceChannel);
+  const parsedSourceInterface = parseInterfaceId(
+    context.startFrame.sourceInterface,
+  );
+  const conversationKey =
+    context.startFrame.conversationId ??
+    resolveDefaultConversationKey(
+      parsedSourceChannel ?? "vellum",
+      parsedSourceInterface ?? "tauri",
+    );
+  const mapping = getOrCreateConversationMapping(conversationKey, {
+    conversationType: "standard",
+  });
+
+  const startFrame: LiveVoiceClientStartFrame = {
+    ...context.startFrame,
+    conversationId: mapping.conversationId,
+  };
+
+  return {
+    ...context,
+    startFrame,
+  };
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -177,7 +242,10 @@ export class RuntimeHttpServer {
     this.guardianFollowUpConversationGenerator =
       options.guardianFollowUpConversationGenerator;
     this.liveVoiceSessionManager = new LiveVoiceSessionManager({
-      createSession: (context) => createLiveVoiceSession(context),
+      createSession: (context) =>
+        createLiveVoiceSession(resolveLiveVoiceConversationContext(context), {
+          openTtsStreamingSession: resolveTtsStreamingSessionOpener(),
+        }),
     });
     this.router = new HttpRouter();
   }
@@ -556,7 +624,6 @@ export class RuntimeHttpServer {
     if (path === "/readyz" && req.method === "GET") {
       return handleReadyz();
     }
-
 
     // WebSocket upgrade for ConversationRelay — before auth check because
     // Twilio WebSocket connections don't use bearer tokens.

--- a/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
@@ -12,24 +12,33 @@ describe("llm-call-sites-routes", () => {
     expect(route.endpoint).toBe("config/llm/call-sites");
   });
 
-  test("response has domains and callSites arrays", async () => {
+  test("response has tiers, domains, and callSites arrays", async () => {
     const result = (await route.handler({})) as {
+      tiers: unknown[];
       domains: unknown[];
       callSites: unknown[];
     };
+    expect(Array.isArray(result.tiers)).toBe(true);
     expect(Array.isArray(result.domains)).toBe(true);
     expect(Array.isArray(result.callSites)).toBe(true);
   });
 
   test("all call site IDs match LLMCallSiteEnum", async () => {
     const result = (await route.handler({})) as {
-      callSites: Array<{ id: string; displayName: string; description: string; domain: string }>;
+      callSites: Array<{
+        id: string;
+        displayName: string;
+        description: string;
+        domain: string;
+        tier: string;
+      }>;
     };
     const validIds = new Set(LLMCallSiteEnum.options);
     for (const site of result.callSites) {
       expect(validIds.has(site.id as never)).toBe(true);
       expect(site.displayName).toBeTruthy();
       expect(site.description).toBeTruthy();
+      expect(site.tier).toBeTruthy();
     }
     expect(result.callSites.length).toBe(LLMCallSiteEnum.options.length);
   });
@@ -42,6 +51,17 @@ describe("llm-call-sites-routes", () => {
     const domainIds = new Set(result.domains.map((d) => d.id));
     for (const site of result.callSites) {
       expect(domainIds.has(site.domain)).toBe(true);
+    }
+  });
+
+  test("all call site tier references match defined tiers", async () => {
+    const result = (await route.handler({})) as {
+      tiers: Array<{ id: string; displayName: string }>;
+      callSites: Array<{ id: string; tier: string }>;
+    };
+    const tierIds = new Set(result.tiers.map((tier) => tier.id));
+    for (const site of result.callSites) {
+      expect(tierIds.has(site.tier)).toBe(true);
     }
   });
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -46,6 +46,7 @@ import {
 } from "../../daemon/first-greeting.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
 import { HostAppControlProxy } from "../../daemon/host-app-control-proxy.js";
+import { HostCameraProxy } from "../../daemon/host-camera-proxy.js";
 import { HostCuProxy } from "../../daemon/host-cu-proxy.js";
 import { preactivateHostProxySkills } from "../../daemon/host-proxy-preactivation.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
@@ -101,6 +102,7 @@ import { silentlyWithLog } from "../../util/silently.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { resolveDefaultConversationKey } from "../conversation-handoff.js";
 import { routeGuardianReply } from "../guardian-reply-router.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
 import type {
@@ -1187,11 +1189,12 @@ export async function handleSendMessage(
       ? (canonicalizeTimeZone(body.clientTimezone) ?? undefined)
       : undefined;
 
-  // When conversationKey is omitted, derive a stable default from
-  // sourceChannel + sourceInterface so that repeated calls from the same
-  // channel/interface pair share a single conversation thread.
+  // When conversationKey is omitted, derive a stable default. Local first-party
+  // interfaces share one handoff thread so users can continue seamlessly
+  // between desktop/browser/mobile clients.
   const resolvedConversationKey =
-    conversationKey ?? `default:${sourceChannel}:${sourceInterface}`;
+    conversationKey ??
+    resolveDefaultConversationKey(sourceChannel, sourceInterface);
 
   // Reject non-string content values (numbers, objects, etc.)
   if (content != null && typeof content !== "string") {
@@ -1418,6 +1421,13 @@ export async function handleSendMessage(
     }
   } else if (!conversation.isProcessing()) {
     conversation.setHostAppControlProxy(undefined);
+  }
+  if (supportsHostProxy(sourceInterface, "host_camera")) {
+    if (!conversation.isProcessing() || !conversation.hostCameraProxy) {
+      conversation.setHostCameraProxy(new HostCameraProxy());
+    }
+  } else if (!conversation.isProcessing()) {
+    conversation.setHostCameraProxy(undefined);
   }
   // Only preactivate when the conversation is idle — if it's processing,
   // this message will be queued and preactivation is deferred to dequeue

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,8 +1,13 @@
-import { CALL_SITE_CATALOG, CALL_SITE_DOMAINS } from "../../config/schemas/call-site-catalog.js";
+import {
+  CALL_SITE_CATALOG,
+  CALL_SITE_DOMAINS,
+  CALL_SITE_TIERS,
+} from "../../config/schemas/call-site-catalog.js";
 import type { RouteDefinition } from "./types.js";
 
 async function handleGetCallSites() {
   return {
+    tiers: CALL_SITE_TIERS,
     domains: CALL_SITE_DOMAINS,
     callSites: CALL_SITE_CATALOG,
   };
@@ -16,7 +21,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleGetCallSites,
     summary: "List LLM call sites",
     description:
-      "Returns the full catalog of LLM call sites with display names, descriptions, and domain groupings. Used by clients to render the per-call-site override settings UI.",
+      "Returns the full catalog of LLM call sites with display names, descriptions, tier/domain groupings, and routing metadata. Used by clients to render per-call-site override settings UI.",
     tags: ["config"],
   },
 ];

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -1018,7 +1018,7 @@ describe("xAI TTS provider adapter", () => {
     expect(socket.url).toContain("voice=eve");
     expect(socket.url).toContain("codec=pcm");
     expect(socket.url).toContain("sample_rate=16000");
-    expect(socket.url).toContain("optimize_streaming_latency=1");
+    expect(socket.url).toContain("optimize_streaming_latency=0");
     expect(socket.init.headers.Authorization).toBe("Bearer test-xai-api-key");
     // The streaming-session implementation sends `text.delta` then `text.done`
     // through separate async ticks (appendText → finalize). Wait for both to

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -131,9 +131,11 @@ import type { TtsSynthesisRequest } from "../types.js";
 // ---------------------------------------------------------------------------
 
 let originalFetch: typeof globalThis.fetch;
+let originalWebSocket: typeof globalThis.WebSocket;
 
 beforeEach(() => {
   originalFetch = globalThis.fetch;
+  originalWebSocket = globalThis.WebSocket;
   mockApiKey = "test-elevenlabs-api-key";
   mockDeepgramApiKey = "test-deepgram-api-key";
   mockElevenLabsConfig = {
@@ -168,6 +170,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  globalThis.WebSocket = originalWebSocket;
   _resetTtsProviderRegistry();
   _resetBuiltinRegistration();
 });
@@ -200,6 +203,55 @@ function mockFetchError(status: number, body: string): void {
   globalThis.fetch = mock(
     async () => new Response(body, { status }),
   ) as unknown as typeof globalThis.fetch;
+}
+
+class FakeWebSocket {
+  static last: FakeWebSocket | undefined;
+
+  readonly url: string;
+  readonly init: { headers: Record<string, string> };
+  readonly sent: string[] = [];
+  private readonly listeners = new Map<string, Array<(event: any) => void>>();
+
+  constructor(url: string, init: { headers: Record<string, string> }) {
+    this.url = url;
+    this.init = init;
+    FakeWebSocket.last = this;
+  }
+
+  addEventListener(type: string, listener: (event: any) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.dispatch("close", {});
+  }
+
+  open(): void {
+    this.dispatch("open", {});
+  }
+
+  receive(data: string): void {
+    this.dispatch("message", { data });
+  }
+
+  private dispatch(type: string, event: any): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function mockWebSocket(): void {
+  FakeWebSocket.last = undefined;
+  globalThis.WebSocket =
+    FakeWebSocket as unknown as typeof globalThis.WebSocket;
 }
 
 // ===========================================================================
@@ -793,11 +845,12 @@ describe("xAI TTS provider adapter", () => {
     expect(provider.id).toBe("xai");
   });
 
-  test("advertises mp3 and wav format support without streaming", () => {
+  test("advertises streaming support with mp3, wav, and pcm formats", () => {
     const provider = createXaiProvider();
     expect(provider.capabilities).toEqual({
-      supportsStreaming: false,
-      supportedFormats: ["mp3", "wav"],
+      supportsStreaming: true,
+      supportsStreamingSessions: true,
+      supportedFormats: ["mp3", "wav", "pcm"],
     });
   });
 
@@ -940,10 +993,66 @@ describe("xAI TTS provider adapter", () => {
     expect(result.audio.byteLength).toBeGreaterThan(0);
   });
 
+  // -- Streaming -----------------------------------------------------------
+
+  test("synthesizeStream sends text over xAI WebSocket and emits audio chunks", async () => {
+    mockWebSocket();
+    const provider = createXaiProvider();
+    const chunks: Uint8Array[] = [];
+
+    const resultPromise = provider.synthesizeStream!(
+      makeRequest({ outputFormat: "pcm" }),
+      (chunk) => chunks.push(chunk),
+    );
+    // Wait for the synthesizeStream microtask chain (resolve api key, resolve
+    // config, build URL) to construct the WebSocket. Anything less than this
+    // races against the multiple awaits inside the adapter.
+    for (let i = 0; i < 10 && FakeWebSocket.last === undefined; i += 1) {
+      await Promise.resolve();
+    }
+
+    const socket = FakeWebSocket.last!;
+    socket.open();
+    expect(socket.url).toContain("wss://api.x.ai/v1/tts?");
+    expect(socket.url).toContain("language=auto");
+    expect(socket.url).toContain("voice=eve");
+    expect(socket.url).toContain("codec=pcm");
+    expect(socket.url).toContain("sample_rate=16000");
+    expect(socket.url).toContain("optimize_streaming_latency=1");
+    expect(socket.init.headers.Authorization).toBe("Bearer test-xai-api-key");
+    // The streaming-session implementation sends `text.delta` then `text.done`
+    // through separate async ticks (appendText → finalize). Wait for both to
+    // be flushed onto the wire before asserting.
+    for (let i = 0; i < 20 && socket.sent.length < 2; i += 1) {
+      await Promise.resolve();
+    }
+    expect(socket.sent).toEqual([
+      JSON.stringify({ type: "text.delta", delta: "Hello world" }),
+      JSON.stringify({ type: "text.done" }),
+    ]);
+
+    const audioChunk = Buffer.from([0x00, 0x01, 0x02]);
+    socket.receive(
+      JSON.stringify({
+        type: "audio.delta",
+        delta: audioChunk.toString("base64"),
+      }),
+    );
+    socket.receive(JSON.stringify({ type: "audio.done" }));
+
+    const result = await resultPromise;
+    expect(Buffer.from(chunks[0]!)).toEqual(audioChunk);
+    expect(result.audio).toEqual(audioChunk);
+    expect(result.contentType).toBe("audio/pcm");
+  });
+
   // -- Required config validation ------------------------------------------
 
   test("throws XAI_TTS_NO_API_KEY when API key is missing", async () => {
     mockXaiApiKey = null;
+    // Also clear the env-var fallback so neither resolution path returns a key.
+    const originalEnv = process.env.XAI_API_KEY;
+    delete process.env.XAI_API_KEY;
 
     const provider = createXaiProvider();
 
@@ -954,6 +1063,58 @@ describe("xAI TTS provider adapter", () => {
       expect(err).toBeInstanceOf(XaiTtsError);
       expect((err as XaiTtsError).code).toBe("XAI_TTS_NO_API_KEY");
       expect((err as XaiTtsError).message).toContain("API key not configured");
+    } finally {
+      if (originalEnv !== undefined) process.env.XAI_API_KEY = originalEnv;
+    }
+  });
+
+  test("falls back to XAI_API_KEY env var when secure store is empty", async () => {
+    mockXaiApiKey = null;
+    const originalEnv = process.env.XAI_API_KEY;
+    process.env.XAI_API_KEY = "env-xai-key";
+
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+        return new Response(new Uint8Array([0x49, 0x44, 0x33]), {
+          status: 200,
+        });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    try {
+      const provider = createXaiProvider();
+      await provider.synthesize(makeRequest());
+      expect(capturedHeaders.Authorization).toBe("Bearer env-xai-key");
+    } finally {
+      if (originalEnv === undefined) delete process.env.XAI_API_KEY;
+      else process.env.XAI_API_KEY = originalEnv;
+    }
+  });
+
+  test("secure-store key wins over XAI_API_KEY env var", async () => {
+    mockXaiApiKey = "store-xai-key";
+    const originalEnv = process.env.XAI_API_KEY;
+    process.env.XAI_API_KEY = "env-xai-key";
+
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+        return new Response(new Uint8Array([0x49, 0x44, 0x33]), {
+          status: 200,
+        });
+      },
+    ) as unknown as typeof globalThis.fetch;
+
+    try {
+      const provider = createXaiProvider();
+      await provider.synthesize(makeRequest());
+      expect(capturedHeaders.Authorization).toBe("Bearer store-xai-key");
+    } finally {
+      if (originalEnv === undefined) delete process.env.XAI_API_KEY;
+      else process.env.XAI_API_KEY = originalEnv;
     }
   });
 

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -162,8 +162,8 @@ const CATALOG: readonly TtsProviderCatalogEntry[] = [
     callMode: "synthesized-play",
     allowNativeFallback: false,
     capabilities: {
-      supportsStreaming: false,
-      supportedFormats: ["mp3", "wav"],
+      supportsStreaming: true,
+      supportedFormats: ["mp3", "wav", "pcm"],
     },
     secretRequirements: [
       {

--- a/assistant/src/tts/providers/xai-provider.ts
+++ b/assistant/src/tts/providers/xai-provider.ts
@@ -1,10 +1,15 @@
 /**
  * xAI TTS provider adapter.
  *
- * Wraps the xAI REST text-to-speech API (`/v1/tts`) behind the uniform
- * {@link TtsProvider} interface. Reads the API key from the secure credential
- * store under `credential/xai/api_key` and the model configuration from the
- * `services.tts.providers.xai` config section.
+ * Wraps the xAI text-to-speech APIs behind the uniform {@link TtsProvider}
+ * interface. Buffer synthesis uses REST (`POST /v1/tts`); streaming synthesis
+ * uses the bidirectional WebSocket endpoint (`wss://api.x.ai/v1/tts`).
+ *
+ * Reads the API key from the secure credential store under
+ * `credential/xai/api_key` first, then falls back to the `XAI_API_KEY`
+ * environment variable so a value in `.env` / `.env.local` works
+ * out of the box for local development. Model/voice configuration is
+ * read from the `services.tts.providers.xai` config section.
  */
 
 import { getConfig } from "../../config/loader.js";
@@ -15,6 +20,8 @@ import { getLogger } from "../../util/logger.js";
 import type {
   TtsProvider,
   TtsProviderCapabilities,
+  TtsStreamingSession,
+  TtsStreamingSessionOptions,
   TtsSynthesisRequest,
   TtsSynthesisResult,
 } from "../types.js";
@@ -43,11 +50,21 @@ export class XaiTtsError extends Error {
   }
 }
 
+interface XaiStreamingEvent {
+  type?: string;
+  delta?: string;
+  message?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const XAI_API_BASE = "https://api.x.ai";
+const XAI_TTS_WS_BASE = "wss://api.x.ai/v1/tts";
+// Lower-latency mode can produce very small bursty chunks that sound choppy
+// over realtime playback links. Favor stable cadence for live voice.
+const XAI_STREAMING_LATENCY_MODE = "0";
 
 /** Map from xAI codec names to MIME content types. */
 const FORMAT_CONTENT_TYPE: Record<string, string> = {
@@ -124,10 +141,27 @@ function resolveVoiceId(
   return request.voiceId?.trim() || config.voiceId || "eve";
 }
 
+/**
+ * Resolve the xAI API key.
+ *
+ * Secure credential store first (`credential/xai/api_key`), then the
+ * `XAI_API_KEY` environment variable. The env-var fallback matches how
+ * the LLM provider abstraction handles keys (see `getProviderKeyAsync`)
+ * so a value placed in `.env.local` works without an explicit
+ * `assistant credentials set` step.
+ */
+async function resolveXaiApiKey(): Promise<string | undefined> {
+  const stored = await getSecureKeyAsync(credentialKey("xai", "api_key"));
+  if (stored) return stored;
+  const envValue = process.env.XAI_API_KEY?.trim();
+  return envValue && envValue.length > 0 ? envValue : undefined;
+}
+
 export function createXaiProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
-    supportedFormats: ["mp3", "wav"],
+    supportsStreaming: true,
+    supportsStreamingSessions: true,
+    supportedFormats: ["mp3", "wav", "pcm"],
   };
 
   return {
@@ -137,12 +171,13 @@ export function createXaiProvider(): TtsProvider {
     async synthesize(
       request: TtsSynthesisRequest,
     ): Promise<TtsSynthesisResult> {
-      const apiKey = await getSecureKeyAsync(credentialKey("xai", "api_key"));
+      const apiKey = await resolveXaiApiKey();
       if (!apiKey) {
         throw new XaiTtsError(
           "XAI_TTS_NO_API_KEY",
           "xAI API key not configured. " +
-            "Add it via: assistant credentials set --service xai --field api_key <key>",
+            "Add it via `assistant credentials set --service xai --field api_key <key>` " +
+            "or set XAI_API_KEY in your environment / .env.local file.",
         );
       }
 
@@ -220,5 +255,295 @@ export function createXaiProvider(): TtsProvider {
         contentType,
       };
     },
+
+    async synthesizeStream(
+      request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      // Buffered streaming synthesis is a thin wrapper over the persistent
+      // session — open a session, push the whole text, finalize. This keeps
+      // the WebSocket protocol logic in exactly one place.
+      const chunks: Buffer[] = [];
+      const session = await openXaiStreamingSession({
+        useCase: request.useCase,
+        voiceId: request.voiceId,
+        outputFormat: request.outputFormat,
+        signal: request.signal,
+        onChunk: (chunk) => {
+          chunks.push(Buffer.from(chunk));
+          onChunk(chunk);
+        },
+      });
+      try {
+        await session.appendText(request.text);
+        await session.finalize();
+      } finally {
+        await session.close();
+      }
+      if (chunks.length === 0) {
+        throw new XaiTtsError(
+          "XAI_TTS_EMPTY_RESPONSE",
+          "xAI TTS streaming returned no audio chunks",
+        );
+      }
+      return {
+        audio: Buffer.concat(chunks),
+        contentType: session.contentType,
+      };
+    },
+
+    async openStreamingSession(
+      options: TtsStreamingSessionOptions,
+    ): Promise<TtsStreamingSession> {
+      return await openXaiStreamingSession(options);
+    },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Persistent streaming session implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a request shape from session options so we can reuse the existing
+ * codec/voice/sample-rate resolution helpers. The session does not yet have a
+ * concrete text payload — that's appended later — but the rest of the
+ * request fields are needed up-front to construct the WebSocket URL.
+ */
+function sessionOptionsToRequest(
+  options: TtsStreamingSessionOptions,
+): TtsSynthesisRequest {
+  return {
+    text: "",
+    useCase: options.useCase,
+    voiceId: options.voiceId,
+    outputFormat: options.outputFormat,
+    signal: options.signal,
+  };
+}
+
+async function openXaiStreamingSession(
+  options: TtsStreamingSessionOptions,
+): Promise<TtsStreamingSession> {
+  const apiKey = await resolveXaiApiKey();
+  if (!apiKey) {
+    throw new XaiTtsError(
+      "XAI_TTS_NO_API_KEY",
+      "xAI API key not configured. " +
+        "Add it via `assistant credentials set --service xai --field api_key <key>` " +
+        "or set XAI_API_KEY in your environment / .env.local file.",
+    );
+  }
+
+  const config = getConfig().services.tts.providers.xai;
+  const request = sessionOptionsToRequest(options);
+  const output = resolveOutputParams(request, config);
+  const voiceId = resolveVoiceId(request, config);
+  const url = buildStreamingUrl({ config, output, voiceId });
+  const contentType =
+    FORMAT_CONTENT_TYPE[output.contentTypeKey] ?? "audio/mpeg";
+  const sampleRate = output.sample_rate;
+
+  log.info(
+    {
+      voiceId,
+      codec: output.codec,
+      sampleRate,
+    },
+    "Opening xAI TTS streaming session",
+  );
+
+  const WebSocketWithHeaders = WebSocket as unknown as new (
+    url: string,
+    init: { headers: Record<string, string> },
+  ) => WebSocket;
+  const socket = new WebSocketWithHeaders(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  let finalized = false;
+  let closed = false;
+  let openResolved = false;
+
+  // Promise that resolves on `open` and rejects on early error/close.
+  // All listeners use `{ once: true }` so we never need `removeEventListener`
+  // for cleanup — that keeps tests honest against the standard WebSocket API.
+  const opened = new Promise<void>((resolve, reject) => {
+    socket.addEventListener(
+      "open",
+      () => {
+        openResolved = true;
+        resolve();
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      "error",
+      () => {
+        if (openResolved) return;
+        reject(
+          new XaiTtsError(
+            "XAI_TTS_REQUEST_FAILED",
+            "xAI TTS streaming WebSocket failed to open",
+          ),
+        );
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      "close",
+      (event) => {
+        if (openResolved) return;
+        const closeEvent = event as CloseEvent;
+        reject(
+          new XaiTtsError(
+            "XAI_TTS_REQUEST_FAILED",
+            `xAI TTS streaming WebSocket closed before open (code=${closeEvent.code}, reason="${closeEvent.reason ?? ""}")`,
+          ),
+        );
+      },
+      { once: true },
+    );
+  });
+
+  // Resolved when xAI emits `audio.done` for the current utterance.
+  // Re-created on each finalize so multi-utterance sessions could be added
+  // later without re-architecting — for now the session is single-utterance.
+  let audioDoneResolve: (() => void) | null = null;
+  let audioDoneReject: ((err: Error) => void) | null = null;
+  const audioDone = new Promise<void>((resolve, reject) => {
+    audioDoneResolve = resolve;
+    audioDoneReject = reject;
+  });
+
+  socket.addEventListener("message", (event) => {
+    const data = typeof event.data === "string" ? event.data : "";
+    if (!data) return;
+    let parsed: XaiStreamingEvent;
+    try {
+      parsed = JSON.parse(data) as XaiStreamingEvent;
+    } catch {
+      return;
+    }
+    if (parsed.type === "audio.delta" && typeof parsed.delta === "string") {
+      const chunk = Buffer.from(parsed.delta, "base64");
+      try {
+        options.onChunk(new Uint8Array(chunk));
+      } catch {
+        // Surface chunk-handler errors via the abort/error path rather than
+        // tearing the whole socket — but if onChunk throws we have no way to
+        // recover, so just swallow and rely on the caller's signal/close.
+      }
+      return;
+    }
+    if (parsed.type === "audio.done") {
+      audioDoneResolve?.();
+      return;
+    }
+    if (parsed.type === "error") {
+      audioDoneReject?.(
+        new XaiTtsError(
+          "XAI_TTS_REQUEST_FAILED",
+          `xAI TTS streaming error: ${parsed.message ?? "unknown error"}`,
+        ),
+      );
+    }
+  });
+
+  socket.addEventListener("close", () => {
+    if (!finalized) {
+      audioDoneReject?.(
+        new XaiTtsError(
+          "XAI_TTS_REQUEST_FAILED",
+          "xAI TTS streaming WebSocket closed before audio.done",
+        ),
+      );
+    }
+    closed = true;
+  });
+
+  socket.addEventListener("error", () => {
+    if (!finalized) {
+      audioDoneReject?.(
+        new XaiTtsError(
+          "XAI_TTS_REQUEST_FAILED",
+          "xAI TTS streaming WebSocket error",
+        ),
+      );
+    }
+  });
+
+  if (options.signal) {
+    const onAbort = (): void => {
+      void session.close();
+    };
+    options.signal.addEventListener("abort", onAbort, { once: true });
+    if (options.signal.aborted) {
+      onAbort();
+    }
+  }
+
+  await opened;
+
+  const session: TtsStreamingSession = {
+    contentType,
+    sampleRate,
+    async appendText(text: string): Promise<void> {
+      if (finalized) {
+        throw new XaiTtsError(
+          "XAI_TTS_REQUEST_FAILED",
+          "Cannot append text after session has been finalized",
+        );
+      }
+      if (closed) {
+        throw new XaiTtsError(
+          "XAI_TTS_REQUEST_FAILED",
+          "Cannot append text after session has been closed",
+        );
+      }
+      if (text.length === 0) return;
+      socket.send(JSON.stringify({ type: "text.delta", delta: text }));
+    },
+    async finalize(): Promise<void> {
+      if (finalized) return;
+      finalized = true;
+      if (!closed) {
+        socket.send(JSON.stringify({ type: "text.done" }));
+      }
+      await audioDone;
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      try {
+        socket.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+
+  return session;
+}
+
+function buildStreamingUrl({
+  config,
+  output,
+  voiceId,
+}: {
+  config: TtsXaiProviderConfig;
+  output: XaiOutputParams;
+  voiceId: string;
+}): string {
+  const params = new URLSearchParams({
+    language: config.language,
+    voice: voiceId,
+    codec: output.codec,
+    sample_rate: String(output.sample_rate),
+    optimize_streaming_latency: XAI_STREAMING_LATENCY_MODE,
+  });
+  if (output.bit_rate != null) {
+    params.set("bit_rate", String(output.bit_rate));
+  }
+  return `${XAI_TTS_WS_BASE}?${params.toString()}`;
 }

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -149,6 +149,105 @@ export interface TtsProviderCapabilities {
    * Optional for backwards compatibility — treat `undefined` as `false`.
    */
   alignment?: boolean;
+
+  /**
+   * Whether the provider supports persistent multi-utterance streaming
+   * sessions via {@link TtsProvider.openStreamingSession}. Sessions let
+   * callers feed text deltas to a single long-lived transport (typically a
+   * WebSocket) — eliminating per-segment connection overhead and allowing
+   * the provider to start synthesising audio before the full text is known.
+   *
+   * Optional for backwards compatibility — treat `undefined` as `false`.
+   */
+  supportsStreamingSessions?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming sessions
+// ---------------------------------------------------------------------------
+
+/** Options for opening a persistent streaming TTS session. */
+export interface TtsStreamingSessionOptions {
+  /** Product surface requesting synthesis. */
+  useCase: TtsUseCase;
+
+  /**
+   * Optional voice identifier whose format is provider-specific.
+   * Bound for the lifetime of the session.
+   */
+  voiceId?: string;
+
+  /**
+   * Optional hint requesting a specific output encoding.
+   * See {@link TtsSynthesisRequest.outputFormat}.
+   */
+  outputFormat?: "pcm";
+
+  /** Optional abort signal — closing it tears the session down. */
+  signal?: AbortSignal;
+
+  /**
+   * Invoked for each chunk of synthesised audio as it arrives from the
+   * provider. Chunks are in the format announced by the session's
+   * `contentType` and `sampleRate` fields.
+   */
+  onChunk: (chunk: Uint8Array) => void;
+
+  /**
+   * Optional per-phoneme alignment callback — only invoked by providers
+   * whose `capabilities.alignment` is `true`.
+   */
+  onAlignment?: (event: TtsAlignmentEvent) => void;
+}
+
+/**
+ * Persistent streaming TTS session.
+ *
+ * Sessions exist so callers can feed text incrementally without paying the
+ * per-call transport handshake cost. The expected lifecycle is:
+ *
+ *   1. {@link TtsProvider.openStreamingSession} opens the transport and
+ *      returns a session whose `contentType` and `sampleRate` are known.
+ *   2. The caller invokes {@link appendText} zero or more times as text
+ *      becomes available (e.g. on every assistant text delta).
+ *   3. The caller invokes {@link finalize} once the full text is known.
+ *      `finalize` resolves after the provider has emitted the final audio
+ *      chunk for this utterance.
+ *   4. The caller invokes {@link close} to release the transport, or aborts
+ *      the original signal.
+ *
+ * Sessions are single-utterance: after `finalize` resolves, subsequent
+ * `appendText` calls throw. Callers should open a fresh session per voice
+ * turn.
+ */
+export interface TtsStreamingSession {
+  /** MIME type that all audio chunks in this session will be in. */
+  readonly contentType: string;
+
+  /** Sample rate that all PCM/WAV chunks in this session will use. */
+  readonly sampleRate: number;
+
+  /**
+   * Feed additional text into the session. Resolves once the text has been
+   * accepted by the transport — not when audio is fully produced.
+   *
+   * Implementations must tolerate empty / whitespace-only strings (typically
+   * by no-oping) so callers can pipe assistant text deltas without filtering.
+   */
+  appendText(text: string): Promise<void>;
+
+  /**
+   * Signal that no more text will be appended. Resolves after the provider
+   * has emitted its terminal audio chunk and the session has cleanly closed.
+   */
+  finalize(): Promise<void>;
+
+  /**
+   * Tear the session down immediately. Safe to call after `finalize`
+   * (no-op) and from abort handlers (interrupts, errors). Resolves once
+   * the transport is closed.
+   */
+  close(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -196,4 +295,19 @@ export interface TtsProvider {
     onChunk: (chunk: Uint8Array) => void,
     onAlignment?: (event: TtsAlignmentEvent) => void,
   ): Promise<TtsSynthesisResult>;
+
+  /**
+   * Open a persistent multi-utterance streaming session.
+   *
+   * Only required when `capabilities.supportsStreamingSessions` is `true`.
+   * See {@link TtsStreamingSession} for the contract.
+   *
+   * Live-voice callers prefer this method when the provider supports it
+   * because the transport (typically a WebSocket) stays open for the
+   * duration of the assistant turn — eliminating the per-segment handshake
+   * latency that synthesizeStream incurs.
+   */
+  openStreamingSession?(
+    options: TtsStreamingSessionOptions,
+  ): Promise<TtsStreamingSession>;
 }


### PR DESCRIPTION
## Summary
- Re-cut live voice/TTS runtime updates to the intended commit set (live voice sessions, conversation handoff, STT/TTS providers, runtime HTTP handoff wiring).
- Keeps the xAI streaming latency expectation fix.

## Test Plan
- cd assistant && bun test src/live-voice/__tests__/live-voice-agent-turn.test.ts src/live-voice/__tests__/live-voice-stt.test.ts src/__tests__/voice-session-bridge.test.ts src/runtime/__tests__/conversation-handoff.test.ts src/providers/speech-to-text/openai-whisper-stream.test.ts src/providers/speech-to-text/openai-whisper.test.ts src/tts/__tests__/provider-adapters.test.ts src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
- cd assistant && bunx tsc --noEmit *(currently requires additional stack dependencies not in main)*

## Risk
- High. Voice/session/runtime contract surface; remains draft until dependency stack is resolved.

Made with [Cursor](https://cursor.com)