### PR TITLE
feat(web): add password reset redirects and desktop OAuth complete page

### DIFF
--- a/apps/web/src/domains/account/pages/desktop-oauth-complete-page.tsx
+++ b/apps/web/src/domains/account/pages/desktop-oauth-complete-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router";
 
 // ── SVG icons ────────────────────────────────────────────────────────────────
@@ -237,7 +237,12 @@ export function DesktopOAuthCompletePage() {
     ? "You can close this tab and return to your assistant."
     : `${displayProvider || "Service"} connection failed. You can try again from the desktop app.`;
 
+  const completionSent = useRef(false);
+
   useEffect(() => {
+    if (completionSent.current) return;
+    completionSent.current = true;
+
     const payload: DesktopOAuthCompletePayload = {
       type: "vellum:oauth-complete",
       requestId,

--- a/apps/web/src/domains/account/pages/desktop-oauth-complete-page.tsx
+++ b/apps/web/src/domains/account/pages/desktop-oauth-complete-page.tsx
@@ -1,0 +1,272 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
+
+// ── SVG icons ────────────────────────────────────────────────────────────────
+
+function CheckmarkIcon() {
+  return (
+    <svg
+      className="oauth-icon"
+      viewBox="0 0 56 56"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="28" cy="28" r="28" fill="var(--oauth-positive-bg)" />
+      <path
+        className="oauth-check"
+        d="M17 28.5L24.5 36L39 21"
+        stroke="var(--oauth-positive-fg)"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      className="oauth-icon"
+      viewBox="0 0 56 56"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="28" cy="28" r="28" fill="var(--oauth-negative-bg)" />
+      <path
+        className="oauth-cross oauth-cross-1"
+        d="M20 20L36 36"
+        stroke="var(--oauth-negative-fg)"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <path
+        className="oauth-cross oauth-cross-2"
+        d="M36 20L20 36"
+        stroke="var(--oauth-negative-fg)"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const OAUTH_STYLES = `
+  :root {
+    --oauth-surface: #F5F3EB;
+    --oauth-surface-card: #FFFFFF;
+    --oauth-card-border: #E8E6DA;
+    --oauth-text-primary: #2A2A28;
+    --oauth-text-secondary: #4A4A46;
+    --oauth-positive-bg: #D4DFD0;
+    --oauth-positive-fg: #516748;
+    --oauth-negative-bg: #F7DAC9;
+    --oauth-negative-fg: #DA491A;
+    --oauth-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
+    --oauth-font: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --oauth-surface: #1A1A18;
+      --oauth-surface-card: #2A2A28;
+      --oauth-card-border: #3A3A37;
+      --oauth-text-primary: #F5F3EB;
+      --oauth-text-secondary: #BDB9A9;
+      --oauth-positive-bg: #1A2316;
+      --oauth-positive-fg: #7A8B6F;
+      --oauth-negative-bg: #4E281D;
+      --oauth-negative-fg: #E86B40;
+      --oauth-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.3);
+    }
+  }
+  :root.dark {
+    --oauth-surface: #1A1A18;
+    --oauth-surface-card: #2A2A28;
+    --oauth-card-border: #3A3A37;
+    --oauth-text-primary: #F5F3EB;
+    --oauth-text-secondary: #BDB9A9;
+    --oauth-positive-bg: #1A2316;
+    --oauth-positive-fg: #7A8B6F;
+    --oauth-negative-bg: #4E281D;
+    --oauth-negative-fg: #E86B40;
+    --oauth-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.3);
+  }
+  .oauth-page {
+    font-family: var(--oauth-font);
+    background: var(--oauth-surface);
+    color: var(--oauth-text-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    margin: 0;
+    padding: 0;
+    -webkit-font-smoothing: antialiased;
+  }
+  .oauth-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 48px 40px 40px;
+    background: var(--oauth-surface-card);
+    border: 1px solid var(--oauth-card-border);
+    border-radius: 16px;
+    box-shadow: var(--oauth-shadow);
+    max-width: 380px;
+    width: 100%;
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+    animation: oauthCardIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards;
+  }
+  @keyframes oauthCardIn {
+    to { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  .oauth-icon {
+    width: 56px;
+    height: 56px;
+    margin-bottom: 20px;
+    flex-shrink: 0;
+  }
+  .oauth-check {
+    stroke-dasharray: 32;
+    stroke-dashoffset: 32;
+    animation: oauthDraw 0.4s ease-out 0.45s forwards;
+  }
+  .oauth-cross {
+    stroke-dasharray: 22;
+    stroke-dashoffset: 22;
+  }
+  .oauth-cross-1 { animation: oauthDraw 0.3s ease-out 0.45s forwards; }
+  .oauth-cross-2 { animation: oauthDraw 0.3s ease-out 0.55s forwards; }
+  @keyframes oauthDraw {
+    to { stroke-dashoffset: 0; }
+  }
+  .oauth-card h1 {
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: -0.2px;
+    color: var(--oauth-text-primary);
+    margin: 0 0 6px;
+  }
+  .oauth-card p {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--oauth-text-secondary);
+    margin: 0;
+  }
+`;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatProviderName(provider: string): string {
+  return provider
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export interface DesktopOAuthCompletePayload {
+  type: "vellum:oauth-complete";
+  requestId: string | null;
+  oauthStatus: string | null;
+  oauthProvider: string | null;
+  oauthCode: string | null;
+}
+
+interface OAuthCompleteTarget {
+  opener: { postMessage(message: unknown, targetOrigin: string): void } | null;
+  origin: string;
+  storage: Pick<Storage, "setItem">;
+  close: () => void;
+}
+
+export function oauthCompletionStorageKey(requestId: string): string {
+  return `vellum:oauth-complete:${requestId}`;
+}
+
+export function completeOAuthPopup(
+  payload: DesktopOAuthCompletePayload,
+  target: OAuthCompleteTarget,
+): void {
+  if (target.opener) {
+    target.opener.postMessage(payload, target.origin);
+  }
+
+  if (payload.requestId) {
+    try {
+      target.storage.setItem(
+        oauthCompletionStorageKey(payload.requestId),
+        JSON.stringify(payload),
+      );
+    } catch {
+      // Best-effort fallback for popup contexts where window.opener is lost.
+    }
+  }
+
+  target.close();
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export function DesktopOAuthCompletePage() {
+  const [searchParams] = useSearchParams();
+  const requestId = searchParams.get("requestId");
+  const oauthStatus = searchParams.get("oauth_status");
+  const oauthProvider = searchParams.get("oauth_provider");
+  const oauthCode = searchParams.get("oauth_code");
+
+  const displayProvider = oauthProvider
+    ? formatProviderName(oauthProvider)
+    : "";
+
+  const isSuccess = oauthStatus === "connected";
+
+  const title = isSuccess
+    ? displayProvider
+      ? `Connected to ${displayProvider}`
+      : "Authorization Successful"
+    : "Authorization Failed";
+
+  const subtitle = isSuccess
+    ? "You can close this tab and return to your assistant."
+    : `${displayProvider || "Service"} connection failed. You can try again from the desktop app.`;
+
+  useEffect(() => {
+    const payload: DesktopOAuthCompletePayload = {
+      type: "vellum:oauth-complete",
+      requestId,
+      oauthStatus: oauthStatus || null,
+      oauthProvider: oauthProvider || null,
+      oauthCode: oauthCode || null,
+    };
+
+    completeOAuthPopup(payload, {
+      opener: window.opener,
+      origin: window.location.origin,
+      storage: window.localStorage,
+      close: () => window.close(),
+    });
+  }, [requestId, oauthStatus, oauthProvider, oauthCode]);
+
+  return (
+    <div className="oauth-page">
+      <style dangerouslySetInnerHTML={{ __html: OAUTH_STYLES }} />
+      <div className="oauth-card">
+        {isSuccess ? <CheckmarkIcon /> : <ErrorIcon />}
+        <h1>{title}</h1>
+        <p>{subtitle}</p>
+        {!isSuccess && oauthCode && (
+          <p style={{ marginTop: 8, fontSize: 11, color: "var(--oauth-text-secondary)", opacity: 0.7 }}>
+            Error: {oauthCode}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/account/pages/password-reset-page.tsx
+++ b/apps/web/src/domains/account/pages/password-reset-page.tsx
@@ -1,0 +1,7 @@
+import { Navigate } from "react-router";
+
+import { routes } from "@/utils/routes.js";
+
+export function PasswordResetPage() {
+  return <Navigate to={routes.account.login} replace />;
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -14,8 +14,10 @@ import { LoginPage } from "@/domains/account/pages/login-page.js";
 import { SignupPage } from "@/domains/account/pages/signup-page.js";
 import { ProviderCallbackPage } from "@/domains/account/pages/provider-callback-page.js";
 import { ProviderSignupPage } from "@/domains/account/pages/provider-signup-page.js";
+import { DesktopOAuthCompletePage } from "@/domains/account/pages/desktop-oauth-complete-page.js";
 import { LogoutPage } from "@/domains/account/pages/logout-page.js";
 import { OAuthPopupCompletePage } from "@/domains/account/pages/oauth-popup-complete-page.js";
+import { PasswordResetPage } from "@/domains/account/pages/password-reset-page.js";
 import { routes } from "@/utils/routes.js";
 
 function HomePageRoute() {
@@ -43,7 +45,10 @@ function HomePageRoute() {
  *   │  ├── SignupPage (/account/signup)
  *   │  ├── ProviderCallbackPage (/account/provider/callback)
  *   │  ├── ProviderSignupPage (/account/provider/signup)
- *   │  └── OAuthPopupCompletePage (/account/oauth/popup-complete)
+ *   │  ├── OAuthPopupCompletePage (/account/oauth/popup-complete)
+ *   │  ├── DesktopOAuthCompletePage (/account/oauth/desktop-complete)
+ *   │  ├── PasswordResetPage (/account/password/reset → redirects to login)
+ *   │  └── PasswordResetPage (/account/password/reset/key/:key → redirects to login)
  *   │
  *   /logout        — standalone logout (calls API, redirects to login)
  *   │
@@ -71,6 +76,9 @@ export const router = createBrowserRouter([
       { path: "provider/callback", element: <ProviderCallbackPage /> },
       { path: "provider/signup", element: <ProviderSignupPage /> },
       { path: "oauth/popup-complete", element: <OAuthPopupCompletePage /> },
+      { path: "oauth/desktop-complete", element: <DesktopOAuthCompletePage /> },
+      { path: "password/reset", element: <PasswordResetPage /> },
+      { path: "password/reset/key/:key", element: <PasswordResetPage /> },
     ],
   },
 

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -37,6 +37,7 @@ export const routes = {
     providerCallback: r("/account/provider/callback"),
     oauth: {
       popupComplete: r("/account/oauth/popup-complete"),
+      desktopComplete: r("/account/oauth/desktop-complete"),
     },
   },
 


### PR DESCRIPTION
## Prompt / plan

Port the remaining account pages from the platform repo to complete the auth page migration.

Closes LUM-1649

## What changed

**Password reset routes** (`/account/password/reset` and `/account/password/reset/key/:key`):
- Both redirect to `/account/login` using React Router's `Navigate` component
- These are fallback routes — allauth handles the actual password reset flow server-side. The email link goes to Django's `/accounts/` namespace, not the SPA. These routes exist so that if a user navigates here directly, they get redirected gracefully instead of a 404.

**Desktop OAuth complete page** (`/account/oauth/desktop-complete`):
- Handles the macOS desktop app's loopback OAuth completion flow
- Reads `requestId`, `oauth_status`, `oauth_provider`, `oauth_code` from query params
- Posts the result to `window.opener` via `postMessage`
- Stores the result in `localStorage` as a fallback for popup contexts where `window.opener` is lost
- Auto-closes the tab
- Shows a success/error card with animated SVG icons while the completion runs
- Exports `completeOAuthPopup`, `DesktopOAuthCompletePayload`, and `oauthCompletionStorageKey` — these are used by other pages (settings integrations, onboarding) that will be ported in future PRs

**Route constant** added: `routes.account.oauth.desktopComplete`

**Migration changes from platform version:**
- `useSearchParams` (Next.js) → `useSearchParams` (React Router)
- `redirect()` (Next.js server function) → `<Navigate>` (React Router client component)
- Removed `"use client"` directive
- Removed `Suspense` wrapper (React Router's `useSearchParams` doesn't suspend)
- Removed `generateStaticParams` (Next.js-specific)
- Added `.js` extensions on imports per repo conventions

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- CI checks

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->