### PR TITLE
fix(web): lift assistant lifecycle to ChatLayout, fix blank pages

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -25,8 +25,8 @@ Read these before making changes:
 - Route constants: `src/utils/routes.ts` — all paths are absolute browser paths
 - No `basename` on the router — `/account/*` and `/assistant/*` are explicit top-level branches
 - Routes must match the platform repo exactly during migration (no URL changes)
-- **Route protection**: uses React Router v7 [middleware](https://reactrouter.com/how-to/middleware) (`v8_middleware` future flag), not layout gate components or `useEffect` redirects. See [CONVENTIONS.md — Route protection via middleware](./CONVENTIONS.md#route-protection-via-middleware).
-- **Auth is optional**: controlled by `VITE_AUTH_REQUIRED` env var — `"true"` for hosted/App Store, `"false"` (default) for local dev and self-hosting. See [CONVENTIONS.md — Auth is optional](./CONVENTIONS.md#auth-is-optional--controlled-by-environment-config).
+- **Route protection**: uses React Router v7 [middleware](https://reactrouter.com/how-to/middleware) (`v8_middleware` future flag), not layout gate components or `useEffect` redirects. Auth is always required — the middleware redirects unauthenticated users to `/account/login`. See [CONVENTIONS.md — Route protection via middleware](./CONVENTIONS.md#route-protection-via-middleware).
+- **Assistant lifecycle**: owned by `ChatLayout`, passed to child routes via [outlet context](https://reactrouter.com/start/framework/outlet). Child routes consume the resolved `assistantId` via `useAssistantContext()` — never hardcode or independently resolve it.
 
 ## Commands
 

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -707,47 +707,8 @@ typed
 [`context`](https://reactrouter.com/start/data/route-object/#middleware),
 accessible in loaders and components.
 
-#### Auth is optional — controlled by environment config
-
-Authentication is **not always required.** The hosted Vellum service
-(`vellum.ai`) and the App Store iOS app enforce login. But contributors
-running the app locally (`bun run dev`) or self-hosting it can use it
-without logging in — the same way they'd use a local desktop app.
-
-A `VITE_AUTH_REQUIRED` environment variable controls enforcement.
-Hosted deployments set it to `"true"`; the default is `"false"` so
-the app works out of the box for local development and self-hosting.
-
-| Environment | `VITE_AUTH_REQUIRED` | Behavior |
-|---|---|---|
-| Hosted web (`vellum.ai`) | `"true"` | Middleware redirects to `/account/login` |
-| App Store iOS (Capacitor) | `"true"` | Same — native login flow via ASWebAuthenticationSession |
-| Local dev / self-hosted | `"false"` (default) | Middleware passes through with anonymous context |
-| Future Electron/macOS | `"false"` (default) | Same — app usable without login |
-
-```ts
-async function authMiddleware({ context }) {
-  const { isAuthenticated, user } = useAuthStore.getState();
-
-  if (!requiresAuth()) {
-    // Local/self-hosted — allow anonymous usage
-    context.set(userContext, user ?? ANONYMOUS_USER);
-    return;
-  }
-
-  if (!isAuthenticated) {
-    throw redirect("/account/login");
-  }
-
-  context.set(userContext, user);
-}
-```
-
-References:
-- [React Router — Middleware](https://reactrouter.com/how-to/middleware)
-- [React Router — Future Flags (`v8_middleware`)](https://reactrouter.com/upgrading/future#futurev8_middleware)
-- [React Router collaborator recommendation for SPA auth](https://github.com/remix-run/react-router/discussions/14697)
-- [Vite — Env Variables](https://vite.dev/guide/env-and-mode.html)
+Authentication is always required. The middleware reads from the Zustand
+auth store and redirects unauthenticated users to `/account/login`.
 
 ### URL-driven routing
 

--- a/apps/web/src/domains/chat/assistant-context.ts
+++ b/apps/web/src/domains/chat/assistant-context.ts
@@ -1,0 +1,31 @@
+/**
+ * Typed outlet context for the assistant lifecycle.
+ *
+ * `ChatLayout` owns `useAssistantLifecycle` and passes the resolved
+ * assistant state to all child routes via React Router's outlet context.
+ * Child routes consume it through `useAssistantContext()`.
+ *
+ * References:
+ * - https://reactrouter.com/start/framework/outlet
+ * - https://reactrouter.com/start/framework/routing#layout-routes
+ */
+import { useOutletContext } from "react-router";
+
+import type {
+  AssistantState,
+  UseAssistantLifecycleReturn,
+} from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+
+export interface AssistantContextValue {
+  assistantId: string | null;
+  assistantState: AssistantState;
+  checkAssistant: UseAssistantLifecycleReturn["checkAssistant"];
+  retryAssistant: UseAssistantLifecycleReturn["retryAssistant"];
+  hatchVersion: UseAssistantLifecycleReturn["hatchVersion"];
+  setAssistantId: UseAssistantLifecycleReturn["setAssistantId"];
+  autoGreetRef: UseAssistantLifecycleReturn["autoGreetRef"];
+}
+
+export function useAssistantContext(): AssistantContextValue {
+  return useOutletContext<AssistantContextValue>();
+}

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -10,6 +11,9 @@ import { Outlet, useLocation, useNavigate } from "react-router";
 import { haptic } from "@/utils/haptics.js";
 import { routes } from "@/utils/routes.js";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile.js";
+import { useAuthStore } from "@/stores/auth-store.js";
+import { useAssistantLifecycle } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+import type { AssistantContextValue } from "@/domains/chat/assistant-context.js";
 
 import { ChatLayoutHeader } from "./chat-layout-header.js";
 import { SideMenu } from "./side-menu.js";
@@ -84,15 +88,48 @@ export interface SideMenuRenderArgs {
 
 /**
  * Chat-specific layout route providing sidebar rail, mobile drawer, keyboard
- * shortcuts (Ctrl+\, Ctrl+K, Ctrl+[/]), and the chat header bar. Renders
- * inside RootLayout and wraps chat child routes via `<Outlet />`.
+ * shortcuts (Ctrl+\, Ctrl+K, Ctrl+[/]), and the chat header bar. Owns the
+ * assistant lifecycle and passes the resolved state to child routes via
+ * outlet context.
  *
  * References:
  * - React Router nested layouts: https://reactrouter.com/start/data/routing
+ * - React Router outlet context: https://reactrouter.com/start/framework/outlet
  */
 export function ChatLayout() {
   const navigate = useNavigate();
   const location = useLocation();
+  const isLoggedIn = useAuthStore.use.isLoggedIn();
+  const authLoading = useAuthStore.use.isLoading();
+
+  const lifecycle = useAssistantLifecycle({
+    isLoggedIn,
+    isLoading: authLoading,
+    isRetired: false,
+    isNonProduction: false,
+    onRedirect: navigate,
+  });
+
+  const assistantContext = useMemo<AssistantContextValue>(
+    () => ({
+      assistantId: lifecycle.assistantId,
+      assistantState: lifecycle.assistantState,
+      checkAssistant: lifecycle.checkAssistant,
+      retryAssistant: lifecycle.retryAssistant,
+      hatchVersion: lifecycle.hatchVersion,
+      setAssistantId: lifecycle.setAssistantId,
+      autoGreetRef: lifecycle.autoGreetRef,
+    }),
+    [
+      lifecycle.assistantId,
+      lifecycle.assistantState,
+      lifecycle.checkAssistant,
+      lifecycle.retryAssistant,
+      lifecycle.hatchVersion,
+      lifecycle.setAssistantId,
+      lifecycle.autoGreetRef,
+    ],
+  );
 
   // --- History tracking for back/forward nav ---
   const historyIndexRef = useRef(0);
@@ -279,7 +316,7 @@ export function ChatLayout() {
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 overflow-y-auto">
-          <Outlet />
+          <Outlet context={assistantContext} />
           {drawerVisible ? (
             <div
               ref={drawerRef}
@@ -326,7 +363,7 @@ export function ChatLayout() {
             className="min-w-0 flex-1 overflow-y-auto"
             style={{ flex: 1 }}
           >
-            <Outlet />
+            <Outlet context={assistantContext} />
           </main>
         </div>
       )}

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -9,7 +9,7 @@ import {
 
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
-import { useAssistantLifecycle } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
 import {
   INITIAL_TURN_STATE,
   useTurnStore,
@@ -34,21 +34,9 @@ const EMPTY_MAP_MESSAGES = new Map<
 const EMPTY_SET_STRINGS = new Set<string>();
 
 export function ChatPage() {
-  const isLoggedIn = useAuthStore.use.isLoggedIn();
   const authLoading = useAuthStore.use.isLoading();
   const isMobile = useIsMobile();
-
-  const navigate = useCallback((_path: string) => {}, []);
-
-  const lifecycle = useAssistantLifecycle({
-    isLoggedIn,
-    isLoading: authLoading,
-    isRetired: false,
-    isNonProduction: false,
-    onRedirect: navigate,
-  });
-
-  const { assistantState, assistantId } = lifecycle;
+  const { assistantId, assistantState } = useAssistantContext();
 
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   useEffect(() => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -36,7 +36,7 @@ const EMPTY_SET_STRINGS = new Set<string>();
 export function ChatPage() {
   const authLoading = useAuthStore.use.isLoading();
   const isMobile = useIsMobile();
-  const { assistantId, assistantState } = useAssistantContext();
+  const { assistantId, assistantState, checkAssistant } = useAssistantContext();
 
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   useEffect(() => {
@@ -213,7 +213,7 @@ export function ChatPage() {
     onStopSubagent: noopVoid,
     onRequestSubagentDetail: noopAsync as ChatRouteContentProps["onRequestSubagentDetail"],
     pushToAiSettings: noopVoid,
-    checkAssistant: noopVoid,
+    checkAssistant,
     setRefreshEpoch,
     streamRetryNonce: 0,
     refs: {

--- a/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-lifecycle.ts
@@ -52,7 +52,7 @@ interface UseAssistantLifecycleOptions {
   onRedirect: (url: string) => void;
 }
 
-interface UseAssistantLifecycleReturn {
+export interface UseAssistantLifecycleReturn {
   assistantState: AssistantState;
   assistantId: string | null;
   setAssistantId: Dispatch<SetStateAction<string | null>>;

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -41,7 +41,7 @@ function HomePageSkeleton() {
 }
 
 export interface HomePageProps {
-  assistantId: string;
+  assistantId: string | null;
   onStartNewChat: () => void;
   onOpenConversation: (conversationId: string) => void;
   onSuggestionSelected: (prompt: string) => void;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -18,13 +18,15 @@ import { DesktopOAuthCompletePage } from "@/domains/account/pages/desktop-oauth-
 import { LogoutPage } from "@/domains/account/pages/logout-page.js";
 import { OAuthPopupCompletePage } from "@/domains/account/pages/oauth-popup-complete-page.js";
 import { PasswordResetPage } from "@/domains/account/pages/password-reset-page.js";
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
 import { routes } from "@/utils/routes.js";
 
 function HomePageRoute() {
   const navigate = useNavigate();
+  const { assistantId } = useAssistantContext();
   return (
     <HomePage
-      assistantId="default"
+      assistantId={assistantId}
       onStartNewChat={() => navigate(routes.assistant)}
       onOpenConversation={(conversationId) =>
         navigate(`${routes.assistant}/conversations/${conversationId}`)


### PR DESCRIPTION
## Prompt / plan

All pages in the Vite web app (`/assistant/home`, `/assistant`, `/assistant/library`, `/assistant/settings`) render blank or with placeholder content when running `vel up --exclude macos --vite`.

### Root cause

The assistant lifecycle (`useAssistantLifecycle`) was scoped to `ChatPage` — one of several child routes — instead of `ChatLayout`, the shared layout wrapping all `/assistant/*` routes.

In the platform repo, `AssistantPageClient` acts as both layout and lifecycle owner — it resolves the real assistant UUID once and passes it to all child views. The Vite app's port placed the lifecycle inside `ChatPage` only, leaving other routes (home, library, settings) without access to the resolved assistant ID.

**`HomePageRoute` hardcoded `assistantId="default"`** as a placeholder. Django's URL pattern `assistants/<uuid:assistant_id>/<path:rest>/` can't match the string `"default"`, so all API calls returned 404 — the home page rendered an empty greeting with no feed items, no avatar, and no suggestions.

### How the code got into this state

1. [#31114](https://github.com/vellum-ai/vellum-assistant/pull/31114) decomposed `AssistantShell` into `RootLayout` + `ChatLayout` — but didn't move the lifecycle to the layout level.
2. [#31109](https://github.com/vellum-ai/vellum-assistant/pull/31109) ported the chat page and placed `useAssistantLifecycle` inside `ChatPage` rather than `ChatLayout`.
3. [#31067](https://github.com/vellum-ai/vellum-assistant/pull/31067) ported the home page and used `assistantId="default"` as a placeholder since the lifecycle wasn't available at that level.
4. [#31168](https://github.com/vellum-ai/vellum-assistant/pull/31168) correctly removed the `requiresAuth()` / `VITE_AUTH_REQUIRED` gating (auth is always required) but left stale documentation in `AGENTS.md` and `CONVENTIONS.md`.

### What changed

1. **Lift `useAssistantLifecycle` to `ChatLayout`** — the layout now owns the lifecycle and passes the resolved `assistantId` + `assistantState` to child routes via React Router v7's [outlet context](https://reactrouter.com/start/framework/outlet).

2. **New `useAssistantContext()` hook** — typed wrapper around `useOutletContext()` for child routes to consume the layout-provided lifecycle. Lives at `src/domains/chat/assistant-context.ts`.

3. **Fix `HomePageRoute`** — consumes `useAssistantContext()` to get the real assistant UUID instead of hardcoding `"default"`.

4. **Simplify `ChatPage`** — removes the duplicate `useAssistantLifecycle` call. Reads `assistantId` and `assistantState` from the layout context.

5. **Wire `checkAssistant` into `ChatRouteContent`** — replaces the pre-existing `noopVoid` placeholder with the real `checkAssistant` from the lifecycle context, so `onMaintenanceExited` actually rechecks assistant status.

6. **Fix stale docs** — removes misleading `VITE_AUTH_REQUIRED` documentation from `AGENTS.md` and `CONVENTIONS.md`. Auth is always required; the env var gating was intentionally removed.

### Prevention

Added guidance to `AGENTS.md` documenting the convention: assistant lifecycle is owned by `ChatLayout` and consumed via `useAssistantContext()` — never hardcode or independently resolve the assistant ID in child routes.

### Alternatives considered and rejected

- **Just fix `HomePageRoute` to call `useAssistantLifecycle` directly** — rejected because it duplicates the lifecycle (each route runs independent hatching/polling). Wasteful and inconsistent with the platform architecture.

- **Zustand store for assistant state** — considered but rejected for this fix. The lifecycle hook has imperative side effects (hatching, polling, retry) that don't map cleanly to a store. Outlet context keeps the lifecycle as a hook in the layout, matching both the platform pattern and React Router conventions.

## Test plan

- `bun run lint` — passes
- `bunx tsc --noEmit` — passes
- CI checks

Link to Devin session: https://app.devin.ai/sessions/1b39bae960a146a498035acc9bb663c6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->