### PR TITLE
feat(compact): show preserved tail message count in /compact result

### DIFF
--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -155,6 +155,11 @@ export interface CompactionRunResult {
   thresholdTokens: number;
   compactedMessages: number;
   compactedPersistedMessages: number;
+  /**
+   * Number of recent ("tail") messages preserved verbatim alongside the
+   * summary. Omitted on no-op / skipped results — defaults to 0 at render.
+   */
+  preservedTailMessages?: number;
   summaryCalls: number;
   summaryInputTokens: number;
   summaryOutputTokens: number;
@@ -841,6 +846,7 @@ export async function runAssistantDrivenCompaction(
     thresholdTokens,
     compactedMessages: compactableMessages.length,
     compactedPersistedMessages,
+    preservedTailMessages: tailMessages.length,
     summaryCalls: 1,
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,
@@ -1090,6 +1096,7 @@ export async function runEmergencyCompaction(
     thresholdTokens,
     compactedMessages: compactedCount,
     compactedPersistedMessages: Math.max(0, compactedCount - nonPersistedAway),
+    preservedTailMessages: keptTail.length,
     summaryCalls: 1,
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -51,6 +51,11 @@ export interface ContextWindowResult {
   thresholdTokens: number;
   compactedMessages: number;
   compactedPersistedMessages: number;
+  /**
+   * Number of recent ("tail") messages preserved verbatim alongside the
+   * summary. Omitted on no-op / skipped results — defaults to 0 at render.
+   */
+  preservedTailMessages?: number;
   summaryCalls: number;
   summaryInputTokens: number;
   summaryOutputTokens: number;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -84,6 +84,7 @@ export function formatCompactResult(result: ContextWindowResult): string {
       result.maxInputTokens,
     )} tokens`,
     `Messages: ${fmt(result.compactedMessages)} compacted`,
+    `Tail:     ${fmt(result.preservedTailMessages)} preserved`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

- Add a \`Tail: N preserved\` line to the user-facing \`/compact\` chat message so it's clear how many recent messages survived the compaction alongside the \`Messages: N compacted\` count.
- Thread a new optional \`preservedTailMessages\` field through \`CompactionRunResult\` / \`ContextWindowResult\`; populated from both the assistant-driven and emergency mid-turn paths in \`compactor.ts\`. Left optional so the ~30 existing test fixtures don't need updates.

## Original prompt

While looking at the post-\`/compact\` summary in the chat, the user noted it only reports how many messages were collapsed into the summary, not how many tail messages were preserved. Add that count to the same message so the cut point is visible without digging into logs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->