### PR TITLE
fix(context): provider-specific image token estimate for Gemini

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -256,7 +256,12 @@ describe("token estimator", () => {
     // tokens = ceil(1461 * 822 / 750) = ceil(1601.26) = ~1,602
     // With IMAGE_BLOCK_OVERHEAD_TOKENS and media_type overhead, still well under 5000.
     // Same result for every provider — dimension-based estimate is universal.
-    for (const providerName of ["anthropic", "openai", "openrouter"]) {
+    for (const providerName of [
+      "anthropic",
+      "openai",
+      "openrouter",
+      "gemini",
+    ]) {
       const tokens = estimateContentBlockTokens(
         {
           type: "image",
@@ -274,7 +279,12 @@ describe("token estimator", () => {
       "not-a-valid-image-header-at-all",
     ).toString("base64");
 
-    for (const providerName of ["anthropic", "openai", "openrouter"]) {
+    for (const providerName of [
+      "anthropic",
+      "openai",
+      "openrouter",
+      "gemini",
+    ]) {
       const tokens = estimateContentBlockTokens(
         {
           type: "image",
@@ -292,6 +302,43 @@ describe("token estimator", () => {
       expect(tokens).toBeGreaterThanOrEqual(1_600);
       expect(tokens).toBeLessThan(2_000);
     }
+  });
+
+  test("Gemini image tokens scale with image area via 768x768 tiling", () => {
+    // Per Google's docs, Gemini tiles images larger than 384px into 768x768
+    // chunks at 258 tokens each. The Anthropic-style ~1,600 cap under-counts
+    // large images badly enough to skip compaction and overflow context.
+    // 4000x4000 → ceil(4000/768)^2 = 6*6 = 36 tiles → 9,288 image tokens.
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(4000, 4000),
+        },
+      },
+      { providerName: "gemini" },
+    );
+    expect(tokens).toBeGreaterThan(9_000);
+    expect(tokens).toBeLessThan(9_500);
+  });
+
+  test("Gemini images ≤384px on both sides count as a single 258-token tile", () => {
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(200, 200),
+        },
+      },
+      { providerName: "gemini" },
+    );
+    // 258 (tile) + 16 (block overhead) + 3 (media type) = 277
+    expect(tokens).toBeGreaterThanOrEqual(258);
+    expect(tokens).toBeLessThan(300);
   });
 
   test("Anthropic image tokens are the same for same-dimension images regardless of payload size", () => {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -52,6 +52,16 @@ const IMAGE_MAX_PIXELS = 1_200_000;
 const IMAGE_TOKENS_PER_PIXEL = 1 / 750;
 const IMAGE_MAX_TOKENS = 1_600;
 
+// Gemini prices images differently: any side ≤384px counts as a single 258-token
+// tile; anything larger is split into 768x768 tiles at 258 tokens each. A
+// 4000x4000 image is ceil(4000/768)^2 = 36 tiles ≈ 9,288 tokens — well above
+// the dimension-based cap — so under-counting these as ~1,600 tokens lets
+// shouldCompact() skip compaction and hit upstream context overflow.
+// See: https://ai.google.dev/gemini-api/docs/tokens#multimodal-tokens
+const GEMINI_IMAGE_SMALL_THRESHOLD = 384;
+const GEMINI_IMAGE_TILE_SIZE = 768;
+const GEMINI_IMAGE_TOKENS_PER_TILE = 258;
+
 // Anthropic renders each PDF page as an image (~1,568 tokens at standard
 // resolution) plus any extracted text. Typical PDF pages are 50-150 KB.
 // Using ~100 KB/page and ~1,600 tokens/page gives ~0.016 tokens/byte.
@@ -129,11 +139,27 @@ function estimateImageTokensByDimensions(
   return Math.ceil(scaledWidth * scaledHeight * IMAGE_TOKENS_PER_PIXEL);
 }
 
+function estimateGeminiImageTokens(width: number, height: number): number {
+  if (
+    width <= GEMINI_IMAGE_SMALL_THRESHOLD &&
+    height <= GEMINI_IMAGE_SMALL_THRESHOLD
+  ) {
+    return GEMINI_IMAGE_TOKENS_PER_TILE;
+  }
+  const tilesWide = Math.ceil(width / GEMINI_IMAGE_TILE_SIZE);
+  const tilesHigh = Math.ceil(height / GEMINI_IMAGE_TILE_SIZE);
+  return tilesWide * tilesHigh * GEMINI_IMAGE_TOKENS_PER_TILE;
+}
+
 function estimateImageTokens(
   block: Extract<ContentBlock, { type: "image" }>,
+  options?: TokenEstimatorOptions,
 ): number {
   const dims = parseImageDimensions(block.source.data, block.source.media_type);
   if (dims) {
+    if (options?.providerName === "gemini") {
+      return estimateGeminiImageTokens(dims.width, dims.height);
+    }
     return estimateImageTokensByDimensions(dims.width, dims.height);
   }
   // Dimensions unparseable (corrupt header, exotic format): use the per-image
@@ -186,7 +212,7 @@ export function estimateContentBlockTokens(
       return (
         IMAGE_BLOCK_OVERHEAD_TOKENS +
         estimateTextTokens(block.source.media_type) +
-        estimateImageTokens(block)
+        estimateImageTokens(block, options)
       );
     case "file":
       return (


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #31056: the universal dimension-based image-token estimator caps every image at ~1,600 tokens, but Gemini tiles images larger than 384px into 768x768 chunks at 258 tokens each ([docs](https://ai.google.dev/gemini-api/docs/tokens#multimodal-tokens)). A 4000x4000 image is 36 tiles ≈ 9,288 tokens — well above the Anthropic cap — so under-counting lets \`shouldCompact()\` skip compaction and hit upstream context overflow.

## Changes
- \`assistant/src/context/token-estimator.ts\`: route image blocks through \`estimateGeminiImageTokens()\` when \`providerName === "gemini"\`. Anthropic-style estimate stays the default for every other provider.
- \`assistant/src/__tests__/context-token-estimator.test.ts\`: add Gemini cases — large image tiling (4000x4000 → ~9,288 tokens) and small-image fast path (200x200 → 258 tokens). Existing fallback and 1920x1080 tests extended to cover Gemini.

## Test plan
- [x] \`bun test src/__tests__/context-token-estimator.test.ts\` (25 pass)
- [x] \`bun test src/__tests__/openrouter-token-estimation.test.ts\` (4 pass)
- [x] \`bunx tsc --noEmit\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->