### PR TITLE
feat(web): add Vite dev proxy for local API routing and auth

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,9 @@
+# Backend target for Vite's development proxy.
+# Not embedded in the client bundle (no VITE_ prefix).
+# Default: http://localhost:8000
+#
+# Reference: https://vite.dev/config/server-options#server-proxy
+# API_PROXY_TARGET=http://localhost:8000
+
+# Dev server port. Default: 3000
+# PORT=3000

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -32,7 +32,7 @@ Read these before making changes:
 
 ```bash
 cd apps/web && bun install            # Install dependencies
-cd apps/web && bun run dev            # Vite dev server (port 3001)
+cd apps/web && bun run dev            # Vite dev server (port 3000)
 cd apps/web && bun run openapi-ts     # Generate API client from OpenAPI specs
 cd apps/web && bunx tsc --noEmit      # Type-check
 cd apps/web && bun run lint           # Lint

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,45 +24,51 @@ Vellum assistant web app (chat, settings, library, docs).
 
 ## Local development
 
-### With `vel up` (recommended)
-
-The `vel up web` command in the
-[vellum-assistant-platform](https://github.com/vellum-ai/vellum-assistant-platform)
-repo starts all required services:
-
-```bash
-vel up web
-```
-
-This starts:
-1. Docker Compose services (Postgres, Valkey, SeaweedFS, Caddy edge proxy)
-2. Django backend on `localhost:8000`
-3. **This Vite dev server on `localhost:3001`**
-4. Caddy edge proxy on `localhost:3000` (canonical browser entry point)
-
-The Caddy proxy routes:
-- `/v1/*`, `/_allauth/*`, `/accounts/*` -> Django `:8000`
-- Everything else -> Vite `:3001`
-
-Browse to **http://localhost:3000** (not :3001 directly) so auth
-cookies and API calls route correctly.
-
-### Without `vel up` (standalone)
-
-If you need to run the web app without the full `vel up` orchestration
-(e.g., working on pure UI without backend):
-
 ```bash
 cd apps/web
 bun install
-bun run openapi-ts  # generate API client from OpenAPI schemas (required before typecheck/dev)
-bun run dev        # Vite dev server on localhost:3001
+bun run openapi-ts  # generate API client (required before typecheck/dev)
+bun run dev         # Vite dev server on localhost:3000
 ```
 
-To connect to a running Django backend, ensure the Caddy edge proxy is
-running (via `docker compose up edge-proxy` in the platform repo) or
-configure your browser to send API requests to `localhost:8000`
-directly.
+### Connecting to a backend
+
+The Vite dev server includes a built-in
+[reverse proxy](https://vite.dev/config/server-options#server-proxy)
+that forwards API paths (`/v1/*`, `/_allauth/*`, `/accounts/*`) to the
+Django backend. This keeps all requests same-origin so session cookies
+work automatically — no CORS configuration or HTTPS setup needed.
+
+By default the proxy targets `http://localhost:8000`. To change it,
+set `API_PROXY_TARGET` in a `.env` file (see
+[`.env.example`](./.env.example)):
+
+```bash
+# .env (not committed)
+API_PROXY_TARGET=http://localhost:8000
+```
+
+Browse to **http://localhost:3000** and log in normally.
+
+> **Note:** Some API endpoints (avatar, feed, assistant state) return
+> 404 unless the assistant daemon is running. This is expected in
+> frontend-only mode — the core UI and auth flow work without the
+> daemon.
+
+### How the proxy works
+
+The client makes relative API requests (e.g. `fetch("/v1/feed")`).
+In development, Vite's proxy intercepts these and forwards them to
+the backend. In production, an infrastructure reverse proxy (nginx,
+cloud LB, etc.) does the same routing. The client code is identical
+in both environments — no environment-specific base URLs.
+
+```
+Development:   Browser ─► Vite :3000 ─(proxy)─► Django :8000
+Production:    Browser ─► Reverse proxy ─► Django
+```
+
+Reference: [Vite server.proxy docs](https://vite.dev/config/server-options#server-proxy)
 
 ### Other commands
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,35 +1,39 @@
 import path from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-// Where the Vite dev server proxies API requests. Only used at dev
-// time — never embedded in the client bundle (no VITE_ prefix).
-// Reference: https://vite.dev/config/server-options#server-proxy
-const apiProxyTarget =
-  process.env.API_PROXY_TARGET || "http://localhost:8000";
+// Reference: https://vite.dev/config/#using-environment-variables-in-config
+export default defineConfig(({ mode }) => {
+  // loadEnv with empty prefix loads all .env variables, not just VITE_-prefixed ones.
+  const env = { ...process.env, ...loadEnv(mode, process.cwd(), "") };
 
-export default defineConfig({
-  base: "/",
-  plugins: [tailwindcss(), react()],
-  resolve: {
-    alias: {
-      "@/": path.resolve(import.meta.dirname, "src") + "/",
+  // Server-only proxy target — never embedded in the client bundle.
+  // Reference: https://vite.dev/config/server-options#server-proxy
+  const apiProxyTarget = env.API_PROXY_TARGET || "http://localhost:8000";
+
+  return {
+    base: "/",
+    plugins: [tailwindcss(), react()],
+    resolve: {
+      alias: {
+        "@/": path.resolve(import.meta.dirname, "src") + "/",
+      },
+      preserveSymlinks: true,
     },
-    preserveSymlinks: true,
-  },
-  server: {
-    port: parseInt(process.env.PORT || "3000"),
-    strictPort: true,
-    host: true,
-    proxy: {
-      "/v1": { target: apiProxyTarget, changeOrigin: true },
-      "/_allauth": { target: apiProxyTarget, changeOrigin: true },
-      "/accounts": { target: apiProxyTarget, changeOrigin: true },
+    server: {
+      port: parseInt(env.PORT || "3000"),
+      strictPort: true,
+      host: true,
+      proxy: {
+        "/v1": { target: apiProxyTarget, changeOrigin: true },
+        "/_allauth": { target: apiProxyTarget, changeOrigin: true },
+        "/accounts": { target: apiProxyTarget, changeOrigin: true },
+      },
     },
-  },
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-  },
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+    },
+  };
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+// Where the Vite dev server proxies API requests. Only used at dev
+// time — never embedded in the client bundle (no VITE_ prefix).
+// Reference: https://vite.dev/config/server-options#server-proxy
+const apiProxyTarget =
+  process.env.API_PROXY_TARGET || "http://localhost:8000";
+
 export default defineConfig({
   base: "/",
   plugins: [tailwindcss(), react()],
@@ -13,9 +19,14 @@ export default defineConfig({
     preserveSymlinks: true,
   },
   server: {
-    port: 3001,
+    port: parseInt(process.env.PORT || "3000"),
     strictPort: true,
     host: true,
+    proxy: {
+      "/v1": { target: apiProxyTarget, changeOrigin: true },
+      "/_allauth": { target: apiProxyTarget, changeOrigin: true },
+      "/accounts": { target: apiProxyTarget, changeOrigin: true },
+    },
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Prompt / plan

OSS contributors running `bun run dev` standalone (without the platform's Caddy proxy) had no way to reach the Django backend — API calls 404'd against Vite and login was impossible. This adds Vite's [built-in dev proxy](https://vite.dev/config/server-options#server-proxy) to forward API paths to Django, keeping everything same-origin so auth cookies work automatically.

### Why Vite proxy (and not alternatives)

Researched how comparable OSS SPAs handle this:

- **[Plane](https://github.com/makeplane/plane)** (47K stars) — forces Docker Compose with Caddy reverse proxy. Higher barrier for contributors.
- **[Hoppscotch](https://github.com/hoppscotch/hoppscotch)** (79K stars) — cross-origin with `withCredentials: true` + backend CORS config. Requires `SameSite=None; Secure` on cookies → [requires HTTPS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure) → cert setup on localhost.

Vite's `server.proxy` is the [officially documented approach](https://vite.dev/config/server-options#server-proxy) for this exact use case. It replicates what the production reverse proxy does, at the dev server level:

- Same-origin requests → Django's default `SameSite=Lax` cookies work over plain HTTP
- No CORS configuration needed on the backend
- No Docker or HTTPS cert setup for contributors
- No client-side code changes — `baseUrl: ""` (relative URLs) continues to work

### Port change: 3001 → 3000

The previous hardcoded `:3001` was chosen to avoid conflicting with the platform's Caddy proxy on `:3000`. But `:3001` is **broken for standalone use**:

1. Django's `CSRF_TRUSTED_ORIGINS` only includes `http://localhost:3000` — login POSTs from `:3001` are rejected
2. Django's `HEADLESS_BASE_URL` defaults to `http://localhost:3000` — OAuth redirects after Google login go to `:3000`, which has nothing when running standalone

Default is now `:3000`, configurable via `PORT` env var. The platform's `vel up` can pass `PORT=3001` to preserve the existing internal setup (companion platform PR to follow).

### How login works through the proxy

```
Browser (localhost:3000) → POST /_allauth/browser/v1/auth/session
  → Vite proxy → Django (localhost:8000)
  ← Set-Cookie: sessionid=...; SameSite=Lax; HttpOnly; Path=/
  ← Cookie passes back through proxy
  → Browser stores cookie for localhost:3000
  → All subsequent requests include cookie → authenticated
```

## Test plan

- `bun run lint` — passes
- `bunx tsc --noEmit` — passes
- CI checks

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->