### PR TITLE
Add platform hatch create mode to CLI

### DIFF
--- a/cli/src/__tests__/hatch.test.ts
+++ b/cli/src/__tests__/hatch.test.ts
@@ -1,0 +1,171 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-hatch-test-"));
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as platformClient from "../lib/platform-client.js";
+
+const readPlatformTokenMock = spyOn(
+  platformClient,
+  "readPlatformToken",
+).mockReturnValue("platform-token");
+const hatchAssistantMock = spyOn(
+  platformClient,
+  "hatchAssistant",
+).mockResolvedValue({
+  assistant: {
+    id: "platform-assistant-id",
+    name: "Platform Assistant",
+    status: "active",
+  },
+  reusedExisting: false,
+});
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.test");
+const saveAssistantEntryMock = spyOn(
+  assistantConfig,
+  "saveAssistantEntry",
+).mockImplementation(() => {});
+const setActiveAssistantMock = spyOn(
+  assistantConfig,
+  "setActiveAssistant",
+).mockImplementation(() => {});
+
+import { hatch } from "../commands/hatch.js";
+
+let originalArgv: string[];
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+let stdout: string[];
+let stderr: string[];
+
+beforeEach(() => {
+  originalArgv = process.argv;
+  originalLog = console.log;
+  originalError = console.error;
+  originalExit = process.exit;
+  stdout = [];
+  stderr = [];
+  console.log = ((...args: unknown[]) => {
+    stdout.push(args.map((arg) => String(arg)).join(" "));
+  }) as typeof console.log;
+  console.error = ((...args: unknown[]) => {
+    stderr.push(args.map((arg) => String(arg)).join(" "));
+  }) as typeof console.error;
+  process.exit = ((code?: number) => {
+    throw new Error(`process.exit:${code ?? 0}`);
+  }) as typeof process.exit;
+
+  readPlatformTokenMock.mockReturnValue("platform-token");
+  hatchAssistantMock.mockReset();
+  hatchAssistantMock.mockResolvedValue({
+    assistant: {
+      id: "platform-assistant-id",
+      name: "Platform Assistant",
+      status: "active",
+    },
+    reusedExisting: false,
+  });
+  getPlatformUrlMock.mockReturnValue("https://platform.test");
+  saveAssistantEntryMock.mockClear();
+  setActiveAssistantMock.mockClear();
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+});
+
+afterAll(() => {
+  readPlatformTokenMock.mockRestore();
+  hatchAssistantMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  saveAssistantEntryMock.mockRestore();
+  setActiveAssistantMock.mockRestore();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("vellum hatch --remote vellum", () => {
+  test("defaults to ensure mode", async () => {
+    process.argv = ["bun", "vellum", "hatch", "--remote", "vellum"];
+
+    await hatch();
+
+    expect(hatchAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      undefined,
+      {
+        mode: "ensure",
+      },
+    );
+    expect(saveAssistantEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assistantId: "platform-assistant-id",
+        runtimeUrl: "https://platform.test",
+        cloud: "vellum",
+      }),
+    );
+    expect(setActiveAssistantMock).toHaveBeenCalledWith(
+      "platform-assistant-id",
+    );
+    expect(stdout).toContain("   Result: created new assistant");
+  });
+
+  test("passes create mode to the platform hatch endpoint", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "hatch",
+      "--remote",
+      "vellum",
+      "--mode",
+      "create",
+    ];
+
+    await hatch();
+
+    expect(hatchAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      undefined,
+      {
+        mode: "create",
+      },
+    );
+  });
+
+  test("rejects platform mode for non-platform hatches", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "hatch",
+      "--remote",
+      "local",
+      "--mode",
+      "create",
+    ];
+
+    await expect(hatch()).rejects.toThrow("process.exit:1");
+
+    expect(stderr).toContain(
+      "Error: --mode is only supported with --remote vellum.",
+    );
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   existsSync,
   mkdtempSync,
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import {
   clearPlatformToken,
   getPlatformUrl,
+  hatchAssistant,
   readPlatformToken,
   savePlatformToken,
 } from "../lib/platform-client.js";
@@ -200,5 +201,64 @@ describe("getPlatformUrl resolution order", () => {
   test("trims whitespace from VELLUM_PLATFORM_URL", () => {
     process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
     expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
+  });
+});
+
+describe("hatchAssistant", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockHatchResponse(status: number) {
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            id: "assistant-123",
+            name: "Test Assistant",
+            status: "active",
+          }),
+          {
+            status,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  }
+
+  test("defaults to ensure mode without a query parameter", async () => {
+    const fetchMock = mockHatchResponse(201);
+
+    const result = await hatchAssistant("vak_test", "https://platform.test");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://platform.test/v1/assistants/hatch/",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("POST");
+    expect(result.reusedExisting).toBe(false);
+    expect(result.assistant.id).toBe("assistant-123");
+  });
+
+  test("passes mode=create to the platform hatch endpoint", async () => {
+    const fetchMock = mockHatchResponse(200);
+
+    const result = await hatchAssistant("vak_test", "https://platform.test", {
+      mode: "create",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://platform.test/v1/assistants/hatch/?mode=create",
+    );
+    expect(result.reusedExisting).toBe(true);
   });
 });

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -22,6 +22,7 @@ import {
   getPlatformUrl,
   hatchAssistant,
   readPlatformToken,
+  type PlatformHatchMode,
 } from "../lib/platform-client";
 import { validateAssistantName } from "../lib/retire-archive";
 
@@ -168,6 +169,7 @@ source ${INSTALL_SCRIPT_REMOTE_PATH}
 
 const DEFAULT_REMOTE: RemoteHost = "local";
 const UNSUPPORTED_REMOTE_HATCH_TARGETS = new Set<RemoteHost>(["aws", "gcp"]);
+const VALID_PLATFORM_HATCH_MODES: PlatformHatchMode[] = ["ensure", "create"];
 
 interface HatchArgs {
   species: Species;
@@ -175,6 +177,7 @@ interface HatchArgs {
   keepAlive: boolean;
   name: string | null;
   remote: RemoteHost;
+  platformMode: PlatformHatchMode;
   watch: boolean;
   sourcePath: string | null;
   configValues: Record<string, string>;
@@ -188,6 +191,7 @@ function parseArgs(): HatchArgs {
   let keepAlive = false;
   let name: string | null = null;
   let remote: RemoteHost = DEFAULT_REMOTE;
+  let platformMode: PlatformHatchMode = "ensure";
   let watch = false;
   let sourcePath: string | null = null;
   const configValues: Record<string, string> = {};
@@ -211,6 +215,9 @@ function parseArgs(): HatchArgs {
         "  --remote <host>           Remote host (local, gcp, aws, docker, custom, vellum)",
       );
       console.log(
+        "  --mode <ensure|create>    Platform hatch mode for --remote vellum. ensure reuses an existing assistant; create requests a new assistant.",
+      );
+      console.log(
         "  --watch                   Run assistant and gateway in watch mode (hot reload on source changes)",
       );
       console.log(
@@ -225,6 +232,11 @@ function parseArgs(): HatchArgs {
       console.log(
         "  --analyze                 Emit a structured hatch-timing log line on stdout",
       );
+      console.log("");
+      console.log("Examples:");
+      console.log("  vellum hatch");
+      console.log("  vellum hatch --remote docker --name local-test");
+      console.log("  vellum hatch --remote vellum --mode create");
       process.exit(0);
     } else if (arg === "-d") {
       detached = true;
@@ -268,6 +280,19 @@ function parseArgs(): HatchArgs {
       }
       remote = next as RemoteHost;
       i++;
+    } else if (arg === "--mode") {
+      const next = args[i + 1];
+      if (
+        !next ||
+        !VALID_PLATFORM_HATCH_MODES.includes(next as PlatformHatchMode)
+      ) {
+        console.error(
+          `Error: --mode requires one of: ${VALID_PLATFORM_HATCH_MODES.join(", ")}`,
+        );
+        process.exit(1);
+      }
+      platformMode = next as PlatformHatchMode;
+      i++;
     } else if (arg === "--config") {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
@@ -289,7 +314,7 @@ function parseArgs(): HatchArgs {
       species = arg as Species;
     } else {
       console.error(
-        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --config <key=value>, --analyze`,
+        `Error: Unknown argument '${arg}'. Valid options: ${VALID_SPECIES.join(", ")}, -d, --watch, --source <path>, --keep-alive, --name <name>, --remote <${VALID_REMOTE_HOSTS.join("|")}>, --mode <${VALID_PLATFORM_HATCH_MODES.join("|")}>, --config <key=value>, --analyze`,
       );
       process.exit(1);
     }
@@ -301,6 +326,7 @@ function parseArgs(): HatchArgs {
     keepAlive,
     name,
     remote,
+    platformMode,
     watch,
     sourcePath,
     configValues,
@@ -535,6 +561,7 @@ export async function hatch(): Promise<void> {
     keepAlive,
     name,
     remote,
+    platformMode,
     watch,
     sourcePath,
     configValues,
@@ -552,6 +579,11 @@ export async function hatch(): Promise<void> {
     console.error(
       "Error: --source is only supported for docker hatch targets.",
     );
+    process.exit(1);
+  }
+
+  if (platformMode !== "ensure" && remote !== "vellum") {
+    console.error("Error: --mode is only supported with --remote vellum.");
     process.exit(1);
   }
 
@@ -579,7 +611,7 @@ export async function hatch(): Promise<void> {
   }
 
   if (remote === "vellum") {
-    await hatchVellumPlatform();
+    await hatchVellumPlatform(platformMode);
     return;
   }
 
@@ -587,7 +619,7 @@ export async function hatch(): Promise<void> {
   process.exit(1);
 }
 
-async function hatchVellumPlatform(): Promise<void> {
+async function hatchVellumPlatform(mode: PlatformHatchMode): Promise<void> {
   const token = readPlatformToken();
   if (!token) {
     console.error("Not logged in. Run `vellum login --token <token>` first.");
@@ -603,7 +635,11 @@ async function hatchVellumPlatform(): Promise<void> {
   console.log("   Hatching assistant on Vellum platform...");
   console.log("");
 
-  const { assistant: result } = await hatchAssistant(token);
+  const { assistant: result, reusedExisting } = await hatchAssistant(
+    token,
+    undefined,
+    { mode },
+  );
 
   const platformUrl = getPlatformUrl();
 
@@ -621,5 +657,8 @@ async function hatchVellumPlatform(): Promise<void> {
   console.log(`   ID:     ${result.id}`);
   console.log(`   Name:   ${result.name}`);
   console.log(`   Status: ${result.status}`);
+  console.log(
+    `   Result: ${reusedExisting ? "reused existing assistant" : "created new assistant"}`,
+  );
   console.log("");
 }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -184,6 +184,12 @@ export interface HatchAssistantResult {
   reusedExisting: boolean;
 }
 
+export type PlatformHatchMode = "ensure" | "create";
+
+export interface HatchAssistantOptions {
+  mode?: PlatformHatchMode;
+}
+
 // ---------------------------------------------------------------------------
 // Self-hosted local assistant registration
 // ---------------------------------------------------------------------------
@@ -482,11 +488,15 @@ export async function injectCredentialsIntoAssistant(
 export async function hatchAssistant(
   token: string,
   platformUrl?: string,
+  options: HatchAssistantOptions = {},
 ): Promise<HatchAssistantResult> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const url = `${resolvedUrl}/v1/assistants/hatch/`;
+  const url = new URL("/v1/assistants/hatch/", resolvedUrl);
+  if (options.mode && options.mode !== "ensure") {
+    url.searchParams.set("mode", options.mode);
+  }
 
-  const response = await fetch(url, {
+  const response = await fetch(url.toString(), {
     method: "POST",
     headers: await authHeaders(token, platformUrl),
     body: JSON.stringify({}),


### PR DESCRIPTION
## Summary
- add a platform hatch mode flag for vellum hatch --remote vellum with default ensure behavior preserved
- send mode=create to the platform hatch endpoint when requested
- print whether the platform created a new assistant or reused an existing one so automation can assert the result

## Tests
- bun test src/__tests__/hatch.test.ts src/__tests__/platform-client.test.ts
- bunx tsc --noEmit
- bun run lint src/commands/hatch.ts src/lib/platform-client.ts src/__tests__/hatch.test.ts src/__tests__/platform-client.test.ts

## Follow-up
- The platform QA PR should switch desktop E2E hatching to vellum hatch --remote vellum --mode create and assert the CLI reports a newly created assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->