### PR TITLE
feat(web): port ConversationActionsMenu from platform (LUM-1661)

### DIFF
--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * Tests for `ConversationActionsMenu`.
+ *
+ * The component swaps surfaces based on `useIsMobile()`:
+ *   - Desktop → Radix dropdown menu (`Menu.Root`)
+ *   - Mobile  → `BottomSheet` (Radix Dialog) with `PanelItem` rows
+ *
+ * The web workspace lacks `@testing-library/react` (no jsdom/happy-dom), so
+ * we exercise behavior through `renderToStaticMarkup` for HTML surface checks
+ * and mock `useIsMobile` per-test to drive each branch.
+ *
+ * We also test the pure `renderConversationMenuItems` helper directly since
+ * it is the shared source of truth for both dropdown and context-menu
+ * surfaces.
+ */
+
+import { describe, expect, mock, test, beforeEach } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile.js", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+// Mock design library compound components that require browser APIs (portals,
+// Radix floating-ui) so renderToStaticMarkup can produce testable HTML.
+const passthrough = ({ children, ...props }: Record<string, unknown>) =>
+  createElement("div", props, children as ReactNode);
+const mockItem = ({
+  children,
+  onSelect: _onSelect,
+  leftIcon,
+  disabled,
+  ...rest
+}: Record<string, unknown>) =>
+  createElement(
+    "div",
+    { "data-testid": "menu-item", "data-disabled": disabled || undefined, ...rest },
+    leftIcon as ReactNode,
+    children as ReactNode,
+  );
+const mockSeparator = () => createElement("hr", { "data-testid": "separator" });
+const mockSubTrigger = ({ children, leftIcon, ...rest }: Record<string, unknown>) =>
+  createElement("div", { "data-testid": "sub-trigger", ...rest }, leftIcon as ReactNode, children as ReactNode);
+const mockTrigger = ({ children }: Record<string, unknown>) =>
+  createElement("div", { "data-testid": "trigger" }, children as ReactNode);
+
+mock.module("@vellum/design-library", () => {
+  const MenuMock = {
+    Root: passthrough,
+    Trigger: mockTrigger,
+    Content: passthrough,
+    Item: mockItem,
+    Separator: mockSeparator,
+    Sub: passthrough,
+    SubTrigger: mockSubTrigger,
+    SubContent: passthrough,
+  };
+
+  const BottomSheetMock = {
+    Root: passthrough,
+    Trigger: mockTrigger,
+    Content: passthrough,
+    Header: passthrough,
+    Title: passthrough,
+    Body: passthrough,
+  };
+
+  const PanelItemMock = ({ label, icon: _icon, ...rest }: Record<string, unknown>) =>
+    createElement("div", { "data-testid": "panel-item", ...rest }, label as string);
+
+  const ContextMenuMock = {
+    Item: mockItem,
+    Separator: mockSeparator,
+    Sub: passthrough,
+    SubTrigger: mockSubTrigger,
+    SubContent: passthrough,
+  };
+
+  return {
+    Menu: MenuMock,
+    ContextMenu: ContextMenuMock,
+    BottomSheet: BottomSheetMock,
+    PanelItem: PanelItemMock,
+  };
+});
+
+import { Menu } from "@vellum/design-library";
+import {
+  ConversationActionsMenu,
+  renderConversationMenuItems,
+  type ConversationMenuPrimitive,
+} from "@/domains/chat/components/conversation-actions-menu.js";
+
+beforeEach(() => {
+  mockIsMobile = false;
+});
+
+// ---------------------------------------------------------------------------
+// renderConversationMenuItems (pure helper)
+// ---------------------------------------------------------------------------
+
+describe("renderConversationMenuItems", () => {
+  test("renders Pin and Rename when handlers are provided", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        onPinToggle: () => {},
+        onRename: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+
+  test("renders Unpin when isPinned is true", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        isPinned: true,
+        onPinToggle: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Unpin");
+    expect(html).not.toContain(">Pin<");
+  });
+
+  test("renders Archive when onArchive is provided", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        onArchive: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Archive");
+  });
+
+  test("renders Unarchive when isArchived and onUnarchive are provided", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        isArchived: true,
+        onUnarchive: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Unarchive");
+  });
+
+  test("hides Mark as unread and Analyze when isReadonly", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        isReadonly: true,
+        onArchive: () => {},
+        onAnalyze: () => {},
+        onMarkUnread: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Archive");
+    expect(html).not.toContain("Mark as unread");
+    expect(html).not.toContain("Analyze");
+  });
+
+  test("renders Move to submenu when groups and handler are provided", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        moveToGroups: [
+          { id: "g1", name: "Work" },
+          { id: "g2", name: "Personal" },
+        ],
+        onMoveToGroup: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Move to");
+    expect(html).toContain("Work");
+    expect(html).toContain("Personal");
+  });
+
+  test("renders header variant with correct item order", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        variant: "header",
+        onCopyConversation: () => {},
+        onForkConversation: () => {},
+        onAnalyze: () => {},
+        onPinToggle: () => {},
+        onRename: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Copy full conversation");
+    expect(html).toContain("Fork conversation");
+    expect(html).toContain("Analyze conversation");
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConversationActionsMenu component
+// ---------------------------------------------------------------------------
+
+describe("ConversationActionsMenu — desktop branch", () => {
+  test("renders the default ellipsis trigger with aria-label", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain('aria-label="Conversation actions"');
+    expect(html).toContain('aria-haspopup="menu"');
+  });
+
+  test("renders Pin and Rename items in the menu content", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+});
+
+describe("ConversationActionsMenu — mobile branch", () => {
+  test("renders BottomSheet surface on mobile", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain("Conversation actions");
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+
+  test("renders Archive on mobile when provided", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu onArchive={() => {}} />,
+    );
+    expect(html).toContain("Archive");
+  });
+});
+
+describe("ConversationActionsMenu — read-only conversations", () => {
+  test("Archive renders when read-only (organizational action)", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        isReadonly
+        onArchive={() => {}}
+        onAnalyze={() => {}}
+        onMarkUnread={() => {}}
+      />,
+    );
+    expect(html).toContain("Archive");
+    expect(html).not.toContain("Mark as unread");
+    expect(html).not.toContain("Analyze");
+  });
+
+  test("Unarchive renders when archived and read-only", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        isReadonly
+        isArchived
+        onUnarchive={() => {}}
+      />,
+    );
+    expect(html).toContain("Unarchive");
+  });
+});

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -213,7 +213,7 @@ describe("ConversationActionsMenu — desktop branch", () => {
       />,
     );
     expect(html).toContain('aria-label="Conversation actions"');
-    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain("<button");
   });
 
   test("renders Pin and Rename items in the menu content", () => {

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -252,6 +252,68 @@ describe("ConversationActionsMenu — mobile branch", () => {
   });
 });
 
+describe("renderConversationMenuItems — mark read/unread exclusivity", () => {
+  test("onMarkRead takes precedence when both onMarkRead and onMarkUnread are provided", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        onMarkRead: () => {},
+        onMarkUnread: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Mark as read");
+    expect(html).not.toContain("Mark as unread");
+  });
+});
+
+describe("ConversationActionsMenu — mobile panel details", () => {
+  test("isMarkUnreadDisabled renders disabled panel item on mobile", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        onMarkUnread={() => {}}
+        isMarkUnreadDisabled
+      />,
+    );
+    expect(html).toContain("Mark as unread");
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("opacity-50");
+  });
+
+  test("onRemoveFromGroup renders in mobile Move to block", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        moveToGroups={[{ id: "g1", name: "Work" }]}
+        onMoveToGroup={() => {}}
+        onRemoveFromGroup={() => {}}
+      />,
+    );
+    expect(html).toContain("Move to");
+    expect(html).toContain("Work");
+    expect(html).toContain("Remove from group");
+  });
+
+  test("variant header renders header-order items on mobile", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      <ConversationActionsMenu
+        variant="header"
+        onCopyConversation={() => {}}
+        onForkConversation={() => {}}
+        onAnalyze={() => {}}
+        onPinToggle={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(html).toContain("Copy full conversation");
+    expect(html).toContain("Fork conversation");
+    expect(html).toContain("Analyze conversation");
+    expect(html).toContain("Pin");
+    expect(html).toContain("Rename");
+  });
+});
+
 describe("ConversationActionsMenu — read-only conversations", () => {
   test("Archive renders when read-only (organizational action)", () => {
     mockIsMobile = false;

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -1,0 +1,730 @@
+import {
+  Archive,
+  ArchiveRestore,
+  Circle,
+  CircleCheck,
+  Copy,
+  ExternalLink,
+  FolderInput,
+  GitBranch,
+  MessageCircle,
+  Microscope,
+  MoreHorizontal,
+  Pencil,
+  Pin,
+  PinOff,
+  RefreshCw,
+  Sparkles,
+  type LucideIcon,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import {
+  BottomSheet,
+  ContextMenu,
+  Menu,
+  PanelItem,
+} from "@vellum/design-library";
+import type { MoveToGroupTarget } from "@/domains/chat/lib/groupConversations.js";
+import { useIsMobile } from "@/hooks/use-is-mobile.js";
+
+/**
+ * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
+ * button; clicking it opens a dropdown menu with Pin / Rename / Archive /
+ * Mark as unread actions, plus an optional "Move to Group" submenu.
+ *
+ * The same item set is also rendered by the row's right-click context menu
+ * (`AssistantSideMenu`) via the shared `renderConversationMenuItems` helper
+ * exported from this module — both surfaces stay byte-identical because
+ * they consume one source of truth.
+ *
+ * On mobile (`useIsMobile() === true`), the dropdown is replaced with a
+ * `BottomSheet` that slides up from the viewport bottom — see
+ * `renderConversationMenuItemsAsPanelItems` for the parallel item builder.
+ *
+ * The ellipsis button is hidden by default and revealed via `group-hover`
+ * on the parent `PanelItem`'s row. When the menu is open the button stays
+ * visible so the menu doesn't snap closed as the mouse leaves the row
+ * on its way to a menu item.
+ */
+
+type MenuSide = "top" | "right" | "bottom" | "left";
+type MenuAlign = "start" | "center" | "end";
+
+/**
+ * Subset of the compound-menu API shared by `Menu` and `ContextMenu`. The
+ * shared `renderConversationMenuItems` helper accepts a value of this type
+ * so a single source of truth produces items for both the dropdown trigger
+ * (right-side ellipsis, topbar) and the row's right-click context menu.
+ */
+export type ConversationMenuPrimitive = {
+  Item: typeof Menu.Item | typeof ContextMenu.Item;
+  Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
+  Sub: typeof Menu.Sub | typeof ContextMenu.Sub;
+  SubTrigger: typeof Menu.SubTrigger | typeof ContextMenu.SubTrigger;
+  SubContent: typeof Menu.SubContent | typeof ContextMenu.SubContent;
+};
+
+export interface ConversationMenuItemsProps {
+  /** True when the conversation is currently pinned (drives Pin / Unpin label). */
+  isPinned?: boolean;
+  /** True when the conversation is archived (drives Archive / Unarchive label). */
+  isArchived?: boolean;
+  /** Toggle the pinned state. Unwired callers can omit this; the row hides the menu item. */
+  onPinToggle?: () => void;
+  /** Prompt for a new title and persist it. */
+  onRename?: () => void;
+  /** Move the conversation to Archived. */
+  onArchive?: () => void;
+  /** Restore an archived conversation. When provided, takes precedence over `onArchive` when `isArchived` is true. */
+  onUnarchive?: () => void;
+  /** Mark the most recent assistant message as unread. */
+  onMarkUnread?: () => void;
+  /**
+   * When true, the "Mark as unread" item is rendered in a disabled state.
+   * Use this for rows where the conversation cannot currently be marked
+   * unread (no assistant message yet, already unread, suppressed group,
+   * or no conversationId).
+   */
+  isMarkUnreadDisabled?: boolean;
+  /**
+   * Mark the conversation as read (clear the unread indicator). When
+   * provided the menu renders "Mark as read" instead of "Mark as unread"
+   * so the two actions never appear simultaneously — callers pass
+   * whichever is appropriate for the current read state.
+   */
+  onMarkRead?: () => void;
+  /**
+   * Groups available as "Move to Group" targets, excluding the
+   * conversation's current group. When non-empty and `onMoveToGroup`
+   * is provided, a submenu appears listing these targets.
+   */
+  moveToGroups?: MoveToGroupTarget[];
+  /** Move the conversation to the specified group. */
+  onMoveToGroup?: (groupId: string) => void;
+  /**
+   * Remove the conversation from its current (non-system) group, falling
+   * back to Recents. When provided, appends a separator + "Remove from
+   * group" item at the end of the Move-to-Group submenu. Callers should
+   * only supply this for conversations that belong to a non-system group
+   * (i.e. `groupId && !groupId.startsWith("system:")`).
+   */
+  onRemoveFromGroup?: () => void;
+  /**
+   * Hide write-affording menu items (Mark-as-read/unread, Analyze) when
+   * the conversation is read-only. Items are hidden entirely, not
+   * disabled. Today this fires for channel-bound conversations (Slack,
+   * Telegram, voice) where outbound writes aren't mirrored back to the
+   * source channel; future read-only sources (e.g. daemon-side locks)
+   * can feed the same gate.
+   *
+   * Archive/Unarchive intentionally stay available even when read-only
+   * — moving a thread out of the active sidebar is an organizational
+   * action that doesn't write to the source channel, and channel
+   * conversations accumulate faster than native ones so users need
+   * to be able to tidy them up.
+   */
+  isReadonly?: boolean;
+  /** Trigger an analysis of this conversation via the daemon. */
+  onAnalyze?: () => void;
+  /** Open this conversation in a new browser tab. */
+  onOpenInNewWindow?: () => void;
+  /** Fork the conversation through the latest persisted message. */
+  onForkConversation?: () => void;
+  /** Open the Share Feedback modal for this conversation. */
+  onShareFeedback?: () => void;
+  /**
+   * Open the per-conversation LLM context inspector. When provided, an
+   * "Inspect" item appears at the bottom of the action set — power-user
+   * affordance for debugging the assistant's prompt/response/memory
+   * decisions per message.
+   */
+  onInspect?: () => void;
+  /** Copy the full conversation as markdown to the clipboard. */
+  onCopyConversation?: () => void;
+  /** Re-fetch the chat context and reload the current conversation. */
+  onRefresh?: () => void;
+  /** Controls item order and labels. "header" uses macOS-parity order; "sidebar" preserves the original order. */
+  variant?: "header" | "sidebar";
+}
+
+/**
+ * Render the conversation row's menu items into either a `Menu` or a
+ * `ContextMenu`. Both namespaces expose the same `Item / Separator / Sub /
+ * SubTrigger / SubContent` shape; passing one in via `Primitive` keeps the
+ * dropdown trigger and the right-click context menu in lockstep without
+ * duplicating the item list.
+ */
+export function renderConversationMenuItems({
+  Primitive,
+  isPinned = false,
+  isArchived = false,
+  onPinToggle,
+  onRename,
+  onArchive,
+  onUnarchive,
+  onMarkUnread,
+  isMarkUnreadDisabled = false,
+  onMarkRead,
+  moveToGroups,
+  onMoveToGroup,
+  onRemoveFromGroup,
+  isReadonly = false,
+  onAnalyze,
+  onForkConversation,
+  onOpenInNewWindow,
+  onShareFeedback,
+  onInspect,
+  onCopyConversation,
+  onRefresh,
+  variant = "sidebar",
+}: ConversationMenuItemsProps & {
+  Primitive: ConversationMenuPrimitive;
+}): ReactNode {
+  const showMoveToGroup =
+    onMoveToGroup && moveToGroups && moveToGroups.length > 0;
+
+  const pinItem = onPinToggle ? (
+    <Primitive.Item
+      leftIcon={isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+      onSelect={onPinToggle}
+    >
+      {isPinned ? "Unpin" : "Pin"}
+    </Primitive.Item>
+  ) : null;
+
+  const renameItem = onRename ? (
+    <Primitive.Item leftIcon={<Pencil size={14} />} onSelect={onRename}>
+      Rename
+    </Primitive.Item>
+  ) : null;
+
+  const archiveItem =
+    isArchived && onUnarchive ? (
+      <Primitive.Item
+        leftIcon={<ArchiveRestore size={14} />}
+        onSelect={onUnarchive}
+      >
+        Unarchive
+      </Primitive.Item>
+    ) : onArchive ? (
+      <Primitive.Item leftIcon={<Archive size={14} />} onSelect={onArchive}>
+        Archive
+      </Primitive.Item>
+    ) : null;
+
+  const markReadUnreadItem =
+    !isReadonly && onMarkRead ? (
+      <Primitive.Item
+        leftIcon={<CircleCheck size={14} />}
+        onSelect={onMarkRead}
+      >
+        Mark as read
+      </Primitive.Item>
+    ) : !isReadonly && onMarkUnread ? (
+      <Primitive.Item
+        leftIcon={<Circle size={14} />}
+        onSelect={onMarkUnread}
+        disabled={isMarkUnreadDisabled}
+      >
+        Mark as unread
+      </Primitive.Item>
+    ) : null;
+
+  const moveToGroupItem = showMoveToGroup ? (
+    <Primitive.Sub>
+      <Primitive.SubTrigger leftIcon={<FolderInput size={14} />}>
+        Move to
+      </Primitive.SubTrigger>
+      <Primitive.SubContent>
+        {moveToGroups.map((group) => (
+          <Primitive.Item
+            key={group.id}
+            onSelect={() => onMoveToGroup(group.id)}
+          >
+            {group.name}
+          </Primitive.Item>
+        ))}
+        {onRemoveFromGroup ? (
+          <>
+            <Primitive.Separator />
+            <Primitive.Item onSelect={onRemoveFromGroup}>
+              Remove from group
+            </Primitive.Item>
+          </>
+        ) : null}
+      </Primitive.SubContent>
+    </Primitive.Sub>
+  ) : null;
+
+  const analyzeItem =
+    !isReadonly && onAnalyze ? (
+      <Primitive.Item leftIcon={<Sparkles size={14} />} onSelect={onAnalyze}>
+        {variant === "header" ? "Analyze conversation" : "Analyze"}
+      </Primitive.Item>
+    ) : null;
+
+  const openInNewWindowItem = onOpenInNewWindow ? (
+    <Primitive.Item
+      leftIcon={<ExternalLink size={14} />}
+      onSelect={onOpenInNewWindow}
+    >
+      {variant === "header" ? "Open in new window" : "Open in New Window"}
+    </Primitive.Item>
+  ) : null;
+
+  const inspectItem = onInspect ? (
+    <Primitive.Item leftIcon={<Microscope size={14} />} onSelect={onInspect}>
+      Inspect
+    </Primitive.Item>
+  ) : null;
+
+  if (variant === "header") {
+    return (
+      <>
+        {onCopyConversation ? (
+          <Primitive.Item
+            leftIcon={<Copy size={14} />}
+            onSelect={onCopyConversation}
+          >
+            Copy full conversation
+          </Primitive.Item>
+        ) : null}
+
+        {onForkConversation ? (
+          <Primitive.Item
+            leftIcon={<GitBranch size={14} />}
+            onSelect={onForkConversation}
+          >
+            Fork conversation
+          </Primitive.Item>
+        ) : null}
+
+        {analyzeItem}
+        {openInNewWindowItem}
+
+        {onRefresh ? (
+          <Primitive.Item
+            leftIcon={<RefreshCw size={14} />}
+            onSelect={onRefresh}
+          >
+            Refresh
+          </Primitive.Item>
+        ) : null}
+
+        {pinItem}
+        {renameItem}
+        {archiveItem}
+        {inspectItem}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {pinItem}
+      {renameItem}
+      {archiveItem}
+
+      {markReadUnreadItem}
+      {analyzeItem}
+      {moveToGroupItem}
+      {openInNewWindowItem}
+
+      {onShareFeedback ? (
+        <>
+          <Primitive.Separator />
+          <Primitive.Item
+            leftIcon={<MessageCircle size={14} />}
+            onSelect={onShareFeedback}
+          >
+            Share Feedback
+          </Primitive.Item>
+        </>
+      ) : null}
+
+      {inspectItem ? (
+        <>
+          <Primitive.Separator />
+          {inspectItem}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * 1px divider for the mobile bottom-sheet menu. Mirrors the in-popover
+ * separator style used elsewhere in the app.
+ */
+function MobileMenuDivider() {
+  return (
+    <div
+      aria-hidden="true"
+      className="my-1 h-px"
+      style={{ background: "var(--border-overlay)" }}
+    />
+  );
+}
+
+/**
+ * Build a single menu row for the mobile bottom sheet. Renders a
+ * `PanelItem` so the row matches the design system spec. The `onSelect`
+ * handler runs first, then the sheet dismisses via `onClose` so the
+ * action's UI feedback (modals, toasts, navigation) doesn't fire under
+ * a still-open sheet.
+ */
+function buildPanelItem({
+  key,
+  icon,
+  label,
+  disabled,
+  className,
+  run,
+  onClose,
+}: {
+  key: string;
+  icon?: LucideIcon;
+  label: string;
+  disabled?: boolean;
+  className?: string;
+  run: () => void;
+  onClose: () => void;
+}): ReactNode {
+  const composedClassName = [
+    disabled ? "pointer-events-none opacity-50" : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <PanelItem
+      key={key}
+      icon={icon}
+      label={label}
+      onSelect={
+        disabled
+          ? undefined
+          : () => {
+              run();
+              onClose();
+            }
+      }
+      aria-disabled={disabled || undefined}
+      className={composedClassName || undefined}
+    />
+  );
+}
+
+/**
+ * Mobile-only renderer for the bottom-sheet surface. Returns the same
+ * conceptual item set as `renderConversationMenuItems` but flattened into
+ * `PanelItem` rows, with the "Move to" submenu rendered inline under a
+ * label since `BottomSheet` is a single-level surface.
+ */
+function renderConversationMenuItemsAsPanelItems({
+  isPinned = false,
+  isArchived = false,
+  onPinToggle,
+  onRename,
+  onArchive,
+  onUnarchive,
+  onMarkUnread,
+  isMarkUnreadDisabled = false,
+  onMarkRead,
+  moveToGroups,
+  onMoveToGroup,
+  onRemoveFromGroup,
+  isReadonly = false,
+  onAnalyze,
+  onForkConversation,
+  onOpenInNewWindow,
+  onShareFeedback,
+  onInspect,
+  onCopyConversation,
+  onRefresh,
+  variant = "sidebar",
+  onClose,
+}: ConversationMenuItemsProps & { onClose: () => void }): ReactNode {
+  const showMoveToGroup =
+    onMoveToGroup && moveToGroups && moveToGroups.length > 0;
+
+  const pinItem = onPinToggle
+    ? buildPanelItem({
+        key: "pin",
+        icon: isPinned ? PinOff : Pin,
+        label: isPinned ? "Unpin" : "Pin",
+        run: onPinToggle,
+        onClose,
+      })
+    : null;
+
+  const renameItem = onRename
+    ? buildPanelItem({
+        key: "rename",
+        icon: Pencil,
+        label: "Rename",
+        run: onRename,
+        onClose,
+      })
+    : null;
+
+  const archiveItem =
+    isArchived && onUnarchive
+      ? buildPanelItem({
+          key: "unarchive",
+          icon: ArchiveRestore,
+          label: "Unarchive",
+          run: onUnarchive,
+          onClose,
+        })
+      : onArchive
+        ? buildPanelItem({
+            key: "archive",
+            icon: Archive,
+            label: "Archive",
+            run: onArchive,
+            onClose,
+          })
+        : null;
+
+  const markReadUnreadItem =
+    !isReadonly && onMarkRead
+      ? buildPanelItem({
+          key: "mark-read",
+          icon: CircleCheck,
+          label: "Mark as read",
+          run: onMarkRead,
+          onClose,
+        })
+      : !isReadonly && onMarkUnread
+        ? buildPanelItem({
+            key: "mark-unread",
+            icon: Circle,
+            label: "Mark as unread",
+            disabled: isMarkUnreadDisabled,
+            run: onMarkUnread,
+            onClose,
+          })
+        : null;
+
+  const analyzeItem =
+    !isReadonly && onAnalyze
+      ? buildPanelItem({
+          key: "analyze",
+          icon: Sparkles,
+          label: variant === "header" ? "Analyze conversation" : "Analyze",
+          run: onAnalyze,
+          onClose,
+        })
+      : null;
+
+  const openInNewWindowItem = onOpenInNewWindow
+    ? buildPanelItem({
+        key: "open-in-new-window",
+        icon: ExternalLink,
+        label:
+          variant === "header" ? "Open in new window" : "Open in New Window",
+        run: onOpenInNewWindow,
+        onClose,
+      })
+    : null;
+
+  const inspectItem = onInspect
+    ? buildPanelItem({
+        key: "inspect",
+        icon: Microscope,
+        label: "Inspect",
+        run: onInspect,
+        onClose,
+      })
+    : null;
+
+  const moveToGroupBlock = showMoveToGroup ? (
+    <>
+      <MobileMenuDivider />
+      <div className="flex items-center gap-2 px-2 pt-1 pb-1 text-body-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
+        <FolderInput size={14} aria-hidden />
+        Move to
+      </div>
+      {moveToGroups.map((group) =>
+        buildPanelItem({
+          key: `move-to-${group.id}`,
+          label: group.name,
+          className: "pl-7",
+          run: () => onMoveToGroup(group.id),
+          onClose,
+        }),
+      )}
+      {onRemoveFromGroup
+        ? buildPanelItem({
+            key: "remove-from-group",
+            label: "Remove from group",
+            className: "pl-7",
+            run: onRemoveFromGroup,
+            onClose,
+          })
+        : null}
+    </>
+  ) : null;
+
+  if (variant === "header") {
+    return (
+      <>
+        {onCopyConversation
+          ? buildPanelItem({
+              key: "copy",
+              icon: Copy,
+              label: "Copy full conversation",
+              run: onCopyConversation,
+              onClose,
+            })
+          : null}
+
+        {onForkConversation
+          ? buildPanelItem({
+              key: "fork",
+              icon: GitBranch,
+              label: "Fork conversation",
+              run: onForkConversation,
+              onClose,
+            })
+          : null}
+
+        {analyzeItem}
+        {openInNewWindowItem}
+
+        {onRefresh
+          ? buildPanelItem({
+              key: "refresh",
+              icon: RefreshCw,
+              label: "Refresh",
+              run: onRefresh,
+              onClose,
+            })
+          : null}
+
+        {pinItem}
+        {renameItem}
+        {archiveItem}
+        {inspectItem}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {pinItem}
+      {renameItem}
+      {archiveItem}
+      {markReadUnreadItem}
+      {analyzeItem}
+      {moveToGroupBlock}
+      {openInNewWindowItem}
+
+      {onShareFeedback ? (
+        <>
+          <MobileMenuDivider />
+          {buildPanelItem({
+            key: "share-feedback",
+            icon: MessageCircle,
+            label: "Share Feedback",
+            run: onShareFeedback,
+            onClose,
+          })}
+        </>
+      ) : null}
+
+      {inspectItem ? (
+        <>
+          <MobileMenuDivider />
+          {inspectItem}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+export interface ConversationActionsMenuProps extends ConversationMenuItemsProps {
+  /**
+   * Override the default hover-revealed ellipsis button with a custom
+   * trigger (e.g. the topbar thread-name dropdown). The element is
+   * wrapped in Radix `Menu.Trigger asChild`, so it must be a
+   * native button/anchor or a component that forwards ref.
+   */
+  trigger?: ReactNode;
+  /** Menu positioning — defaults reproduce the row-aligned ellipsis menu. */
+  side?: MenuSide;
+  align?: MenuAlign;
+  sideOffset?: number;
+}
+
+export function ConversationActionsMenu({
+  trigger,
+  side = "right",
+  align = "start",
+  sideOffset = 4,
+  ...itemProps
+}: ConversationActionsMenuProps) {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
+
+  const defaultTrigger = (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label="Conversation actions"
+      aria-haspopup="menu"
+      onClick={(event) => event.stopPropagation()}
+      onContextMenu={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          event.stopPropagation();
+          (event.currentTarget as HTMLElement).click();
+        }
+      }}
+      className="flex h-6 w-6 items-center justify-center rounded-[4px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+    >
+      <MoreHorizontal size={14} aria-hidden />
+    </span>
+  );
+
+  const resolvedTrigger = trigger ?? defaultTrigger;
+
+  if (isMobile) {
+    return (
+      <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Trigger asChild>{resolvedTrigger}</BottomSheet.Trigger>
+        <BottomSheet.Content aria-describedby={undefined}>
+          <BottomSheet.Header className="sr-only">
+            <BottomSheet.Title>Conversation actions</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="pt-0">
+            {renderConversationMenuItemsAsPanelItems({
+              ...itemProps,
+              onClose: () => setOpen(false),
+            })}
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    );
+  }
+
+  return (
+    <Menu.Root open={open} onOpenChange={setOpen}>
+      <Menu.Trigger asChild>{resolvedTrigger}</Menu.Trigger>
+      <Menu.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {renderConversationMenuItems({ Primitive: Menu, ...itemProps })}
+      </Menu.Content>
+    </Menu.Root>
+  );
+}

--- a/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -361,8 +361,7 @@ function MobileMenuDivider() {
   return (
     <div
       aria-hidden="true"
-      className="my-1 h-px"
-      style={{ background: "var(--border-overlay)" }}
+      className="my-1 h-px bg-[var(--border-overlay)]"
     />
   );
 }
@@ -670,27 +669,18 @@ export function ConversationActionsMenu({
   const [open, setOpen] = useState(false);
 
   const defaultTrigger = (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Conversation actions"
-      aria-haspopup="menu"
       onClick={(event) => event.stopPropagation()}
       onContextMenu={(event) => {
         event.stopPropagation();
         event.preventDefault();
       }}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          event.stopPropagation();
-          (event.currentTarget as HTMLElement).click();
-        }
-      }}
       className="flex h-6 w-6 items-center justify-center rounded-[4px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
     >
       <MoreHorizontal size={14} aria-hidden />
-    </span>
+    </button>
   );
 
   const resolvedTrigger = trigger ?? defaultTrigger;


### PR DESCRIPTION
## Prompt / plan

Port `ConversationActionsMenu` from `vellum-assistant-platform/web/src/components/app/assistant/ConversationActionsMenu/` to the OSS repo. This is the highest-value unblocked migration ticket — it unblocks LUM-1662 (CollapsedConversationsButton) and LUM-1663 (AssistantSideMenu).

**What this component does:** Dual-surface dropdown/bottom-sheet menu for conversation rows. On desktop, renders a Radix `Menu.Root` dropdown triggered by a hover-revealed ellipsis button. On mobile (`useIsMobile()`), renders a `BottomSheet` with `PanelItem` rows. Both surfaces render the same item set: Pin/Unpin, Rename, Archive/Unarchive, Mark as read/unread, Move to Group (submenu), Analyze, Open in New Window, Share Feedback, Inspect, Copy/Fork/Refresh.

**Key exports:**
- `ConversationActionsMenu` — the main component (dropdown trigger + menu content)
- `renderConversationMenuItems()` — shared item builder accepting a `ConversationMenuPrimitive` type param so both the dropdown and the right-click context menu (future LUM-1663) render identical items
- `ConversationMenuPrimitive` type — union of `Menu` and `ContextMenu` compound APIs
- `ConversationMenuItemsProps` interface — all action handlers and state flags

**Convention compliance:**
- kebab-case filename (`conversation-actions-menu.tsx`)
- `.js` extensions on all imports
- `@/` aliases for app-layer imports
- Design library barrel imports (`@vellum/design-library`)
- All Capacitor/mobile code paths preserved (BottomSheet branch, useIsMobile)
- No `"use client"` directive

**Improvements over platform source:**
- Default trigger uses native `<button type="button">` instead of `<span role="button">` with manual keyboard handling — Radix handles Enter/Space and aria attributes natively ([MDN: button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button), [Radix Menu.Trigger](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#trigger))
- `MobileMenuDivider` uses Tailwind `className` instead of inline `style` for consistency with the repo's no-inline-style convention

**Dependencies (all pre-existing in OSS repo):**
- Design library: `Menu`, `ContextMenu`, `BottomSheet`, `PanelItem`
- App: `useIsMobile` hook, `MoveToGroupTarget` type from `groupConversations`
- Icons: 17 lucide-react icons

## Test plan

17 tests covering:
- `renderConversationMenuItems` pure helper: Pin/Unpin, Archive/Unarchive, read-only gating, Move to Group submenu, header variant ordering, mark read/unread mutual exclusivity
- Desktop branch: default trigger with native button + aria attributes, menu item rendering
- Mobile branch: BottomSheet surface, archive, disabled mark-unread panel item, Move-to submenu with remove-from-group, header variant ordering
- Read-only conversations: Archive visible, Mark-as-unread/Analyze hidden

Verification:
- `bun test src/domains/chat/components/conversation-actions-menu.test.tsx` — 17/17 pass
- `bun run lint` — clean
- `bun run build` — succeeds
- CI typecheck and build verify full compilation

Closes LUM-1661

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->