### PR TITLE
feat(assistant): add A2A invite/accept broker endpoint for self-hosted deployments (LUM-1689)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
 - **Multi-step efforts.** Use a parent issue with [sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues) or sibling issues when the effort has multiple phases. Link intermediate PRs with `Part of #N` or `Related to #N` (no auto-close). Issues earn their keep here — they're the tracking artifact across multiple PRs.
 - **Branch name**: include the issue number when one exists, e.g. `123-fix-stale-approvals`.
 - **Human attention comments**: After creating a PR with non-routine changes (architectural decisions, security, complex logic, deletions, low confidence), leave a `gh pr comment` highlighting where to focus review and the risk level. Skip for routine changes.
+- **Open-source hygiene**: This repo is public. Before opening a PR, review your diff for internal URLs, hardcoded credentials, proprietary infrastructure details, or references to internal services that should not be publicly visible. Generated files (OpenAPI specs, API clients) must be regenerated from committed sources — verify with `bun run generate:openapi` in `assistant/`.
 
 ### Notes for Vellum team members
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9741,6 +9741,18 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/integrations/a2a/invite/accept:
+    post:
+      operationId: integrations_a2a_invite_accept_post
+      summary: Accept A2A invite (self-hosted broker)
+      description:
+        Orchestrate cross-daemon invite acceptance for self-hosted deployments. Calls the sender's invite/complete,
+        then creates a local contact via invite/redeem.
+      tags:
+        - integrations
+      responses:
+        "200":
+          description: Successful response
   /v1/integrations/a2a/invite/complete:
     post:
       operationId: integrations_a2a_invite_complete_post

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Tests for the self-hosted A2A invite accept broker (acceptA2AInvite).
+ *
+ * Uses the real DB (via `initializeDb()`) and the test preload which sets
+ * `VELLUM_WORKSPACE_DIR` to a per-file temp directory. Global `fetch` is
+ * mocked to simulate the outbound call to the sender's gateway.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import {
+  getAssistantContactMetadata,
+  getContact,
+  searchContacts,
+} from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { acceptA2AInvite, createA2AInvite } from "../config-a2a.js";
+
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM assistant_ingress_invites");
+  sqlite.run("DELETE FROM assistant_contact_metadata");
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+function setConfig(opts: {
+  a2aEnabled?: boolean;
+  publicBaseUrl?: string;
+  ingressEnabled?: boolean;
+  assistantName?: string;
+}): void {
+  const raw = loadRawConfig();
+  if (opts.a2aEnabled !== undefined) {
+    setNestedValue(raw, "a2a.enabled", opts.a2aEnabled);
+  }
+  if (opts.publicBaseUrl !== undefined) {
+    setNestedValue(raw, "ingress.publicBaseUrl", opts.publicBaseUrl);
+  }
+  if (opts.ingressEnabled !== undefined) {
+    setNestedValue(raw, "ingress.enabled", opts.ingressEnabled);
+  }
+  saveRawConfig(raw);
+  invalidateConfigCache();
+}
+
+const SENDER_GATEWAY_URL = "https://sender.example.com";
+const SENDER_ASSISTANT_ID = "sender-assistant-abc";
+const RECEIVER_GATEWAY_URL = "https://receiver.example.com";
+
+interface MockFetchOptions {
+  status?: number;
+  body?: Record<string, unknown>;
+  networkError?: string;
+}
+
+function mockFetchOnce(opts: MockFetchOptions): void {
+  const originalFetch = globalThis.fetch;
+  const mockFn = mock(
+    async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      // Restore after first call
+      globalThis.fetch = originalFetch;
+
+      if (opts.networkError) {
+        throw new Error(opts.networkError);
+      }
+      return new Response(JSON.stringify(opts.body ?? {}), {
+        status: opts.status ?? 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+  globalThis.fetch = mockFn as unknown as typeof fetch;
+}
+
+/** Track the outbound fetch call and return a mock response. */
+function mockFetchCapture(opts: MockFetchOptions): {
+  getCall: () => { url: string; body: Record<string, unknown> } | null;
+} {
+  const originalFetch = globalThis.fetch;
+  let captured: { url: string; body: Record<string, unknown> } | null = null;
+  const mockFn = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = originalFetch;
+    captured = {
+      url: String(input),
+      body: JSON.parse((init?.body as string) ?? "{}") as Record<
+        string,
+        unknown
+      >,
+    };
+    if (opts.networkError) {
+      throw new Error(opts.networkError);
+    }
+    return new Response(JSON.stringify(opts.body ?? {}), {
+      status: opts.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  globalThis.fetch = mockFn as unknown as typeof fetch;
+  return { getCall: () => captured };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("acceptA2AInvite", () => {
+  let savedFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    savedFetch = globalThis.fetch;
+    resetTables();
+    setConfig({
+      a2aEnabled: true,
+      publicBaseUrl: RECEIVER_GATEWAY_URL,
+      ingressEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = savedFetch;
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────
+
+  test("happy path: creates local contact from sender identity", async () => {
+    // Create an invite on the sender side so we have a valid token
+    const created = createA2AInvite({});
+    expect(created.success).toBe(true);
+
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "Sender Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.contactId).toBeDefined();
+    expect(result.alreadyConnected).toBeFalsy();
+
+    // Verify the contact was created with correct identity
+    const contact = getContact(result.contactId!);
+    expect(contact).not.toBeNull();
+    expect(contact!.channels).toHaveLength(1);
+    expect(contact!.channels[0]!.type).toBe("a2a");
+    expect(contact!.channels[0]!.status).toBe("active");
+
+    // Verify assistant metadata
+    const metadata = getAssistantContactMetadata(result.contactId!);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.metadata).toEqual({
+      assistantId: SENDER_ASSISTANT_ID,
+      gatewayUrl: SENDER_GATEWAY_URL,
+    });
+  });
+
+  test("uses invite-link values for sender identity, not daemon response", async () => {
+    const maliciousGateway = "https://evil.example.com";
+    const maliciousId = "evil-assistant";
+
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          // Sender daemon tries to misrepresent identity
+          assistantId: maliciousId,
+          displayName: "Legit Bot",
+          gatewayUrl: maliciousGateway,
+        },
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify contact uses invite-link values, NOT the daemon response
+    const metadata = getAssistantContactMetadata(result.contactId!);
+    expect(metadata!.metadata).toEqual({
+      assistantId: SENDER_ASSISTANT_ID,
+      gatewayUrl: SENDER_GATEWAY_URL,
+    });
+  });
+
+  test("uses sender displayName from complete response", async () => {
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "My Cool Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(true);
+    const contact = getContact(result.contactId!);
+    expect(contact!.displayName).toBe("My Cool Bot");
+  });
+
+  test("falls back to senderAssistantId when displayName is missing", async () => {
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          // No displayName
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(true);
+    const contact = getContact(result.contactId!);
+    expect(contact!.displayName).toBe(SENDER_ASSISTANT_ID);
+  });
+
+  test("sends correct request to sender's invite/complete endpoint", async () => {
+    const capture = mockFetchCapture({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "Sender Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+
+    await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "test-token-123",
+    });
+
+    const call = capture.getCall();
+    expect(call).not.toBeNull();
+    expect(call!.url).toBe(
+      `${SENDER_GATEWAY_URL}/v1/integrations/a2a/invite/complete`,
+    );
+    expect(call!.body).toEqual({
+      token: "test-token-123",
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      acceptor: {
+        assistantId: RECEIVER_GATEWAY_URL,
+        displayName: "Vellum Assistant",
+        gatewayUrl: RECEIVER_GATEWAY_URL,
+      },
+    });
+  });
+
+  test("strips trailing slashes from senderGatewayUrl", async () => {
+    const capture = mockFetchCapture({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+
+    await acceptA2AInvite({
+      senderGatewayUrl: `${SENDER_GATEWAY_URL}///`,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "test-token",
+    });
+
+    const call = capture.getCall();
+    expect(call!.url).toBe(
+      `${SENDER_GATEWAY_URL}/v1/integrations/a2a/invite/complete`,
+    );
+  });
+
+  // ── Already connected ───────────────────────────────────────────────
+
+  test("returns alreadyConnected when sender is already a contact", async () => {
+    // First accept
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "Sender Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+    const first = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "token-1",
+    });
+    expect(first.success).toBe(true);
+
+    // Second accept with same sender
+    mockFetchOnce({
+      body: {
+        success: true,
+        sender: {
+          assistantId: SENDER_ASSISTANT_ID,
+          displayName: "Sender Bot",
+          gatewayUrl: SENDER_GATEWAY_URL,
+        },
+      },
+    });
+    const second = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "token-2",
+    });
+    expect(second.success).toBe(true);
+    expect(second.alreadyConnected).toBe(true);
+  });
+
+  // ── Sender unreachable ──────────────────────────────────────────────
+
+  test("returns sender_unreachable when fetch throws", async () => {
+    mockFetchOnce({ networkError: "Connection refused" });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("sender_unreachable");
+    expect(result.error).toContain("Connection refused");
+  });
+
+  // ── Sender returns error ────────────────────────────────────────────
+
+  test("returns complete_failed when sender reports failure", async () => {
+    mockFetchOnce({
+      status: 400,
+      body: {
+        success: false,
+        error: "not_found",
+        errorCode: "not_found",
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "expired-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("not_found");
+    expect(result.errorCode).toBe("not_found");
+  });
+
+  test("returns complete_failed when sender returns success:false with 200", async () => {
+    mockFetchOnce({
+      status: 200,
+      body: {
+        success: false,
+        error: "expired",
+      },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("expired");
+    expect(result.errorCode).toBe("complete_failed");
+  });
+
+  // ── No public base URL ──────────────────────────────────────────────
+
+  test("returns no_public_url when publicBaseUrl is not configured", async () => {
+    setConfig({ publicBaseUrl: "", ingressEnabled: true });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("no_public_url");
+    expect(result.error).toContain("public base URL");
+  });
+
+  test("returns no_public_url when ingress is disabled", async () => {
+    setConfig({ ingressEnabled: false });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("no_public_url");
+  });
+
+  // ── No existing contacts leaked ─────────────────────────────────────
+
+  test("does not create a contact when sender returns failure", async () => {
+    mockFetchOnce({
+      status: 400,
+      body: { success: false, error: "invalid" },
+    });
+
+    await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "bad-token",
+    });
+
+    const contacts = searchContacts({ channelType: "a2a" });
+    expect(contacts).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
@@ -297,7 +297,7 @@ describe("acceptA2AInvite", () => {
     });
   });
 
-  test("strips trailing slashes from senderGatewayUrl", async () => {
+  test("strips trailing slashes from senderGatewayUrl in fetch URL and stored metadata", async () => {
     const capture = mockFetchCapture({
       body: {
         success: true,
@@ -309,22 +309,32 @@ describe("acceptA2AInvite", () => {
       },
     });
 
-    await acceptA2AInvite({
+    const result = await acceptA2AInvite({
       senderGatewayUrl: `${SENDER_GATEWAY_URL}///`,
       senderAssistantId: SENDER_ASSISTANT_ID,
       token: "test-token",
     });
 
+    // Fetch URL is normalized
     const call = capture.getCall();
     expect(call!.url).toBe(
       `${SENDER_GATEWAY_URL}/v1/integrations/a2a/invite/complete`,
+    );
+
+    // Stored contact metadata is also normalized (no trailing slashes)
+    expect(result.success).toBe(true);
+    const contact = getContact(result.contactId!);
+    expect(contact).toBeTruthy();
+    const meta = getAssistantContactMetadata(result.contactId!);
+    expect((meta?.metadata as { gatewayUrl?: string } | null)?.gatewayUrl).toBe(
+      SENDER_GATEWAY_URL,
     );
   });
 
   // ── Already connected ───────────────────────────────────────────────
 
-  test("returns alreadyConnected when sender is already a contact", async () => {
-    // First accept
+  test("returns alreadyConnected without calling sender when already a contact", async () => {
+    // First accept — creates the contact
     mockFetchOnce({
       body: {
         success: true,
@@ -342,17 +352,9 @@ describe("acceptA2AInvite", () => {
     });
     expect(first.success).toBe(true);
 
-    // Second accept with same sender
-    mockFetchOnce({
-      body: {
-        success: true,
-        sender: {
-          assistantId: SENDER_ASSISTANT_ID,
-          displayName: "Sender Bot",
-          gatewayUrl: SENDER_GATEWAY_URL,
-        },
-      },
-    });
+    // Second accept — should short-circuit before any outbound call.
+    // No mockFetchOnce here: if fetch is called, it hits the real
+    // (unmocked) fetch and the test would fail or hang.
     const second = await acceptA2AInvite({
       senderGatewayUrl: SENDER_GATEWAY_URL,
       senderAssistantId: SENDER_ASSISTANT_ID,
@@ -379,14 +381,18 @@ describe("acceptA2AInvite", () => {
   });
 
   // ── Sender returns error ────────────────────────────────────────────
+  // The daemon HTTP adapter always converts RouteError throws into the
+  // standard envelope: { error: { code, message } } (see http-errors.ts).
+  // These mocks match the real wire format.
 
-  test("returns complete_failed when sender reports failure", async () => {
+  test("returns complete_failed when sender returns 400 with token error", async () => {
     mockFetchOnce({
       status: 400,
       body: {
-        success: false,
-        error: "not_found",
-        errorCode: "not_found",
+        error: {
+          code: "BAD_REQUEST",
+          message: "Invite token has expired or was already claimed",
+        },
       },
     });
 
@@ -397,16 +403,21 @@ describe("acceptA2AInvite", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("not_found");
-    expect(result.errorCode).toBe("not_found");
+    expect(result.error).toBe(
+      "Invite token has expired or was already claimed",
+    );
+    expect(result.errorCode).toBe("complete_failed");
   });
 
-  test("returns complete_failed when sender returns success:false with 200", async () => {
+  test("returns complete_failed when sender returns 400 for validation", async () => {
     mockFetchOnce({
-      status: 200,
+      status: 400,
       body: {
-        success: false,
-        error: "expired",
+        error: {
+          code: "BAD_REQUEST",
+          message:
+            "acceptor must include non-empty assistantId, displayName, and gatewayUrl",
+        },
       },
     });
 
@@ -417,7 +428,24 @@ describe("acceptA2AInvite", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("expired");
+    expect(result.error).toContain("acceptor must include");
+    expect(result.errorCode).toBe("complete_failed");
+  });
+
+  test("falls back to generic message when error envelope is malformed", async () => {
+    mockFetchOnce({
+      status: 500,
+      body: { unexpected: "shape" },
+    });
+
+    const result = await acceptA2AInvite({
+      senderGatewayUrl: SENDER_GATEWAY_URL,
+      senderAssistantId: SENDER_ASSISTANT_ID,
+      token: "any-token",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Invite completion failed");
     expect(result.errorCode).toBe("complete_failed");
   });
 
@@ -455,7 +483,7 @@ describe("acceptA2AInvite", () => {
   test("does not create a contact when sender returns failure", async () => {
     mockFetchOnce({
       status: 400,
-      body: { success: false, error: "invalid" },
+      body: { error: { code: "BAD_REQUEST", message: "Invalid token" } },
     });
 
     await acceptA2AInvite({

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -31,6 +31,7 @@ import {
   hashToken,
 } from "../../memory/invite-store.js";
 import { assistantContactMetadata } from "../../memory/schema.js";
+import type { HttpErrorResponse } from "../../runtime/http-errors.js";
 import { getLogger } from "../../util/logger.js";
 import { getAssistantName } from "../identity-helpers.js";
 const log = getLogger("config-a2a");
@@ -306,6 +307,25 @@ export function redeemA2AInvite(params: {
 const ACCEPT_TIMEOUT_MS = 15_000;
 
 /**
+ * Extract a human-readable error message from a daemon HTTP error
+ * response. The daemon always returns `{ error: { code, message } }`
+ * (see `HttpErrorResponse` in `runtime/http-errors.ts`).
+ */
+function extractDaemonErrorMessage(
+  body: Record<string, unknown>,
+): string | undefined {
+  const envelope = body as Partial<HttpErrorResponse>;
+  if (
+    typeof envelope.error === "object" &&
+    envelope.error !== null &&
+    typeof envelope.error.message === "string"
+  ) {
+    return envelope.error.message;
+  }
+  return undefined;
+}
+
+/**
  * Orchestrate cross-daemon A2A invite acceptance for self-hosted
  * deployments. Calls the sender's `invite/complete` endpoint, then
  * creates a local contact via `redeemA2AInvite`.
@@ -321,6 +341,9 @@ export async function acceptA2AInvite(params: {
   senderAssistantId: string;
   token: string;
 }): Promise<AcceptA2AInviteResult> {
+  const senderGatewayUrl = params.senderGatewayUrl.replace(/\/+$/, "");
+
+  // 1. Validate local config
   const displayName = getAssistantName() ?? "Vellum Assistant";
   let localGatewayUrl: string;
   try {
@@ -334,8 +357,18 @@ export async function acceptA2AInvite(params: {
     };
   }
 
-  // 1. Call the sender's invite/complete endpoint
-  const completeUrl = `${params.senderGatewayUrl.replace(/\/+$/, "")}/v1/integrations/a2a/invite/complete`;
+  // 2. Short-circuit if already connected — avoids a network round-trip
+  //    and consuming a token on the sender side.
+  const existing = findContactByAddress("a2a", params.senderAssistantId);
+  if (
+    existing &&
+    existing.channels.some((ch) => ch.type === "a2a" && ch.status === "active")
+  ) {
+    return { success: true, alreadyConnected: true, contactId: existing.id };
+  }
+
+  // 3. Call the sender's invite/complete endpoint
+  const completeUrl = `${senderGatewayUrl}/v1/integrations/a2a/invite/complete`;
   const completeBody = {
     token: params.token,
     senderAssistantId: params.senderAssistantId,
@@ -357,19 +390,19 @@ export async function acceptA2AInvite(params: {
 
     completeData = (await response.json()) as Record<string, unknown>;
 
-    if (!response.ok || !completeData.success) {
-      const error = String(completeData.error ?? "Invite completion failed");
-      const errorCode = String(completeData.errorCode ?? "complete_failed");
+    if (!response.ok) {
+      const error =
+        extractDaemonErrorMessage(completeData) ?? "Invite completion failed";
       log.warn(
-        { senderGatewayUrl: params.senderGatewayUrl, error, errorCode },
-        "Sender invite/complete returned failure",
+        { senderGatewayUrl, status: response.status, error },
+        "Sender invite/complete returned error",
       );
-      return { success: false, error, errorCode };
+      return { success: false, error, errorCode: "complete_failed" };
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.warn(
-      { senderGatewayUrl: params.senderGatewayUrl, error: message },
+      { senderGatewayUrl, error: message },
       "Failed to reach sender for invite/complete",
     );
     return {
@@ -379,7 +412,7 @@ export async function acceptA2AInvite(params: {
     };
   }
 
-  // 2. Extract sender display name from the complete response; use
+  // 4. Extract sender display name from the complete response; use
   //    invite-link values for assistantId and gatewayUrl (trusted source).
   const senderFromResponse = completeData.sender as
     | { displayName?: string }
@@ -391,10 +424,10 @@ export async function acceptA2AInvite(params: {
       (typeof senderFromResponse?.displayName === "string" &&
         senderFromResponse.displayName) ||
       params.senderAssistantId,
-    gatewayUrl: params.senderGatewayUrl,
+    gatewayUrl: senderGatewayUrl,
   };
 
-  // 3. Create the sender as a local trusted contact
+  // 5. Create the sender as a local trusted contact
   const redeemResult = redeemA2AInvite({ sender: senderIdentity });
   if (!redeemResult.success) {
     log.warn(

--- a/assistant/src/daemon/handlers/config-a2a.ts
+++ b/assistant/src/daemon/handlers/config-a2a.ts
@@ -5,7 +5,9 @@
  * - setA2AConfig()     — set a2a.enabled = true
  * - clearA2AConfig()   — set a2a.enabled = false
  * - createA2AInvite()  — create a shareable invite token for link-based contact creation
+ * - completeA2AInvite() — sender-side: claim token and return sender identity
  * - redeemA2AInvite()  — receiver-side: create trusted contact from sender identity
+ * - acceptA2AInvite()  — self-hosted broker: orchestrate complete + redeem across daemons
  */
 
 import {
@@ -29,7 +31,10 @@ import {
   hashToken,
 } from "../../memory/invite-store.js";
 import { assistantContactMetadata } from "../../memory/schema.js";
+import { getLogger } from "../../util/logger.js";
 import { getAssistantName } from "../identity-helpers.js";
+const log = getLogger("config-a2a");
+
 // ── Result types ────────────────────────────────────────────────────
 
 export interface A2AConfigResult {
@@ -59,6 +64,14 @@ export interface RedeemA2AInviteResult {
   contactId?: string;
   alreadyConnected?: boolean;
   error?: string;
+}
+
+export interface AcceptA2AInviteResult {
+  success: boolean;
+  contactId?: string;
+  alreadyConnected?: boolean;
+  error?: string;
+  errorCode?: string;
 }
 
 // ── Config operations ───────────────────────────────────────────────
@@ -286,4 +299,118 @@ export function redeemA2AInvite(params: {
     .run();
 
   return { success: true, contactId: contact.id };
+}
+
+// ── Self-hosted broker ──────────────────────────────────────────────
+
+const ACCEPT_TIMEOUT_MS = 15_000;
+
+/**
+ * Orchestrate cross-daemon A2A invite acceptance for self-hosted
+ * deployments. Calls the sender's `invite/complete` endpoint, then
+ * creates a local contact via `redeemA2AInvite`.
+ *
+ * Trust model: the user explicitly chose to connect to `senderGatewayUrl`
+ * and provided a token from the sender's invite link. We trust the
+ * invite-link values (`senderAssistantId`, `senderGatewayUrl`) as the
+ * canonical sender identity, and only use the `complete` response for the
+ * sender's display name (which has no other source in self-hosted mode).
+ */
+export async function acceptA2AInvite(params: {
+  senderGatewayUrl: string;
+  senderAssistantId: string;
+  token: string;
+}): Promise<AcceptA2AInviteResult> {
+  const displayName = getAssistantName() ?? "Vellum Assistant";
+  let localGatewayUrl: string;
+  try {
+    localGatewayUrl = getPublicBaseUrl(getConfig());
+  } catch {
+    return {
+      success: false,
+      error:
+        "No public base URL configured. Set ingress.publicBaseUrl in config.",
+      errorCode: "no_public_url",
+    };
+  }
+
+  // 1. Call the sender's invite/complete endpoint
+  const completeUrl = `${params.senderGatewayUrl.replace(/\/+$/, "")}/v1/integrations/a2a/invite/complete`;
+  const completeBody = {
+    token: params.token,
+    senderAssistantId: params.senderAssistantId,
+    acceptor: {
+      assistantId: localGatewayUrl,
+      displayName,
+      gatewayUrl: localGatewayUrl,
+    },
+  };
+
+  let completeData: Record<string, unknown>;
+  try {
+    const response = await fetch(completeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(completeBody),
+      signal: AbortSignal.timeout(ACCEPT_TIMEOUT_MS),
+    });
+
+    completeData = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok || !completeData.success) {
+      const error = String(completeData.error ?? "Invite completion failed");
+      const errorCode = String(completeData.errorCode ?? "complete_failed");
+      log.warn(
+        { senderGatewayUrl: params.senderGatewayUrl, error, errorCode },
+        "Sender invite/complete returned failure",
+      );
+      return { success: false, error, errorCode };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { senderGatewayUrl: params.senderGatewayUrl, error: message },
+      "Failed to reach sender for invite/complete",
+    );
+    return {
+      success: false,
+      error: `Failed to reach sender: ${message}`,
+      errorCode: "sender_unreachable",
+    };
+  }
+
+  // 2. Extract sender display name from the complete response; use
+  //    invite-link values for assistantId and gatewayUrl (trusted source).
+  const senderFromResponse = completeData.sender as
+    | { displayName?: string }
+    | undefined;
+
+  const senderIdentity = {
+    assistantId: params.senderAssistantId,
+    displayName:
+      (typeof senderFromResponse?.displayName === "string" &&
+        senderFromResponse.displayName) ||
+      params.senderAssistantId,
+    gatewayUrl: params.senderGatewayUrl,
+  };
+
+  // 3. Create the sender as a local trusted contact
+  const redeemResult = redeemA2AInvite({ sender: senderIdentity });
+  if (!redeemResult.success) {
+    log.warn(
+      { error: redeemResult.error },
+      "Local invite/redeem failed after successful complete",
+    );
+    return {
+      success: false,
+      error: redeemResult.error ?? "Failed to create sender contact",
+      errorCode: "redeem_failed",
+    };
+  }
+
+  return {
+    success: true,
+    contactId: redeemResult.contactId,
+    alreadyConnected: redeemResult.alreadyConnected,
+  };
 }

--- a/assistant/src/runtime/routes/integrations/a2a.ts
+++ b/assistant/src/runtime/routes/integrations/a2a.ts
@@ -7,11 +7,13 @@
  * POST   /v1/integrations/a2a/invite          — create a shareable A2A invite token
  * POST   /v1/integrations/a2a/invite/complete — sender-side invite completion
  * POST   /v1/integrations/a2a/invite/redeem   — receiver-side invite redemption
+ * POST   /v1/integrations/a2a/invite/accept   — self-hosted broker: orchestrate complete + redeem
  */
 
 import { isA2AEnabled } from "../../../a2a/feature-gate.js";
 import { getConfig } from "../../../config/loader.js";
 import {
+  acceptA2AInvite,
   clearA2AConfig,
   completeA2AInvite,
   createA2AInvite,
@@ -19,7 +21,7 @@ import {
   redeemA2AInvite,
   setA2AConfig,
 } from "../../../daemon/handlers/config-a2a.js";
-import { BadRequestError } from "../errors.js";
+import { BadGatewayError, BadRequestError } from "../errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -164,6 +166,52 @@ function handleRedeemA2AInvite({ body = {} }: RouteHandlerArgs) {
   return result;
 }
 
+async function handleAcceptA2AInvite({ body = {} }: RouteHandlerArgs) {
+  assertA2AFlag();
+  const { senderGatewayUrl, senderAssistantId, token } = body as {
+    senderGatewayUrl?: unknown;
+    senderAssistantId?: unknown;
+    token?: unknown;
+  };
+
+  if (typeof senderGatewayUrl !== "string" || !senderGatewayUrl) {
+    throw new BadRequestError(
+      "senderGatewayUrl is required and must be a non-empty string",
+    );
+  }
+  try {
+    new URL(senderGatewayUrl);
+  } catch {
+    throw new BadRequestError("senderGatewayUrl must be a valid URL");
+  }
+  if (typeof senderAssistantId !== "string" || !senderAssistantId) {
+    throw new BadRequestError(
+      "senderAssistantId is required and must be a non-empty string",
+    );
+  }
+  if (typeof token !== "string" || !token) {
+    throw new BadRequestError(
+      "token is required and must be a non-empty string",
+    );
+  }
+
+  const result = await acceptA2AInvite({
+    senderGatewayUrl,
+    senderAssistantId,
+    token,
+  });
+  if (!result.success) {
+    const isSenderFault =
+      result.errorCode === "sender_unreachable" ||
+      result.errorCode === "complete_failed";
+    if (isSenderFault) {
+      throw new BadGatewayError(result.error ?? "Failed to accept A2A invite");
+    }
+    throw new BadRequestError(result.error ?? "Failed to accept A2A invite");
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -231,5 +279,16 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["integrations"],
     requirePolicyEnforcement: true,
     handler: handleRedeemA2AInvite,
+  },
+  {
+    operationId: "integrations_a2a_invite_accept_post",
+    endpoint: "integrations/a2a/invite/accept",
+    method: "POST",
+    summary: "Accept A2A invite (self-hosted broker)",
+    description:
+      "Orchestrate cross-daemon invite acceptance for self-hosted deployments. Calls the sender's invite/complete, then creates a local contact via invite/redeem.",
+    tags: ["integrations"],
+    requirePolicyEnforcement: true,
+    handler: handleAcceptA2AInvite,
   },
 ];


### PR DESCRIPTION
## Prompt / plan

Add `POST /v1/integrations/a2a/invite/accept` — a self-hosted broker endpoint that orchestrates cross-daemon A2A invite acceptance, replacing the platform's Django broker for OSS deployments.

**Why needed:** The platform uses a Django broker to orchestrate the two-step invite exchange between sender and receiver daemons. In self-hosted OSS mode there is no Django — the daemon itself must act as the broker. The web frontend cannot make cross-origin calls to another assistant's gateway (CORS), so this server-to-server orchestration must happen daemon-side.

**How it works:**
1. Validates local config (public base URL required)
2. Short-circuits if sender is already an active contact (avoids network round-trip + token consumption)
3. Calls sender's `POST /v1/integrations/a2a/invite/complete` with the token + local assistant identity
4. On success, calls local `redeemA2AInvite()` to create the sender as a trusted contact
5. Returns `{ success, contactId?, alreadyConnected?, error?, errorCode? }`

**Trust model:** The invite-link values (`senderAssistantId`, `senderGatewayUrl`) are treated as the canonical sender identity — the user explicitly chose to connect to that gateway. Only `displayName` is taken from the sender daemon's `complete` response, since there is no central authority to derive it from in self-hosted mode. This differs from the platform broker which derives sender identity from its own database.

**Error handling:** The sender daemon returns errors using the standard daemon envelope `{ error: { code, message } }` (see `HttpErrorResponse` in `runtime/http-errors.ts`). Error responses are parsed via a typed `extractDaemonErrorMessage()` helper that imports `HttpErrorResponse`. The `!response.ok` check (daemon envelope) is separated from success-response parsing — these are fundamentally different wire shapes and must not be conflated. Test mocks use the real daemon wire format to validate against actual runtime behavior.

**Safety:**
- Behind `a2aChannel` feature flag
- No new attack surface — the daemon already calls arbitrary external URLs for A2A push notifications (`deliver.ts`)
- Route uses `requirePolicyEnforcement: true`
- Follows existing route architecture conventions (transport-agnostic handler, `RouteError` subclasses, shared `ROUTES` array)
- No internal URLs, credentials, or proprietary infrastructure details

**Alternatives not taken:**
- Trusting the sender's `complete` response for `assistantId`/`gatewayUrl`: rejected because a compromised sender could redirect traffic to a different gateway. Invite-link values are user-provided and canonical.
- Checking `!response.ok || !completeData.success` in a single condition: rejected because non-2xx responses use the standard daemon error envelope `{ error: { code, message } }` while 2xx responses use the handler's return shape `{ success, sender }`. Conflating them caused the original `[object Object]` bug.
- Deferring the existing-contact check until `redeemA2AInvite`: rejected because it wastefully consumes a token on the sender side and makes an unnecessary network call.

## Test plan

14 unit tests in `config-a2a-accept.test.ts` covering:
- Happy path: creates local contact from sender identity
- Trust boundary: uses invite-link values for identity, not sender daemon response
- Display name: uses sender response displayName, falls back to senderAssistantId
- Request validation: verifies correct URL and body sent to sender
- URL normalization: strips trailing slashes from both fetch URL and stored metadata
- Already connected: short-circuits before outbound call (no fetch mock needed)
- Sender unreachable: network errors → `sender_unreachable` error code
- Sender 400: standard daemon error envelope → extracts `error.message`
- Sender validation error: 400 with validation message → propagates
- Malformed error envelope: falls back to generic message
- No public URL: missing publicBaseUrl config → `no_public_url`
- No contact leak: failed complete does not create local contacts

All tests pass locally (`bun test`). Lint + typecheck clean.

## CLI verb checklist

- [ ] This route does **not** need a CLI verb. It is called by the web UI (via gateway proxy) to orchestrate the invite acceptance flow. Direct CLI usage would require the user to manually provide `senderGatewayUrl`, `senderAssistantId`, and `token` — the web UI handles this via invite link URL parsing. A CLI verb could be added in a follow-up if manual invite acceptance is desired.

Closes LUM-1689

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
