### PR TITLE
feat(web-search): emit structured per-result metadata from Brave/Perplexity/Tavily

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mutable mock state - set per test
+let mockWebSearchProvider: string | undefined = "perplexity";
+let mockBraveSecureKey: string | undefined;
+let mockPerplexitySecureKey: string | undefined;
+let mockTavilySecureKey: string | undefined;
+
+// Capture the registered tool
+let capturedTool: any = null;
+
+mock.module("../../registry.js", () => ({
+  registerTool: (tool: any) => {
+    capturedTool = tool;
+  },
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    services: {
+      "web-search": { provider: mockWebSearchProvider },
+    },
+  }),
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) => {
+    if (provider === "brave") return mockBraveSecureKey;
+    if (provider === "perplexity") return mockPerplexitySecureKey;
+    if (provider === "tavily") return mockTavilySecureKey;
+    return undefined;
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../../permissions/types.js", () => ({
+  RiskLevel: { Low: "low", Medium: "medium", High: "high" },
+}));
+
+// Force the module to load (triggers registerTool)
+await import("../web-search.js");
+
+describe("web_search activity metadata", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockWebSearchProvider = "perplexity";
+    mockBraveSecureKey = undefined;
+    mockPerplexitySecureKey = undefined;
+    mockTavilySecureKey = undefined;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function execute(input: Record<string, unknown>) {
+    return capturedTool.execute(input, {} as any);
+  }
+
+  // ---- Brave --------------------------------------------------------------
+
+  test("Brave populates webSearch metadata on success", async () => {
+    mockWebSearchProvider = "brave";
+    mockBraveSecureKey = "brave-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          web: {
+            results: [
+              {
+                title: "Brave One",
+                url: "https://example.com/one",
+                description: "First Brave result",
+                age: "1 day ago",
+              },
+              {
+                title: "Brave Two",
+                url: "https://other.example.org/two",
+                description: "Second result",
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "brave query" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("brave");
+    expect(meta.query).toBe("brave query");
+    expect(meta.resultCount).toBe(2);
+    expect(typeof meta.durationMs).toBe("number");
+    expect(meta.errorMessage).toBeUndefined();
+    expect(meta.results[0].rank).toBe(1);
+    expect(meta.results[0].title).toBe("Brave One");
+    expect(meta.results[0].url).toBe("https://example.com/one");
+    expect(meta.results[0].domain).toBe("example.com");
+    expect(meta.results[0].snippet).toBe("First Brave result");
+    expect(meta.results[0].age).toBe("1 day ago");
+    expect(meta.results[1].rank).toBe(2);
+    expect(meta.results[1].domain).toBe("other.example.org");
+  });
+
+  test("Brave populates errorMessage and empty results on auth failure", async () => {
+    mockWebSearchProvider = "brave";
+    mockBraveSecureKey = "bad-key";
+    globalThis.fetch = (async () =>
+      new Response("Forbidden", { status: 403 })) as any;
+
+    const result = await execute({ query: "brave fail" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("brave");
+    expect(meta.resultCount).toBe(0);
+    expect(meta.results).toEqual([]);
+    expect(meta.errorMessage).toContain("Invalid or expired Brave Search");
+  });
+
+  // ---- Perplexity ---------------------------------------------------------
+
+  test("Perplexity populates webSearch metadata from citations", async () => {
+    mockPerplexitySecureKey = "pplx-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "answer text" } }],
+          citations: [
+            "https://typescriptlang.org/docs",
+            "https://example.com/article",
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "perplexity query" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("perplexity");
+    expect(meta.query).toBe("perplexity query");
+    expect(meta.resultCount).toBe(2);
+    expect(meta.results[0].rank).toBe(1);
+    expect(meta.results[0].url).toBe("https://typescriptlang.org/docs");
+    expect(meta.results[0].domain).toBe("typescriptlang.org");
+    expect(meta.results[0].title).toBe("");
+    expect(meta.results[0].snippet).toBeUndefined();
+    expect(meta.results[1].domain).toBe("example.com");
+  });
+
+  test("Perplexity populates errorMessage on rate-limit exhaustion", async () => {
+    mockPerplexitySecureKey = "pplx-key";
+    globalThis.fetch = (async () =>
+      new Response("Too Many Requests", {
+        status: 429,
+        headers: { "retry-after": "0" },
+      })) as any;
+
+    const result = await execute({ query: "rate limited" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("perplexity");
+    expect(meta.resultCount).toBe(0);
+    expect(meta.results).toEqual([]);
+    expect(meta.errorMessage).toContain("rate limit exceeded");
+  });
+
+  // ---- Tavily -------------------------------------------------------------
+
+  test("Tavily populates webSearch metadata with favicon and score", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "Tavily One",
+              url: "https://docs.example.com/page",
+              content: "Tavily snippet text",
+              score: 0.87,
+              favicon: "https://docs.example.com/favicon.ico",
+            },
+            {
+              title: "Tavily Two",
+              url: "https://blog.example.org/post",
+              content: "Second tavily content",
+              score: 0.42,
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "tavily query" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("tavily");
+    expect(meta.resultCount).toBe(2);
+    expect(meta.results[0].rank).toBe(1);
+    expect(meta.results[0].title).toBe("Tavily One");
+    expect(meta.results[0].url).toBe("https://docs.example.com/page");
+    expect(meta.results[0].domain).toBe("docs.example.com");
+    expect(meta.results[0].faviconUrl).toBe(
+      "https://docs.example.com/favicon.ico",
+    );
+    expect(meta.results[0].snippet).toBe("Tavily snippet text");
+    expect(meta.results[0].score).toBe(0.87);
+    expect(meta.results[1].faviconUrl).toBeUndefined();
+    expect(meta.results[1].score).toBe(0.42);
+  });
+
+  test("Tavily falls back to url for missing title", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              url: "https://example.net/article",
+              content: "No title here",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "no title" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.results[0].title).toBe("https://example.net/article");
+    expect(meta.results[0].domain).toBe("example.net");
+  });
+
+  test("Tavily populates errorMessage on auth failure", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "bad-key";
+    globalThis.fetch = (async () =>
+      new Response("Unauthorized", { status: 401 })) as any;
+
+    const result = await execute({ query: "tavily fail" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("tavily");
+    expect(meta.resultCount).toBe(0);
+    expect(meta.results).toEqual([]);
+    expect(meta.errorMessage).toContain("Invalid or expired Tavily");
+  });
+});

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -80,6 +80,23 @@ export function normalizeDomain(input: string): DomainInfo | null {
   };
 }
 
+/**
+ * Best-effort host extractor for URLs surfaced in tool activity metadata
+ * (web-search result items, web-fetch metadata). Returns the lowercased
+ * host portion of `rawUrl`, or `""` when the input cannot be parsed.
+ *
+ * Distinct from {@link normalizeDomain} above: callers here only need a
+ * stable display string, not a registrable-domain analysis. We return ""
+ * (rather than null) so consumers can treat the result as a plain string.
+ */
+export function extractDomain(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).host.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
 function isIPAddress(hostname: string): boolean {
   // IPv4
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return true;

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -1,4 +1,8 @@
 import { getConfig } from "../../config/loader.js";
+import type {
+  WebSearchMetadata,
+  WebSearchResultItem,
+} from "../../daemon/message-types/web-activity.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
@@ -12,6 +16,7 @@ import {
 } from "../../util/retry.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import { extractDomain } from "./domain-normalize.js";
 
 const log = getLogger("web-search");
 
@@ -201,6 +206,76 @@ function formatTavilyResults(
   return lines.join("\n");
 }
 
+function buildBraveMetadata(
+  results: BraveSearchResult[],
+  query: string,
+  durationMs: number,
+): WebSearchMetadata {
+  const items: WebSearchResultItem[] = results.map((r, i) => ({
+    rank: i + 1,
+    title: r.title,
+    url: r.url,
+    domain: extractDomain(r.url),
+    snippet: r.description,
+    age: r.age,
+  }));
+  return {
+    query,
+    provider: "brave",
+    resultCount: items.length,
+    durationMs,
+    results: items,
+  };
+}
+
+function buildPerplexityMetadata(
+  data: PerplexityResponse,
+  query: string,
+  durationMs: number,
+): WebSearchMetadata {
+  const citations = data.citations ?? [];
+  const items: WebSearchResultItem[] = citations.map((url, i) => ({
+    rank: i + 1,
+    title: "",
+    url,
+    domain: extractDomain(url),
+  }));
+  return {
+    query,
+    provider: "perplexity",
+    resultCount: items.length,
+    durationMs,
+    results: items,
+  };
+}
+
+function buildTavilyMetadata(
+  data: TavilySearchResponse,
+  query: string,
+  durationMs: number,
+): WebSearchMetadata {
+  const results = data.results ?? [];
+  const items: WebSearchResultItem[] = results.map((r, i) => {
+    const url = r.url ?? "";
+    return {
+      rank: i + 1,
+      title: r.title ?? url,
+      url,
+      domain: extractDomain(url),
+      faviconUrl: r.favicon,
+      snippet: r.content,
+      score: r.score,
+    };
+  });
+  return {
+    query,
+    provider: "tavily",
+    resultCount: items.length,
+    durationMs,
+    results: items,
+  };
+}
+
 function tavilyTimeRangeForFreshness(
   freshness: string | undefined,
 ): "day" | "week" | "month" | "year" | undefined {
@@ -216,6 +291,28 @@ function tavilyTimeRangeForFreshness(
     default:
       return undefined;
   }
+}
+
+function errorResult(
+  query: string,
+  provider: WebSearchProvider,
+  startedAt: number,
+  errorMessage: string,
+): ToolExecutionResult {
+  return {
+    content: `Error: ${errorMessage}`,
+    isError: true,
+    activityMetadata: {
+      webSearch: {
+        query,
+        provider,
+        resultCount: 0,
+        durationMs: Date.now() - startedAt,
+        results: [],
+        errorMessage,
+      },
+    },
+  };
 }
 
 async function executeBraveSearch(
@@ -238,6 +335,7 @@ async function executeBraveSearch(
   }
 
   const url = `${BRAVE_API_URL}?${params.toString()}`;
+  const startedAt = Date.now();
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(url, {
@@ -252,6 +350,7 @@ async function executeBraveSearch(
     if (response.ok) {
       const data = (await response.json()) as BraveSearchResponse;
       const results = data.web?.results ?? [];
+      const durationMs = Date.now() - startedAt;
       return {
         content:
           wrapUntrustedContent(formatBraveResults(results, query), {
@@ -259,16 +358,21 @@ async function executeBraveSearch(
             sourceDetail: "brave",
           }) + CITATION_INSTRUCTION,
         isError: false,
+        activityMetadata: {
+          webSearch: buildBraveMetadata(results, query, durationMs),
+        },
       };
     }
 
     await response.text();
 
     if (response.status === 401 || response.status === 403) {
-      return {
-        content: "Error: Invalid or expired Brave Search API key",
-        isError: true,
-      };
+      return errorResult(
+        query,
+        "brave",
+        startedAt,
+        "Invalid or expired Brave Search API key",
+      );
     }
 
     if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
@@ -286,24 +390,22 @@ async function executeBraveSearch(
     }
 
     log.warn({ status: response.status }, "Brave Search API error");
-    if (response.status === 429) {
-      return {
-        content:
-          "Error: Brave Search rate limit exceeded after retries. Try again shortly.",
-        isError: true,
-      };
-    }
-    return {
-      content: `Error: Brave Search API returned status ${response.status}`,
-      isError: true,
-    };
+    return errorResult(
+      query,
+      "brave",
+      startedAt,
+      response.status === 429
+        ? "Brave Search rate limit exceeded after retries. Try again shortly."
+        : `Brave Search API returned status ${response.status}`,
+    );
   }
 
-  return {
-    content:
-      "Error: Brave Search rate limit exceeded after retries. Try again shortly.",
-    isError: true,
-  };
+  return errorResult(
+    query,
+    "brave",
+    startedAt,
+    "Brave Search rate limit exceeded after retries. Try again shortly.",
+  );
 }
 
 async function executePerplexitySearch(
@@ -311,6 +413,7 @@ async function executePerplexitySearch(
   apiKey: string,
   signal?: AbortSignal,
 ): Promise<ToolExecutionResult> {
+  const startedAt = Date.now();
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(PERPLEXITY_API_URL, {
       method: "POST",
@@ -327,6 +430,7 @@ async function executePerplexitySearch(
 
     if (response.ok) {
       const data = (await response.json()) as PerplexityResponse;
+      const durationMs = Date.now() - startedAt;
       return {
         content:
           wrapUntrustedContent(formatPerplexityResults(data, query), {
@@ -334,16 +438,21 @@ async function executePerplexitySearch(
             sourceDetail: "perplexity",
           }) + CITATION_INSTRUCTION,
         isError: false,
+        activityMetadata: {
+          webSearch: buildPerplexityMetadata(data, query, durationMs),
+        },
       };
     }
 
     await response.text();
 
     if (response.status === 401 || response.status === 403) {
-      return {
-        content: "Error: Invalid or expired Perplexity API key",
-        isError: true,
-      };
+      return errorResult(
+        query,
+        "perplexity",
+        startedAt,
+        "Invalid or expired Perplexity API key",
+      );
     }
 
     if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
@@ -361,24 +470,22 @@ async function executePerplexitySearch(
     }
 
     log.warn({ status: response.status }, "Perplexity API error");
-    if (response.status === 429) {
-      return {
-        content:
-          "Error: Perplexity rate limit exceeded after retries. Try again shortly.",
-        isError: true,
-      };
-    }
-    return {
-      content: `Error: Perplexity API returned status ${response.status}`,
-      isError: true,
-    };
+    return errorResult(
+      query,
+      "perplexity",
+      startedAt,
+      response.status === 429
+        ? "Perplexity rate limit exceeded after retries. Try again shortly."
+        : `Perplexity API returned status ${response.status}`,
+    );
   }
 
-  return {
-    content:
-      "Error: Perplexity rate limit exceeded after retries. Try again shortly.",
-    isError: true,
-  };
+  return errorResult(
+    query,
+    "perplexity",
+    startedAt,
+    "Perplexity rate limit exceeded after retries. Try again shortly.",
+  );
 }
 
 async function executeTavilySearch(
@@ -398,6 +505,8 @@ async function executeTavilySearch(
     body.time_range = timeRange;
   }
 
+  const startedAt = Date.now();
+
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     const response = await fetch(TAVILY_API_URL, {
       method: "POST",
@@ -412,6 +521,7 @@ async function executeTavilySearch(
 
     if (response.ok) {
       const data = (await response.json()) as TavilySearchResponse;
+      const durationMs = Date.now() - startedAt;
       return {
         content:
           wrapUntrustedContent(formatTavilyResults(data, query), {
@@ -419,16 +529,21 @@ async function executeTavilySearch(
             sourceDetail: "tavily",
           }) + CITATION_INSTRUCTION,
         isError: false,
+        activityMetadata: {
+          webSearch: buildTavilyMetadata(data, query, durationMs),
+        },
       };
     }
 
     await response.text();
 
     if (response.status === 401 || response.status === 403) {
-      return {
-        content: "Error: Invalid or expired Tavily API key",
-        isError: true,
-      };
+      return errorResult(
+        query,
+        "tavily",
+        startedAt,
+        "Invalid or expired Tavily API key",
+      );
     }
 
     if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
@@ -446,24 +561,22 @@ async function executeTavilySearch(
     }
 
     log.warn({ status: response.status }, "Tavily Search API error");
-    if (response.status === 429) {
-      return {
-        content:
-          "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
-        isError: true,
-      };
-    }
-    return {
-      content: `Error: Tavily Search API returned status ${response.status}`,
-      isError: true,
-    };
+    return errorResult(
+      query,
+      "tavily",
+      startedAt,
+      response.status === 429
+        ? "Tavily Search rate limit exceeded after retries. Try again shortly."
+        : `Tavily Search API returned status ${response.status}`,
+    );
   }
 
-  return {
-    content:
-      "Error: Tavily Search rate limit exceeded after retries. Try again shortly.",
-    isError: true,
-  };
+  return errorResult(
+    query,
+    "tavily",
+    startedAt,
+    "Tavily Search rate limit exceeded after retries. Try again shortly.",
+  );
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Brave/Perplexity/Tavily web_search adapters now return WebSearchMetadata alongside formatted text
- Each adapter captures durationMs, builds per-result items with title/url/domain/snippet/score/favicon as available
- Error paths populate errorMessage with results: [] so failures are surfaced to clients

Part of plan: web-activity-ui-data.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->