### PR TITLE
feat(daemon): structured web-search metadata for Anthropic native server tool

### DIFF
--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests that the native Anthropic `server_tool_complete` agent event produces
+ * a structured `WebSearchMetadata` payload on the emitted `tool_result` server
+ * message while keeping the back-compat `result: string` byte-identical.
+ *
+ * Mirrors the mocked-dependency collector pattern used in
+ * tool-result-metadata-plumbing.test.ts.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock platform (must precede imports that read it) ─────────────────────────
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+}));
+
+mock.module("../../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+} from "../conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../message-protocol.js";
+
+type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createCollectorDeps(): {
+  deps: EventHandlerDeps;
+  events: ServerMessage[];
+} {
+  const events: ServerMessage[] = [];
+  const deps = {
+    ctx: {
+      conversationId: "conv-native-meta",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: () => {},
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (msg: ServerMessage) => events.push(msg),
+    reqId: "req-native-meta",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, events };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("native server_tool_complete metadata", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("builds structured WebSearchMetadata and keeps result text byte-identical", async () => {
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "tu1";
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId,
+      input: { query: "Air Jordan auction" },
+    });
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId,
+      isError: false,
+      content: [
+        {
+          type: "web_search_result",
+          title: "X",
+          url: "https://www.cnn.com/a",
+        },
+        {
+          type: "web_search_result",
+          title: "Y",
+          url: "https://www.nbcnews.com/b",
+        },
+      ],
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent).toBeDefined();
+
+    const meta = toolResultEvent?.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta?.query).toBe("Air Jordan auction");
+    expect(meta?.provider).toBe("anthropic-native");
+    expect(meta?.resultCount).toBe(2);
+    expect(meta?.results[0]?.domain).toBe("www.cnn.com");
+    expect(meta?.results[1]?.domain).toBe("www.nbcnews.com");
+    expect(meta?.results[0]?.rank).toBe(1);
+    expect(meta?.results[1]?.rank).toBe(2);
+    expect(meta?.durationMs).toBeGreaterThanOrEqual(0);
+
+    // Back-compat: result text must be byte-identical to the legacy format.
+    expect(toolResultEvent?.result).toBe(
+      "X\nhttps://www.cnn.com/a\n\nY\nhttps://www.nbcnews.com/b",
+    );
+
+    // Per-toolUseId scratch maps must be cleaned up after completion.
+    expect(state.serverToolStartedAt.has(toolUseId)).toBe(false);
+    expect(state.serverToolInputs.has(toolUseId)).toBe(false);
+  });
+
+  test("sets errorMessage when the search errored", async () => {
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "tu_err";
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId,
+      input: { query: "broken" },
+    });
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId,
+      isError: true,
+      content: [],
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    const meta = toolResultEvent?.activityMetadata?.webSearch;
+    expect(meta?.errorMessage).toBe("Search failed");
+    expect(meta?.resultCount).toBe(0);
+    expect(meta?.results).toEqual([]);
+    expect(toolResultEvent?.isError).toBe(true);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -46,6 +46,7 @@ import type {
 import type { ContentBlock, ImageContent } from "../providers/types.js";
 import { isContextOverflowError } from "../providers/types.js";
 import { redactSecrets } from "../security/secret-scanner.js";
+import { extractDomain } from "../tools/network/domain-normalize.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
@@ -61,6 +62,10 @@ import {
 } from "./conversation-error.js";
 import { isProviderOrderingError } from "./conversation-slash.js";
 import type { ServerMessage } from "./message-protocol.js";
+import type {
+  WebSearchMetadata,
+  WebSearchResultItem,
+} from "./message-types/web-activity.js";
 
 const log = getLogger("agent-loop-handlers");
 
@@ -199,6 +204,10 @@ export interface EventHandlerState {
   currentTurnToolUseIds: string[];
   /** Wall-clock time (ms since epoch) when the agent loop turn started, used as the display timestamp for assistant messages. */
   turnStartedAt: number;
+  /** Wall-clock start time of native server tool calls, keyed by tool_use_id. */
+  readonly serverToolStartedAt: Map<string, number>;
+  /** Original input from server_tool_start, keyed by tool_use_id, so the complete handler can read the query. */
+  readonly serverToolInputs: Map<string, Record<string, unknown>>;
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -257,6 +266,8 @@ export function createEventHandlerState(): EventHandlerState {
     toolRiskOutcomes: new Map(),
     currentTurnToolUseIds: [],
     turnStartedAt: Date.now(),
+    serverToolStartedAt: new Map(),
+    serverToolInputs: new Map(),
   };
 }
 
@@ -1258,6 +1269,8 @@ export async function dispatchAgentEvent(
           deps.reqId,
           statusText,
         );
+        state.serverToolStartedAt.set(event.toolUseId, Date.now());
+        state.serverToolInputs.set(event.toolUseId, event.input);
         deps.onEvent({
           type: "tool_use_start",
           toolName: event.name,
@@ -1276,19 +1289,43 @@ export async function dispatchAgentEvent(
           "Thinking",
         );
 
-        // Format web search results into a human-readable string for the client.
-        let resultText = "";
-        if (Array.isArray(event.content) && event.content.length > 0) {
-          resultText = (event.content as unknown[])
-            .filter(
-              (r): r is { type: string; title: string; url: string } =>
-                typeof r === "object" &&
-                r != null &&
-                (r as { type?: string }).type === "web_search_result",
-            )
-            .map((r) => `${r.title}\n${r.url}`)
-            .join("\n\n");
-        }
+        const inputForCall = state.serverToolInputs.get(event.toolUseId);
+        const query =
+          typeof inputForCall?.query === "string" ? inputForCall.query : "";
+        const startedAt =
+          state.serverToolStartedAt.get(event.toolUseId) ?? Date.now();
+        const durationMs = Date.now() - startedAt;
+        state.serverToolStartedAt.delete(event.toolUseId);
+        state.serverToolInputs.delete(event.toolUseId);
+
+        const rawBlocks = Array.isArray(event.content) ? event.content : [];
+        const results: WebSearchResultItem[] = rawBlocks
+          .filter(
+            (r): r is { type: string; title: string; url: string } =>
+              typeof r === "object" &&
+              r != null &&
+              (r as { type?: string }).type === "web_search_result",
+          )
+          .map((r, i) => ({
+            rank: i + 1,
+            title: r.title,
+            url: r.url,
+            domain: extractDomain(r.url),
+            // snippet intentionally absent — Anthropic native content is encrypted/opaque
+          }));
+
+        const metadata: WebSearchMetadata = {
+          query,
+          provider: "anthropic-native",
+          resultCount: results.length,
+          durationMs,
+          results,
+          ...(event.isError ? { errorMessage: "Search failed" } : {}),
+        };
+
+        const resultText = results
+          .map((r) => `${r.title}\n${r.url}`)
+          .join("\n\n");
 
         deps.onEvent({
           type: "tool_result",
@@ -1297,7 +1334,7 @@ export async function dispatchAgentEvent(
           isError: event.isError,
           conversationId: deps.ctx.conversationId,
           toolUseId: event.toolUseId,
-          activityMetadata: undefined,
+          activityMetadata: { webSearch: metadata },
         });
         break;
       }

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -104,20 +104,3 @@ function isIPAddress(hostname: string): boolean {
   if (hostname.startsWith("[") || hostname.includes(":")) return true;
   return false;
 }
-
-/**
- * Extract a lowercased host from a raw URL string for display purposes.
- *
- * Returns `""` for inputs that cannot be parsed as a URL. Unlike
- * `normalizeDomain`, this preserves the full host (including subdomains) and
- * does not reject IPs or localhost — it's intended for UI display of
- * web-search and web-fetch result origins where the bare host is what users
- * recognize (e.g. `www.cnn.com`, not `cnn.com`).
- */
-export function extractDomain(rawUrl: string): string {
-  try {
-    return new URL(rawUrl).host.toLowerCase();
-  } catch {
-    return "";
-  }
-}

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -87,3 +87,20 @@ function isIPAddress(hostname: string): boolean {
   if (hostname.startsWith("[") || hostname.includes(":")) return true;
   return false;
 }
+
+/**
+ * Extract a lowercased host from a raw URL string for display purposes.
+ *
+ * Returns `""` for inputs that cannot be parsed as a URL. Unlike
+ * `normalizeDomain`, this preserves the full host (including subdomains) and
+ * does not reject IPs or localhost — it's intended for UI display of
+ * web-search and web-fetch result origins where the bare host is what users
+ * recognize (e.g. `www.cnn.com`, not `cnn.com`).
+ */
+export function extractDomain(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).host.toLowerCase();
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- server_tool_start now captures the query input and start timestamp keyed by toolUseId
- server_tool_complete builds a structured WebSearchMetadata from web_search_result blocks (title, url, domain, rank) and forwards it on activityMetadata
- Back-compat: result: string text remains byte-identical for existing clients

Part of plan: web-activity-ui-data.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->