### PR TITLE
docs(web): add Linear project link to migration status section

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -42,7 +42,7 @@ cd apps/web && bun test src/path/to/file.test.ts  # Run specific tests
 
 ## Migration status
 
-This app is being migrated from [`vellum-assistant-platform/web/`](https://github.com/vellum-ai/vellum-assistant-platform). During migration:
+This app is being migrated from [`vellum-assistant-platform/web/`](https://github.com/vellum-ai/vellum-assistant-platform). Remaining work is tracked in the [Web App Repo Move](https://linear.app/vellum/project/web-app-repo-move-platform-vellum-assistant-1b8cd4f8-49cf-4b7b-b8e9-98b92046d2c3) Linear project. During migration:
 
 - **Faithful copy, not simplification.** Port real implementations, not stubs. All Capacitor/native code paths must be preserved.
 - **Convention compliance on arrival.** Apply this repo's naming (kebab-case), import conventions (`.js` extensions, `@/` aliases), and directory structure as code is ported.


### PR DESCRIPTION
## Prompt / plan

Add a link to the [Web App Repo Move](https://linear.app/vellum/project/web-app-repo-move-platform-vellum-assistant-1b8cd4f8-49cf-4b7b-b8e9-98b92046d2c3) Linear project in the migration status section of `apps/web/AGENTS.md` so contributors can find the migration tracker without needing to know the project name.

## Test plan

Documentation-only change — no code affected. Verified the link resolves to the correct Linear project.

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->