### PR TITLE
Fix Slack threaded DM backfill scope

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -2236,6 +2236,66 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(backfillThreadMock).not.toHaveBeenCalled();
   });
 
+  test("threaded Slack DMs use thread backfill instead of whole-DM backfill", async () => {
+    const dmChannelId = "D0HTTPAPPTHREAD";
+    const threadTs = "1700000000.000100";
+    const inboundTs = "1700000000.000300";
+    seedHttpActiveMember(dmChannelId);
+    backfillDmMock.mockImplementation(async () => {
+      throw new Error("whole-DM backfill should not run for threaded DMs");
+    });
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: threadTs,
+        conversationId: dmChannelId,
+        text: "app DM thread root",
+        sender: { id: HTTP_SLACK_USER_ID, name: HTTP_SLACK_DISPLAY_NAME },
+      }),
+      makeBackfillMessage({
+        id: "1700000000.000200",
+        conversationId: dmChannelId,
+        text: "app DM thread context",
+        threadId: threadTs,
+        sender: { id: HTTP_SLACK_USER_ID, name: HTTP_SLACK_DISPLAY_NAME },
+      }),
+    ]);
+
+    const processMessage = async (
+      conversationId: string,
+      content: string,
+      _attachmentIds?: string[],
+      options?: SlackInboundProcessOptions,
+    ): Promise<{ messageId: string }> => ({
+      messageId: persistSlackInboundFromProcessMessage(
+        conversationId,
+        content,
+        options,
+      ),
+    });
+    setAdapterProcessMessage(processMessage);
+
+    const resp = await handleChannelInbound(
+      buildSlackDmRequest(dmChannelId, inboundTs, {
+        sourceMetadata: {
+          messageId: inboundTs,
+          threadId: threadTs,
+          chatType: "im",
+        },
+      }),
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    expect(resp.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(backfillDmMock).not.toHaveBeenCalled();
+    expect(backfillThreadMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
+    expect(calledChannel).toBe(dmChannelId);
+    expect(calledThread).toBe(threadTs);
+  });
+
   test("second thread reply within the TTL window can fetch a newer bounded gap", async () => {
     backfillThreadMock.mockImplementation(async () => [
       makeBackfillMessage({ id: "5678.0", text: "parent" }),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1075,13 +1075,16 @@ export async function handleChannelInbound({
         sourceChannel === "slack" && sourceMetadata?.slackBotMentioned === true;
 
       // ── DM cold-start backfill ──
-      // First time a Slack DM lands in a conversation that has fewer than
-      // SLACK_DM_BACKFILL_WARM_THRESHOLD stored slackMeta messages, fetch a
-      // window of recent history so the agent sees prior context. One-shot:
-      // once persistence warms up past the threshold, subsequent DMs no
-      // longer trigger backfill. Failures are non-fatal — the new message
-      // proceeds without backfilled history.
-      if (sourceChannel === "slack" && sourceChatType === "im") {
+      // First time a Slack DM without thread_ts lands in a conversation that
+      // has fewer than SLACK_DM_BACKFILL_WARM_THRESHOLD stored slackMeta
+      // messages, fetch a window of recent history so the agent sees prior
+      // context. Threaded Slack DMs use the thread gap/delta path below so
+      // separate app conversations do not pull unrelated whole-DM history.
+      if (
+        sourceChannel === "slack" &&
+        sourceChatType === "im" &&
+        !slackThreadTs
+      ) {
         // Exclude the just-arrived webhook message from the history window —
         // the normal inbound persistence path writes it separately, so
         // including it here would produce duplicate user turns. Only pass a
@@ -1102,16 +1105,17 @@ export async function handleChannelInbound({
       }
 
       // ── Thread gap/delta backfill ──
-      // When a Slack thread reply arrives, compare the stored thread state
-      // with the inbound message's ts and fetch only the bounded unseen
-      // window. Initial late-join turns hydrate the earliest thread messages
-      // plus a recent window adjacent to the inbound reply; later turns use
-      // a delta window after the latest stored thread ts and before the
-      // inbound ts. Awaited (mirrors the DM cold-start path above) so the
-      // agent loop dispatched immediately afterwards observes hydrated
-      // context. A late-join notice is added only to the current turn's
-      // runtime context, not persisted as durable Slack metadata. Failures
-      // are swallowed inside the helper so they never block dispatch.
+      // When a Slack thread reply arrives, including app/agent DMs that carry
+      // thread_ts, compare the stored thread state with the inbound message's
+      // ts and fetch only the bounded unseen window. Initial late-join turns
+      // hydrate the earliest thread messages plus a recent window adjacent to
+      // the inbound reply; later turns use a delta window after the latest
+      // stored thread ts and before the inbound ts. Awaited (mirrors the DM
+      // cold-start path above) so the agent loop dispatched immediately
+      // afterwards observes hydrated context. A late-join notice is added only
+      // to the current turn's runtime context, not persisted as durable Slack
+      // metadata. Failures are swallowed inside the helper so they never block
+      // dispatch.
       if (slackThreadTs) {
         const backfillResult = await triggerSlackThreadBackfillIfNeeded({
           conversationId: result.conversationId,


### PR DESCRIPTION
## Summary
- Skip legacy whole-DM cold-start backfill when Slack DMs include a thread timestamp.
- Route Slack app/agent DM conversations through the existing thread-scoped backfill path.
- Add a regression test that threaded DMs do not call whole-DM backfill.

## Original prompt
Slack app/agent DMs now expose separate conversation threads that map closely to Vellum Conversations, but the cold-start DM backfill was pulling unrelated history from the entire Slack DM channel. The requested change was to backfill assistant DM conversations by their Slack `thread_ts` instead of using whole-channel DM history, while preserving legacy unthreaded DM behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->