### PR TITLE
Remove credit balance and Earn credits rows from Preferences drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -53,15 +53,6 @@ extension MainWindowView {
                             AppDelegate.shared?.handlePlatformLoginSucceeded()
                         })
                     }
-                },
-                onOpenBilling: {
-                    sidebar.showPreferencesDrawer = false
-                    settingsStore.pendingSettingsTab = .billing
-                    windowState.selection = .panel(.settings)
-                },
-                onEarnCredits: {
-                    sidebar.showPreferencesDrawer = false
-                    showEarnCreditsModal = true
                 }
             )
             .frame(width: drawerWidth)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -86,7 +86,6 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     @State var showConversationSwitcher = false
-    @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
     /// Selected conversation currently being activated from a user navigation
     /// action. While non-nil, the chat surface renders a switch-loading
@@ -623,10 +622,6 @@ struct MainWindowView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .overlay { preferencesDismissLayer }
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
-            .sheet(isPresented: $showEarnCreditsModal) {
-                EarnCreditsModal()
-                    .preferredColorScheme(themePreference == "light" ? .light : (themePreference == "dark" || themePreference == "velvet") ? .dark : systemIsDark ? .dark : .light)
-            }
             .overlay { conversationSwitcherDismissLayer }
             .overlay(alignment: .topLeading) { conversationSwitcherDrawerLayer }
             .ignoresSafeArea(edges: .top)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -8,24 +8,6 @@ struct DrawerMenuView: View {
     let onShareFeedback: () -> Void
     let onLogOut: () -> Void
     let onSignIn: () -> Void
-    let onOpenBilling: () -> Void
-    let onEarnCredits: () -> Void
-
-    @State private var effectiveBalance: String?
-    @State private var isLowBalance = false
-    @State private var isZeroBalance = false
-    @State private var bootstrapGeneration: Int = 0
-    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-
-    private var isBillingVisible: Bool {
-        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
-        return authManager.isAuthenticated &&
-        connectedOrgId != nil
-    }
-
-    private var isReferralVisible: Bool {
-        isBillingVisible
-    }
 
     var body: some View {
         VMenu {
@@ -35,42 +17,6 @@ struct DrawerMenuView: View {
 
             VMenuCustomRow {
                 tightDividerLine
-            }
-
-            if let balance = effectiveBalance {
-                VMenuCustomRow {
-                    HStack {
-                        Text("\(balance) credits")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(
-                                isZeroBalance ? VColor.systemNegativeStrong :
-                                isLowBalance ? VColor.systemMidStrong :
-                                VColor.contentDefault
-                            )
-                        Spacer()
-                        if isBillingVisible {
-                            Button("Add credits") { onOpenBilling() }
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.primaryBase)
-                                .buttonStyle(.plain)
-                        }
-                    }
-                    .frame(minHeight: VSize.rowMinHeight)
-                }
-
-                VMenuCustomRow {
-                    tightDividerLine
-                }
-
-                if isReferralVisible {
-                    VMenuItem(icon: VIcon.gift.rawValue, label: String(localized: "Earn credits")) {
-                        onEarnCredits()
-                    }
-
-                    VMenuCustomRow {
-                        tightDividerLine
-                    }
-                }
             }
 
             VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
@@ -84,12 +30,6 @@ struct DrawerMenuView: View {
                 VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
-            bootstrapGeneration += 1
-        }
-        .task {
-            await loadBalance()
-        }
     }
 
     /// 1pt divider line without VMenuDivider's 4pt vertical padding,
@@ -98,23 +38,5 @@ struct DrawerMenuView: View {
         Rectangle()
             .fill(VColor.borderOverlay)
             .frame(height: 1)
-    }
-
-    private func loadBalance() async {
-        guard authManager.isAuthenticated else { return }
-        do {
-            var summary = try await BillingService.shared.getBillingSummary()
-            if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
-                summary = bootstrapped
-            }
-            let balanceString = summary.effective_balance
-            effectiveBalance = balanceString
-            if let value = Double(balanceString) {
-                isZeroBalance = value <= 0
-                isLowBalance = value < 1.0
-            }
-        } catch {
-            // Silently ignore errors — don't show error state in the popup
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Remove the credit balance display and 'Add credits' button from the Preferences drawer
- Remove the 'Earn credits' referral row from the Preferences drawer
- Remove related state and billing service calls from DrawerMenuView

Part of plan: remove-credits-drawer.md (PR 1 of 1)

## Test plan
- [ ] Open the Preferences drawer and verify it shows: Theme toggle, divider, Settings, Usage, Share Feedback, Log Out/In
- [ ] Confirm no credit balance or "Earn credits" row appears
- [ ] Open Settings > Billing tab and verify "Earn credits" modal is still accessible from there
- [ ] Verify no compiler warnings from removed parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->