### PR TITLE
feat(web): port nudge sidebar entry components from platform (LUM-1664)

### DIFF
--- a/apps/web/src/domains/nudges/components/discord-nudge-sidebar-entry.tsx
+++ b/apps/web/src/domains/nudges/components/discord-nudge-sidebar-entry.tsx
@@ -1,0 +1,25 @@
+import { DiscordLogo } from "@/components/icons/discord-logo.js";
+import { NudgeSidebarEntry } from "@/domains/nudges/components/nudge-sidebar-entry.js";
+
+interface DiscordNudgeSidebarEntryProps {
+  onJoin: () => void;
+  onDismiss: () => void;
+}
+
+export function DiscordNudgeSidebarEntry({ onJoin, onDismiss }: DiscordNudgeSidebarEntryProps) {
+  return (
+    <NudgeSidebarEntry
+      title="Join our community"
+      description="Talk to the team — share feedback, request features, get answers faster."
+      ctaLabel="Join Discord"
+      ctaLeftIcon={
+        <DiscordLogo
+          size={16}
+          style={{ color: "currentColor" }}
+        />
+      }
+      onAction={onJoin}
+      onDismiss={onDismiss}
+    />
+  );
+}

--- a/apps/web/src/domains/nudges/components/github-nudge-sidebar-entry.tsx
+++ b/apps/web/src/domains/nudges/components/github-nudge-sidebar-entry.tsx
@@ -1,0 +1,21 @@
+import { Star } from "lucide-react";
+
+import { NudgeSidebarEntry } from "@/domains/nudges/components/nudge-sidebar-entry.js";
+
+interface GitHubNudgeSidebarEntryProps {
+  onStar: () => void;
+  onDismiss: () => void;
+}
+
+export function GitHubNudgeSidebarEntry({ onStar, onDismiss }: GitHubNudgeSidebarEntryProps) {
+  return (
+    <NudgeSidebarEntry
+      title="Star us on GitHub"
+      description="Vellum is open source — help us build it."
+      ctaLabel="Star on GitHub"
+      ctaLeftIcon={<Star />}
+      onAction={onStar}
+      onDismiss={onDismiss}
+    />
+  );
+}

--- a/apps/web/src/domains/nudges/components/ios-app-sidebar-entry.tsx
+++ b/apps/web/src/domains/nudges/components/ios-app-sidebar-entry.tsx
@@ -1,0 +1,21 @@
+import { Smartphone } from "lucide-react";
+
+import { NudgeSidebarEntry } from "@/domains/nudges/components/nudge-sidebar-entry.js";
+
+interface IOSAppSidebarEntryProps {
+  onDownload: () => void;
+  onDismiss: () => void;
+}
+
+export function IOSAppSidebarEntry({ onDownload, onDismiss }: IOSAppSidebarEntryProps) {
+  return (
+    <NudgeSidebarEntry
+      title="Get the iOS App"
+      description="Push notifications, biometric login, haptics & more."
+      ctaLabel="Download"
+      ctaLeftIcon={<Smartphone />}
+      onAction={onDownload}
+      onDismiss={onDismiss}
+    />
+  );
+}

--- a/apps/web/src/domains/nudges/components/macos-app-sidebar-entry.tsx
+++ b/apps/web/src/domains/nudges/components/macos-app-sidebar-entry.tsx
@@ -1,0 +1,21 @@
+import { Download } from "lucide-react";
+
+import { NudgeSidebarEntry } from "@/domains/nudges/components/nudge-sidebar-entry.js";
+
+interface MacOSAppSidebarEntryProps {
+  onDownload: () => void;
+  onDismiss: () => void;
+}
+
+export function MacOSAppSidebarEntry({ onDownload, onDismiss }: MacOSAppSidebarEntryProps) {
+  return (
+    <NudgeSidebarEntry
+      title="Get the macOS App"
+      description="Computer use, terminal access, native automation & more."
+      ctaLabel="Download"
+      ctaLeftIcon={<Download />}
+      onAction={onDownload}
+      onDismiss={onDismiss}
+    />
+  );
+}

--- a/apps/web/src/domains/nudges/components/nudge-sidebar-entry.tsx
+++ b/apps/web/src/domains/nudges/components/nudge-sidebar-entry.tsx
@@ -1,0 +1,82 @@
+/**
+ * Shared sidebar footer entry used by the iOS, macOS, Discord, and GitHub
+ * nudges. Each nudge supplies its own copy and CTA icon while the chrome
+ * — overlay surface, base border, dismiss affordance — is consistent.
+ */
+
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "@vellum/design-library";
+
+export interface NudgeSidebarEntryProps {
+  /** Single-line title (rendered with `text-body-small-default`). */
+  title: string;
+  /** Body description (rendered with `text-label-small-default`). */
+  description: string;
+  /** CTA button label. */
+  ctaLabel: string;
+  /** CTA button leading icon. */
+  ctaLeftIcon: ReactNode;
+  /** Fired when the user clicks the CTA. */
+  onAction: () => void;
+  /** Fired when the user dismisses the sidebar entry. */
+  onDismiss: () => void;
+}
+
+export function NudgeSidebarEntry({
+  title,
+  description,
+  ctaLabel,
+  ctaLeftIcon,
+  onAction,
+  onDismiss,
+}: NudgeSidebarEntryProps) {
+  return (
+    <div
+      className="group relative overflow-hidden rounded-lg border"
+      style={{
+        background: "var(--surface-overlay)",
+        borderColor: "var(--border-base)",
+        animation: "fadeInUp 0.25s ease-out both",
+      }}
+    >
+      <button
+        type="button"
+        className="absolute right-1.5 top-1.5 flex size-5 cursor-pointer items-center justify-center rounded-md transition-opacity hover:opacity-70"
+        style={{ color: "var(--content-tertiary)" }}
+        onClick={onDismiss}
+        aria-label="Dismiss"
+      >
+        <X size={12} aria-hidden />
+      </button>
+
+      <div className="flex flex-col gap-2.5 px-3 py-3">
+        <div>
+          <p
+            className="text-body-small-default leading-tight"
+            style={{ color: "var(--content-default)" }}
+          >
+            {title}
+          </p>
+          <p
+            className="text-label-small-default mt-1 leading-relaxed"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {description}
+          </p>
+        </div>
+
+        <Button
+          variant="primary"
+          size="compact"
+          fullWidth
+          leftIcon={ctaLeftIcon}
+          onClick={onAction}
+        >
+          {ctaLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,42 @@
 @import "tailwindcss";
 @import "@vellum/design-library/tokens.css";
 @source "../node_modules/@vellum/design-library/src/**/*.tsx";
+
+/* Functional keyframes — ported from platform appTheme.css */
+
+@keyframes indeterminate {
+  0% { width: 0%; margin-left: 0%; }
+  50% { width: 60%; margin-left: 20%; }
+  100% { width: 0%; margin-left: 100%; }
+}
+
+@keyframes fadeInUp {
+  0% { transform: translateY(16px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes typing-dot-pulse {
+  0%, 100% { opacity: 0.45; transform: scale(0.6); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+/* Avatar breathing — gentle scale pulse matching macOS
+   AnimatedAvatarView.swift startBreathing() (2s in, 2s out). */
+@keyframes avatar-breathe-kf {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+@keyframes avatar-morph-scale {
+  0%, 100% { transform: scale(1, 1); }
+  25% { transform: scale(1.02, 0.99); }
+  50% { transform: scale(0.99, 1.02); }
+  75% { transform: scale(1.01, 0.99); }
+}
+
+@keyframes avatar-morph-rotate {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(0.86deg); }
+  50% { transform: rotate(0deg); }
+  75% { transform: rotate(-0.86deg); }
+}


### PR DESCRIPTION
## Prompt / plan

Port the 5 nudge sidebar entry components from `vellum-assistant-platform` → `vellum-assistant` as part of the web app migration ([LUM-1664](https://linear.app/vellum/issue/LUM-1664)).

### What this ports

**NudgeSidebarEntry** (`domains/nudges/components/nudge-sidebar-entry.tsx`) — shared sidebar footer entry chrome: overlay surface, base border, dismiss affordance, and full-width primary CTA button. All concrete nudge entries compose this.

**MacOSAppSidebarEntry** — "Get the macOS App" with Download CTA.
**IOSAppSidebarEntry** — "Get the iOS App" with Download CTA.
**DiscordNudgeSidebarEntry** — "Join our community" with Join Discord CTA.
**GitHubNudgeSidebarEntry** — "Star us on GitHub" with Star on GitHub CTA.

### What was NOT ported (already exists)

The Linear issue mentioned `MacOSAppBanner` and `IOSAppBanner` as missing, but both already exist in the OSS repo at `domains/nudges/components/{macos-app-banner,ios-app-banner}.tsx`. No changes needed.

### Convention changes from platform source

- Removed `"use client"` directives (Vite SPA)
- `@/components/app/core/Button/Button` → `@vellum/design-library` barrel import
- `@/components/app/assistant/NudgeSidebarEntry/NudgeSidebarEntry` → `@/domains/nudges/components/nudge-sidebar-entry.js`
- `@/components/app/icons/discord-logo` → `@/components/icons/discord-logo.js`
- PascalCase directories → kebab-case files
- All imports use `.js` extensions (NodeNext resolution)

### Dependencies (all pre-existing on main)

- `Button` — `@vellum/design-library`
- `DiscordLogo` — `@/components/icons/discord-logo.js`
- `lucide-react` icons: `X`, `Download`, `Smartphone`, `Star`

### Consumption

These sidebar entries will be consumed by `AssistantSideMenu` (LUM-1663) via the `footerBanner` prop. They can be ported independently since they have no route or layout dependencies.

## Test plan

- ESLint: all 5 new files pass clean
- All dependencies verified to exist on main with matching prop signatures
- Pure presentational components with no side effects — no runtime testing needed beyond type/lint
- Will be integration-tested when wired into `AssistantSideMenu` (LUM-1663)

Closes LUM-1664

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->