### PR TITLE
chore(memory): add file_read summary instruction to PKB system_reminder

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -8,6 +8,7 @@ const BASE_REMINDER =
   "<system_reminder>" +
   "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+  '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
   "\n</system_reminder>";
 
 describe("buildPkbReminder", () => {
@@ -21,6 +22,7 @@ describe("buildPkbReminder", () => {
       "<system_reminder>" +
       "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+      '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
       "\n</system_reminder>";
@@ -41,6 +43,7 @@ describe("buildPkbReminder", () => {
       "<system_reminder>" +
       "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+      '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- a.md" +
       "\n- sub/b.md" +

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -1,6 +1,7 @@
 const BODY =
   "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
-  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing.";
+  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+  '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.';
 
 /**
  * Render the PKB system_reminder text, optionally with a bulleted list of


### PR DESCRIPTION
## Summary
- Append the \`file_read(\"memory/concepts/path/to/file.md\")\` instruction line to the PKB \`<system_reminder>\` body, immediately below the \`recall\` guidance.
- Update the byte-for-byte \`BASE_REMINDER\` fixture plus the two hinted-render fixtures in \`pkb-reminder-builder.test.ts\` to keep them in sync.

## Original prompt
Mirror the v2 memory injection header change from #31257 into the PKB \`<system_reminder>\` body — that block already nudges the agent toward \`remember\`/\`recall\`, so it's the right second home for the new \`file_read\` instruction so the agent sees consistent guidance about expanding injected memory summaries regardless of which block is on a given turn.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->