### PR TITLE
[v2] Add macOS camera snapshot and conversation handoff support

### DIFF
--- a/clients/macos/app-entitlements.plist
+++ b/clients/macos/app-entitlements.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
     <key>com.apple.security.virtualization</key>
     <true/>
 </dict>

--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -145,6 +145,29 @@ public final class WatchSession {
                 log.error("Failed to send watch observation")
             }
 
+            // Phase 10C: also publish a `screen_snapshot` perception event so the
+            // perception spine can reason over the same data. The daemon gates this
+            // on its own feature flag + per-conversation consent grant — a failure
+            // here is normal when the flag is off and must not interrupt the watch
+            // loop. The legacy `watch_observation` path above remains the
+            // authoritative producer until 10C ships fully.
+            let truncatedOcr = String(screenContent.prefix(2048))
+            let perceptionMsg = ScreenSnapshotPerceptionMessage(
+                eventId: "screen-snapshot:\(watchId):\(captureCount)",
+                ts: ISO8601DateFormatter().string(from: Date()),
+                source: ScreenSnapshotPerceptionMessage.Source(module: "clients/macos/WatchSession"),
+                payload: ScreenSnapshotPerceptionMessage.Payload(
+                    appId: bundleIdentifier ?? appName,
+                    appName: appName,
+                    windowTitle: windowTitle ?? "",
+                    ocrTextRedacted: truncatedOcr,
+                    redacted: false,
+                    captureMethod: "ocr",
+                    confidence: 0.8
+                )
+            )
+            _ = await computerUseClient.sendScreenSnapshotPerception(perceptionMsg)
+
             try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
         }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -86,9 +86,12 @@ extension AppDelegate {
         }
 
         guard let assistant, assistant.isRemote else {
-            // Local assistant or no assistant.
-            let conversationKey = assistant?.assistantId ?? UUID().uuidString
-            services.reconfigureConnection(conversationKey: conversationKey)
+            // Local assistant (and pre-assistant bootstrap) both bind SSE/local
+            // ownership to the shared handoff key so host actions can resume
+            // cleanly when the user moves between local first-party interfaces.
+            services.reconfigureConnection(
+                conversationKey: ConversationHandoff.defaultLocalConversationKey
+            )
             log.info("Configured local assistant")
             return
         }
@@ -431,6 +434,45 @@ extension AppDelegate {
                     }
                     self.inFlightCuTasks[msg.requestId] = task
 
+                case .hostCameraRequest(let msg):
+                    let localClientId = DeviceIdStore.getOrCreate()
+                    let isLocalConversation = self.mainWindow?.conversationManager
+                        .conversations.contains(where: { $0.conversationId == msg.conversationId }) ?? false
+                    let isTargeted = msg.targetClientId == localClientId
+                    let isUntargetedLocal = msg.targetClientId == nil && isLocalConversation
+                    guard isTargeted || isUntargetedLocal else {
+                        break
+                    }
+                    let task = Task { @MainActor in
+                        defer { self.inFlightCameraTasks.removeValue(forKey: msg.requestId) }
+                        guard !Task.isCancelled else { return }
+
+                        let result: HostCameraResultPayload
+                        do {
+                            let snapshot = try await CameraSnapshotProvider().captureOnce()
+                            result = HostCameraResultPayload(
+                                requestId: msg.requestId,
+                                imageBase64: snapshot.jpegBase64,
+                                mediaType: "image/jpeg",
+                                width: snapshot.width,
+                                height: snapshot.height
+                            )
+                        } catch {
+                            result = HostCameraResultPayload(
+                                requestId: msg.requestId,
+                                error: error.localizedDescription
+                            )
+                        }
+
+                        guard !Task.isCancelled else { return }
+                        if HostToolExecutor.isCancelledAndConsume(msg.requestId) {
+                            log.debug("Host camera result suppressed (cancelled) — requestId=\(msg.requestId, privacy: .public)")
+                            return
+                        }
+                        _ = await HostProxyClient().postCameraResult(result)
+                    }
+                    self.inFlightCameraTasks[msg.requestId] = task
+
                 case .hostAppControlRequest(let msg):
                     let task = Task { @MainActor in
                         defer { self.inFlightAppControlTasks.removeValue(forKey: msg.requestId) }
@@ -452,6 +494,8 @@ extension AppDelegate {
                     self.hostBrowserExecutor.execute(msg)
                 case .hostBrowserCancel(let msg):
                     self.hostBrowserExecutor.cancel(msg.requestId)
+                case .hostCameraCancel(let msg):
+                    self.cancelHostCameraRequest(msg.requestId)
 
                 case .hostTransferRequest(let msg):
                     let localClientId = DeviceIdStore.getOrCreate()
@@ -564,6 +608,14 @@ extension AppDelegate {
             task.cancel()
         }
         log.info("Cancelling host app-control — requestId=\(requestId, privacy: .public)")
+    }
+
+    func cancelHostCameraRequest(_ requestId: String) {
+        HostToolExecutor.markCancelled(requestId)
+        if let task = inFlightCameraTasks.removeValue(forKey: requestId) {
+            task.cancel()
+        }
+        log.info("Cancelling host camera — requestId=\(requestId, privacy: .public)")
     }
 
     // MARK: - Signing Identity

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -55,6 +55,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var inFlightCuTasks: [String: Task<Void, Never>] = [:]
     /// In-flight host app-control tasks keyed by request ID, for cancel support.
     var inFlightAppControlTasks: [String: Task<Void, Never>] = [:]
+    /// In-flight host camera tasks keyed by request ID, for cancel support.
+    var inFlightCameraTasks: [String: Task<Void, Never>] = [:]
     /// Executor for host browser (CDP) requests.
     let hostBrowserExecutor = HostBrowserExecutor()
     var isStartingSession = false

--- a/clients/macos/vellum-assistant/App/PermissionManager.swift
+++ b/clients/macos/vellum-assistant/App/PermissionManager.swift
@@ -35,6 +35,19 @@ enum PermissionManager {
         }
     }
 
+    static func cameraStatus() -> PermissionStatus {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return .granted
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+
     static func speechRecognitionStatus() -> PermissionStatus {
         switch SFSpeechRecognizer.authorizationStatus() {
         case .authorized:
@@ -134,6 +147,19 @@ enum PermissionManager {
         }
     }
 
+    static func requestCameraAccess() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            openCameraSettings()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { _ in }
+        case .denied, .restricted:
+            openCameraSettings()
+        @unknown default:
+            openCameraSettings()
+        }
+    }
+
     static func requestSpeechRecognitionAccess() {
         switch SFSpeechRecognizer.authorizationStatus() {
         case .authorized:
@@ -189,6 +215,10 @@ enum PermissionManager {
 
     static func openMicrophoneSettings() {
         _ = openPrivacySettingsPane("Privacy_Microphone")
+    }
+
+    static func openCameraSettings() {
+        _ = openPrivacySettingsPane("Privacy_Camera")
     }
 
     static func openSpeechRecognitionSettings() {

--- a/clients/macos/vellum-assistant/CameraSnapshotProvider.swift
+++ b/clients/macos/vellum-assistant/CameraSnapshotProvider.swift
@@ -1,0 +1,117 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+struct CameraSnapshot {
+    let jpegBase64: String
+    let width: Int
+    let height: Int
+}
+
+enum CameraSnapshotError: LocalizedError {
+    case permissionDenied
+    case noCamera
+    case cannotAddInput
+    case cannotAddOutput
+    case captureFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .permissionDenied:
+            return "Camera permission is required for a webcam snapshot."
+        case .noCamera:
+            return "No camera is available."
+        case .cannotAddInput:
+            return "Unable to attach the camera input."
+        case .cannotAddOutput:
+            return "Unable to attach the camera output."
+        case .captureFailed(let message):
+            return "Camera capture failed: \(message)"
+        }
+    }
+}
+
+final class CameraSnapshotProvider: NSObject, AVCapturePhotoCaptureDelegate, @unchecked Sendable {
+    private var continuation: CheckedContinuation<CameraSnapshot, Error>?
+    private var session: AVCaptureSession?
+
+    func captureOnce() async throws -> CameraSnapshot {
+        let granted = try await ensureCameraAccess()
+        guard granted else { throw CameraSnapshotError.permissionDenied }
+
+        let session = AVCaptureSession()
+        session.sessionPreset = .photo
+
+        guard let device = AVCaptureDevice.default(for: .video) else {
+            throw CameraSnapshotError.noCamera
+        }
+        let input = try AVCaptureDeviceInput(device: device)
+        guard session.canAddInput(input) else {
+            throw CameraSnapshotError.cannotAddInput
+        }
+        session.addInput(input)
+
+        let output = AVCapturePhotoOutput()
+        guard session.canAddOutput(output) else {
+            throw CameraSnapshotError.cannotAddOutput
+        }
+        session.addOutput(output)
+
+        self.session = session
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            DispatchQueue.global(qos: .userInitiated).async {
+                session.startRunning()
+                let settings: AVCapturePhotoSettings
+                if output.availablePhotoCodecTypes.contains(.jpeg) {
+                    settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+                } else {
+                    settings = AVCapturePhotoSettings()
+                }
+                output.capturePhoto(with: settings, delegate: self)
+            }
+        }
+    }
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        defer {
+            session?.stopRunning()
+            session = nil
+            continuation = nil
+        }
+
+        if let error {
+            continuation?.resume(throwing: CameraSnapshotError.captureFailed(error.localizedDescription))
+            return
+        }
+        guard let data = photo.fileDataRepresentation() else {
+            continuation?.resume(throwing: CameraSnapshotError.captureFailed("No image data returned."))
+            return
+        }
+
+        let dimensions = photo.resolvedSettings.photoDimensions
+        continuation?.resume(
+            returning: CameraSnapshot(
+                jpegBase64: data.base64EncodedString(),
+                width: Int(dimensions.width),
+                height: Int(dimensions.height)
+            )
+        )
+    }
+
+    private func ensureCameraAccess() async throws -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await AVCaptureDevice.requestAccess(for: .video)
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -6,6 +6,8 @@
     <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Vellum needs microphone access to transcribe voice commands.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Vellum needs camera access only when you approve a one-time webcam snapshot request.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>CFBundleURLTypes</key>

--- a/clients/macos/vellum-assistantTests/MessageClientTimezoneTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageClientTimezoneTests.swift
@@ -48,4 +48,16 @@ final class MessageClientTimezoneTests: XCTestCase {
         XCTAssertEqual(body["hostHomeDir"] as? String, NSHomeDirectory())
         XCTAssertEqual(body["hostUsername"] as? String, NSUserName())
     }
+
+    func testMessageBodyFallsBackToSharedHandoffConversationKeyWhenBlank() {
+        let body = MessageClient.messageBody(
+            content: "Hello",
+            conversationKey: "   "
+        )
+
+        XCTAssertEqual(
+            body["conversationKey"] as? String,
+            ConversationHandoff.defaultLocalConversationKey
+        )
+    }
 }

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -58,6 +58,13 @@ final class MockSettingsClient: SettingsClientProtocol {
     var callSiteCatalogResponse: CallSiteCatalogResponse? = MockSettingsClient.defaultCallSiteCatalogResponse
 
     static let defaultCallSiteCatalogResponse = CallSiteCatalogResponse(
+        tiers: [
+            CallSiteCatalogTier(
+                id: "default",
+                displayName: "Default",
+                description: "Default test tier"
+            ),
+        ],
         domains: [
             CallSiteCatalogDomain(id: "agentLoop", displayName: "Agent Loop"),
             CallSiteCatalogDomain(id: "memory", displayName: "Memory"),
@@ -70,31 +77,36 @@ final class MockSettingsClient: SettingsClientProtocol {
                 id: "mainAgent",
                 displayName: "Main Agent",
                 description: "The primary conversation agent that handles user messages.",
-                domain: "agentLoop"
+                domain: "agentLoop",
+                tier: "default"
             ),
             CallSiteCatalogEntry(
                 id: "memoryRetrieval",
                 displayName: "Memory Retrieval",
                 description: "Retrieves relevant memories to augment the agent context.",
-                domain: "memory"
+                domain: "memory",
+                tier: "default"
             ),
             CallSiteCatalogEntry(
                 id: "commitMessage",
                 displayName: "Commit Message",
                 description: "Generates a git commit message for staged changes.",
-                domain: "workspace"
+                domain: "workspace",
+                tier: "default"
             ),
             CallSiteCatalogEntry(
                 id: "trustRuleSuggestion",
                 displayName: "Trust Rule Suggestion",
                 description: "Suggests a trust rule pattern when the user creates a new rule.",
-                domain: "ui"
+                domain: "ui",
+                tier: "default"
             ),
             CallSiteCatalogEntry(
                 id: "inference",
                 displayName: "Inference",
                 description: "General-purpose LLM inference call site for skill use.",
-                domain: "skills"
+                domain: "skills",
+                tier: "default"
             ),
         ]
     )

--- a/clients/shared/Network/BtwClient.swift
+++ b/clients/shared/Network/BtwClient.swift
@@ -33,8 +33,9 @@ public struct BtwClient: BtwClientProtocol {
         conversationKey: String,
         continuation: AsyncThrowingStream<String, Error>.Continuation
     ) async throws {
+        let resolvedConversationKey = ConversationHandoff.normalizeConversationKey(conversationKey)
         let body: [String: String] = [
-            "conversationKey": conversationKey,
+            "conversationKey": resolvedConversationKey,
             "content": content,
         ]
         let bodyData = try JSONSerialization.data(withJSONObject: body)

--- a/clients/shared/Network/ComputerUseClient.swift
+++ b/clients/shared/Network/ComputerUseClient.swift
@@ -7,6 +7,10 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Compu
 public protocol ComputerUseClientProtocol {
     func sendWatchObservation(_ msg: WatchObservationMessage) async -> Bool
     func sendRecordingStatus(_ msg: RecordingStatus) async -> Bool
+    /// Publish a `screen_snapshot` perception event alongside the legacy
+    /// `watch_observation` path. Best-effort — failures are logged at debug
+    /// and never bubble to the watch loop.
+    func sendScreenSnapshotPerception(_ msg: ScreenSnapshotPerceptionMessage) async -> Bool
 }
 
 /// Gateway-backed implementation of ``ComputerUseClientProtocol``.
@@ -49,5 +53,83 @@ public struct ComputerUseClient: ComputerUseClientProtocol {
             log.error("sendRecordingStatus error: \(error.localizedDescription)")
             return false
         }
+    }
+
+    public func sendScreenSnapshotPerception(_ msg: ScreenSnapshotPerceptionMessage) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(msg)
+            let response = try await GatewayHTTPClient.post(
+                path: "perception/publish",
+                body: body,
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.debug("sendScreenSnapshotPerception non-success HTTP \(response.statusCode) — perception may be disabled or consent missing")
+                return false
+            }
+            return true
+        } catch {
+            log.debug("sendScreenSnapshotPerception error: \(error.localizedDescription)")
+            return false
+        }
+    }
+}
+
+// MARK: - Screen snapshot perception envelope
+
+/// Wire-compatible payload for the daemon's `perception/publish` route when
+/// emitting `screen_snapshot` events. The redacted/truncated OCR text MUST
+/// already be capped to 2048 characters by the producer.
+public struct ScreenSnapshotPerceptionMessage: Codable {
+    public struct Source: Codable {
+        public let module: String
+        public let version: String?
+
+        public init(module: String, version: String? = nil) {
+            self.module = module
+            self.version = version
+        }
+    }
+
+    public struct Payload: Codable {
+        public let kind: String
+        public let appId: String
+        public let appName: String
+        public let windowTitle: String
+        public let ocrTextRedacted: String
+        public let redacted: Bool
+        public let captureMethod: String
+        public let confidence: Double
+
+        public init(
+            appId: String,
+            appName: String,
+            windowTitle: String,
+            ocrTextRedacted: String,
+            redacted: Bool,
+            captureMethod: String,
+            confidence: Double
+        ) {
+            self.kind = "screen_snapshot"
+            self.appId = appId
+            self.appName = appName
+            self.windowTitle = windowTitle
+            self.ocrTextRedacted = ocrTextRedacted
+            self.redacted = redacted
+            self.captureMethod = captureMethod
+            self.confidence = confidence
+        }
+    }
+
+    public let eventId: String
+    public let ts: String
+    public let source: Source
+    public let payload: Payload
+
+    public init(eventId: String, ts: String, source: Source, payload: Payload) {
+        self.eventId = eventId
+        self.ts = ts
+        self.source = source
+        self.payload = payload
     }
 }

--- a/clients/shared/Network/ConversationHandoff.swift
+++ b/clients/shared/Network/ConversationHandoff.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Shared default conversation key used to continue a local first-party session
+/// across desktop/browser/mobile interfaces when a caller does not provide a
+/// specific conversation key.
+public enum ConversationHandoff {
+    public static let defaultLocalConversationKey = "default:vellum:handoff"
+
+    public static func normalizeConversationKey(_ value: String?) -> String {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return defaultLocalConversationKey
+        }
+        return trimmed
+    }
+}

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -625,6 +625,11 @@ public final class EventStreamClient {
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
             log.warning("Ignoring host_cu_request for non-local conversation \(msg.conversationId, privacy: .public)")
             return true
+        case .hostCameraRequest(let msg):
+            if msg.targetClientId != nil { return false }
+            if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
+            log.warning("Ignoring host_camera_request for non-local conversation \(msg.conversationId, privacy: .public)")
+            return true
         case .hostAppControlRequest(let msg):
             if locallyOwnedConversationIds.contains(msg.conversationId) { return false }
             log.warning("Ignoring host_app_control_request for non-local conversation \(msg.conversationId, privacy: .public)")

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -8,6 +8,7 @@ public protocol HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool
     func postFileResult(_ result: HostFileResultPayload) async -> Bool
     func postCuResult(_ result: HostCuResultPayload) async -> Bool
+    func postCameraResult(_ result: HostCameraResultPayload) async -> Bool
     func postAppControlResult(_ result: HostAppControlResultPayload) async -> Bool
     func postBrowserResult(_ result: HostBrowserResultPayload) async -> Bool
     func postTransferResult(_ result: HostTransferResultPayload) async -> Bool
@@ -80,6 +81,29 @@ public struct HostProxyClient: HostProxyClientProtocol {
             return true
         } catch {
             log.error("postCuResult error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func postCameraResult(_ result: HostCameraResultPayload) async -> Bool {
+        do {
+            let body = try JSONEncoder().encode(result)
+            let timeout: TimeInterval = result.imageBase64 != nil
+                ? max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
+                : 30
+            let response = try await GatewayHTTPClient.post(
+                path: "host-camera-result",
+                body: body,
+                extraHeaders: ["X-Vellum-Client-Id": DeviceIdStore.getOrCreate()],
+                timeout: timeout
+            )
+            guard response.isSuccess else {
+                log.error("postCameraResult failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("postCameraResult error: \(error.localizedDescription)")
             return false
         }
     }

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -81,8 +81,9 @@ public struct MessageClient: MessageClientProtocol {
         riskThreshold: String? = nil,
         clientTimezone: String? = MessageClient.clientTimezone
     ) -> [String: Any] {
+        let resolvedConversationKey = ConversationHandoff.normalizeConversationKey(conversationKey)
         var body: [String: Any] = [
-            "conversationKey": conversationKey,
+            "conversationKey": resolvedConversationKey,
             "sourceChannel": "vellum",
             "interface": Self.interfaceValue
         ]

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1706,6 +1706,58 @@ public struct HostCuCancelRequest: Decodable, Sendable {
     public let requestId: String
 }
 
+// MARK: - Host Camera Proxy
+
+/// Request from the daemon to capture one webcam snapshot and return it for
+/// immediate summarization. The client must stop the camera after one frame.
+public struct HostCameraRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let conversationId: String
+    public let toolName: String
+    public let input: [String: AnyCodable]
+    public let targetClientId: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case requestId
+        case conversationId
+        case toolName
+        case input
+        case targetClientId
+    }
+}
+
+public struct HostCameraCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
+public struct HostCameraResultPayload: Codable, Sendable {
+    public let requestId: String
+    public let imageBase64: String?
+    public let mediaType: String?
+    public let width: Int?
+    public let height: Int?
+    public let error: String?
+
+    public init(
+        requestId: String,
+        imageBase64: String? = nil,
+        mediaType: String? = nil,
+        width: Int? = nil,
+        height: Int? = nil,
+        error: String? = nil
+    ) {
+        self.requestId = requestId
+        self.imageBase64 = imageBase64
+        self.mediaType = mediaType
+        self.width = width
+        self.height = height
+        self.error = error
+    }
+}
+
 // MARK: - Host App Control
 
 /// Request from the daemon to execute an app-control action on the host.
@@ -2970,6 +3022,8 @@ public enum ServerMessage: Decodable, Sendable {
     case hostFileCancel(HostFileCancelRequest)
     case hostCuRequest(HostCuRequest)
     case hostCuCancel(HostCuCancelRequest)
+    case hostCameraRequest(HostCameraRequest)
+    case hostCameraCancel(HostCameraCancelRequest)
     case hostAppControlRequest(HostAppControlRequest)
     case hostAppControlCancel(HostAppControlCancel)
     case hostBrowserRequest(HostBrowserRequest)
@@ -3473,6 +3527,12 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_cu_cancel":
             let message = try HostCuCancelRequest(from: decoder)
             self = .hostCuCancel(message)
+        case "host_camera_request":
+            let message = try HostCameraRequest(from: decoder)
+            self = .hostCameraRequest(message)
+        case "host_camera_cancel":
+            let message = try HostCameraCancelRequest(from: decoder)
+            self = .hostCameraCancel(message)
         case "host_app_control_request":
             let message = try HostAppControlRequest(from: decoder)
             self = .hostAppControlRequest(message)

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -667,25 +667,41 @@ public struct CallSiteCatalogDomain: Codable {
     }
 }
 
+public struct CallSiteCatalogTier: Codable {
+    public let id: String
+    public let displayName: String
+    public let description: String
+
+    public init(id: String, displayName: String, description: String) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+    }
+}
+
 public struct CallSiteCatalogEntry: Codable {
     public let id: String
     public let displayName: String
     public let description: String
     public let domain: String
+    public let tier: String
 
-    public init(id: String, displayName: String, description: String, domain: String) {
+    public init(id: String, displayName: String, description: String, domain: String, tier: String) {
         self.id = id
         self.displayName = displayName
         self.description = description
         self.domain = domain
+        self.tier = tier
     }
 }
 
 public struct CallSiteCatalogResponse: Codable {
+    public let tiers: [CallSiteCatalogTier]
     public let domains: [CallSiteCatalogDomain]
     public let callSites: [CallSiteCatalogEntry]
 
-    public init(domains: [CallSiteCatalogDomain], callSites: [CallSiteCatalogEntry]) {
+    public init(tiers: [CallSiteCatalogTier], domains: [CallSiteCatalogDomain], callSites: [CallSiteCatalogEntry]) {
+        self.tiers = tiers
         self.domains = domains
         self.callSites = callSites
     }

--- a/clients/shared/Tests/HostBrowserExecutorTests.swift
+++ b/clients/shared/Tests/HostBrowserExecutorTests.swift
@@ -13,6 +13,7 @@ private final class MockHostProxyClient: HostProxyClientProtocol {
     func postBashResult(_ result: HostBashResultPayload) async -> Bool { true }
     func postFileResult(_ result: HostFileResultPayload) async -> Bool { true }
     func postCuResult(_ result: HostCuResultPayload) async -> Bool { true }
+    func postCameraResult(_ result: HostCameraResultPayload) async -> Bool { true }
     func postAppControlResult(_ result: HostAppControlResultPayload) async -> Bool { true }
     func postTransferResult(_ result: HostTransferResultPayload) async -> Bool { true }
     func pullTransferContent(transferId: String) async throws -> Data { Data() }


### PR DESCRIPTION
## Summary
- Re-cut macOS camera snapshot + conversation handoff client changes with updated test fixture.
- Includes required `HostProxyClient` camera result API used by macOS handoff flow.

## Test Plan
- cd clients/macos && ./build.sh test

## Risk
- Medium-high. Native camera permissions and shared network contracts; still a stack-dependent draft.

Made with [Cursor](https://cursor.com)