### PR TITLE
fix(notifications): treat whitespace-only seed body as empty when deciding title drop

### DIFF
--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -234,6 +234,20 @@ describe("composeConversationSeed", () => {
       expect(seed).toBe("Reminder");
     });
 
+    test("falls back to title when body is whitespace-only", () => {
+      const signal = makeSignal();
+      const copy = makeCopy({ title: "Reminder", body: "   " });
+      const seed = composeConversationSeed(
+        signal,
+        "vellum" as NotificationChannel,
+        copy,
+      );
+      // Whitespace-only bodies must be treated as empty — otherwise the
+      // title would be suppressed (header dedupe) and the seed would
+      // render as a blank bubble.
+      expect(seed).toBe("Reminder");
+    });
+
     test('appends "Action required." when requiresAction is true', () => {
       const signal = makeSignal({
         attentionHints: {

--- a/assistant/src/notifications/conversation-seed-composer.ts
+++ b/assistant/src/notifications/conversation-seed-composer.ts
@@ -158,16 +158,18 @@ export function composeConversationSeed(
     const parts: string[] = [];
     const usableTitle =
       copy.title && copy.title !== "Notification" ? copy.title : "";
+    const hasBody = Boolean(copy.body && copy.body.trim());
     // copy.title is used as the conversation header in chat surfaces
     // whenever copy.conversationTitle is absent (see
     // conversation-pairing.ts), so prepending it here would render it
     // twice — once in the header bar and once at the start of the
     // bubble. Skip it in that case, unless there's no body and we'd
-    // otherwise produce an empty seed.
-    if (usableTitle && (copy.conversationTitle || !copy.body)) {
+    // otherwise produce an empty seed. Treat whitespace-only bodies as
+    // empty so the title still populates the bubble.
+    if (usableTitle && (copy.conversationTitle || !hasBody)) {
       parts.push(usableTitle);
     }
-    if (copy.body) parts.push(copy.body);
+    if (hasBody) parts.push(copy.body);
     const alreadyMentionsAction = parts.some((part) =>
       /\baction required\b/i.test(part),
     );


### PR DESCRIPTION
Addresses Codex P2 feedback on #31228.

The rich-mode title-drop heuristic added in #31228 checked `!copy.body` with raw truthiness. If the model returned a whitespace-only body (e.g. `\"   \"`), the title was suppressed (as if a body existed) and the whitespace string was then pushed as the seed — producing an effectively blank message bubble.

Switch the check to a trimmed-content guard so whitespace-only bodies are treated as empty: the title still wins and the bubble is non-empty. Also gate the body push on the same trimmed check so we don't emit whitespace-only bubbles.

Regression test added: \`falls back to title when body is whitespace-only\`.

Related to #31228.