### PR TITLE
fix(workspace): migrate stale background-conversation overrides

### DIFF
--- a/assistant/src/__tests__/workspace-migration-088-deprecate-background-conversation-override.test.ts
+++ b/assistant/src/__tests__/workspace-migration-088-deprecate-background-conversation-override.test.ts
@@ -1,0 +1,158 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { deprecateBackgroundConversationOverrideMigration } from "../workspace/migrations/088-deprecate-background-conversation-override.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-088-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function promptSystemDir(): string {
+  return join(workspaceDir, "prompts", "system");
+}
+
+function writeOverride(body: string): string {
+  const dir = promptSystemDir();
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, "08-background-conversation.md");
+  writeFileSync(filePath, body, "utf-8");
+  return filePath;
+}
+
+describe("088-deprecate-background-conversation-override migration", () => {
+  test("has expected id and description", () => {
+    expect(deprecateBackgroundConversationOverrideMigration.id).toBe(
+      "088-deprecate-background-conversation-override",
+    );
+    expect(
+      deprecateBackgroundConversationOverrideMigration.description,
+    ).toContain("08-background-conversation");
+  });
+
+  test("renames the override to .deprecated, preserving body", () => {
+    const body = "## Custom\n\nUser-customized background note.\n";
+    writeOverride(body);
+
+    deprecateBackgroundConversationOverrideMigration.run(workspaceDir);
+
+    const originalPath = join(
+      promptSystemDir(),
+      "08-background-conversation.md",
+    );
+    const deprecatedPath = join(
+      promptSystemDir(),
+      "08-background-conversation.md.deprecated",
+    );
+
+    expect(existsSync(originalPath)).toBe(false);
+    expect(existsSync(deprecatedPath)).toBe(true);
+    expect(readFileSync(deprecatedPath, "utf-8")).toBe(body);
+  });
+
+  test("no-ops when the override is absent", () => {
+    expect(() =>
+      deprecateBackgroundConversationOverrideMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    const deprecatedPath = join(
+      promptSystemDir(),
+      "08-background-conversation.md.deprecated",
+    );
+    expect(existsSync(deprecatedPath)).toBe(false);
+  });
+
+  test("does not touch unrelated section overrides", () => {
+    const dir = promptSystemDir();
+    mkdirSync(dir, { recursive: true });
+    const otherPath = join(dir, "07-external-content.md");
+    writeFileSync(otherPath, "## External Content\n\nUntouched.\n", "utf-8");
+    writeOverride("body");
+
+    deprecateBackgroundConversationOverrideMigration.run(workspaceDir);
+
+    expect(readFileSync(otherPath, "utf-8")).toContain("Untouched");
+  });
+
+  test("is safe to re-run after the rename has happened", () => {
+    writeOverride("body");
+
+    deprecateBackgroundConversationOverrideMigration.run(workspaceDir);
+    expect(() =>
+      deprecateBackgroundConversationOverrideMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    const deprecatedPath = join(
+      promptSystemDir(),
+      "08-background-conversation.md.deprecated",
+    );
+    expect(readFileSync(deprecatedPath, "utf-8")).toBe("body");
+  });
+
+  test("drops the .md and keeps the .deprecated copy when both exist", () => {
+    // A user re-created the override after a prior partial run. The bundled
+    // section is gone, so the .md would render unconditionally — drop it.
+    const dir = promptSystemDir();
+    mkdirSync(dir, { recursive: true });
+    const deprecatedPath = join(
+      dir,
+      "08-background-conversation.md.deprecated",
+    );
+    writeFileSync(deprecatedPath, "preserved.\n", "utf-8");
+    const recreatedPath = writeOverride("re-created body\n");
+
+    deprecateBackgroundConversationOverrideMigration.run(workspaceDir);
+
+    expect(existsSync(recreatedPath)).toBe(false);
+    expect(readFileSync(deprecatedPath, "utf-8")).toBe("preserved.\n");
+  });
+
+  test("down() restores the override when only .deprecated exists", () => {
+    writeOverride("body");
+    deprecateBackgroundConversationOverrideMigration.run(workspaceDir);
+
+    deprecateBackgroundConversationOverrideMigration.down(workspaceDir);
+
+    const overridePath = join(
+      promptSystemDir(),
+      "08-background-conversation.md",
+    );
+    const deprecatedPath = join(
+      promptSystemDir(),
+      "08-background-conversation.md.deprecated",
+    );
+    expect(existsSync(overridePath)).toBe(true);
+    expect(existsSync(deprecatedPath)).toBe(false);
+    expect(readFileSync(overridePath, "utf-8")).toBe("body");
+  });
+
+  test("down() is a no-op when only the .md exists", () => {
+    writeOverride("body");
+
+    expect(() =>
+      deprecateBackgroundConversationOverrideMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    const overridePath = join(
+      promptSystemDir(),
+      "08-background-conversation.md",
+    );
+    expect(readFileSync(overridePath, "utf-8")).toBe("body");
+  });
+});

--- a/assistant/src/workspace/migrations/088-deprecate-background-conversation-override.ts
+++ b/assistant/src/workspace/migrations/088-deprecate-background-conversation-override.ts
@@ -1,0 +1,102 @@
+/**
+ * Workspace migration 088: Deprecate stale
+ * `prompts/system/08-background-conversation.md` overrides.
+ *
+ * PR #31210 moved the background-conversation guidance out of the bundled
+ * system prompt and into a per-turn user-message injector. As a side effect:
+ *
+ *   - Workspace overrides that gated on `{{#isBackgroundConversation}}` now
+ *     evaluate the gate as false (the key is no longer passed to the system
+ *     prompt context) and silently stop rendering in background turns.
+ *   - Plain-text overrides without a gate would now render unconditionally
+ *     in ALL conversations — the opposite of intended behavior.
+ *
+ * Either failure mode is silent. To prevent it, this migration renames any
+ * existing `prompts/system/08-background-conversation.md` to
+ * `08-background-conversation.md.deprecated` so the section-discovery walker
+ * (which only picks up `.md` files) stops loading it, while preserving the
+ * user's customized text on disk for manual review.
+ *
+ * Idempotent: re-runs after `08-background-conversation.md` has already been
+ * renamed are no-ops. If both files exist (a user re-created the override
+ * after a prior partial run), the bundled section is gone — drop the `.md`
+ * and keep the previously-preserved `.deprecated` copy.
+ */
+
+import { existsSync, renameSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-088-deprecate-background-conversation-override",
+);
+
+const OVERRIDE_FILENAME = "08-background-conversation.md";
+const DEPRECATED_FILENAME = "08-background-conversation.md.deprecated";
+
+export const deprecateBackgroundConversationOverrideMigration: WorkspaceMigration =
+  {
+    id: "088-deprecate-background-conversation-override",
+    description:
+      "Rename stale prompts/system/08-background-conversation.md overrides to .deprecated so they stop rendering after the section moved to a per-turn injector",
+    retryFailedCheckpoint: true,
+
+    run(workspaceDir: string): void {
+      const promptDir = join(workspaceDir, "prompts", "system");
+      const overridePath = join(promptDir, OVERRIDE_FILENAME);
+      const deprecatedPath = join(promptDir, DEPRECATED_FILENAME);
+
+      if (!existsSync(overridePath)) return;
+
+      if (existsSync(deprecatedPath)) {
+        try {
+          unlinkSync(overridePath);
+          log.info(
+            { path: overridePath, preserved: deprecatedPath },
+            "Removed re-created background-conversation override; preserved copy already exists",
+          );
+        } catch (err) {
+          log.warn(
+            { err, path: overridePath },
+            "Failed to remove background-conversation override",
+          );
+          throw err;
+        }
+        return;
+      }
+
+      try {
+        renameSync(overridePath, deprecatedPath);
+        log.info(
+          { from: overridePath, to: deprecatedPath },
+          "Renamed stale background-conversation override to .deprecated",
+        );
+      } catch (err) {
+        log.warn(
+          { err, from: overridePath, to: deprecatedPath },
+          "Failed to rename background-conversation override",
+        );
+        throw err;
+      }
+    },
+
+    down(workspaceDir: string): void {
+      const promptDir = join(workspaceDir, "prompts", "system");
+      const overridePath = join(promptDir, OVERRIDE_FILENAME);
+      const deprecatedPath = join(promptDir, DEPRECATED_FILENAME);
+
+      if (!existsSync(deprecatedPath)) return;
+      if (existsSync(overridePath)) return;
+
+      try {
+        renameSync(deprecatedPath, overridePath);
+      } catch (err) {
+        log.warn(
+          { err, from: deprecatedPath, to: overridePath },
+          "Failed to restore background-conversation override",
+        );
+      }
+    },
+  };

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -85,6 +85,7 @@ import { removeLegacySkillsIndexMigration } from "./084-remove-legacy-skills-ind
 import { memoryV2Bm25BReembedDisabledV2PagesMigration } from "./085-memory-v2-bm25-b-reembed-disabled-v2-pages.js";
 import { revertStaleGeminiMisRewritesMigration } from "./086-revert-stale-gemini-mis-rewrites.js";
 import { memoryRouterBalancedProfileMigration } from "./087-memory-router-balanced-profile.js";
+import { deprecateBackgroundConversationOverrideMigration } from "./088-deprecate-background-conversation-override.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -181,4 +182,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   memoryV2Bm25BReembedDisabledV2PagesMigration,
   revertStaleGeminiMisRewritesMigration,
   memoryRouterBalancedProfileMigration,
+  deprecateBackgroundConversationOverrideMigration,
 ];


### PR DESCRIPTION
Addresses review feedback on #31210 (both Codex and Devin flagged this).

PR #31210 moved the background-conversation guidance from a bundled system-prompt section into a per-turn user-message injector and stopped passing \`isBackgroundConversation\` to the system prompt context. Two latent regressions in workspaces with custom overrides at \`prompts/system/08-background-conversation.md\`:

- Overrides that gated on \`{{#isBackgroundConversation}}\` now evaluate the gate as false (the key is no longer in context) and silently stop rendering in background turns.
- Plain-text overrides without a gate would render unconditionally in ALL conversations — the opposite of intended behavior.

This adds workspace migration 088 which renames any existing \`prompts/system/08-background-conversation.md\` to \`08-background-conversation.md.deprecated\`. The section-discovery walker only picks up \`.md\` files, so the rename stops the override from rendering while preserving the user's customized text on disk for manual review.

Idempotent + \`retryFailedCheckpoint: true\` so a transient FS error is retried on next startup.

## Test plan
- [x] \`bun test src/__tests__/workspace-migration-088-deprecate-background-conversation-override.test.ts\` — 8/8 pass
- [x] \`bunx tsc --noEmit\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->