### PR TITLE
[JARVIS-907] feat(daemon): rewrite first message to URL scan instruction when onboarding provides a URL

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it } from "bun:test";
 
 const tempDir = process.env.VELLUM_WORKSPACE_DIR!;
 
-const { isWakeUpGreeting, getCannedFirstGreeting, CANNED_FIRST_GREETING } =
-  await import("../daemon/first-greeting.js");
+const {
+  isWakeUpGreeting,
+  getCannedFirstGreeting,
+  buildScanFirstMessage,
+  CANNED_FIRST_GREETING,
+} = await import("../daemon/first-greeting.js");
 import type { OnboardingGreetingContext } from "../daemon/first-greeting.js";
 
 describe("first-greeting", () => {
@@ -267,6 +271,23 @@ describe("first-greeting", () => {
       });
       const unique = new Set(invites);
       expect(unique.size).toBe(tones.length);
+    });
+  });
+
+  describe("buildScanFirstMessage", () => {
+    it("website variant includes 'my website' and the URL", () => {
+      const msg = buildScanFirstMessage("https://acme.com", "website");
+      expect(msg).toContain("my website");
+      expect(msg).toContain("https://acme.com");
+    });
+
+    it("content-source variant includes 'content' and the URL", () => {
+      const msg = buildScanFirstMessage(
+        "https://blog.acme.com/post",
+        "content-source",
+      );
+      expect(msg).toContain("content");
+      expect(msg).toContain("https://blog.acme.com/post");
     });
   });
 

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -102,6 +102,16 @@ function resolveTone(raw?: string): Tone {
   return raw && VALID_TONES.has(raw) ? (raw as Tone) : "grounded";
 }
 
+export function buildScanFirstMessage(
+  url: string,
+  variant: "website" | "content-source",
+): string {
+  if (variant === "content-source") {
+    return `Here's a page with content I'd like you to look at: ${url}`;
+  }
+  return `Here's my website: ${url}`;
+}
+
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
   const name = ctx.userName?.trim();
   const assistant = ctx.assistantName?.trim();

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -34,6 +34,7 @@ import {
 import { getOrCreateConversation as getOrCreateConversationInstance } from "../../daemon/conversation-store.js";
 import { canonicalizeTimeZone } from "../../daemon/date-context.js";
 import {
+  buildScanFirstMessage,
   getCannedFirstGreeting,
   isWakeUpGreeting,
 } from "../../daemon/first-greeting.js";
@@ -1114,6 +1115,7 @@ export async function handleSendMessage(
       googleScopes?: string[];
       cohort?: string;
       websiteUrl?: string;
+      contentSourceUrl?: string;
     };
   };
 
@@ -1445,12 +1447,28 @@ export async function handleSendMessage(
     );
   }
 
-  // ── Canned first-greeting fast path ──
-  // On a completely fresh workspace, skip LLM inference for the macOS
-  // wake-up greeting and return a pre-written response. When onboarding
-  // context is present the greeting is personalized using the selections;
-  // otherwise a generic greeting is served. Both paths are instant.
-  if (isWakeUpGreeting(trimmedContent, conversation.getMessages().length)) {
+  // ── URL scan path: rewrite first message for scan onboarding ──
+  // When onboarding provides a websiteUrl or contentSourceUrl and the
+  // first message is the macOS wake-up greeting, bypass the canned
+  // greeting and rewrite the user message to a scan instruction so real
+  // LLM inference runs against the URL.
+  const scanUrl =
+    body.onboarding?.websiteUrl?.trim() ||
+    body.onboarding?.contentSourceUrl?.trim();
+  const isWakeUp = isWakeUpGreeting(
+    trimmedContent,
+    conversation.getMessages().length,
+  );
+  const isScanPath = !!scanUrl && isWakeUp;
+
+  let effectiveContent: string | undefined;
+  if (isScanPath) {
+    const scanVariant = body.onboarding?.contentSourceUrl
+      ? ("content-source" as const)
+      : ("website" as const);
+    effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
+    // Fall through to normal inference path below
+  } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 
     conversation.processing = true;
@@ -1746,7 +1764,9 @@ export async function handleSendMessage(
   await conversation.ensureActorScopedHistory();
 
   // Resolve slash commands before persisting or running the agent loop.
-  const rawContent = content ?? "";
+  // When the scan path rewrote the first message, use the rewritten content
+  // so the persisted user message and agent loop see the scan instruction.
+  const rawContent = effectiveContent ?? content ?? "";
   const slashContext = buildSlashContextForContent(rawContent, {
     conversationId: mapping.conversationId,
     messageCount: conversation.getMessages().length,


### PR DESCRIPTION
## Summary
- When onboarding provides `websiteUrl` or `contentSourceUrl`, bypass canned greeting and rewrite the wake-up message to a scan instruction
- Add `buildScanFirstMessage` helper with website and content-source variants
- Fall through to normal LLM inference so the assistant actually scans the site

Part of plan: url-scan-objective.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->