### PR TITLE
feat(daemon): show actual query in 'Searching <query>' activity status text

### DIFF
--- a/assistant/src/daemon/__tests__/web-search-status-text.test.ts
+++ b/assistant/src/daemon/__tests__/web-search-status-text.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests that the in-flight activity status text emitted for `web_search`
+ * and `web_fetch` tool starts surfaces per-call detail (the query / domain)
+ * instead of a generic placeholder. Covers both the Anthropic native
+ * `server_tool_start` path and the non-native `tool_use` path.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock platform (must precede imports that read it) ─────────────────────────
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: false, watchDebounceMs: 0 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getMessageById: () => null,
+  updateMessageContent: () => {},
+  provenanceFromTrustContext: () => ({}),
+}));
+
+mock.module("../../memory/llm-request-log-store.js", () => ({
+  recordRequestLog: () => {},
+  backfillMessageIdOnLogs: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  dispatchAgentEvent,
+  formatFetchStatusText,
+  formatSearchStatusText,
+} from "../conversation-agent-loop-handlers.js";
+import type { ServerMessage } from "../message-protocol.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface ActivityStateCapture {
+  phase: string;
+  reason: string;
+  scope: string;
+  reqId: string;
+  statusText?: string;
+}
+
+function createCollectorDeps(): {
+  deps: EventHandlerDeps;
+  activityStates: ActivityStateCapture[];
+} {
+  const activityStates: ActivityStateCapture[] = [];
+  const deps = {
+    ctx: {
+      conversationId: "conv-status-text",
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      streamThinking: false,
+      emitActivityState: (
+        phase: string,
+        reason: string,
+        scope: string,
+        reqId: string,
+        statusText?: string,
+      ) => {
+        activityStates.push({ phase, reason, scope, reqId, statusText });
+      },
+      markWorkspaceTopLevelDirty: () => {},
+      currentTurnSurfaces: [],
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: (_msg: ServerMessage) => {},
+    reqId: "req-status-text",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  } as EventHandlerDeps;
+  return { deps, activityStates };
+}
+
+// ── Pure helper tests ─────────────────────────────────────────────────────────
+
+describe("formatSearchStatusText", () => {
+  test("surfaces the query in quotes", () => {
+    expect(formatSearchStatusText("web_search", "foo")).toBe(
+      'Searching "foo"',
+    );
+  });
+
+  test("truncates queries longer than 60 chars with an ellipsis", () => {
+    const longQuery = "a".repeat(120);
+    const result = formatSearchStatusText("web_search", longQuery);
+    // 57 chars + "..." = 60 char body, wrapped in 'Searching "..."'
+    expect(result).toBe(`Searching "${"a".repeat(57)}..."`);
+  });
+
+  test("preserves 60-char queries as-is (no truncation at the boundary)", () => {
+    const sixty = "a".repeat(60);
+    expect(formatSearchStatusText("web_search", sixty)).toBe(
+      `Searching "${sixty}"`,
+    );
+  });
+
+  test("falls back to the generic phrasing when the query is empty", () => {
+    expect(formatSearchStatusText("web_search", "")).toBe("Searching the web");
+    expect(formatSearchStatusText("web_search", "   ")).toBe(
+      "Searching the web",
+    );
+  });
+
+  test("emits 'Running <tool>' for non-web_search tools", () => {
+    expect(formatSearchStatusText("other_tool", "x")).toBe(
+      "Running other_tool",
+    );
+  });
+});
+
+describe("formatFetchStatusText", () => {
+  test("returns the domain when given a parseable URL", () => {
+    expect(formatFetchStatusText("https://example.com/path")).toBe(
+      "Reading example.com",
+    );
+  });
+
+  test("lowercases the host", () => {
+    expect(formatFetchStatusText("https://EXAMPLE.COM/x")).toBe(
+      "Reading example.com",
+    );
+  });
+
+  test("falls back when the URL is unparseable or missing", () => {
+    expect(formatFetchStatusText("not a url")).toBe("Reading a page");
+    expect(formatFetchStatusText(undefined)).toBe("Reading a page");
+    expect(formatFetchStatusText(42)).toBe("Reading a page");
+  });
+});
+
+// ── Dispatch-path tests ───────────────────────────────────────────────────────
+
+describe("server_tool_start status text", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("native web_search emits 'Searching \"<query>\"'", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId: "tu_native_q",
+      input: { query: "foo" },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe('Searching "foo"');
+  });
+
+  test("native web_search with long query truncates", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+    const longQuery = "a".repeat(120);
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId: "tu_native_long",
+      input: { query: longQuery },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe(`Searching "${"a".repeat(57)}..."`);
+  });
+
+  test("native web_search with missing query falls back to the generic phrasing", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId: "tu_native_empty",
+      input: {},
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe("Searching the web");
+  });
+});
+
+describe("tool_use status text (non-native)", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    state = createEventHandlerState();
+  });
+
+  test("web_search emits 'Searching \"<query>\"'", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_ws",
+      name: "web_search",
+      input: { query: "bar" },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe('Searching "bar"');
+  });
+
+  test("web_fetch emits 'Reading <domain>'", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_wf",
+      name: "web_fetch",
+      input: { url: "https://www.nytimes.com/article" },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe("Reading www.nytimes.com");
+  });
+
+  test("web_fetch with malformed url falls back to a generic phrase", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_wf_bad",
+      name: "web_fetch",
+      input: { url: "not-a-url" },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe("Reading a page");
+  });
+
+  test("unrelated tools keep the existing 'Running <friendly>' fallback", async () => {
+    const { deps, activityStates } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "tool_use",
+      id: "tu_bash",
+      name: "bash",
+      input: { command: "ls" },
+    });
+
+    const toolStart = activityStates.find((s) => s.reason === "tool_use_start");
+    expect(toolStart?.statusText).toBe("Running command");
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -335,6 +335,56 @@ function friendlyToolName(name: string): string {
   return TOOL_FRIENDLY_NAMES[name] ?? name.replace(/_/g, " ");
 }
 
+/**
+ * Status text shown to the client while a web search is in flight.
+ * Surfaces the actual query so the loading state is meaningful instead of
+ * a generic "Searching the web". Used for both Anthropic native server-tool
+ * starts and non-native `web_search` tool starts.
+ */
+export function formatSearchStatusText(
+  toolName: string,
+  query: string,
+): string {
+  if (toolName !== "web_search") return `Running ${toolName}`;
+  const trimmed = query.trim();
+  if (!trimmed) return "Searching the web";
+  const truncated =
+    trimmed.length > 60 ? trimmed.slice(0, 57) + "..." : trimmed;
+  return `Searching "${truncated}"`;
+}
+
+/**
+ * Status text shown to the client while a web fetch is in flight.
+ * Surfaces the domain so users can tell what page is being read.
+ */
+export function formatFetchStatusText(url: unknown): string {
+  if (typeof url !== "string") return "Reading a page";
+  const domain = extractDomain(url);
+  if (!domain) return "Reading a page";
+  return `Reading ${domain}`;
+}
+
+function computeToolUseStatusText(
+  name: string,
+  input: Record<string, unknown>,
+): string {
+  if (name === "web_search") {
+    const query = typeof input.query === "string" ? input.query : "";
+    return formatSearchStatusText("web_search", query);
+  }
+  if (name === "web_fetch") {
+    return formatFetchStatusText(input.url);
+  }
+  if (
+    name === "skill_execute" &&
+    typeof input.activity === "string" &&
+    input.activity.length > 0
+  ) {
+    return input.activity;
+  }
+  return `Running ${friendlyToolName(name)}`;
+}
+
 // ── Individual Handlers ──────────────────────────────────────────────
 
 function handleTextDelta(
@@ -416,12 +466,7 @@ export function handleToolUse(
   state.toolCallTimestamps.set(event.id, { startedAt: Date.now() });
   state.currentToolUseId = event.id;
   state.currentTurnToolUseIds.push(event.id);
-  const statusText =
-    event.name === "skill_execute" &&
-    typeof event.input.activity === "string" &&
-    event.input.activity.length > 0
-      ? event.input.activity
-      : `Running ${friendlyToolName(event.name)}`;
+  const statusText = computeToolUseStatusText(event.name, event.input);
   deps.ctx.emitActivityState(
     "tool_running",
     "tool_use_start",
@@ -1258,10 +1303,9 @@ export async function dispatchAgentEvent(
         handleToolResult(state, deps, event);
         break;
       case "server_tool_start": {
-        const friendlyNames: Record<string, string> = {
-          web_search: "Searching the web",
-        };
-        const statusText = friendlyNames[event.name] ?? `Running ${event.name}`;
+        const query =
+          typeof event.input.query === "string" ? event.input.query : "";
+        const statusText = formatSearchStatusText(event.name, query);
         deps.ctx.emitActivityState(
           "tool_running",
           "tool_use_start",


### PR DESCRIPTION
## Summary
- Replace hardcoded 'Searching the web' status text with 'Searching "<query>"' for web_search (native + third-party)
- Add 'Reading <domain>' status text for web_fetch
- Truncate long queries at 60 chars

Part of plan: web-activity-ui-data.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->