### PR TITLE
Wire websiteUrl through onboarding and restructure content-automation bootstrap for pre-chat routing

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it } from "bun:test";
 
 const tempDir = process.env.VELLUM_WORKSPACE_DIR!;
 
-const { isWakeUpGreeting, getCannedFirstGreeting, CANNED_FIRST_GREETING } =
-  await import("../daemon/first-greeting.js");
+const {
+  isWakeUpGreeting,
+  getCannedFirstGreeting,
+  buildScanFirstMessage,
+  CANNED_FIRST_GREETING,
+} = await import("../daemon/first-greeting.js");
 import type { OnboardingGreetingContext } from "../daemon/first-greeting.js";
 
 describe("first-greeting", () => {
@@ -267,6 +271,23 @@ describe("first-greeting", () => {
       });
       const unique = new Set(invites);
       expect(unique.size).toBe(tones.length);
+    });
+  });
+
+  describe("buildScanFirstMessage", () => {
+    it("website variant includes 'my website' and the URL", () => {
+      const msg = buildScanFirstMessage("https://acme.com", "website");
+      expect(msg).toContain("my website");
+      expect(msg).toContain("https://acme.com");
+    });
+
+    it("content-source variant includes 'content' and the URL", () => {
+      const msg = buildScanFirstMessage(
+        "https://blog.acme.com/post",
+        "content-source",
+      );
+      expect(msg).toContain("content");
+      expect(msg).toContain("https://blog.acme.com/post");
     });
   });
 

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -102,6 +102,16 @@ function resolveTone(raw?: string): Tone {
   return raw && VALID_TONES.has(raw) ? (raw as Tone) : "grounded";
 }
 
+export function buildScanFirstMessage(
+  url: string,
+  variant: "website" | "content-source",
+): string {
+  if (variant === "content-source") {
+    return `Here's a page with content I'd like you to look at: ${url}`;
+  }
+  return `Here's my website: ${url}`;
+}
+
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
   const name = ctx.userName?.trim();
   const assistant = ctx.assistantName?.trim();

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -97,54 +97,37 @@ describe("maybeReseedBootstrapForCohort — content-automation template", () => 
     expect(content).toContain("action `prompt`");
   });
 
-  test("contains all four path options", () => {
+  test("routes to website scrape path when Website URL is in user context", () => {
     const content = reseedAndRead();
-    expect(content).toContain("I have a Sanity account");
-    expect(content).toContain("I want to try Sanity");
-    expect(content).toContain("website or blog");
-    expect(content).toContain("somewhere else");
+    expect(content).toContain("Website URL in user context");
+    expect(content).toContain("Website scrape path");
   });
 
-  test("does NOT contain the old three-question pattern", () => {
-    const content = reseedAndRead();
-    // Old pattern batched three ask_question calls for separate fields
-    expect(content).not.toContain("Batch three");
-    expect(content).not.toContain("one question per field");
-    expect(content).not.toContain("Project ID (options:");
-    expect(content).not.toContain("Dataset name (options:");
-    expect(content).not.toContain('API token (options: "I have one ready"');
-  });
-
-  test("references data/sanity-connection.json for project/dataset state", () => {
+  test("routes to Sanity path when sanity-connection.json sidecar exists", () => {
     const content = reseedAndRead();
     expect(content).toContain("data/sanity-connection.json");
+    expect(content).toContain("Sanity path");
   });
 
-  test("references data/content-source.json for URL-import sidecar detection", () => {
+  test("routes to website scrape path when content-source.json sidecar exists", () => {
     const content = reseedAndRead();
     expect(content).toContain("data/content-source.json");
+    expect(content).toContain("Website scrape path");
   });
 
-  test("instructs to skip triage when sanity-connection.json sidecar exists", () => {
+  test("website scrape path includes web_fetch instructions for homepage, blog, and posts", () => {
     const content = reseedAndRead();
-    // The preamble check must instruct skipping triage when the sidecar is present
-    expect(content).toContain("data/sanity-connection.json");
-    expect(content).toContain("Skip the triage question");
+    expect(content).toContain("Scrape homepage");
+    expect(content).toContain("web_fetch");
+    expect(content).toContain("scrape blog index");
+    expect(content).toContain("Scrape top content pages");
   });
 
-  test("instructs to skip triage when content-source.json sidecar exists", () => {
+  test("website scrape path infers topics and voice to VOICE.md", () => {
     const content = reseedAndRead();
-    expect(content).toContain("data/content-source.json");
-    expect(content).toContain("Skip the triage question");
-  });
-
-  test("still contains four-option triage as fallback when no sidecars exist", () => {
-    const content = reseedAndRead();
-    // The "If neither exists" path must still present the four-option triage
-    expect(content).toContain("I have a Sanity account");
-    expect(content).toContain("I want to try Sanity");
-    expect(content).toContain("website or blog");
-    expect(content).toContain("somewhere else");
+    expect(content).toContain("## Topics");
+    expect(content).toContain("## Style");
+    expect(content).toContain("## Audience");
   });
 
   test("references assistant oauth request --provider sanity for authenticated API calls", () => {

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -65,6 +65,7 @@ export interface NormalizedOnboarding {
   googleConnected?: boolean;
   googleServices?: string[];
   cohort?: string;
+  websiteUrl?: string;
 }
 
 const SCOPE_SERVICE_MAP: Record<string, string> = {
@@ -105,5 +106,6 @@ export function normalizeOnboardingContext(
       ? deriveGoogleServices(ctx.googleScopes)
       : undefined,
     cohort: ctx.cohort,
+    websiteUrl: ctx.websiteUrl?.trim() || undefined,
   };
 }

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -106,6 +106,6 @@ export function normalizeOnboardingContext(
       ? deriveGoogleServices(ctx.googleScopes)
       : undefined,
     cohort: ctx.cohort,
-    websiteUrl: ctx.websiteUrl?.trim() || undefined,
+    websiteUrl: ctx.websiteUrl?.trim().replace(/[\r\n\t]/g, "") || undefined,
   };
 }

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -66,6 +66,7 @@ export interface NormalizedOnboarding {
   googleServices?: string[];
   cohort?: string;
   websiteUrl?: string;
+  contentSourceUrl?: string;
 }
 
 const SCOPE_SERVICE_MAP: Record<string, string> = {
@@ -109,6 +110,10 @@ export function normalizeOnboardingContext(
     websiteUrl:
       typeof ctx.websiteUrl === "string"
         ? ctx.websiteUrl.trim().replace(/[\r\n\t]/g, "") || undefined
+        : undefined,
+    contentSourceUrl:
+      typeof ctx.contentSourceUrl === "string"
+        ? ctx.contentSourceUrl.trim().replace(/[\r\n\t]/g, "") || undefined
         : undefined,
   };
 }

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -106,6 +106,9 @@ export function normalizeOnboardingContext(
       ? deriveGoogleServices(ctx.googleScopes)
       : undefined,
     cohort: ctx.cohort,
-    websiteUrl: ctx.websiteUrl?.trim().replace(/[\r\n\t]/g, "") || undefined,
+    websiteUrl:
+      typeof ctx.websiteUrl === "string"
+        ? ctx.websiteUrl.trim().replace(/[\r\n\t]/g, "") || undefined
+        : undefined,
   };
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -408,6 +408,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
       if (n.cohort) lines.push(`- Cohort: ${n.cohort}`);
       if (n.websiteUrl) lines.push(`- Website URL: ${n.websiteUrl}`);
+      if (n.contentSourceUrl)
+        lines.push(`- Content source URL: ${n.contentSourceUrl}`);
       if (n.googleConnected && n.googleServices?.length) {
         lines.push(
           `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -407,6 +407,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
         lines.push(`- Chosen assistant name: ${n.assistantName}`);
       if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
       if (n.cohort) lines.push(`- Cohort: ${n.cohort}`);
+      if (n.websiteUrl) lines.push(`- Website URL: ${n.websiteUrl}`);
       if (n.googleConnected && n.googleServices?.length) {
         lines.push(
           `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -16,7 +16,7 @@ Before asking anything, check for pre-existing state in this order:
 2. **`data/sanity-connection.json`**: Sanity is already connected. Read `projectId` and `dataset` from it. Go directly to "After connection — Sanity path."
 3. **`data/content-source.json`**: a content source URL was provided. Read `url` from it. Go directly to "After connection — Website scrape path" using this URL.
 
-One of the above will always be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message.
+One of the above will usually be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message. If none are found, ask for their website URL in one `ask_question` (free-text input).
 
 ## After connection — Sanity path
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -9,59 +9,14 @@ One goal: turn their existing content into a publishable draft, then automate it
 
 ## First turn
 
-Before greeting, check for pre-existing connection state:
-- If `data/sanity-connection.json` exists: Sanity is already connected. Read `projectId` and `dataset` from it. Skip the triage question — go directly to "After connection — Sanity path."
-- If `data/content-source.json` exists: a content source URL was provided. Read `url` from it. Skip the triage question — go directly to "After connection — Website scrape path" using this URL.
-- If neither exists: greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot. Then present the four-option triage below.
+Greet briefly — one sentence. Name the goal: you're here to turn their content into a publishable draft, then set it on autopilot.
 
-One `ask_question` to triage the path. Four options:
-1. "I have a Sanity account" — Sanity token path
-2. "I want to try Sanity (free)" — Sign-up path
-3. "Just point me at my website or blog" — URL scrape path
-4. "I have content somewhere else" — free-text URL/source path
+Before asking anything, check for pre-existing state in this order:
+1. **Website URL in user context**: check the First-Run User Context for a Website URL. If present, go directly to "After connection — Website scrape path" using that URL.
+2. **`data/sanity-connection.json`**: Sanity is already connected. Read `projectId` and `dataset` from it. Go directly to "After connection — Sanity path."
+3. **`data/content-source.json`**: a content source URL was provided. Read `url` from it. Go directly to "After connection — Website scrape path" using this URL.
 
-### Sanity token path
-
-Use `credential_store` with action `prompt` to securely collect the API token:
-- service: "sanity"
-- field: "api_token"
-- label: "Sanity API Token"
-- description: "Paste a token from sanity.io/manage → API → Tokens → Add token (Editor permissions recommended)"
-- placeholder: "skXXXXXXXX..."
-- allowed_tools: ["bash"]
-- allowed_domains: ["sanity.io", "api.sanity.io"]
-- injection_templates: [{"hostPattern": "*.sanity.io", "injectionType": "header", "headerName": "Authorization", "valuePrefix": "Bearer "}]
-
-The token never enters the conversation.
-
-After it's stored, attempt auto-discovery of project and dataset. This is best-effort — project-scoped robot tokens cannot list all projects via the Management API (401/403).
-
-Try: `assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects`
-
-If 200 with one project: use it. If multiple: `ask_question` with project titles as options. If 401/403: the token is likely project-scoped — ask for the project ID manually via `ask_question` (one question, free-text, with a hint to find it in sanity.io/manage). Do not treat this as an error; project-scoped tokens are valid and common for content operations.
-
-Once the project is resolved, query datasets:
-`assistant oauth request --provider sanity https://api.sanity.io/v2021-06-07/projects/{projectId}/datasets`
-
-If one dataset: use it. If multiple: `ask_question`. If this also fails, ask for the dataset name (default suggestion: "production").
-
-Store the resolved project ID and dataset in a structured sidecar JSON at `data/sanity-connection.json`:
-```json
-{ "projectId": "abc123", "dataset": "production" }
-```
-This is machine state — not prose, not SANITY.md. The token stays only in secure credential storage.
-
-### Sign-up path
-
-Open the browser to `https://www.sanity.io/get-started`. Tell the user: "I'm opening Sanity's sign-up page. Create a free account and a project, then come back and I'll connect it." After they return, transition to the Sanity token path above.
-
-### URL scrape path
-
-One `ask_question`: "Drop your URL and I'll start scanning." Free-text input, example options: "My blog", "My company website", "My X/Twitter profile". Use browser tools to scrape. This is first-class — same energy and specificity as the Sanity path.
-
-### "Somewhere else" path
-
-Free-text: let them describe or paste a URL. Route to URL scrape logic.
+One of the above will always be present — the pre-chat onboarding flow collects either a Sanity connection or a website URL before the first message.
 
 ## After connection — Sanity path
 
@@ -81,7 +36,35 @@ Write initial observations to VOICE.md immediately (create the file if it doesn'
 
 ## After connection — Website scrape path
 
-Use browser tools to find and read their top content pages. Look for blog posts, articles, landing copy — anything with voice signal. Extract the same observations as the Sanity path. Write to VOICE.md the same way.
+Use the website URL from the user context, `data/content-source.json`, or the URL they provided.
+
+### Step 1: Scrape homepage
+Use `web_fetch` to load the homepage. Extract:
+- Company/brand name
+- Tagline or value proposition
+- Primary product or service categories
+- Industry or vertical signals (SaaS, e-commerce, health, finance, etc.)
+
+### Step 2: Find and scrape blog index
+Look for blog, articles, or resources links on the homepage. Common patterns: `/blog`, `/articles`, `/resources`, `/news`, `/insights`. If found, `web_fetch` the blog index page. If not found, try appending `/blog` to the base URL.
+
+From the blog index, extract:
+- Post titles (up to 10 most recent)
+- Categories or tags if visible
+- Author names if listed
+
+### Step 3: Scrape top content pages
+Pick the 3-5 most recent or prominent posts from the blog index. `web_fetch` each one. Extract the full article text.
+
+### Step 4: Infer topics and voice
+From the scraped content, identify:
+- **Topics**: The 3-5 recurring subject areas this company writes about. Be specific — "developer tooling for CI/CD" not "technology". Write these as a bulleted list to VOICE.md under a `## Topics` heading.
+- **Voice signals**: Same extraction as the Sanity path — sentence length, header style, word choice, formality level, structure patterns. Write to VOICE.md under `## Style` heading.
+- **Audience**: Who the content is written for. Write to VOICE.md under `## Audience` heading.
+
+Write all observations to VOICE.md immediately. Be specific. Never mention VOICE.md or the write to the user.
+
+After scraping, summarize what you found in one short paragraph to the user: their topics, voice tone, and audience — framed as "here's what I picked up from your content." Then move directly to drafting.
 
 ## First draft
 
@@ -113,13 +96,15 @@ with a `createOrReplace` mutation.
 
 Never publish without explicit approval. Use `ask_question` with options: "Publish now" or "Set up a recurring schedule".
 
-For the website-scrape path, skip Sanity publishing. Present the finished draft as copyable text and offer to set up the recurring schedule directly.
+For the website-scrape path, skip Sanity publishing. Present the finished draft as copyable markdown text. If the user mentions a CMS (WordPress, Ghost, Webflow, etc.), offer to format the draft for that platform. Then offer to set up the recurring schedule.
 
 ## Scheduled drafting
 
 This is the conversion event. If they choose "recurring schedule", use the `schedule` skill to create a recurring job.
 
 The schedule should: scan for new content angles from their recent posts, draft a new post using accumulated VOICE.md, present it for review.
+
+Use the topics in VOICE.md to generate angles. Rotate through topics to maintain coverage breadth.
 
 Default cadence: weekly. Let them adjust.
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1036,6 +1036,7 @@ export function persistOnboardingArtifacts(onboarding: {
   assistantName?: string;
   cohort?: string;
   websiteUrl?: string;
+  contentSourceUrl?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1452,9 +1453,11 @@ export async function handleSendMessage(
   // first message is the macOS wake-up greeting, bypass the canned
   // greeting and rewrite the user message to a scan instruction so real
   // LLM inference runs against the URL.
-  const scanUrl =
-    body.onboarding?.websiteUrl?.trim() ||
-    body.onboarding?.contentSourceUrl?.trim();
+  const sanitizeUrl = (u?: string) =>
+    u?.trim().replace(/[\r\n\t]/g, "") || undefined;
+  const websiteUrl = sanitizeUrl(body.onboarding?.websiteUrl);
+  const contentSourceUrl = sanitizeUrl(body.onboarding?.contentSourceUrl);
+  const scanUrl = websiteUrl || contentSourceUrl;
   const isWakeUp = isWakeUpGreeting(
     trimmedContent,
     conversation.getMessages().length,
@@ -1463,9 +1466,9 @@ export async function handleSendMessage(
 
   let effectiveContent: string | undefined;
   if (isScanPath) {
-    const scanVariant = body.onboarding?.contentSourceUrl
-      ? ("content-source" as const)
-      : ("website" as const);
+    const scanVariant = websiteUrl
+      ? ("website" as const)
+      : ("content-source" as const);
     effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
     // Fall through to normal inference path below
   } else if (isWakeUp) {
@@ -1592,6 +1595,11 @@ export async function handleSendMessage(
     }
   }
 
+  // When the scan path rewrote the first message, prefer the rewritten
+  // content for all downstream consumers (guardian reply, enqueue, agent
+  // loop) so they see the scan instruction rather than the wake-up greeting.
+  const contentAfterScan = effectiveContent ?? content ?? "";
+
   const attachments = hasAttachments
     ? smDeps.resolveAttachments(attachmentIds)
     : [];
@@ -1611,7 +1619,7 @@ export async function handleSendMessage(
       conversationId: mapping.conversationId,
       sourceChannel,
       sourceInterface,
-      content: content ?? "",
+      content: contentAfterScan,
       attachments,
       conversation,
       onEvent: broadcastMessage,
@@ -1645,7 +1653,7 @@ export async function handleSendMessage(
     // Queue the message so it's processed when the current turn completes
     const requestId = crypto.randomUUID();
     const enqueueResult = conversation.enqueueMessage(
-      content ?? "",
+      contentAfterScan,
       attachments,
       broadcastMessage,
       requestId,
@@ -1764,9 +1772,9 @@ export async function handleSendMessage(
   await conversation.ensureActorScopedHistory();
 
   // Resolve slash commands before persisting or running the agent loop.
-  // When the scan path rewrote the first message, use the rewritten content
-  // so the persisted user message and agent loop see the scan instruction.
-  const rawContent = effectiveContent ?? content ?? "";
+  // `contentAfterScan` already carries the scan-rewritten content when
+  // applicable; reuse it here for consistency.
+  const rawContent = contentAfterScan;
   const slashContext = buildSlashContextForContent(rawContent, {
     conversationId: mapping.conversationId,
     messageCount: conversation.getMessages().length,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -34,6 +34,7 @@ import {
 import { getOrCreateConversation as getOrCreateConversationInstance } from "../../daemon/conversation-store.js";
 import { canonicalizeTimeZone } from "../../daemon/date-context.js";
 import {
+  buildScanFirstMessage,
   getCannedFirstGreeting,
   isWakeUpGreeting,
 } from "../../daemon/first-greeting.js";
@@ -1114,6 +1115,7 @@ export async function handleSendMessage(
       googleScopes?: string[];
       cohort?: string;
       websiteUrl?: string;
+      contentSourceUrl?: string;
     };
   };
 
@@ -1445,12 +1447,28 @@ export async function handleSendMessage(
     );
   }
 
-  // ── Canned first-greeting fast path ──
-  // On a completely fresh workspace, skip LLM inference for the macOS
-  // wake-up greeting and return a pre-written response. When onboarding
-  // context is present the greeting is personalized using the selections;
-  // otherwise a generic greeting is served. Both paths are instant.
-  if (isWakeUpGreeting(trimmedContent, conversation.getMessages().length)) {
+  // ── URL scan path: rewrite first message for scan onboarding ──
+  // When onboarding provides a websiteUrl or contentSourceUrl and the
+  // first message is the macOS wake-up greeting, bypass the canned
+  // greeting and rewrite the user message to a scan instruction so real
+  // LLM inference runs against the URL.
+  const scanUrl =
+    body.onboarding?.websiteUrl?.trim() ||
+    body.onboarding?.contentSourceUrl?.trim();
+  const isWakeUp = isWakeUpGreeting(
+    trimmedContent,
+    conversation.getMessages().length,
+  );
+  const isScanPath = !!scanUrl && isWakeUp;
+
+  let effectiveContent: string | undefined;
+  if (isScanPath) {
+    const scanVariant = body.onboarding?.contentSourceUrl
+      ? ("content-source" as const)
+      : ("website" as const);
+    effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
+    // Fall through to normal inference path below
+  } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 
     conversation.processing = true;
@@ -1746,7 +1764,9 @@ export async function handleSendMessage(
   await conversation.ensureActorScopedHistory();
 
   // Resolve slash commands before persisting or running the agent loop.
-  const rawContent = content ?? "";
+  // When the scan path rewrote the first message, use the rewritten content
+  // so the persisted user message and agent loop see the scan instruction.
+  const rawContent = effectiveContent ?? content ?? "";
   const slashContext = buildSlashContextForContent(rawContent, {
     conversationId: mapping.conversationId,
     messageCount: conversation.getMessages().length,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1034,6 +1034,7 @@ export function persistOnboardingArtifacts(onboarding: {
   userName?: string;
   assistantName?: string;
   cohort?: string;
+  websiteUrl?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
 
@@ -1112,6 +1113,7 @@ export async function handleSendMessage(
       googleConnected?: boolean;
       googleScopes?: string[];
       cohort?: string;
+      websiteUrl?: string;
     };
   };
 

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -8,4 +8,5 @@ export interface OnboardingContext {
   googleScopes?: string[];
   cohort?: string;
   websiteUrl?: string;
+  contentSourceUrl?: string;
 }

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -7,4 +7,5 @@ export interface OnboardingContext {
   googleConnected?: boolean;
   googleScopes?: string[];
   cohort?: string;
+  websiteUrl?: string;
 }


### PR DESCRIPTION
## Summary
- Wire `websiteUrl` through daemon onboarding pipeline (types, normalization, system prompt, conversation routes)
- Restructure content-automation bootstrap template to use pre-chat state routing instead of in-chat four-option triage
- Expand website scrape path with detailed `web_fetch` instructions for homepage, blog index, and top posts
- Add topic/voice/audience inference written to VOICE.md under separate headings
- Update publishing section with CMS-agnostic path for website-scrape users
- Add graceful fallback when no pre-chat state exists

## Self-review result
GAPS FOUND — 1 gap fixed in 1 fix PR (missing fallback when no pre-chat state exists)

## PRs merged into feature branch
- #31279: feat(assistant): wire `websiteUrl` through onboarding context pipeline
- #31287: feat(assistant): restructure content-automation bootstrap for pre-chat website URL skip path

### Fix PRs
- #31290: fix: add fallback URL prompt when no pre-chat state exists

Part of plan: url-scrape-skip-path.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->