### PR TITLE
fix(notifications): drop title from rich chat seed when it's the conversation header

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -250,7 +250,7 @@ describe("pairDeliveryWithConversation", () => {
     // Should NOT be the JSON dump
     expect(contentArg).not.toContain('"raw"');
     // Should be the runtime-composed seed from copy.title/body
-    expect(contentArg).toContain("Reminder");
+    expect(contentArg).toContain("Daily standup");
   });
 
   test("rejects very short conversationSeedMessage and uses runtime composer", async () => {
@@ -273,7 +273,7 @@ describe("pairDeliveryWithConversation", () => {
     const contentArg = addMessageMock.mock.calls[0]![2] as string;
     expect(contentArg).not.toBe("Hi");
     // Runtime composer builds from copy.title/body
-    expect(contentArg).toContain("Reminder");
+    expect(contentArg).toContain("Test reminder");
   });
 
   test("passes skipIndexing option to addMessage", async () => {

--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -175,7 +175,7 @@ describe("isConversationSeedSane", () => {
 
 describe("composeConversationSeed", () => {
   describe("rich verbosity (vellum/macos)", () => {
-    test("combines title and body into flowing prose", () => {
+    test("omits title when conversationTitle is absent (it's the chat header)", () => {
       const signal = makeSignal();
       const copy = makeCopy({ title: "Reminder", body: "Take out the trash" });
       const seed = composeConversationSeed(
@@ -183,10 +183,55 @@ describe("composeConversationSeed", () => {
         "vellum" as NotificationChannel,
         copy,
       );
-      expect(seed).toContain("Reminder");
-      expect(seed).toContain("Take out the trash");
-      // Should be flowing prose (joined with ". "), not newline-separated
+      // The conversation header already shows copy.title — including it in
+      // the bubble would duplicate it.
+      expect(seed).toBe("Take out the trash");
+    });
+
+    test("includes title when conversationTitle provides a distinct header", () => {
+      const signal = makeSignal();
+      const copy = makeCopy({
+        conversationTitle: "Updates",
+        title: "Heart rate spike",
+        body: "You hit 103 bpm.",
+      });
+      const seed = composeConversationSeed(
+        signal,
+        "vellum" as NotificationChannel,
+        copy,
+      );
+      expect(seed).toContain("Heart rate spike");
+      expect(seed).toContain("You hit 103 bpm");
       expect(seed).not.toContain("\n");
+    });
+
+    test("does not duplicate title when body already starts with it", () => {
+      const signal = makeSignal();
+      const copy = makeCopy({
+        title: "Status update — service running",
+        body: "Status update — service running since 12:00 PM.",
+      });
+      const seed = composeConversationSeed(
+        signal,
+        "vellum" as NotificationChannel,
+        copy,
+      );
+      // Without the fix, this would produce
+      // "Status update — service running. Status update — service running since 12:00 PM."
+      expect(seed).toBe("Status update — service running since 12:00 PM.");
+    });
+
+    test("falls back to title when body is empty and title is the header", () => {
+      const signal = makeSignal();
+      const copy = makeCopy({ title: "Reminder", body: "" });
+      const seed = composeConversationSeed(
+        signal,
+        "vellum" as NotificationChannel,
+        copy,
+      );
+      // Even though the title is the conversation header, keeping the
+      // bubble non-empty wins over avoiding the redundancy.
+      expect(seed).toBe("Reminder");
     });
 
     test('appends "Action required." when requiresAction is true', () => {
@@ -277,6 +322,7 @@ describe("composeConversationSeed", () => {
     test("preserves localized LLM copy on vellum (rich)", () => {
       const signal = makeSignal();
       const copy = makeCopy({
+        conversationTitle: "通知",
         title: "リマインダー",
         body: "ゴミを出してください",
       });
@@ -285,6 +331,7 @@ describe("composeConversationSeed", () => {
         "vellum" as NotificationChannel,
         copy,
       );
+      // conversationTitle is set, so the rich seed includes both title and body.
       expect(seed).toContain("リマインダー");
       expect(seed).toContain("ゴミを出してください");
     });
@@ -314,6 +361,7 @@ describe("composeConversationSeed", () => {
         },
       });
       const copy = makeCopy({
+        conversationTitle: "ガーディアン",
         title: "ガーディアンの質問",
         body: "ゲートコードは何ですか？",
       });

--- a/assistant/src/notifications/conversation-seed-composer.ts
+++ b/assistant/src/notifications/conversation-seed-composer.ts
@@ -156,7 +156,17 @@ export function composeConversationSeed(
 
   if (verbosity === "rich") {
     const parts: string[] = [];
-    if (copy.title && copy.title !== "Notification") parts.push(copy.title);
+    const usableTitle =
+      copy.title && copy.title !== "Notification" ? copy.title : "";
+    // copy.title is used as the conversation header in chat surfaces
+    // whenever copy.conversationTitle is absent (see
+    // conversation-pairing.ts), so prepending it here would render it
+    // twice — once in the header bar and once at the start of the
+    // bubble. Skip it in that case, unless there's no body and we'd
+    // otherwise produce an empty seed.
+    if (usableTitle && (copy.conversationTitle || !copy.body)) {
+      parts.push(usableTitle);
+    }
     if (copy.body) parts.push(copy.body);
     const alreadyMentionsAction = parts.some((part) =>
       /\baction required\b/i.test(part),


### PR DESCRIPTION
## Summary
- For rich verbosity (web/macOS/iOS chat surfaces), `composeConversationSeed` no longer prepends `copy.title` to the body when `copy.conversationTitle` is absent. In that case `copy.title` is already shown as the conversation header in the chat surface (see `conversation-pairing.ts:116-117`), so prepending it duplicated the text inside the message bubble — the title appeared once in the header bar and again at the start of the body.
- Fallback preserved: when the body is empty and we'd otherwise produce a blank seed, the title is still included.
- Compact verbosity (Telegram, etc.) is unchanged — those surfaces don't render a separate conversation title.

## Original prompt
A notification rendering bug in the macOS chat surface showed the title twice: truncated in the conversation header bar at the top of the chat view, and again as a prefix on the message body. Root cause was daemon-side seed composition — the rich branch of `composeConversationSeed` joined `[title, body]` with `". "` even when `copy.title` was being used as the conversation header. Fix the seed composer so the title isn't prepended in that case, while preserving it when a distinct `conversationTitle` provides the header.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->