### PR TITLE
feat(web): replace library page stubs with real implementations

### DIFF
--- a/apps/web/src/domains/library/library-detail-page.tsx
+++ b/apps/web/src/domains/library/library-detail-page.tsx
@@ -1,13 +1,101 @@
-import { useParams } from "react-router";
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { openApp, shareApp } from "@/domains/chat/lib/apps.js";
+import { AppViewerContainer } from "@/domains/intelligence/components/apps/app-viewer-container.js";
+import { routes } from "@/utils/routes.js";
+
+interface LoadedApp {
+  appId: string;
+  dirName?: string;
+  name: string;
+  html: string;
+}
 
 export function LibraryDetailPage() {
   const { appId } = useParams<{ appId: string }>();
+  const { assistantId } = useAssistantContext();
+  const navigate = useNavigate();
+
+  const [app, setApp] = useState<LoadedApp | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSharing, setIsSharing] = useState(false);
+  const requestRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!assistantId || !appId) return;
+    requestRef.current = appId;
+    setApp(null);
+    setError(null);
+
+    openApp(assistantId, appId)
+      .then((result) => {
+        if (requestRef.current !== appId) return;
+        setApp({
+          appId: result.appId,
+          dirName: result.dirName,
+          name: result.name,
+          html: result.html,
+        });
+      })
+      .catch((err) => {
+        if (requestRef.current !== appId) return;
+        setError(err instanceof Error ? err.message : "Failed to open app");
+      });
+  }, [assistantId, appId]);
+
+  const handleClose = useCallback(() => {
+    void navigate(routes.library.root);
+  }, [navigate]);
+
+  const handleShare = useCallback(async () => {
+    if (!assistantId || !app || isSharing) return;
+    setIsSharing(true);
+    try {
+      await shareApp(assistantId, app.appId, app.name);
+    } finally {
+      setIsSharing(false);
+    }
+  }, [assistantId, app, isSharing]);
+
+  if (!assistantId || !appId) return null;
+
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+        <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+          {error}
+        </p>
+        <button
+          type="button"
+          onClick={handleClose}
+          className="text-body-medium-default text-[var(--primary-base)] underline"
+        >
+          Back to Library
+        </button>
+      </div>
+    );
+  }
+
+  if (!app) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+      </div>
+    );
+  }
+
   return (
-    <section>
-      <h2>Library item</h2>
-      <p>
-        Placeholder for library item <code>{appId}</code>.
-      </p>
-    </section>
+    <AppViewerContainer
+      appId={app.appId}
+      appName={app.name}
+      html={app.html}
+      assistantId={assistantId}
+      onClose={handleClose}
+      onShare={handleShare}
+      isSharing={isSharing}
+    />
   );
 }

--- a/apps/web/src/domains/library/library-detail-page.tsx
+++ b/apps/web/src/domains/library/library-detail-page.tsx
@@ -2,6 +2,8 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
+import { toast } from "@vellum/design-library";
+
 import { useAssistantContext } from "@/domains/chat/assistant-context.js";
 import { openApp, shareApp } from "@/domains/chat/lib/apps.js";
 import { AppViewerContainer } from "@/domains/intelligence/components/apps/app-viewer-container.js";
@@ -44,6 +46,10 @@ export function LibraryDetailPage() {
         if (requestRef.current !== appId) return;
         setError(err instanceof Error ? err.message : "Failed to open app");
       });
+
+    return () => {
+      requestRef.current = null;
+    };
   }, [assistantId, appId]);
 
   const handleClose = useCallback(() => {
@@ -55,6 +61,11 @@ export function LibraryDetailPage() {
     setIsSharing(true);
     try {
       await shareApp(assistantId, app.appId, app.name);
+      toast.success("App exported", { description: `${app.name}.vellum` });
+    } catch (err) {
+      toast.error("Failed to share app", {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
       setIsSharing(false);
     }

--- a/apps/web/src/domains/library/library-page.tsx
+++ b/apps/web/src/domains/library/library-page.tsx
@@ -10,12 +10,14 @@ export function LibraryPage() {
   const navigate = useNavigate();
 
   const handleNewConversation = useCallback(
-    (initialMessage?: string) => {
-      void navigate(
-        initialMessage
-          ? `${routes.assistant}?message=${encodeURIComponent(initialMessage)}`
-          : routes.assistant,
-      );
+    (_initialMessage?: string) => {
+      // TODO: initialMessage seeding requires cross-route state coordination
+      // (e.g. a Zustand store or sessionStorage handoff). The platform passes
+      // initialMessage directly via startNewConversation() in the same React
+      // tree, but here the library is a separate route. For now we just
+      // navigate to chat; the deploy-flow prompt handoff will come with the
+      // broader cross-route state work.
+      void navigate(routes.assistant);
     },
     [navigate],
   );

--- a/apps/web/src/domains/library/library-page.tsx
+++ b/apps/web/src/domains/library/library-page.tsx
@@ -1,8 +1,33 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { LibraryView } from "@/domains/intelligence/components/apps/library-view.js";
+import { routes } from "@/utils/routes.js";
+
 export function LibraryPage() {
+  const { assistantId } = useAssistantContext();
+  const navigate = useNavigate();
+
+  const handleNewConversation = useCallback(
+    (initialMessage?: string) => {
+      void navigate(
+        initialMessage
+          ? `${routes.assistant}?message=${encodeURIComponent(initialMessage)}`
+          : routes.assistant,
+      );
+    },
+    [navigate],
+  );
+
+  if (!assistantId) return null;
+
   return (
-    <section>
-      <h2>Library</h2>
-      <p>Placeholder route. Library listing lands with the platform/web code port.</p>
-    </section>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)]">
+      <LibraryView
+        assistantId={assistantId}
+        onNewConversation={handleNewConversation}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Prompt / plan

Replace the placeholder library pages with real implementations that wire the already-ported `LibraryView` and `AppViewerContainer` components (from [PR #31271](https://github.com/vellum-ai/vellum-assistant/pull/31271), LUM-1654).

**Why needed:** The library routes (`/assistant/library`, `/assistant/library/:appId`) currently render placeholder stubs with "Placeholder route" text. The actual components they need were ported in LUM-1654 but never wired into the route pages.

**What changed:**

- **`library-page.tsx`** — Renders `LibraryView` with `assistantId` from outlet context, wrapped in the same container styling the platform uses (rounded border, surface overlay background). Provides `onNewConversation` callback that navigates to the chat route.

- **`library-detail-page.tsx`** — Deep-link page for `/assistant/library/:appId`. Fetches the app via `openApp()` on mount, renders `AppViewerContainer` once loaded, with loading spinner and error states. Close navigates back to the library listing. Uses a request ref to handle concurrent/stale responses (same pattern as `use-app-viewer-actions.ts`).

**Why safe:** Additive change replacing inert placeholders. No route changes needed — `routes.tsx` already had both routes correctly wired. All optional callbacks (`onOpenDocument`, `onEditApp`) are omitted for now since they require cross-route state coordination that will come with further migration work. `LibraryView` handles these gracefully (conditionally hides buttons when callbacks aren't provided).

**Alternatives not taken:**
- Rendering `LibraryView` on the detail page with a pre-opened app: Rejected because the platform's `/library/:appId` route bypasses the listing entirely and goes straight to the app viewer via the `deepLinkAppId` flow. A dedicated detail page that loads the app directly is the faithful port of this behavior.
- Wiring `onEditApp` (which enters chat editing mode): Requires the chat page's editing state machine and conversation context. This is cross-route coordination that belongs in a future task, not this stub-replacement PR.

Closes LUM-1657

## Test plan

- `bunx tsc --noEmit` — passes (no type errors)
- `bun run lint` — passes
- `bun run build` — passes (production bundle succeeds)
- Routes unchanged in `routes.tsx` — already correctly wired at `/assistant/library` and `/assistant/library/:appId`
- Runtime testing requires the assistant daemon (not available on CI) — compile-time checks verify all imports resolve, types match, and components compose correctly

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->