### PR TITLE
feat(memory): fork-based retrospectives behind a feature flag

### DIFF
--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -327,7 +327,7 @@ export function renderImageManifest(entries: ManifestEntry[]): string {
  * runtime emitted — typically
  * `2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)`).
  */
-function extractTurnContextTimestamp(message: Message): string | null {
+export function extractTurnContextTimestamp(message: Message): string | null {
   if (message.role !== "user") return null;
   for (const block of message.content) {
     if (block.type !== "text") continue;

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -60,6 +60,22 @@ mock.module("../conversation-crud.js", () => ({
   },
   findMostRecentRetrospectiveFor: (_id: string) =>
     priorRetroId ? { id: priorRetroId } : null,
+  // `collectPriorRetrospectiveRemembers` reads the prior row to discriminate
+  // between legacy and fork-kind sources. Return a legacy-shaped row so the
+  // existing tests exercise the unchanged extract-everything code path.
+  getConversation: (_id: string) => ({
+    source: "memory-retrospective",
+    forkParentMessageId: null,
+  }),
+  // Imported by `runForkBasedRetrospective`; legacy-path tests never hit it.
+  forkConversation: (_params: unknown) => {
+    throw new Error(
+      "forkConversation should not be called in legacy-path tests",
+    );
+  },
+  addMessage: async () => {
+    throw new Error("addMessage should not be called in legacy-path tests");
+  },
   deleteConversation: (id: string) => {
     deletedConversationIds.push(id);
   },

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -50,7 +50,7 @@ import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { getDb, getSqliteFrom } from "./db-connection.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
-import { MEMORY_RETROSPECTIVE_SOURCE } from "./memory-retrospective-constants.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
 import { rawExec, rawGet, rawRun } from "./raw-query.js";
 import {
@@ -482,7 +482,7 @@ export function findMostRecentRetrospectiveFor(
       .from(conversations)
       .where(
         and(
-          eq(conversations.source, MEMORY_RETROSPECTIVE_SOURCE),
+          inArray(conversations.source, MEMORY_RETROSPECTIVE_SOURCES),
           eq(conversations.forkParentConversationId, currentId),
         ),
       )
@@ -535,6 +535,18 @@ function getConversationGroupId(conversationId: string): string | null {
 export function forkConversation(params: {
   conversationId: string;
   throughMessageId?: string;
+  /**
+   * Override the fork's `source` column. Defaults to the standard
+   * `createConversation` default (`"user"`). Used by fork-based memory
+   * retrospectives to mark the fork as a retrospective artifact distinct
+   * from a user-initiated fork, so dedup and cleanup queries can scope
+   * correctly.
+   */
+  source?: string;
+  /**
+   * Optional title for the fork. Defaults to `<parent title> (Fork)`.
+   */
+  title?: string;
 }): ConversationRow {
   const { conversationId, throughMessageId } = params;
   const db = getDb();
@@ -577,7 +589,8 @@ export function forkConversation(params: {
       ? sourceMessages.slice(0, copyBoundaryIndex + 1)
       : ([] as MessageRow[]);
   const forkParentMessageId = messagesToCopy.at(-1)?.id ?? null;
-  const forkTitle = `${sourceConversation.title ?? "Untitled"} (Fork)`;
+  const forkTitle =
+    params.title ?? `${sourceConversation.title ?? "Untitled"} (Fork)`;
 
   // Collect disk-sync work to run after the transaction commits.
   const diskSyncQueue: Array<{
@@ -599,6 +612,7 @@ export function forkConversation(params: {
       title: forkTitle,
       conversationType: "standard",
       groupId: parentGroupId ?? "system:all",
+      ...(params.source != null ? { source: params.source } : {}),
     });
 
     db.update(conversations)

--- a/assistant/src/memory/memory-retrospective-constants.ts
+++ b/assistant/src/memory/memory-retrospective-constants.ts
@@ -6,8 +6,36 @@
 export const MEMORY_RETROSPECTIVE_SOURCE = "memory-retrospective";
 
 /**
+ * Sentinel value for the `source` column of fork-based memory-retrospective
+ * conversations (the new `memory-retrospective-fork` flag path). Distinct
+ * from MEMORY_RETROSPECTIVE_SOURCE so dedup can scope its message scan to the
+ * post-fork tail — fork-kind rows carry the full source prefix and would
+ * otherwise pollute prior-remember dedup with source-inline `remember` calls.
+ */
+export const MEMORY_RETROSPECTIVE_FORK_SOURCE = "memory-retrospective-fork";
+
+/**
+ * Union of both retrospective source sentinels. Use when looking up the most
+ * recent retrospective for a source conversation (either kind is valid) or
+ * when filtering retrospective bg conversations out of recursion queries.
+ */
+export const MEMORY_RETROSPECTIVE_SOURCES: readonly string[] = [
+  MEMORY_RETROSPECTIVE_SOURCE,
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+];
+
+/**
  * Dedicated `group_id` value for memory-retrospective background
  * conversations. Placed under `system:background` alongside auto-analysis,
  * heartbeat, and filing conversations.
  */
 export const MEMORY_RETROSPECTIVE_GROUP_ID = "system:background";
+
+/**
+ * `metadata.kind` value stamped on the user-role instruction message that
+ * fork-based retrospectives append to the forked conversation. Used purely
+ * for observability — operators inspecting a retrospective fork's history
+ * can tell the user-role message apart from a real user turn.
+ */
+export const MEMORY_RETROSPECTIVE_INSTRUCTION_KIND =
+  "memory_retrospective_instruction";

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -20,7 +20,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import { getConversationSource } from "./conversation-crud.js";
 import { upsertMemoryRetrospectiveJob } from "./jobs-store.js";
-import { MEMORY_RETROSPECTIVE_SOURCE } from "./memory-retrospective-constants.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 
 const log = getLogger("memory-retrospective-enqueue");
 
@@ -67,7 +67,8 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
 export function isMemoryRetrospectiveConversation(
   conversationId: string,
 ): boolean {
-  return getConversationSource(conversationId) === MEMORY_RETROSPECTIVE_SOURCE;
+  const source = getConversationSource(conversationId);
+  return source !== null && MEMORY_RETROSPECTIVE_SOURCES.includes(source);
 }
 
 /**

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -32,7 +32,9 @@
 // conversations left by a mid-run crash are swept by
 // `memory-retrospective-startup-cleanup.ts`.
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/types.js";
+import { extractTurnContextTimestamp } from "../context/compactor.js";
 import { resolveTurnTimezoneContext } from "../daemon/date-context.js";
 import {
   getAssistantName,
@@ -40,13 +42,17 @@ import {
 } from "../daemon/identity-helpers.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { formatMessageSliceForTranscript } from "../export/transcript-formatter.js";
+import type { Message } from "../providers/types.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { bootstrapConversation } from "./conversation-bootstrap.js";
 import {
+  addMessage,
   deleteConversation,
   findMostRecentRetrospectiveFor,
+  forkConversation,
+  getConversation,
   getMessages,
   getMessagesAfter,
 } from "./conversation-crud.js";
@@ -56,7 +62,9 @@ import {
   type MemoryJobType,
 } from "./jobs-store.js";
 import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
+  MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
   MEMORY_RETROSPECTIVE_SOURCE,
 } from "./memory-retrospective-constants.js";
 import {
@@ -64,6 +72,17 @@ import {
   getRetrospectiveState,
   upsertRetrospectiveState,
 } from "./memory-retrospective-state.js";
+
+/**
+ * Feature flag that switches the retrospective handler between the legacy
+ * transcript-based path (renders the new-message slice into a `<transcript>`
+ * block and wakes an empty background conversation) and the new fork-based
+ * path (forks the source through its latest message, persists a user-role
+ * instruction, and wakes the fork). The fork path lets the retrospective hit
+ * the provider prompt cache and read compaction summary + tail messages
+ * natively.
+ */
+const MEMORY_RETROSPECTIVE_FORK_FLAG = "memory-retrospective-fork" as const;
 
 const log = getLogger("memory-retrospective-job");
 
@@ -96,6 +115,24 @@ export async function memoryRetrospectiveJob(
     return { kind: "no_new_messages" };
   }
 
+  const useFork = isAssistantFeatureFlagEnabled(
+    MEMORY_RETROSPECTIVE_FORK_FLAG,
+    config,
+  );
+  return useFork
+    ? runForkBasedRetrospective(sourceConversationId, config)
+    : runLegacyRetrospective(sourceConversationId, config);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy path — transcript-rendered slice + empty background conversation.
+// Kept behind the `memory-retrospective-fork` flag for safe rollback.
+// ---------------------------------------------------------------------------
+
+async function runLegacyRetrospective(
+  sourceConversationId: string,
+  config: AssistantConfig,
+): Promise<MemoryRetrospectiveOutcome> {
   // 1. Load state + compute the message slice.
   const state = getRetrospectiveState(sourceConversationId);
   const lastProcessedMessageId = state?.lastProcessedMessageId ?? null;
@@ -142,7 +179,7 @@ export async function memoryRetrospectiveJob(
     assistantName: getAssistantName(),
     userName: resolveUserName(getWorkspaceDir()),
   });
-  const prompt = buildPrompt({
+  const prompt = buildLegacyPrompt({
     transcript,
     priorRemembers,
     timeZone: timezoneContext.effectiveTimezone,
@@ -191,17 +228,7 @@ export async function memoryRetrospectiveJob(
       lastRunAt: Date.now(),
     });
 
-    const followUpJobIds: string[] = [];
-    for (const jobType of FOLLOW_UP_JOB_TYPES) {
-      try {
-        followUpJobIds.push(enqueueMemoryJob(jobType, {}));
-      } catch (err) {
-        log.warn(
-          { err, jobType },
-          "memory-retrospective: failed to enqueue follow-up job; continuing",
-        );
-      }
-    }
+    const followUpJobIds = enqueueFollowUpJobs();
 
     log.info(
       {
@@ -210,6 +237,7 @@ export async function memoryRetrospectiveJob(
         cutoffMessageId,
         newMessageCount: newMessages.length,
         priorRememberCount: priorRemembers.length,
+        kind: "legacy",
       },
       "memory-retrospective invoked",
     );
@@ -252,6 +280,230 @@ export async function memoryRetrospectiveJob(
 }
 
 // ---------------------------------------------------------------------------
+// Fork-based path — fork the source through its latest message, persist a
+// user-role retrospective instruction at the tail, and wake the fork. The
+// fork inherits compaction state (summary + tail messages) via the existing
+// `forkConversation` machinery, and its prefix matches the source's prefix
+// so provider prompt caching hits.
+// ---------------------------------------------------------------------------
+
+async function runForkBasedRetrospective(
+  sourceConversationId: string,
+  config: AssistantConfig,
+): Promise<MemoryRetrospectiveOutcome> {
+  const sourceConversation = getConversation(sourceConversationId);
+  if (!sourceConversation) {
+    log.warn(
+      { sourceConversationId },
+      "memory-retrospective (fork): source conversation not found; skipping",
+    );
+    return { kind: "no_new_messages" };
+  }
+
+  const state = getRetrospectiveState(sourceConversationId);
+  const lastProcessedMessageId = state?.lastProcessedMessageId ?? null;
+  const newMessages = getMessagesAfter(
+    sourceConversationId,
+    lastProcessedMessageId,
+  );
+
+  if (newMessages.length === 0) {
+    return { kind: "no_new_messages" };
+  }
+
+  const cutoffMessage = newMessages[newMessages.length - 1];
+  if (!cutoffMessage) {
+    return { kind: "no_new_messages" };
+  }
+  const cutoffMessageId = cutoffMessage.id;
+
+  // The fork carries the full conversation, so the agent needs an explicit
+  // anchor telling it where the review window begins. Prefer the user
+  // turn's `<turn_context>` `current_time:` (matches the conversation's
+  // own clock); fall back to ISO-formatted `createdAt` when the slice
+  // begins with an assistant turn or tool_result-only user message.
+  const windowStartTimestamp =
+    findFirstTurnContextTimestamp(newMessages) ??
+    new Date(newMessages[0]!.createdAt).toISOString();
+
+  // Pull prior `remember` calls BEFORE forking — otherwise
+  // `findMostRecentRetrospectiveFor` could locate this run's own fork.
+  const priorRemembers =
+    collectPriorRetrospectiveRemembers(sourceConversationId);
+
+  // `forkConversation` inherits `contextSummary` /
+  // `contextCompactedMessageCount` / `contextCompactedAt` when the fork
+  // point sits within the visible window — always true here since no
+  // `throughMessageId` means fork through latest. Compacted source ⇒
+  // compacted fork ⇒ summary + tail visible to the agent natively.
+  let forkConversationRow: ReturnType<typeof forkConversation>;
+  try {
+    forkConversationRow = forkConversation({
+      conversationId: sourceConversationId,
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+      title: `${sourceConversation.title ?? "Untitled"} (Retrospective)`,
+    });
+  } catch (err) {
+    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    log.error(
+      { err, sourceConversationId },
+      "memory-retrospective (fork): forkConversation failed",
+    );
+    throw err;
+  }
+  const forkId = forkConversationRow.id;
+
+  const timezoneContext = resolveTurnTimezoneContext({
+    configuredUserTimeZone: config.ui.userTimezone ?? null,
+    detectedTimezone: config.ui.detectedTimezone ?? null,
+  });
+  const instruction = buildForkInstruction({
+    windowStartTimestamp,
+    priorRemembers,
+    timeZone: timezoneContext.effectiveTimezone,
+    isFirstPass: lastProcessedMessageId == null,
+  });
+  try {
+    await addMessage(
+      forkId,
+      "user",
+      JSON.stringify([{ type: "text", text: instruction }]),
+      { kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND },
+      { skipIndexing: true },
+    );
+  } catch (err) {
+    log.error(
+      { err, forkId, sourceConversationId },
+      "memory-retrospective (fork): failed to persist instruction message",
+    );
+    safeDeleteForkOnFailure(forkId);
+    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    throw err;
+  }
+
+  // `skipHintInjection: true` because the instruction is already a
+  // persisted message — the wake's hint sandwich would only duplicate it.
+  let wakeSucceeded = false;
+  let failureReason: string | undefined;
+  let threw: unknown;
+  try {
+    const result = await wakeAgentForOpportunity({
+      conversationId: forkId,
+      hint: "",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+      callSite: "memoryRetrospective",
+      hintRole: "user",
+      skipHintInjection: true,
+      suppressAutoCompaction: true,
+    });
+    wakeSucceeded = result.invoked;
+    failureReason = result.reason;
+  } catch (err) {
+    threw = err;
+    failureReason = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, forkId, sourceConversationId },
+      "memory-retrospective (fork): wake threw",
+    );
+  }
+
+  if (wakeSucceeded) {
+    upsertRetrospectiveState({
+      conversationId: sourceConversationId,
+      lastProcessedMessageId: cutoffMessageId,
+      lastRunAt: Date.now(),
+    });
+
+    const followUpJobIds = enqueueFollowUpJobs();
+
+    log.info(
+      {
+        sourceConversationId,
+        backgroundConversationId: forkId,
+        cutoffMessageId,
+        newMessageCount: newMessages.length,
+        priorRememberCount: priorRemembers.length,
+        windowStartTimestamp,
+        kind: "fork",
+      },
+      "memory-retrospective invoked",
+    );
+    return {
+      kind: "invoked",
+      backgroundConversationId: forkId,
+      cutoffMessageId,
+      newMessageCount: newMessages.length,
+      followUpJobIds,
+    };
+  }
+
+  bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+  safeDeleteForkOnFailure(forkId);
+
+  if (threw !== undefined) {
+    throw threw;
+  }
+
+  return {
+    kind: "wake_failed",
+    reason: failureReason,
+    conversationId: forkId,
+  };
+}
+
+function enqueueFollowUpJobs(): string[] {
+  const followUpJobIds: string[] = [];
+  for (const jobType of FOLLOW_UP_JOB_TYPES) {
+    try {
+      followUpJobIds.push(enqueueMemoryJob(jobType, {}));
+    } catch (err) {
+      log.warn(
+        { err, jobType },
+        "memory-retrospective: failed to enqueue follow-up job; continuing",
+      );
+    }
+  }
+  return followUpJobIds;
+}
+
+function safeDeleteForkOnFailure(forkId: string): void {
+  try {
+    deleteConversation(forkId);
+  } catch (err) {
+    log.warn(
+      { err, forkId },
+      "memory-retrospective (fork): failed to delete fork on wake failure; continuing",
+    );
+  }
+}
+
+/**
+ * Walk the slice and return the `<turn_context>` `current_time:` value from
+ * the first message that has one (typically the first user message). The
+ * agent uses this as the explicit anchor for the review window inside its
+ * forked history.
+ */
+function findFirstTurnContextTimestamp(
+  messages: Array<{ role: string; content: string }>,
+): string | null {
+  for (const row of messages) {
+    if (row.role !== "user") continue;
+    let blocks: unknown;
+    try {
+      blocks = JSON.parse(row.content);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(blocks)) continue;
+    const message = { role: "user", content: blocks } as Message;
+    const ts = extractTurnContextTimestamp(message);
+    if (ts) return ts;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Prior-retrospective remember extraction
 // ---------------------------------------------------------------------------
 
@@ -261,9 +513,23 @@ export async function memoryRetrospectiveJob(
  * array on first run (no prior retrospective) or when the prior run had no
  * `remember` calls (it found nothing to save).
  *
- * This is bounded — a single retrospective conversation, however long the
- * source conversation has grown. Older retrospectives' saves are already
- * baked into the most recent one's `<already_remembered>` block transitively.
+ * Two artifact shapes exist depending on which path produced the prior
+ * retrospective:
+ *
+ *   - **Legacy** (`source === MEMORY_RETROSPECTIVE_SOURCE`): empty bg
+ *     conversation containing only the wake's tail (`remember` tool_use
+ *     blocks). Scan everything.
+ *   - **Fork** (`source === MEMORY_RETROSPECTIVE_FORK_SOURCE`): full source
+ *     prefix forked in, followed by the retrospective's post-fork tail.
+ *     The forked prefix contains the source conversation's own inline
+ *     `remember` calls — scanning the whole row would dump source-inline
+ *     saves into the dedup baseline and inflate it dramatically. Restrict
+ *     to messages created **after** `forkParentMessageId` (the last copied
+ *     message); only messages after that boundary came from this
+ *     retrospective's own work.
+ *
+ * Older retrospectives' saves remain reflected transitively because each
+ * retrospective dedups against the one before it.
  */
 function collectPriorRetrospectiveRemembers(
   sourceConversationId: string,
@@ -280,7 +546,74 @@ function collectPriorRetrospectiveRemembers(
     );
     return [];
   }
+
+  const priorConv = getConversation(prior.id);
+  if (priorConv?.source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
+    // For fork-kind rows, prior `remember` calls live in the post-fork
+    // tail (messages created after the last copied source message).
+    // `cloneForkMessageMetadata` stamps every copied message with
+    // `forkSourceMessageId`; the cloned row whose stamp equals
+    // `forkParentMessageId` sits at the boundary, and the fork preserves
+    // `createdAt` on cloned messages, so everything strictly greater than
+    // that timestamp is post-fork.
+    if (priorConv.forkParentMessageId == null) {
+      log.warn(
+        { priorConversationId: prior.id },
+        "memory-retrospective: fork-kind prior has null forkParentMessageId; treating dedup as empty",
+      );
+      return [];
+    }
+    const boundaryCreatedAt = findForkBoundaryCreatedAt(
+      messages,
+      priorConv.forkParentMessageId,
+    );
+    if (boundaryCreatedAt == null) {
+      log.warn(
+        {
+          priorConversationId: prior.id,
+          forkParentMessageId: priorConv.forkParentMessageId,
+        },
+        "memory-retrospective: fork-kind prior's boundary message missing; treating dedup as empty",
+      );
+      return [];
+    }
+    return extractRememberContents(
+      messages.filter((m) => m.createdAt > boundaryCreatedAt),
+    );
+  }
+
   return extractRememberContents(messages);
+}
+
+/**
+ * Locate the boundary timestamp between the fork's prefix and its post-fork
+ * tail. The cloned row with `metadata.forkSourceMessageId === forkParentMessageId`
+ * marks the last copied source message; its `createdAt` is the boundary.
+ * Returns `null` only if the stamp is missing — which indicates corrupted
+ * fork metadata (caller logs + degrades).
+ */
+function findForkBoundaryCreatedAt(
+  forkMessages: Array<{
+    id: string;
+    createdAt: number;
+    metadata: string | null;
+  }>,
+  forkParentMessageId: string,
+): number | null {
+  for (const row of forkMessages) {
+    if (!row.metadata) continue;
+    try {
+      const parsed = JSON.parse(row.metadata) as {
+        forkSourceMessageId?: string;
+      };
+      if (parsed.forkSourceMessageId === forkParentMessageId) {
+        return row.createdAt;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 interface MessageLike {
@@ -339,17 +672,17 @@ function neutralizeSentinels(s: string): string {
     );
 }
 
-interface PromptArgs {
+interface LegacyPromptArgs {
   transcript: string;
   priorRemembers: string[];
   timeZone: string;
 }
 
-function buildPrompt({
+function buildLegacyPrompt({
   transcript,
   priorRemembers,
   timeZone,
-}: PromptArgs): string {
+}: LegacyPromptArgs): string {
   const safeTranscript = neutralizeSentinels(transcript);
   const renderedPrior =
     priorRemembers.length === 0
@@ -374,5 +707,58 @@ Two dedup sources to skip:
 2. Anything you already called \`remember\` on inline in this slice's transcript — those appear as \`[Tool: remember] {...}\` entries above.
 
 For everything else, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. One \`remember\` call per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Fork-based retrospective instruction
+// ---------------------------------------------------------------------------
+
+interface ForkInstructionArgs {
+  windowStartTimestamp: string;
+  priorRemembers: string[];
+  timeZone: string;
+  /** True when this is the first retrospective pass over the source conversation. */
+  isFirstPass: boolean;
+}
+
+/**
+ * Build the user-role instruction message appended to the forked conversation.
+ * The agent reads the conversation natively (including any inherited compaction
+ * summary + tail messages), so the prompt is short — it just anchors the
+ * review window by `<turn_context>` timestamp and lists the prior
+ * retrospective's saves for cross-kind dedup (a legacy-kind prior's
+ * `remember` calls aren't visible inside the forked conversation history).
+ */
+function buildForkInstruction({
+  windowStartTimestamp,
+  priorRemembers,
+  timeZone,
+  isFirstPass,
+}: ForkInstructionArgs): string {
+  const renderedPrior =
+    priorRemembers.length === 0
+      ? "(none — this is your first retrospective over this conversation)"
+      : priorRemembers.map((c) => `- ${neutralizeSentinels(c)}`).join("\n");
+
+  const windowAnchor = isFirstPass
+    ? "Your review window is the full conversation above."
+    : `Your review window starts at the user turn with \`current_time: ${neutralizeSentinels(windowStartTimestamp)}\` (timezone: ${timeZone}) and ends at the most recent message.`;
+
+  return `This is a memory retrospective pass over the conversation above.
+
+${windowAnchor}
+
+Here are the facts you saved in your previous retrospective pass over this conversation (so you don't restate them):
+
+<already_remembered>
+${renderedPrior}
+</already_remembered>
+
+Two dedup sources to skip:
+1. Anything semantically captured in <already_remembered> above (from your prior retrospective pass).
+2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
+
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. One \`remember\` call per fact. If nothing new is worth saving, say "Nothing new to save." and stop.
 `;
 }

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -45,7 +45,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import { deleteConversation } from "./conversation-crud.js";
 import { getDb } from "./db-connection.js";
-import { MEMORY_RETROSPECTIVE_SOURCE } from "./memory-retrospective-constants.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { conversations, memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-retrospective-startup-cleanup");
@@ -103,7 +103,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     .from(conversations)
     .where(
       and(
-        eq(conversations.source, MEMORY_RETROSPECTIVE_SOURCE),
+        inArray(conversations.source, MEMORY_RETROSPECTIVE_SOURCES),
         isNotNull(conversations.forkParentConversationId),
       ),
     )
@@ -129,7 +129,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     .from(conversations)
     .where(
       and(
-        eq(conversations.source, MEMORY_RETROSPECTIVE_SOURCE),
+        inArray(conversations.source, MEMORY_RETROSPECTIVE_SOURCES),
         // Conservative: only sweep rows that have had at least one message
         // AND haven't seen activity recently. Conversations without a
         // last_message_at value are too fresh to assess.

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -68,9 +68,6 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");
 
-/** Number of messages injected for the wake hint (user + assistant + user). */
-const WAKE_HINT_MESSAGE_COUNT = 3;
-
 /** Static preamble user message — no dynamic content, injection-safe. */
 const WAKE_PREAMBLE =
   "[system] The following assistant message comes from an external system.";
@@ -196,6 +193,42 @@ export interface WakeOptions {
    * tune the model/profile and observability bucket independently.
    */
   callSite?: LLMCallSite;
+  /**
+   * Role to use for the injected hint message. Defaults to `"assistant"` so
+   * the hint is sandwiched between two static user bookends — the canonical
+   * anti-injection pattern for hints that may carry text from an external
+   * source. Trusted internal callers (e.g. fork-based memory retrospectives)
+   * can pass `"user"` to inject a single user-role message containing the
+   * hint directly, which reads more naturally as an instruction from the
+   * user/system rather than a self-directed assistant note.
+   */
+  hintRole?: "assistant" | "user";
+  /**
+   * Documented intent: this wake must not trigger auto-threshold compaction.
+   *
+   * Today this is automatically satisfied because the wake invokes
+   * `target.agentLoop.run()` directly, bypassing the daemon orchestrator
+   * (`conversation-agent-loop.ts`) where the compaction pipeline lives. The
+   * flag is recorded in the wake's structured log line so operators can
+   * verify the contract holds across refactors. If compaction is ever moved
+   * into `AgentLoop.run` or invoked from the wake path, callers that pass
+   * `true` here MUST be updated to suppress it; callers that pass `false`
+   * (or omit it) MUST tolerate compaction firing.
+   *
+   * Used by fork-based memory retrospectives: the wake operates on a
+   * freshly-forked conversation that may already be near (or past) the
+   * source's auto-threshold, but the goal is to operate on that exact
+   * context — running a compaction LLM call before the wake's own first
+   * call would waste tokens and defeat prompt-cache reuse.
+   */
+  suppressAutoCompaction?: boolean;
+  /**
+   * Skip injection of the hint sandwich entirely. Used when the caller has
+   * already persisted the instruction as a real message in the conversation
+   * (e.g. fork-based memory retrospectives that append a user message to the
+   * forked conversation before waking). When `true`, `hint` is ignored.
+   */
+  skipHintInjection?: boolean;
 }
 
 /**
@@ -376,6 +409,7 @@ function buildWakeTurnContext(
  */
 function inspectWakeOutput(
   baselineLength: number,
+  hintMessageCount: number,
   updatedHistory: Message[],
 ): {
   tailMessages: Message[];
@@ -383,10 +417,10 @@ function inspectWakeOutput(
   toolUseNames: string[];
 } {
   // The agent loop appends messages onto the history it was given. We
-  // injected 3 hint messages (user preamble + assistant hint + user
-  // postamble), so anything at index >= baselineLength + 3 came from
-  // the run.
-  const firstAssistantIndex = baselineLength + WAKE_HINT_MESSAGE_COUNT;
+  // injected `hintMessageCount` hint messages (0, 1, or 3 depending on
+  // hint mode), so anything at index >= baselineLength + hintMessageCount
+  // came from the run.
+  const firstAssistantIndex = baselineLength + hintMessageCount;
   if (updatedHistory.length <= firstAssistantIndex) {
     return { tailMessages: [], hasVisibleText: false, toolUseNames: [] };
   }
@@ -505,28 +539,45 @@ export async function wakeAgentForOpportunity(
     // tail-slice math would skip every message.
     const baselineLength = baseline.length;
     const wakeTurnContext = buildWakeTurnContext(opts, diskPressureDecision);
-    const hintContent = `[opportunity:${source}] ${hint}`;
-    // Sandwich the hint as an assistant message between two hardcoded
-    // user messages. The assistant role prevents prompt injection — LLMs
-    // don't follow instructions in their own prior output. The trailing
-    // user message satisfies providers that reject assistant prefill
-    // (conversation must end on a user turn). Both user messages are
-    // static strings with no dynamic content so they cannot carry
-    // injection payloads.
-    const wakeMessages: Message[] = [
-      {
-        role: "user",
-        content: [{ type: "text", text: WAKE_PREAMBLE }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: hintContent }],
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: WAKE_POSTAMBLE }],
-      },
-    ];
+    // Build the hint injection. Three modes:
+    //   - `skipHintInjection`: caller has already persisted an instruction
+    //     message into the conversation history (typical for fork-based
+    //     memory retrospectives that append a user message before waking).
+    //   - `hintRole === "user"`: single user-role message containing the
+    //     hint directly. Used by trusted internal callers where the hint
+    //     reads naturally as an instruction.
+    //   - default (`hintRole === "assistant"`): sandwich the hint as an
+    //     assistant message between two hardcoded user bookends. The
+    //     assistant role defangs prompt injection (LLMs don't follow
+    //     instructions in their own prior output) and the trailing user
+    //     message satisfies providers that reject assistant prefill.
+    const hintRole = opts.hintRole ?? "assistant";
+    const wakeMessages: Message[] = opts.skipHintInjection
+      ? []
+      : hintRole === "user"
+        ? [
+            {
+              role: "user",
+              content: [{ type: "text", text: hint }],
+            },
+          ]
+        : [
+            {
+              role: "user",
+              content: [{ type: "text", text: WAKE_PREAMBLE }],
+            },
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: `[opportunity:${source}] ${hint}` },
+              ],
+            },
+            {
+              role: "user",
+              content: [{ type: "text", text: WAKE_POSTAMBLE }],
+            },
+          ];
+    const wakeHintMessageCount = wakeMessages.length;
     const runInput: Message[] = [...baseline, ...wakeMessages];
 
     // Event handling runs in two modes. While `mode === "buffering"`,
@@ -663,7 +714,7 @@ export async function wakeAgentForOpportunity(
     const goLive = (currentHistory: Message[]): void => {
       if (mode === "live") return;
       if (!surfaceInjected) {
-        const tailStart = baselineLength + WAKE_HINT_MESSAGE_COUNT;
+        const tailStart = baselineLength + wakeHintMessageCount;
         const tail = currentHistory.slice(tailStart);
         const firstAssistant = tail.find((m) => m.role === "assistant");
         if (firstAssistant && Array.isArray(firstAssistant.content)) {
@@ -721,8 +772,7 @@ export async function wakeAgentForOpportunity(
     const flushPendingTail = async (
       currentHistory: Message[],
     ): Promise<void> => {
-      const start =
-        baselineLength + WAKE_HINT_MESSAGE_COUNT + persistedTailIndex;
+      const start = baselineLength + wakeHintMessageCount + persistedTailIndex;
       if (start >= currentHistory.length) return;
       const newMessages = currentHistory.slice(start);
       for (const msg of newMessages) {
@@ -825,7 +875,11 @@ export async function wakeAgentForOpportunity(
         tailMessages,
         hasVisibleText,
         toolUseNames: names,
-      } = inspectWakeOutput(baselineLength, updatedHistory);
+      } = inspectWakeOutput(
+        baselineLength,
+        wakeHintMessageCount,
+        updatedHistory,
+      );
       toolUseNames = names;
       producedToolCalls = names.length > 0;
       const producedOutput = producedToolCalls || hasVisibleText;
@@ -904,9 +958,17 @@ export async function wakeAgentForOpportunity(
       }
 
       const durationMs = nowFn() - startedAt;
+      const suppressAutoCompaction = opts.suppressAutoCompaction === true;
       if (runError) {
         log.error(
-          { conversationId, source, durationMs, err: runError },
+          {
+            conversationId,
+            source,
+            durationMs,
+            suppressAutoCompaction,
+            hintRole,
+            err: runError,
+          },
           "agent-wake: agent loop threw; treating as no-op",
         );
       } else if (tailMessageCount === 0) {
@@ -915,6 +977,8 @@ export async function wakeAgentForOpportunity(
             source,
             conversationId,
             durationMs,
+            suppressAutoCompaction,
+            hintRole,
             producedToolCalls: false,
             toolNamesCalled: [],
           },
@@ -926,6 +990,8 @@ export async function wakeAgentForOpportunity(
             source,
             conversationId,
             durationMs,
+            suppressAutoCompaction,
+            hintRole,
             producedToolCalls,
             toolNamesCalled: toolUseNames,
             tailMessageCount,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -10,6 +10,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "memory-retrospective-fork",
+      "scope": "assistant",
+      "key": "memory-retrospective-fork",
+      "label": "Fork-based memory retrospective",
+      "description": "Fork the source conversation through its latest message for memory retrospectives, instead of rendering the slice into a transcript and waking an empty background conversation. Lets the retrospective hit the provider prompt cache and read compaction summary + tail messages natively.",
+      "defaultEnabled": false
+    },
+    {
       "id": "user-hosted-enabled",
       "scope": "client",
       "key": "user-hosted-enabled",


### PR DESCRIPTION
## Summary

- New fork-based memory retrospective path behind `memory-retrospective-fork` flag (default off). The retrospective forks the source conversation through its latest message, persists a user-role instruction at the tail anchored by `<turn_context>` `current_time:`, and wakes the fork. Provider prompt caching hits the source's prefix, and compaction state (summary + tail messages) flows in via `forkConversation`'s existing inheritance.
- Extends `WakeOptions` with `hintRole` (`"user" | "assistant"`), `skipHintInjection`, and `suppressAutoCompaction` (documented intent + observability log line; today a no-op since wakes bypass the compaction pipeline).
- New `MEMORY_RETROSPECTIVE_FORK_SOURCE` sentinel + updated dedup in `collectPriorRetrospectiveRemembers` to scope post-fork tail when reading fork-kind priors — keeps `<already_remembered>` clean across the flag boundary. Startup cleanup and recursion guards broadened to match either retrospective source.

## Original prompt

Memory retrospectives should fork the source conversation at the cut point so they take advantage of provider prompt caching and get the full native context (including compaction summary + tail messages when the source has been compacted, mirroring what the desktop "fork from assistant message" button produces). The retrospective instruction is a new user message tacked onto the end of the fork, identifying the window-start via the `<turn_context>` `current_time:` timestamp of the slice's first user message. The retrospective job should have an elevated compaction threshold to avoid compaction running immediately if the retrospective was triggered by automatic compaction. The entire new system ships behind a feature flag that toggles between the old and new systems.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Retrospective job tests (`memory-retrospective-job.test.ts`): 16/16 pass
- [x] Wake tests (`agent-wake.test.ts`): 28/28 pass
- [x] Fork CRUD tests (`conversation-fork-crud.test.ts`): 20/20 pass
- [x] Find-most-recent + startup-cleanup + enqueue tests: all green
- [ ] Manual E2E with flag off (legacy path regression)
- [ ] Manual E2E with flag on, uncompacted source — verify fork created with full message count, `source = "memory-retrospective-fork"`, instruction persisted, `remember` calls land in post-fork tail
- [ ] Manual E2E with flag on, compacted source — verify fork inherits `contextSummary` and the wake's first LLM call doesn't trigger another compaction
- [ ] Two-pass dedup — second retrospective's `<already_remembered>` includes only the first fork's post-fork tail, not its forked prefix
- [ ] Companion PR in `vellum-assistant-platform` adds `memory-retrospective-fork` to the LaunchDarkly Terraform flag map

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->