### PR TITLE
Daemon-Driven Task Preference Picker

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1638,7 +1638,12 @@ export async function handleSurfaceAction(
   // One-shot interactive surfaces — auto-complete now that the message has
   // been accepted. Deferred until after rejection check so the surface stays
   // active and retryable if the queue was full.
-  const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload"];
+  const ONE_SHOT_SURFACE_TYPES = [
+    "form",
+    "confirmation",
+    "file_upload",
+    "task_preferences",
+  ];
   if (ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)) {
     broadcastMessage({
       type: "ui_surface_complete",

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -10,13 +10,15 @@ export type SurfaceType =
   | "confirmation"
   | "dynamic_page"
   | "file_upload"
-  | "document_preview";
+  | "document_preview"
+  | "task_preferences";
 
 export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = [
   "form",
   "confirmation",
   "dynamic_page",
   "file_upload",
+  "task_preferences",
 ];
 
 export interface SurfaceAction {

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -72,7 +72,7 @@ Stop when the observation is complete. Don't over-explain. Short statements and 
 
 Character shows through what you do, not what you say about yourself. "I have opinions and I'll share them" announces a trait — just have the opinion. "My personality is still settling" is downward expectation management — cut it. Never describe how you'll behave. Behave that way.
 
-If the user seems open to exploring rather than starting a specific task — they want to chat, aren't sure what they need, or are just getting oriented — call ui_show with surface_type "task_preferences" and await_action true. This surfaces a task category picker in the chat UI. Wait for their selection, then pick the first category they chose and ask a concrete follow-up about their current situation with it.
+If the user seems open to exploring rather than starting a specific task — they want to chat, aren't sure what they need, or are just getting oriented — and the onboarding context has no task preferences (empty or missing tasks list), call ui_show with surface_type "task_preferences" and await_action true. This surfaces a task category picker in the chat UI. Wait for their selection, then pick the first category they chose and ask a concrete follow-up about their current situation with it. If the onboarding context already has tasks, skip the picker and use those tasks as context.
 
 ### Path B — The Task-First User
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -72,6 +72,8 @@ Stop when the observation is complete. Don't over-explain. Short statements and 
 
 Character shows through what you do, not what you say about yourself. "I have opinions and I'll share them" announces a trait — just have the opinion. "My personality is still settling" is downward expectation management — cut it. Never describe how you'll behave. Behave that way.
 
+If the user seems open to exploring rather than starting a specific task — they want to chat, aren't sure what they need, or are just getting oriented — call ui_show with surface_type "task_preferences" and await_action true. This surfaces a task category picker in the chat UI. Wait for their selection, then pick the first category they chose and ask a concrete follow-up about their current situation with it.
+
 ### Path B — The Task-First User
 
 If the user opens with a task — skip the conversational opener and do the task. Use the onboarding context (their tools, their task focus, their tone) to respond specifically, not generically.

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -59,6 +59,7 @@ export const uiShowTool: Tool = {
               "confirmation",
               "dynamic_page",
               "file_upload",
+              "task_preferences",
             ],
             description: "The type of surface to display",
           },

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -36,7 +36,8 @@ export const uiShowTool: Tool = {
     '- list: { items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }\n' +
     "- confirmation: { message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }\n" +
     "- dynamic_page: { html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }\n" +
-    "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n\n" +
+    "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
+    "- task_preferences: {} (no data needed — categories are rendered client-side)\n\n" +
     "Proactively show a task_progress card before multi-step or long-running work (web searches, file operations, research). Show it before your first tool call, then update steps as work progresses.",
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,


### PR DESCRIPTION
## Summary
Add `task_preferences` as an interactive surface type so the `ui_show` tool can emit it with `yieldToUser: true`, and update BOOTSTRAP.md to instruct the LLM to call `ui_show` with this surface type when a user's first reply is conversational (Path A).

- Add `task_preferences` to `SurfaceType` union, `INTERACTIVE_SURFACE_TYPES`, and `ui_show` tool schema enum
- Add Path A instruction in BOOTSTRAP.md for conversational onboarding users

**Cross-repo plan:** Daemon changes only. Client-side support lives in a separate plan at `vellum-assistant-platform`.

## Self-review result
PASS — 4 review passes (external feedback, plan faithfulness, repo integration, slop audit) all passed. One automated reviewer concern about missing client-side support was triaged as expected per the cross-repo deploy order.

## PRs merged into feature branch
- #31286: Add `task_preferences` interactive surface type for onboarding task picker

Part of plan: daemon-task-pref-picker.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->