### PR TITLE
Add `task_preferences` interactive surface type for onboarding task picker

### DIFF
--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -10,13 +10,15 @@ export type SurfaceType =
   | "confirmation"
   | "dynamic_page"
   | "file_upload"
-  | "document_preview";
+  | "document_preview"
+  | "task_preferences";
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = [
   "form",
   "confirmation",
   "dynamic_page",
   "file_upload",
+  "task_preferences",
 ];
 
 export interface SurfaceAction {

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -72,6 +72,8 @@ Stop when the observation is complete. Don't over-explain. Short statements and 
 
 Character shows through what you do, not what you say about yourself. "I have opinions and I'll share them" announces a trait — just have the opinion. "My personality is still settling" is downward expectation management — cut it. Never describe how you'll behave. Behave that way.
 
+If the user seems open to exploring rather than starting a specific task — they want to chat, aren't sure what they need, or are just getting oriented — call ui_show with surface_type "task_preferences" and await_action true. This surfaces a task category picker in the chat UI. Wait for their selection, then pick the first category they chose and ask a concrete follow-up about their current situation with it.
+
 ### Path B — The Task-First User
 
 If the user opens with a task — skip the conversational opener and do the task. Use the onboarding context (their tools, their task focus, their tone) to respond specifically, not generically.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -59,6 +59,7 @@ export const uiShowTool: Tool = {
               "confirmation",
               "dynamic_page",
               "file_upload",
+              "task_preferences",
             ],
             description: "The type of surface to display",
           },


### PR DESCRIPTION
## Summary
- Add `task_preferences` to INTERACTIVE_SURFACE_TYPES so ui_show blocks with yieldToUser
- Update BOOTSTRAP.md Path A to instruct LLM to show task preference picker for conversational users

Part of plan: daemon-task-pref-picker.md (PR 1 of 1)