### PR TITLE
fix(design-library): use @playwright/browser-chromium for declarative browser setup

### DIFF
--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -241,6 +241,7 @@ References:
 
 ```bash
 cd packages/design-library
+bun install                # installs deps + Playwright Chromium via postinstall
 bun run storybook          # dev server → http://localhost:6006
 bun run build-storybook    # static build → storybook-static/
 ```
@@ -258,7 +259,9 @@ cd packages/design-library
 bun run test               # run all render tests (Playwright Chromium)
 ```
 
-Tests run in a real browser (headless Chromium) and verify that each story renders without errors. No extra test files needed — stories _are_ the tests.
+Tests run in a real browser (headless Chromium via [Playwright](https://playwright.dev/)) and verify that each story renders without errors. No extra test files needed — stories _are_ the tests.
+
+Playwright Chromium is installed automatically by the `postinstall` script. The Storybook dev server also uses Playwright to power the in-UI testing widget — if you see a "Failed to initialize Vitest" error on startup, run `bunx playwright install chromium` to fix it.
 
 ### MCP (AI agent integration)
 

--- a/packages/design-library/README.md
+++ b/packages/design-library/README.md
@@ -241,7 +241,7 @@ References:
 
 ```bash
 cd packages/design-library
-bun install                # installs deps + Playwright Chromium via postinstall
+bun install                # installs deps + Playwright Chromium via @playwright/browser-chromium
 bun run storybook          # dev server → http://localhost:6006
 bun run build-storybook    # static build → storybook-static/
 ```
@@ -261,7 +261,7 @@ bun run test               # run all render tests (Playwright Chromium)
 
 Tests run in a real browser (headless Chromium via [Playwright](https://playwright.dev/)) and verify that each story renders without errors. No extra test files needed — stories _are_ the tests.
 
-Playwright Chromium is installed automatically by the `postinstall` script. The Storybook dev server also uses Playwright to power the in-UI testing widget — if you see a "Failed to initialize Vitest" error on startup, run `bunx playwright install chromium` to fix it.
+Playwright Chromium is installed automatically by the [`@playwright/browser-chromium`](https://www.npmjs.com/package/@playwright/browser-chromium) package (listed in `trustedDependencies` so bun runs its install script). The Storybook dev server also uses Playwright to power the in-UI testing widget — if you see a "Failed to initialize Vitest" error on startup, run `bunx playwright install chromium` to fix it.
 
 ### MCP (AI agent integration)
 

--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -23,6 +23,7 @@
         "tailwind-merge": "3.6.0",
       },
       "devDependencies": {
+        "@playwright/browser-chromium": "1.60.0",
         "@storybook/addon-a11y": "10.4.0",
         "@storybook/addon-docs": "10.4.0",
         "@storybook/addon-mcp": "0.6.0",
@@ -50,6 +51,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@playwright/browser-chromium",
+  ],
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
@@ -252,6 +256,8 @@
     "@oxc-resolver/binding-win32-ia32-msvc": ["@oxc-resolver/binding-win32-ia32-msvc@11.19.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA=="],
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
+
+    "@playwright/browser-chromium": ["@playwright/browser-chromium@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" } }, "sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -573,11 +579,11 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.357", "", {}, "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.359", "", {}, "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw=="],
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-wE4fDO8OjJhrPFH69HUQStq5oKvGRTNXEyW+k5C/pUQLASSsTu7obd2V3GvCDgPcY9AWjhJ4jz9Kh7iRvrxhJg=="],
+    "enhanced-resolve": ["enhanced-resolve@5.21.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
@@ -827,7 +833,7 @@
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -14,8 +14,8 @@
     "./utils/*": "./src/utils/*.ts",
     "./utils/portal-container": "./src/utils/portal-container.tsx"
   },
+  "trustedDependencies": ["@playwright/browser-chromium"],
   "scripts": {
-    "postinstall": "playwright install chromium",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest",
@@ -38,6 +38,7 @@
     "@types/react-dom": "19.2.3",
     "@vitest/browser": "4.1.6",
     "@vitest/browser-playwright": "4.1.6",
+    "@playwright/browser-chromium": "1.60.0",
     "@vitest/runner": "4.1.6",
     "playwright": "1.60.0",
     "react": "19.2.6",

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -15,6 +15,7 @@
     "./utils/portal-container": "./src/utils/portal-container.tsx"
   },
   "scripts": {
+    "postinstall": "playwright install chromium",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest",


### PR DESCRIPTION
## Summary

The `@storybook/addon-vitest` added in #31197 requires Playwright's Chromium browser binaries to power both the CLI test runner (`bun run test`) and the in-UI testing widget (sidebar test status, watch mode). The CI workflow correctly installs them, but the local dev path was missing this step — causing a noisy "Failed to initialize Vitest" error on `bun run storybook` startup.

## Changes

- **`packages/design-library/package.json`**: Add [`@playwright/browser-chromium`](https://www.npmjs.com/package/@playwright/browser-chromium) as a devDependency. This is Playwright's official mechanism (introduced in [v1.38](https://github.com/microsoft/playwright/pull/26672)) for declarative browser downloads — the package's `install` script auto-downloads Chromium on `bun install`. Added to `trustedDependencies` since bun doesn't run third-party lifecycle scripts by default and this package isn't in bun's [default allowlist](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).
- **`packages/design-library/README.md`**: Updated Storybook/Testing sections to document the Playwright dependency and troubleshooting.

## Why this approach

| Approach | Pros | Cons |
|---|---|---|
| **`@playwright/browser-chromium` devDep** (chosen) | Declarative (dependency, not script), Playwright's recommended mechanism, version-locked | Requires `trustedDependencies` for bun |
| Custom `postinstall` script | Simple, package-manager agnostic | Imperative workaround duplicating what Playwright already provides |
| Documentation only (MUI approach) | Simplest | Bad DX — developers hit confusing error |

References:
- [Playwright v1.38 — make `playwright` package not install browsers automatically](https://github.com/microsoft/playwright/pull/26672)
- [`@playwright/browser-chromium` on npm](https://www.npmjs.com/package/@playwright/browser-chromium)
- [Bun lifecycle scripts — trustedDependencies](https://bun.sh/docs/install/lifecycle)
- [Storybook Vitest addon docs](https://storybook.js.org/docs/writing-tests/integrations/vitest-addon)

## Root cause analysis

1. **How did the code get into this state?** PR #31197 added `@storybook/addon-vitest` with `@vitest/browser-playwright` and correctly configured CI to install browsers (`bunx playwright install chromium --with-deps`), but missed the local dev setup step. Since Playwright v1.38, the `playwright` npm package no longer auto-downloads browsers — an explicit install mechanism is required.
2. **What mistakes or decisions led to it?** The separation between `playwright` (API-only) and `@playwright/browser-chromium` (browser download) introduced in v1.38 is not widely known. It's easy to assume adding `playwright` as a dependency is sufficient.
3. **Were there warning signs?** The Storybook `storybook add` wizard handles browser installation during interactive setup, but the addon was added via direct dependency installation which skipped that wizard.
4. **What can prevent recurrence?** The `@playwright/browser-chromium` devDependency makes browser availability declarative — it will be maintained alongside other dependency updates.
5. **Should AGENTS.md be updated?** No — this is a one-time setup gap, not a recurring pattern.

## Safety

- Additive only — no existing behavior changes
- Design library is a standalone package (own `bun.lock`, not a workspace member); `file:` deps from `apps/web` do not trigger its lifecycle scripts
- Browsers are cached in `~/.cache/ms-playwright/`; subsequent installs are fast no-ops (~0.5s)
- CI workflow unchanged — continues using `bunx playwright install chromium --with-deps` for OS-level deps

[Session](https://app.devin.ai/sessions/c94b8299a1ec42d388d8b05a37fad094)
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
