### PR TITLE
[codex] Fix managed inference hatch connection disable

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1042,6 +1042,44 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
   });
 
+  test("off-platform managed-inference hatch respects explicit non-managed active connection", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "anthropic" },
+            profiles: {
+              balanced: {
+                source: "managed",
+                provider: "anthropic",
+                provider_connection: "anthropic-personal",
+                model: "claude-sonnet-4-6",
+              },
+            },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+      "anthropic-personal",
+    );
+    expect(getConnection(db, "anthropic-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "openai-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
+  });
+
   test("off-platform BYOK hatch still disables managed connections", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import {
   afterAll,
   afterEach,
@@ -16,6 +17,8 @@ import {
   mock,
   test,
 } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before imports that depend on platform/logger
@@ -73,6 +76,12 @@ import {
   mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import type { DrizzleDb } from "../memory/db-connection.js";
+import { migrateCreateProviderConnections } from "../memory/migrations/243-provider-connections.js";
+import { migrateProviderConnectionStatusLabel } from "../memory/migrations/244-provider-connection-status-label.js";
+import { migrateProviderConnectionBaseUrlAndModels } from "../memory/migrations/250-provider-connection-base-url-and-models.js";
+import * as schema from "../memory/schema.js";
+import { getConnection } from "../providers/inference/connections.js";
 import { _setStorePath } from "../security/encrypted-store.js";
 
 // ---------------------------------------------------------------------------
@@ -83,13 +92,24 @@ function writeConfig(obj: unknown): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
 }
 
-function mergeDefaultConfigAndSeedInferenceProfiles(): void {
+function mergeDefaultConfigAndSeedInferenceProfiles(db?: DrizzleDb): void {
   const defaultConfigMerge = mergeDefaultWorkspaceConfig();
   seedInferenceProfiles({
     preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
     preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
     isHatch: defaultConfigMerge.hadOverlay,
+    db,
   });
+}
+
+function createProviderConnectionsDb(): DrizzleDb {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  const db = drizzle(sqlite, { schema });
+  migrateCreateProviderConnections(db);
+  migrateProviderConnectionStatusLabel(db);
+  migrateProviderConnectionBaseUrlAndModels(db);
+  return db;
 }
 
 // ---------------------------------------------------------------------------
@@ -989,6 +1009,54 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.balanced?.status).toBe("disabled");
     expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
     expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
+  });
+
+  test("off-platform managed-inference hatch keeps selected managed connection active", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "anthropic" },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+      "anthropic-managed",
+    );
+    expect("status" in raw.llm.profiles.balanced).toBe(false);
+    expect(getConnection(db, "anthropic-managed")?.status).toBe("active");
+    expect(getConnection(db, "openai-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
+  });
+
+  test("off-platform BYOK hatch still disables managed connections", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+    const db = createProviderConnectionsDb();
+
+    mergeDefaultConfigAndSeedInferenceProfiles(db);
+
+    expect(getConnection(db, "anthropic-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "openai-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
   });
 
   test("non-hatch off-platform boot does NOT auto-disable freshly-materialized managed profiles", () => {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -3,6 +3,7 @@ import {
   createConnection,
   disableManagedConnectionsForByokHatch,
   getConnection,
+  MANAGED_CONNECTION_NAMES,
   PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
 } from "../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
@@ -177,11 +178,12 @@ export function seedInferenceProfiles(
   // BYOK mode = off-platform installs. The user is bringing their own provider
   // API key; managed profile labels get a " (Managed)" suffix to disambiguate
   // from the personal "custom-*" profiles that share base labels. Managed
-  // profile + connection status is initially "disabled" so the picker doesn't
-  // offer an unusable platform-auth option on day one — but ONLY at hatch
-  // time, and ONLY when the entry isn't already in the user's config (i.e.
-  // first materialization). Post-hatch user toggles survive every subsequent
-  // boot.
+  // profile + connection status is initially "disabled" for true BYOK hatches
+  // so the picker doesn't offer an unusable platform-auth option on day one.
+  // When the hatch overlay explicitly selects a managed profile, the matching
+  // managed connection stays active so the first post-onboarding message can
+  // use the user's chosen managed route. Post-hatch user toggles survive every
+  // subsequent boot.
   const isByokMode = !isPlatform;
 
   // 1. Managed profiles. Off-platform: overwrite on every boot so Vellum can
@@ -211,10 +213,18 @@ export function seedInferenceProfiles(
   //        rewritten to the suffixed form. Any other previous label value
   //        (user-set custom string, explicit null, already-suffixed) is
   //        preserved as-is.
-  //      • status: "disabled" on fresh materialization at hatch only —
-  //        gated on (isHatch && !previous) so post-hatch boots and existing
-  //        installs are never auto-disabled. A user re-enable persists
-  //        across boots via the key-presence preservation below.
+  //      • status: "disabled" on fresh materialization at BYOK hatch only —
+  //        gated on (isHatch && !previous) and skipped for any managed
+  //        connection explicitly selected by the hatch overlay. Post-hatch
+  //        boots and existing installs are never auto-disabled. A user
+  //        re-enable persists across boots via the key-presence preservation
+  //        below.
+  const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
+    llm,
+    profiles,
+    options,
+  );
+
   for (const [name, template] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
     if (preservedProfileNames.has(name)) continue;
     if (isPlatform && readObject(profiles[name]) !== null) continue;
@@ -228,7 +238,12 @@ export function seedInferenceProfiles(
       template.provider,
       template.connectionName,
     ) as Record<string, unknown>;
-    if (isByokMode && options.isHatch && !previous) {
+    if (
+      isByokMode &&
+      options.isHatch &&
+      !previous &&
+      template.connectionName !== hatchSelectedManagedConnection
+    ) {
       next.status = "disabled";
     }
     if (previous) {
@@ -251,13 +266,16 @@ export function seedInferenceProfiles(
   // 2. User profiles — only at hatch time for off-platform installations.
   let userConnectionName: string | undefined;
   if (options.isHatch && !isPlatform) {
-    // BYOK hatch: disable the three canonical managed connections so the
-    // picker doesn't surface unusable platform-auth options on day one.
-    // Runs only here, only at hatch — `seedCanonicalConnections` leaves
-    // `status` alone on subsequent boots so a post-hatch user re-enable
-    // persists.
+    // BYOK hatch: disable canonical managed connections so the picker doesn't
+    // surface unusable platform-auth options on day one. If the hatch overlay
+    // selected a managed profile, leave that connection active; the user has
+    // already chosen managed inference. Runs only here, only at hatch —
+    // `seedCanonicalConnections` leaves `status` alone on subsequent boots so
+    // a post-hatch user re-enable persists.
     if (options.db) {
-      disableManagedConnectionsForByokHatch(options.db);
+      disableManagedConnectionsForByokHatch(options.db, {
+        excludeConnection: hatchSelectedManagedConnection,
+      });
     }
 
     const hatchProvider = readString(readObject(llm.default)?.provider);
@@ -375,6 +393,32 @@ function readObject(value: unknown): Record<string, unknown> | null {
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getHatchSelectedManagedConnection(
+  llm: Record<string, unknown>,
+  profiles: Record<string, Record<string, unknown>>,
+  options: SeedInferenceProfilesOptions,
+): string | undefined {
+  if (!options.isHatch || options.preserveActiveProfile !== true) {
+    return undefined;
+  }
+
+  const activeProfile = readString(llm.activeProfile);
+  if (!activeProfile) return undefined;
+
+  const explicitConnection = readString(
+    readObject(profiles[activeProfile])?.provider_connection,
+  );
+  if (explicitConnection && MANAGED_CONNECTION_NAMES.has(explicitConnection)) {
+    return explicitConnection;
+  }
+
+  const templateConnection =
+    MANAGED_PROFILE_TEMPLATES[activeProfile]?.connectionName;
+  return templateConnection && MANAGED_CONNECTION_NAMES.has(templateConnection)
+    ? templateConnection
+    : undefined;
 }
 
 /**

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -407,11 +407,21 @@ function getHatchSelectedManagedConnection(
   const activeProfile = readString(llm.activeProfile);
   if (!activeProfile) return undefined;
 
-  const explicitConnection = readString(
-    readObject(profiles[activeProfile])?.provider_connection,
-  );
-  if (explicitConnection && MANAGED_CONNECTION_NAMES.has(explicitConnection)) {
-    return explicitConnection;
+  const activeProfileEntry = readObject(profiles[activeProfile]);
+  if (
+    activeProfileEntry &&
+    Object.prototype.hasOwnProperty.call(
+      activeProfileEntry,
+      "provider_connection",
+    )
+  ) {
+    const explicitConnection = readString(
+      activeProfileEntry.provider_connection,
+    );
+    return explicitConnection &&
+      MANAGED_CONNECTION_NAMES.has(explicitConnection)
+      ? explicitConnection
+      : undefined;
   }
 
   const templateConnection =

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -138,7 +138,7 @@ export async function tryResolveProviderForConnectionName(
     }
   }
   if (connection.status === "disabled") {
-    log.warn(
+    log.debug(
       { connectionName, provider: connection.provider },
       "provider_connection is disabled — returning null",
     );

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -138,8 +138,8 @@ export async function tryResolveProviderForConnectionName(
     }
   }
   if (connection.status === "disabled") {
-    log.debug(
-      { connectionName },
+    log.warn(
+      { connectionName, provider: connection.provider },
       "provider_connection is disabled — returning null",
     );
     return null;

--- a/assistant/src/providers/inference/__tests__/connections-status-label.test.ts
+++ b/assistant/src/providers/inference/__tests__/connections-status-label.test.ts
@@ -201,6 +201,19 @@ describe("disableManagedConnectionsForByokHatch", () => {
     expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
   });
 
+  test("leaves an excluded managed connection active", () => {
+    const db = bootDb();
+    seedCanonicalConnections(db);
+
+    disableManagedConnectionsForByokHatch(db, {
+      excludeConnection: "anthropic-managed",
+    });
+
+    expect(getConnection(db, "anthropic-managed")?.status).toBe("active");
+    expect(getConnection(db, "openai-managed")?.status).toBe("disabled");
+    expect(getConnection(db, "gemini-managed")?.status).toBe("disabled");
+  });
+
   test("subsequent seedCanonicalConnections call does NOT re-flip a user-re-enabled connection", () => {
     // Models the post-hatch lifecycle: at hatch we disable; the user
     // later flips one back to active (e.g. after Vellum login). Every

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -402,7 +402,7 @@ export const MANAGED_CONNECTION_NAMES: ReadonlySet<string> = new Set(
  *
  * Status handling: the upsert never touches `status` so user customization
  * is preserved across reboots. New rows default to `status: "active"` via the
- * column default. Off-platform installs flip the three canonical rows to
+ * column default. Off-platform installs flip canonical managed rows to
  * `status: "disabled"` ONCE at hatch time via
  * `disableManagedConnectionsForByokHatch` (called from `seedInferenceProfiles`
  * when `isHatch && !isPlatform`); subsequent boots leave whatever the user
@@ -446,7 +446,7 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
 }
 
 /**
- * Flip the three canonical managed connections to `status: "disabled"` at
+ * Flip canonical managed connections to `status: "disabled"` at
  * hatch time on BYOK (off-platform) installs.
  *
  * Why hatch-time only: managed connections need platform auth that a fresh
@@ -461,10 +461,18 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
  *
  * Idempotent: a second hatch (workspace reset) re-disables the rows, which
  * is the right call — re-hatch means re-onboard.
+ *
+ * When onboarding explicitly selected a managed profile, callers may exclude
+ * that selected connection so the managed route remains usable for the first
+ * post-onboarding message.
  */
-export function disableManagedConnectionsForByokHatch(db: DrizzleDb): void {
+export function disableManagedConnectionsForByokHatch(
+  db: DrizzleDb,
+  options: { excludeConnection?: string } = {},
+): void {
   const now = Date.now();
   for (const name of MANAGED_CONNECTION_NAMES) {
+    if (name === options.excludeConnection) continue;
     db.update(providerConnections)
       .set({ status: "disabled", updatedAt: now })
       .where(eq(providerConnections.name, name))


### PR DESCRIPTION
## Summary
- keep the hatch-selected managed provider connection active when onboarding explicitly selects managed inference
- preserve the BYOK hatch safety behavior that disables unmanaged managed-provider rows
- raise disabled-connection filtering from debug to warn so this failure mode is visible in normal logs

## Root Cause
The macOS managed-inference onboarding path pins `llm.activeProfile` to `balanced`, which maps to `anthropic-managed`. The daemon still treated the hatch as off-platform/BYOK because `IS_PLATFORM` is unset locally, so `disableManagedConnectionsForByokHatch()` disabled `anthropic-managed`. The first chat message then resolved the selected managed profile to a disabled connection, returned `null`, and surfaced as provider-not-configured.

## Validation
- `bun test src/providers/inference/__tests__/connections-status-label.test.ts src/__tests__/config-loader-backfill.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- pre-commit hook: formatting, targeted lint, type-check
- pre-push hook: type-check and targeted lint

## Review Notes
Please loop in Abhishek Garg on this PR; he has been editing this provider-connection area recently.