### PR TITLE
feat(assistant): wire `websiteUrl` through onboarding context pipeline

### DIFF
--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -65,6 +65,7 @@ export interface NormalizedOnboarding {
   googleConnected?: boolean;
   googleServices?: string[];
   cohort?: string;
+  websiteUrl?: string;
 }
 
 const SCOPE_SERVICE_MAP: Record<string, string> = {
@@ -105,5 +106,6 @@ export function normalizeOnboardingContext(
       ? deriveGoogleServices(ctx.googleScopes)
       : undefined,
     cohort: ctx.cohort,
+    websiteUrl: ctx.websiteUrl?.trim() || undefined,
   };
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -407,6 +407,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
       if (n.cohort) lines.push(`- Cohort: ${n.cohort}`);
+      if (n.websiteUrl) lines.push(`- Website URL: ${n.websiteUrl}`);
       if (n.googleConnected && n.googleServices?.length) {
         lines.push(
           `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1034,6 +1034,7 @@ export function persistOnboardingArtifacts(onboarding: {
   userName?: string;
   assistantName?: string;
   cohort?: string;
+  websiteUrl?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1112,6 +1113,7 @@ export async function handleSendMessage(
       googleConnected?: boolean;
       googleScopes?: string[];
       cohort?: string;
+      websiteUrl?: string;
     };
   };
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -7,4 +7,5 @@ export interface OnboardingContext {
   googleConnected?: boolean;
   googleScopes?: string[];
   cohort?: string;
+  websiteUrl?: string;
 }


### PR DESCRIPTION
## Summary
- Add websiteUrl optional field to OnboardingContext and NormalizedOnboarding interfaces
- Wire websiteUrl through normalization and into the system prompt First-Run User Context section
- Add websiteUrl to conversation-routes inline onboarding types

Part of plan: url-scrape-skip-path.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->