### PR TITLE
fix(web): fix chat scroll — use overflow-hidden on main containers (LUM-1703)

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -375,7 +375,7 @@ export function ChatLayout() {
       <OfflineBanner />
 
       {isMobile ? (
-        <main className="relative flex min-w-0 flex-1 min-h-0 overflow-y-auto">
+        <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
           <Outlet context={assistantContext} />
           {drawerVisible ? (
             <div
@@ -411,7 +411,7 @@ export function ChatLayout() {
           ) : null}
         </main>
       ) : (
-        <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden">
+        <div className="flex min-w-0 flex-1 gap-4 p-4 min-h-0 overflow-hidden flex-col md:flex-row">
           <aside
             id="chat-side-menu"
             className="shrink-0"
@@ -419,10 +419,7 @@ export function ChatLayout() {
           >
             {renderSideMenu({ collapsed, variant: "rail" })}
           </aside>
-          <main
-            className="min-w-0 flex-1 overflow-y-auto"
-            style={{ flex: 1 }}
-          >
+          <main className="flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
             <Outlet context={assistantContext} />
           </main>
         </div>

--- a/apps/web/src/domains/contacts/contacts-page.tsx
+++ b/apps/web/src/domains/contacts/contacts-page.tsx
@@ -462,7 +462,7 @@ function ContactsPageInner({
   };
 
   return (
-    <div className="flex h-full flex-col gap-4 sm:flex-row sm:gap-6">
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden sm:flex-row sm:gap-6">
       <div className="flex items-center sm:hidden">
         <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
       </div>
@@ -475,11 +475,11 @@ function ContactsPageInner({
         <ContactsList {...contactsListProps} onSelect={handleSelect} />
       </MobileSidebarDrawer>
 
-      <aside className="hidden h-full w-[320px] shrink-0 self-stretch sm:block">
+      <aside className="hidden min-h-0 w-[320px] shrink-0 overflow-y-auto self-stretch sm:block">
         <ContactsList {...contactsListProps} onSelect={handleSelect} />
       </aside>
 
-      <section className="min-w-0 flex-1">
+      <section className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         {selection.kind === "assistant" ? (
           <AssistantChannelsDetail
             assistantName={assistantName}

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -171,9 +171,11 @@ export function HomePage({
   }
 
   return (
-    <div className="mx-auto w-full max-w-[960px] px-[var(--app-spacing-xl)] py-[var(--app-spacing-2xl)]">
-      <div className="flex flex-col gap-[var(--app-spacing-xl)]">
-        {feedContent}
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="mx-auto w-full max-w-[960px] px-[var(--app-spacing-xl)] py-[var(--app-spacing-2xl)]">
+        <div className="flex flex-col gap-[var(--app-spacing-xl)]">
+          {feedContent}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Prompt / plan

Investigation from comparing localhost screenshots vs dev-deployed revealed the chat page wasn't scrollable and the composer was pushed off-screen.

## Why

The outer `<main>` elements in both the mobile and desktop layout paths of `chat-layout.tsx` used `overflow-y-auto`. This made the entire content area (transcript + composer) scroll as one unit, defeating the inner flex height constraint chain. The Transcript's own `overflow-y-auto` never kicked in because the parent allowed unbounded growth — so messages pushed the composer off the bottom of the viewport.

The platform repo's equivalent wrapper uses `overflow-hidden` + `flex-col` on the outer container, letting inner components manage their own scrolling.

## What changed

**`chat-layout.tsx`** — both mobile and desktop `<main>` containers:
- `overflow-y-auto` → `overflow-hidden flex-col min-h-0`
- Desktop outer div: added `flex-col md:flex-row` for correct flex direction
- Desktop inner `<main>`: removed redundant `style={{ flex: 1 }}`

**`home-page.tsx`** — default view (no detail panel selected):
- Wrapped content in `flex min-h-0 flex-1 flex-col overflow-y-auto` so the feed list scrolls independently within the `overflow-hidden` parent

**`contacts-page.tsx`** — list and detail panels:
- Root div: `h-full` → `min-h-0 flex-1 overflow-hidden`
- Aside (contact list): added `min-h-0 overflow-y-auto`
- Section (detail panel): added `min-h-0 overflow-y-auto`

This ensures every child route manages its own scrolling:
1. `<main>` (`overflow-hidden`, `flex-col`, `min-h-0`) → constrains height
2. ChatBody / HomePage / ContactsPage / LibraryPage → each has `overflow-y-auto` on the appropriate scroll container
3. Composer stays pinned at the bottom in chat

## Root cause analysis

1. **How did the code get into this state?** During the initial chat layout port from the platform, the outer containers were given `overflow-y-auto` — likely a quick heuristic to "make things scroll" without tracing the full flex chain.
2. **What led to it?** The platform's `AssistantPageClient.tsx` is ~2900 lines with deeply nested layout. The outer container pattern (`overflow-hidden` + flex column) was easy to miss when porting only the relevant sections.
3. **Warning signs?** The desktop path had both `className="min-w-0 flex-1 overflow-y-auto"` AND `style={{ flex: 1 }}` — the redundant inline style hints at uncertainty about the layout.
4. **Prevention:** When porting layout containers, trace the full flex height chain from outermost container to the scrolling element. The constraint chain must be: `overflow-hidden` on all ancestors, `min-h-0` on flex children, and `overflow-y-auto` on exactly one leaf.

## References

- [CSS `overflow` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
- [Flexbox `min-height: 0` for nested scroll containers — W3C spec](https://www.w3.org/TR/css-flexbox-1/#min-size-auto)

## Test plan

Build passes locally. Visual testing to follow after merge.

Closes LUM-1703

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->