### PR TITLE
feat(web-fetch): emit structured fetch metadata for visited URLs

### DIFF
--- a/assistant/src/tools/network/__tests__/web-fetch-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-fetch-metadata.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { executeWebFetch } from "../web-fetch.js";
+
+type RequestExecutor = (
+  url: URL,
+  requestOptions: {
+    signal: AbortSignal;
+    headers: Record<string, string>;
+    resolvedAddress?: string;
+  },
+) => Promise<Response>;
+
+const executeWithMockFetch = (
+  input: Record<string, unknown>,
+  options?: {
+    resolveHostAddresses?: (hostname: string) => Promise<string[]>;
+    requestExecutor?: RequestExecutor;
+  },
+) =>
+  executeWebFetch(input, {
+    resolveHostAddresses:
+      options?.resolveHostAddresses ?? (async () => ["93.184.216.34"]),
+    requestExecutor:
+      options?.requestExecutor ??
+      ((url, requestOptions) =>
+        globalThis.fetch(url.href, {
+          method: "GET",
+          redirect: "manual",
+          signal: requestOptions.signal,
+          headers: requestOptions.headers,
+        }) as Promise<Response>),
+  });
+
+describe("web_fetch activityMetadata", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("populates metadata on a 200 HTML response with a <title>", async () => {
+    const body =
+      "<!doctype html><html><head><title>Example Domain</title></head>" +
+      "<body><p>Hello, world.</p></body></html>";
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({ url: "https://example.com/" });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta).toBeDefined();
+    expect(meta?.url).toBe("https://example.com/");
+    expect(meta?.finalUrl).toBe("https://example.com/");
+    expect(meta?.status).toBe(200);
+    expect(meta?.contentType).toContain("text/html");
+    expect(meta?.title).toBe("Example Domain");
+    expect(meta?.domain).toBe("example.com");
+    expect(meta?.byteCount).toBe(Buffer.byteLength(body));
+    expect(meta?.charCount).toBeGreaterThan(0);
+    expect(meta?.redirectCount).toBe(0);
+    expect(meta?.truncated).toBe(false);
+    expect(meta?.durationMs).toBeGreaterThanOrEqual(0);
+    expect(meta?.errorMessage).toBeUndefined();
+  });
+
+  test("tracks redirect chains in finalUrl and redirectCount", async () => {
+    let callCount = 0;
+    globalThis.fetch = (async (rawUrl: string) => {
+      callCount++;
+      if (callCount === 1) {
+        expect(rawUrl).toBe("https://example.com/start");
+        return new Response("", {
+          status: 302,
+          headers: { location: "https://example.com/middle" },
+        });
+      }
+      if (callCount === 2) {
+        return new Response("", {
+          status: 301,
+          headers: { location: "https://example.com/final" },
+        });
+      }
+      return new Response(
+        "<!doctype html><title>Final</title><p>done</p>",
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({
+      url: "https://example.com/start",
+    });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta).toBeDefined();
+    expect(meta?.url).toBe("https://example.com/start");
+    expect(meta?.finalUrl).toBe("https://example.com/final");
+    expect(meta?.finalUrl).not.toBe(meta?.url);
+    expect(meta?.redirectCount).toBe(2);
+    expect(meta?.title).toBe("Final");
+  });
+
+  test("flags truncation when content exceeds max_chars", async () => {
+    const longBody = "x".repeat(50_000);
+    globalThis.fetch = (async () =>
+      new Response(longBody, {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const maxChars = 1_000;
+    const result = await executeWithMockFetch({
+      url: "https://example.com/large",
+      max_chars: maxChars,
+    });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta).toBeDefined();
+    expect(meta?.truncated).toBe(true);
+    expect(meta?.charCount).toBe(maxChars);
+  });
+
+  test("populates errorMessage and status on a 404 response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("<title>Not Found</title>not here", {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({
+      url: "https://example.com/missing",
+    });
+    expect(result.isError).toBe(true);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta).toBeDefined();
+    expect(meta?.status).toBe(404);
+    expect(meta?.errorMessage).toBeDefined();
+    expect(meta?.errorMessage).toContain("HTTP 404");
+    expect(meta?.url).toBe("https://example.com/missing");
+    expect(meta?.finalUrl).toBe("https://example.com/missing");
+    expect(meta?.domain).toBe("example.com");
+  });
+
+  test("populates metadata for blocked private-network targets", async () => {
+    const result = await executeWithMockFetch({
+      url: "http://127.0.0.1/admin",
+    });
+    expect(result.isError).toBe(true);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta).toBeDefined();
+    expect(meta?.errorMessage).toContain(
+      "Refusing to fetch local/private network target",
+    );
+    expect(meta?.domain).toBe("127.0.0.1");
+    expect(meta?.status).toBe(0);
+  });
+});

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -104,21 +104,3 @@ function isIPAddress(hostname: string): boolean {
   if (hostname.startsWith("[") || hostname.includes(":")) return true;
   return false;
 }
-
-/**
- * Extract a lowercased hostname suitable for client display from a raw URL.
- *
- * Unlike {@link normalizeDomain}, this is permissive: it accepts IP-literal
- * URLs, returns the bare hostname (no registrable-domain reduction), and
- * falls back to the input string when it cannot be parsed. Intended for
- * UI labels like favicons, badge text, and metadata fields.
- */
-export function extractDomain(rawUrl: string): string {
-  if (!rawUrl || typeof rawUrl !== "string") return "";
-  try {
-    const url = new URL(rawUrl);
-    return url.hostname.toLowerCase().replace(/\.$/, "");
-  } catch {
-    return rawUrl.toLowerCase();
-  }
-}

--- a/assistant/src/tools/network/domain-normalize.ts
+++ b/assistant/src/tools/network/domain-normalize.ts
@@ -87,3 +87,21 @@ function isIPAddress(hostname: string): boolean {
   if (hostname.startsWith("[") || hostname.includes(":")) return true;
   return false;
 }
+
+/**
+ * Extract a lowercased hostname suitable for client display from a raw URL.
+ *
+ * Unlike {@link normalizeDomain}, this is permissive: it accepts IP-literal
+ * URLs, returns the bare hostname (no registrable-domain reduction), and
+ * falls back to the input string when it cannot be parsed. Intended for
+ * UI labels like favicons, badge text, and metadata fields.
+ */
+export function extractDomain(rawUrl: string): string {
+  if (!rawUrl || typeof rawUrl !== "string") return "";
+  try {
+    const url = new URL(rawUrl);
+    return url.hostname.toLowerCase().replace(/\.$/, "");
+  } catch {
+    return rawUrl.toLowerCase();
+  }
+}

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -558,20 +558,23 @@ export async function executeWebFetch(
       redirectCount?: number;
     },
   ): ToolExecutionResult => {
-    const finalUrl = meta.finalUrl ?? meta.url;
+    const safeUrl = sanitizeUrlStringForOutput(meta.url);
+    const safeFinalUrl = meta.finalUrl
+      ? sanitizeUrlStringForOutput(meta.finalUrl)
+      : safeUrl;
     return {
       content: errorMessage,
       isError: true,
       activityMetadata: {
         webFetch: {
-          url: meta.url,
-          finalUrl,
+          url: safeUrl,
+          finalUrl: safeFinalUrl,
           status: meta.status ?? 0,
           contentType: meta.contentType,
           byteCount: 0,
           charCount: 0,
           truncated: false,
-          domain: extractDomain(finalUrl),
+          domain: extractDomain(safeFinalUrl),
           redirectCount: meta.redirectCount ?? 0,
           durationMs: Date.now() - startedAt,
           errorMessage,
@@ -906,12 +909,10 @@ export async function executeWebFetch(
     });
 
     const truncated = body.truncated || safeEnd < processed.length;
-    const parsedTitle = isHtmlContentType(contentType)
-      ? parseHtmlTitle(body.text)
-      : undefined;
+    const parsedTitle = html ? parseHtmlTitle(body.text) : undefined;
     const meta: WebFetchMetadata = {
-      url: requestedUrl,
-      finalUrl: currentUrl.href,
+      url: safeRequestedUrl,
+      finalUrl: sanitizeUrlForOutput(currentUrl),
       status: response.status,
       contentType: contentType || undefined,
       byteCount: body.bytesRead,

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -5,6 +5,7 @@ import {
 } from "node:https";
 import { Readable } from "node:stream";
 
+import type { WebFetchMetadata } from "../../daemon/message-types/web-activity.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { wrapUntrustedContent } from "../../security/untrusted-content.js";
@@ -12,6 +13,7 @@ import { getLogger } from "../../util/logger.js";
 import { safeStringSlice } from "../../util/unicode.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import { extractDomain } from "./domain-normalize.js";
 import {
   buildHostHeader,
   isIPv4,
@@ -351,6 +353,26 @@ function extractFirstMatch(
   return value || undefined;
 }
 
+const MAX_TITLE_CHARS = 200;
+
+/**
+ * Parse the first HTML `<title>` element from a response body.
+ *
+ * Used to populate {@link WebFetchMetadata.title}. Returns `undefined`
+ * when no `<title>` is present. The result is HTML-entity-decoded and
+ * capped at {@link MAX_TITLE_CHARS} characters so client UIs never have
+ * to truncate.
+ */
+function parseHtmlTitle(html: string): string | undefined {
+  // Bound the search to the first 200KB to avoid scanning huge bodies.
+  const searchRegion = safeStringSlice(html, 0, 200_000);
+  const match = /<title[^>]*>([^<]+)<\/title>/i.exec(searchRegion);
+  if (!match) return undefined;
+  const decoded = decodeHtmlEntities(match[1]).trim();
+  if (!decoded) return undefined;
+  return safeStringSlice(decoded, 0, MAX_TITLE_CHARS);
+}
+
 function extractHtmlMetadata(html: string): {
   title?: string;
   description?: string;
@@ -518,15 +540,57 @@ export async function executeWebFetch(
   input: Record<string, unknown>,
   options?: ExecuteWebFetchOptions,
 ): Promise<ToolExecutionResult> {
+  const startedAt = Date.now();
+
+  /**
+   * Build a {@link ToolExecutionResult} for an early-exit error path (bad
+   * input, blocked target, timeout, bad content-type, HTTP error, ...).
+   * Always attaches structured {@link WebFetchMetadata} so client UIs can
+   * still render failed visits.
+   */
+  const buildErrorResult = (
+    errorMessage: string,
+    meta: {
+      url: string;
+      finalUrl?: string;
+      status?: number;
+      contentType?: string;
+      redirectCount?: number;
+    },
+  ): ToolExecutionResult => {
+    const finalUrl = meta.finalUrl ?? meta.url;
+    return {
+      content: errorMessage,
+      isError: true,
+      activityMetadata: {
+        webFetch: {
+          url: meta.url,
+          finalUrl,
+          status: meta.status ?? 0,
+          contentType: meta.contentType,
+          byteCount: 0,
+          charCount: 0,
+          truncated: false,
+          domain: extractDomain(finalUrl),
+          redirectCount: meta.redirectCount ?? 0,
+          durationMs: Date.now() - startedAt,
+          errorMessage,
+        },
+      },
+    };
+  };
+
   const parsedUrl = parseUrl(input.url);
   if (!parsedUrl) {
-    return {
-      content: "Error: url is required and must be a valid HTTP(S) URL",
-      isError: true,
-    };
+    return buildErrorResult(
+      "Error: url is required and must be a valid HTTP(S) URL",
+      { url: typeof input.url === "string" ? input.url : "" },
+    );
   }
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    return { content: "Error: url must use http or https", isError: true };
+    return buildErrorResult("Error: url must use http or https", {
+      url: parsedUrl.href,
+    });
   }
 
   const allowPrivateNetwork = input.allow_private_network === true;
@@ -534,10 +598,10 @@ export async function executeWebFetch(
   const requestExecutor = options?.requestExecutor ?? defaultRequestExecutor;
 
   if (!allowPrivateNetwork && isPrivateOrLocalHost(parsedUrl.hostname)) {
-    return {
-      content: `Error: Refusing to fetch local/private network target (${parsedUrl.hostname}). Set allow_private_network=true if you explicitly need it.`,
-      isError: true,
-    };
+    return buildErrorResult(
+      `Error: Refusing to fetch local/private network target (${parsedUrl.hostname}). Set allow_private_network=true if you explicitly need it.`,
+      { url: parsedUrl.href },
+    );
   }
   const timeoutSeconds = clampInteger(
     input.timeout_seconds,
@@ -576,6 +640,9 @@ export async function executeWebFetch(
     }
   }
 
+  let currentUrl = new URL(requestedUrl);
+  let redirectCount = 0;
+
   try {
     log.debug(
       { url: safeRequestedUrl, timeoutSeconds, maxChars, startIndex, rawMode },
@@ -591,8 +658,6 @@ export async function executeWebFetch(
         "VellumAssistant/1.0 (+https://vellum.ai)",
     };
 
-    let currentUrl = new URL(requestedUrl);
-    let redirectCount = 0;
     let response: Response | null = null;
     let currentResolvedAddresses: string[] | undefined;
 
@@ -606,16 +671,16 @@ export async function executeWebFetch(
         controller.signal,
       );
       if (resolution.blockedAddress) {
-        return {
-          content: `Error: Refusing to fetch target (${currentUrl.hostname}) because it resolves to local/private network address ${resolution.blockedAddress}. Set allow_private_network=true if you explicitly need it.`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Refusing to fetch target (${currentUrl.hostname}) because it resolves to local/private network address ${resolution.blockedAddress}. Set allow_private_network=true if you explicitly need it.`,
+          { url: requestedUrl, finalUrl: currentUrl.href, redirectCount },
+        );
       }
       if (resolution.addresses.length === 0) {
-        return {
-          content: `Error: Unable to resolve host "${currentUrl.hostname}" while fetching ${safeRequestedUrl}`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Unable to resolve host "${currentUrl.hostname}" while fetching ${safeRequestedUrl}`,
+          { url: requestedUrl, finalUrl: currentUrl.href, redirectCount },
+        );
       }
       currentResolvedAddresses = resolution.addresses;
     }
@@ -650,10 +715,10 @@ export async function executeWebFetch(
       currentResolvedAddresses = undefined;
 
       if (!response) {
-        return {
-          content: "Error: Web fetch failed: no response returned",
-          isError: true,
-        };
+        return buildErrorResult(
+          "Error: Web fetch failed: no response returned",
+          { url: requestedUrl, finalUrl: currentUrl.href, redirectCount },
+        );
       }
 
       const location = response.headers.get("location");
@@ -662,10 +727,15 @@ export async function executeWebFetch(
       if (!isRedirect) break;
 
       if (redirectCount >= MAX_REDIRECTS) {
-        return {
-          content: `Error: Too many redirects (>${MAX_REDIRECTS}) while fetching ${safeRequestedUrl}`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Too many redirects (>${MAX_REDIRECTS}) while fetching ${safeRequestedUrl}`,
+          {
+            url: requestedUrl,
+            finalUrl: currentUrl.href,
+            status: response.status,
+            redirectCount,
+          },
+        );
       }
 
       let nextUrl: URL;
@@ -677,24 +747,39 @@ export async function executeWebFetch(
           currentUrl,
         );
         const safeCurrentUrl = sanitizeUrlForOutput(currentUrl);
-        return {
-          content: `Error: Invalid redirect location "${safeLocation}" received from ${safeCurrentUrl}`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Invalid redirect location "${safeLocation}" received from ${safeCurrentUrl}`,
+          {
+            url: requestedUrl,
+            finalUrl: currentUrl.href,
+            status: response.status,
+            redirectCount,
+          },
+        );
       }
 
       if (nextUrl.protocol !== "http:" && nextUrl.protocol !== "https:") {
-        return {
-          content: `Error: Refusing redirect to unsupported protocol "${nextUrl.protocol}"`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Refusing redirect to unsupported protocol "${nextUrl.protocol}"`,
+          {
+            url: requestedUrl,
+            finalUrl: currentUrl.href,
+            status: response.status,
+            redirectCount,
+          },
+        );
       }
 
       if (!allowPrivateNetwork && isPrivateOrLocalHost(nextUrl.hostname)) {
-        return {
-          content: `Error: Refusing redirect to local/private network target (${nextUrl.hostname}). Set allow_private_network=true if you explicitly need it.`,
-          isError: true,
-        };
+        return buildErrorResult(
+          `Error: Refusing redirect to local/private network target (${nextUrl.hostname}). Set allow_private_network=true if you explicitly need it.`,
+          {
+            url: requestedUrl,
+            finalUrl: currentUrl.href,
+            status: response.status,
+            redirectCount,
+          },
+        );
       }
       if (!allowPrivateNetwork) {
         const resolution = await withAbortSignal(
@@ -706,17 +791,27 @@ export async function executeWebFetch(
           controller.signal,
         );
         if (resolution.blockedAddress) {
-          return {
-            content: `Error: Refusing redirect to target (${nextUrl.hostname}) because it resolves to local/private network address ${resolution.blockedAddress}. Set allow_private_network=true if you explicitly need it.`,
-            isError: true,
-          };
+          return buildErrorResult(
+            `Error: Refusing redirect to target (${nextUrl.hostname}) because it resolves to local/private network address ${resolution.blockedAddress}. Set allow_private_network=true if you explicitly need it.`,
+            {
+              url: requestedUrl,
+              finalUrl: currentUrl.href,
+              status: response.status,
+              redirectCount,
+            },
+          );
         }
         if (resolution.addresses.length === 0) {
           const safeCurrentUrl = sanitizeUrlForOutput(currentUrl);
-          return {
-            content: `Error: Unable to resolve redirect host "${nextUrl.hostname}" from ${safeCurrentUrl}`,
-            isError: true,
-          };
+          return buildErrorResult(
+            `Error: Unable to resolve redirect host "${nextUrl.hostname}" from ${safeCurrentUrl}`,
+            {
+              url: requestedUrl,
+              finalUrl: currentUrl.href,
+              status: response.status,
+              redirectCount,
+            },
+          );
         }
         currentResolvedAddresses = resolution.addresses;
       }
@@ -726,18 +821,25 @@ export async function executeWebFetch(
     }
 
     if (!response) {
-      return {
-        content: "Error: Web fetch failed: no response returned",
-        isError: true,
-      };
+      return buildErrorResult("Error: Web fetch failed: no response returned", {
+        url: requestedUrl,
+        finalUrl: currentUrl.href,
+        redirectCount,
+      });
     }
 
     const contentType = response.headers.get("content-type") ?? "";
     if (!isTextLikeContentType(contentType)) {
-      return {
-        content: `Error: Unsupported content type "${contentType || "unknown"}". web_fetch only supports text-like responses.`,
-        isError: true,
-      };
+      return buildErrorResult(
+        `Error: Unsupported content type "${contentType || "unknown"}". web_fetch only supports text-like responses.`,
+        {
+          url: requestedUrl,
+          finalUrl: currentUrl.href,
+          status: response.status,
+          contentType,
+          redirectCount,
+        },
+      );
     }
 
     const body = await readResponseText(response, MAX_DOWNLOAD_BYTES);
@@ -803,11 +905,32 @@ export async function executeWebFetch(
       markdownTokens,
     });
 
+    const truncated = body.truncated || safeEnd < processed.length;
+    const parsedTitle = isHtmlContentType(contentType)
+      ? parseHtmlTitle(body.text)
+      : undefined;
+    const meta: WebFetchMetadata = {
+      url: requestedUrl,
+      finalUrl: currentUrl.href,
+      status: response.status,
+      contentType: contentType || undefined,
+      byteCount: body.bytesRead,
+      charCount: sliced.length,
+      truncated,
+      title: parsedTitle,
+      domain: extractDomain(currentUrl.href),
+      // faviconUrl intentionally omitted — added by PR 5.
+      redirectCount,
+      durationMs: Date.now() - startedAt,
+    };
+
     if (!response.ok) {
+      const errorMessage = `Error: HTTP ${response.status}`;
       return {
-        content: `Error: HTTP ${response.status}\n\n${content}`,
+        content: `${errorMessage}\n\n${content}`,
         isError: true,
         status: notices.length > 0 ? notices.join("\n") : undefined,
+        activityMetadata: { webFetch: { ...meta, errorMessage } },
       };
     }
 
@@ -815,21 +938,30 @@ export async function executeWebFetch(
       content,
       isError: false,
       status: notices.length > 0 ? notices.join("\n") : undefined,
+      activityMetadata: { webFetch: meta },
     };
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       if (externalSignal?.aborted) {
-        return { content: "Error: web fetch was cancelled", isError: true };
+        return buildErrorResult("Error: web fetch was cancelled", {
+          url: requestedUrl,
+          finalUrl: currentUrl.href,
+          redirectCount,
+        });
       }
-      return {
-        content: `Error: web fetch timed out after ${timeoutSeconds}s`,
-        isError: true,
-      };
+      return buildErrorResult(
+        `Error: web fetch timed out after ${timeoutSeconds}s`,
+        { url: requestedUrl, finalUrl: currentUrl.href, redirectCount },
+      );
     }
 
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, url: safeRequestedUrl }, "Web fetch failed");
-    return { content: `Error: Web fetch failed: ${msg}`, isError: true };
+    return buildErrorResult(`Error: Web fetch failed: ${msg}`, {
+      url: requestedUrl,
+      finalUrl: currentUrl.href,
+      redirectCount,
+    });
   } finally {
     clearTimeout(timeoutHandle);
     externalSignal?.removeEventListener("abort", onExternalAbort);


### PR DESCRIPTION
## Summary
- web_fetch now returns WebFetchMetadata alongside the body text (url, finalUrl, status, byteCount, charCount, truncated, title, domain, redirectCount, durationMs)
- HTML title parsed from response body when content-type is text/html
- Error paths populate errorMessage so failed visits are still surfaced

Part of plan: web-activity-ui-data.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->