### PR TITLE
chore(memory): clarify v2 injection header instruction

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -743,7 +743,7 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.block).not.toBeNull();
     expect(result.block).toContain(
-      "**CRITICAL:** These are page summaries. Read the page file if it looks relevant.",
+      "**CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.",
     );
     expect(result.block).toContain(
       "# memory/concepts/summarized-page.md\nA short prose description",

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -712,7 +712,7 @@ interface RenderInjectionBlockResult {
  * the agent into wasted reads.
  */
 const INJECTION_HEADER =
-  "**CRITICAL:** These are page summaries. Read the page file if it looks relevant.";
+  "**CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.";
 
 /**
  * Render the inner content of the `<memory>` block for a list of slugs.
@@ -747,7 +747,7 @@ const INJECTION_HEADER =
  * after the skills under `### CLI Commands You Can Use`. The leading
  * `**CRITICAL:**` line tells the agent how to read the block.
  *
- *   **CRITICAL:** These are page summaries. Read the page file if it looks relevant.
+ *   **CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.
  *
  *   # memory/concepts/<concept-slug-1>.md
  *   <summary-1>


### PR DESCRIPTION
## Summary
- Reword the `INJECTION_HEADER` constant in `assistant/src/memory/v2/injection.ts` from "Read the page file if it looks relevant." to "Read full page files at the paths below with file_read if you want more information." — clearer signal to the agent that the path-style entries below are file paths it can pass to its read tool.
- Update the matching JSDoc example in the same file and the test expectation in `injection.test.ts` so they stay in sync with the constant.

## Original prompt
Update the memory-v2 injection block's leading instruction line so the agent treats the listed page paths as files to read with the `file_read` tool when it wants the full content, rather than the vaguer "if it looks relevant" framing. Change both the runtime constant and the JSDoc/test references so the wording matches everywhere.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->