### PR TITLE
feat(bootstrap): skip triage when Sanity or content-source sidecar exists (JARVIS-895)

### DIFF
--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -120,6 +120,33 @@ describe("maybeReseedBootstrapForCohort — content-automation template", () => 
     expect(content).toContain("data/sanity-connection.json");
   });
 
+  test("references data/content-source.json for URL-import sidecar detection", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("data/content-source.json");
+  });
+
+  test("instructs to skip triage when sanity-connection.json sidecar exists", () => {
+    const content = reseedAndRead();
+    // The preamble check must instruct skipping triage when the sidecar is present
+    expect(content).toContain("data/sanity-connection.json");
+    expect(content).toContain("Skip the triage question");
+  });
+
+  test("instructs to skip triage when content-source.json sidecar exists", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("data/content-source.json");
+    expect(content).toContain("Skip the triage question");
+  });
+
+  test("still contains four-option triage as fallback when no sidecars exist", () => {
+    const content = reseedAndRead();
+    // The "If neither exists" path must still present the four-option triage
+    expect(content).toContain("I have a Sanity account");
+    expect(content).toContain("I want to try Sanity");
+    expect(content).toContain("website or blog");
+    expect(content).toContain("somewhere else");
+  });
+
   test("references assistant oauth request --provider sanity for authenticated API calls", () => {
     const content = reseedAndRead();
     expect(content).toContain("assistant oauth request --provider sanity");

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -9,7 +9,10 @@ One goal: turn their existing content into a publishable draft, then automate it
 
 ## First turn
 
-Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
+Before greeting, check for pre-existing connection state:
+- If `data/sanity-connection.json` exists: Sanity is already connected. Read `projectId` and `dataset` from it. Skip the triage question — go directly to "After connection — Sanity path."
+- If `data/content-source.json` exists: a content source URL was provided. Read `url` from it. Skip the triage question — go directly to "After connection — Website scrape path" using this URL.
+- If neither exists: greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot. Then present the four-option triage below.
 
 One `ask_question` to triage the path. Four options:
 1. "I have a Sanity account" — Sanity token path


### PR DESCRIPTION
## Summary

- Updates `BOOTSTRAP-CONTENT-AUTOMATION.md` to check for `data/sanity-connection.json` and `data/content-source.json` sidecars at the start of the first turn
- If either sidecar exists, the daemon skips the four-option triage and jumps directly to the appropriate post-connection path
- The four-option triage is preserved as fallback for users who skip the pre-chat screen, arrive via macOS, or use a non-content-automation path
- Adds 4 new tests to `system-prompt.test.ts` to verify sidecar detection instructions and fallback triage coexist in the template

## Test plan

- [ ] `maybeReseedBootstrapForCohort("content-automation")` produces a template containing `data/sanity-connection.json`
- [ ] Template contains `data/content-source.json`
- [ ] Template contains "Skip the triage question" instructions
- [ ] Template still contains all four triage options as fallback
- [ ] All 10 system-prompt tests pass (`bun test src/prompts/__tests__/system-prompt.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)