### PR TITLE
fix(daemon): scope native web-search metadata to Anthropic + plumb resolved query + forward error codes

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -163,6 +163,17 @@ export type AgentEvent =
       toolUseId: string;
       isError: boolean;
       content?: unknown[];
+      /**
+       * Finalized input for the server tool (e.g. the actual web-search
+       * query). Carried through so the daemon can populate accurate activity
+       * metadata; Anthropic streams server-tool input via deltas that aren't
+       * resolved at `server_tool_start` time.
+       */
+      resolvedInput?: Record<string, unknown>;
+      /** Provider-specific error code (e.g. `max_uses_exceeded`). */
+      errorCode?: string;
+      /** Optional human-readable error message from the provider. */
+      errorMessage?: string;
     }
   | { type: "error"; error: Error }
   | {
@@ -693,6 +704,13 @@ export class AgentLoop {
                   toolUseId: event.toolUseId,
                   isError: event.isError,
                   ...(event.content ? { content: event.content } : {}),
+                  ...(event.resolvedInput
+                    ? { resolvedInput: event.resolvedInput }
+                    : {}),
+                  ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+                  ...(event.errorMessage
+                    ? { errorMessage: event.errorMessage }
+                    : {}),
                 });
               }
             },

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -64,7 +64,7 @@ type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function createCollectorDeps(): {
+function createCollectorDeps(providerName = "anthropic"): {
   deps: EventHandlerDeps;
   events: ServerMessage[];
 } {
@@ -72,7 +72,7 @@ function createCollectorDeps(): {
   const deps = {
     ctx: {
       conversationId: "conv-native-meta",
-      provider: { name: "anthropic" },
+      provider: { name: providerName },
       traceEmitter: { emit: () => {} },
       streamThinking: false,
       emitActivityState: () => {},
@@ -152,6 +152,11 @@ describe("native server_tool_complete metadata", () => {
     expect(meta?.results[1]?.rank).toBe(2);
     expect(meta?.durationMs).toBeGreaterThanOrEqual(0);
 
+    // Favicons are synthesized from the result domain so clients can render
+    // a per-result icon without an extra round-trip.
+    expect(meta?.results[0]?.faviconUrl).toContain("google.com/s2/favicons");
+    expect(meta?.results[1]?.faviconUrl).toContain("google.com/s2/favicons");
+
     // Back-compat: result text must be byte-identical to the legacy format.
     expect(toolResultEvent?.result).toBe(
       "X\nhttps://www.cnn.com/a\n\nY\nhttps://www.nbcnews.com/b",
@@ -160,6 +165,166 @@ describe("native server_tool_complete metadata", () => {
     // Per-toolUseId scratch maps must be cleaned up after completion.
     expect(state.serverToolStartedAt.has(toolUseId)).toBe(false);
     expect(state.serverToolInputs.has(toolUseId)).toBe(false);
+  });
+
+  test("prefers `resolvedInput.query` over the input captured at server_tool_start", async () => {
+    // Mirrors the live Anthropic flow: server_tool_start fires with `input: {}`
+    // because the SDK streams server-tool input via `input_json_delta`, then
+    // the provider populates `resolvedInput` on `server_tool_complete` from
+    // the accumulated JSON. Without this plumb-through, `meta.query` is empty.
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "tu_resolved";
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId,
+      input: {},
+    });
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId,
+      isError: false,
+      resolvedInput: { query: "OpenAI Dev Day recap" },
+      content: [
+        {
+          type: "web_search_result",
+          title: "Recap",
+          url: "https://example.com/a",
+        },
+      ],
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent?.activityMetadata?.webSearch?.query).toBe(
+      "OpenAI Dev Day recap",
+    );
+  });
+
+  test("fires per-toolUseId for parallel server tool calls with independent queries and timings", async () => {
+    const { deps, events } = createCollectorDeps();
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId: "tu_a",
+      input: { query: "alpha" },
+    });
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId: "tu_b",
+      input: { query: "beta" },
+    });
+
+    // Hold long enough that the two completions can't share a duration.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId: "tu_a",
+      isError: false,
+      content: [
+        {
+          type: "web_search_result",
+          title: "A1",
+          url: "https://a.example.com/1",
+        },
+      ],
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId: "tu_b",
+      isError: false,
+      content: [
+        {
+          type: "web_search_result",
+          title: "B1",
+          url: "https://b.example.com/1",
+        },
+      ],
+    });
+
+    const toolResults = events.filter(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResults).toHaveLength(2);
+
+    const byId = new Map(
+      toolResults.map((r) => [r.toolUseId, r] as const),
+    );
+    expect(byId.get("tu_a")?.activityMetadata?.webSearch?.query).toBe("alpha");
+    expect(byId.get("tu_b")?.activityMetadata?.webSearch?.query).toBe("beta");
+
+    const durA = byId.get("tu_a")?.activityMetadata?.webSearch?.durationMs ?? 0;
+    const durB = byId.get("tu_b")?.activityMetadata?.webSearch?.durationMs ?? 0;
+    // Each duration is computed against its own startedAt — tu_b should run
+    // longer because we slept once more between its start and its complete.
+    expect(durB).toBeGreaterThanOrEqual(durA);
+  });
+
+  test("forwards provider error codes instead of generic 'Search failed'", async () => {
+    const { deps, events } = createCollectorDeps();
+    const toolUseId = "tu_err_code";
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId,
+      input: { query: "over the limit" },
+    });
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId,
+      isError: true,
+      errorCode: "max_uses_exceeded",
+      content: [],
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent?.activityMetadata?.webSearch?.errorMessage).toBe(
+      "max_uses_exceeded",
+    );
+  });
+
+  test("does NOT emit activityMetadata for non-Anthropic providers", async () => {
+    // OpenAI's responses provider shares `server_tool_start`/`server_tool_complete`
+    // for `web_search_call`, but its results live inside the assistant text
+    // stream — emitting "anthropic-native" metadata for an OpenAI search would
+    // mis-label the provider and ship an empty `results` array.
+    const { deps, events } = createCollectorDeps("openai");
+    const toolUseId = "tu_openai";
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_start",
+      name: "web_search",
+      toolUseId,
+      input: {},
+    });
+
+    await dispatchAgentEvent(state, deps, {
+      type: "server_tool_complete",
+      toolUseId,
+      isError: false,
+    });
+
+    const toolResultEvent = events.find(
+      (e): e is ToolResultEvent => e.type === "tool_result",
+    );
+    expect(toolResultEvent).toBeDefined();
+    expect(toolResultEvent?.activityMetadata).toBeUndefined();
+    // The back-compat `result: string` channel still fires (empty for OpenAI
+    // since the results are woven into the text stream, not structured).
+    expect(toolResultEvent?.result).toBe("");
   });
 
   test("sets errorMessage when the search errored", async () => {

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1334,7 +1334,11 @@ export async function dispatchAgentEvent(
           "Thinking",
         );
 
-        const inputForCall = state.serverToolInputs.get(event.toolUseId);
+        // Prefer `resolvedInput` (Anthropic's accumulated server-tool input,
+        // populated on content_block_stop) over the input captured at
+        // server_tool_start, which is `{}` on Anthropic until the deltas land.
+        const inputForCall =
+          event.resolvedInput ?? state.serverToolInputs.get(event.toolUseId);
         const query =
           typeof inputForCall?.query === "string" ? inputForCall.query : "";
         const startedAt =
@@ -1363,14 +1367,28 @@ export async function dispatchAgentEvent(
             };
           });
 
-        const metadata: WebSearchMetadata = {
-          query,
-          provider: "anthropic-native",
-          resultCount: results.length,
-          durationMs,
-          results,
-          ...(event.isError ? { errorMessage: "Search failed" } : {}),
-        };
+        // Only Anthropic produces structured `web_search_tool_result` blocks
+        // that map cleanly onto `WebSearchMetadata` (provider-tagged
+        // "anthropic-native"). Other providers (e.g. OpenAI's responses
+        // `web_search_call`) share this event channel but their results are
+        // woven into the text stream — emitting "anthropic-native" metadata
+        // for them would mis-label the provider and ship empty results.
+        const isAnthropicNative = deps.ctx.provider.name === "anthropic";
+
+        const errorMessage = event.isError
+          ? (event.errorMessage ?? event.errorCode ?? "Search failed")
+          : undefined;
+
+        const metadata: WebSearchMetadata | undefined = isAnthropicNative
+          ? {
+              query,
+              provider: "anthropic-native",
+              resultCount: results.length,
+              durationMs,
+              results,
+              ...(errorMessage ? { errorMessage } : {}),
+            }
+          : undefined;
 
         const resultText = results
           .map((r) => `${r.title}\n${r.url}`)
@@ -1383,7 +1401,7 @@ export async function dispatchAgentEvent(
           isError: event.isError,
           conversationId: deps.ctx.conversationId,
           toolUseId: event.toolUseId,
-          activityMetadata: { webSearch: metadata },
+          ...(metadata ? { activityMetadata: { webSearch: metadata } } : {}),
         });
         break;
       }

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1274,6 +1274,19 @@ export class AnthropicProvider implements Provider {
         let lastInputJsonEmitMs = 0;
         let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
 
+        // Anthropic streams `server_tool_use` block input via `input_json_delta`
+        // events (the block's own `input` field is `{}` at content_block_start).
+        // We accumulate the JSON separately from regular `tool_use` blocks so
+        // the daemon can read the resolved query when the paired
+        // `web_search_tool_result` arrives — without this, downstream activity
+        // metadata sees an empty query.
+        let currentServerToolUseId: string | undefined;
+        let accumulatedServerToolInputJson = "";
+        const resolvedServerToolInputs = new Map<
+          string,
+          Record<string, unknown>
+        >();
+
         stream.on("streamEvent", (event) => {
           // Reset the text sentinel buffer at each content-block boundary.
           // A new block starts fresh; at the end of a block, flush any
@@ -1300,6 +1313,8 @@ export class AnthropicProvider implements Provider {
             event.type === "content_block_start" &&
             event.content_block.type === "server_tool_use"
           ) {
+            currentServerToolUseId = event.content_block.id;
+            accumulatedServerToolInputJson = "";
             onEvent?.({
               type: "server_tool_start",
               name: event.content_block.name,
@@ -1315,11 +1330,21 @@ export class AnthropicProvider implements Provider {
           ) {
             const block = event.content_block as {
               tool_use_id: string;
-              content?: { type: "web_search_tool_result_error" } | unknown[];
+              content?:
+                | { type: "web_search_tool_result_error"; error_code?: string }
+                | unknown[];
             };
             const isError =
               !Array.isArray(block.content) &&
               block.content?.type === "web_search_tool_result_error";
+            const errorCode =
+              isError && !Array.isArray(block.content)
+                ? block.content?.error_code
+                : undefined;
+            const resolvedInput = resolvedServerToolInputs.get(
+              block.tool_use_id,
+            );
+            resolvedServerToolInputs.delete(block.tool_use_id);
             onEvent?.({
               type: "server_tool_complete",
               toolUseId: block.tool_use_id,
@@ -1327,6 +1352,8 @@ export class AnthropicProvider implements Provider {
               ...(Array.isArray(block.content)
                 ? { content: block.content }
                 : {}),
+              ...(resolvedInput ? { resolvedInput } : {}),
+              ...(errorCode ? { errorCode } : {}),
             });
           }
           if (event.type === "content_block_stop") {
@@ -1345,6 +1372,25 @@ export class AnthropicProvider implements Provider {
             currentStreamingToolName = undefined;
             currentStreamingToolUseId = undefined;
             accumulatedInputJson = "";
+            // Finalize the resolved input for a `server_tool_use` block (e.g.
+            // the actual web-search query) so the paired `web_search_tool_result`
+            // emits `server_tool_complete` with `resolvedInput` populated.
+            if (currentServerToolUseId && accumulatedServerToolInputJson) {
+              try {
+                const parsed = JSON.parse(accumulatedServerToolInputJson);
+                if (parsed && typeof parsed === "object") {
+                  resolvedServerToolInputs.set(
+                    currentServerToolUseId,
+                    parsed as Record<string, unknown>,
+                  );
+                }
+              } catch {
+                // Malformed partial JSON — drop silently; downstream falls
+                // back to whatever was captured at server_tool_start.
+              }
+            }
+            currentServerToolUseId = undefined;
+            accumulatedServerToolInputJson = "";
             // Flush residual text buffer unless it's exactly a sentinel.
             if (textBuffer.length > 0 && !isCompleteSentinel(textBuffer)) {
               onEvent?.({ type: "text_delta", text: textBuffer });
@@ -1354,6 +1400,13 @@ export class AnthropicProvider implements Provider {
         });
 
         stream.on("inputJson", (partialJson) => {
+          if (currentServerToolUseId) {
+            // Server-tool input (e.g. `web_search` query) — accumulate without
+            // emitting `input_json_delta`; the daemon only consumes the
+            // finalized value from `server_tool_complete.resolvedInput`.
+            accumulatedServerToolInputJson += partialJson;
+            return;
+          }
           if (!currentStreamingToolName) return;
           accumulatedInputJson += partialJson;
           const now = Date.now();

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -137,6 +137,22 @@ export type ProviderEvent =
       toolUseId: string;
       isError: boolean;
       content?: unknown[];
+      /**
+       * Finalized input for the server tool call (e.g. the actual query).
+       * Anthropic streams `server_tool_use` block input via `input_json_delta`
+       * events, so consumers reading the input at `server_tool_start` see `{}`.
+       * The provider accumulates the JSON and surfaces it here once the block
+       * stops, so downstream handlers can build accurate activity metadata.
+       */
+      resolvedInput?: Record<string, unknown>;
+      /**
+       * Provider-specific error code when `isError` is true (e.g. Anthropic's
+       * `max_uses_exceeded`, `query_too_long`). Surfaced so user-facing
+       * messages can be specific instead of a generic "Search failed".
+       */
+      errorCode?: string;
+      /** Optional human-readable error message from the provider. */
+      errorMessage?: string;
     };
 
 export interface SendMessageConfig {


### PR DESCRIPTION
## Summary
Addresses three gaps from the web-activity-ui-data.md plan self-review:
- Plumb the resolved query from server_tool_use input to server_tool_complete (Anthropic streaming was dropping input_json_delta for server tool blocks, leaving WebSearchMetadata.query empty in production)
- Gate the activityMetadata emission to Anthropic web_search only (OpenAI's web_search_call was being mis-labeled as anthropic-native)
- Forward specific error codes (max_uses_exceeded, query_too_long, etc) from web_search_tool_result_error instead of generic 'Search failed'
- Add multi-query parallel test + favicon assertion to the native metadata test

Part of plan: web-activity-ui-data.md (remediation 1/2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->