### PR TITLE
fix(assistant): fall back to custom-* user profiles in call-site defaults (BYOK)

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -572,7 +572,43 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("max");
   });
 
-  test("CALL_SITE_DEFAULTS profile is stripped when the target profile is disabled (BYOK)", () => {
+  test("BYOK: disabled managed profile falls back to custom-* user profile", () => {
+    const llm = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        provider: "openai",
+        model: "gpt-5.5",
+        provider_connection: "openai-personal",
+      },
+      profiles: {
+        "cost-optimized": {
+          status: "disabled",
+          model: "claude-haiku-4-5-20251001",
+          provider: "anthropic",
+          provider_connection: "anthropic-managed",
+        },
+        "custom-cost-optimized": {
+          source: "user",
+          model: "gpt-5.4-nano",
+          provider: "openai",
+          provider_connection: "openai-personal",
+        },
+        "custom-balanced": {
+          source: "user",
+          model: "gpt-5.5",
+          provider: "openai",
+          provider_connection: "openai-personal",
+        },
+      },
+      activeProfile: "custom-balanced",
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe("gpt-5.4-nano");
+    expect(resolved.provider_connection).toBe("openai-personal");
+  });
+
+  test("BYOK: strips profile when neither managed nor custom-* is available", () => {
     const llm = LLMSchema.parse({
       default: {
         ...fullDefault,
@@ -601,7 +637,7 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.provider_connection).toBe("openai-personal");
   });
 
-  test("BYOK full-workspace: no call site resolves to a disabled managed profile", () => {
+  test("BYOK full-workspace: cost-optimized call sites use custom-cost-optimized, balanced use custom-balanced", () => {
     const byokConfig = LLMSchema.parse({
       default: {
         ...fullDefault,
@@ -643,6 +679,12 @@ describe("resolveCallSiteConfig", () => {
           model: "gpt-5.4-nano",
           provider_connection: "openai-personal",
         },
+        "custom-quality-optimized": {
+          source: "user",
+          provider: "openai",
+          model: "gpt-5.5-pro",
+          provider_connection: "openai-personal",
+        },
       },
       activeProfile: "custom-balanced",
     });
@@ -662,9 +704,17 @@ describe("resolveCallSiteConfig", () => {
       expect(resolved.provider_connection).not.toBe("anthropic-managed");
       expect(resolved.provider).toBe("openai");
     }
+
+    // Cost-optimized call sites should use the user's nano model
+    const costSite = resolveCallSiteConfig("heartbeatAgent", byokConfig);
+    expect(costSite.model).toBe("gpt-5.4-nano");
+
+    // Balanced call sites should use the user's balanced model
+    const balancedSite = resolveCallSiteConfig("mainAgent", byokConfig);
+    expect(balancedSite.model).toBe("gpt-5.5");
   });
 
-  test("BYOK: tuning overrides from defaults still apply even with disabled profiles", () => {
+  test("BYOK: tuning overrides from defaults apply on top of custom-* fallback profile", () => {
     const byokConfig = LLMSchema.parse({
       default: {
         ...fullDefault,
@@ -679,6 +729,12 @@ describe("resolveCallSiteConfig", () => {
           model: "claude-haiku-4-5-20251001",
           provider_connection: "anthropic-managed",
         },
+        "custom-cost-optimized": {
+          source: "user",
+          provider: "openai",
+          model: "gpt-5.4-nano",
+          provider_connection: "openai-personal",
+        },
         "custom-balanced": {
           provider: "openai",
           model: "gpt-5.5",
@@ -690,7 +746,7 @@ describe("resolveCallSiteConfig", () => {
 
     const resolved = resolveCallSiteConfig("commitMessage", byokConfig);
     expect(resolved.provider).toBe("openai");
-    expect(resolved.model).toBe("gpt-5.5");
+    expect(resolved.model).toBe("gpt-5.4-nano");
     expect(resolved.maxTokens).toBe(120);
     expect(resolved.effort).toBe("low");
     expect(resolved.thinking.enabled).toBe(false);

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -80,6 +80,25 @@ export function resolveCallSiteConfig(
 
 type Mergeable = Record<string, unknown>;
 
+/**
+ * Returns the resolved default profile key for a call site, accounting for
+ * the `custom-*` user-profile fallback when the managed profile is unavailable.
+ */
+export function resolveDefaultProfileKey(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+): string | undefined {
+  const dflt = CALL_SITE_DEFAULTS[callSite];
+  if (dflt?.profile == null) return undefined;
+  const target = llm.profiles?.[dflt.profile];
+  if (target != null && target.status !== "disabled") return dflt.profile;
+  const customKey = `custom-${dflt.profile}`;
+  const customTarget = llm.profiles?.[customKey];
+  if (customTarget != null && customTarget.status !== "disabled")
+    return customKey;
+  return dflt.profile;
+}
+
 function effectiveDefault(
   callSite: LLMCallSite,
   llm: z.infer<typeof LLMSchema>,
@@ -89,10 +108,19 @@ function effectiveDefault(
   if (dflt == null) return undefined;
   const targetProfile =
     dflt.profile != null ? llm.profiles?.[dflt.profile] : undefined;
-  const stripProfile =
-    hasOverrideProfile ||
-    (dflt.profile != null &&
-      (targetProfile == null || targetProfile.status === "disabled"));
+  const profileUnavailable =
+    dflt.profile != null &&
+    (targetProfile == null || targetProfile.status === "disabled");
+
+  if (profileUnavailable && !hasOverrideProfile) {
+    const customKey = `custom-${dflt.profile}`;
+    const customProfile = llm.profiles?.[customKey];
+    if (customProfile != null && customProfile.status !== "disabled") {
+      return { ...dflt, profile: customKey };
+    }
+  }
+
+  const stripProfile = hasOverrideProfile || profileUnavailable;
   if (stripProfile) {
     const { profile: _profile, ...rest } = dflt;
     return Object.keys(rest).length > 0 ? rest : undefined;

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -96,7 +96,7 @@ export function resolveDefaultProfileKey(
   const customTarget = llm.profiles?.[customKey];
   if (customTarget != null && customTarget.status !== "disabled")
     return customKey;
-  return dflt.profile;
+  return undefined;
 }
 
 function effectiveDefault(

--- a/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
@@ -45,13 +45,15 @@ describe("llm-call-sites-routes", () => {
     }
   });
 
-  test("every call site includes a defaultProfile string", async () => {
+  test("defaultProfile is a non-empty string or undefined per call site", async () => {
     const result = (await route.handler({})) as {
       callSites: Array<{ id: string; defaultProfile?: string }>;
     };
     for (const site of result.callSites) {
-      expect(typeof site.defaultProfile).toBe("string");
-      expect(site.defaultProfile!.length).toBeGreaterThan(0);
+      if (site.defaultProfile != null) {
+        expect(typeof site.defaultProfile).toBe("string");
+        expect(site.defaultProfile.length).toBeGreaterThan(0);
+      }
     }
   });
 

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,14 +1,19 @@
-import { CALL_SITE_DEFAULTS } from "../../config/call-site-defaults.js";
+import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { CALL_SITE_CATALOG, CALL_SITE_DOMAINS } from "../../config/schemas/call-site-catalog.js";
 import type { LLMCallSite } from "../../config/schemas/llm.js";
+import { loadConfig } from "../../config/loader.js";
 import type { RouteDefinition } from "./types.js";
 
 async function handleGetCallSites() {
+  const { llm } = loadConfig();
   return {
     domains: CALL_SITE_DOMAINS,
     callSites: CALL_SITE_CATALOG.map((entry) => ({
       ...entry,
-      defaultProfile: CALL_SITE_DEFAULTS[entry.id as LLMCallSite]?.profile,
+      defaultProfile: resolveDefaultProfileKey(
+        entry.id as LLMCallSite,
+        llm,
+      ),
     })),
   };
 }

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,7 +1,7 @@
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
+import { loadConfig } from "../../config/loader.js";
 import { CALL_SITE_CATALOG, CALL_SITE_DOMAINS } from "../../config/schemas/call-site-catalog.js";
 import type { LLMCallSite } from "../../config/schemas/llm.js";
-import { loadConfig } from "../../config/loader.js";
 import type { RouteDefinition } from "./types.js";
 
 async function handleGetCallSites() {

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
@@ -38,6 +38,10 @@ public struct CallSiteOverride: Identifiable, Equatable, Hashable {
     /// Domain ID matching a `CallSiteDomain.id` from the API catalog.
     public let domain: String
 
+    /// The shipped default profile key for this call site, resolved by the
+    /// daemon to account for `custom-*` user-profile fallback.
+    public let defaultProfile: String?
+
     /// Provider override; `nil` means "follows the default".
     public var provider: String?
 
@@ -53,6 +57,7 @@ public struct CallSiteOverride: Identifiable, Equatable, Hashable {
         displayName: String,
         callSiteDescription: String = "",
         domain: String,
+        defaultProfile: String? = nil,
         provider: String? = nil,
         model: String? = nil,
         profile: String? = nil
@@ -61,6 +66,7 @@ public struct CallSiteOverride: Identifiable, Equatable, Hashable {
         self.displayName = displayName
         self.callSiteDescription = callSiteDescription
         self.domain = domain
+        self.defaultProfile = defaultProfile
         self.provider = provider
         self.model = model
         self.profile = profile
@@ -207,7 +213,8 @@ public final class CallSiteCatalog {
                 id: $0.id,
                 displayName: $0.displayName,
                 callSiteDescription: $0.description,
-                domain: $0.domain
+                domain: $0.domain,
+                defaultProfile: $0.defaultProfile
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
@@ -129,6 +129,12 @@ struct CallSiteOverrideRow: View {
 
             if isOverrideOn {
                 inlineProfilePicker
+            } else if let dp = draft.defaultProfile,
+                      let match = profiles.first(where: { $0.name == dp }) {
+                Text("Default: \(match.displayName)")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(.secondary)
+                    .opacity(0.6)
             }
 
             VToggle(
@@ -137,23 +143,17 @@ struct CallSiteOverrideRow: View {
                     set: { newValue in
                         if newValue {
                             if !draft.hasOverride {
-                                // Seed from the same filtered list the
-                                // picker uses (active profiles only) so
-                                // toggle-on can't silently select a
-                                // disabled profile when one happens to
-                                // sort first in `profileOrder`. Codex P1
-                                // + Devin findings on PR #30349.
                                 let candidates = Self.visibleProfilesForPicker(
                                     profiles
                                 )
-                                if let firstActive = candidates.first {
+                                let defaultMatch = draft.defaultProfile.flatMap { dp in
+                                    candidates.first { $0.name == dp }
+                                }
+                                if let defaultMatch {
+                                    draft.profile = defaultMatch.name
+                                } else if let firstActive = candidates.first {
                                     draft.profile = firstActive.name
                                 } else if let firstAny = profiles.first {
-                                    // Edge case: every profile is disabled.
-                                    // Better to seed with *something* the
-                                    // user can immediately swap than to
-                                    // silently fall through to a custom
-                                    // fragment they didn't ask for.
                                     draft.profile = firstAny.name
                                 } else {
                                     seedCustomFragment()

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -652,12 +652,14 @@ public struct CallSiteCatalogEntry: Codable {
     public let displayName: String
     public let description: String
     public let domain: String
+    public let defaultProfile: String?
 
-    public init(id: String, displayName: String, description: String, domain: String) {
+    public init(id: String, displayName: String, description: String, domain: String, defaultProfile: String? = nil) {
         self.id = id
         self.displayName = displayName
         self.description = description
         self.domain = domain
+        self.defaultProfile = defaultProfile
     }
 }
 


### PR DESCRIPTION
## Summary
- When managed profiles are disabled (BYOK), the resolver now tries `custom-{profile}` before stripping — so call sites like `heartbeatAgent` and `filingAgent` use the user's Speed profile instead of falling through to Balanced
- The call-sites API (`GET /config/llm/call-sites`) now returns the resolved default profile key (e.g., `custom-cost-optimized` for BYOK) instead of the raw managed key
- macOS Action Overrides UI shows "Default: Speed/Balanced/Quality" label and seeds toggle-on with the default profile

## Test plan
- [x] Resolver tests pass — BYOK fallback, tuning overrides, full-workspace sweep
- [x] Type-check clean
- [ ] Rebuild macOS app and verify default labels appear in Action Overrides
- [ ] Verify toggle-on seeds with default profile (e.g., Speed for heartbeatAgent)
- [ ] Verify inference-time routing uses correct profile for BYOK users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->