### PR TITLE
feat(design-library): port SideMenu + CollapsibleNavSection from platform

### DIFF
--- a/packages/design-library/bun.lock
+++ b/packages/design-library/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vellum/design-library",
       "dependencies": {
+        "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-checkbox": "1.3.3",
         "@radix-ui/react-context-menu": "2.2.16",
         "@radix-ui/react-dialog": "1.1.15",
@@ -265,9 +266,13 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
+    "@radix-ui/react-accordion": ["@radix-ui/react-accordion@1.2.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA=="],
+
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
     "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
 

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -11,6 +11,8 @@
     "./components/*": "./src/components/*.tsx",
     "./components/panel-item": "./src/components/panel-item/panel-item.tsx",
     "./components/panel-item/marquee-text": "./src/components/panel-item/marquee-text.tsx",
+    "./components/side-menu": "./src/components/side-menu/side-menu.tsx",
+    "./components/side-menu/collapsible-nav-section": "./src/components/side-menu/collapsible-nav-section.tsx",
     "./utils/*": "./src/utils/*.ts",
     "./utils/portal-container": "./src/utils/portal-container.tsx"
   },
@@ -49,6 +51,7 @@
     "vitest": "4.1.6"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-checkbox": "1.3.3",
     "@radix-ui/react-context-menu": "2.2.16",
     "@radix-ui/react-dialog": "1.1.15",

--- a/packages/design-library/src/components/side-menu/collapsible-nav-section.test.tsx
+++ b/packages/design-library/src/components/side-menu/collapsible-nav-section.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for the CollapsibleNavSection primitive.
+ *
+ * Renders to static markup via `react-dom/server` and asserts on the
+ * emitted HTML. Radix's interactive behavior is covered by Radix's
+ * own test suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Clock } from "lucide-react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CollapsibleNavSection } from "./collapsible-nav-section.js";
+
+function renderSingleSection(opts: {
+  value: string;
+  label: string;
+  trailing?: string;
+  defaultValue?: string[];
+}) {
+  return renderToStaticMarkup(
+    createElement(
+      CollapsibleNavSection.Root,
+      { type: "multiple", defaultValue: opts.defaultValue ?? [] },
+      createElement(
+        CollapsibleNavSection.Section,
+        {
+          value: opts.value,
+          icon: Clock,
+          label: opts.label,
+          trailing: opts.trailing
+            ? createElement("span", null, opts.trailing)
+            : undefined,
+        },
+        createElement("div", null, "child-content"),
+      ),
+    ),
+  );
+}
+
+describe("CollapsibleNavSection", () => {
+  test("renders the label and accordion trigger markup", () => {
+    const html = renderSingleSection({ value: "recents", label: "Recents" });
+    expect(html).toContain("Recents");
+    expect(html).toContain("<button");
+    expect(html).toContain('data-state="closed"');
+  });
+
+  test("renders the section in its open state when value is in defaultValue", () => {
+    const html = renderSingleSection({
+      value: "recents",
+      label: "Recents",
+      defaultValue: ["recents"],
+    });
+    expect(html).toContain('data-state="open"');
+    expect(html).toContain("child-content");
+  });
+
+  test("renders the trailing slot when provided", () => {
+    const html = renderSingleSection({
+      value: "pinned",
+      label: "Pinned",
+      trailing: "4",
+    });
+    expect(html).toContain("4");
+  });
+
+  test("omits the trailing slot entirely when not provided", () => {
+    const html = renderSingleSection({ value: "pinned", label: "Pinned" });
+    expect(html).not.toContain("cns-trailing");
+  });
+
+  test("trailing slot is rendered OUTSIDE the Accordion.Trigger button", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        CollapsibleNavSection.Root,
+        { type: "multiple" },
+        createElement(
+          CollapsibleNavSection.Section,
+          {
+            value: "pinned",
+            icon: Clock,
+            label: "Pinned",
+            trailing: createElement(
+              "button",
+              { type: "button" },
+              "action",
+            ),
+          },
+          null,
+        ),
+      ),
+    );
+    const triggerClose = html.indexOf("</button>");
+    const trailingMarker = html.indexOf("cns-trailing");
+    expect(triggerClose).toBeGreaterThanOrEqual(0);
+    expect(trailingMarker).toBeGreaterThan(triggerClose);
+  });
+
+  test("trigger carries the text-body-small-default typography utility", () => {
+    const html = renderSingleSection({ value: "recents", label: "Recents" });
+    expect(html).toContain("text-body-small-default");
+    expect(html).toContain("leading-[16px]");
+  });
+
+  test("emits both leading glyphs (category icon + chevron-right) layered", () => {
+    const html = renderSingleSection({ value: "recents", label: "Recents" });
+    const svgCount = (html.match(/<\/svg>/g) ?? []).length;
+    expect(svgCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("root renders data-slot attribute", () => {
+    const html = renderSingleSection({ value: "recents", label: "Recents" });
+    expect(html).toContain('data-slot="collapsible-nav-section"');
+  });
+});

--- a/packages/design-library/src/components/side-menu/collapsible-nav-section.tsx
+++ b/packages/design-library/src/components/side-menu/collapsible-nav-section.tsx
@@ -1,0 +1,164 @@
+import * as Accordion from "@radix-ui/react-accordion";
+import { ChevronRight, type LucideIcon } from "lucide-react";
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+import { cn } from "../../utils/cn.js";
+
+/**
+ * Collapsible navigation section — a Radix-backed accordion item with a
+ * header row that:
+ *
+ *   - Carries a leading icon which swaps to a disclosure chevron on
+ *     hover only. The chevron rotates 90° when expanded (matching
+ *     macOS SidebarSectionHeader). The original icon is always
+ *     visible when not hovered, regardless of expanded state.
+ *   - Takes an optional `trailing` slot for an ellipsis menu, a count
+ *     badge, or any other per-row affordance. The trailing slot isolates
+ *     pointer events so clicking it doesn't also toggle the section.
+ *   - Renders no hover background — keeps the rail quiet. The chevron
+ *     swap is the affordance.
+ *
+ * Usage:
+ *
+ *   <CollapsibleNavSection.Root type="multiple" defaultValue={["recents"]}>
+ *     <CollapsibleNavSection.Section
+ *       value="recents"
+ *       icon={Clock}
+ *       label="Recents"
+ *       trailing={<Badge>12</Badge>}
+ *     >
+ *       {childRows}
+ *     </CollapsibleNavSection.Section>
+ *   </CollapsibleNavSection.Root>
+ *
+ * Animations use Radix's `--radix-accordion-content-height` variable —
+ * the keyframes are defined in `tokens.css` so they stay out of Tailwind's
+ * JIT output.
+ */
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+type RootProps = ComponentPropsWithoutRef<typeof Accordion.Root> & {
+  ref?: Ref<ElementRef<typeof Accordion.Root>>;
+};
+
+function CollapsibleNavSectionRoot({ className, ref, ...props }: RootProps) {
+  return (
+    <Accordion.Root
+      ref={ref}
+      data-slot="collapsible-nav-section"
+      className={cn("flex w-full flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export interface CollapsibleNavSectionSectionProps
+  extends Omit<ComponentPropsWithoutRef<typeof Accordion.Item>, "children"> {
+  value: string;
+  icon?: LucideIcon;
+  label: string;
+  trailing?: ReactNode;
+  children?: ReactNode;
+  contentClassName?: string;
+  ref?: Ref<ElementRef<typeof Accordion.Item>>;
+}
+
+function CollapsibleNavSectionSection({
+  value,
+  icon: Icon,
+  label,
+  trailing,
+  children,
+  className,
+  contentClassName,
+  ref,
+  ...itemProps
+}: CollapsibleNavSectionSectionProps) {
+  return (
+    <Accordion.Item
+      ref={ref}
+      value={value}
+      className={cn("flex flex-col", className)}
+      {...itemProps}
+    >
+      <Accordion.Header className="flex items-center">
+        <Accordion.Trigger
+          className={cn(
+            "group flex h-[28px] max-md:h-auto min-w-0 flex-1 items-center gap-[4px] max-md:gap-[8px]",
+            "rounded-[6px] p-[6px] max-md:px-2 max-md:py-3",
+            "text-left text-body-small-default leading-[16px] max-md:text-body-large-default",
+            "text-[var(--content-tertiary)]",
+            "cursor-pointer select-none",
+            "outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+          )}
+        >
+          <span className="relative inline-flex size-[14px] shrink-0 items-center justify-center">
+            {Icon ? (
+              <Icon
+                size={14}
+                aria-hidden
+                className={cn(
+                  "absolute inset-0 m-auto transition-opacity",
+                  "text-[var(--content-tertiary)]",
+                  "group-hover:opacity-0 group-focus-visible:opacity-0",
+                )}
+              />
+            ) : null}
+            <ChevronRight
+              size={14}
+              aria-hidden
+              className={cn(
+                "absolute inset-0 m-auto transition-[opacity,transform]",
+                "text-[var(--content-tertiary)]",
+                Icon
+                  ? "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
+                  : "opacity-100",
+                "group-data-[state=open]:rotate-90",
+              )}
+            />
+          </span>
+          <span className="min-w-0 flex-1 truncate">{label}</span>
+        </Accordion.Trigger>
+        {trailing ? (
+          <span
+            className="cns-trailing flex items-center shrink-0 pr-[6px] max-md:pr-2"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {trailing}
+          </span>
+        ) : null}
+      </Accordion.Header>
+      <Accordion.Content
+        className={cn(
+          "cns-content overflow-hidden",
+          contentClassName,
+        )}
+      >
+        {children}
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const CollapsibleNavSection = {
+  Root: CollapsibleNavSectionRoot,
+  Section: CollapsibleNavSectionSection,
+};
+
+export type CollapsibleNavSectionRootProps = RootProps;

--- a/packages/design-library/src/components/side-menu/collapsible-nav-section.tsx
+++ b/packages/design-library/src/components/side-menu/collapsible-nav-section.tsx
@@ -89,6 +89,7 @@ function CollapsibleNavSectionSection({
   return (
     <Accordion.Item
       ref={ref}
+      data-slot="collapsible-nav-section-section"
       value={value}
       className={cn("flex flex-col", className)}
       {...itemProps}

--- a/packages/design-library/src/components/side-menu/side-menu.test.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * Tests for the SideMenu primitive.
+ *
+ * Renders to static markup via `react-dom/server` and asserts on the
+ * emitted HTML — no DOM testing library required.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { Globe } from "lucide-react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SideMenu } from "./side-menu.js";
+
+describe("SideMenu root", () => {
+  test("renders a <nav> with the provided aria-label and data-slot", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(SideMenu.Body, { key: "body" }, null),
+      ),
+    );
+    expect(html).toContain("<nav");
+    expect(html).toContain('aria-label="Primary"');
+    expect(html).toContain('data-slot="side-menu"');
+  });
+
+  test("default variant is rail with expanded width", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(SideMenu.Body, { key: "body" }, null),
+      ),
+    );
+    expect(html).toContain("w-[230px]");
+    expect(html).toContain("rounded-[12px]");
+    expect(html).toContain("bg-[var(--surface-overlay)]");
+  });
+
+  test("collapsed rail shrinks the width", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary", collapsed: true },
+        createElement(SideMenu.Body, { key: "body" }, null),
+      ),
+    );
+    expect(html).toContain("w-[48px]");
+    expect(html).not.toContain("w-[230px]");
+  });
+
+  test("overlay variant is full-bleed with no radius", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary", variant: "overlay" },
+        createElement(SideMenu.Body, { key: "body" }, null),
+      ),
+    );
+    expect(html).toContain("w-full");
+    expect(html).toContain("rounded-none");
+  });
+});
+
+describe("SideMenu collapsed rail content visibility", () => {
+  test("section titles and labels are absent from the DOM in collapsed rail mode", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary", collapsed: true },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(
+            SideMenu.Section,
+            { key: "s", title: "Intelligence" },
+            createElement(
+              SideMenu.SubList,
+              { key: "sl" },
+              createElement(SideMenu.Item, {
+                key: "i",
+                icon: Globe,
+                label: "Pinned App",
+                badge: "3",
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(html).not.toContain("Intelligence");
+    expect(html).not.toContain(">3<");
+    expect(html).not.toContain("Pinned App");
+  });
+
+  test("collapsed item rendered outside a SubList still hides its label", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary", collapsed: true },
+        createElement(
+          SideMenu.Footer,
+          { key: "f" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Preferences",
+          }),
+        ),
+      ),
+    );
+    expect(html).not.toContain(">Preferences<");
+    expect(html).toContain('title="Preferences"');
+  });
+});
+
+describe("SideMenu overlay always shows labels", () => {
+  test("overlay ignores `collapsed` and renders labels + titles", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary", variant: "overlay", collapsed: true },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(
+            SideMenu.Section,
+            { key: "s", title: "Intelligence" },
+            createElement(
+              SideMenu.SubList,
+              { key: "sl" },
+              createElement(SideMenu.Item, {
+                key: "i",
+                icon: Globe,
+                label: "Pinned App",
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(html).toContain("Intelligence");
+    expect(html).toContain("Pinned App");
+  });
+});
+
+describe("SideMenu.Item active / aria-current", () => {
+  test("active item sets aria-current=page", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+            active: true,
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain('aria-current="page"');
+  });
+
+  test("inactive item does not set aria-current", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+          }),
+        ),
+      ),
+    );
+    expect(html).not.toContain("aria-current");
+  });
+});
+
+describe("SideMenu.Item typography", () => {
+  test("default size uses body-medium-lighter", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("text-body-medium-lighter");
+    expect(html).not.toContain("text-body-small-default");
+  });
+
+  test("compact size uses body-small-default", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Thread",
+            size: "compact",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("text-body-small-default");
+    expect(html).not.toContain("text-body-medium-lighter");
+  });
+
+  test("badge chip uses label-small-default", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Inbox",
+            badge: "9",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("text-label-small-default");
+  });
+});
+
+describe("SideMenu.Item rendering", () => {
+  test("renders as <button type=button> when no href is given", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("<button");
+    expect(html).toContain('type="button"');
+  });
+
+  test("renders as <a> when href is provided", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+            href: "/somewhere",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/somewhere"');
+    expect(html).not.toContain("<button");
+  });
+
+  test("onSelect prop call contract", () => {
+    const onSelect = mock(() => {});
+    renderToStaticMarkup(
+      createElement(
+        SideMenu,
+        { ariaLabel: "Primary" },
+        createElement(
+          SideMenu.Body,
+          { key: "body" },
+          createElement(SideMenu.Item, {
+            key: "i",
+            icon: Globe,
+            label: "Home",
+            onSelect,
+          }),
+        ),
+      ),
+    );
+    onSelect();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -1,0 +1,547 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+import { Typography } from "../typography.js";
+import { cn } from "../../utils/cn.js";
+
+/**
+ * SideMenu primitive — a docked application navigation rail.
+ *
+ * Two variants:
+ * - `rail` (default) — desktop, docked left. Supports a `collapsed` state
+ *   that shrinks the rail to an icon-only 48 px column. When collapsed,
+ *   section titles, sublists, labels, badges, and trailing icons are
+ *   suppressed via a shared context so consumers never conditionally render
+ *   child content themselves.
+ * - `overlay` — mobile, full-bleed. `collapsed` is ignored (labels always
+ *   render) and the radius goes to 0 to read as a full-height drawer.
+ *
+ * Compound API:
+ *
+ *   SideMenu
+ *     ├── SideMenu.Header        — top slot (non-scrolling)
+ *     ├── SideMenu.Body          — scrolling middle; flex-1
+ *     │   ├── SideMenu.Section   — labeled group with optional `actions`
+ *     │   │   └── SideMenu.SubList
+ *     │   │       └── SideMenu.Item
+ *     │   └── SideMenu.Separator
+ *     └── SideMenu.Footer        — bottom slot (sticks via margin-top: auto)
+ *
+ * All colors come from semantic tokens (`--surface-overlay`, `--content-default`,
+ * `--border-base`, etc.). Zero hex literals live in this file.
+ */
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+export type SideMenuVariant = "rail" | "overlay";
+
+interface SideMenuContextValue {
+  collapsed: boolean;
+  /** Content-level collapsed — lags behind `collapsed` when expanding so
+   *  labels appear after the width transition finishes. */
+  contentCollapsed: boolean;
+  variant: SideMenuVariant;
+}
+
+const SideMenuContext = createContext<SideMenuContextValue>({
+  collapsed: false,
+  contentCollapsed: false,
+  variant: "rail",
+});
+
+function useSideMenuContext(): SideMenuContextValue {
+  return useContext(SideMenuContext);
+}
+
+/**
+ * Whether content (labels, sublists, section headers) should be hidden.
+ * Uses the delayed `contentCollapsed` so content lingers while the width
+ * transition completes on collapse.
+ */
+function isCollapsedRail(ctx: SideMenuContextValue): boolean {
+  return ctx.variant === "rail" && ctx.contentCollapsed;
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export interface SideMenuProps extends ComponentProps<"nav"> {
+  /** Ignored when `variant="overlay"`. */
+  collapsed?: boolean;
+  /** `rail` = desktop docked; `overlay` = mobile full-bleed. */
+  variant?: SideMenuVariant;
+  /** Required for the `navigation` landmark role. */
+  ariaLabel: string;
+  ref?: Ref<HTMLElement>;
+}
+
+const ROOT_BASE_CLASSES = [
+  "flex flex-col",
+  "bg-[var(--surface-overlay)]",
+  "text-[color:var(--content-default)]",
+  "border border-[var(--border-base)]",
+  "overflow-hidden",
+].join(" ");
+
+const ROOT_RAIL_EXPANDED_CLASSES = [
+  "w-[230px]",
+  "rounded-[12px]",
+  "pt-4 px-4 pb-2",
+].join(" ");
+
+const ROOT_RAIL_COLLAPSED_CLASSES = [
+  "w-[48px]",
+  "rounded-[12px]",
+  "pt-4 px-2 pb-2",
+].join(" ");
+
+const ROOT_OVERLAY_CLASSES = [
+  "w-full",
+  "rounded-none",
+  "p-4",
+].join(" ");
+
+const RAIL_TRANSITION_MS = 150;
+const ROOT_RAIL_TRANSITION = `transition-[width,padding] duration-[${RAIL_TRANSITION_MS}ms] ease-in-out`;
+
+function rootChromeClasses(variant: SideMenuVariant, collapsed: boolean): string {
+  if (variant === "overlay") return ROOT_OVERLAY_CLASSES;
+  const rail = collapsed ? ROOT_RAIL_COLLAPSED_CLASSES : ROOT_RAIL_EXPANDED_CLASSES;
+  return `${rail} ${ROOT_RAIL_TRANSITION}`;
+}
+
+function SideMenuRoot({
+  ariaLabel,
+  collapsed = false,
+  variant = "rail",
+  className,
+  children,
+  ref,
+  ...rest
+}: SideMenuProps) {
+  const effectiveCollapsed = variant === "overlay" ? false : collapsed;
+
+  const [contentCollapsed, setContentCollapsed] = useState(effectiveCollapsed);
+  if (!effectiveCollapsed && contentCollapsed) {
+    setContentCollapsed(false);
+  }
+  useEffect(() => {
+    if (!effectiveCollapsed) return;
+    const id = setTimeout(() => setContentCollapsed(true), RAIL_TRANSITION_MS);
+    return () => clearTimeout(id);
+  }, [effectiveCollapsed]);
+
+  return (
+    <SideMenuContext
+      value={{ collapsed: effectiveCollapsed, contentCollapsed, variant }}
+    >
+      <nav
+        ref={ref}
+        data-slot="side-menu"
+        role="navigation"
+        aria-label={ariaLabel}
+        className={cn(
+          ROOT_BASE_CLASSES,
+          rootChromeClasses(variant, effectiveCollapsed),
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </nav>
+    </SideMenuContext>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header / Body / Footer
+// ---------------------------------------------------------------------------
+
+interface SlotProps extends ComponentProps<"div"> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function SideMenuHeader({ className, children, ref, ...rest }: SlotProps) {
+  return (
+    <div
+      ref={ref}
+      data-slot="side-menu-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SideMenuBody({ className, children, ref, ...rest }: SlotProps) {
+  return (
+    <div
+      ref={ref}
+      data-slot="side-menu-body"
+      className={cn(
+        "flex flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SideMenuFooter({ className, children, ref, ...rest }: SlotProps) {
+  return (
+    <div
+      ref={ref}
+      data-slot="side-menu-footer"
+      className={cn("mt-auto flex flex-col gap-2 pt-2", className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Separator
+// ---------------------------------------------------------------------------
+
+function SideMenuSeparator({
+  className,
+  ref,
+  ...rest
+}: ComponentProps<"hr"> & { ref?: Ref<HTMLHRElement> }) {
+  return (
+    <hr
+      ref={ref}
+      data-slot="side-menu-separator"
+      className={cn(
+        "my-1 h-px w-full border-0 bg-[var(--border-base)]",
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section — title row + right-aligned actions
+// ---------------------------------------------------------------------------
+
+export interface SideMenuSectionProps extends ComponentProps<"div"> {
+  title?: string;
+  actions?: ReactNode;
+  ref?: Ref<HTMLDivElement>;
+}
+
+function SideMenuSection({
+  title,
+  actions,
+  className,
+  children,
+  ref,
+  ...rest
+}: SideMenuSectionProps) {
+  const ctx = useSideMenuContext();
+  const hideHeader = isCollapsedRail(ctx);
+  return (
+    <div
+      ref={ref}
+      data-slot="side-menu-section"
+      className={cn("flex flex-col gap-2", className)}
+      {...rest}
+    >
+      {!hideHeader && (title || actions) ? (
+        <div className="flex h-[21px] items-center justify-between">
+          {title ? (
+            <Typography
+              variant="body-small-default"
+              as="span"
+              className="text-[color:var(--content-tertiary)]"
+            >
+              {title}
+            </Typography>
+          ) : (
+            <span />
+          )}
+          {actions ? (
+            <div className="flex items-center gap-[4px]">{actions}</div>
+          ) : null}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SubList — suppressed in collapsed rail mode
+// ---------------------------------------------------------------------------
+
+function SideMenuSubList({
+  className,
+  children,
+  ref,
+  ...rest
+}: ComponentProps<"ul"> & { ref?: Ref<HTMLUListElement> }) {
+  const ctx = useSideMenuContext();
+  if (isCollapsedRail(ctx)) return null;
+  return (
+    <ul
+      ref={ref}
+      data-slot="side-menu-sub-list"
+      className={cn("flex flex-col gap-[2px] list-none p-0 m-0", className)}
+      {...rest}
+    >
+      {children}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item
+// ---------------------------------------------------------------------------
+
+export interface SideMenuItemProps {
+  icon?: LucideIcon;
+  label: string;
+  badge?: ReactNode;
+  trailingIcon?: LucideIcon;
+  trailingIconClassName?: string;
+  indent?: boolean;
+  active?: boolean;
+  emphasized?: boolean;
+  size?: "default" | "compact";
+  onSelect?: () => void;
+  href?: string;
+  className?: string;
+  ref?: Ref<HTMLAnchorElement | HTMLButtonElement>;
+}
+
+function ItemLeadingIcon({
+  Icon,
+  indent,
+  active,
+  collapsed,
+}: {
+  Icon: LucideIcon | undefined;
+  indent: boolean;
+  active: boolean;
+  collapsed: boolean;
+}) {
+  if (indent) {
+    return (
+      <span
+        aria-hidden
+        className="inline-block h-[14px] w-[14px] shrink-0"
+      />
+    );
+  }
+  if (!Icon) return null;
+  const iconClass = cn(
+    "shrink-0",
+    active
+      ? "text-[color:var(--content-emphasised)]"
+      : "text-[color:var(--content-secondary)]",
+    collapsed ? "mx-auto" : undefined,
+  );
+  return <Icon size={14} aria-hidden className={iconClass} />;
+}
+
+function ItemBadge({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center",
+        "px-[4px] py-[2px] rounded-[4px]",
+        "bg-[var(--surface-base)]",
+        "text-label-small-default",
+        "text-[color:var(--content-tertiary)]",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+type SharedAnchorProps = Omit<
+  ComponentProps<"a">,
+  "href" | "children" | "ref"
+>;
+type SharedButtonProps = Omit<
+  ComponentProps<"button">,
+  "children" | "type" | "ref"
+>;
+
+function SideMenuItem({
+  icon: Icon,
+  label,
+  badge,
+  trailingIcon: TrailingIcon,
+  trailingIconClassName,
+  indent = false,
+  active = false,
+  emphasized = false,
+  size = "default",
+  onSelect,
+  href,
+  className,
+  ref,
+  ...rest
+}: SideMenuItemProps & SharedAnchorProps & SharedButtonProps) {
+  const ctx = useSideMenuContext();
+  const collapsed = isCollapsedRail(ctx);
+
+  const rowClasses = cn(
+    "group relative flex items-center",
+    "rounded-[6px]",
+    "outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+    "cursor-pointer select-none",
+    "transition-colors",
+    "gap-[8px] p-2",
+    collapsed ? "justify-center" : "justify-start",
+    size === "compact"
+      ? "text-body-small-default max-md:text-body-large-default"
+      : "text-body-medium-lighter max-md:py-3 max-md:text-body-large-default",
+    emphasized
+      ? "text-[color:var(--content-emphasised)]"
+      : "text-[color:var(--content-secondary)]",
+    active
+      ? "bg-[var(--surface-active)] text-[color:var(--content-emphasised)]"
+      : "hover:bg-[var(--surface-hover)]",
+    className,
+  );
+
+  const labelNode = collapsed ? null : (
+    <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+  );
+  const badgeNode = collapsed || !badge ? null : <ItemBadge>{badge}</ItemBadge>;
+  const trailingNode =
+    collapsed || !TrailingIcon ? null : (
+      <TrailingIcon
+        size={14}
+        aria-hidden
+        className={cn(
+          "shrink-0 text-[color:var(--content-tertiary)]",
+          trailingIconClassName,
+        )}
+      />
+    );
+
+  const leadingIconNode = (
+    <ItemLeadingIcon
+      Icon={Icon}
+      indent={indent}
+      active={active}
+      collapsed={collapsed}
+    />
+  );
+
+  const titleAttr = collapsed ? label : undefined;
+  const ariaCurrent = active ? ("page" as const) : undefined;
+
+  if (href) {
+    const anchorProps = rest as SharedAnchorProps;
+    return (
+      <a
+        ref={ref as Ref<HTMLAnchorElement>}
+        data-slot="side-menu-item"
+        href={href}
+        title={titleAttr}
+        aria-current={ariaCurrent}
+        className={rowClasses}
+        onClick={(event) => {
+          anchorProps.onClick?.(event);
+          if (!event.defaultPrevented) {
+            onSelect?.();
+          }
+        }}
+        {...anchorProps}
+      >
+        {leadingIconNode}
+        {labelNode}
+        {badgeNode}
+        {trailingNode}
+      </a>
+    );
+  }
+
+  const {
+    onClick: buttonOnClick,
+    onKeyDown: buttonOnKeyDown,
+    ...buttonProps
+  } = rest as SharedButtonProps;
+
+  const composedOnClick = (event: MouseEvent<HTMLButtonElement>) => {
+    buttonOnClick?.(event);
+    if (!event.defaultPrevented) {
+      onSelect?.();
+    }
+  };
+
+  return (
+    <button
+      ref={ref as Ref<HTMLButtonElement>}
+      data-slot="side-menu-item"
+      type="button"
+      title={titleAttr}
+      aria-current={ariaCurrent}
+      className={rowClasses}
+      onClick={composedOnClick}
+      onKeyDown={buttonOnKeyDown}
+      {...buttonProps}
+    >
+      {leadingIconNode}
+      {labelNode}
+      {badgeNode}
+      {trailingNode}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+type SideMenuComponent = typeof SideMenuRoot & {
+  Header: typeof SideMenuHeader;
+  Body: typeof SideMenuBody;
+  Footer: typeof SideMenuFooter;
+  Section: typeof SideMenuSection;
+  SubList: typeof SideMenuSubList;
+  Item: typeof SideMenuItem;
+  Separator: typeof SideMenuSeparator;
+};
+
+const SideMenu = SideMenuRoot as SideMenuComponent;
+SideMenu.Header = SideMenuHeader;
+SideMenu.Body = SideMenuBody;
+SideMenu.Footer = SideMenuFooter;
+SideMenu.Section = SideMenuSection;
+SideMenu.SubList = SideMenuSubList;
+SideMenu.Item = SideMenuItem;
+SideMenu.Separator = SideMenuSeparator;
+
+export {
+  SideMenu,
+  SideMenuBody,
+  SideMenuFooter,
+  SideMenuHeader,
+  SideMenuItem,
+  SideMenuSection,
+  SideMenuSeparator,
+  SideMenuSubList,
+};

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -119,7 +119,7 @@ const ROOT_RAIL_TRANSITION = "transition-[width,padding] duration-[150ms] ease-i
 function rootChromeClasses(variant: SideMenuVariant, collapsed: boolean): string {
   if (variant === "overlay") return ROOT_OVERLAY_CLASSES;
   const rail = collapsed ? ROOT_RAIL_COLLAPSED_CLASSES : ROOT_RAIL_EXPANDED_CLASSES;
-  return `${rail} ${ROOT_RAIL_TRANSITION}`;
+  return cn(rail, ROOT_RAIL_TRANSITION);
 }
 
 function SideMenuRoot({

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -114,7 +114,7 @@ const ROOT_OVERLAY_CLASSES = [
 ].join(" ");
 
 const RAIL_TRANSITION_MS = 150;
-const ROOT_RAIL_TRANSITION = `transition-[width,padding] duration-[${RAIL_TRANSITION_MS}ms] ease-in-out`;
+const ROOT_RAIL_TRANSITION = "transition-[width,padding] duration-[150ms] ease-in-out";
 
 function rootChromeClasses(variant: SideMenuVariant, collapsed: boolean): string {
   if (variant === "overlay") return ROOT_OVERLAY_CLASSES;
@@ -454,7 +454,10 @@ function SideMenuItem({
   const ariaCurrent = active ? ("page" as const) : undefined;
 
   if (href) {
-    const anchorProps = rest as SharedAnchorProps;
+    const {
+      onClick: anchorOnClick,
+      ...anchorProps
+    } = rest as SharedAnchorProps;
     return (
       <a
         ref={ref as Ref<HTMLAnchorElement>}
@@ -464,7 +467,7 @@ function SideMenuItem({
         aria-current={ariaCurrent}
         className={rowClasses}
         onClick={(event) => {
-          anchorProps.onClick?.(event);
+          anchorOnClick?.(event);
           if (!event.defaultPrevented) {
             onSelect?.();
           }

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -161,6 +161,25 @@ export {
   type MarkdownMessageProps,
   type MarkdownLinkComponent,
 } from "./components/markdown-message.js";
+export {
+  SideMenu,
+  SideMenuBody,
+  SideMenuFooter,
+  SideMenuHeader,
+  SideMenuItem,
+  SideMenuSection,
+  SideMenuSeparator,
+  SideMenuSubList,
+  type SideMenuProps,
+  type SideMenuVariant,
+  type SideMenuSectionProps,
+  type SideMenuItemProps,
+} from "./components/side-menu/side-menu.js";
+export {
+  CollapsibleNavSection,
+  type CollapsibleNavSectionRootProps,
+  type CollapsibleNavSectionSectionProps,
+} from "./components/side-menu/collapsible-nav-section.js";
 export { cn } from "./utils/cn.js";
 export {
   PortalContainerProvider,

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -427,4 +427,24 @@
   100% { transform: translateX(0); }
 }
 
+/* ---------------------------------------------------------------------------
+ * CollapsibleNavSection — Radix Accordion content animation.
+ * Uses Radix's `--radix-accordion-content-height` variable so the animation
+ * always targets the actual content height (no JS measuring needed).
+ * --------------------------------------------------------------------------- */
+@keyframes cns-slide-down {
+  from { height: 0; }
+  to { height: var(--radix-accordion-content-height); }
+}
+@keyframes cns-slide-up {
+  from { height: var(--radix-accordion-content-height); }
+  to { height: 0; }
+}
+.cns-content[data-state="open"] {
+  animation: cns-slide-down 200ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.cns-content[data-state="closed"] {
+  animation: cns-slide-up 200ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 


### PR DESCRIPTION
## Prompt / plan

Port the `SideMenu` and `CollapsibleNavSection` design system primitives from [`vellum-assistant-platform/web/src/components/app/core/`](https://github.com/vellum-ai/vellum-assistant-platform/tree/main/web/src/components/app/core) to `packages/design-library/`, adapting them for React 19 and the design library's conventions. These are prerequisite components for [LUM-1663](https://linear.app/vellum/issue/LUM-1663) (port AssistantSideMenu).

### SideMenu (~480 lines)

Compound navigation rail with 7 subcomponents:

| Subcomponent | Purpose |
|---|---|
| `SideMenu` (Root) | `<nav>` landmark with rail/overlay chrome, width transition |
| `SideMenu.Header` | Non-scrolling top slot |
| `SideMenu.Body` | Scrollable middle section (flex-1) |
| `SideMenu.Footer` | Sticky bottom slot (margin-top: auto) |
| `SideMenu.Section` | Labeled group with optional action buttons |
| `SideMenu.SubList` | `<ul>` wrapper, suppressed in collapsed rail mode |
| `SideMenu.Item` | Row with icon, label, badge, trailing icon. Renders `<a>` or `<button>` based on `href` prop |

Two variants:
- **`rail`** (default) — desktop docked, 230px expanded / 48px collapsed. Content (labels, badges, sublists) suppressed in collapsed mode via shared context.
- **`overlay`** — mobile full-bleed, `collapsed` ignored, square corners.

### CollapsibleNavSection (~150 lines)

[Radix Accordion](https://www.radix-ui.com/primitives/docs/components/accordion)-backed collapsible section:
- Leading icon swaps to `ChevronRight` disclosure chevron on hover (CSS-only, no JS)
- Chevron rotates 90° when expanded (matching macOS `SidebarSectionHeader`)
- Trailing slot with isolated pointer events (buttons in trailing don't toggle the section)
- Slide-down/up animations via `--radix-accordion-content-height` CSS variable (keyframes in `tokens.css`)

### Conventions applied (platform → design library)

- `forwardRef` → ref as prop ([React 19](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop))
- Added `data-slot` on every root element ([shadcn/ui v4 pattern](https://ui.shadcn.com/docs/changelog/2025-03-data-slot))
- `HTMLAttributes` → `ComponentProps<"element">` for element-specific props + ref
- `"use client"` directives removed (framework-agnostic)
- Function declarations for all components (hoisting + DevTools visibility)
- Named exports only
- `.js` extensions on all relative imports

### New dependency

`@radix-ui/react-accordion@1.2.12` ([MIT](https://github.com/radix-ui/primitives/blob/main/LICENSE), consistent with existing Radix deps in the design library).

## Test plan

- 23 tests pass (8 for CollapsibleNavSection, 15 for SideMenu) — `bun test src/components/side-menu/`
- Tests use `renderToStaticMarkup` to assert structural HTML contracts (same pattern as existing `markdown-message.test.tsx`)
- `bunx tsc --noEmit` passes in both `packages/design-library/` and `apps/web/`
- `bun run lint` passes in `apps/web/`
- CI checks

Closes LUM-1660

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->