### PR TITLE
fix(web): move settings routes outside ChatLayout to hide main sidebar

### DIFF
--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -79,21 +79,21 @@ function HomePageRoute() {
  *   │
  *   /assistant/* — auth-protected app with RootLayout
  *   │  middleware: [authMiddleware] — redirects to login when auth required
- *   │  ├── Onboarding (no ChatLayout chrome)
+ *   │  ├── Onboarding (full-screen, no app chrome)
  *   │  │   ├── PrivacyScreen (/assistant/onboarding/privacy)
  *   │  │   ├── PreChatFlow (/assistant/onboarding/prechat)
  *   │  │   └── HatchingScreen (/assistant/onboarding/hatching)
+ *   │  ├── SettingsLayout (full-screen overlay panel, no ChatLayout sidebar)
+ *   │  │   ├── GeneralPage (/assistant/settings/general)
+ *   │  │   ├── AiPage (/assistant/settings/ai)
+ *   │  │   ├── IntegrationsPage, SchedulesPage, VoicePage, ...
+ *   │  │   ├── BillingPage (/assistant/settings/billing)
+ *   │  │   │   ├── onboarding, upgrade/cancel, upgrade/success
+ *   │  │   └── AdvancedPage, DeveloperPage, DebugPage
  *   │  └── ChatLayout — sidebar rail, drawer, shortcuts
  *   │       ├── ChatPage (index, /assistant)
  *   │       ├── HomePageRoute (/assistant/home)
- *   │       ├── LibraryPage / LibraryDetailPage
- *   │       └── SettingsLayout (/assistant/settings)
- *   │            ├── GeneralPage (/assistant/settings/general)
- *   │            ├── AiPage (/assistant/settings/ai)
- *   │            ├── IntegrationsPage, SchedulesPage, ...
- *   │            ├── BillingPage (/assistant/settings/billing)
- *   │            │   ├── onboarding, upgrade/cancel, upgrade/success
- *   │            └── AdvancedPage, DeveloperPage, DebugPage
+ *   │       └── LibraryPage / LibraryDetailPage
  *
  * References:
  * - React Router data mode routing: https://reactrouter.com/start/data/routing
@@ -131,38 +131,42 @@ export const router = createBrowserRouter([
       { path: "onboarding/prechat", element: <PreChatFlow /> },
       { path: "onboarding/hatching", element: <HatchingScreen /> },
 
+      // Settings routes — full-screen overlay panel (no ChatLayout sidebar).
+      // SettingsShell provides its own layout with back-arrow, sidebar nav,
+      // and content area — the main app sidebar is intentionally hidden.
+      {
+        path: "settings",
+        element: <SettingsLayout />,
+        children: [
+          { index: true, element: <GeneralPage /> },
+          { path: "general", element: <GeneralPage /> },
+          { path: "ai", element: <AiPage /> },
+          { path: "integrations", element: <IntegrationsPage /> },
+          { path: "schedules", element: <SchedulesPage /> },
+          { path: "notifications", element: <NotificationsPage /> },
+          { path: "sounds", element: <SoundsPage /> },
+          { path: "voice", element: <VoicePage /> },
+          { path: "devices", element: <DevicesPage /> },
+          { path: "privacy", element: <PrivacyPage /> },
+          { path: "archive", element: <ArchivePage /> },
+          { path: "billing", element: <BillingPage /> },
+          { path: "billing/onboarding", element: <BillingOnboardingPage /> },
+          { path: "billing/upgrade/cancel", element: <UpgradeCancelPage /> },
+          { path: "billing/upgrade/success", element: <UpgradeSuccessPage /> },
+          { path: "community", element: <CommunityPage /> },
+          { path: "debug", element: <DebugPage /> },
+          { path: "developer", element: <DeveloperPage /> },
+          { path: "advanced", element: <AdvancedPage /> },
+          { path: "danger-zone", element: <DangerZoneRedirectPage /> },
+          { path: "system-events", element: <SystemEventsRedirectPage /> },
+        ],
+      },
+
       {
         element: <ChatLayout />,
         children: [
           { index: true, element: <ChatPage /> },
           { path: "home", element: <HomePageRoute /> },
-          {
-            path: "settings",
-            element: <SettingsLayout />,
-            children: [
-              { index: true, element: <GeneralPage /> },
-              { path: "general", element: <GeneralPage /> },
-              { path: "ai", element: <AiPage /> },
-              { path: "integrations", element: <IntegrationsPage /> },
-              { path: "schedules", element: <SchedulesPage /> },
-              { path: "notifications", element: <NotificationsPage /> },
-              { path: "sounds", element: <SoundsPage /> },
-              { path: "voice", element: <VoicePage /> },
-              { path: "devices", element: <DevicesPage /> },
-              { path: "privacy", element: <PrivacyPage /> },
-              { path: "archive", element: <ArchivePage /> },
-              { path: "billing", element: <BillingPage /> },
-              { path: "billing/onboarding", element: <BillingOnboardingPage /> },
-              { path: "billing/upgrade/cancel", element: <UpgradeCancelPage /> },
-              { path: "billing/upgrade/success", element: <UpgradeSuccessPage /> },
-              { path: "community", element: <CommunityPage /> },
-              { path: "debug", element: <DebugPage /> },
-              { path: "developer", element: <DeveloperPage /> },
-              { path: "advanced", element: <AdvancedPage /> },
-              { path: "danger-zone", element: <DangerZoneRedirectPage /> },
-              { path: "system-events", element: <SystemEventsRedirectPage /> },
-            ],
-          },
           { path: "library", element: <LibraryPage /> },
           { path: "library/:appId", element: <LibraryDetailPage /> },
         ],


### PR DESCRIPTION
## Prompt / plan

The main navigation sidebar (Home, Chat, Library, Settings) was rendering alongside the settings sidebar, resulting in a double-sidebar layout. In the platform, `SettingsShell` uses `<Layout hideHeader>` to suppress global navigation chrome when settings is active. The equivalent fix in React Router v7 is simpler: move the settings route group outside of `ChatLayout` entirely so it never renders the chat sidebar.

**Why this is correct:**
- `SettingsShell` is a full-viewport overlay panel with its own back button, sidebar nav, and content area
- It's designed to replace the entire app chrome, not nest inside it
- This matches the platform behavior where settings takes over the full screen
- Onboarding routes already follow this pattern (siblings of ChatLayout, not children)

**Why this is safe:**
- Route URLs are unchanged (`/assistant/settings/*`)
- SettingsLayout already provides complete navigation (sidebar + back arrow to `/assistant`)
- No functional changes to any component — only the route tree nesting is adjusted
- Additive-only pattern already proven by onboarding routes

## Test plan

- Verified lint passes clean
- Visual confirmation: settings page now renders without the main sidebar (only the settings sidebar)
- Route URLs are unchanged — no broken links

References:
- React Router nested routes: https://reactrouter.com/start/data/routing
- Platform equivalent: `SettingsShell` uses `<Layout hideHeader>` in `web/src/components/app/settings/SettingsShell.tsx`


Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->