### PR TITLE
[LUM-1625] Remove permission chips from tool call progress cards

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -38,6 +38,7 @@ import {
   friendlyRunningLabel,
   friendlyToolIcon,
   friendlyToolLabel,
+  toolCategory,
 } from "@/domains/chat/components/tool-call-chip/utils.js";
 
 export interface ToolCallChipProps {
@@ -341,8 +342,10 @@ export function ToolCallChip({
       })()}
       {embedded && (
         <span className="ml-auto flex items-center gap-1.5 text-[var(--content-tertiary)]">
-          {/* Chip pill — same style as CollapsedPermissionChips, shown per-row when expanded */}
-          {toolCall.riskLevel && !isRunning && !(hasPendingConfirmation && isActiveConfirmation) && (() => {
+          {/* Chip pill — same style as CollapsedPermissionChips, shown per-row when expanded.
+             Bash tools ("Run Command") are excluded — they dominate the header during
+             bash-heavy operations (e.g. rebasing) and add no value over the row label. */}
+          {toolCall.riskLevel && !isRunning && !(hasPendingConfirmation && isActiveConfirmation) && toolCategory(toolCall.toolName) !== "Run Command" && (() => {
             const isTimeout = toolCall.confirmationDecision === "timed_out";
             const isDenied = toolCall.confirmationDecision === "denied";
             const chipColor = isDenied

--- a/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -1,10 +1,8 @@
 
 import { BusyIndicator } from "@/domains/chat/components/busy-indicator.js";
 import {
-  AlertCircle,
   Camera,
   CheckCircle2,
-  Clock,
   ChevronDown,
   ChevronRight,
   ChevronUp,
@@ -34,11 +32,9 @@ import { useElapsedTime } from "@/domains/chat/lib/use-elapsed-time.js";
 
 import {
   extractInputSummary,
-  friendlyName,
   friendlyRunningLabel,
   friendlyToolIcon,
   friendlyToolLabel,
-  toolCategory,
 } from "@/domains/chat/components/tool-call-chip/utils.js";
 
 export interface ToolCallChipProps {
@@ -342,36 +338,6 @@ export function ToolCallChip({
       })()}
       {embedded && (
         <span className="ml-auto flex items-center gap-1.5 text-[var(--content-tertiary)]">
-          {/* Chip pill — same style as CollapsedPermissionChips, shown per-row when expanded.
-             Bash tools ("Run Command") are excluded — they dominate the header during
-             bash-heavy operations (e.g. rebasing) and add no value over the row label. */}
-          {toolCall.riskLevel && !isRunning && !(hasPendingConfirmation && isActiveConfirmation) && toolCategory(toolCall.toolName) !== "Run Command" && (() => {
-            const isTimeout = toolCall.confirmationDecision === "timed_out";
-            const isDenied = toolCall.confirmationDecision === "denied";
-            const chipColor = isDenied
-              ? "var(--system-negative-strong)"
-              : isTimeout
-              ? "var(--content-tertiary)"
-              : "var(--primary-base)";
-            return (
-              <span
-                className="flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-label-small-default"
-                style={{
-                  color: chipColor,
-                  boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${chipColor} 30%, transparent)`,
-                }}
-              >
-                {isDenied ? (
-                  <AlertCircle className="h-2.5 w-2.5 shrink-0" />
-                ) : isTimeout ? (
-                  <Clock className="h-2.5 w-2.5 shrink-0" />
-                ) : (
-                  <CheckCircle2 className="h-2.5 w-2.5 shrink-0" />
-                )}
-                <span className="max-w-[8rem] truncate">{friendlyName(toolCall.toolName)}</span>
-              </span>
-            );
-          })()}
           {duration && (
             <span className="text-label-small-default">{duration}</span>
           )}

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -8,7 +8,7 @@ import {
   Clock,
   X,
 } from "lucide-react";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 
 import { BusyIndicator } from "@/domains/chat/components/busy-indicator.js";
 import { ToolCallChip } from "@/domains/chat/components/tool-call-chip/tool-call-chip.js";
@@ -16,7 +16,6 @@ import {
   extractInputSummary,
   friendlyRunningLabel,
   progressiveLabels,
-  toolCategory,
 } from "@/domains/chat/components/tool-call-chip/utils.js";
 import type {
   AllowlistOption,
@@ -243,155 +242,6 @@ function CardStatusIcon({
   }
 }
 
-/**
- * Dynamically shows as many permission chips as fit in the available space,
- * with a "+N" overflow indicator for the rest. Uses ResizeObserver to
- * recalculate on container resize.
- *
- * The component returns a Fragment with a divider + a flex-1 container so the
- * chip area fills the remaining header space between headline and time/chevron.
- */
-function CollapsedPermissionChips({
-  toolCalls,
-}: {
-  toolCalls: ChatMessageToolCall[];
-}) {
-  const containerRef = useRef<HTMLSpanElement>(null);
-  const chipWidthsRef = useRef<Map<string, number>>(new Map());
-  const [maxVisible, setMaxVisible] = useState<number | null>(null);
-
-  const decidedCalls = useMemo(
-    () => toolCalls.filter((tc) => tc.riskLevel != null && toolCategory(tc.toolName) !== "Run Command"),
-    [toolCalls],
-  );
-
-  // Measure chip widths and calculate how many fit. useLayoutEffect prevents
-  // a visible flash on first render (all chips are rendered initially to
-  // measure them, then trimmed before the browser paints).
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container || decidedCalls.length === 0) return;
-
-    const GAP = 6; // gap-1.5
-    const OVERFLOW_BADGE_WIDTH = 32; // approximate "+N" width
-
-    const recalculate = () => {
-      const containerWidth = container.offsetWidth;
-      if (containerWidth <= 0) {
-        setMaxVisible(0);
-        return;
-      }
-
-      // Cache widths of any chip elements currently in the DOM
-      const chipEls = container.querySelectorAll<HTMLElement>("[data-chip-id]");
-      chipEls.forEach((el) => {
-        chipWidthsRef.current.set(el.dataset.chipId!, el.offsetWidth);
-      });
-
-      let usedWidth = 0;
-      let count = 0;
-
-      for (let i = 0; i < decidedCalls.length; i++) {
-        const tc = decidedCalls[i];
-        if (!tc) break;
-        const chipWidth = chipWidthsRef.current.get(tc.id) ?? 140;
-        const needed = (count > 0 ? GAP : 0) + chipWidth;
-
-        if (i === decidedCalls.length - 1) {
-          // Last chip — only needs to fit (no overflow badge)
-          if (usedWidth + needed <= containerWidth) count++;
-        } else {
-          // Not last — needs room for chip + gap + overflow badge
-          if (
-            usedWidth + needed + GAP + OVERFLOW_BADGE_WIDTH <=
-            containerWidth
-          ) {
-            usedWidth += needed;
-            count++;
-          } else {
-            break;
-          }
-        }
-      }
-
-      setMaxVisible(count);
-    };
-
-    recalculate();
-    const observer = new ResizeObserver(recalculate);
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [decidedCalls]);
-
-  if (decidedCalls.length === 0) return null;
-
-  // On initial render (maxVisible === null), show all chips so we can measure
-  // them. overflow-hidden on the container prevents the user from seeing any
-  // overflow before the layout effect trims the list.
-  const effectiveMax = maxVisible ?? decidedCalls.length;
-  const visible = decidedCalls.slice(0, effectiveMax);
-  const overflowCount = decidedCalls.length - effectiveMax;
-
-  return (
-    <>
-      <span className="h-4 w-px shrink-0 bg-[var(--border-base)]" />
-      <span
-        ref={containerRef}
-        className="flex-1 min-w-0 flex items-center gap-1.5 overflow-hidden"
-      >
-        {visible.map((tc) => {
-          const isTimeout = tc.confirmationDecision === "timed_out";
-          const isDenied = tc.confirmationDecision === "denied";
-          // 3-state color matching macOS CompactPermissionChip:
-          // approved → primaryBase, denied → systemNegativeStrong, timedOut → contentTertiary
-          const color = isDenied
-            ? "var(--system-negative-strong)"
-            : isTimeout
-              ? "var(--content-tertiary)"
-              : "var(--primary-base)";
-          // timedOut chips show "Timed Out" label override, matching macOS CompactPermissionChip.
-          // Non-timeout chips use toolCategory for short category labels ("Run Command",
-          // "Write File", "Browser") instead of past-tense contextual text.
-          const label = isTimeout
-            ? "Timed Out"
-            : toolCategory(tc.toolName);
-
-          return (
-            <span
-              key={tc.id}
-              data-chip-id={tc.id}
-              className="flex items-center gap-0.5 text-label-small-default rounded-full px-1.5 py-0.5 shrink-0"
-              style={{
-                color,
-                // Colored capsule border at 30% opacity — mirrors macOS
-                // Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
-                boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${color} 30%, transparent)`,
-              }}
-            >
-              {isDenied ? (
-                <AlertCircle className="h-2.5 w-2.5 shrink-0" />
-              ) : isTimeout ? (
-                <Clock className="h-2.5 w-2.5 shrink-0" />
-              ) : (
-                <CheckCircle2 className="h-2.5 w-2.5 shrink-0" />
-              )}
-              <span className="truncate max-w-[8rem]">{label}</span>
-            </span>
-          );
-        })}
-        {overflowCount > 0 && (
-          <span
-            data-overflow
-            className="text-label-small-default text-[var(--content-tertiary)] shrink-0"
-          >
-            +{overflowCount}
-          </span>
-        )}
-      </span>
-    </>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // ThinkingRow — post-tool synthetic thinking phase row
 // ---------------------------------------------------------------------------
@@ -580,9 +430,6 @@ export function ToolCallProgressCard({
         <span className="shrink-0 text-[var(--content-default)]">
           {headline}
         </span>
-        {!expanded && (
-          <CollapsedPermissionChips toolCalls={toolCalls} />
-        )}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {elapsed && (
             <span className="text-label-small-default text-[var(--content-tertiary)]">

--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -261,7 +261,7 @@ function CollapsedPermissionChips({
   const [maxVisible, setMaxVisible] = useState<number | null>(null);
 
   const decidedCalls = useMemo(
-    () => toolCalls.filter((tc) => tc.riskLevel != null),
+    () => toolCalls.filter((tc) => tc.riskLevel != null && toolCategory(tc.toolName) !== "Run Command"),
     [toolCalls],
   );
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -58,7 +58,6 @@ struct AssistantProgressView: View {
     @State private var isExpanded: Bool
     @State private var startDate: Date
     @State private var processingStartDate: Date?
-    @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
     /// When the post-tool-completion thinking phase started (typically the last
     /// tool's `completedAt`). Nil until all tools complete and the card remains active.
@@ -788,49 +787,7 @@ struct AssistantProgressView: View {
 
     @ViewBuilder
     private var inlinePermissionChips: some View {
-        let resolved = decidedConfirmations.filter { $0.state != .pending && $0.toolCategory != "Run Command" }
-        if !resolved.isEmpty {
-            // Vertical divider
-            Divider()
-                .frame(height: 16)
-
-            // Show up to 2 chips inline
-            let visible = Array(resolved.prefix(2))
-            let overflow = resolved.count - visible.count
-
-            ForEach(Array(visible.enumerated()), id: \.offset) { _, confirmation in
-                CompactPermissionChip(state: confirmation.state, label: confirmation.toolCategory)
-            }
-
-            // +N overflow badge with popover
-            if overflow > 0 {
-                Button(action: {
-                    suppressNextExpand = true
-                    isOverflowPopoverShown.toggle()
-                }) {
-                    Text("+\(overflow)")
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                        .padding(EdgeInsets(top: VSpacing.xxs, leading: VSpacing.xs, bottom: VSpacing.xxs, trailing: VSpacing.xs))
-                        .background(
-                            Capsule().fill(VColor.surfaceBase)
-                        )
-                        .overlay(
-                            Capsule().stroke(VColor.borderBase, lineWidth: 1)
-                        )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("\(overflow) more permissions")
-                .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(Array(resolved.dropFirst(2).enumerated()), id: \.offset) { _, confirmation in
-                            CompactPermissionChip(state: confirmation.state, label: confirmation.toolCategory)
-                        }
-                    }
-                    .padding(VSpacing.sm)
-                }
-            }
-        }
+        EmptyView()
     }
 
 }
@@ -1196,20 +1153,9 @@ struct ToolCallStepDetailRow: View {
         }
     }
 
-    /// Permission chip rendered before the duration label on the right side.
-    /// The original layout left an extra `xs` of trailing padding between the
-    /// chip and the duration — preserved via `.padding(.trailing, xs)` so the
-    /// pixel-level spacing is identical.
     @ViewBuilder
     private var trailingAccessory: some View {
-        if let decision = toolCall.confirmationDecision,
-           toolCall.toolCategory != "Run Command" {
-            CompactPermissionChip(
-                state: decision,
-                label: toolCall.confirmationLabel ?? toolCall.friendlyName
-            )
-            .padding(.trailing, VSpacing.xs)
-        }
+        EmptyView()
     }
 
     // MARK: - Scope Options
@@ -1796,49 +1742,6 @@ private struct ElapsedTimeLabel: View {
         .onReceive(timer) { date in
             now = date
         }
-    }
-}
-
-// MARK: - Compact Permission Chip
-
-/// Shared permission chip used in both the collapsed header (inline chips)
-/// and expanded step detail rows (per-tool-call badge).
-private struct CompactPermissionChip: View {
-    let state: ToolConfirmationState
-    let label: String
-
-    private var chipColor: Color {
-        switch state {
-        case .approved: VColor.primaryBase
-        case .denied: VColor.systemNegativeStrong
-        default: VColor.contentTertiary
-        }
-    }
-
-    var body: some View {
-        HStack(spacing: VSpacing.xxs) {
-            switch state {
-            case .approved:
-                VIconView(.circleCheck, size: 10)
-                    .foregroundStyle(chipColor)
-            case .denied:
-                VIconView(.circleAlert, size: 10)
-                    .foregroundStyle(chipColor)
-            case .timedOut:
-                VIconView(.clock, size: 10)
-                    .foregroundStyle(chipColor)
-            default:
-                EmptyView()
-            }
-
-            Text(state == .approved || state == .denied ? label : "Timed Out")
-                .font(VFont.labelSmall)
-                .foregroundStyle(chipColor)
-        }
-        .padding(EdgeInsets(top: VSpacing.xxs, leading: VSpacing.xs, bottom: VSpacing.xxs, trailing: VSpacing.xs))
-        .overlay(
-            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
-        )
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -788,7 +788,7 @@ struct AssistantProgressView: View {
 
     @ViewBuilder
     private var inlinePermissionChips: some View {
-        let resolved = decidedConfirmations.filter { $0.state != .pending }
+        let resolved = decidedConfirmations.filter { $0.state != .pending && $0.toolCategory != "Run Command" }
         if !resolved.isEmpty {
             // Vertical divider
             Divider()
@@ -1202,7 +1202,8 @@ struct ToolCallStepDetailRow: View {
     /// pixel-level spacing is identical.
     @ViewBuilder
     private var trailingAccessory: some View {
-        if let decision = toolCall.confirmationDecision {
+        if let decision = toolCall.confirmationDecision,
+           toolCall.toolCategory != "Run Command" {
             CompactPermissionChip(
                 state: decision,
                 label: toolCall.confirmationLabel ?? toolCall.friendlyName

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -168,14 +168,19 @@ extension ChatBubble {
             }
         } else if !effectiveConfirmations.isEmpty, !inlineToolProgressRenderedInContent {
             // No tool display needed — only show permission chips.
+            // Bash tools ("Run Command") are excluded — they dominate during bash-heavy
+            // operations and add no value over the row label.
             // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
-            HStack(alignment: .center, spacing: VSpacing.sm) {
-                ForEach(Array(effectiveConfirmations.enumerated()), id: \.offset) { _, confirmation in
-                    compactPermissionChip(confirmation)
+            let filtered = effectiveConfirmations.filter { $0.toolCategory != "Run Command" }
+            if !filtered.isEmpty {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    ForEach(Array(filtered.enumerated()), id: \.offset) { _, confirmation in
+                        compactPermissionChip(confirmation)
+                    }
+                    Spacer(minLength: 0)
                 }
-                Spacer(minLength: 0)
+                .padding(.top, VSpacing.xxs)
             }
-            .padding(.top, VSpacing.xxs)
         } else if isStreamingContinuation {
             // Assistant is still generating after producing initial text.
             // Show a subtle typing indicator so the user knows more content is coming.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -166,21 +166,6 @@ extension ChatBubble {
                 .padding(.top, VSpacing.xxs)
                 .transition(.opacity)
             }
-        } else if !effectiveConfirmations.isEmpty, !inlineToolProgressRenderedInContent {
-            // No tool display needed — only show permission chips.
-            // Bash tools ("Run Command") are excluded — they dominate during bash-heavy
-            // operations and add no value over the row label.
-            // ⚠️ No .frame(maxWidth:) in LazyVStack cells — see AGENTS.md.
-            let filtered = effectiveConfirmations.filter { $0.toolCategory != "Run Command" }
-            if !filtered.isEmpty {
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    ForEach(Array(filtered.enumerated()), id: \.offset) { _, confirmation in
-                        compactPermissionChip(confirmation)
-                    }
-                    Spacer(minLength: 0)
-                }
-                .padding(.top, VSpacing.xxs)
-            }
         } else if isStreamingContinuation {
             // Assistant is still generating after producing initial text.
             // Show a subtle typing indicator so the user knows more content is coming.
@@ -202,34 +187,4 @@ extension ChatBubble {
         return text
     }
 
-    func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
-        let isApproved = confirmation.state == .approved
-        let isDenied = confirmation.state == .denied
-        let chipColor: Color = isApproved ? VColor.primaryBase : isDenied ? VColor.systemNegativeStrong : VColor.contentTertiary
-
-        return HStack(spacing: VSpacing.xs) {
-            switch confirmation.state {
-            case .approved:
-                VIconView(.circleCheck, size: 12)
-                    .foregroundStyle(chipColor)
-            case .denied:
-                VIconView(.circleAlert, size: 12)
-                    .foregroundStyle(chipColor)
-            case .timedOut:
-                VIconView(.clock, size: 12)
-                    .foregroundStyle(chipColor)
-            default:
-                EmptyView()
-            }
-
-            Text(isApproved || isDenied ? "\(confirmation.toolCategory)" :
-                 "Timed Out")
-                .font(VFont.labelDefault)
-                .foregroundStyle(chipColor)
-        }
-        .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
-        .overlay(
-            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
-        )
-    }
 }


### PR DESCRIPTION
Removes all permission chips from tool call progress cards across web and macOS. Strips `CollapsedPermissionChips` from the collapsed header, per-row `PermissionChip` pills from embedded `ToolCallChip` rows, `inlinePermissionChips` from the macOS progress card header, per-row `CompactPermissionChip` from macOS step detail rows, and standalone permission chip display from `ChatBubbleToolStatusView`. These chips add visual noise without providing actionable information beyond what the row labels already convey.

To verify (web): open a conversation with completed tool calls and confirm no capsule-style permission badges appear in either collapsed or expanded progress card views. macOS changes need local Xcode verification (CI skips macOS builds).

Companion PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/7291

Closes LUM-1625

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/283bbed5307a40319ef85c1b9521d9bd
