### PR TITLE
fix(heartbeat): defer in-band notifications until background job completes

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -8,6 +8,7 @@ import {
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { tryResolveConversationId } from "../utils/conversation-id.js";
 
 // ---------------------------------------------------------------------------
 // Command registration
@@ -261,6 +262,11 @@ Examples:
                 return;
               }
 
+              // Picks up __CONVERSATION_ID / __SKILL_CONTEXT_JSON env vars
+              // so deferred-emit can buffer notifications when called from a
+              // background job that hasn't confirmed success yet.
+              const originatingConversationId = tryResolveConversationId();
+
               const result = await cliIpcCall<{
                 signalId: string;
                 dispatched: boolean;
@@ -288,6 +294,9 @@ Examples:
                   ...(opts.dedupeKey ? { dedupeKey: opts.dedupeKey } : {}),
                   ...(conversationId
                     ? { conversationAffinityHint: { vellum: conversationId } }
+                    : {}),
+                  ...(originatingConversationId
+                    ? { originatingConversationId }
                     : {}),
                   throwOnError: true,
                 },

--- a/assistant/src/cli/utils/conversation-id.ts
+++ b/assistant/src/cli/utils/conversation-id.ts
@@ -3,12 +3,11 @@
  *   1. Explicit value provided in `opts.explicit`
  *   2. `__SKILL_CONTEXT_JSON` env var (set by skill sandbox runner)
  *   3. `__CONVERSATION_ID` env var (set by bash tool subprocess)
- *   4. Throw with the provided `failureHelp` message
+ *   4. `undefined`
  */
-export function resolveConversationId(opts: {
-  explicit?: string;
-  failureHelp: string;
-}): string {
+export function tryResolveConversationId(
+  opts: { explicit?: string } = {},
+): string | undefined {
   if (opts.explicit) return opts.explicit;
 
   const contextJson = process.env.__SKILL_CONTEXT_JSON;
@@ -26,5 +25,18 @@ export function resolveConversationId(opts: {
   const envConvId = process.env.__CONVERSATION_ID;
   if (envConvId && typeof envConvId === "string") return envConvId;
 
+  return undefined;
+}
+
+/**
+ * Same precedence as `tryResolveConversationId` but throws with the
+ * provided `failureHelp` when no source produces a value.
+ */
+export function resolveConversationId(opts: {
+  explicit?: string;
+  failureHelp: string;
+}): string {
+  const resolved = tryResolveConversationId({ explicit: opts.explicit });
+  if (resolved) return resolved;
   throw new Error(opts.failureHelp);
 }

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -686,6 +686,7 @@ export class HeartbeatService {
       callSite: "heartbeatAgent",
       timeoutMs: HEARTBEAT_TIMEOUT_MS,
       origin: "heartbeat",
+      deferNotifications: true,
       onConversationCreated: (newConversationId) => {
         conversationId = newConversationId;
         this.deps.onConversationCreated?.({

--- a/assistant/src/notifications/deferred-emit.ts
+++ b/assistant/src/notifications/deferred-emit.ts
@@ -1,0 +1,113 @@
+/**
+ * Per-conversation notification buffer used to keep a background job's
+ * "success" notification from racing the runner's `activity.failed` when
+ * the job times out after the model already invoked `notifications send`.
+ *
+ * `registerDeferredConversation` arms the buffer before the LLM turn.
+ * `bufferIfDeferred` is called from the IPC route handler — it buffers when
+ * armed, swallows when tombstoned (post-discard grace window), and returns
+ * null otherwise so the route emits normally.
+ * `commitDeferredConversation` flushes on success; `discardDeferredConversation`
+ * drops on failure and tombstones briefly to catch late tool calls that
+ * arrive after `processMessage` keeps running past the runner's timeout.
+ */
+
+import { v4 as uuid } from "uuid";
+
+import { getLogger } from "../util/logger.js";
+import {
+  emitNotificationSignal,
+  type EmitSignalParams,
+  type EmitSignalResult,
+} from "./emit-signal.js";
+
+const log = getLogger("notifications-deferred-emit");
+
+// How long after a discard we keep swallowing late notifications. `work`
+// in `runBackgroundJob` is not cancelled on timeout — it can continue
+// running and emit skill calls. Five minutes is long enough to cover any
+// realistic in-flight tool call while still bounding the map size.
+const TOMBSTONE_TTL_MS = 5 * 60 * 1000;
+
+type BufferEntry =
+  | { state: "buffered"; items: EmitSignalParams<string>[] }
+  | { state: "tombstoned" };
+
+const buffers = new Map<string, BufferEntry>();
+
+export function registerDeferredConversation(conversationId: string): void {
+  buffers.set(conversationId, { state: "buffered", items: [] });
+}
+
+/**
+ * Buffer the signal when the originating conversation is armed, swallow it
+ * when tombstoned, otherwise return null so the caller emits normally.
+ */
+export function bufferIfDeferred(
+  originatingConversationId: string | undefined,
+  params: EmitSignalParams<string>,
+): EmitSignalResult | null {
+  if (!originatingConversationId) return null;
+  const entry = buffers.get(originatingConversationId);
+  if (!entry) return null;
+  if (entry.state === "tombstoned") {
+    return {
+      signalId: uuid(),
+      deduplicated: false,
+      dispatched: false,
+      reason: "Notification dropped: background job did not complete",
+      deliveryResults: [],
+    };
+  }
+  entry.items.push(params);
+  return {
+    signalId: uuid(),
+    deduplicated: false,
+    dispatched: false,
+    reason: "Notification deferred until background job completes",
+    deliveryResults: [],
+  };
+}
+
+export async function commitDeferredConversation(
+  conversationId: string,
+): Promise<void> {
+  const entry = buffers.get(conversationId);
+  if (!entry || entry.state !== "buffered") return;
+  buffers.delete(conversationId);
+  for (const params of entry.items) {
+    try {
+      await emitNotificationSignal(params);
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Buffered notification failed to emit on commit",
+      );
+    }
+  }
+}
+
+/** Drop any buffered signals and tombstone the conversation briefly. */
+export function discardDeferredConversation(conversationId: string): number {
+  const entry = buffers.get(conversationId);
+  if (!entry) return 0;
+  const droppedCount = entry.state === "buffered" ? entry.items.length : 0;
+  buffers.set(conversationId, { state: "tombstoned" });
+  const timer = setTimeout(() => {
+    const cur = buffers.get(conversationId);
+    if (cur?.state === "tombstoned") buffers.delete(conversationId);
+  }, TOMBSTONE_TTL_MS);
+  timer.unref?.();
+  if (droppedCount > 0) {
+    log.info(
+      { conversationId, droppedCount },
+      "Discarded buffered notifications for failed background job",
+    );
+  }
+  return droppedCount;
+}
+
+/** @internal Test-only reset hook. */
+export function resetDeferredForTest(): void {
+  buffers.clear();
+}

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -94,6 +94,8 @@ mock.module("../pre-first-message-gate.js", () => ({
 
 // Import after mocks are in place.
 const { runBackgroundJob } = await import("../background-job-runner.js");
+const { bufferIfDeferred, resetDeferredForTest } =
+  await import("../../notifications/deferred-emit.js");
 
 // ── Shared fixtures ──────────────────────────────────────────────────
 
@@ -121,6 +123,7 @@ beforeEach(() => {
   processMessageCalls.length = 0;
   emitCalls.length = 0;
   addMessageCalls.length = 0;
+  resetDeferredForTest();
   preFirstMessageGateOpen = true;
   processMessageImpl = async () => ({ messageId: "msg-1" });
   emitImpl = async () => ({
@@ -352,6 +355,131 @@ describe("runBackgroundJob", () => {
       expect(result.skipReason).toBeUndefined();
       expect(bootstrapCalls).toBe(1);
       expect(processMessageCalls).toHaveLength(1);
+    });
+  });
+
+  describe("deferNotifications", () => {
+    function buildSkillNotificationParams(message: string) {
+      return {
+        sourceEventName: "assistant.share",
+        sourceChannel: "assistant_tool" as const,
+        sourceContextId: "skill-ctx",
+        contextPayload: { requestedMessage: message },
+        attentionHints: {
+          requiresAction: false,
+          urgency: "low" as const,
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      };
+    }
+
+    test("success path commits buffered in-band notifications", async () => {
+      processMessageImpl = async () => {
+        // Stand in for the IPC route's bufferIfDeferred call when the model
+        // invokes `notifications send` mid-turn.
+        const buffered = bufferIfDeferred(
+          STUB_CONVERSATION_ID,
+          buildSkillNotificationParams("all green"),
+        );
+        expect(buffered).not.toBeNull();
+        expect(buffered!.dispatched).toBe(false);
+        return { messageId: "msg-success" };
+      };
+
+      const result = await runBackgroundJob(
+        baseOpts({ deferNotifications: true }),
+      );
+
+      expect(result.ok).toBe(true);
+      // Commit flushed the buffered notification through emitNotificationSignal.
+      const successEmits = emitCalls.filter(
+        (e) => e.sourceEventName !== "activity.failed",
+      );
+      expect(successEmits).toHaveLength(1);
+      expect(successEmits[0].sourceEventName).toBe("assistant.share");
+    });
+
+    // Regression for the PR #31216 Codex P1 finding: a heartbeat that calls
+    // the notifications skill and then times out must not leave a "success"
+    // notification standing alongside the runner's `activity.failed` emit.
+    test("timeout drops buffered in-band notifications; only activity.failed emits", async () => {
+      processMessageImpl = () => {
+        bufferIfDeferred(
+          STUB_CONVERSATION_ID,
+          buildSkillNotificationParams("premature success"),
+        );
+        return new Promise(() => {});
+      };
+
+      const result = await runBackgroundJob(
+        baseOpts({ deferNotifications: true, timeoutMs: 30 }),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.errorKind).toBe("timeout");
+      // Only the runner's failure signal makes it out — the buffered
+      // "success" notification is discarded.
+      expect(emitCalls).toHaveLength(1);
+      expect(emitCalls[0].sourceEventName).toBe("activity.failed");
+    });
+
+    test("thrown exception also drops buffered notifications", async () => {
+      processMessageImpl = async () => {
+        bufferIfDeferred(
+          STUB_CONVERSATION_ID,
+          buildSkillNotificationParams("doomed"),
+        );
+        throw new Error("kaboom");
+      };
+
+      const result = await runBackgroundJob(
+        baseOpts({ deferNotifications: true }),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(emitCalls).toHaveLength(1);
+      expect(emitCalls[0].sourceEventName).toBe("activity.failed");
+    });
+
+    // Regression: after timeout, `processMessage` keeps running and may
+    // emit a late skill call. The tombstone must swallow it instead of
+    // letting it bypass the buffer and reach the dispatch pipeline.
+    test("late skill call after timeout is swallowed by the tombstone", async () => {
+      processMessageImpl = () => new Promise(() => {});
+
+      const result = await runBackgroundJob(
+        baseOpts({ deferNotifications: true, timeoutMs: 20 }),
+      );
+      expect(result.ok).toBe(false);
+
+      const late = bufferIfDeferred(
+        STUB_CONVERSATION_ID,
+        buildSkillNotificationParams("post-timeout"),
+      );
+      expect(late).not.toBeNull();
+      expect(late!.dispatched).toBe(false);
+      expect(late!.reason).toMatch(/did not complete/);
+
+      // Only the runner's failure signal made it out.
+      expect(emitCalls).toHaveLength(1);
+      expect(emitCalls[0].sourceEventName).toBe("activity.failed");
+    });
+
+    test("without deferNotifications, bufferIfDeferred is a no-op", async () => {
+      processMessageImpl = async () => {
+        const buffered = bufferIfDeferred(
+          STUB_CONVERSATION_ID,
+          buildSkillNotificationParams("immediate"),
+        );
+        // Buffer was never armed, so the call returns null and the IPC
+        // handler would emit directly.
+        expect(buffered).toBeNull();
+        return { messageId: "msg-success" };
+      };
+
+      const result = await runBackgroundJob(baseOpts());
+      expect(result.ok).toBe(true);
     });
   });
 });

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -24,6 +24,11 @@ import type { TrustContext } from "../daemon/trust-context.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { addMessage } from "../memory/conversation-crud.js";
 import type { TitleOrigin } from "../memory/conversation-title-service.js";
+import {
+  commitDeferredConversation,
+  discardDeferredConversation,
+  registerDeferredConversation,
+} from "../notifications/deferred-emit.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { AttentionHints } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
@@ -121,6 +126,11 @@ export interface RunBackgroundJobOptions {
    * the `assistant` role and cannot override the action prompt.
    */
   assistantSandwich?: { preamble: string; content: string; postamble: string };
+  /**
+   * Buffer in-band `notifications send` calls and only flush them after the
+   * run completes successfully. See `notifications/deferred-emit.ts`.
+   */
+  deferNotifications?: boolean;
 }
 
 export interface RunBackgroundJobResult {
@@ -205,6 +215,10 @@ export async function runBackgroundJob(
       ...(opts.scheduleJobId ? { scheduleJobId: opts.scheduleJobId } : {}),
     });
 
+    if (opts.deferNotifications) {
+      registerDeferredConversation(conversation.id);
+    }
+
     // Fire the sidebar-creation callback synchronously after bootstrap so
     // connected clients (macOS sidebar, etc.) see the conversation appear
     // immediately rather than after `processMessage` returns. Wrapped so a
@@ -273,6 +287,9 @@ export async function runBackgroundJob(
     });
 
     await Promise.race([work, timeout]);
+    if (opts.deferNotifications) {
+      await commitDeferredConversation(conversation.id);
+    }
     return { conversationId: conversation.id, ok: true };
   } catch (err) {
     const errorKind = classifyError(err);
@@ -280,6 +297,10 @@ export async function runBackgroundJob(
     // Bootstrap can fail before `conversation` is assigned; fall back to ""
     // so the structured failure result still flows to the caller.
     const conversationId = conversation?.id ?? "";
+
+    if (opts.deferNotifications && conversationId) {
+      discardDeferredConversation(conversationId);
+    }
 
     log.error(
       {

--- a/assistant/src/runtime/routes/notification-routes.ts
+++ b/assistant/src/runtime/routes/notification-routes.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { getDb } from "../../memory/db-connection.js";
 import { notificationDeliveries } from "../../memory/schema.js";
+import { bufferIfDeferred } from "../../notifications/deferred-emit.js";
 import { emitNotificationSignal } from "../../notifications/emit-signal.js";
 import { listEvents } from "../../notifications/events-store.js";
 import type { AttentionHints } from "../../notifications/signal.js";
@@ -78,6 +79,9 @@ const EmitSignalParams = z.object({
   conversationAffinityHint: z.record(z.string(), z.string()).optional(),
   dedupeKey: z.string().optional(),
   throwOnError: z.boolean().optional(),
+  // Conversation that originated this signal — used by `deferred-emit` to
+  // buffer notifications during in-band background-job tool calls.
+  originatingConversationId: z.string().optional(),
 });
 
 const ListNotificationEventsParams = z.object({
@@ -89,7 +93,7 @@ const ListNotificationEventsParams = z.object({
 
 async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
   const validated = EmitSignalParams.parse(body);
-  const result = await emitNotificationSignal({
+  const params = {
     sourceEventName: validated.sourceEventName,
     sourceChannel: validated.sourceChannel,
     sourceContextId: validated.sourceContextId,
@@ -99,7 +103,20 @@ async function handleEmitSignal({ body = {} }: RouteHandlerArgs) {
     conversationAffinityHint: validated.conversationAffinityHint,
     dedupeKey: validated.dedupeKey,
     throwOnError: validated.throwOnError,
-  });
+  };
+  const buffered = bufferIfDeferred(
+    validated.originatingConversationId,
+    params,
+  );
+  if (buffered) {
+    return {
+      signalId: buffered.signalId,
+      dispatched: buffered.dispatched,
+      deduplicated: buffered.deduplicated,
+      reason: buffered.reason,
+    };
+  }
+  const result = await emitNotificationSignal(params);
   return {
     signalId: result.signalId,
     dispatched: result.dispatched,


### PR DESCRIPTION
## Summary

Fixes the Codex P1 review feedback on #31216. A heartbeat run could fire a 'success' notification mid-turn via the \`notifications\` skill, then time out, producing both a success toast and an \`activity.failed\` row.

This restores ordering: notifications emitted in-band during a background job are buffered and only committed after the job actually succeeds. If the job times out or throws, the buffered notifications are discarded.

## Approach

- New \`assistant/src/notifications/deferred-emit.ts\` module with a per-conversation buffer + tombstone state (tombstone TTL 5 min) to swallow late skill calls after a timeout late-rejection.
- \`runBackgroundJob\` accepts \`deferNotifications\` and calls \`registerDeferredConversation\` / \`commitDeferredConversation\` / \`discardDeferredConversation\` around the work.
- \`emit_notification_signal\` route + CLI forward \`originatingConversationId\` (resolved via the existing \`tryResolveConversationId\` helper). When the conversation has a buffer, the route returns a synthetic deferred result without dispatching.
- Heartbeat service opts in via \`deferNotifications: true\`.

## Test plan

- [x] \`bun test src/runtime/__tests__/background-job-runner.test.ts src/heartbeat/__tests__/heartbeat-service.test.ts src/cli/commands/__tests__/notifications.test.ts\` (51 tests pass)
- [x] \`bunx tsc --noEmit\` clean
- [x] New tests cover: success path commits, timeout drops + only \`activity.failed\` emits (regression), thrown exception drops, late skill call swallowed by tombstone, no-op without \`deferNotifications\`

Addresses Codex P1 on #31216.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->