### PR TITLE
feat(inference): seed managed Fireworks balanced profile

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -74,6 +74,18 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
+  "fireworks-balanced": {
+    intent: "balanced",
+    provider: "fireworks",
+    connectionName: "fireworks-managed",
+    source: "managed",
+    label: "Balanced (Fireworks)",
+    description: "Good balance of quality, cost, and speed via Fireworks",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add a new `fireworks-balanced` managed profile template in `seed-inference-profiles.ts`
- Uses the existing `fireworks-managed` canonical connection and resolves to Kimi K2.6 via the `balanced` intent
- The three existing Anthropic managed profiles (balanced, quality-optimized, cost-optimized) are unchanged

## Original prompt
During a cherry-pick of Kimi/Fireworks commits to the v0.8.3 release branch, we discovered that the `fireworks-managed` connection infrastructure was added (canonical connection, managed proxy config, model catalog entries) but no managed profile actually uses it. The intent was to seed a Fireworks managed profile alongside the Anthropic ones so that Fireworks is available as a managed provider out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->