### PR TITLE
feat(web): port PreferencesMenu from platform (LUM-1669)

### DIFF
--- a/apps/web/src/components/earn-credits-modal.tsx
+++ b/apps/web/src/components/earn-credits-modal.tsx
@@ -1,0 +1,274 @@
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  CreditCard,
+  Gift,
+  Loader2,
+  Share2,
+  Users,
+} from "lucide-react";
+import { useCallback, useState, type ReactNode } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { Button, Input, Modal } from "@vellum/design-library";
+
+import { referralCodesMeRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen.js";
+
+interface EarnCreditsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function stripDecimals(amount: string): string {
+  return amount.replace(/\.00$/, "");
+}
+
+function buildSubtitle(
+  referrerCreditAmount: string,
+  creditAmount: string,
+  earningCap: string,
+): string {
+  const cap = stripDecimals(earningCap);
+  const referrerAmount = stripDecimals(referrerCreditAmount);
+  const refereeAmount = stripDecimals(creditAmount);
+  if (referrerAmount === refereeAmount) {
+    return `Share Vellum with friends — you'll each earn ${referrerAmount} credits when they sign up, up to ${cap} total.`;
+  }
+  return `Share Vellum with friends — you'll earn ${referrerAmount} credits and they'll get ${refereeAmount} when they sign up, up to ${cap} total.`;
+}
+
+export function EarnCreditsModal({ open, onClose }: EarnCreditsModalProps) {
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      {open ? <EarnCreditsModalInner /> : null}
+    </Modal.Root>
+  );
+}
+
+function EarnCreditsModalInner() {
+  const [copied, setCopied] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery(
+    referralCodesMeRetrieveOptions(),
+  );
+
+  const handleCopy = useCallback((url: string) => {
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
+
+  const subtitle = data
+    ? buildSubtitle(
+        data.referrer_credit_amount,
+        data.credit_amount,
+        data.earning_cap,
+      )
+    : "Refer friends to earn free credits.";
+
+  const cap = data ? stripDecimals(data.earning_cap) : "";
+  const title = showTerms ? "Referral Program Terms" : "Earn free credits";
+
+  return (
+    <Modal.Content size="sm">
+      <Modal.Header>
+        <div className="flex min-w-0 items-start gap-2">
+          {showTerms && (
+            <Button
+              variant="ghost"
+              size="compact"
+              iconOnly={<ArrowLeft />}
+              onClick={() => setShowTerms(false)}
+              aria-label="Back"
+              className="mt-0.5"
+              tintColor="var(--content-secondary)"
+            />
+          )}
+          <div className="min-w-0">
+            <Modal.Title>{title}</Modal.Title>
+            {!showTerms && <Modal.Description>{subtitle}</Modal.Description>}
+          </div>
+        </div>
+      </Modal.Header>
+      <Modal.Body>
+        {showTerms && data ? (
+          <TermsContent cap={cap} />
+        ) : isLoading ? (
+          <div
+            className="flex items-center gap-2 py-2 text-body-medium-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading referral information…
+          </div>
+        ) : isError || !data ? (
+          <div className="space-y-3">
+            <p
+              className="!m-0 text-body-medium-lighter"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              Failed to load referral information.
+            </p>
+            <Button
+              variant="outlined"
+              onClick={() => void refetch()}
+              disabled={isFetching}
+            >
+              {isFetching ? "Retrying…" : "Try Again"}
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <HowItWorksStep
+                icon={<Share2 className="h-4 w-4" />}
+                label="Share your invite link"
+              />
+              <HowItWorksStep
+                icon={<Users className="h-4 w-4" />}
+                label="They sign up"
+              />
+              <HowItWorksStep
+                icon={<Gift className="h-4 w-4" />}
+                label="You earn credits"
+              />
+            </div>
+
+            <div style={{ borderTop: "1px solid var(--border-base)" }} />
+
+            <div className="flex items-center gap-2">
+              <Input
+                type="text"
+                readOnly
+                value={data.referral_url}
+                fullWidth
+                wrapperClassName="flex-1"
+                className="font-mono"
+                onFocus={(e) => e.currentTarget.select()}
+              />
+              <Button
+                variant="outlined"
+                iconOnly={copied ? <Check /> : <Copy />}
+                onClick={() => handleCopy(data.referral_url)}
+                aria-label="Copy referral link"
+                className="h-9 w-9"
+              />
+            </div>
+
+            <div style={{ borderTop: "1px solid var(--border-base)" }} />
+
+            <div className="flex items-center justify-between gap-4">
+              <StatItem
+                icon={<Users className="h-3.5 w-3.5" />}
+                value={String(data.referred_count)}
+                label="Friends Referred"
+              />
+              <StatItem
+                icon={<CreditCard className="h-3.5 w-3.5" />}
+                value={stripDecimals(data.total_earned)}
+                label="Credits Earned"
+              />
+            </div>
+
+            <div style={{ borderTop: "1px solid var(--border-base)" }} />
+
+            <Button
+              variant="ghost"
+              size="compact"
+              onClick={() => setShowTerms(true)}
+              fullWidth
+              className="text-body-small-default"
+              tintColor="var(--content-tertiary)"
+            >
+              View Terms and Conditions
+            </Button>
+          </div>
+        )}
+      </Modal.Body>
+    </Modal.Content>
+  );
+}
+
+function HowItWorksStep({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+        style={{
+          background: "var(--surface-base)",
+          color: "var(--content-secondary)",
+        }}
+      >
+        {icon}
+      </div>
+      <span
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function StatItem({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-body-medium-lighter">
+      <span style={{ color: "var(--content-tertiary)" }}>{icon}</span>
+      <span
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {value}
+      </span>
+      <span style={{ color: "var(--content-tertiary)" }}>{label}</span>
+    </div>
+  );
+}
+
+function TermsContent({ cap }: { cap: string }) {
+  const bullets = [
+    "This promotion is available to new users who sign up through your referral link only.",
+    "Rewards are earned once your invitee completes the creation of their Vellum account.",
+    `You may earn up to ${cap} free credits through the Referral Program. We may change this limit at any time.`,
+    "We do not grant credits for disposable or high-risk email accounts.",
+    "Each new user can generate only one (1) reward. No stacking or loophole hunting.",
+    "Please avoid spamming or misusing your referral link. Our systems actively monitor referral engagement.",
+    "If we detect suspicious or non-compliant activity, we reserve the right to withhold rewards or deactivate your referral link.",
+    "We may update, pause, or discontinue this program at any time.",
+  ];
+
+  return (
+    <ul className="!m-0 !list-none space-y-2 !p-0">
+      {bullets.map((text) => (
+        <li
+          key={text}
+          className="flex items-start gap-2 text-body-medium-lighter"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          <span aria-hidden="true" className="mt-0.5">
+            •
+          </span>
+          <span>{text}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/layout/root-layout.tsx
+++ b/apps/web/src/components/layout/root-layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router";
 
+import { useAppTheme } from "@/hooks/use-app-theme.js";
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useVisibleViewport } from "@/hooks/use-visible-viewport.js";
 
@@ -21,6 +22,7 @@ const KEYBOARD_OPEN_THRESHOLD_PX = 100;
  * - Visual Viewport API: https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
  */
 export function RootLayout() {
+  useAppTheme();
   const isMobile = useIsMobile();
   const visibleViewport = useVisibleViewport();
 

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,94 @@
+import { Heart, Monitor, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { cn, SegmentControl } from "@vellum/design-library";
+
+import { useAppFeatureFlags } from "@/lib/feature-flags/app.js";
+import {
+  applyThemePreference,
+  normalizeThemePreference,
+  readStoredThemePreference,
+  type ThemePreference,
+  writeStoredThemePreference,
+} from "@/domains/settings/utils/theme-preferences.js";
+
+const BASE_THEME_OPTIONS: ReadonlyArray<{
+  value: ThemePreference;
+  label: string;
+  Icon: typeof Monitor;
+}> = [
+  { value: "system", label: "System", Icon: Monitor },
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+];
+
+const VELVET_THEME_OPTION = {
+  value: "velvet",
+  label: "Velvet",
+  Icon: Heart,
+} satisfies {
+  value: ThemePreference;
+  label: string;
+  Icon: typeof Monitor;
+};
+
+export function ThemeToggle({ className }: { className?: string } = {}) {
+  const { velvet } = useAppFeatureFlags();
+  const [theme, setTheme] = useState<ThemePreference>(() =>
+    readStoredThemePreference({ velvetEnabled: velvet }),
+  );
+
+  useEffect(() => {
+    const handleExternalThemeChange = (event: CustomEvent<string>) => {
+      setTheme(
+        normalizeThemePreference(event.detail, { velvetEnabled: velvet }),
+      );
+    };
+    window.addEventListener(
+      "vellumThemeChange",
+      handleExternalThemeChange as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        "vellumThemeChange",
+        handleExternalThemeChange as EventListener,
+      );
+  }, [velvet]);
+
+  const handleChange = (next: ThemePreference) => {
+    setTheme(next);
+    writeStoredThemePreference(next);
+    applyThemePreference(next);
+  };
+
+  const themeOptions = velvet
+    ? [...BASE_THEME_OPTIONS, VELVET_THEME_OPTION]
+    : BASE_THEME_OPTIONS;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 px-4 py-2 max-md:py-3",
+        className,
+      )}
+    >
+      <span
+        className="text-body-small-default max-md:text-body-large-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Theme
+      </span>
+      <SegmentControl<ThemePreference>
+        ariaLabel="Theme"
+        value={theme}
+        onChange={handleChange}
+        iconOnly
+        items={themeOptions.map(({ value, label, Icon }) => ({
+          value,
+          label,
+          icon: <Icon className="h-3.5 w-3.5 max-md:h-4 max-md:w-4" />,
+        }))}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -1,13 +1,11 @@
 /**
  * Tests for `PreferencesMenu`.
  *
- * Verifies:
- *   - Renders nothing when not logged in
- *   - Renders a "Preferences" trigger when logged in
- *   - Desktop uses Popover surface, mobile uses BottomSheet
- *   - Admin row only appears for staff users
- *   - Credits row appears when billing summary has a balance
- *   - Earn credits row appears when referralCodes flag is enabled
+ * Uses `renderToStaticMarkup` (SSR) so only the trigger and top-level
+ * structure are exercisable — Radix Popover/BottomSheet content is not
+ * rendered when `open={false}`. Interactive content tests (menu items,
+ * admin visibility, credits row) would require a DOM environment with
+ * React Testing Library.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -97,32 +95,15 @@ describe("PreferencesMenu", () => {
     expect(html).toContain("Preferences");
   });
 
-  test("desktop render uses Popover (no BottomSheet)", () => {
+  test("desktop renders trigger (Popover surface)", () => {
     isMobileRef.value = false;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
     expect(html).toContain("Preferences");
-    // Popover trigger should be in the markup
-    expect(html).not.toBe("");
   });
 
-  test("mobile render uses BottomSheet", () => {
+  test("mobile renders trigger (BottomSheet surface)", () => {
     isMobileRef.value = true;
     const html = renderToStaticMarkup(createElement(PreferencesMenu));
     expect(html).toContain("Preferences");
-  });
-});
-
-describe("PreferencesMenuContent (via SSR)", () => {
-  test("renders standard menu items: Settings, Usage, Share Feedback, Log Out", () => {
-    const html = renderToStaticMarkup(createElement(PreferencesMenu));
-    // Menu content is inside Popover which is closed by default,
-    // so items won't appear in SSR. Only the trigger renders.
-    expect(html).toContain("Preferences");
-  });
-
-  test("does not render Admin row for non-staff users", () => {
-    authRef.user = { ...authRef.user, isStaff: false };
-    const html = renderToStaticMarkup(createElement(PreferencesMenu));
-    expect(html).not.toContain("Admin");
   });
 });

--- a/apps/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for `PreferencesMenu`.
+ *
+ * Verifies:
+ *   - Renders nothing when not logged in
+ *   - Renders a "Preferences" trigger when logged in
+ *   - Desktop uses Popover surface, mobile uses BottomSheet
+ *   - Admin row only appears for staff users
+ *   - Credits row appears when billing summary has a balance
+ *   - Earn credits row appears when referralCodes flag is enabled
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const isMobileRef = { value: false };
+
+mock.module("@/hooks/use-is-mobile.js", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const authRef = {
+  isLoggedIn: true,
+  user: { id: "u1", email: "user@example.com", isStaff: false, username: null, firstName: "", lastName: "" },
+  logout: async () => {},
+};
+
+mock.module("@/stores/auth-store.js", () => {
+  const store = () => null;
+  store.use = {
+    isLoggedIn: () => authRef.isLoggedIn,
+    user: () => authRef.user,
+    logout: () => authRef.logout,
+  };
+  store.getState = () => authRef;
+  return { useAuthStore: store };
+});
+
+const flagsRef = { referralCodes: false, referralCodesAdmin: false };
+
+mock.module("@/lib/feature-flags/app.js", () => ({
+  useAppFeatureFlags: () => flagsRef,
+}));
+
+const billingRef = { data: undefined as { effective_balance: string } | undefined };
+
+mock.module("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: billingRef.data, isLoading: false, isError: false }),
+}));
+
+mock.module("@/generated/api/@tanstack/react-query.gen.js", () => ({
+  organizationsBillingSummaryRetrieveOptions: () => ({
+    queryKey: [{ _id: "organizationsBillingSummaryRetrieve" }],
+  }),
+  referralCodesMeRetrieveOptions: () => ({
+    queryKey: [{ _id: "referralCodesMeRetrieve" }],
+  }),
+}));
+
+mock.module("react-router", () => ({
+  useNavigate: () => () => {},
+}));
+
+mock.module("@/components/share-feedback-modal.js", () => ({
+  ShareFeedbackModal: () => null,
+}));
+
+mock.module("@/components/earn-credits-modal.js", () => ({
+  EarnCreditsModal: () => null,
+}));
+
+mock.module("@/components/theme-toggle.js", () => ({
+  ThemeToggle: () => createElement("div", { "data-testid": "theme-toggle" }, "Theme"),
+}));
+
+import { PreferencesMenu } from "@/domains/chat/components/preferences-menu.js";
+
+beforeEach(() => {
+  isMobileRef.value = false;
+  authRef.isLoggedIn = true;
+  authRef.user = { id: "u1", email: "user@example.com", isStaff: false, username: null, firstName: "", lastName: "" };
+  flagsRef.referralCodes = false;
+  billingRef.data = undefined;
+});
+
+describe("PreferencesMenu", () => {
+  test("renders nothing when not logged in", () => {
+    authRef.isLoggedIn = false;
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    expect(html).toBe("");
+  });
+
+  test("renders a Preferences trigger when logged in", () => {
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    expect(html).toContain("Preferences");
+  });
+
+  test("desktop render uses Popover (no BottomSheet)", () => {
+    isMobileRef.value = false;
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    expect(html).toContain("Preferences");
+    // Popover trigger should be in the markup
+    expect(html).not.toBe("");
+  });
+
+  test("mobile render uses BottomSheet", () => {
+    isMobileRef.value = true;
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    expect(html).toContain("Preferences");
+  });
+});
+
+describe("PreferencesMenuContent (via SSR)", () => {
+  test("renders standard menu items: Settings, Usage, Share Feedback, Log Out", () => {
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    // Menu content is inside Popover which is closed by default,
+    // so items won't appear in SSR. Only the trigger renders.
+    expect(html).toContain("Preferences");
+  });
+
+  test("does not render Admin row for non-staff users", () => {
+    authRef.user = { ...authRef.user, isStaff: false };
+    const html = renderToStaticMarkup(createElement(PreferencesMenu));
+    expect(html).not.toContain("Admin");
+  });
+});

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -76,7 +76,6 @@ export function PreferencesMenu({
       label="Preferences"
       trailingIcon={isOpen ? ChevronDown : ChevronUp}
       active={isOpen}
-      onSelect={() => undefined}
     />
   );
 

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -1,0 +1,269 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChartColumn,
+  ChevronDown,
+  ChevronUp,
+  Gift,
+  LogOut,
+  MessageSquareText,
+  Settings as SettingsIcon,
+  Shield,
+  SlidersHorizontal,
+} from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  BottomSheet,
+  Button,
+  PanelItem,
+  Popover,
+  SideMenu,
+} from "@vellum/design-library";
+
+import { useIsMobile } from "@/hooks/use-is-mobile.js";
+import { useAppFeatureFlags } from "@/lib/feature-flags/app.js";
+import { useAuthStore } from "@/stores/auth-store.js";
+import { routes } from "@/utils/routes.js";
+import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen.js";
+import { ShareFeedbackModal } from "@/components/share-feedback-modal.js";
+import { EarnCreditsModal } from "@/components/earn-credits-modal.js";
+import { ThemeToggle } from "@/components/theme-toggle.js";
+
+/**
+ * Preferences menu rendered inside the assistant sidebar footer.
+ *
+ * Owns both its trigger (a `SideMenu.Item` labelled "Preferences") and
+ * its popover content. The trigger flips to its active state while the
+ * popover is open and its chevron swaps from Up → Down to signal the
+ * expansion direction (popover opens *above* the trigger since it's
+ * pinned to the bottom of the rail).
+ *
+ * Content mirrors `UserMenu`'s dropdown — Theme, Credits, Earn credits,
+ * Settings, Usage, Share Feedback, Admin, Log Out — but rendered
+ * with `PanelItem` for every row except the two custom ones (Theme
+ * toggle group + Credits / Add credits row). Those two have bespoke
+ * layout that doesn't map onto a generic icon + label + badge row.
+ *
+ * **Mobile parity**: when `useIsMobile()` is true, the same content is
+ * rendered inside a `BottomSheet` (Radix Dialog) so it slides up from the
+ * bottom edge full-width. Desktop keeps the existing `Popover` behavior.
+ */
+export interface PreferencesMenuProps {
+  assistantId?: string | null;
+  assistantVersion?: string | null;
+}
+
+export function PreferencesMenu({
+  assistantId,
+  assistantVersion,
+}: PreferencesMenuProps) {
+  const isLoggedIn = useAuthStore.use.isLoggedIn();
+  const isMobile = useIsMobile();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+  const [isEarnCreditsOpen, setIsEarnCreditsOpen] = useState(false);
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  const closeMenu = () => setIsOpen(false);
+
+  const trigger = (
+    <SideMenu.Item
+      icon={SlidersHorizontal}
+      label="Preferences"
+      trailingIcon={isOpen ? ChevronDown : ChevronUp}
+      active={isOpen}
+      onSelect={() => undefined}
+    />
+  );
+
+  const content = (
+    <PreferencesMenuContent
+      onClose={closeMenu}
+      onShareFeedback={() => setIsFeedbackOpen(true)}
+      onEarnCredits={() => setIsEarnCreditsOpen(true)}
+    />
+  );
+
+  return (
+    <>
+      {isMobile ? (
+        <BottomSheet.Root open={isOpen} onOpenChange={setIsOpen}>
+          <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
+          <BottomSheet.Content>
+            <BottomSheet.Header className="sr-only">
+              <BottomSheet.Title>Preferences</BottomSheet.Title>
+            </BottomSheet.Header>
+            <BottomSheet.Body className="pt-0">{content}</BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet.Root>
+      ) : (
+        <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
+          <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+          <Popover.Content
+            side="top"
+            align="start"
+            sideOffset={8}
+            className="w-64 rounded-lg p-4"
+          >
+            {content}
+          </Popover.Content>
+        </Popover.Root>
+      )}
+
+      <ShareFeedbackModal
+        open={isFeedbackOpen}
+        onClose={() => setIsFeedbackOpen(false)}
+        assistantId={assistantId}
+        assistantVersion={assistantVersion}
+      />
+
+      <EarnCreditsModal
+        open={isEarnCreditsOpen}
+        onClose={() => setIsEarnCreditsOpen(false)}
+      />
+    </>
+  );
+}
+
+interface PreferencesMenuContentProps {
+  onClose: () => void;
+  onShareFeedback: () => void;
+  onEarnCredits: () => void;
+}
+
+function PreferencesMenuContent({
+  onClose,
+  onShareFeedback,
+  onEarnCredits,
+}: PreferencesMenuContentProps) {
+  const navigate = useNavigate();
+  const user = useAuthStore.use.user();
+  const logout = useAuthStore.use.logout();
+  const { referralCodes } = useAppFeatureFlags();
+
+  const isAdmin = user?.isStaff ?? false;
+
+  const { data: billingSummary } = useQuery({
+    ...organizationsBillingSummaryRetrieveOptions(),
+  });
+  const effectiveBalance = billingSummary?.effective_balance ?? null;
+
+  return (
+    <>
+      <ThemeToggle className="px-2 pt-0" />
+
+      <MenuDivider />
+
+      {effectiveBalance !== null ? (
+        <>
+          <div className="flex items-center justify-between gap-3 py-2 pl-[8px]">
+            <span
+              className="text-body-medium-lighter"
+              style={{ color: "var(--content-default)" }}
+            >
+              {formatWholeCredits(effectiveBalance)} credits
+            </span>
+            <Button
+              variant="ghost"
+              size="compact"
+              onClick={() => {
+                onClose();
+                navigate(routes.settings.billing);
+              }}
+            >
+              Add credits
+            </Button>
+          </div>
+          <MenuDivider />
+        </>
+      ) : null}
+
+      {referralCodes ? (
+        <>
+          <PanelItem
+            icon={Gift}
+            label="Earn credits"
+            onSelect={() => {
+              onClose();
+              onEarnCredits();
+            }}
+          />
+          <MenuDivider />
+        </>
+      ) : null}
+
+      <PanelItem
+        icon={SettingsIcon}
+        label="Settings"
+        onSelect={() => {
+          onClose();
+          navigate(routes.settings.root);
+        }}
+      />
+
+      <PanelItem
+        icon={ChartColumn}
+        label="Usage"
+        onSelect={() => {
+          onClose();
+          navigate(routes.logs.usage);
+        }}
+      />
+
+      <PanelItem
+        icon={MessageSquareText}
+        label="Share Feedback"
+        onSelect={() => {
+          onClose();
+          onShareFeedback();
+        }}
+      />
+
+      {isAdmin ? (
+        <PanelItem
+          icon={Shield}
+          label="Admin"
+          onSelect={() => {
+            onClose();
+            navigate(routes.admin.root);
+          }}
+        />
+      ) : null}
+
+      <PanelItem
+        icon={LogOut}
+        label="Log Out"
+        onSelect={async () => {
+          await logout();
+          onClose();
+          navigate(routes.account.login);
+        }}
+      />
+    </>
+  );
+}
+
+function formatWholeCredits(value: string): string {
+  const num = parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return value;
+  }
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function MenuDivider() {
+  return (
+    <div
+      aria-hidden="true"
+      className="my-1 h-px"
+      style={{ background: "var(--border-overlay)" }}
+    />
+  );
+}

--- a/apps/web/src/hooks/use-app-theme.ts
+++ b/apps/web/src/hooks/use-app-theme.ts
@@ -1,0 +1,54 @@
+/**
+ * Applies the user's stored theme preference on mount and keeps
+ * the document in sync when the OS-level `prefers-color-scheme`
+ * changes.
+ *
+ * Call this once from the root layout so theme is applied before
+ * any child UI paints.
+ */
+import { useEffect } from "react";
+
+import { useAppFeatureFlags } from "@/lib/feature-flags/app.js";
+import {
+  applyThemePreference,
+  normalizeThemePreference,
+  THEME_STORAGE_KEY,
+  writeStoredThemePreference,
+} from "@/domains/settings/utils/theme-preferences.js";
+
+function readRawStoredTheme(): string | null {
+  try {
+    return window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function useAppTheme() {
+  const { velvet } = useAppFeatureFlags();
+
+  useEffect(() => {
+    const stored = readRawStoredTheme();
+    const theme = normalizeThemePreference(stored, {
+      velvetEnabled: velvet,
+    });
+
+    if (stored !== null && stored !== theme) {
+      writeStoredThemePreference(theme);
+    }
+    applyThemePreference(theme);
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleMediaChange = () => {
+      const next = normalizeThemePreference(readRawStoredTheme(), {
+        velvetEnabled: velvet,
+      });
+      if (next === "system") {
+        applyThemePreference(next);
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleMediaChange);
+    return () => mediaQuery.removeEventListener("change", handleMediaChange);
+  }, [velvet]);
+}


### PR DESCRIPTION
## Prompt / plan

Port `PreferencesMenu` and its dependencies from `vellum-assistant-platform` → `vellum-assistant` as part of the web app migration ([LUM-1669](https://linear.app/vellum/issue/LUM-1669)).

### What this ports

**PreferencesMenu** (`domains/chat/components/preferences-menu.tsx`) — sidebar footer menu with Theme toggle, Credits display, Settings/Usage/Share Feedback/Admin/Log Out actions. Desktop renders a Popover; mobile renders a BottomSheet.

**ThemeToggle** (`components/theme-toggle.tsx`) — compact theme switcher row (System/Light/Dark/Velvet) using SegmentControl with icon-only mode. Listens for external `vellumThemeChange` events for cross-component sync.

**EarnCreditsModal** (`components/earn-credits-modal.tsx`) — referral program modal showing invite link, copy-to-clipboard, how-it-works steps, stats, and terms. Gated behind `referralCodes` feature flag.

**useAppTheme** (`hooks/use-app-theme.ts`) — applies the stored theme preference on startup and tracks OS-level `prefers-color-scheme` changes. Ported from platform's `AppThemeManager` as a hook (renders no UI, only side effects). Fixes a pre-existing gap where theme reverted to OS default on page reload.

### Convention changes from platform source

- Removed `"use client"` directives (Vite SPA, not Next.js)
- `useRouter` from `next/navigation` → `useNavigate` from `react-router`
- `useAuth()` hook → `useAuthStore` Zustand store (`.use.isLoggedIn()`, `.use.user()`, `.use.logout()`)
- `isAdmin` → `user?.isStaff` (OSS auth store uses `isStaff` from Django allauth)
- `@/lib/routes` → `@/utils/routes.js`
- `@/clients/platform/@tanstack/react-query.gen` → `@/generated/api/@tanstack/react-query.gen.js`
- `@/components/app/core/*` → `@vellum/design-library` barrel import
- `@/lib/utils` (cn) → `@vellum/design-library` barrel import
- `@/lib/theme-preferences` → `@/domains/settings/utils/theme-preferences.js`
- All imports use `.js` extensions for NodeNext resolution
- `AppThemeManager` (null-rendering component) → `useAppTheme` hook (per convention: side-effect-only code should be a hook, not a component)
- Dropped no-op `onSelect={() => undefined}` on trigger (`SideMenu.Item.onSelect` is optional; `Popover.Trigger asChild` composes the click)

### File placement rationale

- `PreferencesMenu` → `domains/chat/components/` — consumed by the chat sidebar (`AssistantSideMenu` footer action)
- `ThemeToggle` → `components/` — cross-domain shared component (preferences menu + could be reused in settings)
- `EarnCreditsModal` → `components/` — cross-domain shared modal (triggered from menus, similar to `ShareFeedbackModal`)
- `useAppTheme` → `hooks/` — app-level hook called from `RootLayout`

### Dependencies (all pre-existing on main)

- `BottomSheet`, `Button`, `Input`, `Modal`, `PanelItem`, `Popover`, `SegmentControl`, `SideMenu`, `cn` — `@vellum/design-library`
- `useIsMobile` — `@/hooks/use-is-mobile.js`
- `useAuthStore` — `@/stores/auth-store.js`
- `useAppFeatureFlags` — `@/lib/feature-flags/app.js`
- `ShareFeedbackModal` — `@/components/share-feedback-modal.js`
- `routes` — `@/utils/routes.js`
- `theme-preferences` — `@/domains/settings/utils/theme-preferences.js`
- `organizationsBillingSummaryRetrieveOptions`, `referralCodesMeRetrieveOptions` — `@/generated/api/@tanstack/react-query.gen.js`

## Test plan

- ESLint: all files pass clean
- Tests: `bun test src/domains/chat/components/preferences-menu.test.tsx` — 4/4 pass
  - Renders nothing when not logged in
  - Renders Preferences trigger when logged in
  - Desktop renders trigger (Popover surface)
  - Mobile renders trigger (BottomSheet surface)
- Test limitations documented: SSR-only tests via `renderToStaticMarkup` cannot exercise Popover/BottomSheet content (Radix portals mount client-side). Interactive content tests would require a DOM environment.
- Verified all design library component APIs match (SideMenu.Item, SegmentControl.iconOnly, Modal compound components, Input.fullWidth/wrapperClassName)
- Not yet wired into the sidebar — this is an additive port; integration happens when AssistantSideMenu passes PreferencesMenu as its `footerAction`

Closes LUM-1669

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->