### PR TITLE
fix(web): auto-generate API client on first install via postinstall

### DIFF
--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -832,13 +832,22 @@ committed to this repo so anyone can regenerate the client locally:
 bun run openapi-ts
 ```
 
-Generated output lives in `src/generated/api/` (gitignored).
+Generated output lives in `src/generated/api/` (gitignored). Codegen runs
+automatically via [npm lifecycle hooks](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts):
+
+- **`postinstall`** — runs after every `bun install`; generates the client
+  when `src/generated/` doesn't exist yet (first-time bootstrap).
+- **`predev`** — runs before every `bun run dev`; always regenerates so
+  the client stays in sync with the committed specs.
+
+No manual codegen step is needed — both `bun install` + `bun run dev` and
+`vel up --vite` trigger these hooks automatically.
 
 **Vellum developers** updating the specs after platform API changes:
 
 ```bash
 ./scripts/sync-openapi-specs.sh   # copies from sibling platform checkout
-bun run openapi-ts                # regenerate client
+bun run dev                       # predev regenerates automatically
 ```
 
 Plugins (configured in `openapi-ts.config.ts`):

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "bun run openapi-ts",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
-    "postinstall": "rm -rf ../../packages/design-library/node_modules/react ../../packages/design-library/node_modules/@types/react ../../packages/design-library/node_modules/react-dom ../../packages/design-library/node_modules/@types/react-dom 2>/dev/null; true",
+    "postinstall": "rm -rf ../../packages/design-library/node_modules/react ../../packages/design-library/node_modules/@types/react ../../packages/design-library/node_modules/react-dom ../../packages/design-library/node_modules/@types/react-dom 2>/dev/null; true && test -d src/generated || bun run openapi-ts",
     "openapi-ts": "openapi-ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1659

The generated API client (`src/generated/`) is gitignored per open-source repo policy, but the app imports from it at the entrypoint level. Two gaps existed:

1. **First-time setup**: `bun install` (via `vel up --vite` or standalone) never ran codegen → missing module errors
2. **Stale generated code**: After OpenAPI spec updates, `bun run dev` used stale generated code with no automatic refresh

### Approach

**Two lifecycle hooks in `package.json`:**

| Hook | When it runs | What it does |
|------|-------------|--------------|
| `postinstall` | Every `bun install` | Conditional codegen — only if `src/generated/` doesn't exist (first-time bootstrap) |
| `predev` | Every `bun run dev` | Always runs codegen — ensures generated code matches current specs |

This follows established OSS patterns:
- [Prisma](https://prisma.io/blog/why-prisma-orm-generates-code-into-node-modules-and-why-it-ll-change) uses `postinstall` for self-bootstrapping codegen
- [GraphQL Codegen](https://graphql-code-generator.com/docs/getting-started/development-workflow) recommends `predev`/`prestart` scripts

Both hooks work with `vel up --vite` (which calls `bun install` then `bun run dev`) and standalone OSS contributor workflows.

### Why this approach over alternatives

- **`postinstall` + `predev` in the app (chosen)**: Self-contained. Works for `vel up --vite`, standalone `bun install` + `bun run dev` (OSS contributors), and CI. The app bootstraps itself.
- **Codegen step in `vel up`**: Rejected. Leaks app-specific build knowledge into the platform's orchestration tool.
- **HeyAPI Vite plugin (`@hey-api/vite-plugin`)**: Considered. First-party but adds a dependency to do what `predev` does for free. Also runs during `vite build` by default (unnecessary in production).
- **`dev` script chaining (`bun run openapi-ts && vite`)**: Rejected. `predev` is the npm/bun lifecycle convention for this pattern.

### Root cause analysis

1. **How did the code get into this state?** The `--vite` flag for `vel up` was added very recently, and the codegen pipeline was set up separately (LUM-1601). Nobody wired the two together — `ensureWebDeps()` runs `bun install` but the postinstall only did React dedup cleanup.
2. **What decisions led to it?** The platform's Next.js app commits its generated code, so `bun install` was always sufficient there. When the Vite app chose to gitignore generated code (correct for open-source), the bootstrapping gap wasn't addressed.
3. **Warning signs?** The `openapi-ts` script existed in `package.json` but was manual-only. The `.gitignore` for `src/generated/` was a signal that something needed to create it.
4. **Prevention?** When gitignoring build outputs that the app imports at the entrypoint level, always add lifecycle hooks to regenerate them.

## Test plan

- Verified `bun install` with `src/generated/` deleted → postinstall runs codegen
- Verified `bun install` with `src/generated/` present → postinstall skips codegen
- Verified `bun run dev` triggers `predev` → codegen runs before Vite starts
- Lint and typecheck pass

Link to Devin session: https://app.devin.ai/sessions/1b39bae960a146a498035acc9bb663c6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->