### PR TITLE
fix(web): use --surface-hover token for menu and listbox elements

### DIFF
--- a/apps/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -181,7 +181,7 @@ export function SkillDetail({
                   key={entry.path}
                   type="button"
                   onClick={() => setSelectedPath(entry.path)}
-                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--ghost-hover)]"
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
                   style={{
                     color: isActive
                       ? "var(--primary-base)"

--- a/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skill-row.tsx
@@ -43,7 +43,7 @@ export function SkillRow({
         tabIndex={0}
         onClick={onSelect}
         onKeyDown={handleRowKeyDown}
-        className="flex cursor-pointer items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-[var(--ghost-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        className="flex cursor-pointer items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center text-2xl">
         {skill.emoji ?? "🧩"}

--- a/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/skills/skills-tab.tsx
@@ -460,7 +460,7 @@ function FilterDropdown({
           type="button"
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="inline-flex w-40 items-center justify-between gap-2 rounded-lg border bg-[var(--surface-active)] px-3 py-2 text-body-medium-lighter transition-colors hover:bg-[var(--ghost-hover)]"
+          className="inline-flex w-40 items-center justify-between gap-2 rounded-lg border bg-[var(--surface-active)] px-3 py-2 text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
           style={{
             borderColor: "var(--border-base)",
             color: "var(--content-default)",
@@ -541,7 +541,7 @@ function FilterGroup({
                 onClick={() => onSelect(option.value)}
                 role="option"
                 aria-selected={isSelected}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--ghost-hover)]"
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
                 style={{
                   color: isSelected
                     ? "var(--primary-base)"


### PR DESCRIPTION
## Prompt / plan

Follow-up from [#31271 review](https://github.com/vellum-ai/vellum-assistant/pull/31271#issuecomment-4328789880): several elements in the skills domain used `--ghost-hover`, which is semantically intended for ghost `Button` hover states only. Menus, list rows, card rows, and file tree entries should use `--surface-hover` per the design token conventions.

Four occurrences fixed across three files:
- `skills-tab.tsx:463` — filter dropdown trigger (`<button aria-haspopup="listbox">`)
- `skills-tab.tsx:544` — listbox option rows
- `skill-row.tsx:46` — skill card row (`<div role="button">`)
- `skill-detail.tsx:184` — file tree entry (`<button>`)

One usage intentionally left unchanged:
- `category-sidebar.tsx:80` — `<Button variant="ghost">` — this IS a ghost Button, so `--ghost-hover` is semantically correct.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- CI checks

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->