### PR TITLE
Remove credit count and Earn credits from Preferences drawer (macOS + web)

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -1,9 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import {
   ChartColumn,
   ChevronDown,
   ChevronUp,
-  Gift,
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
@@ -14,7 +12,6 @@ import { useNavigate } from "react-router";
 
 import {
   BottomSheet,
-  Button,
   PanelItem,
   Popover,
   SideMenu,
@@ -23,40 +20,12 @@ import {
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
-import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen.js";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal.js";
-import { EarnCreditsModal } from "@/components/earn-credits-modal.js";
 import { ThemeToggle } from "@/components/theme-toggle.js";
 
-/**
- * Preferences menu rendered inside the assistant sidebar footer.
- *
- * Owns both its trigger (a `SideMenu.Item` labelled "Preferences") and
- * its popover content. The trigger flips to its active state while the
- * popover is open and its chevron swaps from Up → Down to signal the
- * expansion direction (popover opens *above* the trigger since it's
- * pinned to the bottom of the rail).
- *
- * Content mirrors `UserMenu`'s dropdown — Theme, Credits, Earn credits,
- * Settings, Usage, Share Feedback, Log Out — but rendered
- * with `PanelItem` for every row except the two custom ones (Theme
- * toggle group + Credits / Add credits row). Those two have bespoke
- * layout that doesn't map onto a generic icon + label + badge row.
- *
- * **Mobile parity**: when `useIsMobile()` is true, the same content is
- * rendered inside a `BottomSheet` (Radix Dialog) so it slides up from the
- * bottom edge full-width. Desktop keeps the existing `Popover` behavior.
- */
 export interface PreferencesMenuProps {
   assistantId?: string | null;
   assistantVersion?: string | null;
-  /**
-   * Key of the currently-open conversation, forwarded into the
-   * `<ShareFeedbackModal>` so the "Include logs" toggle scopes the
-   * exported assistant logs (messages / LLM request logs / usage events
-   * / tool invocations) to that conversation. `null` / `undefined` =
-   * unscoped export across all conversations.
-   */
   activeConversationKey?: string | null;
 }
 
@@ -69,7 +38,6 @@ export function PreferencesMenu({
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
-  const [isEarnCreditsOpen, setIsEarnCreditsOpen] = useState(false);
 
   if (!isLoggedIn) {
     return null;
@@ -90,7 +58,6 @@ export function PreferencesMenu({
     <PreferencesMenuContent
       onClose={closeMenu}
       onShareFeedback={() => setIsFeedbackOpen(true)}
-      onEarnCredits={() => setIsEarnCreditsOpen(true)}
     />
   );
 
@@ -127,11 +94,6 @@ export function PreferencesMenu({
         assistantVersion={assistantVersion}
         activeConversationKey={activeConversationKey}
       />
-
-      <EarnCreditsModal
-        open={isEarnCreditsOpen}
-        onClose={() => setIsEarnCreditsOpen(false)}
-      />
     </>
   );
 }
@@ -139,59 +101,19 @@ export function PreferencesMenu({
 interface PreferencesMenuContentProps {
   onClose: () => void;
   onShareFeedback: () => void;
-  onEarnCredits: () => void;
 }
 
 function PreferencesMenuContent({
   onClose,
   onShareFeedback,
-  onEarnCredits,
 }: PreferencesMenuContentProps) {
   const navigate = useNavigate();
   const logout = useAuthStore.use.logout();
-  const { data: billingSummary } = useQuery({
-    ...organizationsBillingSummaryRetrieveOptions(),
-  });
-  const effectiveBalance = billingSummary?.effective_balance ?? null;
 
   return (
     <>
       <ThemeToggle className="px-2 pt-0" />
 
-      <MenuDivider />
-
-      {effectiveBalance !== null ? (
-        <>
-          <div className="flex items-center justify-between gap-3 py-2 pl-[8px]">
-            <span
-              className="text-body-medium-lighter"
-              style={{ color: "var(--content-default)" }}
-            >
-              {formatWholeCredits(effectiveBalance)} credits
-            </span>
-            <Button
-              variant="ghost"
-              size="compact"
-              onClick={() => {
-                onClose();
-                navigate(routes.settings.billing);
-              }}
-            >
-              Add credits
-            </Button>
-          </div>
-          <MenuDivider />
-        </>
-      ) : null}
-
-      <PanelItem
-        icon={Gift}
-        label="Earn credits"
-        onSelect={() => {
-          onClose();
-          onEarnCredits();
-        }}
-      />
       <MenuDivider />
 
       <PanelItem
@@ -232,17 +154,6 @@ function PreferencesMenuContent({
       />
     </>
   );
-}
-
-function formatWholeCredits(value: string): string {
-  const num = parseFloat(value);
-  if (!Number.isFinite(num)) {
-    return value;
-  }
-  return num.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
 }
 
 function MenuDivider() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -53,15 +53,6 @@ extension MainWindowView {
                             AppDelegate.shared?.handlePlatformLoginSucceeded()
                         })
                     }
-                },
-                onOpenBilling: {
-                    sidebar.showPreferencesDrawer = false
-                    settingsStore.pendingSettingsTab = .billing
-                    windowState.selection = .panel(.settings)
-                },
-                onEarnCredits: {
-                    sidebar.showPreferencesDrawer = false
-                    showEarnCreditsModal = true
                 }
             )
             .frame(width: drawerWidth)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -86,7 +86,6 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     @State var showConversationSwitcher = false
-    @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
     /// Selected conversation currently being activated from a user navigation
     /// action. While non-nil, the chat surface renders a switch-loading
@@ -623,10 +622,6 @@ struct MainWindowView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .overlay { preferencesDismissLayer }
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
-            .sheet(isPresented: $showEarnCreditsModal) {
-                EarnCreditsModal()
-                    .preferredColorScheme(themePreference == "light" ? .light : (themePreference == "dark" || themePreference == "velvet") ? .dark : systemIsDark ? .dark : .light)
-            }
             .overlay { conversationSwitcherDismissLayer }
             .overlay(alignment: .topLeading) { conversationSwitcherDrawerLayer }
             .ignoresSafeArea(edges: .top)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -8,24 +8,6 @@ struct DrawerMenuView: View {
     let onShareFeedback: () -> Void
     let onLogOut: () -> Void
     let onSignIn: () -> Void
-    let onOpenBilling: () -> Void
-    let onEarnCredits: () -> Void
-
-    @State private var effectiveBalance: String?
-    @State private var isLowBalance = false
-    @State private var isZeroBalance = false
-    @State private var bootstrapGeneration: Int = 0
-    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-
-    private var isBillingVisible: Bool {
-        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
-        return authManager.isAuthenticated &&
-        connectedOrgId != nil
-    }
-
-    private var isReferralVisible: Bool {
-        isBillingVisible
-    }
 
     var body: some View {
         VMenu {
@@ -35,42 +17,6 @@ struct DrawerMenuView: View {
 
             VMenuCustomRow {
                 tightDividerLine
-            }
-
-            if let balance = effectiveBalance {
-                VMenuCustomRow {
-                    HStack {
-                        Text("\(balance) credits")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(
-                                isZeroBalance ? VColor.systemNegativeStrong :
-                                isLowBalance ? VColor.systemMidStrong :
-                                VColor.contentDefault
-                            )
-                        Spacer()
-                        if isBillingVisible {
-                            Button("Add credits") { onOpenBilling() }
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.primaryBase)
-                                .buttonStyle(.plain)
-                        }
-                    }
-                    .frame(minHeight: VSize.rowMinHeight)
-                }
-
-                VMenuCustomRow {
-                    tightDividerLine
-                }
-
-                if isReferralVisible {
-                    VMenuItem(icon: VIcon.gift.rawValue, label: String(localized: "Earn credits")) {
-                        onEarnCredits()
-                    }
-
-                    VMenuCustomRow {
-                        tightDividerLine
-                    }
-                }
             }
 
             VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
@@ -84,12 +30,6 @@ struct DrawerMenuView: View {
                 VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
-            bootstrapGeneration += 1
-        }
-        .task {
-            await loadBalance()
-        }
     }
 
     /// 1pt divider line without VMenuDivider's 4pt vertical padding,
@@ -98,23 +38,5 @@ struct DrawerMenuView: View {
         Rectangle()
             .fill(VColor.borderOverlay)
             .frame(height: 1)
-    }
-
-    private func loadBalance() async {
-        guard authManager.isAuthenticated else { return }
-        do {
-            var summary = try await BillingService.shared.getBillingSummary()
-            if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
-                summary = bootstrapped
-            }
-            let balanceString = summary.effective_balance
-            effectiveBalance = balanceString
-            if let value = Double(balanceString) {
-                isZeroBalance = value <= 0
-                isLowBalance = value < 1.0
-            }
-        } catch {
-            // Silently ignore errors — don't show error state in the popup
-        }
     }
 }


### PR DESCRIPTION
## Summary
Remove the credit balance display ("X credits" + "Add credits" button) and the "Earn credits" referral row from the Preferences drawer/menu on both macOS and web clients. The drawer now shows only: theme toggle, Settings, Usage, Share Feedback, and Log Out/In. `EarnCreditsModal` remains accessible from Settings > Billing.

### macOS
- Removed credit balance row, "Add credits" button, and "Earn credits" menu item from `DrawerMenuView`
- Removed `onOpenBilling` and `onEarnCredits` callbacks from `MainWindowView+Drawers`
- Removed `showEarnCreditsModal` state and sheet from `MainWindowView`

### Web
- Removed credit balance row, "Add credits" button, and "Earn credits" menu item from `PreferencesMenu`
- Removed billing query, `EarnCreditsModal` state/rendering, and `formatWholeCredits` helper
- Cleaned up unused imports (`useQuery`, `Gift`, `Button`, `organizationsBillingSummaryRetrieveOptions`, `EarnCreditsModal`)

## Self-review result
PASS — all changes are pure deletions with no behavioral side effects.

## PRs merged into feature branch
- #31227: Remove credit balance and Earn credits rows from Preferences drawer (macOS)
- Web changes added directly to feature branch

Part of plan: remove-credits-drawer-web.md