### PR TITLE
fix(web-search): trim Tavily titles + populate activityMetadata on top-level errors

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search-metadata.test.ts
@@ -244,6 +244,54 @@ describe("web_search activity metadata", () => {
     expect(meta.results[0].domain).toBe("example.net");
   });
 
+  test("Tavily falls back to url for empty string title", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "",
+              url: "https://example.net/empty-title",
+              content: "Empty title",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "empty title" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.results[0].title).toBe("https://example.net/empty-title");
+  });
+
+  test("Tavily falls back to url for whitespace-only title", async () => {
+    mockWebSearchProvider = "tavily";
+    mockTavilySecureKey = "tvly-key";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "   ",
+              url: "https://example.net/whitespace-title",
+              content: "Whitespace title",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as any;
+
+    const result = await execute({ query: "whitespace title" });
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.results[0].title).toBe(
+      "https://example.net/whitespace-title",
+    );
+  });
+
   test("Tavily populates errorMessage on auth failure", async () => {
     mockWebSearchProvider = "tavily";
     mockTavilySecureKey = "bad-key";
@@ -257,5 +305,42 @@ describe("web_search activity metadata", () => {
     expect(meta.resultCount).toBe(0);
     expect(meta.results).toEqual([]);
     expect(meta.errorMessage).toContain("Invalid or expired Tavily");
+  });
+
+  // ---- Top-level error paths ---------------------------------------------
+
+  test("top-level catch populates activityMetadata with errorMessage", async () => {
+    mockWebSearchProvider = "perplexity";
+    mockPerplexitySecureKey = "pplx-key";
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as any;
+
+    const result = await execute({ query: "catch query" });
+    expect(result.isError).toBe(true);
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("perplexity");
+    expect(meta.query).toBe("catch query");
+    expect(meta.resultCount).toBe(0);
+    expect(meta.results).toEqual([]);
+    expect(meta.errorMessage).toContain("network down");
+    expect(typeof meta.durationMs).toBe("number");
+  });
+
+  test("no-API-key branch populates activityMetadata with errorMessage", async () => {
+    mockWebSearchProvider = "perplexity";
+    // All provider keys remain undefined from beforeEach.
+
+    const result = await execute({ query: "no key query" });
+    expect(result.isError).toBe(true);
+    const meta = result.activityMetadata?.webSearch;
+    expect(meta).toBeDefined();
+    expect(meta.provider).toBe("perplexity");
+    expect(meta.query).toBe("no key query");
+    expect(meta.resultCount).toBe(0);
+    expect(meta.results).toEqual([]);
+    expect(meta.errorMessage).toContain("No web search API key configured");
+    expect(typeof meta.durationMs).toBe("number");
   });
 });

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -269,7 +269,7 @@ function buildTavilyMetadata(
     const domain = extractDomain(url);
     return {
       rank: i + 1,
-      title: r.title ?? url,
+      title: r.title?.trim() || url.trim() || "Untitled result",
       url,
       domain,
       faviconUrl: r.favicon ?? faviconUrlForDomain(domain),
@@ -696,6 +696,7 @@ class WebSearchTool implements Tool {
       };
     }
 
+    const startedAt = Date.now();
     let provider = getWebSearchProvider();
     let apiKey = await getApiKey(provider);
 
@@ -717,11 +718,12 @@ class WebSearchTool implements Tool {
       }
 
       if (!apiKey) {
-        return {
-          content:
-            "Error: No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, or `keys set tavily <key>`, or configure it from the Settings page under API Keys.",
-          isError: true,
-        };
+        return errorResult(
+          query,
+          provider,
+          startedAt,
+          "No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, or `keys set tavily <key>`, or configure it from the Settings page under API Keys.",
+        );
       }
     }
 
@@ -750,7 +752,7 @@ class WebSearchTool implements Tool {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err }, "Web search failed");
-      return { content: `Error: Web search failed: ${msg}`, isError: true };
+      return errorResult(query, provider, startedAt, `Web search failed: ${msg}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
Addresses two gaps from the web-activity-ui-data.md plan self-review:
- buildTavilyMetadata now trims titles and falls back to URL on empty/whitespace (matches the existing formatTavilyResults behavior)
- WebSearchTool.execute() catch branch and no-API-key branch now populate activityMetadata.webSearch with errorMessage so the UI can render the failure with context

Part of plan: web-activity-ui-data.md (remediation 2/2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->