### PR TITLE
feat(daemon): add Sanity connect/discover and content-source endpoints with sidecar persistence (JARVIS-895)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33,283 +33,6 @@ paths:
       responses:
         "200":
           description: Successful response
-  /v1/acp/{id}/cancel:
-    post:
-      operationId: acp_by_id_cancel_post
-      summary: Cancel ACP session
-      description: Cancel an active ACP session.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acpSessionId:
-                    type: string
-                  cancelled:
-                    type: boolean
-                required:
-                  - acpSessionId
-                  - cancelled
-                additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-  /v1/acp/{id}/close:
-    post:
-      operationId: acp_by_id_close_post
-      summary: Close ACP session
-      description: Close a completed ACP session.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acpSessionId:
-                    type: string
-                  closed:
-                    type: boolean
-                required:
-                  - acpSessionId
-                  - closed
-                additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-  /v1/acp/{id}/steer:
-    post:
-      operationId: acp_by_id_steer_post
-      summary: Steer ACP session
-      description: Send a steering instruction to an active ACP session.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acpSessionId:
-                    type: string
-                  steered:
-                    type: boolean
-                required:
-                  - acpSessionId
-                  - steered
-                additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                instruction:
-                  type: string
-              required:
-                - instruction
-              additionalProperties: false
-  /v1/acp/sessions:
-    delete:
-      operationId: acp_sessions_delete
-      summary: Bulk-clear terminal ACP sessions
-      description: Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: integer
-                    minimum: -9007199254740991
-                    maximum: 9007199254740991
-                required:
-                  - deleted
-                additionalProperties: false
-      parameters:
-        - name: status
-          in: query
-          required: true
-          schema:
-            type: string
-          description: Must be 'completed'. Shorthand for all terminal statuses (completed/failed/cancelled).
-    get:
-      operationId: acp_sessions_get
-      summary: List ACP sessions
-      description:
-        Return the merged set of in-memory and persisted ACP sessions, newest first. In-memory sessions take
-        precedence on id collision.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sessions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        agentId:
-                          type: string
-                        acpSessionId:
-                          type: string
-                        parentConversationId:
-                          type: string
-                        status:
-                          type: string
-                        startedAt:
-                          type: number
-                        completedAt:
-                          anyOf:
-                            - type: number
-                            - type: "null"
-                        error:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        stopReason:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        eventLog:
-                          type: array
-                          items: {}
-                      required:
-                        - id
-                        - agentId
-                        - acpSessionId
-                        - status
-                        - startedAt
-                      additionalProperties: false
-                    description: Merged in-memory and persisted ACP sessions.
-                required:
-                  - sessions
-                additionalProperties: false
-      parameters:
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-          description: Maximum number of sessions to return (default 50, max 500).
-        - name: conversationId
-          in: query
-          required: false
-          schema:
-            type: string
-          description: Filter to sessions whose parentConversationId matches this value.
-  /v1/acp/sessions/{id}:
-    delete:
-      operationId: acp_sessions_by_id_delete
-      summary: Delete ACP session from history
-      description:
-        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory; idempotent
-        for unknown ids.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-                required:
-                  - deleted
-                additionalProperties: false
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-  /v1/acp/spawn:
-    post:
-      operationId: acp_spawn_post
-      summary: Spawn ACP session
-      description: Start a new Agent Communication Protocol session.
-      tags:
-        - acp
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acpSessionId:
-                    type: string
-                  protocolSessionId:
-                    type: string
-                  agent:
-                    type: string
-                required:
-                  - acpSessionId
-                  - protocolSessionId
-                  - agent
-                additionalProperties: false
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                agent:
-                  type: string
-                  description: Agent name
-                task:
-                  type: string
-                  description: Task description
-                conversationId:
-                  type: string
-                cwd:
-                  type: string
-                  description: Working directory
-              required:
-                - agent
-                - task
-                - conversationId
-              additionalProperties: false
   /v1/admin/rollback-migrations:
     post:
       operationId: admin_rollbackmigrations_post
@@ -4218,6 +3941,27 @@ paths:
                   type: string
                 limit:
                   type: number
+              additionalProperties: false
+  /v1/content-source:
+    post:
+      operationId: contentsource_post
+      summary: Validate and persist a content source URL
+      tags:
+        - content-source
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+              required:
+                - url
               additionalProperties: false
   /v1/conversation-starters:
     get:
@@ -12517,6 +12261,49 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/sanity/connect:
+    post:
+      operationId: sanity_connect_post
+      summary: Finalise Sanity connection and write sidecar file
+      tags:
+        - sanity
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                projectId:
+                  type: string
+                dataset:
+                  type: string
+              required:
+                - projectId
+                - dataset
+              additionalProperties: false
+  /v1/sanity/discover:
+    post:
+      operationId: sanity_discover_post
+      summary: Discover Sanity projects and datasets using the stored API token
+      tags:
+        - sanity
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                projectId:
+                  type: string
+              additionalProperties: false
   /v1/schedules:
     get:
       operationId: schedules_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33,6 +33,283 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/acp/{id}/cancel:
+    post:
+      operationId: acp_by_id_cancel_post
+      summary: Cancel ACP session
+      description: Cancel an active ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  cancelled:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - cancelled
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/{id}/close:
+    post:
+      operationId: acp_by_id_close_post
+      summary: Close ACP session
+      description: Close a completed ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  closed:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - closed
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/{id}/steer:
+    post:
+      operationId: acp_by_id_steer_post
+      summary: Steer ACP session
+      description: Send a steering instruction to an active ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  steered:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - steered
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+              required:
+                - instruction
+              additionalProperties: false
+  /v1/acp/sessions:
+    delete:
+      operationId: acp_sessions_delete
+      summary: Bulk-clear terminal ACP sessions
+      description: Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - deleted
+                additionalProperties: false
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Must be 'completed'. Shorthand for all terminal statuses (completed/failed/cancelled).
+    get:
+      operationId: acp_sessions_get
+      summary: List ACP sessions
+      description:
+        Return the merged set of in-memory and persisted ACP sessions, newest first. In-memory sessions take
+        precedence on id collision.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        agentId:
+                          type: string
+                        acpSessionId:
+                          type: string
+                        parentConversationId:
+                          type: string
+                        status:
+                          type: string
+                        startedAt:
+                          type: number
+                        completedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        stopReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        eventLog:
+                          type: array
+                          items: {}
+                      required:
+                        - id
+                        - agentId
+                        - acpSessionId
+                        - status
+                        - startedAt
+                      additionalProperties: false
+                    description: Merged in-memory and persisted ACP sessions.
+                required:
+                  - sessions
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Maximum number of sessions to return (default 50, max 500).
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter to sessions whose parentConversationId matches this value.
+  /v1/acp/sessions/{id}:
+    delete:
+      operationId: acp_sessions_by_id_delete
+      summary: Delete ACP session from history
+      description:
+        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory; idempotent
+        for unknown ids.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                required:
+                  - deleted
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/spawn:
+    post:
+      operationId: acp_spawn_post
+      summary: Spawn ACP session
+      description: Start a new Agent Communication Protocol session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  protocolSessionId:
+                    type: string
+                  agent:
+                    type: string
+                required:
+                  - acpSessionId
+                  - protocolSessionId
+                  - agent
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent:
+                  type: string
+                  description: Agent name
+                task:
+                  type: string
+                  description: Task description
+                conversationId:
+                  type: string
+                cwd:
+                  type: string
+                  description: Working directory
+              required:
+                - agent
+                - task
+                - conversationId
+              additionalProperties: false
   /v1/admin/rollback-migrations:
     post:
       operationId: admin_rollbackmigrations_post

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -223,6 +223,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/daemon-skill-host.ts", // SkillHost secureKeys facet adapter (delegates to getProviderKeyAsync)
       "runtime/routes/credential-prompt-routes.ts", // Route for secure credential prompt (stores secret via setSecureKeyAsync)
       "runtime/routes/credential-routes.ts", // CLI credential management routes (CLI-migrated to IPC)
+      "runtime/routes/sanity-routes.ts", // Sanity connect/discover routes (reads stored api_token from credential store)
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path

--- a/assistant/src/runtime/routes/__tests__/content-source-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/content-source-routes.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for content-source-routes.ts.
+ *
+ * Drives the handler function directly (bypassing the router) and mocks
+ * out node:fs writes so no real I/O occurs.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const FAKE_WORKSPACE = "/tmp/content-source-routes-test-workspace";
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => FAKE_WORKSPACE,
+}));
+
+const writtenFiles = new Map<string, string>();
+
+mock.module("node:fs", () => ({
+  mkdirSync: () => {},
+  writeFileSync: (path: string, content: string) => {
+    writtenFiles.set(path, content);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { ROUTES } from "../content-source-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+function makeArgs(body?: Record<string, unknown>): RouteHandlerArgs {
+  return { body };
+}
+
+const handler = findHandler("content_source_set");
+
+beforeEach(() => {
+  writtenFiles.clear();
+});
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+describe("content_source_set — URL validation", () => {
+  test("https URL is accepted and sidecar written", () => {
+    const result = handler(makeArgs({ url: "https://myblog.com/posts" }));
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written.url).toBe("https://myblog.com/posts");
+  });
+
+  test("http URL is accepted and sidecar written", () => {
+    const result = handler(makeArgs({ url: "http://intranet.example.com" }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("URL with leading/trailing whitespace is trimmed", () => {
+    const result = handler(makeArgs({ url: "  https://blog.example.com  " }));
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written.url).toBe("https://blog.example.com/");
+  });
+
+  test("bare hostname without protocol returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "myblog.com" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("ftp:// URL is rejected", () => {
+    const result = handler(makeArgs({ url: "ftp://files.example.com" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("empty string returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("whitespace-only string returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "   " }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("javascript: URL is rejected", () => {
+    const result = handler(makeArgs({ url: "javascript:alert(1)" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("missing url field returns invalid_url", () => {
+    const result = handler(makeArgs({}));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sidecar content verification
+// ---------------------------------------------------------------------------
+
+describe("content_source_set — sidecar contents", () => {
+  test("writes url to data/content-source.json", () => {
+    handler(makeArgs({ url: "https://example.com/blog" }));
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(Object.keys(written)).toEqual(["url"]);
+  });
+
+  test("no sidecar written on invalid URL", () => {
+    handler(makeArgs({ url: "not-a-url" }));
+    expect(writtenFiles.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy key verification
+// ---------------------------------------------------------------------------
+
+describe("route policy key", () => {
+  test("content_source_set uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "content_source_set");
+    expect(route?.policyKey).toBe("secrets");
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
@@ -85,25 +85,30 @@ const connectHandler = findHandler("sanity_connect");
 type FetchReturn = { status: number; json: () => unknown };
 let mockFetchImpl: ((url: string) => FetchReturn) | undefined = undefined;
 
-const originalFetch = global.fetch;
+const originalFetch = globalThis.fetch;
+
+function mockFetch(url: string | URL | Request): Promise<Response> {
+  const urlStr =
+    typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+  if (!mockFetchImpl) throw new Error(`Unexpected fetch: ${urlStr}`);
+  const result = mockFetchImpl(urlStr);
+  return Promise.resolve({
+    ok: result.status >= 200 && result.status < 300,
+    status: result.status,
+    json: async () => result.json(),
+  } as Response);
+}
 
 beforeEach(() => {
   writtenFiles.clear();
   storedToken = undefined;
   mockFetchImpl = undefined;
-  global.fetch = async (url: string) => {
-    if (!mockFetchImpl) throw new Error(`Unexpected fetch: ${url}`);
-    const result = mockFetchImpl(String(url));
-    return {
-      ok: result.status >= 200 && result.status < 300,
-      status: result.status,
-      json: async () => result.json(),
-    } as Response;
-  };
+
+  (globalThis as any).fetch = mockFetch;
 });
 
 afterEach(() => {
-  global.fetch = originalFetch;
+  (globalThis as any).fetch = originalFetch;
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for sanity-routes.ts.
+ *
+ * Drives the handler functions directly (bypassing the router) and mocks
+ * out secure-keys, the node:fs writes, and fetch so no real I/O occurs.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the module under test
+// ---------------------------------------------------------------------------
+
+let storedToken: string | undefined = undefined;
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (_key: string) => storedToken,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const FAKE_WORKSPACE = "/tmp/sanity-routes-test-workspace";
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => FAKE_WORKSPACE,
+}));
+
+const writtenFiles = new Map<string, string>();
+
+mock.module("node:fs", () => ({
+  mkdirSync: () => {},
+  writeFileSync: (path: string, content: string) => {
+    writtenFiles.set(path, content);
+  },
+  // Expose the rest of node:fs unchanged so other imports still work.
+  // Bun's mock.module replaces only what we return, and the module under
+  // test only imports mkdirSync and writeFileSync from node:fs.
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { ROUTES } from "../sanity-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+function makeArgs(body?: Record<string, unknown>): RouteHandlerArgs {
+  return { body };
+}
+
+const discoverHandler = findHandler("sanity_discover");
+const connectHandler = findHandler("sanity_connect");
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchReturn = { status: number; json: () => unknown };
+let mockFetchImpl: ((url: string) => FetchReturn) | undefined = undefined;
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  writtenFiles.clear();
+  storedToken = undefined;
+  mockFetchImpl = undefined;
+  global.fetch = async (url: string) => {
+    if (!mockFetchImpl) throw new Error(`Unexpected fetch: ${url}`);
+    const result = mockFetchImpl(String(url));
+    return {
+      ok: result.status >= 200 && result.status < 300,
+      status: result.status,
+      json: async () => result.json(),
+    } as Response;
+  };
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — no stored token
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — no stored token", () => {
+  test("returns { error: 'no_token' } when token absent", async () => {
+    storedToken = undefined;
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "no_token" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — project listing
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — list projects", () => {
+  beforeEach(() => {
+    storedToken = "sk-test-token";
+  });
+
+  test("returns projects when API responds 200", async () => {
+    mockFetchImpl = () => ({
+      status: 200,
+      json: () => [
+        { id: "proj-a", displayName: "Project Alpha" },
+        { id: "proj-b", displayName: "Project Beta" },
+      ],
+    });
+
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({
+      projects: [
+        { id: "proj-a", displayName: "Project Alpha" },
+        { id: "proj-b", displayName: "Project Beta" },
+      ],
+    });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 401", async () => {
+    mockFetchImpl = () => ({ status: 401, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 403", async () => {
+    mockFetchImpl = () => ({ status: 403, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'discovery_failed' } on 500", async () => {
+    mockFetchImpl = () => ({ status: 500, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "discovery_failed" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — dataset listing (projectId provided)
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — list datasets", () => {
+  beforeEach(() => {
+    storedToken = "sk-test-token";
+  });
+
+  test("returns datasets when API responds 200", async () => {
+    mockFetchImpl = (url) => {
+      expect(url).toContain("/projects/my-project/datasets");
+      return {
+        status: 200,
+        json: () => [{ name: "production" }, { name: "staging" }],
+      };
+    };
+
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({
+      projectId: "my-project",
+      datasets: ["production", "staging"],
+    });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 403 for dataset list", async () => {
+    mockFetchImpl = () => ({ status: 403, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'discovery_failed' } on 500 for dataset list", async () => {
+    mockFetchImpl = () => ({ status: 500, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({ error: "discovery_failed" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/connect
+// ---------------------------------------------------------------------------
+
+describe("sanity_connect", () => {
+  test("writes sidecar when token present and inputs valid", async () => {
+    storedToken = "sk-test-token";
+
+    const result = await connectHandler(
+      makeArgs({ projectId: "my-proj", dataset: "production" }),
+    );
+
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/sanity-connection.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written).toEqual({ projectId: "my-proj", dataset: "production" });
+  });
+
+  test("throws when no token is stored", async () => {
+    storedToken = undefined;
+
+    expect(
+      connectHandler(makeArgs({ projectId: "p", dataset: "production" })),
+    ).rejects.toThrow();
+  });
+
+  test("throws when projectId is empty", async () => {
+    storedToken = "sk-test-token";
+
+    expect(
+      connectHandler(makeArgs({ projectId: "  ", dataset: "production" })),
+    ).rejects.toThrow();
+  });
+
+  test("throws when dataset is empty", async () => {
+    storedToken = "sk-test-token";
+
+    expect(
+      connectHandler(makeArgs({ projectId: "my-proj", dataset: "" })),
+    ).rejects.toThrow();
+  });
+
+  test("does not return token in response", async () => {
+    storedToken = "sk-super-secret";
+
+    const result = (await connectHandler(
+      makeArgs({ projectId: "p", dataset: "d" }),
+    )) as Record<string, unknown>;
+
+    const resultStr = JSON.stringify(result);
+    expect(resultStr).not.toContain("sk-super-secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy key verification
+// ---------------------------------------------------------------------------
+
+describe("route policy keys", () => {
+  test("sanity_discover uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "sanity_discover");
+    expect(route?.policyKey).toBe("secrets");
+  });
+
+  test("sanity_connect uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "sanity_connect");
+    expect(route?.policyKey).toBe("secrets");
+  });
+});

--- a/assistant/src/runtime/routes/content-source-routes.ts
+++ b/assistant/src/runtime/routes/content-source-routes.ts
@@ -1,0 +1,76 @@
+/**
+ * Route definitions for content-source configuration.
+ *
+ * POST /v1/content-source — validate and persist a content source URL as sidecar
+ *
+ * Uses policyKey: "secrets" — writes workspace data, same policy tier as
+ * the existing secrets routes.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { z } from "zod";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeSidecar(relPath: string, data: Record<string, unknown>): void {
+  const workspaceDir = getWorkspaceDir();
+  const absPath = join(workspaceDir, relPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+function validateUrl(
+  raw: string,
+): { ok: true; normalized: string } | { ok: false; error: "invalid_url" } {
+  const trimmed = raw.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, error: "invalid_url" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: "invalid_url" };
+  }
+  return { ok: true, normalized: parsed.href };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/content-source
+// ---------------------------------------------------------------------------
+
+function handleContentSource(args: RouteHandlerArgs): Record<string, unknown> {
+  const rawUrl = typeof args.body?.url === "string" ? args.body.url : "";
+
+  const result = validateUrl(rawUrl);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  writeSidecar("data/content-source.json", { url: result.normalized });
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "content_source_set",
+    endpoint: "/v1/content-source",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Validate and persist a content source URL",
+    requestBody: z.object({ url: z.string() }),
+    handler: handleContentSource,
+  },
+];

--- a/assistant/src/runtime/routes/content-source-routes.ts
+++ b/assistant/src/runtime/routes/content-source-routes.ts
@@ -66,7 +66,7 @@ function handleContentSource(args: RouteHandlerArgs): Record<string, unknown> {
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "content_source_set",
-    endpoint: "/v1/content-source",
+    endpoint: "content-source",
     method: "POST",
     policyKey: "secrets",
     summary: "Validate and persist a content source URL",

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -33,6 +33,7 @@ import { ROUTES as CLIENT_ROUTES } from "./client-routes.js";
 import { ROUTES as CONSOLIDATION_ROUTES } from "./consolidation-routes.js";
 import { CONTACT_PROMPT_ROUTES } from "./contact-prompt-routes.js";
 import { ROUTES as CONTACT_ROUTES } from "./contact-routes.js";
+import { ROUTES as CONTENT_SOURCE_ROUTES } from "./content-source-routes.js";
 import { ROUTES as CONVERSATION_ANALYSIS_ROUTES } from "./conversation-analysis-routes.js";
 import { ROUTES as CONVERSATION_ATTENTION_ROUTES } from "./conversation-attention-routes.js";
 import { ROUTES as CONVERSATION_CLI_ROUTES } from "./conversation-cli-routes.js";
@@ -101,6 +102,7 @@ import { ROUTES as PUBLISH_ROUTES } from "./publish-routes.js";
 import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
+import { ROUTES as SANITY_ROUTES } from "./sanity-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "./schedule-routes.js";
 import { ROUTES as SECRET_ROUTES } from "./secret-routes.js";
 import { ROUTES as SEQUENCE_ROUTES } from "./sequence-routes.js";
@@ -153,6 +155,7 @@ export const ROUTES: RouteDefinition[] = [
   ...BTW_ROUTES,
   ...BRAIN_GRAPH_ROUTES,
   ...CLIENT_ROUTES,
+  ...CONTENT_SOURCE_ROUTES,
   ...CONTACT_PROMPT_ROUTES,
   ...CONTACT_ROUTES,
   ...CONVERSATION_ANALYSIS_ROUTES,
@@ -219,6 +222,7 @@ export const ROUTES: RouteDefinition[] = [
   ...RECORDING_ROUTES,
   ...RENAME_CONVERSATION_ROUTES,
   ...SCHEDULE_ROUTES,
+  ...SANITY_ROUTES,
   ...SECRET_ROUTES,
   ...SETTINGS_ROUTES,
   ...SKILL_ROUTES,

--- a/assistant/src/runtime/routes/sanity-routes.ts
+++ b/assistant/src/runtime/routes/sanity-routes.ts
@@ -137,7 +137,7 @@ async function handleConnect(
 export const ROUTES: RouteDefinition[] = [
   {
     operationId: "sanity_discover",
-    endpoint: "/v1/sanity/discover",
+    endpoint: "sanity/discover",
     method: "POST",
     policyKey: "secrets",
     summary: "Discover Sanity projects and datasets using the stored API token",
@@ -146,7 +146,7 @@ export const ROUTES: RouteDefinition[] = [
   },
   {
     operationId: "sanity_connect",
-    endpoint: "/v1/sanity/connect",
+    endpoint: "sanity/connect",
     method: "POST",
     policyKey: "secrets",
     summary: "Finalise Sanity connection and write sidecar file",

--- a/assistant/src/runtime/routes/sanity-routes.ts
+++ b/assistant/src/runtime/routes/sanity-routes.ts
@@ -1,0 +1,159 @@
+/**
+ * Route definitions for Sanity CMS connection management.
+ *
+ * POST /v1/sanity/discover — project/dataset discovery using the stored API token
+ * POST /v1/sanity/connect  — finalise connection by writing the sidecar file
+ *
+ * Both routes use policyKey: "secrets" — they read credentials and write
+ * workspace data, the same policy tier as the existing secrets routes.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { z } from "zod";
+
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getStoredToken(): Promise<string | undefined> {
+  return getSecureKeyAsync(credentialKey("sanity", "api_token"));
+}
+
+function writeSidecar(relPath: string, data: Record<string, unknown>): void {
+  const workspaceDir = getWorkspaceDir();
+  const absPath = join(workspaceDir, relPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover
+// ---------------------------------------------------------------------------
+
+async function handleDiscover(
+  args: RouteHandlerArgs,
+): Promise<Record<string, unknown>> {
+  const token = await getStoredToken();
+  if (!token) {
+    return { error: "no_token" };
+  }
+
+  const projectId =
+    typeof args.body?.projectId === "string" ? args.body.projectId : undefined;
+
+  if (!projectId) {
+    // List all projects this token has access to
+    const response = await fetch("https://api.sanity.io/v2021-06-07/projects", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { error: "token_scope_limited" };
+    }
+
+    if (!response.ok) {
+      return { error: "discovery_failed" };
+    }
+
+    const raw = (await response.json()) as Array<{
+      id: string;
+      displayName?: string;
+    }>;
+    const projects = raw.map((p) => ({
+      id: p.id,
+      displayName: p.displayName ?? p.id,
+    }));
+    return { projects };
+  }
+
+  // List datasets for a specific project
+  const response = await fetch(
+    `https://api.sanity.io/v2021-06-07/projects/${projectId}/datasets`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    return { error: "token_scope_limited" };
+  }
+
+  if (!response.ok) {
+    return { error: "discovery_failed" };
+  }
+
+  const raw = (await response.json()) as Array<{ name: string }>;
+  const datasets = raw.map((d) => d.name);
+  return { projectId, datasets };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/connect
+// ---------------------------------------------------------------------------
+
+async function handleConnect(
+  args: RouteHandlerArgs,
+): Promise<Record<string, unknown>> {
+  const token = await getStoredToken();
+  if (!token) {
+    throw new BadRequestError(
+      "Sanity API token not found. Store it first via POST /v1/secrets.",
+    );
+  }
+
+  const projectId =
+    typeof args.body?.projectId === "string" ? args.body.projectId.trim() : "";
+  const dataset =
+    typeof args.body?.dataset === "string" ? args.body.dataset.trim() : "";
+
+  if (!projectId) {
+    throw new BadRequestError(
+      "projectId is required and must be a non-empty string",
+    );
+  }
+  if (!dataset) {
+    throw new BadRequestError(
+      "dataset is required and must be a non-empty string",
+    );
+  }
+
+  writeSidecar("data/sanity-connection.json", { projectId, dataset });
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "sanity_discover",
+    endpoint: "/v1/sanity/discover",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Discover Sanity projects and datasets using the stored API token",
+    requestBody: z.object({ projectId: z.string().optional() }).optional(),
+    handler: handleDiscover,
+  },
+  {
+    operationId: "sanity_connect",
+    endpoint: "/v1/sanity/connect",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Finalise Sanity connection and write sidecar file",
+    requestBody: z.object({
+      projectId: z.string(),
+      dataset: z.string(),
+    }),
+    handler: handleConnect,
+  },
+];


### PR DESCRIPTION
## Summary
- Adds `POST /v1/sanity/discover` — reads stored API token, calls Sanity Management API to list projects or datasets; returns `token_scope_limited` when 401/403
- Adds `POST /v1/sanity/connect` — verifies stored token, validates non-empty projectId/dataset, writes `data/sanity-connection.json` immediately
- Adds `POST /v1/content-source` — server-side URL validation (http/https only via `new URL()`), writes `data/content-source.json` immediately
- All routes use `policyKey: "secrets"` for proper authorization
- Token never returned to client

## Test plan
- [ ] `bun test src/runtime/routes/__tests__/sanity-routes.test.ts` — token-present/absent, scope-limited, project/dataset listing, sidecar writes, policy key
- [ ] `bun test src/runtime/routes/__tests__/content-source-routes.test.ts` — https/http/invalid/ftp/empty URLs, sidecar writes, policy key

Depends on JARVIS-895 feature branch (Sanity manual-token provider plumbing) being merged to main — confirmed merged. Wave 1, PR 2 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->