### PR TITLE
fix: settings page hover padding and inline code block styling

### DIFF
--- a/apps/web/src/domains/settings/components/access-consent-setting.tsx
+++ b/apps/web/src/domains/settings/components/access-consent-setting.tsx
@@ -52,7 +52,7 @@ export function AccessConsentSetting() {
         <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
           Lets Vellum administrators reach privileged data on your assistant
           pod for debugging — today this means tailing{" "}
-          <code className="rounded bg-[var(--surface-overlay)] px-1 py-0.5 text-body-small-default">
+          <code className="rounded bg-[var(--surface-base)] px-1.5 py-0.5 font-mono text-[var(--content-secondary)] dark:bg-[var(--surface-lift)] dark:text-[var(--content-default)]">
             /workspace/data/logs/vellum.log
           </code>
           . Off by default. Turn on temporarily when asking support to

--- a/apps/web/src/domains/settings/components/access-consent-setting.tsx
+++ b/apps/web/src/domains/settings/components/access-consent-setting.tsx
@@ -52,7 +52,7 @@ export function AccessConsentSetting() {
         <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
           Lets Vellum administrators reach privileged data on your assistant
           pod for debugging — today this means tailing{" "}
-          <code className="rounded bg-[var(--surface-base)] px-1.5 py-0.5 font-mono text-[var(--content-secondary)] dark:bg-[var(--surface-lift)] dark:text-[var(--content-default)]">
+          <code className="rounded bg-[var(--surface-base)] px-1.5 font-mono text-[var(--content-secondary)] dark:bg-[var(--surface-lift)] dark:text-[var(--content-default)]">
             /workspace/data/logs/vellum.log
           </code>
           . Off by default. Turn on temporarily when asking support to

--- a/apps/web/src/domains/settings/components/media-embeds-card.tsx
+++ b/apps/web/src/domains/settings/components/media-embeds-card.tsx
@@ -108,7 +108,7 @@ export function MediaEmbedsCard() {
             type="button"
             variant="ghost"
             onClick={() => setExpanded((prev) => !prev)}
-            className="mt-4 w-full justify-between px-0"
+            className="mt-4 w-full justify-between px-3"
             aria-expanded={expanded}
           >
             <span className="flex items-center gap-2">


### PR DESCRIPTION
Mirrors the same fix from the platform repo for the migrated settings pages. Fixes two visual issues:

1. **Video Domain Allowlist button missing horizontal padding on hover** — ghost button had `px-0`, changed to `px-3`.
2. **Inline code block in access-consent-setting visually indistinct** — updated to use `bg-[var(--surface-base)]` with `font-mono` and dark mode handling, matching the established pattern.

## Test plan
Visual inspection of the settings page — hover the Video Domain Allowlist button and check the code block in "Allow admin access to assistant data" renders with a visible background and monospace font.

Link to Devin session: https://app.devin.ai/sessions/32ab99628262488b8325c7d9092a9774
Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->