### PR TITLE
refactor(web): convert conversation-list-store to Zustand with direct named actions

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-app-viewer-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-app-viewer-actions.ts
@@ -11,7 +11,7 @@
  */
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, type MutableRefObject, type RefObject, useCallback, useEffect, useRef } from "react";
+import { type MutableRefObject, type RefObject, useCallback, useEffect, useRef } from "react";
 
 import { toast } from "@vellum/design-library";
 import { openApp, shareApp } from "@/domains/chat/lib/apps.js";
@@ -25,7 +25,7 @@ import type {
 } from "@/stores/viewer-store.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
 import type { Conversation } from "@/domains/chat/lib/api.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { haptic } from "@/utils/haptics.js";
 
 import { useActiveAppPinSync } from "@/domains/chat/hooks/use-active-app-pin-sync.js";
@@ -42,7 +42,6 @@ export interface UseAppViewerActionsParams {
   isSharing: boolean;
   isDeploying: boolean;
   pendingDeployAppId: string | null;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   lastConversationKeyRef: MutableRefObject<string | null>;
   deepLinkAppId: RefObject<string | undefined>;
   switchConversation: (key: string) => void;
@@ -84,7 +83,6 @@ export function useAppViewerActions({
   isSharing,
   isDeploying,
   pendingDeployAppId,
-  dispatchConversationList,
   lastConversationKeyRef,
   deepLinkAppId,
   switchConversation,
@@ -229,13 +227,13 @@ export function useAppViewerActions({
 
   const handleCloseApp = useCallback(() => {
     useViewerStore.getState().closeApp();
-    dispatchConversationList({ type: "SET_EDITING_KEY", key: null });
+    useConversationListStore.getState().setEditingKey(null);
     if (lastConversationKeyRef.current) {
       switchConversationRef.current(lastConversationKeyRef.current);
     } else {
       useViewerStore.getState().setMainView("chat");
     }
-  }, [dispatchConversationList, lastConversationKeyRef]);
+  }, [lastConversationKeyRef]);
 
   const handleToggleAppMinimized = useCallback(() => {
     useViewerStore.getState().toggleAppMinimized();
@@ -269,7 +267,7 @@ export function useAppViewerActions({
         setEditChatKey(assistantId, appId, conversationKey);
       }
 
-      dispatchConversationList({ type: "SET_EDITING_KEY", key: conversationKey });
+      useConversationListStore.getState().setEditingKey(conversationKey);
       useViewerStore.getState().enterAppEditing();
       if (activeConversationKey !== conversationKey) {
         pushConversationKeyParamRef.current(conversationKey);
@@ -279,7 +277,6 @@ export function useAppViewerActions({
       assistantId,
       conversations,
       activeConversationKey,
-      dispatchConversationList,
     ],
   );
 
@@ -303,9 +300,9 @@ export function useAppViewerActions({
   );
 
   const handleCloseEditPanel = useCallback(() => {
-    dispatchConversationList({ type: "SET_EDITING_KEY", key: null });
+    useConversationListStore.getState().setEditingKey(null);
     useViewerStore.getState().exitAppEditing();
-  }, [dispatchConversationList]);
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Share / Deploy
@@ -409,10 +406,10 @@ export function useAppViewerActions({
         activeAppId === appId &&
         (mainView === "app" || mainView === "app-editing")
       ) {
-        dispatchConversationList({ type: "SET_EDITING_KEY", key: null });
+        useConversationListStore.getState().setEditingKey(null);
       }
     },
-    [dispatchConversationList],
+    [],
   );
 
   useActiveAppPinSync(handleActiveAppUnpinned);

--- a/apps/web/src/domains/chat/hooks/use-attention-tracking.ts
+++ b/apps/web/src/domains/chat/hooks/use-attention-tracking.ts
@@ -1,7 +1,6 @@
 
 import * as Sentry from "@sentry/react";
 import {
-  type Dispatch,
   type MutableRefObject,
   useEffect,
   useRef,
@@ -12,7 +11,7 @@ import {
   listConversationKeysWithPendingInteractions,
   markConversationSeen,
 } from "@/domains/chat/lib/api.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import type { AssistantStateKind } from "@/domains/chat/types.js";
 
 interface UseAttentionTrackingParams {
@@ -30,8 +29,6 @@ interface UseAttentionTrackingParams {
   conversationsRef: MutableRefObject<Conversation[]>;
   processingSnapshotsRef: MutableRefObject<Map<string, string | undefined>>;
 
-  // State setters
-  dispatchConversationList: Dispatch<ConversationListAction>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +92,6 @@ export function useAttentionTracking({
   attentionKeys,
   conversationsRef,
   processingSnapshotsRef,
-  dispatchConversationList,
 }: UseAttentionTrackingParams) {
   const lastSeenOnOpenConversationKeyRef = useRef<string | null>(null);
   const initialAttentionSweepDoneRef = useRef(false);
@@ -116,7 +112,7 @@ export function useAttentionTracking({
     markConversationSeen(assistantId, activeConversationKey)
       .then(() => {
         if (cancelled) return;
-        dispatchConversationList({ type: "MARK_CONVERSATION_SEEN", key: activeConversationKey });
+        useConversationListStore.getState().markConversationSeen(activeConversationKey);
       })
       .catch((err) => {
         Sentry.captureException(err, {
@@ -132,7 +128,6 @@ export function useAttentionTracking({
     activeConversationKey,
     assistantId,
     assistantStateKind,
-    dispatchConversationList,
   ]);
 
   // -------------------------------------------------------------------------
@@ -168,15 +163,17 @@ export function useAttentionTracking({
       if (cancelled) return;
       const actions = decideGraduationDispatches(graduatingKeys, pendingKeys);
       for (const action of actions) {
-        dispatchConversationList(action);
-        if (action.type === "REMOVE_PROCESSING_KEY") {
+        if (action.type === "ADD_ATTENTION_KEY") {
+          useConversationListStore.getState().addAttentionKey(action.key);
+        } else {
+          useConversationListStore.getState().removeProcessingKey(action.key);
           processingSnapshotsRef.current.delete(action.key);
         }
       }
     })();
 
     return () => { cancelled = true; };
-  }, [conversations, processingKeys, activeConversationKey, assistantId, processingSnapshotsRef, dispatchConversationList]);
+  }, [conversations, processingKeys, activeConversationKey, assistantId, processingSnapshotsRef]);
 
   // -------------------------------------------------------------------------
   // Poll processing + attention conversations every 10s.
@@ -210,14 +207,14 @@ export function useAttentionTracking({
         if (key === activeConversationKey) continue;
         if (attentionKeys.has(key)) continue;
         if (pendingKeys.has(key)) {
-          dispatchConversationList({ type: "ADD_ATTENTION_KEY", key });
-          dispatchConversationList({ type: "REMOVE_PROCESSING_KEY", key });
+          useConversationListStore.getState().addAttentionKey(key);
+          useConversationListStore.getState().removeProcessingKey(key);
           continue;
         }
         const conv = conversationsRef.current.find((c) => c.conversationKey === key);
         const snapshot = processingSnapshotsRef.current.get(key);
         if (conv?.latestAssistantMessageAt && conv.latestAssistantMessageAt !== snapshot) {
-          dispatchConversationList({ type: "REMOVE_PROCESSING_KEY", key });
+          useConversationListStore.getState().removeProcessingKey(key);
           processingSnapshotsRef.current.delete(key);
         }
       }
@@ -226,7 +223,7 @@ export function useAttentionTracking({
       for (const key of attentionKeys) {
         if (key === activeConversationKey) continue;
         if (!pendingKeys.has(key)) {
-          dispatchConversationList({ type: "REMOVE_ATTENTION_KEY", key });
+          useConversationListStore.getState().removeAttentionKey(key);
         }
       }
     }, 10_000);
@@ -242,7 +239,6 @@ export function useAttentionTracking({
     activeConversationKey,
     conversationsRef,
     processingSnapshotsRef,
-    dispatchConversationList,
   ]);
 
   // -------------------------------------------------------------------------
@@ -267,11 +263,11 @@ export function useAttentionTracking({
       for (const conv of conversations) {
         if (conv.conversationKey === activeConversationKey) continue;
         if (pendingKeys.has(conv.conversationKey)) {
-          dispatchConversationList({ type: "ADD_ATTENTION_KEY", key: conv.conversationKey });
+          useConversationListStore.getState().addAttentionKey(conv.conversationKey);
         }
       }
     })();
 
     return () => { cancelled = true; };
-  }, [assistantId, conversations, activeConversationKey, dispatchConversationList]);
+  }, [assistantId, conversations, activeConversationKey]);
 }

--- a/apps/web/src/domains/chat/hooks/use-conversation-actions.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-actions.test.ts
@@ -2,31 +2,31 @@ import { describe, expect, test } from "bun:test";
 
 import type { Conversation } from "@/domains/chat/lib/api.js";
 
-import { patchConversation } from "@/domains/conversations/conversation-list-store.js";
+import { applyConversationPatch } from "@/domains/conversations/conversation-list-store.js";
 import { resolveUnpinGroupId } from "@/domains/chat/hooks/use-conversation-actions.js";
 
 // ---------------------------------------------------------------------------
-// patchConversation
+// applyConversationPatch
 // ---------------------------------------------------------------------------
 
 function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
   return { conversationKey: "conv-1", ...overrides };
 }
 
-describe("patchConversation", () => {
+describe("applyConversationPatch", () => {
   test("patches the matching conversation by key", () => {
     const convs = [
       makeConversation({ conversationKey: "a", title: "old" }),
       makeConversation({ conversationKey: "b", title: "keep" }),
     ];
-    const result = patchConversation(convs, "a", { title: "new" });
+    const result = applyConversationPatch(convs, "a", { title: "new" });
     expect(result[0]!.title).toBe("new");
     expect(result[1]!.title).toBe("keep");
   });
 
   test("returns a new array (immutable)", () => {
     const convs = [makeConversation()];
-    const result = patchConversation(convs, "conv-1", { title: "x" });
+    const result = applyConversationPatch(convs, "conv-1", { title: "x" });
     expect(result).not.toBe(convs);
     expect(result[0]).not.toBe(convs[0]);
   });
@@ -35,13 +35,13 @@ describe("patchConversation", () => {
     const convs = [
       makeConversation({ conversationKey: "a", title: "keep" }),
     ];
-    const result = patchConversation(convs, "no-match", { title: "nope" });
+    const result = applyConversationPatch(convs, "no-match", { title: "nope" });
     expect(result[0]!.title).toBe("keep");
   });
 
   test("applies multiple fields at once", () => {
     const convs = [makeConversation({ conversationKey: "a" })];
-    const result = patchConversation(convs, "a", {
+    const result = applyConversationPatch(convs, "a", {
       isPinned: true,
       groupId: "system:pinned",
     });
@@ -50,7 +50,7 @@ describe("patchConversation", () => {
   });
 
   test("handles empty array", () => {
-    const result = patchConversation([], "a", { title: "x" });
+    const result = applyConversationPatch([], "a", { title: "x" });
     expect(result).toEqual([]);
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -1,9 +1,8 @@
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, type MutableRefObject, useCallback } from "react";
+import { type MutableRefObject, useCallback } from "react";
 
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
-import { patchConversation as _patchConversation } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { isSlackConversation } from "@/domains/chat/lib/groupConversations.js";
 
 import {
@@ -49,18 +48,15 @@ export function resolveUnpinGroupId(
  * Conversation CRUD actions: archive, unarchive, rename, mark read/unread,
  * pin/unpin, and move between groups.
  *
- * All mutations apply an optimistic update via `dispatchConversationList`
+ * All mutations apply optimistic updates via `useConversationListStore`
  * before calling the API, and roll back on failure.
  *
- * @param dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Used for all optimistic state updates.
  * @returns Stable callbacks for each conversation action.
  */
 interface UseConversationActionsParams {
   assistantId: string | null;
   activeConversationKey: string | null;
   conversations: Conversation[];
-  dispatchConversationList: Dispatch<ConversationListAction>;
   refreshConversations: () => Promise<void>;
   switchConversation: (key: string) => void;
   startNewConversation: (opts?: { silent?: boolean }) => void;
@@ -71,7 +67,6 @@ export function useConversationActions({
   assistantId,
   activeConversationKey,
   conversations,
-  dispatchConversationList,
   refreshConversations,
   switchConversation,
   startNewConversation,
@@ -128,14 +123,14 @@ export function useConversationActions({
           assistantId,
           conversation.conversationKey,
         );
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { archivedAt: undefined } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { archivedAt: undefined });
       } catch (err) {
         Sentry.captureException(err, {
           tags: { context: "unarchiveConversation" },
         });
       }
     },
-    [assistantId, dispatchConversationList],
+    [assistantId],
   );
 
   const handleMarkConversationUnread = useCallback(
@@ -149,14 +144,14 @@ export function useConversationActions({
       }
       try {
         await markConversationUnread(assistantId, conversation.conversationKey);
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { hasUnseenLatestAssistantMessage: true } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { hasUnseenLatestAssistantMessage: true });
       } catch (err) {
         Sentry.captureException(err, {
           tags: { context: "markConversationUnread" },
         });
       }
     },
-    [assistantId, dispatchConversationList],
+    [assistantId],
   );
 
   const handleMarkConversationRead = useCallback(
@@ -165,14 +160,14 @@ export function useConversationActions({
       if (!conversation.hasUnseenLatestAssistantMessage) return;
       try {
         await markConversationSeen(assistantId, conversation.conversationKey);
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { hasUnseenLatestAssistantMessage: false } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { hasUnseenLatestAssistantMessage: false });
       } catch (err) {
         Sentry.captureException(err, {
           tags: { context: "markConversationRead" },
         });
       }
     },
-    [assistantId, dispatchConversationList],
+    [assistantId],
   );
 
   const handleTogglePinConversation = useCallback(
@@ -201,7 +196,7 @@ export function useConversationActions({
       const prevIsPinned = conversation.isPinned;
       const prevGroupId = conversation.groupId;
 
-      dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { isPinned: newIsPinned, groupId: newGroupId } });
+      useConversationListStore.getState().patchConversation(conversation.conversationKey, { isPinned: newIsPinned, groupId: newGroupId });
 
       try {
         await reorderConversations(assistantId, [
@@ -218,13 +213,13 @@ export function useConversationActions({
         if (newIsPinned) {
           prePinGroupIdsRef.current.delete(conversation.conversationKey);
         }
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { isPinned: prevIsPinned, groupId: prevGroupId } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { isPinned: prevIsPinned, groupId: prevGroupId });
         Sentry.captureException(err, {
           tags: { context: "togglePinConversation" },
         });
       }
     },
-    [assistantId, prePinGroupIdsRef, dispatchConversationList],
+    [assistantId, prePinGroupIdsRef],
   );
 
   const handleMoveToGroup = useCallback(
@@ -243,7 +238,7 @@ export function useConversationActions({
         );
       }
 
-      dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { isPinned: newIsPinned, groupId } });
+      useConversationListStore.getState().patchConversation(conversation.conversationKey, { isPinned: newIsPinned, groupId });
 
       try {
         await reorderConversations(assistantId, [
@@ -260,13 +255,13 @@ export function useConversationActions({
         if (newIsPinned) {
           prePinGroupIdsRef.current.delete(conversation.conversationKey);
         }
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { isPinned: prevIsPinned, groupId: prevGroupId } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { isPinned: prevIsPinned, groupId: prevGroupId });
         Sentry.captureException(err, {
           tags: { context: "moveToGroup" },
         });
       }
     },
-    [assistantId, prePinGroupIdsRef, dispatchConversationList],
+    [assistantId, prePinGroupIdsRef],
   );
 
   const handleRemoveFromGroup = useCallback(
@@ -288,7 +283,7 @@ export function useConversationActions({
       const trimmed = next.trim();
       if (!trimmed || trimmed === current) return;
 
-      dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { title: trimmed } });
+      useConversationListStore.getState().patchConversation(conversation.conversationKey, { title: trimmed });
 
       try {
         await renameConversation(
@@ -297,13 +292,13 @@ export function useConversationActions({
           trimmed,
         );
       } catch (err) {
-        dispatchConversationList({ type: "PATCH_CONVERSATION", key: conversation.conversationKey, patch: { title: current } });
+        useConversationListStore.getState().patchConversation(conversation.conversationKey, { title: current });
         Sentry.captureException(err, {
           tags: { context: "renameConversation" },
         });
       }
     },
-    [assistantId, dispatchConversationList],
+    [assistantId],
   );
 
   return {

--- a/apps/web/src/domains/chat/hooks/use-conversation-group-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-group-actions.ts
@@ -1,8 +1,8 @@
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, useCallback } from "react";
+import { useCallback } from "react";
 
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 
 import {
   type ConversationGroup,
@@ -34,26 +34,22 @@ export function patchGroup(
 /**
  * Folder/group CRUD actions: create, rename, and delete conversation groups.
  *
- * Each action applies an optimistic update via `dispatchConversationList`
+ * Each action applies an optimistic update via `useConversationListStore`
  * before hitting the API. On failure, create/rename roll back optimistically;
  * delete refetches the full conversation list for accuracy.
  *
- * @param dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Used for all optimistic group mutations.
  * @returns Stable callbacks: `handleCreateGroup`, `handleRenameGroup`,
  *   `handleDeleteGroup`.
  */
 interface UseConversationGroupActionsParams {
   assistantId: string | null;
   conversationGroups: ConversationGroup[];
-  dispatchConversationList: Dispatch<ConversationListAction>;
   refreshConversations: () => Promise<void>;
 }
 
 export function useConversationGroupActions({
   assistantId,
   conversationGroups,
-  dispatchConversationList,
   refreshConversations,
 }: UseConversationGroupActionsParams) {
   const handleCreateGroup = useCallback(async () => {
@@ -68,18 +64,18 @@ export function useConversationGroupActions({
     if (!trimmed) return;
 
     const optimisticId = `optimistic-${Date.now()}`;
-    dispatchConversationList({ type: "APPEND_GROUP", group: { id: optimisticId, name: trimmed, sortPosition: 0, isSystemGroup: false } });
+    useConversationListStore.getState().appendGroup({ id: optimisticId, name: trimmed, sortPosition: 0, isSystemGroup: false });
 
     try {
       const created = await createGroup(assistantId, trimmed);
-      dispatchConversationList({ type: "REPLACE_OPTIMISTIC_GROUP", optimisticId, group: created });
+      useConversationListStore.getState().replaceOptimisticGroup(optimisticId, created);
     } catch (err) {
-      dispatchConversationList({ type: "REMOVE_GROUP", groupId: optimisticId });
+      useConversationListStore.getState().removeGroup(optimisticId);
       Sentry.captureException(err, {
         tags: { context: "createGroup" },
       });
     }
-  }, [assistantId, dispatchConversationList]);
+  }, [assistantId]);
 
   const handleRenameGroup = useCallback(
     async (groupId: string) => {
@@ -93,18 +89,18 @@ export function useConversationGroupActions({
       const trimmed = next.trim();
       if (!trimmed || trimmed === current) return;
 
-      dispatchConversationList({ type: "PATCH_GROUP", groupId, patch: { name: trimmed } });
+      useConversationListStore.getState().patchGroup(groupId, { name: trimmed });
 
       try {
         await updateGroup(assistantId, groupId, { name: trimmed });
       } catch (err) {
-        dispatchConversationList({ type: "PATCH_GROUP", groupId, patch: { name: current } });
+        useConversationListStore.getState().patchGroup(groupId, { name: current });
         Sentry.captureException(err, {
           tags: { context: "renameGroup" },
         });
       }
     },
-    [assistantId, conversationGroups, dispatchConversationList],
+    [assistantId, conversationGroups],
   );
 
   const handleDeleteGroup = useCallback(
@@ -112,7 +108,7 @@ export function useConversationGroupActions({
       if (!assistantId) return;
       haptic.medium();
 
-      dispatchConversationList({ type: "DELETE_GROUP_AND_RESET_CONVERSATIONS", groupId });
+      useConversationListStore.getState().deleteGroupAndResetConversations(groupId);
 
       try {
         await deleteGroup(assistantId, groupId);
@@ -126,7 +122,7 @@ export function useConversationGroupActions({
         });
       }
     },
-    [assistantId, dispatchConversationList, refreshConversations],
+    [assistantId, refreshConversations],
   );
 
   return {

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -30,7 +30,7 @@ import type { TranscriptPaginationState } from "@/domains/chat/lib/transcript/ty
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import { useTurnStore } from "@/domains/messaging/turn-store.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 import type { SubagentStatus } from "@/domains/chat/lib/event-types.js";
 
@@ -119,7 +119,6 @@ interface UseConversationHistoryParams {
   loadEpochRef: MutableRefObject<number>;
 
   // State setters
-  dispatchConversationList: Dispatch<ConversationListAction>;
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setTranscriptPagination: Dispatch<SetStateAction<Omit<TranscriptPaginationState, "items">>>;
   setIsLoadingHistory: Dispatch<SetStateAction<boolean>>;
@@ -192,7 +191,6 @@ export function useConversationHistory({
   isLoadingOlderRef,
   historyLoadedRef,
   loadEpochRef,
-  dispatchConversationList,
   setMessages,
   setTranscriptPagination,
   setIsLoadingHistory,
@@ -249,7 +247,7 @@ export function useConversationHistory({
       // needing attention so the sidebar shows an alert icon.
       const interactionSnapshot = useInteractionStore.getState();
       if (interactionSnapshot.pendingSecret || interactionSnapshot.pendingConfirmation) {
-        dispatchConversationList({ type: "ADD_ATTENTION_KEY", key: outgoingKey });
+        useConversationListStore.getState().addAttentionKey(outgoingKey);
       }
       // Cache outgoing conversation's messages (LRU eviction)
       const outgoingMessages = messagesRef.current;
@@ -400,7 +398,7 @@ export function useConversationHistory({
           }
         }
         if (!interactions.pendingSecret && !interactions.pendingConfirmation) {
-          dispatchConversationList({ type: "REMOVE_ATTENTION_KEY", key: activeConversationKey });
+          useConversationListStore.getState().removeAttentionKey(activeConversationKey);
         }
       } catch {
         // Keep attention key on failure -- the prompt wasn't restored.
@@ -657,7 +655,6 @@ export function useConversationHistory({
     setMessages,
     setTranscriptPagination,
     setIsLoadingHistory,
-    dispatchConversationList,
     setError,
     setAutoGreetPending,
     setContextWindowUsage,

--- a/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -34,7 +34,7 @@ import type { TranscriptPaginationState } from "@/domains/chat/lib/transcript/ty
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 
 
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { haptic } from "@/utils/haptics.js";
 
 import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
@@ -124,7 +124,6 @@ interface UseConversationLoaderParams {
 
   // State setters
   setAssistantId: Dispatch<SetStateAction<string | null>>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setTranscriptPagination: Dispatch<SetStateAction<Omit<TranscriptPaginationState, "items">>>;
   setIsLoadingHistory: Dispatch<SetStateAction<boolean>>;
@@ -214,7 +213,6 @@ export function useConversationLoader({
   loadEpochRef,
   pendingInitialMessageRef,
   setAssistantId,
-  dispatchConversationList,
   setMessages,
   setTranscriptPagination,
   setIsLoadingHistory,
@@ -244,7 +242,7 @@ export function useConversationLoader({
     if (!assistantId) return;
     try {
       const updated = await listConversations(assistantId);
-      dispatchConversationList({ type: "SET_CONVERSATIONS", conversations: updated });
+      useConversationListStore.getState().setConversations(updated);
     } catch (err) {
       Sentry.captureException(err, {
         tags: { context: "refresh_conversations" },
@@ -252,7 +250,7 @@ export function useConversationLoader({
     }
     if (conversationGroupsUI) {
       fetchGroups(assistantId)
-        .then((groups) => dispatchConversationList({ type: "SET_GROUPS", groups }))
+        .then((groups) => useConversationListStore.getState().setGroups(groups))
         .catch((err) => {
           Sentry.captureException(err, {
             level: "warning",
@@ -260,7 +258,7 @@ export function useConversationLoader({
           });
         });
     }
-  }, [assistantId, conversationGroupsUI, dispatchConversationList]);
+  }, [assistantId, conversationGroupsUI]);
 
   // Keep the ref in sync so the debounced scheduler always calls the latest.
   useEffect(() => {
@@ -340,12 +338,12 @@ export function useConversationLoader({
         setError((prev) =>
           prev?.code === CHAT_CONTEXT_LOAD_FAILED_CODE ? null : prev,
         );
-        dispatchConversationList({ type: "SET_CONVERSATIONS", conversations: ctx.conversations });
+        useConversationListStore.getState().setConversations(ctx.conversations);
 
         if (conversationGroupsUI) {
           fetchGroups(ctx.assistantId)
             .then((groups) => {
-              if (!cancelled) dispatchConversationList({ type: "SET_GROUPS", groups });
+              if (!cancelled) useConversationListStore.getState().setGroups(groups);
             })
             .catch((err) => {
               Sentry.captureException(err, {
@@ -355,7 +353,7 @@ export function useConversationLoader({
             });
         }
 
-        dispatchConversationList({ type: "SET_ACTIVE_KEY", key });
+        useConversationListStore.getState().setActiveKey(key);
       } catch (err) {
         if (cancelled) return;
         if (err instanceof ApiError && err.status === 401) {
@@ -399,7 +397,6 @@ export function useConversationLoader({
     conversationGroupsUI,
     setAssistantId,
     setError,
-    dispatchConversationList,
     shouldSuppressGenericChatErrorNotice,
   ]);
 
@@ -453,7 +450,6 @@ export function useConversationLoader({
     isLoadingOlderRef,
     historyLoadedRef,
     loadEpochRef,
-    dispatchConversationList,
     setMessages,
     setTranscriptPagination,
     setIsLoadingHistory,
@@ -482,7 +478,6 @@ export function useConversationLoader({
     attentionKeys,
     conversationsRef,
     processingSnapshotsRef,
-    dispatchConversationList,
   });
 
   // -------------------------------------------------------------------------
@@ -510,13 +505,13 @@ export function useConversationLoader({
       if (initialMessage) {
         pendingInitialMessageRef.current = { conversationKey: draftKey, content: initialMessage };
       }
-      dispatchConversationList({ type: "SET_ACTIVE_KEY", key: draftKey });
+      useConversationListStore.getState().setActiveKey(draftKey);
       navPush({ type: "conversation", key: draftKey });
       const params = new URLSearchParams(searchParams.toString());
       params.set("conversationKey", draftKey);
       pushRoute(`?${params.toString()}`);
     },
-    [pushRoute, searchParams, navPush, setMainView, pendingInitialMessageRef, dispatchConversationList],
+    [pushRoute, searchParams, navPush, setMainView, pendingInitialMessageRef],
   );
 
   return {

--- a/apps/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-event-stream.ts
@@ -50,7 +50,7 @@ import type {
   WebSyncRouter,
 } from "@/lib/sync/web-sync-router.js";
 
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import type { DisplayMessage } from "@/domains/chat/lib/reconcile.js";
 import { isSending, useTurnStore } from "@/domains/messaging/turn-store.js";
 
@@ -90,7 +90,6 @@ export interface UseEventStreamParams {
   reachabilityReset: () => void;
 
   // Conversation list
-  dispatchConversationList: Dispatch<ConversationListAction>;
   processingSnapshotsRef: MutableRefObject<Map<string, string | undefined>>;
 
   // Messages
@@ -142,7 +141,6 @@ export function useEventStream({
   reachabilityProbe,
   reachabilityPhase,
   reachabilityReset,
-  dispatchConversationList,
   processingSnapshotsRef,
   setMessages,
   setError,
@@ -171,9 +169,6 @@ export function useEventStream({
 
   const reachabilityProbeRef = useRef(reachabilityProbe);
   reachabilityProbeRef.current = reachabilityProbe;
-
-  const dispatchConversationListRef = useRef(dispatchConversationList);
-  dispatchConversationListRef.current = dispatchConversationList;
 
   const setMessagesRef = useRef(setMessages);
   setMessagesRef.current = setMessages;
@@ -255,10 +250,7 @@ export function useEventStream({
           {
             const convKey = streamContextRef.current?.conversationKey;
             if (convKey) {
-              dispatchConversationListRef.current({
-                type: "REMOVE_PROCESSING_KEY",
-                key: convKey,
-              });
+              useConversationListStore.getState().removeProcessingKey(convKey);
               processingSnapshotsRef.current.delete(convKey);
             }
           }

--- a/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
@@ -29,7 +29,7 @@ import {
 import { addTrustRule } from "@/domains/trust-rules/api.js";
 import type { DisplayMessage } from "@/domains/chat/lib/reconcile.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { useTurnStore } from "@/domains/messaging/turn-store.js";
 
 import { clearConfirmationByRequestId } from "@/domains/chat/hooks/send-message-utils.js";
@@ -74,8 +74,6 @@ export interface ToolCallRuleContext {
 // ---------------------------------------------------------------------------
 
 export interface UseInteractionActionsParams {
-  dispatchConversationList: Dispatch<ConversationListAction>;
-
   setMessages: Dispatch<DisplayMessage[] | ((prev: DisplayMessage[]) => DisplayMessage[])>;
   setError: Dispatch<ChatError | null>;
   messagesRef: MutableRefObject<DisplayMessage[]>;
@@ -113,7 +111,6 @@ export interface UseInteractionActionsReturn {
 // ---------------------------------------------------------------------------
 
 export function useInteractionActions({
-  dispatchConversationList,
   setMessages,
   setError,
   messagesRef,
@@ -168,7 +165,7 @@ export function useInteractionActions({
         useInteractionStore.getState().submitSecretEnd(true);
         const convKey = activeConversationKeyRef.current;
         if (convKey) {
-          dispatchConversationList({ type: "REMOVE_ATTENTION_KEY", key: convKey });
+          useConversationListStore.getState().removeAttentionKey(convKey);
         }
         const savedRequestId = pendingSecret.requestId;
         setTimeout(() => {
@@ -195,7 +192,7 @@ export function useInteractionActions({
     useInteractionStore.getState().dismissSecret();
     const convKey = activeConversationKeyRef.current;
     if (convKey) {
-      dispatchConversationList({ type: "REMOVE_ATTENTION_KEY", key: convKey });
+      useConversationListStore.getState().removeAttentionKey(convKey);
     }
     useTurnStore.getState().onStreamError();
   }, []);
@@ -270,7 +267,7 @@ export function useInteractionActions({
       useInteractionStore.getState().setInlineConfirmationToolCallId(null);
       const convKey = activeConversationKeyRef.current;
       if (convKey) {
-        dispatchConversationList({ type: "REMOVE_ATTENTION_KEY", key: convKey });
+        useConversationListStore.getState().removeAttentionKey(convKey);
       }
 
       // Clear inline confirmation from the matched tool call by requestId

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -41,7 +41,7 @@ import { newStableId } from "@/domains/chat/lib/stable-id.js";
 import { saveDismissedSurfaceIds } from "@/domains/chat/lib/dismissedSurfacesStorage.js";
 import { isSending, useTurnStore } from "@/domains/messaging/turn-store.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 import type { PreChatOnboardingContext } from "@/lib/onboarding/prechat.js";
 
@@ -108,7 +108,6 @@ interface UseSendMessageParams {
   // State setters
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
   setError: Dispatch<SetStateAction<ChatError | null>>;
-  dispatchConversationList: Dispatch<ConversationListAction>;
   setStreamRetryNonce: Dispatch<SetStateAction<number>>;
   setInput: Dispatch<SetStateAction<string>>;
 
@@ -151,7 +150,6 @@ export function useSendMessage({
   confirmationToolCallMapRef,
   setMessages,
   setError,
-  dispatchConversationList,
   setStreamRetryNonce,
   setInput,
   startReconciliationLoop,
@@ -491,7 +489,7 @@ export function useSendMessage({
             const fallbackTurnId = newTurnId();
             useTurnStore.getState().requestSend(fallbackTurnId);
             useTurnStore.getState().acceptSend(fallbackTurnId);
-            dispatchConversationList({ type: "ADD_PROCESSING_KEY", key: activeConversationKey });
+            useConversationListStore.getState().addProcessingKey(activeConversationKey);
             const currentConv = conversationsRef.current.find(
               (c) => c.conversationKey === activeConversationKey,
             );
@@ -511,7 +509,7 @@ export function useSendMessage({
       const turnId = newTurnId();
       useTurnStore.getState().requestSend(turnId);
 
-      dispatchConversationList({ type: "ADD_PROCESSING_KEY", key: activeConversationKey });
+      useConversationListStore.getState().addProcessingKey(activeConversationKey);
       const currentConv = conversationsRef.current.find(c => c.conversationKey === activeConversationKey);
       processingSnapshotsRef.current.set(
         activeConversationKey,
@@ -521,7 +519,7 @@ export function useSendMessage({
       // Optimistically add a stub conversation to the sidebar for draft
       // conversations that don't exist on the server yet.
       if (!currentConv) {
-        dispatchConversationList({ type: "PREPEND_CONVERSATION", conversation: { conversationKey: activeConversationKey, lastMessageAt: new Date().toISOString(), draft: true } as Conversation });
+        useConversationListStore.getState().prependConversation({ conversationKey: activeConversationKey, lastMessageAt: new Date().toISOString(), draft: true } as Conversation);
       }
 
       cancelReconciliation();
@@ -541,21 +539,21 @@ export function useSendMessage({
         // Resolve draft key -> server-assigned conversation ID.
         if (resolvedId && resolvedId !== activeConversationKey) {
           const newKey = resolvedId;
-          dispatchConversationList({ type: "TRANSFER_PROCESSING_KEY", oldKey: activeConversationKey, newKey });
+          useConversationListStore.getState().transferProcessingKey(activeConversationKey, newKey);
           const snapshot = processingSnapshotsRef.current.get(activeConversationKey);
           processingSnapshotsRef.current.delete(activeConversationKey);
           if (snapshot !== undefined) {
             processingSnapshotsRef.current.set(newKey, snapshot);
           }
           navRemapKey(activeConversationKey, newKey);
-          dispatchConversationList({ type: "RESOLVE_DRAFT_KEY", oldKey: activeConversationKey, newKey });
+          useConversationListStore.getState().resolveDraftKey(activeConversationKey, newKey);
           resolveEditChatDraftKey(activeConversationKey, newKey);
 
           // Only update active view state if the user is still on this conversation.
           if (activeConversationKeyRef.current === activeConversationKey) {
             draftKeyResolutionRef.current = true;
             previousConversationKeyRef.current = newKey;
-            dispatchConversationList({ type: "SET_ACTIVE_KEY", key: newKey });
+            useConversationListStore.getState().setActiveKey(newKey);
             const params = new URLSearchParams(window.location.search);
             params.set("conversationKey", newKey);
             replaceUrl(`?${params.toString()}`);
@@ -575,10 +573,10 @@ export function useSendMessage({
         const keysToClean = [activeConversationKey, resolvedId].filter(Boolean) as string[];
         for (const k of keysToClean) processingSnapshotsRef.current.delete(k);
         if (keysToClean.length > 0) {
-          dispatchConversationList({ type: "REMOVE_MULTIPLE_PROCESSING_KEYS", keys: keysToClean });
+          useConversationListStore.getState().removeMultipleProcessingKeys(keysToClean);
         }
         if (isDraft) {
-          dispatchConversationList({ type: "REMOVE_CONVERSATION", key: activeConversationKey });
+          useConversationListStore.getState().removeConversation(activeConversationKey);
         }
       }
     },
@@ -605,7 +603,7 @@ export function useSendMessage({
     useInteractionStore.getState().resetAll();
     useSubagentStore.getState().reset();
     confirmationToolCallMapRef.current.clear();
-    dispatchConversationList({ type: "REMOVE_PROCESSING_KEY", key: activeConversationKey });
+    useConversationListStore.getState().removeProcessingKey(activeConversationKey);
     processingSnapshotsRef.current.delete(activeConversationKey);
     try {
       await cancelGeneration(assistantId, activeConversationKey);

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -1,14 +1,14 @@
 
 import {
-  type Dispatch,
   type MutableRefObject,
+  type Dispatch,
   type SetStateAction,
   useCallback,
   useRef,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import type {
   AssistantEvent,
   AssistantSyncChangedEvent,
@@ -98,7 +98,6 @@ export interface UseStreamEventHandlerParams {
   needsNewBubbleRef: MutableRefObject<boolean>;
 
   // --- Processing ---
-  dispatchConversationList: Dispatch<ConversationListAction>;
   processingSnapshotsRef: MutableRefObject<
     Map<string, string | undefined>
   >;
@@ -161,9 +160,6 @@ interface UseStreamEventHandlerReturn {
  * Builds a `StreamHandlerContext` on each call and delegates to the
  * appropriate handler based on event type via an exhaustive switch.
  *
- * @param params.dispatchConversationList - Dispatch function from the
- *   `conversationListReducer`. Passed through to handlers that update
- *   conversation state (e.g., title updates, processing key removal).
  * @returns `handleStreamEvent(event, epoch)` — call this for each SSE event.
  */
 export function useStreamEventHandler(
@@ -181,7 +177,6 @@ export function useStreamEventHandler(
     setMessages,
     messagesRef,
     needsNewBubbleRef,
-    dispatchConversationList,
     processingSnapshotsRef,
     setError,
     streamRef,
@@ -222,10 +217,10 @@ export function useStreamEventHandler(
   /** Remove a conversation key from the processing set and snapshots map. */
   const clearProcessingKey = useCallback(
     (convKey: string) => {
-      dispatchConversationList({ type: "REMOVE_PROCESSING_KEY", key: convKey });
+      useConversationListStore.getState().removeProcessingKey(convKey);
       processingSnapshotsRef.current.delete(convKey);
     },
-    [dispatchConversationList, processingSnapshotsRef],
+    [processingSnapshotsRef],
   );
 
   // --- Main event handler ---
@@ -299,7 +294,6 @@ export function useStreamEventHandler(
         contextWindowUsageByConversationRef,
         setContextWindowUsage,
         scheduleConversationListRefetch,
-        dispatchConversationList,
         setCompactionCircuitOpenUntil,
         applyDiskPressureStatusEvent: (...args) =>
           applyDiskPressureStatusEventRef.current(...args),
@@ -467,7 +461,6 @@ export function useStreamEventHandler(
       dismissedSurfaceIdsRef,
       contextWindowUsageByConversationRef,
       setContextWindowUsage,
-      dispatchConversationList,
       setCompactionCircuitOpenUntil,
       pendingQueuedStableIdsRef,
       requestIdToStableIdRef,

--- a/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
+import type { Conversation } from "@/domains/chat/lib/api.js";
 import {
   handleUsageUpdate,
   handleConversationListInvalidated,
@@ -86,7 +88,15 @@ describe("handleConversationListInvalidated", () => {
 });
 
 describe("handleConversationTitleUpdated", () => {
-  it("dispatches PATCH_CONVERSATION with updated title", () => {
+  afterEach(() => {
+    useConversationListStore.getState().reset();
+  });
+
+  it("patches conversation title in the store", () => {
+    useConversationListStore.getState().setConversations([
+      { conversationKey: "conv-1", title: "Old Title" } as Conversation,
+    ]);
+
     const ctx = makeCtx();
     handleConversationTitleUpdated(
       {
@@ -96,11 +106,10 @@ describe("handleConversationTitleUpdated", () => {
       },
       ctx,
     );
-    expect(ctx.dispatchConversationList).toHaveBeenCalledWith({
-      type: "PATCH_CONVERSATION",
-      key: "conv-1",
-      patch: { title: "New Title" },
-    });
+    const conv = useConversationListStore.getState().conversations.find(
+      (c) => c.conversationKey === "conv-1",
+    );
+    expect(conv?.title).toBe("New Title");
   });
 });
 

--- a/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/metadata-handlers.ts
@@ -16,6 +16,7 @@ import {
   postLocalNotification,
   sendNotificationIntentAck,
 } from "@/runtime/notifications.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types.js";
 
 export function handleUsageUpdate(
@@ -65,9 +66,9 @@ export function handleConversationListInvalidated(
 
 export function handleConversationTitleUpdated(
   event: ConversationTitleUpdatedEvent,
-  ctx: StreamHandlerContext,
+  _ctx: StreamHandlerContext,
 ): void {
-  ctx.dispatchConversationList({ type: "PATCH_CONVERSATION", key: event.conversationId, patch: { title: event.title } });
+  useConversationListStore.getState().patchConversation(event.conversationId, { title: event.title });
 }
 
 export function handleNotificationIntent(

--- a/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -58,7 +58,6 @@ export function makeCtx(
     contextWindowUsageByConversationRef: { current: new Map() },
     setContextWindowUsage: mock(() => {}),
     scheduleConversationListRefetch: mock(() => {}),
-    dispatchConversationList: mock(() => {}),
     setCompactionCircuitOpenUntil: mock(() => {}),
     applyDiskPressureStatusEvent: mock(() => {}),
     refreshAssistantIdentity: mock(() => Promise.resolve()),

--- a/apps/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -4,7 +4,6 @@ import type {
   SetStateAction,
 } from "react";
 import type { ChatEventStream } from "@/domains/chat/lib/api.js";
-import type { ConversationListAction } from "@/domains/conversations/conversation-list-store.js";
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import type { DisplayMessage } from "@/domains/chat/lib/reconcile.js";
 import type { TurnActions, TurnState } from "@/domains/messaging/turn-store.js";
@@ -78,7 +77,6 @@ export interface StreamHandlerContext {
 
   // --- Conversations ---
   scheduleConversationListRefetch: () => void;
-  dispatchConversationList: Dispatch<ConversationListAction>;
 
   // --- Compaction ---
   setCompactionCircuitOpenUntil: Dispatch<SetStateAction<Date | null>>;

--- a/apps/web/src/domains/conversations/conversation-list-store.test.ts
+++ b/apps/web/src/domains/conversations/conversation-list-store.test.ts
@@ -1,11 +1,7 @@
-import { describe, it, expect } from "bun:test";
+import { afterEach, describe, it, expect } from "bun:test";
 
 import type { Conversation, ConversationGroup } from "@/domains/chat/lib/api.js";
-import {
-  type ConversationListState,
-  INITIAL_CONVERSATION_LIST_STATE,
-  conversationListReducer,
-} from "@/domains/conversations/conversation-list-store.js";
+import { useConversationListStore } from "@/domains/conversations/conversation-list-store.js";
 
 function makeConversation(key: string, overrides?: Partial<Conversation>): Conversation {
   return { conversationKey: key, ...overrides } as Conversation;
@@ -15,124 +11,90 @@ function makeGroup(id: string, name: string, overrides?: Partial<ConversationGro
   return { id, name, sortPosition: 0, isSystemGroup: false, ...overrides };
 }
 
-function stateWith(overrides: Partial<ConversationListState>): ConversationListState {
-  return { ...INITIAL_CONVERSATION_LIST_STATE, ...overrides };
+function getState() {
+  return useConversationListStore.getState();
 }
+
+afterEach(() => {
+  getState().reset();
+});
 
 // ---------------------------------------------------------------------------
 // Conversations
 // ---------------------------------------------------------------------------
 
-describe("conversationListReducer", () => {
-  describe("SET_CONVERSATIONS", () => {
+describe("useConversationListStore", () => {
+  describe("setConversations", () => {
     it("replaces the conversation list", () => {
       const convs = [makeConversation("a"), makeConversation("b")];
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "SET_CONVERSATIONS",
-        conversations: convs,
-      });
-      expect(next.conversations).toBe(convs);
+      getState().setConversations(convs);
+      expect(getState().conversations).toBe(convs);
     });
   });
 
-  describe("PATCH_CONVERSATION", () => {
+  describe("patchConversation", () => {
     it("patches the matching conversation", () => {
-      const state = stateWith({
-        conversations: [makeConversation("a", { title: "old" }), makeConversation("b")],
-      });
-      const next = conversationListReducer(state, {
-        type: "PATCH_CONVERSATION",
-        key: "a",
-        patch: { title: "new" },
-      });
-      expect(next.conversations[0]!.title).toBe("new");
-      expect(next.conversations[1]).toBe(state.conversations[1]!);
+      const convs = [makeConversation("a", { title: "old" }), makeConversation("b")];
+      getState().setConversations(convs);
+      getState().patchConversation("a", { title: "new" });
+      expect(getState().conversations[0]!.title).toBe("new");
+      expect(getState().conversations[1]).toBe(convs[1]!);
     });
 
     it("returns the same conversations array when key is not found", () => {
-      const state = stateWith({
-        conversations: [makeConversation("a")],
-      });
-      const next = conversationListReducer(state, {
-        type: "PATCH_CONVERSATION",
-        key: "missing",
-        patch: { title: "x" },
-      });
-      expect(next.conversations).toBe(state.conversations);
+      const convs = [makeConversation("a")];
+      getState().setConversations(convs);
+      getState().patchConversation("missing", { title: "x" });
+      expect(getState().conversations).toBe(convs);
     });
   });
 
-  describe("MARK_CONVERSATION_SEEN", () => {
+  describe("markConversationSeen", () => {
     it("clears the unseen flag and sets lastSeenAssistantMessageAt", () => {
-      const state = stateWith({
-        conversations: [
-          makeConversation("a", {
-            hasUnseenLatestAssistantMessage: true,
-            latestAssistantMessageAt: "2024-01-01T00:00:00Z",
-          }),
-        ],
-      });
-      const next = conversationListReducer(state, {
-        type: "MARK_CONVERSATION_SEEN",
-        key: "a",
-      });
-      expect(next.conversations[0]!.hasUnseenLatestAssistantMessage).toBe(false);
-      expect(next.conversations[0]!.lastSeenAssistantMessageAt).toBe("2024-01-01T00:00:00Z");
+      getState().setConversations([
+        makeConversation("a", {
+          hasUnseenLatestAssistantMessage: true,
+          latestAssistantMessageAt: "2024-01-01T00:00:00Z",
+        }),
+      ]);
+      getState().markConversationSeen("a");
+      expect(getState().conversations[0]!.hasUnseenLatestAssistantMessage).toBe(false);
+      expect(getState().conversations[0]!.lastSeenAssistantMessageAt).toBe("2024-01-01T00:00:00Z");
     });
 
     it("uses explicit lastSeenAssistantMessageAt when provided", () => {
-      const state = stateWith({
-        conversations: [
-          makeConversation("a", { hasUnseenLatestAssistantMessage: true }),
-        ],
-      });
-      const next = conversationListReducer(state, {
-        type: "MARK_CONVERSATION_SEEN",
-        key: "a",
-        lastSeenAssistantMessageAt: "2024-06-01T00:00:00Z",
-      });
-      expect(next.conversations[0]!.lastSeenAssistantMessageAt).toBe("2024-06-01T00:00:00Z");
+      getState().setConversations([
+        makeConversation("a", { hasUnseenLatestAssistantMessage: true }),
+      ]);
+      getState().markConversationSeen("a", "2024-06-01T00:00:00Z");
+      expect(getState().conversations[0]!.lastSeenAssistantMessageAt).toBe("2024-06-01T00:00:00Z");
     });
   });
 
-  describe("PREPEND_CONVERSATION", () => {
+  describe("prependConversation", () => {
     it("adds to front of list", () => {
-      const state = stateWith({ conversations: [makeConversation("b")] });
-      const next = conversationListReducer(state, {
-        type: "PREPEND_CONVERSATION",
-        conversation: makeConversation("a"),
-      });
-      expect(next.conversations).toHaveLength(2);
-      expect(next.conversations[0]!.conversationKey).toBe("a");
+      getState().setConversations([makeConversation("b")]);
+      getState().prependConversation(makeConversation("a"));
+      expect(getState().conversations).toHaveLength(2);
+      expect(getState().conversations[0]!.conversationKey).toBe("a");
     });
   });
 
-  describe("REMOVE_CONVERSATION", () => {
+  describe("removeConversation", () => {
     it("removes the matching conversation", () => {
-      const state = stateWith({
-        conversations: [makeConversation("a"), makeConversation("b")],
-      });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_CONVERSATION",
-        key: "a",
-      });
-      expect(next.conversations).toHaveLength(1);
-      expect(next.conversations[0]!.conversationKey).toBe("b");
+      getState().setConversations([makeConversation("a"), makeConversation("b")]);
+      getState().removeConversation("a");
+      expect(getState().conversations).toHaveLength(1);
+      expect(getState().conversations[0]!.conversationKey).toBe("b");
     });
   });
 
-  describe("RESOLVE_DRAFT_KEY", () => {
+  describe("resolveDraftKey", () => {
     it("remaps the conversation key and clears draft flag", () => {
-      const state = stateWith({
-        conversations: [makeConversation("draft-1", { draft: true })],
-      });
-      const next = conversationListReducer(state, {
-        type: "RESOLVE_DRAFT_KEY",
-        oldKey: "draft-1",
-        newKey: "real-1",
-      });
-      expect(next.conversations[0]!.conversationKey).toBe("real-1");
-      expect(next.conversations[0]!.draft).toBe(false);
+      getState().setConversations([makeConversation("draft-1", { draft: true })]);
+      getState().resolveDraftKey("draft-1", "real-1");
+      expect(getState().conversations[0]!.conversationKey).toBe("real-1");
+      expect(getState().conversations[0]!.draft).toBe(false);
     });
   });
 
@@ -140,117 +102,77 @@ describe("conversationListReducer", () => {
   // Conversation groups
   // ---------------------------------------------------------------------------
 
-  describe("SET_GROUPS", () => {
+  describe("setGroups", () => {
     it("replaces the groups list", () => {
       const groups = [makeGroup("g1", "Group 1")];
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "SET_GROUPS",
-        groups,
-      });
-      expect(next.conversationGroups).toBe(groups);
+      getState().setGroups(groups);
+      expect(getState().conversationGroups).toBe(groups);
     });
   });
 
-  describe("APPEND_GROUP", () => {
+  describe("appendGroup", () => {
     it("adds to end of list", () => {
-      const state = stateWith({
-        conversationGroups: [makeGroup("g1", "First")],
-      });
-      const next = conversationListReducer(state, {
-        type: "APPEND_GROUP",
-        group: makeGroup("g2", "Second"),
-      });
-      expect(next.conversationGroups).toHaveLength(2);
-      expect(next.conversationGroups[1]!.name).toBe("Second");
+      getState().setGroups([makeGroup("g1", "First")]);
+      getState().appendGroup(makeGroup("g2", "Second"));
+      expect(getState().conversationGroups).toHaveLength(2);
+      expect(getState().conversationGroups[1]!.name).toBe("Second");
     });
 
     it("auto-computes sortPosition from current group count when 0", () => {
-      const state = stateWith({
-        conversationGroups: [
-          makeGroup("g1", "First", { sortPosition: 0 }),
-          makeGroup("g2", "Second", { sortPosition: 1 }),
-        ],
-      });
-      const next = conversationListReducer(state, {
-        type: "APPEND_GROUP",
-        group: makeGroup("g3", "Third", { sortPosition: 0 }),
-      });
-      expect(next.conversationGroups).toHaveLength(3);
-      expect(next.conversationGroups[2]!.sortPosition).toBe(2);
+      getState().setGroups([
+        makeGroup("g1", "First", { sortPosition: 0 }),
+        makeGroup("g2", "Second", { sortPosition: 1 }),
+      ]);
+      getState().appendGroup(makeGroup("g3", "Third", { sortPosition: 0 }));
+      expect(getState().conversationGroups).toHaveLength(3);
+      expect(getState().conversationGroups[2]!.sortPosition).toBe(2);
     });
   });
 
-  describe("PATCH_GROUP", () => {
+  describe("patchGroup", () => {
     it("patches the matching group", () => {
-      const state = stateWith({
-        conversationGroups: [makeGroup("g1", "Old")],
-      });
-      const next = conversationListReducer(state, {
-        type: "PATCH_GROUP",
-        groupId: "g1",
-        patch: { name: "New" },
-      });
-      expect(next.conversationGroups[0]!.name).toBe("New");
+      getState().setGroups([makeGroup("g1", "Old")]);
+      getState().patchGroup("g1", { name: "New" });
+      expect(getState().conversationGroups[0]!.name).toBe("New");
     });
 
     it("returns same array when group not found", () => {
-      const state = stateWith({
-        conversationGroups: [makeGroup("g1", "Name")],
-      });
-      const next = conversationListReducer(state, {
-        type: "PATCH_GROUP",
-        groupId: "missing",
-        patch: { name: "X" },
-      });
-      expect(next.conversationGroups).toBe(state.conversationGroups);
+      const groups = [makeGroup("g1", "Name")];
+      getState().setGroups(groups);
+      getState().patchGroup("missing", { name: "X" });
+      expect(getState().conversationGroups).toBe(groups);
     });
   });
 
-  describe("REPLACE_OPTIMISTIC_GROUP", () => {
+  describe("replaceOptimisticGroup", () => {
     it("swaps the optimistic group with the real one", () => {
-      const state = stateWith({
-        conversationGroups: [makeGroup("opt-1", "Temp")],
-      });
+      getState().setGroups([makeGroup("opt-1", "Temp")]);
       const real = makeGroup("real-1", "Real Group");
-      const next = conversationListReducer(state, {
-        type: "REPLACE_OPTIMISTIC_GROUP",
-        optimisticId: "opt-1",
-        group: real,
-      });
-      expect(next.conversationGroups[0]!).toBe(real);
+      getState().replaceOptimisticGroup("opt-1", real);
+      expect(getState().conversationGroups[0]!).toBe(real);
     });
   });
 
-  describe("REMOVE_GROUP", () => {
+  describe("removeGroup", () => {
     it("removes the matching group", () => {
-      const state = stateWith({
-        conversationGroups: [makeGroup("g1", "A"), makeGroup("g2", "B")],
-      });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_GROUP",
-        groupId: "g1",
-      });
-      expect(next.conversationGroups).toHaveLength(1);
-      expect(next.conversationGroups[0]!.id).toBe("g2");
+      getState().setGroups([makeGroup("g1", "A"), makeGroup("g2", "B")]);
+      getState().removeGroup("g1");
+      expect(getState().conversationGroups).toHaveLength(1);
+      expect(getState().conversationGroups[0]!.id).toBe("g2");
     });
   });
 
-  describe("DELETE_GROUP_AND_RESET_CONVERSATIONS", () => {
+  describe("deleteGroupAndResetConversations", () => {
     it("removes the group and clears groupId on affected conversations", () => {
-      const state = stateWith({
-        conversations: [
-          makeConversation("a", { groupId: "g1" }),
-          makeConversation("b", { groupId: "g2" }),
-        ],
-        conversationGroups: [makeGroup("g1", "G1"), makeGroup("g2", "G2")],
-      });
-      const next = conversationListReducer(state, {
-        type: "DELETE_GROUP_AND_RESET_CONVERSATIONS",
-        groupId: "g1",
-      });
-      expect(next.conversationGroups).toHaveLength(1);
-      expect(next.conversations[0]!.groupId).toBeUndefined();
-      expect(next.conversations[1]!.groupId).toBe("g2");
+      getState().setConversations([
+        makeConversation("a", { groupId: "g1" }),
+        makeConversation("b", { groupId: "g2" }),
+      ]);
+      getState().setGroups([makeGroup("g1", "G1"), makeGroup("g2", "G2")]);
+      getState().deleteGroupAndResetConversations("g1");
+      expect(getState().conversationGroups).toHaveLength(1);
+      expect(getState().conversations[0]!.groupId).toBeUndefined();
+      expect(getState().conversations[1]!.groupId).toBe("g2");
     });
   });
 
@@ -258,23 +180,17 @@ describe("conversationListReducer", () => {
   // Active / editing key
   // ---------------------------------------------------------------------------
 
-  describe("SET_ACTIVE_KEY", () => {
+  describe("setActiveKey", () => {
     it("sets the active conversation key", () => {
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "SET_ACTIVE_KEY",
-        key: "abc",
-      });
-      expect(next.activeConversationKey).toBe("abc");
+      getState().setActiveKey("abc");
+      expect(getState().activeConversationKey).toBe("abc");
     });
   });
 
-  describe("SET_EDITING_KEY", () => {
+  describe("setEditingKey", () => {
     it("sets the editing conversation key", () => {
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "SET_EDITING_KEY",
-        key: "edit-1",
-      });
-      expect(next.editingConversationKey).toBe("edit-1");
+      getState().setEditingKey("edit-1");
+      expect(getState().editingConversationKey).toBe("edit-1");
     });
   });
 
@@ -282,87 +198,68 @@ describe("conversationListReducer", () => {
   // Processing keys
   // ---------------------------------------------------------------------------
 
-  describe("ADD_PROCESSING_KEY", () => {
+  describe("addProcessingKey", () => {
     it("adds a key to the set", () => {
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "ADD_PROCESSING_KEY",
-        key: "k1",
-      });
-      expect(next.processingKeys.has("k1")).toBe(true);
+      getState().addProcessingKey("k1");
+      expect(getState().processingKeys.has("k1")).toBe(true);
     });
 
     it("returns the same Set reference when key already present", () => {
-      const state = stateWith({ processingKeys: new Set(["k1"]) });
-      const next = conversationListReducer(state, {
-        type: "ADD_PROCESSING_KEY",
-        key: "k1",
-      });
-      expect(next.processingKeys).toBe(state.processingKeys);
+      getState().addProcessingKey("k1");
+      const before = getState().processingKeys;
+      getState().addProcessingKey("k1");
+      expect(getState().processingKeys).toBe(before);
     });
   });
 
-  describe("REMOVE_PROCESSING_KEY", () => {
+  describe("removeProcessingKey", () => {
     it("removes a key from the set", () => {
-      const state = stateWith({ processingKeys: new Set(["k1", "k2"]) });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_PROCESSING_KEY",
-        key: "k1",
-      });
-      expect(next.processingKeys.has("k1")).toBe(false);
-      expect(next.processingKeys.has("k2")).toBe(true);
+      getState().addProcessingKey("k1");
+      getState().addProcessingKey("k2");
+      getState().removeProcessingKey("k1");
+      expect(getState().processingKeys.has("k1")).toBe(false);
+      expect(getState().processingKeys.has("k2")).toBe(true);
     });
 
     it("returns the same Set reference when key not present", () => {
-      const state = stateWith({ processingKeys: new Set(["k1"]) });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_PROCESSING_KEY",
-        key: "missing",
-      });
-      expect(next.processingKeys).toBe(state.processingKeys);
+      getState().addProcessingKey("k1");
+      const before = getState().processingKeys;
+      getState().removeProcessingKey("missing");
+      expect(getState().processingKeys).toBe(before);
     });
   });
 
-  describe("REMOVE_MULTIPLE_PROCESSING_KEYS", () => {
+  describe("removeMultipleProcessingKeys", () => {
     it("removes multiple keys at once", () => {
-      const state = stateWith({ processingKeys: new Set(["a", "b", "c"]) });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_MULTIPLE_PROCESSING_KEYS",
-        keys: ["a", "c"],
-      });
-      expect(next.processingKeys.size).toBe(1);
-      expect(next.processingKeys.has("b")).toBe(true);
+      getState().addProcessingKey("a");
+      getState().addProcessingKey("b");
+      getState().addProcessingKey("c");
+      getState().removeMultipleProcessingKeys(["a", "c"]);
+      expect(getState().processingKeys.size).toBe(1);
+      expect(getState().processingKeys.has("b")).toBe(true);
     });
 
     it("returns same Set when no keys match", () => {
-      const state = stateWith({ processingKeys: new Set(["a"]) });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_MULTIPLE_PROCESSING_KEYS",
-        keys: ["x", "y"],
-      });
-      expect(next.processingKeys).toBe(state.processingKeys);
+      getState().addProcessingKey("a");
+      const before = getState().processingKeys;
+      getState().removeMultipleProcessingKeys(["x", "y"]);
+      expect(getState().processingKeys).toBe(before);
     });
   });
 
-  describe("TRANSFER_PROCESSING_KEY", () => {
+  describe("transferProcessingKey", () => {
     it("replaces oldKey with newKey", () => {
-      const state = stateWith({ processingKeys: new Set(["old"]) });
-      const next = conversationListReducer(state, {
-        type: "TRANSFER_PROCESSING_KEY",
-        oldKey: "old",
-        newKey: "new",
-      });
-      expect(next.processingKeys.has("old")).toBe(false);
-      expect(next.processingKeys.has("new")).toBe(true);
+      getState().addProcessingKey("old");
+      getState().transferProcessingKey("old", "new");
+      expect(getState().processingKeys.has("old")).toBe(false);
+      expect(getState().processingKeys.has("new")).toBe(true);
     });
 
-    it("returns same state when oldKey not present", () => {
-      const state = stateWith({ processingKeys: new Set(["other"]) });
-      const next = conversationListReducer(state, {
-        type: "TRANSFER_PROCESSING_KEY",
-        oldKey: "missing",
-        newKey: "new",
-      });
-      expect(next).toBe(state);
+    it("is a no-op when oldKey not present", () => {
+      getState().addProcessingKey("other");
+      const before = getState().processingKeys;
+      getState().transferProcessingKey("missing", "new");
+      expect(getState().processingKeys).toBe(before);
     });
   });
 
@@ -370,24 +267,18 @@ describe("conversationListReducer", () => {
   // Attention keys
   // ---------------------------------------------------------------------------
 
-  describe("ADD_ATTENTION_KEY", () => {
+  describe("addAttentionKey", () => {
     it("adds a key", () => {
-      const next = conversationListReducer(INITIAL_CONVERSATION_LIST_STATE, {
-        type: "ADD_ATTENTION_KEY",
-        key: "a1",
-      });
-      expect(next.attentionKeys.has("a1")).toBe(true);
+      getState().addAttentionKey("a1");
+      expect(getState().attentionKeys.has("a1")).toBe(true);
     });
   });
 
-  describe("REMOVE_ATTENTION_KEY", () => {
+  describe("removeAttentionKey", () => {
     it("removes a key", () => {
-      const state = stateWith({ attentionKeys: new Set(["a1"]) });
-      const next = conversationListReducer(state, {
-        type: "REMOVE_ATTENTION_KEY",
-        key: "a1",
-      });
-      expect(next.attentionKeys.has("a1")).toBe(false);
+      getState().addAttentionKey("a1");
+      getState().removeAttentionKey("a1");
+      expect(getState().attentionKeys.has("a1")).toBe(false);
     });
   });
 
@@ -395,38 +286,35 @@ describe("conversationListReducer", () => {
   // Compound actions
   // ---------------------------------------------------------------------------
 
-  describe("GRADUATE_PROCESSING_KEY", () => {
+  describe("graduateProcessingKey", () => {
     it("removes from processing and adds to attention when interaction pending", () => {
-      const state = stateWith({ processingKeys: new Set(["k1"]) });
-      const next = conversationListReducer(state, {
-        type: "GRADUATE_PROCESSING_KEY",
-        key: "k1",
-        hasPendingInteraction: true,
-      });
-      expect(next.processingKeys.has("k1")).toBe(false);
-      expect(next.attentionKeys.has("k1")).toBe(true);
+      getState().addProcessingKey("k1");
+      getState().graduateProcessingKey("k1", true);
+      expect(getState().processingKeys.has("k1")).toBe(false);
+      expect(getState().attentionKeys.has("k1")).toBe(true);
     });
 
     it("removes from processing without adding to attention when no interaction pending", () => {
-      const state = stateWith({ processingKeys: new Set(["k1"]) });
-      const next = conversationListReducer(state, {
-        type: "GRADUATE_PROCESSING_KEY",
-        key: "k1",
-        hasPendingInteraction: false,
-      });
-      expect(next.processingKeys.has("k1")).toBe(false);
-      expect(next.attentionKeys.has("k1")).toBe(false);
+      getState().addProcessingKey("k1");
+      getState().graduateProcessingKey("k1", false);
+      expect(getState().processingKeys.has("k1")).toBe(false);
+      expect(getState().attentionKeys.has("k1")).toBe(false);
     });
   });
 
   // ---------------------------------------------------------------------------
-  // Unknown action passthrough
+  // Reset
   // ---------------------------------------------------------------------------
 
-  it("returns the same state for an unknown action type", () => {
-    const state = stateWith({ conversations: [makeConversation("a")] });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const next = conversationListReducer(state, { type: "UNKNOWN" } as any);
-    expect(next).toBe(state);
+  it("reset clears all state", () => {
+    getState().setConversations([makeConversation("a")]);
+    getState().setActiveKey("a");
+    getState().addProcessingKey("k1");
+    getState().addAttentionKey("a1");
+    getState().reset();
+    expect(getState().conversations).toEqual([]);
+    expect(getState().activeConversationKey).toBeNull();
+    expect(getState().processingKeys.size).toBe(0);
+    expect(getState().attentionKeys.size).toBe(0);
   });
 });

--- a/apps/web/src/domains/conversations/conversation-list-store.ts
+++ b/apps/web/src/domains/conversations/conversation-list-store.ts
@@ -1,9 +1,9 @@
 /**
- * Conversation-list state machine.
+ * Zustand store for conversation-list state.
  *
- * Manages the sidebar / conversation-selection state as a single
- * `useReducer` with typed domain events. All state transitions go through
- * `conversationListReducer`, keeping updates atomic and testable.
+ * Manages the sidebar / conversation-selection state with direct named
+ * actions. Each action calls `set()` to apply pure transitions so UI
+ * components can derive display state deterministically.
  *
  * **State managed:**
  * - `conversations` — the full list of conversations for the sidebar
@@ -13,38 +13,18 @@
  * - `processingKeys` — conversations with in-flight assistant responses
  * - `attentionKeys` — conversations needing user attention (pending interactions)
  *
- * @see https://react.dev/learn/extracting-state-logic-into-a-reducer
+ * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
+ * @see https://zustand.docs.pmnd.rs/guides/updating-state
  */
 
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors.js";
 import type { Conversation, ConversationGroup } from "@/domains/chat/lib/api.js";
 
 // ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
-
-/** All conversation-list UI state managed by `conversationListReducer`. */
-export interface ConversationListState {
-  conversations: Conversation[];
-  conversationGroups: ConversationGroup[];
-  activeConversationKey: string | null;
-  editingConversationKey: string | null;
-  processingKeys: Set<string>;
-  attentionKeys: Set<string>;
-}
-
-/** Empty initial state — used as the `useReducer` initializer. */
-export const INITIAL_CONVERSATION_LIST_STATE: ConversationListState = {
-  conversations: [],
-  conversationGroups: [],
-  activeConversationKey: null,
-  editingConversationKey: null,
-  processingKeys: new Set(),
-  attentionKeys: new Set(),
-};
-
-// ---------------------------------------------------------------------------
 // Set helpers — return the same reference when the mutation is a no-op so
-// React can bail out of unnecessary re-renders.
+// Zustand's shallow equality check can bail out of unnecessary re-renders.
 // ---------------------------------------------------------------------------
 
 function addToSet<T>(prev: Set<T>, key: T): Set<T> {
@@ -76,9 +56,9 @@ function removeMultipleFromSet<T>(prev: Set<T>, keys: T[]): Set<T> {
 /**
  * Immutably patch the conversation matching `key`, leaving all others
  * untouched. Returns the same array reference when no conversation matches
- * so React can bail out of re-renders.
+ * so Zustand can bail out of re-renders.
  */
-export function patchConversation(
+export function applyConversationPatch(
   conversations: Conversation[],
   key: string,
   patch: Partial<Conversation>,
@@ -92,7 +72,7 @@ export function patchConversation(
   return changed ? result : conversations;
 }
 
-function patchGroup(
+function applyGroupPatch(
   groups: ConversationGroup[],
   id: string,
   patch: Partial<ConversationGroup>,
@@ -107,351 +87,239 @@ function patchGroup(
 }
 
 // ---------------------------------------------------------------------------
-// Domain events (actions)
+// State & Actions
 // ---------------------------------------------------------------------------
 
-// --- Conversations ---
-
-export interface SetConversations {
-  type: "SET_CONVERSATIONS";
+export interface ConversationListState {
   conversations: Conversation[];
+  conversationGroups: ConversationGroup[];
+  activeConversationKey: string | null;
+  editingConversationKey: string | null;
+  processingKeys: Set<string>;
+  attentionKeys: Set<string>;
 }
 
-export interface PatchConversation {
-  type: "PATCH_CONVERSATION";
-  key: string;
-  patch: Partial<Conversation>;
+export interface ConversationListActions {
+  // --- Conversations ---
+  setConversations: (conversations: Conversation[]) => void;
+  patchConversation: (key: string, patch: Partial<Conversation>) => void;
+  markConversationSeen: (key: string, lastSeenAssistantMessageAt?: string) => void;
+  prependConversation: (conversation: Conversation) => void;
+  removeConversation: (key: string) => void;
+  resolveDraftKey: (oldKey: string, newKey: string) => void;
+
+  // --- Conversation groups ---
+  setGroups: (groups: ConversationGroup[]) => void;
+  appendGroup: (group: ConversationGroup) => void;
+  patchGroup: (groupId: string, patch: Partial<ConversationGroup>) => void;
+  replaceOptimisticGroup: (optimisticId: string, group: ConversationGroup) => void;
+  removeGroup: (groupId: string) => void;
+  deleteGroupAndResetConversations: (groupId: string) => void;
+
+  // --- Active / editing key ---
+  setActiveKey: (key: string | null) => void;
+  setEditingKey: (key: string | null) => void;
+
+  // --- Processing keys ---
+  addProcessingKey: (key: string) => void;
+  removeProcessingKey: (key: string) => void;
+  removeMultipleProcessingKeys: (keys: string[]) => void;
+  transferProcessingKey: (oldKey: string, newKey: string) => void;
+
+  // --- Attention keys ---
+  addAttentionKey: (key: string) => void;
+  removeAttentionKey: (key: string) => void;
+
+  // --- Compound ---
+  graduateProcessingKey: (key: string, hasPendingInteraction: boolean) => void;
+
+  // --- Reset ---
+  reset: () => void;
 }
 
-export interface MarkConversationSeen {
-  type: "MARK_CONVERSATION_SEEN";
-  key: string;
-  lastSeenAssistantMessageAt?: string;
-}
+type ConversationListStore = ConversationListState & ConversationListActions;
 
-export interface PrependConversation {
-  type: "PREPEND_CONVERSATION";
-  conversation: Conversation;
-}
-
-export interface RemoveConversation {
-  type: "REMOVE_CONVERSATION";
-  key: string;
-}
-
-export interface ResolveDraftKey {
-  type: "RESOLVE_DRAFT_KEY";
-  oldKey: string;
-  newKey: string;
-}
-
-// --- Conversation groups ---
-
-export interface SetGroups {
-  type: "SET_GROUPS";
-  groups: ConversationGroup[];
-}
-
-export interface AppendGroup {
-  type: "APPEND_GROUP";
-  group: ConversationGroup;
-}
-
-export interface PatchGroup {
-  type: "PATCH_GROUP";
-  groupId: string;
-  patch: Partial<ConversationGroup>;
-}
-
-export interface ReplaceOptimisticGroup {
-  type: "REPLACE_OPTIMISTIC_GROUP";
-  optimisticId: string;
-  group: ConversationGroup;
-}
-
-export interface RemoveGroup {
-  type: "REMOVE_GROUP";
-  groupId: string;
-}
-
-export interface DeleteGroupAndResetConversations {
-  type: "DELETE_GROUP_AND_RESET_CONVERSATIONS";
-  groupId: string;
-}
-
-// --- Active / editing key ---
-
-export interface SetActiveKey {
-  type: "SET_ACTIVE_KEY";
-  key: string | null;
-}
-
-export interface SetEditingKey {
-  type: "SET_EDITING_KEY";
-  key: string | null;
-}
-
-// --- Processing keys ---
-
-export interface AddProcessingKey {
-  type: "ADD_PROCESSING_KEY";
-  key: string;
-}
-
-export interface RemoveProcessingKey {
-  type: "REMOVE_PROCESSING_KEY";
-  key: string;
-}
-
-export interface RemoveMultipleProcessingKeys {
-  type: "REMOVE_MULTIPLE_PROCESSING_KEYS";
-  keys: string[];
-}
-
-export interface TransferProcessingKey {
-  type: "TRANSFER_PROCESSING_KEY";
-  oldKey: string;
-  newKey: string;
-}
-
-// --- Attention keys ---
-
-export interface AddAttentionKey {
-  type: "ADD_ATTENTION_KEY";
-  key: string;
-}
-
-export interface RemoveAttentionKey {
-  type: "REMOVE_ATTENTION_KEY";
-  key: string;
-}
-
-// --- Compound actions ---
-
-export interface GraduateProcessingKey {
-  type: "GRADUATE_PROCESSING_KEY";
-  key: string;
-  hasPendingInteraction: boolean;
-}
-
-export type ConversationListAction =
-  | SetConversations
-  | PatchConversation
-  | MarkConversationSeen
-  | PrependConversation
-  | RemoveConversation
-  | ResolveDraftKey
-  | SetGroups
-  | AppendGroup
-  | PatchGroup
-  | ReplaceOptimisticGroup
-  | RemoveGroup
-  | DeleteGroupAndResetConversations
-  | SetActiveKey
-  | SetEditingKey
-  | AddProcessingKey
-  | RemoveProcessingKey
-  | RemoveMultipleProcessingKeys
-  | TransferProcessingKey
-  | AddAttentionKey
-  | RemoveAttentionKey
-  | GraduateProcessingKey;
+const INITIAL_STATE: ConversationListState = {
+  conversations: [],
+  conversationGroups: [],
+  activeConversationKey: null,
+  editingConversationKey: null,
+  processingKeys: new Set(),
+  attentionKeys: new Set(),
+};
 
 // ---------------------------------------------------------------------------
-// Reducer
+// Store
 // ---------------------------------------------------------------------------
 
-/**
- * Pure reducer for conversation-list state.
- *
- * Accepts a `ConversationListAction` discriminated union and returns the
- * next state. Set helpers return the same reference on no-ops so React
- * can bail out of re-renders.
- *
- * Compound actions like `DELETE_GROUP_AND_RESET_CONVERSATIONS` and
- * `GRADUATE_PROCESSING_KEY` update multiple fields atomically.
- */
-export function conversationListReducer(
-  state: ConversationListState,
-  action: ConversationListAction,
-): ConversationListState {
-  switch (action.type) {
-    // ----- Conversations -----
+export const useConversationListStore = createSelectors(
+  create<ConversationListStore>((set, get) => ({
+    ...INITIAL_STATE,
 
-    case "SET_CONVERSATIONS":
-      return { ...state, conversations: action.conversations };
+    // --- Conversations ---
 
-    case "PATCH_CONVERSATION":
-      return {
-        ...state,
-        conversations: patchConversation(
-          state.conversations,
-          action.key,
-          action.patch,
-        ),
-      };
+    setConversations: (conversations) => {
+      set({ conversations });
+    },
 
-    case "MARK_CONVERSATION_SEEN": {
-      return {
-        ...state,
-        conversations: state.conversations.map((c) =>
-          c.conversationKey !== action.key
+    patchConversation: (key, patch) => {
+      set({ conversations: applyConversationPatch(get().conversations, key, patch) });
+    },
+
+    markConversationSeen: (key, lastSeenAssistantMessageAt) => {
+      set({
+        conversations: get().conversations.map((c) =>
+          c.conversationKey !== key
             ? c
             : {
                 ...c,
                 hasUnseenLatestAssistantMessage: false,
                 lastSeenAssistantMessageAt:
-                  action.lastSeenAssistantMessageAt ??
+                  lastSeenAssistantMessageAt ??
                   c.latestAssistantMessageAt ??
                   c.lastSeenAssistantMessageAt,
               },
         ),
-      };
-    }
+      });
+    },
 
-    case "PREPEND_CONVERSATION":
-      return {
-        ...state,
-        conversations: [action.conversation, ...state.conversations],
-      };
+    prependConversation: (conversation) => {
+      set({ conversations: [conversation, ...get().conversations] });
+    },
 
-    case "REMOVE_CONVERSATION":
-      return {
-        ...state,
-        conversations: state.conversations.filter(
-          (c) => c.conversationKey !== action.key,
+    removeConversation: (key) => {
+      set({
+        conversations: get().conversations.filter(
+          (c) => c.conversationKey !== key,
         ),
-      };
+      });
+    },
 
-    case "RESOLVE_DRAFT_KEY":
-      return {
-        ...state,
-        conversations: state.conversations.map((c) =>
-          c.conversationKey === action.oldKey
-            ? { ...c, conversationKey: action.newKey, draft: false }
+    resolveDraftKey: (oldKey, newKey) => {
+      set({
+        conversations: get().conversations.map((c) =>
+          c.conversationKey === oldKey
+            ? { ...c, conversationKey: newKey, draft: false }
             : c,
         ),
-      };
+      });
+    },
 
-    // ----- Conversation groups -----
+    // --- Conversation groups ---
 
-    case "SET_GROUPS":
-      return { ...state, conversationGroups: action.groups };
+    setGroups: (groups) => {
+      set({ conversationGroups: groups });
+    },
 
-    case "APPEND_GROUP":
-      return {
-        ...state,
+    appendGroup: (group) => {
+      set({
         conversationGroups: [
-          ...state.conversationGroups,
+          ...get().conversationGroups,
           {
-            ...action.group,
-            sortPosition: action.group.sortPosition || state.conversationGroups.length,
+            ...group,
+            sortPosition: group.sortPosition || get().conversationGroups.length,
           },
         ],
-      };
+      });
+    },
 
-    case "PATCH_GROUP":
-      return {
-        ...state,
-        conversationGroups: patchGroup(
-          state.conversationGroups,
-          action.groupId,
-          action.patch,
+    patchGroup: (groupId, patch) => {
+      set({
+        conversationGroups: applyGroupPatch(
+          get().conversationGroups,
+          groupId,
+          patch,
         ),
-      };
+      });
+    },
 
-    case "REPLACE_OPTIMISTIC_GROUP":
-      return {
-        ...state,
-        conversationGroups: state.conversationGroups.map((g) =>
-          g.id === action.optimisticId ? action.group : g,
+    replaceOptimisticGroup: (optimisticId, group) => {
+      set({
+        conversationGroups: get().conversationGroups.map((g) =>
+          g.id === optimisticId ? group : g,
         ),
-      };
+      });
+    },
 
-    case "REMOVE_GROUP":
-      return {
-        ...state,
-        conversationGroups: state.conversationGroups.filter(
-          (g) => g.id !== action.groupId,
+    removeGroup: (groupId) => {
+      set({
+        conversationGroups: get().conversationGroups.filter(
+          (g) => g.id !== groupId,
         ),
-      };
+      });
+    },
 
-    case "DELETE_GROUP_AND_RESET_CONVERSATIONS":
-      return {
-        ...state,
-        conversationGroups: state.conversationGroups.filter(
-          (g) => g.id !== action.groupId,
+    deleteGroupAndResetConversations: (groupId) => {
+      set({
+        conversationGroups: get().conversationGroups.filter(
+          (g) => g.id !== groupId,
         ),
-        conversations: state.conversations.map((c) =>
-          c.groupId === action.groupId ? { ...c, groupId: undefined } : c,
+        conversations: get().conversations.map((c) =>
+          c.groupId === groupId ? { ...c, groupId: undefined } : c,
         ),
-      };
+      });
+    },
 
-    // ----- Active / editing key -----
+    // --- Active / editing key ---
 
-    case "SET_ACTIVE_KEY":
-      return { ...state, activeConversationKey: action.key };
+    setActiveKey: (key) => {
+      set({ activeConversationKey: key });
+    },
 
-    case "SET_EDITING_KEY":
-      return { ...state, editingConversationKey: action.key };
+    setEditingKey: (key) => {
+      set({ editingConversationKey: key });
+    },
 
-    // ----- Processing keys -----
+    // --- Processing keys ---
 
-    case "ADD_PROCESSING_KEY":
-      return {
-        ...state,
-        processingKeys: addToSet(state.processingKeys, action.key),
-      };
+    addProcessingKey: (key) => {
+      set({ processingKeys: addToSet(get().processingKeys, key) });
+    },
 
-    case "REMOVE_PROCESSING_KEY":
-      return {
-        ...state,
-        processingKeys: removeFromSet(state.processingKeys, action.key),
-      };
+    removeProcessingKey: (key) => {
+      set({ processingKeys: removeFromSet(get().processingKeys, key) });
+    },
 
-    case "REMOVE_MULTIPLE_PROCESSING_KEYS":
-      return {
-        ...state,
-        processingKeys: removeMultipleFromSet(
-          state.processingKeys,
-          action.keys,
-        ),
-      };
+    removeMultipleProcessingKeys: (keys) => {
+      set({
+        processingKeys: removeMultipleFromSet(get().processingKeys, keys),
+      });
+    },
 
-    case "TRANSFER_PROCESSING_KEY": {
-      if (!state.processingKeys.has(action.oldKey)) return state;
-      const next = new Set(state.processingKeys);
-      next.delete(action.oldKey);
-      next.add(action.newKey);
-      return { ...state, processingKeys: next };
-    }
+    transferProcessingKey: (oldKey, newKey) => {
+      const { processingKeys } = get();
+      if (!processingKeys.has(oldKey)) return;
+      const next = new Set(processingKeys);
+      next.delete(oldKey);
+      next.add(newKey);
+      set({ processingKeys: next });
+    },
 
-    // ----- Attention keys -----
+    // --- Attention keys ---
 
-    case "ADD_ATTENTION_KEY":
-      return {
-        ...state,
-        attentionKeys: addToSet(state.attentionKeys, action.key),
-      };
+    addAttentionKey: (key) => {
+      set({ attentionKeys: addToSet(get().attentionKeys, key) });
+    },
 
-    case "REMOVE_ATTENTION_KEY":
-      return {
-        ...state,
-        attentionKeys: removeFromSet(state.attentionKeys, action.key),
-      };
+    removeAttentionKey: (key) => {
+      set({ attentionKeys: removeFromSet(get().attentionKeys, key) });
+    },
 
-    // ----- Compound -----
+    // --- Compound ---
 
-    case "GRADUATE_PROCESSING_KEY":
-      return {
-        ...state,
-        processingKeys: removeFromSet(state.processingKeys, action.key),
-        attentionKeys: action.hasPendingInteraction
-          ? addToSet(state.attentionKeys, action.key)
-          : state.attentionKeys,
-      };
+    graduateProcessingKey: (key, hasPendingInteraction) => {
+      set({
+        processingKeys: removeFromSet(get().processingKeys, key),
+        attentionKeys: hasPendingInteraction
+          ? addToSet(get().attentionKeys, key)
+          : get().attentionKeys,
+      });
+    },
 
-    default:
-      return state;
-  }
-}
+    // --- Reset ---
+
+    reset: () => {
+      set({ ...INITIAL_STATE, processingKeys: new Set(), attentionKeys: new Set() });
+    },
+  })),
+);

--- a/apps/web/src/domains/conversations/conversation-list-store.ts
+++ b/apps/web/src/domains/conversations/conversation-list-store.ts
@@ -308,12 +308,12 @@ export const useConversationListStore = createSelectors(
     // --- Compound ---
 
     graduateProcessingKey: (key, hasPendingInteraction) => {
-      set({
-        processingKeys: removeFromSet(get().processingKeys, key),
+      set((state) => ({
+        processingKeys: removeFromSet(state.processingKeys, key),
         attentionKeys: hasPendingInteraction
-          ? addToSet(get().attentionKeys, key)
-          : get().attentionKeys,
-      });
+          ? addToSet(state.attentionKeys, key)
+          : state.attentionKeys,
+      }));
     },
 
     // --- Reset ---


### PR DESCRIPTION
## Prompt / plan

Closes [LUM-1622](https://linear.app/vellum/issue/LUM-1622). Converts the last remaining reducer-pattern shared store (`conversationListReducer`) to Zustand with `create()` + `createSelectors` + direct named actions — completing the migration started by #31201 (subagent-store) and #31209 (viewer-store).

### Why needed

`conversationListReducer` used `useReducer` with a 20-type discriminated union (`ConversationListAction`) and threaded `dispatchConversationList: Dispatch<ConversationListAction>` through **12 consumer files** and `StreamHandlerContext`. This is the exact prop-drilling / parameter-threading anti-pattern that Zustand is designed to eliminate.

### What changed

**Store conversion** (`conversation-list-store.ts`):
- Replaced `conversationListReducer` + `ConversationListAction` (20 type interfaces + discriminated union) with a Zustand store using `create()` + `createSelectors`
- 20 named actions: `setConversations()`, `patchConversation()`, `markConversationSeen()`, `prependConversation()`, `removeConversation()`, `resolveDraftKey()`, `setGroups()`, `appendGroup()`, `patchGroup()`, `replaceOptimisticGroup()`, `removeGroup()`, `deleteGroupAndResetConversations()`, `setActiveKey()`, `setEditingKey()`, `addProcessingKey()`, `removeProcessingKey()`, `removeMultipleProcessingKeys()`, `transferProcessingKey()`, `addAttentionKey()`, `removeAttentionKey()`, `graduateProcessingKey()`, `reset()`
- Renamed the exported `patchConversation()` helper to `applyConversationPatch()` to avoid collision with the store action
- Removed `INITIAL_CONVERSATION_LIST_STATE`, `conversationListReducer`, `ConversationListAction`, and all 20 action type interfaces

**Consumer updates** (12 files):
- Removed `dispatchConversationList` parameter from all hook interfaces and function signatures
- Replaced all `dispatchConversationList({ type: "ACTION_NAME", ... })` calls with `useConversationListStore.getState().actionName(...)` — correct pattern for event handlers/callbacks per [CONVENTIONS.md](./CONVENTIONS.md#state-management)
- Removed `dispatchConversationList` from `StreamHandlerContext` (the last remaining `Dispatch<Action>` in the context)
- Cleaned up unused `Dispatch`, `ConversationListAction` imports throughout

**Tests:**
- Rewrote 31 store tests from `conversationListReducer(state, action)` pattern to `getState().actionName()` with `afterEach` reset
- Updated metadata-handlers test to verify store state directly instead of mock dispatch calls

### Benefits

- **Eliminates dispatch threading**: 12 files no longer need `dispatchConversationList` as a parameter
- **Completes the migration**: All shared stores now use Zustand with direct named actions (subagent, viewer, interaction, turn, conversation-list)
- **Net -281 lines**: 748 insertions, 1029 deletions — the discriminated union + action interfaces are gone
- **Type-safe actions**: Named methods with typed parameters replace stringly-typed `{ type: "ACTION_NAME" }` dispatch objects

### Safety

- Pure state management refactor — no UI changes, no behavioral changes
- Each named action preserves the exact same state transition logic from the original reducer `case` block
- All 31 store tests pass with the new API
- `tsc --noEmit` passes, lint passes
- Follows the exact same pattern established in #31201 and #31209

### What was NOT done and why

- **Did not extract navigation state from conversation-list-store**: `activeConversationKey` and `editingConversationKey` could arguably live in a separate store, but this would add churn without benefit — [LUM-1651](https://linear.app/vellum/issue/LUM-1651) (mainView → URL routing) will likely reshape this state anyway
- **Did not convert component-local `useReducer` instances** (terminal, voice, navigation-history): Per Zustand guidance, component-local state that isn't shared doesn't need a Zustand store

### References

- [Zustand flux-inspired practice](https://zustand.docs.pmnd.rs/guides/flux-inspired-practice)
- [Zustand updating state](https://zustand.docs.pmnd.rs/guides/updating-state)
- [CONVENTIONS.md — State management](./CONVENTIONS.md#state-management)

## Test plan

- 31 unit tests pass (`bun test conversation-list-store.test.ts`)
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- CI

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->