### PR TITLE
feat(events): emit tool_progress SSE events during tool execution

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -116,6 +116,12 @@ export type AgentEvent =
     }
   | { type: "tool_output_chunk"; toolUseId: string; chunk: string }
   | {
+      type: "tool_progress";
+      toolUseId: string;
+      toolName: string;
+      elapsedSec: number;
+    }
+  | {
       type: "tool_result";
       toolUseId: string;
       content: string;
@@ -1023,6 +1029,22 @@ export class AgentLoop {
           }),
         );
 
+        // Emit periodic tool_progress events so clients can show a
+        // "still working" indicator for long-running tool executions.
+        // The first progress fires after 10s; subsequent ones every 10s.
+        const TOOL_PROGRESS_INTERVAL_MS = 10_000;
+        const progressHandle = setInterval(() => {
+          const elapsedSec = Math.round((Date.now() - toolExecStart) / 1000);
+          for (const toolUse of toolUseBlocks) {
+            onEvent({
+              type: "tool_progress",
+              toolUseId: toolUse.id,
+              toolName: toolUse.name,
+              elapsedSec,
+            });
+          }
+        }, TOOL_PROGRESS_INTERVAL_MS);
+
         let toolResults: Awaited<typeof toolExecutionPromise>;
         if (signal && !signal.aborted) {
           let abortHandler!: () => void;
@@ -1039,12 +1061,17 @@ export class AgentLoop {
               abortPromise,
             ]);
           } finally {
+            clearInterval(progressHandle);
             signal.removeEventListener("abort", abortHandler);
             // Suppress unhandled rejection from abandoned tool executions
             toolExecutionPromise.catch(() => {});
           }
         } else {
-          toolResults = await toolExecutionPromise;
+          try {
+            toolResults = await toolExecutionPromise;
+          } finally {
+            clearInterval(progressHandle);
+          }
         }
 
         rlog.info(

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1242,6 +1242,15 @@ export async function dispatchAgentEvent(
       case "input_json_delta":
         handleInputJsonDelta(state, deps, event);
         break;
+      case "tool_progress":
+        deps.onEvent({
+          type: "tool_progress",
+          toolName: event.toolName,
+          elapsedSec: event.elapsedSec,
+          conversationId: deps.ctx.conversationId,
+          toolUseId: event.toolUseId,
+        });
+        break;
       case "tool_result":
         handleToolResult(state, deps, event);
         break;

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -120,6 +120,16 @@ export interface ToolInputDelta {
   toolUseId?: string;
 }
 
+export interface ToolProgress {
+  type: "tool_progress";
+  toolName: string;
+  /** Elapsed time in seconds since tool execution started. */
+  elapsedSec: number;
+  conversationId?: string;
+  /** The tool_use block ID for client-side correlation. */
+  toolUseId?: string;
+}
+
 export interface ToolResult {
   type: "tool_result";
   toolName: string;
@@ -487,6 +497,7 @@ export type _MessagesServerMessages =
   | ToolUsePreviewStart
   | ToolOutputChunk
   | ToolInputDelta
+  | ToolProgress
   | ToolResult
   | ConfirmationRequest
   | SecretRequest

--- a/assistant/src/daemon/wake-target-adapter.ts
+++ b/assistant/src/daemon/wake-target-adapter.ts
@@ -133,6 +133,7 @@ function translateAgentEventToServerMessage(
         conversationId,
       };
     case "input_json_delta":
+    case "tool_progress":
     case "usage":
     case "error":
     case "provider_error":


### PR DESCRIPTION
## Summary
- Adds a new `tool_progress` SSE event type that fires every 10s while tools are executing in the agent loop
- Gives clients a heartbeat to show "still working..." indicators during long-running tool executions
- Event shape: `{ type: "tool_progress", toolName, elapsedSec, conversationId?, toolUseId? }`
- Fixes pre-existing TS2366 in `wake-target-adapter.ts` (exhaustive switch for new event type)

## Context
Companion to #31218 (watchdog). During a 38-minute tool stall, the SSE stream went completely silent — no events between `tool_use_start` and the user's manual interruption. This event gives clients something to show.

## Test plan
- [ ] `bun test src/__tests__/agent-loop.test.ts` — 46 pass
- [ ] `bun test src/__tests__/runtime-events-sse-parity.test.ts` — 14 pass
- [ ] `bunx tsc --noEmit` — clean
- [ ] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->