### PR TITLE
chore(memory): make v2 injection header a concrete file_read example

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -743,7 +743,7 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.block).not.toBeNull();
     expect(result.block).toContain(
-      "**CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.",
+      'Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.',
     );
     expect(result.block).toContain(
       "# memory/concepts/summarized-page.md\nA short prose description",
@@ -776,11 +776,13 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.block).not.toBeNull();
-    // CRITICAL header appears exactly once.
-    const criticalCount = (
-      result.block!.match(/\*\*CRITICAL:\*\* These are page summaries\./g) ?? []
+    // Header appears exactly once.
+    const headerCount = (
+      result.block!.match(
+        /Use `file_read\("memory\/concepts\/path\/to\/file\.md"\)` to read/g,
+      ) ?? []
     ).length;
-    expect(criticalCount).toBe(1);
+    expect(headerCount).toBe(1);
     // summarized-page → short form (path + summary, no body, no frontmatter).
     expect(result.block).toContain("# memory/concepts/summarized-page.md\nA");
     expect(result.block).not.toContain("Long-form body content");

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -712,7 +712,7 @@ interface RenderInjectionBlockResult {
  * the agent into wasted reads.
  */
 const INJECTION_HEADER =
-  "**CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.";
+  'Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.';
 
 /**
  * Render the inner content of the `<memory>` block for a list of slugs.
@@ -745,9 +745,9 @@ const INJECTION_HEADER =
  * fallback for pages predating the summary field). Skills sit after the
  * concept sections under `### Skills You Can Use`, and CLI subcommands sit
  * after the skills under `### CLI Commands You Can Use`. The leading
- * `**CRITICAL:**` line tells the agent how to read the block.
+ * instruction line tells the agent how to read the block.
  *
- *   **CRITICAL:** These are page summaries. Read full page files at the paths below with file_read if you want more information.
+ *   Use `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.
  *
  *   # memory/concepts/<concept-slug-1>.md
  *   <summary-1>


### PR DESCRIPTION
## Summary
- Rewrite the v2 memory \`INJECTION_HEADER\` from the prior \`**CRITICAL:** These are page summaries...\` instruction into a single sentence that names \`file_read\` with a concrete \`memory/concepts/path/to/file.md\` placeholder.
- Update the docstring example and the two test assertions in \`injection.test.ts\` to match.

## Original prompt
Update the v2 memory injection header to include the line \`Use \`file_read(\"memory/concepts/path/to/file.md\")\` to read the full pages for any of the injected memory summaries you want more information on.\` — an iterative refinement of the header that was last clarified in #31233, replacing the generic \"with file_read\" phrasing with the explicit tool-call syntax so the agent sees exactly how to call into a summary's full page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->