### PR TITLE
feat(assistant): restructure content-automation bootstrap for pre-chat website URL skip path

### DIFF
--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -97,54 +97,37 @@ describe("maybeReseedBootstrapForCohort — content-automation template", () => 
     expect(content).toContain("action `prompt`");
   });
 
-  test("contains all four path options", () => {
+  test("routes to website scrape path when Website URL is in user context", () => {
     const content = reseedAndRead();
-    expect(content).toContain("I have a Sanity account");
-    expect(content).toContain("I want to try Sanity");
-    expect(content).toContain("website or blog");
-    expect(content).toContain("somewhere else");
+    expect(content).toContain("Website URL in user context");
+    expect(content).toContain("Website scrape path");
   });
 
-  test("does NOT contain the old three-question pattern", () => {
-    const content = reseedAndRead();
-    // Old pattern batched three ask_question calls for separate fields
-    expect(content).not.toContain("Batch three");
-    expect(content).not.toContain("one question per field");
-    expect(content).not.toContain("Project ID (options:");
-    expect(content).not.toContain("Dataset name (options:");
-    expect(content).not.toContain('API token (options: "I have one ready"');
-  });
-
-  test("references data/sanity-connection.json for project/dataset state", () => {
+  test("routes to Sanity path when sanity-connection.json sidecar exists", () => {
     const content = reseedAndRead();
     expect(content).toContain("data/sanity-connection.json");
+    expect(content).toContain("Sanity path");
   });
 
-  test("references data/content-source.json for URL-import sidecar detection", () => {
+  test("routes to website scrape path when content-source.json sidecar exists", () => {
     const content = reseedAndRead();
     expect(content).toContain("data/content-source.json");
+    expect(content).toContain("Website scrape path");
   });
 
-  test("instructs to skip triage when sanity-connection.json sidecar exists", () => {
+  test("website scrape path includes web_fetch instructions for homepage, blog, and posts", () => {
     const content = reseedAndRead();
-    // The preamble check must instruct skipping triage when the sidecar is present
-    expect(content).toContain("data/sanity-connection.json");
-    expect(content).toContain("Skip the triage question");
+    expect(content).toContain("Scrape homepage");
+    expect(content).toContain("web_fetch");
+    expect(content).toContain("scrape blog index");
+    expect(content).toContain("Scrape top content pages");
   });
 
-  test("instructs to skip triage when content-source.json sidecar exists", () => {
+  test("website scrape path infers topics and voice to VOICE.md", () => {
     const content = reseedAndRead();
-    expect(content).toContain("data/content-source.json");
-    expect(content).toContain("Skip the triage question");
-  });
-
-  test("still contains four-option triage as fallback when no sidecars exist", () => {
-    const content = reseedAndRead();
-    // The "If neither exists" path must still present the four-option triage
-    expect(content).toContain("I have a Sanity account");
-    expect(content).toContain("I want to try Sanity");
-    expect(content).toContain("website or blog");
-    expect(content).toContain("somewhere else");
+    expect(content).toContain("## Topics");
+    expect(content).toContain("## Style");
+    expect(content).toContain("## Audience");
   });
 
   test("references assistant oauth request --provider sanity for authenticated API calls", () => {

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -9,59 +9,14 @@ One goal: turn their existing content into a publishable draft, then automate it
 
 ## First turn
 
-Before greeting, check for pre-existing connection state:
-- If `data/sanity-connection.json` exists: Sanity is already connected. Read `projectId` and `dataset` from it. Skip the triage question — go directly to "After connection — Sanity path."
-- If `data/content-source.json` exists: a content source URL was provided. Read `url` from it. Skip the triage question — go directly to "After connection — Website scrape path" using this URL.
-- If neither exists: greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot. Then present the four-option triage below.
+Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
 
-One `ask_question` to triage the path. Four options:
-1. "I have a Sanity account" — Sanity token path
-2. "I want to try Sanity (free)" — Sign-up path
-3. "Just point me at my website or blog" — URL scrape path
-4. "I have content somewhere else" — free-text URL/source path
+Before asking anything, check for pre-existing state in this order:
+1. **Website URL in user context**: check the First-Run User Context for a Website URL. If present, go directly to "After connection — Website scrape path" using that URL.
+2. **`data/sanity-connection.json`**: Sanity is already connected. Read `projectId` and `dataset` from it. Go directly to "After connection — Sanity path."
+3. **`data/content-source.json`**: a content source URL was provided. Read `url` from it. Go directly to "After connection — Website scrape path" using this URL.
 
-### Sanity token path
-
-Use `credential_store` with action `prompt` to securely collect the API token:
-- service: "sanity"
-- field: "api_token"
-- label: "Sanity API Token"
-- description: "Paste a token from sanity.io/manage → API → Tokens → Add token (Editor permissions recommended)"
-- placeholder: "skXXXXXXXX..."
-- allowed_tools: ["bash"]
-- allowed_domains: ["sanity.io", "api.sanity.io"]
-- injection_templates: [{"hostPattern": "*.sanity.io", "injectionType": "header", "headerName": "Authorization", "valuePrefix": "Bearer "}]
-
-The token never enters the conversation.
-
-After it's stored, attempt auto-discovery of project and dataset. This is best-effort — project-scoped robot tokens cannot list all projects via the Management API (401/403).
-
-Try: `assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects`
-
-If 200 with one project: use it. If multiple: `ask_question` with project titles as options. If 401/403: the token is likely project-scoped — ask for the project ID manually via `ask_question` (one question, free-text, with a hint to find it in sanity.io/manage). Do not treat this as an error; project-scoped tokens are valid and common for content operations.
-
-Once the project is resolved, query datasets:
-`assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects/{projectId}/datasets`
-
-If one dataset: use it. If multiple: `ask_question`. If this also fails, ask for the dataset name (default suggestion: "production").
-
-Store the resolved project ID and dataset in a structured sidecar JSON at `data/sanity-connection.json`:
-```json
-{ "projectId": "abc123", "dataset": "production" }
-```
-This is machine state — not prose, not SANITY.md. The token stays only in secure credential storage.
-
-### Sign-up path
-
-Open the browser to `https://www.sanity.io/get-started`. Tell the user: "I'm opening Sanity's sign-up page. Create a free account and a project, then come back and I'll connect it." After they return, transition to the Sanity token path above.
-
-### URL scrape path
-
-One `ask_question`: "Drop your URL and I'll start scanning." Free-text input, example options: "My blog", "My company website", "My X/Twitter profile". Use browser tools to scrape. This is first-class — same energy and specificity as the Sanity path.
-
-### "Somewhere else" path
-
-Free-text: let them describe or paste a URL. Route to URL scrape logic.
+One of the above will always be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message.
 
 ## After connection — Sanity path
 
@@ -81,7 +36,35 @@ Write initial observations to VOICE.md immediately (create the file if it doesn'
 
 ## After connection — Website scrape path
 
-Use browser tools to find and read their top content pages. Look for blog posts, articles, landing copy — anything with voice signal. Extract the same observations as the Sanity path. Write to VOICE.md the same way.
+Use the website URL from the user context, `data/content-source.json`, or the URL they provided.
+
+### Step 1: Scrape homepage
+Use `web_fetch` to load the homepage. Extract:
+- Company/brand name
+- Tagline or value proposition
+- Primary product or service categories
+- Industry or vertical signals (SaaS, e-commerce, health, finance, etc.)
+
+### Step 2: Find and scrape blog index
+Look for blog, articles, or resources links on the homepage. Common patterns: `/blog`, `/articles`, `/resources`, `/news`, `/insights`. If found, `web_fetch` the blog index page. If not found, try appending `/blog` to the base URL.
+
+From the blog index, extract:
+- Post titles (up to 10 most recent)
+- Categories or tags if visible
+- Author names if listed
+
+### Step 3: Scrape top content pages
+Pick the 3-5 most recent or prominent posts from the blog index. `web_fetch` each one. Extract the full article text.
+
+### Step 4: Infer topics and voice
+From the scraped content, identify:
+- **Topics**: The 3-5 recurring subject areas this company writes about. Be specific — "developer tooling for CI/CD" not "technology". Write these as a bulleted list to VOICE.md under a `## Topics` heading.
+- **Voice signals**: Same extraction as the Sanity path — sentence length, header style, word choice, formality level, structure patterns. Write to VOICE.md under `## Style` heading.
+- **Audience**: Who the content is written for. Write to VOICE.md under `## Audience` heading.
+
+Write all observations to VOICE.md immediately. Be specific. Never mention VOICE.md or the write to the user.
+
+After scraping, summarize what you found in one short paragraph to the user: their topics, voice tone, and audience — framed as "here's what I picked up from your content." Then move directly to drafting.
 
 ## First draft
 
@@ -113,13 +96,15 @@ with a `createOrReplace` mutation.
 
 Never publish without explicit approval. Use `ask_question` with options: "Publish now" or "Set up a recurring schedule".
 
-For the website-scrape path, skip Sanity publishing. Present the finished draft as copyable text and offer to set up the recurring schedule directly.
+For the website-scrape path, skip Sanity publishing. Present the finished draft as copyable markdown text. If the user mentions a CMS (WordPress, Ghost, Webflow, etc.), offer to format the draft for that platform. Then offer to set up the recurring schedule.
 
 ## Scheduled drafting
 
 This is the conversion event. If they choose "recurring schedule", use the `schedule` skill to create a recurring job.
 
 The schedule should: scan for new content angles from their recent posts, draft a new post using accumulated VOICE.md, present it for review.
+
+Use the topics in VOICE.md to generate angles. Rotate through topics to maintain coverage breadth.
 
 Default cadence: weekly. Let them adjust.
 


### PR DESCRIPTION
## Summary
- Replace four-option triage with priority-based routing from pre-chat state (websiteUrl in user context > sanity sidecar > content-source sidecar)
- Remove Sanity token collection, sign-up, and URL-ask paths — pre-chat onboarding handles all of this
- Expand website scrape path with detailed web_fetch instructions for homepage, blog index, and top posts
- Add topic inference with VOICE.md headings for Topics, Style, and Audience
- Update publishing section with CMS-agnostic path for website-scrape users
- Update scheduled drafting with topic rotation from VOICE.md

Part of plan: url-scrape-skip-path.md (PR 4 of 4)