### PR TITLE
fix(bootstrap): use correct CLI flag for POST mutations in content-automation template (JARVIS-895)

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -104,7 +104,7 @@ Check if the token has write permissions by attempting a dry-run mutation via `a
 
 Convert the draft to Sanity Portable Text blocks based on the field structure observed from existing documents (see "After connection — Sanity path"), not assumed field names. Use the Sanity Mutations API via `assistant oauth request --provider sanity`:
 
-`assistant oauth request --provider sanity --method POST "https://{projectId}.api.sanity.io/v2024-01-01/data/mutate/{dataset}"`
+`assistant oauth request --provider sanity -X POST "https://{projectId}.api.sanity.io/v2024-01-01/data/mutate/{dataset}"`
 
 with a `createOrReplace` mutation.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sanity-connect-frictionless.md.

**Gap:** Incorrect CLI flag in publishing section
**What was expected:** `-X POST` (the actual flag defined in `assistant oauth request`)
**What was found:** `--method POST` (non-existent flag that would cause an unknown option error)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->