### PR TITLE
test(heartbeat): add disposition to co-located test stub config

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -54,6 +54,7 @@ const stubConfig: {
     activeHoursStart: number | null;
     activeHoursEnd: number | null;
     maxConsecutiveRuns: number | null;
+    disposition: string;
   };
 } = {
   heartbeat: {
@@ -62,6 +63,7 @@ const stubConfig: {
     activeHoursStart: null,
     activeHoursEnd: null,
     maxConsecutiveRuns: null,
+    disposition: "Default disposition text.",
   },
 };
 mock.module("../../config/loader.js", () => ({


### PR DESCRIPTION
## Summary
- PR #31216 added a `<heartbeat-disposition>` block to the heartbeat prompt and updated the legacy test file, but missed the co-located duplicate at `assistant/src/heartbeat/__tests__/heartbeat-service.test.ts`.
- That test's `stubConfig.heartbeat` was missing `disposition`, so the prompt builder fell through the `if (disposition)` branch and the new `expect(call.prompt).toContain("<heartbeat-disposition>")` assertion failed.
- Adds `disposition` to the stub config so the co-located test exercises the same prompt branch as the legacy one.

## Original prompt
Fix the CI failure on the Test job in run 26130218071: `heartbeat-service.test.ts` failed with `Expected to contain: "<heartbeat-disposition>"` because PR #31216 updated only one of two duplicate heartbeat test files. Limit the fix to that specific test failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->