### PR TITLE
fix(macos): preserve read-row text contrast in home feed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -54,7 +54,11 @@ struct HomeRecapRow: View {
         return isHovering ? VColor.surfaceLift : VColor.surfaceOverlay
     }
 
-    private var contentOpacity: Double {
+    /// Dim only the decorative icon for read rows — blanket-fading the
+    /// row would drop title/timestamp contrast below WCAG minimums on
+    /// `surfaceOverlay`. Unread vs. read is already signalled by the
+    /// title font weight (see `titleFont`).
+    private var iconOpacity: Double {
         if isUrgent { return 1.0 }
         return status == .new ? 1.0 : 0.55
     }
@@ -64,6 +68,7 @@ struct HomeRecapRow: View {
             HStack(spacing: VSpacing.sm) {
                 leadingIcon
                     .frame(width: 26, height: 26)
+                    .opacity(iconOpacity)
 
                 Text(title)
                     // Mock uses #A9B2BB which is `contentSecondary` in the
@@ -104,7 +109,6 @@ struct HomeRecapRow: View {
                 }
             }
             .contentShape(Rectangle())
-            .opacity(contentOpacity)
         }
         .buttonStyle(.plain)
         .pointerCursor()


### PR DESCRIPTION
Addresses Codex feedback on #31080: applying 55% opacity to the whole row dropped `contentSecondary` text on `surfaceOverlay` to ~2.3:1 (light) / ~3.3:1 (dark), well below WCAG body-text minimums.

Scope the dim to the decorative leading icon only. The title font-weight swap (`bodyMediumEmphasised` vs `bodyMediumDefault`, already on `HomeRecapRow`) keeps the unread-vs-read signal; text/timestamp now render at full opacity with their existing tokens, which clear contrast minimums.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->