### PR TITLE
fix(assistant): keep kata apt libraries out of daemon startup

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -8,7 +8,6 @@ chmod 1777 /tmp 2>/dev/null || true
 KATA_APT_INIT_PID=""
 if [ "${VELLUM_SANDBOX_RUNTIME:-}" = "kata" ] && [ -x /app/assistant/docker-init-apt-root.sh ]; then
   export VELLUM_APT_DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
-  . /app/assistant/docker-kata-apt-env.sh
   # Warm the chroot used by kata apt wrappers without blocking assistant readiness.
   /app/assistant/docker-init-apt-root.sh &
   KATA_APT_INIT_PID="$!"

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -67,6 +67,7 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 import {
   ALWAYS_INJECTED_ENV_VARS,
   buildSanitizedEnv,
+  KATA_INJECTED_ENV_VARS,
   KATA_SAFE_ENV_VARS,
   SAFE_ENV_VARS,
 } from "../tools/terminal/safe-env.js";
@@ -145,7 +146,7 @@ describe("buildSanitizedEnv", () => {
     process.env.VELLUM_SANDBOX_RUNTIME = "gvisor";
     process.env.PATH = "/usr/bin";
     process.env.VELLUM_APT_DATA_ROOT = "/data/system";
-    process.env.LD_LIBRARY_PATH = "/data/system/usr/lib";
+    process.env.LD_LIBRARY_PATH = "/host/lib";
 
     let env = buildSanitizedEnv();
     expect(env.VELLUM_APT_DATA_ROOT).toBeUndefined();
@@ -161,6 +162,7 @@ describe("buildSanitizedEnv", () => {
     expect(env.LD_LIBRARY_PATH.split(":")).toContain(
       "/data/system/usr/local/lib",
     );
+    expect(env.LD_LIBRARY_PATH.split(":")).not.toContain("/host/lib");
   });
 
   test("defaults LANG and LC_ALL to UTF-8 when unset", () => {
@@ -181,12 +183,20 @@ describe("buildSanitizedEnv", () => {
     delete process.env.GATEWAY_PORT;
   });
 
+  test("Kata entrypoint initializes apt root without inheriting apt loader paths", () => {
+    const entrypoint = readFileSync("docker-entrypoint.sh", "utf8");
+
+    expect(entrypoint).toContain("/app/assistant/docker-init-apt-root.sh");
+    expect(entrypoint).not.toContain(". /app/assistant/docker-kata-apt-env.sh");
+  });
+
   test("result is a plain object with no prototype-inherited secrets", () => {
     const env = buildSanitizedEnv();
     const keys = Object.keys(env);
     const safeKeys: string[] = [
       ...SAFE_ENV_VARS,
       ...KATA_SAFE_ENV_VARS,
+      ...KATA_INJECTED_ENV_VARS,
       ...ALWAYS_INJECTED_ENV_VARS,
     ];
     for (const key of keys) {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -846,6 +846,7 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
 // Import the real buildSanitizedEnv (not mocked) for baseline credential tests
 const {
   buildSanitizedEnv,
+  KATA_INJECTED_ENV_VARS,
   KATA_SAFE_ENV_VARS,
   SAFE_ENV_VARS,
   ALWAYS_INJECTED_ENV_VARS,
@@ -910,6 +911,7 @@ describe("buildSanitizedEnv — baseline: credential exclusion", () => {
     const allowed: string[] = [
       ...SAFE_ENV_VARS,
       ...KATA_SAFE_ENV_VARS,
+      ...KATA_INJECTED_ENV_VARS,
       ...ALWAYS_INJECTED_ENV_VARS,
     ];
     const env = buildSanitizedEnv();

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -61,11 +61,12 @@ export const SAFE_ENV_VARS = [
 ] as const;
 
 export const KATA_SAFE_ENV_VARS = [
-  "LD_LIBRARY_PATH",
   "VELLUM_APT_DATA_ROOT",
   "VELLUM_APT_DATA_SUITE",
   "VELLUM_APT_DATA_MIRROR",
 ] as const;
+
+export const KATA_INJECTED_ENV_VARS = ["LD_LIBRARY_PATH"] as const;
 
 const KATA_APT_DATA_ROOT = "/data/system";
 
@@ -132,7 +133,7 @@ export function buildSanitizedEnv(): Record<string, string> {
     env.VELLUM_APT_DATA_ROOT = kataAptDataRoot;
     env.PATH = appendUniquePathEntries(env.PATH, kataAptPaths(kataAptDataRoot));
     env.LD_LIBRARY_PATH = appendUniquePathEntries(
-      env.LD_LIBRARY_PATH,
+      undefined,
       kataAptLibraryPaths(kataAptDataRoot),
     );
   }


### PR DESCRIPTION
## Summary
- Stop sourcing the Kata apt-root environment in docker-entrypoint before daemon startup so Bun does not inherit mutable /data/system library paths.
- Keep Kata tool subprocess support for persisted apt packages by injecting only the explicit apt-root LD_LIBRARY_PATH entries instead of passing through the daemon environment value.
- Add regression coverage for sanitized env behavior and the entrypoint startup path.

## Original prompt
Triage and fix the Codex security finding that Kata mode persisted apt-root library directories were added to LD_LIBRARY_PATH before daemon startup and propagated to tool subprocesses. The fix should preserve persisted system-package support while preventing assistant-controlled tool activity from poisoning the daemon dynamic-loader search path on restart.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/1104b88ca1288191bb2a3275c1bb8200?sev=critical%2Chigh%2Cmedium

## Test plan
- `bun test src/__tests__/terminal-tools.test.ts src/__tests__/tool-executor.test.ts --grep "buildSanitizedEnv|Kata entrypoint"`