### PR TITLE
feat(web): port CollapsedConversationsButton from platform (LUM-1662)

### DIFF
--- a/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Tests for `CollapsedConversationsButton`.
+ *
+ * The component renders a small badge-button showing the total conversation
+ * count; clicking it opens a Popover with categorized sections (Pinned,
+ * Scheduled, Background, Slack, Recents, custom groups). Background
+ * conversations sub-group by source with collapsible rows.
+ *
+ * Uses `renderToStaticMarkup` since the workspace lacks jsdom.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Mock design library components
+const passthrough = ({ children, ...props }: Record<string, unknown>) =>
+  createElement("div", props, children as ReactNode);
+const mockTrigger = ({ children }: Record<string, unknown>) =>
+  createElement("div", { "data-testid": "trigger" }, children as ReactNode);
+const mockPanelItem = ({
+  label,
+  icon: Icon,
+  badge,
+  active,
+  trailingAction,
+  className,
+  ...rest
+}: Record<string, unknown>) =>
+  createElement(
+    "div",
+    {
+      "data-testid": "panel-item",
+      "data-active": active || undefined,
+      className: className as string | undefined,
+      ...rest,
+    },
+    Icon
+      ? createElement(Icon as React.FC<Record<string, unknown>>, { size: 14 })
+      : null,
+    label as string,
+    badge != null ? createElement("span", { "data-testid": "badge" }, String(badge)) : null,
+    trailingAction as ReactNode,
+  );
+
+mock.module("@vellum/design-library", () => ({
+  Popover: {
+    Root: passthrough,
+    Trigger: mockTrigger,
+    Content: passthrough,
+  },
+  PanelItem: mockPanelItem,
+}));
+
+import type { Conversation } from "@/domains/chat/lib/conversations.js";
+import { CollapsedConversationsButton } from "@/domains/chat/components/collapsed-conversations-button.js";
+
+function makeConversation(overrides: Partial<Conversation> & { conversationKey: string }): Conversation {
+  return {
+    title: "Untitled",
+    status: "active",
+    lastMessageAt: null,
+    channel: null,
+    groupId: undefined,
+    ...overrides,
+  } as Conversation;
+}
+
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("CollapsedConversationsButton", () => {
+  test("returns null when all buckets are empty", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toBe("");
+  });
+
+  test("renders total count badge", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[makeConversation({ conversationKey: "p1" })]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[
+          makeConversation({ conversationKey: "r1" }),
+          makeConversation({ conversationKey: "r2" }),
+        ]}
+        onSelectConversation={noop}
+      />,
+    );
+    // 1 pinned + 2 recents = 3
+    expect(html).toContain(">3<");
+  });
+
+  test("renders section headers for non-empty buckets", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[makeConversation({ conversationKey: "p1", title: "My Pinned" })]}
+        scheduled={[]}
+        background={[]}
+        slack={[makeConversation({ conversationKey: "s1", title: "Slack Thread" })]}
+        recents={[]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toContain("Pinned");
+    expect(html).toContain("Slack");
+    expect(html).not.toContain("Scheduled");
+    expect(html).not.toContain("Background");
+    expect(html).not.toContain("Recents");
+  });
+
+  test("renders conversation titles as panel items", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[
+          makeConversation({ conversationKey: "r1", title: "Chat about dogs" }),
+          makeConversation({ conversationKey: "r2", title: "Chat about cats" }),
+        ]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toContain("Chat about dogs");
+    expect(html).toContain("Chat about cats");
+  });
+
+  test("renders 'Untitled' for conversations without a title", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[makeConversation({ conversationKey: "r1", title: null as unknown as string })]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toContain("Untitled");
+  });
+
+  test("includes attention indicator in aria-label when attentionConversationKeys is non-empty", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[makeConversation({ conversationKey: "r1" })]}
+        onSelectConversation={noop}
+        attentionConversationKeys={new Set(["r1"])}
+      />,
+    );
+    expect(html).toContain("action needed");
+  });
+
+  test("renders custom groups", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[]}
+        customGroups={[
+          {
+            id: "g1",
+            name: "Work Projects",
+            conversations: [makeConversation({ conversationKey: "c1", title: "Project Alpha" })],
+          },
+        ]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toContain("Work Projects");
+    expect(html).toContain("Project Alpha");
+  });
+
+  test("includes custom group count in total", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[]}
+        slack={[]}
+        recents={[makeConversation({ conversationKey: "r1" })]}
+        customGroups={[
+          {
+            id: "g1",
+            name: "Work",
+            conversations: [
+              makeConversation({ conversationKey: "c1" }),
+              makeConversation({ conversationKey: "c2" }),
+            ],
+          },
+        ]}
+        onSelectConversation={noop}
+      />,
+    );
+    // 1 recent + 2 custom = 3
+    expect(html).toContain(">3<");
+  });
+
+  test("renders background conversations with sub-group labels", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[
+          makeConversation({ conversationKey: "b1", title: "BG 1", source: "heartbeat" }),
+          makeConversation({ conversationKey: "b2", title: "BG 2", source: "heartbeat" }),
+        ]}
+        slack={[]}
+        recents={[]}
+        onSelectConversation={noop}
+      />,
+    );
+    expect(html).toContain("Background");
+    expect(html).toContain("Heartbeat");
+  });
+});

--- a/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
@@ -217,6 +217,45 @@ describe("CollapsedConversationsButton", () => {
     expect(html).toContain(">3<");
   });
 
+  test("auto-expands background sub-groups containing attention conversations", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[
+          makeConversation({ conversationKey: "b1", title: "Needs Review", source: "heartbeat" }),
+          makeConversation({ conversationKey: "b2", title: "Other BG", source: "heartbeat" }),
+        ]}
+        slack={[]}
+        recents={[]}
+        onSelectConversation={noop}
+        attentionConversationKeys={new Set(["b1"])}
+      />,
+    );
+    // Sub-group should be auto-expanded because b1 needs attention
+    expect(html).toContain("Needs Review");
+    expect(html).toContain("Other BG");
+  });
+
+  test("renders single-source background conversations as flat leaf rows", () => {
+    const html = renderToStaticMarkup(
+      <CollapsedConversationsButton
+        pinned={[]}
+        scheduled={[]}
+        background={[
+          makeConversation({ conversationKey: "b1", title: "Solo BG" }),
+        ]}
+        slack={[]}
+        recents={[]}
+        onSelectConversation={noop}
+      />,
+    );
+    // Single conversations without a source get __single__: prefix and
+    // render as a flat leaf row, not a collapsible group header
+    expect(html).toContain("Solo BG");
+    expect(html).toContain("Background");
+  });
+
   test("renders background conversations with sub-group labels", () => {
     const html = renderToStaticMarkup(
       <CollapsedConversationsButton

--- a/apps/web/src/domains/chat/components/collapsed-conversations-button.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-conversations-button.tsx
@@ -268,7 +268,7 @@ function BackgroundSection({
   renderActions,
   attentionConversationKeys,
 }: BackgroundSectionProps) {
-  const subGroups = groupBackgroundConversationsBySource(conversations);
+  const subGroups = useMemo(() => groupBackgroundConversationsBySource(conversations), [conversations]);
   const [manualExpandedKeys, setManualExpandedKeys] = useState<Set<string>>(new Set());
 
   const attentionExpandedKeys = useMemo(() => {

--- a/apps/web/src/domains/chat/components/collapsed-conversations-button.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-conversations-button.tsx
@@ -1,0 +1,362 @@
+import { ChevronDown, ChevronRight, CircleAlert, Pin } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { PanelItem, Popover } from "@vellum/design-library";
+import {
+  formatBackgroundSubGroupLabel,
+  groupBackgroundConversationsBySource,
+} from "@/domains/chat/lib/backgroundSubGroups.js";
+import {
+  isConversationPinned,
+  type CustomGroup,
+} from "@/domains/chat/lib/groupConversations.js";
+import type { Conversation } from "@/domains/chat/lib/conversations.js";
+
+/**
+ * Collapsed-rail conversations affordance. Renders a small square button
+ * showing the total live-conversation count; clicking it opens a popover
+ * to the right with every non-empty category (Pinned / Scheduled /
+ * Background / Slack / Recents) as a section of `PanelItem` rows.
+ *
+ * Background additionally sub-groups by `source` (via
+ * `groupBackgroundConversationsBySource`) so Heartbeat / Reflections /
+ * any custom background source each get their own collapsible row. Empty
+ * categories are skipped entirely.
+ */
+
+export interface CollapsedConversationsButtonProps {
+  pinned: Conversation[];
+  scheduled: Conversation[];
+  background: Conversation[];
+  slack: Conversation[];
+  recents: Conversation[];
+  /** Custom conversation groups (visible when the conversationGroupsUI flag is on). */
+  customGroups?: CustomGroup[];
+  activeConversationKey?: string;
+  onSelectConversation: (conversationKey: string) => void;
+  /**
+   * Optional: build the hover-revealed action menu for a given
+   * conversation row. When omitted, rows render without a trailing
+   * action. Sharing the same render function keeps behavior identical
+   * between the expanded rail and this collapsed popover.
+   */
+  renderActions?: (conversation: Conversation) => ReactNode;
+  /** Set of conversation keys that need user attention (pending approval/secret). */
+  attentionConversationKeys?: Set<string>;
+}
+
+export function CollapsedConversationsButton({
+  pinned,
+  scheduled,
+  background,
+  slack,
+  recents,
+  customGroups,
+  activeConversationKey,
+  onSelectConversation,
+  renderActions,
+  attentionConversationKeys,
+}: CollapsedConversationsButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const customGroupCount = customGroups
+    ? customGroups.reduce((sum, g) => sum + g.conversations.length, 0)
+    : 0;
+
+  const totalCount =
+    pinned.length +
+    scheduled.length +
+    background.length +
+    slack.length +
+    recents.length +
+    customGroupCount;
+
+  // Nothing to show when every bucket is empty — hide the trigger
+  // entirely rather than render a "0" badge the user can't act on.
+  if (totalCount === 0) {
+    return null;
+  }
+
+  const hasAttention = attentionConversationKeys && attentionConversationKeys.size > 0;
+
+  const closeMenu = () => setOpen(false);
+  const handleSelect = (conversationKey: string) => {
+    closeMenu();
+    onSelectConversation(conversationKey);
+  };
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`${totalCount} conversations${hasAttention ? " — action needed" : ""}`}
+          aria-haspopup="dialog"
+          className="relative flex h-8 w-8 items-center justify-center rounded-[6px] bg-[var(--surface-base)] text-label-small-default text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+        >
+          {totalCount}
+          {hasAttention ? (
+            <span
+              aria-hidden
+              className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-base)] bg-[var(--system-mid-strong)]"
+            />
+          ) : null}
+        </button>
+      </Popover.Trigger>
+      <Popover.Content
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="max-h-[500px] w-72 overflow-y-auto rounded-lg py-2 px-0"
+      >
+        {pinned.length > 0 ? (
+          <SimpleSection
+            title="Pinned"
+            conversations={pinned}
+            activeConversationKey={activeConversationKey}
+            onSelect={handleSelect}
+            renderActions={renderActions}
+            attentionConversationKeys={attentionConversationKeys}
+          />
+        ) : null}
+
+        {scheduled.length > 0 ? (
+          <SimpleSection
+            title="Scheduled"
+            conversations={scheduled}
+            activeConversationKey={activeConversationKey}
+            onSelect={handleSelect}
+            renderActions={renderActions}
+            attentionConversationKeys={attentionConversationKeys}
+          />
+        ) : null}
+
+        {background.length > 0 ? (
+          <BackgroundSection
+            conversations={background}
+            activeConversationKey={activeConversationKey}
+            onSelect={handleSelect}
+            renderActions={renderActions}
+            attentionConversationKeys={attentionConversationKeys}
+          />
+        ) : null}
+
+        {slack.length > 0 ? (
+          <SimpleSection
+            title="Slack"
+            conversations={slack}
+            activeConversationKey={activeConversationKey}
+            onSelect={handleSelect}
+            renderActions={renderActions}
+            attentionConversationKeys={attentionConversationKeys}
+          />
+        ) : null}
+
+        {recents.length > 0 ? (
+          <SimpleSection
+            title="Recents"
+            conversations={recents}
+            activeConversationKey={activeConversationKey}
+            onSelect={handleSelect}
+            renderActions={renderActions}
+            attentionConversationKeys={attentionConversationKeys}
+          />
+        ) : null}
+
+        {customGroups?.map((group) =>
+          group.conversations.length > 0 ? (
+            <SimpleSection
+              key={group.id}
+              title={group.name}
+              conversations={group.conversations}
+              activeConversationKey={activeConversationKey}
+              onSelect={handleSelect}
+              renderActions={renderActions}
+              attentionConversationKeys={attentionConversationKeys}
+            />
+          ) : null,
+        )}
+      </Popover.Content>
+    </Popover.Root>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+interface SectionHeaderProps {
+  title: string;
+  count: number;
+}
+
+function SectionHeader({ title, count }: SectionHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-1">
+      <span className="text-body-small-default text-[var(--content-tertiary)]">
+        {title}
+      </span>
+      <span className="text-body-small-default text-[var(--content-tertiary)]">
+        {count}
+      </span>
+    </div>
+  );
+}
+
+interface SimpleSectionProps {
+  title: string;
+  conversations: Conversation[];
+  activeConversationKey?: string;
+  onSelect: (conversationKey: string) => void;
+  renderActions?: (conversation: Conversation) => ReactNode;
+  attentionConversationKeys?: Set<string>;
+}
+
+/**
+ * Flat section — header + `PanelItem` per conversation. Used for every
+ * bucket except Background (which has sub-group sub-rows).
+ */
+function SimpleSection({
+  title,
+  conversations,
+  activeConversationKey,
+  onSelect,
+  renderActions,
+  attentionConversationKeys,
+}: SimpleSectionProps) {
+  return (
+    <div className="pb-1">
+      <SectionHeader title={title} count={conversations.length} />
+      <div className="px-2">
+        {conversations.map((c) => {
+          const needsAttention = attentionConversationKeys?.has(c.conversationKey) ?? false;
+          return (
+            <PanelItem
+              key={c.conversationKey}
+              icon={needsAttention ? CircleAlert : isConversationPinned(c) ? Pin : undefined}
+              label={c.title ?? "Untitled"}
+              active={c.conversationKey === activeConversationKey}
+              onSelect={() => onSelect(c.conversationKey)}
+              trailingAction={renderActions?.(c)}
+              className={needsAttention ? "text-[var(--system-mid-strong)]" : undefined}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface BackgroundSectionProps {
+  conversations: Conversation[];
+  activeConversationKey?: string;
+  onSelect: (conversationKey: string) => void;
+  renderActions?: (conversation: Conversation) => ReactNode;
+  attentionConversationKeys?: Set<string>;
+}
+
+/**
+ * Background section with source sub-grouping. Each group with >1
+ * conversation gets a collapsible header row (`PanelItem` with an
+ * expand chevron as its icon). Sources with a single conversation flatten
+ * into a single leaf row.
+ */
+function BackgroundSection({
+  conversations,
+  activeConversationKey,
+  onSelect,
+  renderActions,
+  attentionConversationKeys,
+}: BackgroundSectionProps) {
+  const subGroups = groupBackgroundConversationsBySource(conversations);
+  const [manualExpandedKeys, setManualExpandedKeys] = useState<Set<string>>(new Set());
+
+  const attentionExpandedKeys = useMemo(() => {
+    if (!attentionConversationKeys || attentionConversationKeys.size === 0) return new Set<string>();
+    const keys = new Set<string>();
+    for (const group of subGroups) {
+      if (group.key.startsWith("__single__:")) continue;
+      if (group.conversations.some(c => attentionConversationKeys.has(c.conversationKey))) {
+        keys.add(group.key);
+      }
+    }
+    return keys;
+  }, [attentionConversationKeys, subGroups]);
+
+  const expandedKeys = useMemo(() => {
+    if (attentionExpandedKeys.size === 0) return manualExpandedKeys;
+    const merged = new Set(manualExpandedKeys);
+    for (const k of attentionExpandedKeys) merged.add(k);
+    return merged;
+  }, [manualExpandedKeys, attentionExpandedKeys]);
+
+  const toggleGroup = (key: string) => {
+    setManualExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="pb-1">
+      <SectionHeader title="Background" count={conversations.length} />
+      <div className="px-2">
+        {subGroups.map((group) => {
+          // `__single__:` prefix comes from backgroundSubGroups for
+          // conversations that have no `source` value — render them as a
+          // flat leaf row with no grouping header.
+          const isSingle = group.key.startsWith("__single__:");
+          if (isSingle) {
+            const c = group.conversations[0];
+            if (!c) return null;
+            const singleNeedsAttention = attentionConversationKeys?.has(c.conversationKey) ?? false;
+            return (
+              <PanelItem
+                key={c.conversationKey}
+                icon={singleNeedsAttention ? CircleAlert : isConversationPinned(c) ? Pin : undefined}
+                label={c.title ?? "Untitled"}
+                active={c.conversationKey === activeConversationKey}
+                onSelect={() => onSelect(c.conversationKey)}
+                trailingAction={renderActions?.(c)}
+                className={singleNeedsAttention ? "text-[var(--system-mid-strong)]" : undefined}
+              />
+            );
+          }
+
+          const isExpanded = expandedKeys.has(group.key);
+          return (
+            <div key={group.key}>
+              <PanelItem
+                icon={isExpanded ? ChevronDown : ChevronRight}
+                label={formatBackgroundSubGroupLabel(group.key)}
+                badge={group.conversations.length}
+                onSelect={() => toggleGroup(group.key)}
+              />
+              {isExpanded
+                ? group.conversations.map((c) => {
+                    const rowNeedsAttention = attentionConversationKeys?.has(c.conversationKey) ?? false;
+                    return (
+                      <PanelItem
+                        key={c.conversationKey}
+                        icon={rowNeedsAttention ? CircleAlert : isConversationPinned(c) ? Pin : undefined}
+                        label={c.title ?? "Untitled"}
+                        active={c.conversationKey === activeConversationKey}
+                        onSelect={() => onSelect(c.conversationKey)}
+                        trailingAction={renderActions?.(c)}
+                        className={rowNeedsAttention ? "text-[var(--system-mid-strong)]" : undefined}
+                      />
+                    );
+                  })
+                : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Prompt / plan

Port `CollapsedConversationsButton` from `vellum-assistant-platform/web/src/components/app/assistant/CollapsedConversationsButton/` to the OSS repo. This component is consumed by `AssistantSideMenu` (LUM-1663) when the sidebar rail is collapsed — it shows a badge with the total conversation count and opens a categorized popover on click.

**What this component does:** Renders a small square button showing the total live-conversation count across all categories. Clicking it opens a `Popover` to the right with every non-empty category (Pinned, Scheduled, Background, Slack, Recents, custom groups) as a section of `PanelItem` rows. Background conversations additionally sub-group by `source` (Heartbeat, Reflections, etc.) with collapsible disclosure rows.

**Key features:**
- Empty-state: returns `null` when all buckets are empty (no "0" badge)
- Attention indicator: dot badge + "action needed" aria-label when `attentionConversationKeys` is non-empty
- Background sub-grouping: `__single__:` prefix conversations render as flat leaf rows; multi-conversation groups get collapsible header rows with chevron icons
- Auto-expand: groups containing conversations needing attention expand automatically
- Custom groups: rendered as additional sections after the system categories

**Convention compliance:**
- kebab-case filename (`collapsed-conversations-button.tsx`)
- `.js` extensions on all imports
- `@/` aliases for app-layer imports
- Design library barrel imports (`@vellum/design-library`)
- No `"use client"` directive

**Dependencies (all pre-existing in OSS repo):**
- Design library: `Popover`, `PanelItem`
- App: `backgroundSubGroups` (`formatBackgroundSubGroupLabel`, `groupBackgroundConversationsBySource`), `groupConversations` (`isConversationPinned`, `CustomGroup`), `Conversation` type
- Icons: `ChevronDown`, `ChevronRight`, `CircleAlert`, `Pin` from lucide-react

## Test plan

9 tests covering:
- Empty-state null return (all buckets empty)
- Total count badge (pinned + recents counted correctly)
- Section header rendering (only non-empty buckets shown)
- Conversation titles as panel items
- Untitled fallback for null titles
- Attention indicator in aria-label
- Custom group rendering
- Custom group count included in total
- Background sub-group labels (source-based grouping)

Verification:
- `bun test src/domains/chat/components/collapsed-conversations-button.test.tsx` — 9/9 pass
- `bun run lint` — clean
- CI typecheck and build verify full compilation

Closes LUM-1662

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->