### PR TITLE
fix: add fallback URL prompt when no pre-chat state exists

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -16,7 +16,7 @@ Before asking anything, check for pre-existing state in this order:
 2. **`data/sanity-connection.json`**: Sanity is already connected. Read `projectId` and `dataset` from it. Go directly to "After connection — Sanity path."
 3. **`data/content-source.json`**: a content source URL was provided. Read `url` from it. Go directly to "After connection — Website scrape path" using this URL.
 
-One of the above will always be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message.
+One of the above will usually be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message. If none are found, ask for their website URL in one `ask_question` (free-text input).
 
 ## After connection — Sanity path
 


### PR DESCRIPTION
## Summary
Adds a one-line fallback to the content-automation bootstrap template: if no pre-chat state (websiteUrl, sanity sidecar, or content-source sidecar) is found, ask for the website URL directly. Prevents unpredictable LLM behavior in edge cases where pre-chat doesn't fire.

Part of plan: url-scrape-skip-path.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->