### PR TITLE
feat(web-activity): synthesize favicon URLs for results missing one

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -48,6 +48,7 @@ import { isContextOverflowError } from "../providers/types.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { extractDomain } from "../tools/network/domain-normalize.js";
 import { ProviderError } from "../util/errors.js";
+import { faviconUrlForDomain } from "../util/favicon.js";
 import { getLogger } from "../util/logger.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
 import {
@@ -1306,13 +1307,17 @@ export async function dispatchAgentEvent(
               r != null &&
               (r as { type?: string }).type === "web_search_result",
           )
-          .map((r, i) => ({
-            rank: i + 1,
-            title: r.title,
-            url: r.url,
-            domain: extractDomain(r.url),
-            // snippet intentionally absent — Anthropic native content is encrypted/opaque
-          }));
+          .map((r, i) => {
+            const domain = extractDomain(r.url);
+            return {
+              rank: i + 1,
+              title: r.title,
+              url: r.url,
+              domain,
+              faviconUrl: faviconUrlForDomain(domain),
+              // snippet intentionally absent — Anthropic native content is encrypted/opaque
+            };
+          });
 
         const metadata: WebSearchMetadata = {
           query,

--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -213,7 +213,11 @@ describe("web_search activity metadata", () => {
     );
     expect(meta.results[0].snippet).toBe("Tavily snippet text");
     expect(meta.results[0].score).toBe(0.87);
-    expect(meta.results[1].faviconUrl).toBeUndefined();
+    // PR 5 backfills a synthesized favicon URL via Google s2 when the
+    // provider doesn't supply one, so this result now has a faviconUrl too.
+    expect(meta.results[1].faviconUrl).toContain(
+      "google.com/s2/favicons",
+    );
     expect(meta.results[1].score).toBe(0.42);
   });
 

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -9,6 +9,7 @@ import type { WebFetchMetadata } from "../../daemon/message-types/web-activity.j
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { wrapUntrustedContent } from "../../security/untrusted-content.js";
+import { faviconUrlForDomain } from "../../util/favicon.js";
 import { getLogger } from "../../util/logger.js";
 import { safeStringSlice } from "../../util/unicode.js";
 import { registerTool } from "../registry.js";
@@ -562,6 +563,7 @@ export async function executeWebFetch(
     const safeFinalUrl = meta.finalUrl
       ? sanitizeUrlStringForOutput(meta.finalUrl)
       : safeUrl;
+    const domain = extractDomain(safeFinalUrl);
     return {
       content: errorMessage,
       isError: true,
@@ -574,7 +576,8 @@ export async function executeWebFetch(
           byteCount: 0,
           charCount: 0,
           truncated: false,
-          domain: extractDomain(safeFinalUrl),
+          domain,
+          faviconUrl: faviconUrlForDomain(domain),
           redirectCount: meta.redirectCount ?? 0,
           durationMs: Date.now() - startedAt,
           errorMessage,
@@ -910,6 +913,7 @@ export async function executeWebFetch(
 
     const truncated = body.truncated || safeEnd < processed.length;
     const parsedTitle = html ? parseHtmlTitle(body.text) : undefined;
+    const finalDomain = extractDomain(currentUrl.href);
     const meta: WebFetchMetadata = {
       url: safeRequestedUrl,
       finalUrl: sanitizeUrlForOutput(currentUrl),
@@ -919,8 +923,8 @@ export async function executeWebFetch(
       charCount: sliced.length,
       truncated,
       title: parsedTitle,
-      domain: extractDomain(currentUrl.href),
-      // faviconUrl intentionally omitted — added by PR 5.
+      domain: finalDomain,
+      faviconUrl: faviconUrlForDomain(finalDomain),
       redirectCount,
       durationMs: Date.now() - startedAt,
     };

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -7,6 +7,7 @@ import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { wrapUntrustedContent } from "../../security/untrusted-content.js";
+import { faviconUrlForDomain } from "../../util/favicon.js";
 import { getLogger } from "../../util/logger.js";
 import {
   DEFAULT_BASE_DELAY_MS,
@@ -211,14 +212,18 @@ function buildBraveMetadata(
   query: string,
   durationMs: number,
 ): WebSearchMetadata {
-  const items: WebSearchResultItem[] = results.map((r, i) => ({
-    rank: i + 1,
-    title: r.title,
-    url: r.url,
-    domain: extractDomain(r.url),
-    snippet: r.description,
-    age: r.age,
-  }));
+  const items: WebSearchResultItem[] = results.map((r, i) => {
+    const domain = extractDomain(r.url);
+    return {
+      rank: i + 1,
+      title: r.title,
+      url: r.url,
+      domain,
+      faviconUrl: faviconUrlForDomain(domain),
+      snippet: r.description,
+      age: r.age,
+    };
+  });
   return {
     query,
     provider: "brave",
@@ -234,12 +239,16 @@ function buildPerplexityMetadata(
   durationMs: number,
 ): WebSearchMetadata {
   const citations = data.citations ?? [];
-  const items: WebSearchResultItem[] = citations.map((url, i) => ({
-    rank: i + 1,
-    title: "",
-    url,
-    domain: extractDomain(url),
-  }));
+  const items: WebSearchResultItem[] = citations.map((url, i) => {
+    const domain = extractDomain(url);
+    return {
+      rank: i + 1,
+      title: "",
+      url,
+      domain,
+      faviconUrl: faviconUrlForDomain(domain),
+    };
+  });
   return {
     query,
     provider: "perplexity",
@@ -257,12 +266,13 @@ function buildTavilyMetadata(
   const results = data.results ?? [];
   const items: WebSearchResultItem[] = results.map((r, i) => {
     const url = r.url ?? "";
+    const domain = extractDomain(url);
     return {
       rank: i + 1,
       title: r.title ?? url,
       url,
-      domain: extractDomain(url),
-      faviconUrl: r.favicon,
+      domain,
+      faviconUrl: r.favicon ?? faviconUrlForDomain(domain),
       snippet: r.content,
       score: r.score,
     };

--- a/assistant/src/util/__tests__/favicon.test.ts
+++ b/assistant/src/util/__tests__/favicon.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { faviconUrlForDomain } from "../favicon.js";
+
+describe("faviconUrlForDomain", () => {
+  test("returns a properly encoded s2 URL for a valid host", () => {
+    expect(faviconUrlForDomain("example.com")).toBe(
+      "https://www.google.com/s2/favicons?domain=example.com&sz=64",
+    );
+  });
+
+  test("lowercases mixed-case hosts before encoding", () => {
+    expect(faviconUrlForDomain("Example.COM")).toBe(
+      "https://www.google.com/s2/favicons?domain=example.com&sz=64",
+    );
+  });
+
+  test("returns undefined for empty input", () => {
+    expect(faviconUrlForDomain("")).toBeUndefined();
+  });
+
+  test("returns undefined for whitespace-only input", () => {
+    expect(faviconUrlForDomain("   ")).toBeUndefined();
+  });
+
+  test("returns undefined for hosts containing a slash", () => {
+    expect(faviconUrlForDomain("example.com/path")).toBeUndefined();
+  });
+
+  test("returns undefined for hosts containing a space", () => {
+    expect(faviconUrlForDomain("example .com")).toBeUndefined();
+  });
+
+  test("URL-encodes unicode/IDN hosts", () => {
+    // Punycode-style raw unicode host should be percent-encoded by encodeURIComponent.
+    const result = faviconUrlForDomain("münchen.de");
+    expect(result).toBe(
+      `https://www.google.com/s2/favicons?domain=${encodeURIComponent("münchen.de")}&sz=64`,
+    );
+    // Sanity check: the encoded form contains percent-encoded bytes for "ü".
+    expect(result).toContain("m%C3%BCnchen.de");
+  });
+});

--- a/assistant/src/util/__tests__/favicon.test.ts
+++ b/assistant/src/util/__tests__/favicon.test.ts
@@ -40,4 +40,21 @@ describe("faviconUrlForDomain", () => {
     // Sanity check: the encoded form contains percent-encoded bytes for "ü".
     expect(result).toContain("m%C3%BCnchen.de");
   });
+
+  test("returns undefined for localhost", () => {
+    expect(faviconUrlForDomain("localhost")).toBeUndefined();
+  });
+
+  test("returns undefined for private IPv4 hosts", () => {
+    expect(faviconUrlForDomain("127.0.0.1")).toBeUndefined();
+    expect(faviconUrlForDomain("10.0.0.5")).toBeUndefined();
+    expect(faviconUrlForDomain("192.168.1.1")).toBeUndefined();
+  });
+
+  test("returns undefined for raw IP literals (we don't reverse-lookup, so any IP is private-equivalent for our purposes)", () => {
+    // isPrivateOrLocalHost rejects raw IP literals because we can't tell from
+    // the host alone whether they belong to a routable public host. Skipping
+    // favicons for them avoids leaking internal IPs.
+    expect(faviconUrlForDomain("172.16.0.1")).toBeUndefined();
+  });
 });

--- a/assistant/src/util/__tests__/favicon.test.ts
+++ b/assistant/src/util/__tests__/favicon.test.ts
@@ -57,4 +57,21 @@ describe("faviconUrlForDomain", () => {
     // favicons for them avoids leaking internal IPs.
     expect(faviconUrlForDomain("172.16.0.1")).toBeUndefined();
   });
+
+  test("strips :port before the private-host check (host:port → undefined for private)", () => {
+    expect(faviconUrlForDomain("localhost:3000")).toBeUndefined();
+    expect(faviconUrlForDomain("127.0.0.1:8080")).toBeUndefined();
+    expect(faviconUrlForDomain("192.168.1.1:443")).toBeUndefined();
+  });
+
+  test("strips :port and encodes only the host (public host with port)", () => {
+    const result = faviconUrlForDomain("example.com:8080");
+    expect(result).toBe(
+      "https://www.google.com/s2/favicons?domain=example.com&sz=64",
+    );
+  });
+
+  test("handles bracketed IPv6 hosts with ports", () => {
+    expect(faviconUrlForDomain("[::1]:8080")).toBeUndefined();
+  });
 });

--- a/assistant/src/util/favicon.ts
+++ b/assistant/src/util/favicon.ts
@@ -1,5 +1,17 @@
 import { isPrivateOrLocalHost } from "../tools/network/url-safety.js";
 
+/** Strip the trailing `:port` from a host string. IPv6 hosts are bracketed
+ *  ("[::1]:8080" → "[::1]"); IPv4/DNS hosts have a single colon ("host:8080" → "host"). */
+function stripPort(host: string): string {
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    return end === -1 ? host : host.slice(0, end + 1);
+  }
+  const lastColon = host.lastIndexOf(":");
+  if (lastColon === -1) return host;
+  return host.slice(0, lastColon);
+}
+
 /** Deterministic favicon URL for a host using Google's s2 service.
  *  Returns undefined for empty/malformed hosts and for private, localhost,
  *  or raw-IP hosts so we never leak internal hostnames to Google when
@@ -9,8 +21,9 @@ export function faviconUrlForDomain(domain: string): string | undefined {
   if (!trimmed || trimmed.includes("/") || trimmed.includes(" ")) {
     return undefined;
   }
-  if (isPrivateOrLocalHost(trimmed)) {
+  const hostOnly = stripPort(trimmed);
+  if (!hostOnly || isPrivateOrLocalHost(hostOnly)) {
     return undefined;
   }
-  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(trimmed)}&sz=64`;
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostOnly)}&sz=64`;
 }

--- a/assistant/src/util/favicon.ts
+++ b/assistant/src/util/favicon.ts
@@ -1,9 +1,15 @@
+import { isPrivateOrLocalHost } from "../tools/network/url-safety.js";
+
 /** Deterministic favicon URL for a host using Google's s2 service.
- *  Returns undefined for empty or malformed hosts so callers can omit
- *  the field rather than emit a broken URL. */
+ *  Returns undefined for empty/malformed hosts and for private, localhost,
+ *  or raw-IP hosts so we never leak internal hostnames to Google when
+ *  clients render the icon. Callers omit the field on undefined. */
 export function faviconUrlForDomain(domain: string): string | undefined {
   const trimmed = domain.trim().toLowerCase();
   if (!trimmed || trimmed.includes("/") || trimmed.includes(" ")) {
+    return undefined;
+  }
+  if (isPrivateOrLocalHost(trimmed)) {
     return undefined;
   }
   return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(trimmed)}&sz=64`;

--- a/assistant/src/util/favicon.ts
+++ b/assistant/src/util/favicon.ts
@@ -1,0 +1,10 @@
+/** Deterministic favicon URL for a host using Google's s2 service.
+ *  Returns undefined for empty or malformed hosts so callers can omit
+ *  the field rather than emit a broken URL. */
+export function faviconUrlForDomain(domain: string): string | undefined {
+  const trimmed = domain.trim().toLowerCase();
+  if (!trimmed || trimmed.includes("/") || trimmed.includes(" ")) {
+    return undefined;
+  }
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(trimmed)}&sz=64`;
+}


### PR DESCRIPTION
## Summary
- Add faviconUrlForDomain helper using Google s2 favicons service
- Backfill faviconUrl on Brave/Perplexity/Tavily search results (Tavily-provided URL takes precedence)
- Backfill faviconUrl on Anthropic native search results
- Backfill faviconUrl on web_fetch metadata (success and error paths)

Part of plan: web-activity-ui-data.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->