### PR TITLE
Daemon endpoints for pre-chat Sanity connection (JARVIS-895)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4219,6 +4219,27 @@ paths:
                 limit:
                   type: number
               additionalProperties: false
+  /v1/content-source:
+    post:
+      operationId: contentsource_post
+      summary: Validate and persist a content source URL
+      tags:
+        - content-source
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+              required:
+                - url
+              additionalProperties: false
   /v1/conversation-starters:
     get:
       operationId: conversationstarters_get
@@ -12517,6 +12538,49 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/sanity/connect:
+    post:
+      operationId: sanity_connect_post
+      summary: Finalise Sanity connection and write sidecar file
+      tags:
+        - sanity
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                projectId:
+                  type: string
+                dataset:
+                  type: string
+              required:
+                - projectId
+                - dataset
+              additionalProperties: false
+  /v1/sanity/discover:
+    post:
+      operationId: sanity_discover_post
+      summary: Discover Sanity projects and datasets using the stored API token
+      tags:
+        - sanity
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                projectId:
+                  type: string
+              additionalProperties: false
   /v1/schedules:
     get:
       operationId: schedules_get

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -223,6 +223,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/daemon-skill-host.ts", // SkillHost secureKeys facet adapter (delegates to getProviderKeyAsync)
       "runtime/routes/credential-prompt-routes.ts", // Route for secure credential prompt (stores secret via setSecureKeyAsync)
       "runtime/routes/credential-routes.ts", // CLI credential management routes (CLI-migrated to IPC)
+      "runtime/routes/sanity-routes.ts", // Sanity connect/discover routes (reads stored api_token from credential store)
       "runtime/routes/platform-routes.ts", // CLI platform connect/disconnect/status routes (CLI-migrated to IPC)
       "ipc/skill-routes/providers.ts", // host.providers.secureKeys.getProviderKey IPC route (out-of-process SkillHost companion)
       "daemon/external-plugins-bootstrap.ts", // reads credentials at plugin init (manifest.requiresCredential) via the CES-mediated getSecureKeyAsync path

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -120,6 +120,33 @@ describe("maybeReseedBootstrapForCohort — content-automation template", () => 
     expect(content).toContain("data/sanity-connection.json");
   });
 
+  test("references data/content-source.json for URL-import sidecar detection", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("data/content-source.json");
+  });
+
+  test("instructs to skip triage when sanity-connection.json sidecar exists", () => {
+    const content = reseedAndRead();
+    // The preamble check must instruct skipping triage when the sidecar is present
+    expect(content).toContain("data/sanity-connection.json");
+    expect(content).toContain("Skip the triage question");
+  });
+
+  test("instructs to skip triage when content-source.json sidecar exists", () => {
+    const content = reseedAndRead();
+    expect(content).toContain("data/content-source.json");
+    expect(content).toContain("Skip the triage question");
+  });
+
+  test("still contains four-option triage as fallback when no sidecars exist", () => {
+    const content = reseedAndRead();
+    // The "If neither exists" path must still present the four-option triage
+    expect(content).toContain("I have a Sanity account");
+    expect(content).toContain("I want to try Sanity");
+    expect(content).toContain("website or blog");
+    expect(content).toContain("somewhere else");
+  });
+
   test("references assistant oauth request --provider sanity for authenticated API calls", () => {
     const content = reseedAndRead();
     expect(content).toContain("assistant oauth request --provider sanity");

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -9,7 +9,10 @@ One goal: turn their existing content into a publishable draft, then automate it
 
 ## First turn
 
-Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
+Before greeting, check for pre-existing connection state:
+- If `data/sanity-connection.json` exists: Sanity is already connected. Read `projectId` and `dataset` from it. Skip the triage question — go directly to "After connection — Sanity path."
+- If `data/content-source.json` exists: a content source URL was provided. Read `url` from it. Skip the triage question — go directly to "After connection — Website scrape path" using this URL.
+- If neither exists: greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot. Then present the four-option triage below.
 
 One `ask_question` to triage the path. Four options:
 1. "I have a Sanity account" — Sanity token path

--- a/assistant/src/runtime/routes/__tests__/content-source-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/content-source-routes.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for content-source-routes.ts.
+ *
+ * Drives the handler function directly (bypassing the router) and mocks
+ * out node:fs writes so no real I/O occurs.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const FAKE_WORKSPACE = "/tmp/content-source-routes-test-workspace";
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => FAKE_WORKSPACE,
+}));
+
+const writtenFiles = new Map<string, string>();
+
+mock.module("node:fs", () => ({
+  mkdirSync: () => {},
+  writeFileSync: (path: string, content: string) => {
+    writtenFiles.set(path, content);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { ROUTES } from "../content-source-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+function makeArgs(body?: Record<string, unknown>): RouteHandlerArgs {
+  return { body };
+}
+
+const handler = findHandler("content_source_set");
+
+beforeEach(() => {
+  writtenFiles.clear();
+});
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+describe("content_source_set — URL validation", () => {
+  test("https URL is accepted and sidecar written", () => {
+    const result = handler(makeArgs({ url: "https://myblog.com/posts" }));
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written.url).toBe("https://myblog.com/posts");
+  });
+
+  test("http URL is accepted and sidecar written", () => {
+    const result = handler(makeArgs({ url: "http://intranet.example.com" }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("URL with leading/trailing whitespace is trimmed", () => {
+    const result = handler(makeArgs({ url: "  https://blog.example.com  " }));
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written.url).toBe("https://blog.example.com/");
+  });
+
+  test("bare hostname without protocol returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "myblog.com" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("ftp:// URL is rejected", () => {
+    const result = handler(makeArgs({ url: "ftp://files.example.com" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("empty string returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("whitespace-only string returns invalid_url", () => {
+    const result = handler(makeArgs({ url: "   " }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("javascript: URL is rejected", () => {
+    const result = handler(makeArgs({ url: "javascript:alert(1)" }));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+    expect(writtenFiles.size).toBe(0);
+  });
+
+  test("missing url field returns invalid_url", () => {
+    const result = handler(makeArgs({}));
+    expect(result).toEqual({ ok: false, error: "invalid_url" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sidecar content verification
+// ---------------------------------------------------------------------------
+
+describe("content_source_set — sidecar contents", () => {
+  test("writes url to data/content-source.json", () => {
+    handler(makeArgs({ url: "https://example.com/blog" }));
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/content-source.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(Object.keys(written)).toEqual(["url"]);
+  });
+
+  test("no sidecar written on invalid URL", () => {
+    handler(makeArgs({ url: "not-a-url" }));
+    expect(writtenFiles.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy key verification
+// ---------------------------------------------------------------------------
+
+describe("route policy key", () => {
+  test("content_source_set uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "content_source_set");
+    expect(route?.policyKey).toBe("secrets");
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sanity-routes.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for sanity-routes.ts.
+ *
+ * Drives the handler functions directly (bypassing the router) and mocks
+ * out secure-keys, the node:fs writes, and fetch so no real I/O occurs.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must appear before any imports of the module under test
+// ---------------------------------------------------------------------------
+
+let storedToken: string | undefined = undefined;
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (_key: string) => storedToken,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const FAKE_WORKSPACE = "/tmp/sanity-routes-test-workspace";
+
+mock.module("../../../util/platform.js", () => ({
+  getWorkspaceDir: () => FAKE_WORKSPACE,
+}));
+
+const writtenFiles = new Map<string, string>();
+
+mock.module("node:fs", () => ({
+  mkdirSync: () => {},
+  writeFileSync: (path: string, content: string) => {
+    writtenFiles.set(path, content);
+  },
+  // Expose the rest of node:fs unchanged so other imports still work.
+  // Bun's mock.module replaces only what we return, and the module under
+  // test only imports mkdirSync and writeFileSync from node:fs.
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { ROUTES } from "../sanity-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+function makeArgs(body?: Record<string, unknown>): RouteHandlerArgs {
+  return { body };
+}
+
+const discoverHandler = findHandler("sanity_discover");
+const connectHandler = findHandler("sanity_connect");
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchReturn = { status: number; json: () => unknown };
+let mockFetchImpl: ((url: string) => FetchReturn) | undefined = undefined;
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(url: string | URL | Request): Promise<Response> {
+  const urlStr =
+    typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+  if (!mockFetchImpl) throw new Error(`Unexpected fetch: ${urlStr}`);
+  const result = mockFetchImpl(urlStr);
+  return Promise.resolve({
+    ok: result.status >= 200 && result.status < 300,
+    status: result.status,
+    json: async () => result.json(),
+  } as Response);
+}
+
+beforeEach(() => {
+  writtenFiles.clear();
+  storedToken = undefined;
+  mockFetchImpl = undefined;
+
+  (globalThis as any).fetch = mockFetch;
+});
+
+afterEach(() => {
+  (globalThis as any).fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — no stored token
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — no stored token", () => {
+  test("returns { error: 'no_token' } when token absent", async () => {
+    storedToken = undefined;
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "no_token" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — project listing
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — list projects", () => {
+  beforeEach(() => {
+    storedToken = "sk-test-token";
+  });
+
+  test("returns projects when API responds 200", async () => {
+    mockFetchImpl = () => ({
+      status: 200,
+      json: () => [
+        { id: "proj-a", displayName: "Project Alpha" },
+        { id: "proj-b", displayName: "Project Beta" },
+      ],
+    });
+
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({
+      projects: [
+        { id: "proj-a", displayName: "Project Alpha" },
+        { id: "proj-b", displayName: "Project Beta" },
+      ],
+    });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 401", async () => {
+    mockFetchImpl = () => ({ status: 401, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 403", async () => {
+    mockFetchImpl = () => ({ status: 403, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'discovery_failed' } on 500", async () => {
+    mockFetchImpl = () => ({ status: 500, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({}));
+    expect(result).toEqual({ error: "discovery_failed" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover — dataset listing (projectId provided)
+// ---------------------------------------------------------------------------
+
+describe("sanity_discover — list datasets", () => {
+  beforeEach(() => {
+    storedToken = "sk-test-token";
+  });
+
+  test("returns datasets when API responds 200", async () => {
+    mockFetchImpl = (url) => {
+      expect(url).toContain("/projects/my-project/datasets");
+      return {
+        status: 200,
+        json: () => [{ name: "production" }, { name: "staging" }],
+      };
+    };
+
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({
+      projectId: "my-project",
+      datasets: ["production", "staging"],
+    });
+  });
+
+  test("returns { error: 'token_scope_limited' } on 403 for dataset list", async () => {
+    mockFetchImpl = () => ({ status: 403, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({ error: "token_scope_limited" });
+  });
+
+  test("returns { error: 'discovery_failed' } on 500 for dataset list", async () => {
+    mockFetchImpl = () => ({ status: 500, json: () => ({}) });
+    const result = await discoverHandler(makeArgs({ projectId: "my-project" }));
+    expect(result).toEqual({ error: "discovery_failed" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/connect
+// ---------------------------------------------------------------------------
+
+describe("sanity_connect", () => {
+  test("writes sidecar when token present and inputs valid", async () => {
+    storedToken = "sk-test-token";
+
+    const result = await connectHandler(
+      makeArgs({ projectId: "my-proj", dataset: "production" }),
+    );
+
+    expect(result).toEqual({ ok: true });
+
+    const expectedPath = `${FAKE_WORKSPACE}/data/sanity-connection.json`;
+    expect(writtenFiles.has(expectedPath)).toBe(true);
+    const written = JSON.parse(writtenFiles.get(expectedPath)!);
+    expect(written).toEqual({ projectId: "my-proj", dataset: "production" });
+  });
+
+  test("throws when no token is stored", async () => {
+    storedToken = undefined;
+
+    expect(
+      connectHandler(makeArgs({ projectId: "p", dataset: "production" })),
+    ).rejects.toThrow();
+  });
+
+  test("throws when projectId is empty", async () => {
+    storedToken = "sk-test-token";
+
+    expect(
+      connectHandler(makeArgs({ projectId: "  ", dataset: "production" })),
+    ).rejects.toThrow();
+  });
+
+  test("throws when dataset is empty", async () => {
+    storedToken = "sk-test-token";
+
+    expect(
+      connectHandler(makeArgs({ projectId: "my-proj", dataset: "" })),
+    ).rejects.toThrow();
+  });
+
+  test("does not return token in response", async () => {
+    storedToken = "sk-super-secret";
+
+    const result = (await connectHandler(
+      makeArgs({ projectId: "p", dataset: "d" }),
+    )) as Record<string, unknown>;
+
+    const resultStr = JSON.stringify(result);
+    expect(resultStr).not.toContain("sk-super-secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy key verification
+// ---------------------------------------------------------------------------
+
+describe("route policy keys", () => {
+  test("sanity_discover uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "sanity_discover");
+    expect(route?.policyKey).toBe("secrets");
+  });
+
+  test("sanity_connect uses policyKey: secrets", () => {
+    const route = ROUTES.find((r) => r.operationId === "sanity_connect");
+    expect(route?.policyKey).toBe("secrets");
+  });
+});

--- a/assistant/src/runtime/routes/content-source-routes.ts
+++ b/assistant/src/runtime/routes/content-source-routes.ts
@@ -39,6 +39,8 @@ function validateUrl(
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return { ok: false, error: "invalid_url" };
   }
+  parsed.username = "";
+  parsed.password = "";
   return { ok: true, normalized: parsed.href };
 }
 

--- a/assistant/src/runtime/routes/content-source-routes.ts
+++ b/assistant/src/runtime/routes/content-source-routes.ts
@@ -1,0 +1,76 @@
+/**
+ * Route definitions for content-source configuration.
+ *
+ * POST /v1/content-source — validate and persist a content source URL as sidecar
+ *
+ * Uses policyKey: "secrets" — writes workspace data, same policy tier as
+ * the existing secrets routes.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { z } from "zod";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeSidecar(relPath: string, data: Record<string, unknown>): void {
+  const workspaceDir = getWorkspaceDir();
+  const absPath = join(workspaceDir, relPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+function validateUrl(
+  raw: string,
+): { ok: true; normalized: string } | { ok: false; error: "invalid_url" } {
+  const trimmed = raw.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, error: "invalid_url" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, error: "invalid_url" };
+  }
+  return { ok: true, normalized: parsed.href };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/content-source
+// ---------------------------------------------------------------------------
+
+function handleContentSource(args: RouteHandlerArgs): Record<string, unknown> {
+  const rawUrl = typeof args.body?.url === "string" ? args.body.url : "";
+
+  const result = validateUrl(rawUrl);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  writeSidecar("data/content-source.json", { url: result.normalized });
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definition
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "content_source_set",
+    endpoint: "content-source",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Validate and persist a content source URL",
+    requestBody: z.object({ url: z.string() }),
+    handler: handleContentSource,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -33,6 +33,7 @@ import { ROUTES as CLIENT_ROUTES } from "./client-routes.js";
 import { ROUTES as CONSOLIDATION_ROUTES } from "./consolidation-routes.js";
 import { CONTACT_PROMPT_ROUTES } from "./contact-prompt-routes.js";
 import { ROUTES as CONTACT_ROUTES } from "./contact-routes.js";
+import { ROUTES as CONTENT_SOURCE_ROUTES } from "./content-source-routes.js";
 import { ROUTES as CONVERSATION_ANALYSIS_ROUTES } from "./conversation-analysis-routes.js";
 import { ROUTES as CONVERSATION_ATTENTION_ROUTES } from "./conversation-attention-routes.js";
 import { ROUTES as CONVERSATION_CLI_ROUTES } from "./conversation-cli-routes.js";
@@ -101,6 +102,7 @@ import { ROUTES as PUBLISH_ROUTES } from "./publish-routes.js";
 import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
+import { ROUTES as SANITY_ROUTES } from "./sanity-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "./schedule-routes.js";
 import { ROUTES as SECRET_ROUTES } from "./secret-routes.js";
 import { ROUTES as SEQUENCE_ROUTES } from "./sequence-routes.js";
@@ -153,6 +155,7 @@ export const ROUTES: RouteDefinition[] = [
   ...BTW_ROUTES,
   ...BRAIN_GRAPH_ROUTES,
   ...CLIENT_ROUTES,
+  ...CONTENT_SOURCE_ROUTES,
   ...CONTACT_PROMPT_ROUTES,
   ...CONTACT_ROUTES,
   ...CONVERSATION_ANALYSIS_ROUTES,
@@ -219,6 +222,7 @@ export const ROUTES: RouteDefinition[] = [
   ...RECORDING_ROUTES,
   ...RENAME_CONVERSATION_ROUTES,
   ...SCHEDULE_ROUTES,
+  ...SANITY_ROUTES,
   ...SECRET_ROUTES,
   ...SETTINGS_ROUTES,
   ...SKILL_ROUTES,

--- a/assistant/src/runtime/routes/sanity-routes.ts
+++ b/assistant/src/runtime/routes/sanity-routes.ts
@@ -1,0 +1,159 @@
+/**
+ * Route definitions for Sanity CMS connection management.
+ *
+ * POST /v1/sanity/discover — project/dataset discovery using the stored API token
+ * POST /v1/sanity/connect  — finalise connection by writing the sidecar file
+ *
+ * Both routes use policyKey: "secrets" — they read credentials and write
+ * workspace data, the same policy tier as the existing secrets routes.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { z } from "zod";
+
+import { credentialKey } from "../../security/credential-key.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getStoredToken(): Promise<string | undefined> {
+  return getSecureKeyAsync(credentialKey("sanity", "api_token"));
+}
+
+function writeSidecar(relPath: string, data: Record<string, unknown>): void {
+  const workspaceDir = getWorkspaceDir();
+  const absPath = join(workspaceDir, relPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/discover
+// ---------------------------------------------------------------------------
+
+async function handleDiscover(
+  args: RouteHandlerArgs,
+): Promise<Record<string, unknown>> {
+  const token = await getStoredToken();
+  if (!token) {
+    return { error: "no_token" };
+  }
+
+  const projectId =
+    typeof args.body?.projectId === "string" ? args.body.projectId : undefined;
+
+  if (!projectId) {
+    // List all projects this token has access to
+    const response = await fetch("https://api.sanity.io/v2021-06-07/projects", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { error: "token_scope_limited" };
+    }
+
+    if (!response.ok) {
+      return { error: "discovery_failed" };
+    }
+
+    const raw = (await response.json()) as Array<{
+      id: string;
+      displayName?: string;
+    }>;
+    const projects = raw.map((p) => ({
+      id: p.id,
+      displayName: p.displayName ?? p.id,
+    }));
+    return { projects };
+  }
+
+  // List datasets for a specific project
+  const response = await fetch(
+    `https://api.sanity.io/v2021-06-07/projects/${projectId}/datasets`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    return { error: "token_scope_limited" };
+  }
+
+  if (!response.ok) {
+    return { error: "discovery_failed" };
+  }
+
+  const raw = (await response.json()) as Array<{ name: string }>;
+  const datasets = raw.map((d) => d.name);
+  return { projectId, datasets };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/sanity/connect
+// ---------------------------------------------------------------------------
+
+async function handleConnect(
+  args: RouteHandlerArgs,
+): Promise<Record<string, unknown>> {
+  const token = await getStoredToken();
+  if (!token) {
+    throw new BadRequestError(
+      "Sanity API token not found. Store it first via POST /v1/secrets.",
+    );
+  }
+
+  const projectId =
+    typeof args.body?.projectId === "string" ? args.body.projectId.trim() : "";
+  const dataset =
+    typeof args.body?.dataset === "string" ? args.body.dataset.trim() : "";
+
+  if (!projectId) {
+    throw new BadRequestError(
+      "projectId is required and must be a non-empty string",
+    );
+  }
+  if (!dataset) {
+    throw new BadRequestError(
+      "dataset is required and must be a non-empty string",
+    );
+  }
+
+  writeSidecar("data/sanity-connection.json", { projectId, dataset });
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "sanity_discover",
+    endpoint: "sanity/discover",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Discover Sanity projects and datasets using the stored API token",
+    requestBody: z.object({ projectId: z.string().optional() }).optional(),
+    handler: handleDiscover,
+  },
+  {
+    operationId: "sanity_connect",
+    endpoint: "sanity/connect",
+    method: "POST",
+    policyKey: "secrets",
+    summary: "Finalise Sanity connection and write sidecar file",
+    requestBody: z.object({
+      projectId: z.string(),
+      dataset: z.string(),
+    }),
+    handler: handleConnect,
+  },
+];


### PR DESCRIPTION
## Summary
- Add `POST /v1/sanity/discover` and `POST /v1/sanity/connect` endpoints for server-side Sanity project/dataset discovery and sidecar persistence
- Add `POST /v1/content-source` endpoint for URL-based content source sidecar persistence with server-side URL validation
- Update bootstrap template to detect sidecars and skip triage when pre-chat already connected Sanity or provided a URL

## PRs merged into feature branch
- #31241: feat(daemon): add Sanity connect/discover and content-source endpoints with sidecar persistence
- #31243: feat(bootstrap): skip triage when Sanity or content-source sidecar exists

Part of plan: sanity-prechat-connect.md

Companion platform-repo PR: vellum-ai/vellum-assistant-platform#7355