### PR TITLE
feat(web): add logout page with post-logout redirect

### DIFF
--- a/apps/web/src/domains/account/pages/logout-page.tsx
+++ b/apps/web/src/domains/account/pages/logout-page.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { AccountHeading } from "@/components/account/account-form.js";
+import { AccountShell } from "@/components/account/account-shell.js";
+import { sanitizeReturnTo } from "@/lib/account/return-to.js";
+import { useAuthStore } from "@/stores/auth-store.js";
+import { routes } from "@/utils/routes.js";
+
+export function LogoutPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const logout = useAuthStore.use.logout();
+  const logoutInitiated = useRef(false);
+
+  useEffect(() => {
+    if (logoutInitiated.current) return;
+    logoutInitiated.current = true;
+
+    const returnTo = sanitizeReturnTo(
+      searchParams.get("returnTo"),
+      routes.account.login,
+    );
+
+    // If returnTo is an absolute URL (cross-origin), redirect there directly.
+    // Otherwise, redirect to login with returnTo as a param.
+    const target = returnTo.startsWith("http")
+      ? returnTo
+      : returnTo === routes.account.login
+        ? routes.account.login
+        : `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`;
+
+    const redirect = (url: string) => {
+      if (url.startsWith("http")) {
+        window.location.href = url;
+      } else {
+        navigate(url);
+      }
+    };
+
+    logout().then(
+      () => redirect(target),
+      () => redirect(target),
+    );
+  }, [logout, navigate, searchParams]);
+
+  return (
+    <AccountShell>
+      <AccountHeading title="Signing out..." />
+    </AccountShell>
+  );
+}

--- a/apps/web/src/domains/account/pages/logout-page.tsx
+++ b/apps/web/src/domains/account/pages/logout-page.tsx
@@ -24,10 +24,9 @@ export function LogoutPage() {
 
     // If returnTo is an absolute URL (cross-origin), redirect there directly.
     // Otherwise, redirect to login with returnTo as a param.
-    const target = returnTo.startsWith("http")
-      ? returnTo
-      : returnTo === routes.account.login
-        ? routes.account.login
+    const target =
+      returnTo.startsWith("http") || returnTo === routes.account.login
+        ? returnTo
         : `${routes.account.login}?returnTo=${encodeURIComponent(returnTo)}`;
 
     const redirect = (url: string) => {
@@ -38,10 +37,12 @@ export function LogoutPage() {
       }
     };
 
+    let cancelled = false;
     logout().then(
-      () => redirect(target),
-      () => redirect(target),
+      () => { if (!cancelled) redirect(target); },
+      () => { if (!cancelled) redirect(target); },
     );
+    return () => { cancelled = true; };
   }, [logout, navigate, searchParams]);
 
   return (

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -14,6 +14,7 @@ import { LoginPage } from "@/domains/account/pages/login-page.js";
 import { SignupPage } from "@/domains/account/pages/signup-page.js";
 import { ProviderCallbackPage } from "@/domains/account/pages/provider-callback-page.js";
 import { ProviderSignupPage } from "@/domains/account/pages/provider-signup-page.js";
+import { LogoutPage } from "@/domains/account/pages/logout-page.js";
 import { OAuthPopupCompletePage } from "@/domains/account/pages/oauth-popup-complete-page.js";
 import { routes } from "@/utils/routes.js";
 
@@ -44,6 +45,8 @@ function HomePageRoute() {
  *   │  ├── ProviderSignupPage (/account/provider/signup)
  *   │  └── OAuthPopupCompletePage (/account/oauth/popup-complete)
  *   │
+ *   /logout        — standalone logout (calls API, redirects to login)
+ *   │
  *   /assistant/* — auth-protected app with RootLayout
  *   │  middleware: [authMiddleware] — redirects to login when auth required
  *   │  └── ChatLayout — sidebar rail, drawer, shortcuts
@@ -70,6 +73,9 @@ export const router = createBrowserRouter([
       { path: "oauth/popup-complete", element: <OAuthPopupCompletePage /> },
     ],
   },
+
+  // Logout — standalone page, no app chrome
+  { path: "/logout", element: <LogoutPage /> },
 
   // Assistant routes — auth-protected app with layout
   {


### PR DESCRIPTION
## Prompt / plan

Port the logout page from the platform repo (`web/src/app/(app)/logout/page.tsx`) to the OSS repo as a React Router route.

Closes LUM-1656

## What changed

Added `/logout` route that:
1. Calls the allauth logout endpoint via `useAuthStore.logout()`
2. Clears auth and organization state
3. Redirects to `/account/login` (or a sanitized `returnTo` URL if provided as a query param)
4. Handles cross-origin redirects (absolute URLs go through `window.location.href`, relative paths use React Router `navigate()`)

**Files:**
- `domains/account/pages/logout-page.tsx` — new page component
- `routes.tsx` — added `/logout` route entry

**Migration changes from platform version:**
- `useRouter` / `useSearchParams` (Next.js) → `useNavigate` / `useSearchParams` (React Router)
- `useAuth()` (React Context) → `useAuthStore` (Zustand)
- Removed `"use client"` directive, `Route` type import
- Added `.js` extensions on imports per repo conventions

**Why `/logout` is a top-level route (not under `/account` or `/assistant`):**
- Matches the platform's URL structure (`/logout` is at the app root, not nested under account)
- The `routes.logout` constant already defines it as `/logout`
- It's a standalone page with `AccountShell` chrome (same as login/signup), not part of the authenticated app layout

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- CI checks

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->