### PR TITLE
fix(tools): add watchdog + logging to tool execution timeout

### DIFF
--- a/assistant/src/tools/execution-timeout.ts
+++ b/assistant/src/tools/execution-timeout.ts
@@ -1,8 +1,19 @@
+import { getLogger } from "../util/logger.js";
 import type { ToolExecutionResult } from "./types.js";
+
+const log = getLogger("tool-execution-timeout");
 
 const TIMEOUT_SENTINEL = Symbol("tool-timeout");
 
 const DEFAULT_TOOL_TIMEOUT_SEC = 120;
+
+/**
+ * Interval at which the watchdog checks whether a tool execution has
+ * exceeded its timeout. Acts as a backup: if the primary `setTimeout`
+ * callback is delayed (event-loop blockage, GC pause, etc.), the
+ * watchdog force-resolves the timeout promise on its next tick.
+ */
+const WATCHDOG_INTERVAL_MS = 30_000;
 
 /**
  * Convert a config-provided seconds value to a safe milliseconds value,
@@ -19,6 +30,13 @@ export function safeTimeoutMs(sec: unknown): number {
 /**
  * Race a tool execution promise against a timeout. Returns a timeout error
  * result instead of throwing so the agent loop can continue gracefully.
+ *
+ * Two independent mechanisms enforce the deadline:
+ * 1. A `setTimeout` that resolves the timeout sentinel after `timeoutMs`.
+ * 2. A periodic watchdog (`setInterval`) that checks elapsed time and
+ *    force-resolves the sentinel if `setTimeout` failed to fire. This
+ *    guards against event-loop stalls where `setTimeout` callbacks are
+ *    delayed indefinitely.
  */
 export async function executeWithTimeout(
   promise: Promise<ToolExecutionResult>,
@@ -30,21 +48,64 @@ export async function executeWithTimeout(
     Number.isFinite(timeoutMs) && timeoutMs > 0
       ? timeoutMs
       : DEFAULT_TOOL_TIMEOUT_SEC * 1000;
+
+  const startTime = Date.now();
+
+  // The resolve function is shared between setTimeout and the watchdog so
+  // either can trip the sentinel. Once resolved, subsequent calls are no-ops.
+  let resolveTimeout: ((v: typeof TIMEOUT_SENTINEL) => void) | undefined;
+
+  const watchdogHandle = setInterval(() => {
+    const elapsedMs = Date.now() - startTime;
+    const elapsedSec = Math.round(elapsedMs / 1000);
+    const timeoutSec = Math.round(safeMs / 1000);
+    if (elapsedMs > safeMs) {
+      log.error(
+        { toolName, elapsedSec, timeoutSec },
+        `Tool "${toolName}" still running ${elapsedSec}s after ${timeoutSec}s timeout — forcing timeout from watchdog`,
+      );
+      // Force-resolve: the primary setTimeout didn't fire in time.
+      resolveTimeout?.(TIMEOUT_SENTINEL);
+    } else {
+      log.warn(
+        { toolName, elapsedSec, timeoutSec },
+        `Tool "${toolName}" still executing after ${elapsedSec}s (timeout: ${timeoutSec}s)`,
+      );
+    }
+  }, WATCHDOG_INTERVAL_MS);
+
   let timeoutHandle: ReturnType<typeof setTimeout>;
   const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    resolveTimeout = resolve;
     timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), safeMs);
   });
   try {
     const result = await Promise.race([promise, timeoutPromise]);
     if (result === TIMEOUT_SENTINEL) {
+      const elapsedMs = Date.now() - startTime;
       const sec = Math.round(safeMs / 1000);
+      log.error(
+        { toolName, timeoutSec: sec, elapsedMs },
+        `Tool "${toolName}" timed out after ${sec}s`,
+      );
       return {
         content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,
         isError: true,
       };
     }
+
+    // Tool completed normally — log duration for observability
+    const elapsedMs = Date.now() - startTime;
+    if (elapsedMs > 60_000) {
+      log.warn(
+        { toolName, elapsedMs, elapsedSec: Math.round(elapsedMs / 1000) },
+        `Tool "${toolName}" completed after ${Math.round(elapsedMs / 1000)}s (slow)`,
+      );
+    }
+
     return result;
   } finally {
     clearTimeout(timeoutHandle!);
+    clearInterval(watchdogHandle);
   }
 }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -241,6 +241,16 @@ export class ToolExecutor {
       // the inner execute-with-timeout wrapper agree on the same budget.
       let execResult: ToolExecutionResult;
       const toolTimeoutMs = computePerToolTimeoutMs(name, input);
+      const toolExecStart = Date.now();
+
+      log.info(
+        {
+          toolName: name,
+          conversationId: context.conversationId,
+          timeoutMs: toolTimeoutMs,
+        },
+        `Tool "${name}" execution start`,
+      );
 
       const execContext = context;
 
@@ -278,6 +288,17 @@ export class ToolExecutor {
           name,
         );
       }
+
+      const toolExecDurationMs = Date.now() - toolExecStart;
+      log.info(
+        {
+          toolName: name,
+          conversationId: context.conversationId,
+          durationMs: toolExecDurationMs,
+          isError: execResult.isError,
+        },
+        `Tool "${name}" execution complete (${toolExecDurationMs}ms)`,
+      );
 
       // CES approval bridge: if the tool returned an approval_required
       // indicator, present the proposal to the guardian via the existing


### PR DESCRIPTION
## Summary
- Adds a 30s interval watchdog to `executeWithTimeout` that force-resolves the timeout promise if `setTimeout` fails to fire — prevents tool execution stalls from blocking the agent loop indefinitely
- Adds INFO-level tool execution start/complete logs to the executor with tool name, conversation ID, timeout budget, and duration
- Logs slow completions (>60s) at WARN and timeouts at ERROR

## Context
A bash tool with `network_mode: "proxied"` hung for 38 minutes despite a 125s timeout. The stall was invisible — no logs, no errors, no client feedback. This PR makes future stalls both self-healing (watchdog force-resolve) and diagnosable (structured logging).

## Test plan
- [ ] `bun test src/__tests__/tool-execute-pipeline.test.ts` — 6 pass
- [ ] `bun test src/__tests__/agent-loop.test.ts` — 46 pass
- [ ] `bunx tsc --noEmit` — clean (pre-existing wake-target-adapter error only)
- [ ] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)