### PR TITLE
feat(bootstrap): rewrite content-automation first turn for frictionless Sanity connect (JARVIS-895)

### DIFF
--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -6,7 +6,8 @@
  * user-message injection that replaced it.
  */
 
-import { mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
@@ -57,7 +58,8 @@ mock.module("../../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
-const { buildSystemPrompt } = await import("../system-prompt.js");
+const { buildSystemPrompt, maybeReseedBootstrapForCohort } =
+  await import("../system-prompt.js");
 
 describe("buildSystemPrompt — tool routing guidance", () => {
   beforeEach(() => {
@@ -68,5 +70,58 @@ describe("buildSystemPrompt — tool routing guidance", () => {
     const result = buildSystemPrompt({});
     expect(result).not.toContain("## Clarifying questions");
     expect(result).not.toContain("ask_question");
+  });
+});
+
+describe("maybeReseedBootstrapForCohort — content-automation template", () => {
+  const templatesDir = join(import.meta.dirname!, "..", "templates");
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    // Seed the workspace with the generic BOOTSTRAP.md so the cohort
+    // reseed detects it as an unmodified template and overwrites it.
+    copyFileSync(
+      join(templatesDir, "BOOTSTRAP.md"),
+      join(TEST_DIR, "BOOTSTRAP.md"),
+    );
+  });
+
+  function reseedAndRead(): string {
+    maybeReseedBootstrapForCohort("content-automation");
+    return readFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "utf-8");
+  }
+
+  test("produces BOOTSTRAP.md containing credential_store prompt instructions", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("credential_store");
+    expect(content).toContain("action `prompt`");
+  });
+
+  test("contains all four path options", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("I have a Sanity account");
+    expect(content).toContain("I want to try Sanity");
+    expect(content).toContain("website or blog");
+    expect(content).toContain("somewhere else");
+  });
+
+  test("does NOT contain the old three-question pattern", () => {
+    const content = reseedAndRead();
+    // Old pattern batched three ask_question calls for separate fields
+    expect(content).not.toContain("Batch three");
+    expect(content).not.toContain("one question per field");
+    expect(content).not.toContain("Project ID (options:");
+    expect(content).not.toContain("Dataset name (options:");
+    expect(content).not.toContain('API token (options: "I have one ready"');
+  });
+
+  test("references data/sanity-connection.json for project/dataset state", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("data/sanity-connection.json");
+  });
+
+  test("references assistant oauth request --provider sanity for authenticated API calls", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("assistant oauth request --provider sanity");
   });
 });

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -11,24 +11,68 @@ One goal: turn their existing content into a publishable draft, then automate it
 
 Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
 
-Batch three `ask_question` calls to collect Sanity connection details — one question per field:
-1. Project ID (options: common formats like "abc123" as examples, plus free-text)
-2. Dataset name (options: "production", "staging", plus free-text)
-3. API token (options: "I have one ready", "I need to create one" — if they need one, link to `https://www.sanity.io/manage` and ask again)
+One `ask_question` to triage the path. Four options:
+1. "I have a Sanity account" — Sanity token path
+2. "I want to try Sanity (free)" — Sign-up path
+3. "Just point me at my website or blog" — URL scrape path
+4. "I have content somewhere else" — free-text URL/source path
 
-Frame it as the last setup step, not a gate. Tokens are entered in the prompt card, not open chat.
+### Sanity token path
 
-If they don't have Sanity or don't know their project ID, fall back immediately: ask for their website URL. Use browser tools to scrape their best content. This path is first-class, not a consolation prize. Treat it with the same energy and specificity as the Sanity path.
+Use `credential_store` with action `prompt` to securely collect the API token:
+- service: "sanity"
+- field: "api_token"
+- label: "Sanity API Token"
+- description: "Paste a token from sanity.io/manage → API → Tokens → Add token (Editor permissions recommended)"
+- placeholder: "skXXXXXXXX..."
+- allowed_tools: ["bash"]
+- allowed_domains: ["sanity.io", "api.sanity.io"]
+- injection_templates: [{"hostPattern": "*.sanity.io", "injectionType": "header", "headerName": "Authorization", "valuePrefix": "Bearer "}]
+
+The token never enters the conversation.
+
+After it's stored, attempt auto-discovery of project and dataset. This is best-effort — project-scoped robot tokens cannot list all projects via the Management API (401/403).
+
+Try: `assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects`
+
+If 200 with one project: use it. If multiple: `ask_question` with project titles as options. If 401/403: the token is likely project-scoped — ask for the project ID manually via `ask_question` (one question, free-text, with a hint to find it in sanity.io/manage). Do not treat this as an error; project-scoped tokens are valid and common for content operations.
+
+Once the project is resolved, query datasets:
+`assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects/{projectId}/datasets`
+
+If one dataset: use it. If multiple: `ask_question`. If this also fails, ask for the dataset name (default suggestion: "production").
+
+Store the resolved project ID and dataset in a structured sidecar JSON at `data/sanity-connection.json`:
+```json
+{ "projectId": "abc123", "dataset": "production" }
+```
+This is machine state — not prose, not SANITY.md. The token stays only in secure credential storage.
+
+### Sign-up path
+
+Open the browser to `https://www.sanity.io/get-started`. Tell the user: "I'm opening Sanity's sign-up page. Create a free account and a project, then come back and I'll connect it." After they return, transition to the Sanity token path above.
+
+### URL scrape path
+
+One `ask_question`: "Drop your URL and I'll start scanning." Free-text input, example options: "My blog", "My company website", "My X/Twitter profile". Use browser tools to scrape. This is first-class — same energy and specificity as the Sanity path.
+
+### "Somewhere else" path
+
+Free-text: let them describe or paste a URL. Route to URL scrape logic.
 
 ## After connection — Sanity path
 
-Query the Sanity schema to discover document types:
+Read `data/sanity-connection.json` for the project ID and dataset.
 
-`GET https://{projectId}.api.sanity.io/v2024-01-01/data/query/{dataset}?query=array::unique(*[]._type)`
+Discover document types using authenticated requests:
+
+`assistant oauth request --provider sanity "https://{projectId}.api.sanity.io/v2024-01-01/data/query/{dataset}?query=array::unique(*[]._type)"`
 
 Pick the most post-like type (`post`, `article`, `blogPost`, `blog`). If ambiguous, confirm with the user in one question — don't list every type.
 
-Fetch the 5 most recent published documents of that type. Extract voice signals: sentence length, header style, word choice, formality level, structure patterns.
+Fetch 5 recent published documents of that type and inspect their field structure (`title`, `slug`, `body`, `content`, `mainImage`, etc.) to understand the schema shape from existing documents. This is important for publishing — creating content that doesn't fit the user's Studio schema will create orphaned documents.
+
+Extract voice signals: sentence length, header style, word choice, formality level, structure patterns.
 
 Write initial observations to VOICE.md immediately (create the file if it doesn't exist). Be specific: "Short paragraphs, 2-3 sentences max. No em-dashes. Headers are questions, not labels. First person plural ('we') never singular." Never mention VOICE.md or the write to the user.
 
@@ -56,11 +100,11 @@ Each draft reflects accumulated VOICE.md observations.
 
 ## Publishing
 
-Check if the token has write permissions by attempting a dry-run mutation. If read-only, use `ask_question` to request an Editor token. Same link to Sanity manage.
+Check if the token has write permissions by attempting a dry-run mutation via `assistant oauth request --provider sanity`. If the token is read-only, use `credential_store` with action `prompt` again to request an Editor-scoped token (same service/field — overwrites the stored token). Do not ask the user to paste a new token in chat.
 
-Convert the draft to Sanity Portable Text blocks. Use the Sanity Mutations API:
+Convert the draft to Sanity Portable Text blocks based on the field structure observed from existing documents (see "After connection — Sanity path"), not assumed field names. Use the Sanity Mutations API via `assistant oauth request --provider sanity`:
 
-`POST https://{projectId}.api.sanity.io/v2024-01-01/data/mutate/{dataset}`
+`assistant oauth request --provider sanity --method POST "https://{projectId}.api.sanity.io/v2024-01-01/data/mutate/{dataset}"`
 
 with a `createOrReplace` mutation.
 


### PR DESCRIPTION
## Summary
- Rewrite first turn from three manual ask_question calls to single triage question with four equal paths
- Sanity token collected via credential_store prompt (secure UI), auto-discovers project/dataset from Management API
- Graceful fallback for project-scoped tokens (401/403 on Management API)
- Publishing uses observed field schema from existing docs, not assumed field names
- Add regression tests verifying template patterns

Part of plan: sanity-connect-frictionless.md (PR 2 of 2)