### PR TITLE
fix(web): surface auth errors in WebLoginForm instead of silently swallowing

### DIFF
--- a/apps/web/src/domains/account/pages/account-page.tsx
+++ b/apps/web/src/domains/account/pages/account-page.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import { AccountHeading } from "@/components/account/account-form.js";
@@ -17,6 +18,20 @@ export function AccountPage() {
   const isLoading = useAuthStore.use.isLoading();
   const user = useAuthStore.use.user();
   const logout = useAuthStore.use.logout();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [signingIn, setSigningIn] = useState(false);
+
+  const handleSignIn = async () => {
+    setErrorMessage(null);
+    setSigningIn(true);
+    try {
+      await startAuthFlow(PROVIDER_ID, PROVIDER_CALLBACK_URL);
+    } catch (err) {
+      console.error("[account] auth flow failed:", err);
+      setErrorMessage("Something went wrong. Please try again.");
+      setSigningIn(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -33,11 +48,17 @@ export function AccountPage() {
           title="Welcome to Vellum"
           subtitle="Sign in to get started."
         />
+        {errorMessage && (
+          <p className="text-center text-sm text-[var(--content-secondary)]">
+            {errorMessage}
+          </p>
+        )}
         <div className="flex flex-col items-center gap-4">
           <button
             type="button"
-            onClick={() => void startAuthFlow(PROVIDER_ID, PROVIDER_CALLBACK_URL)}
-            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-[var(--primary-hover)]"
+            onClick={() => void handleSignIn()}
+            disabled={signingIn}
+            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-[var(--primary-base)] px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-[var(--primary-hover)] disabled:opacity-50"
           >
             Sign in
           </button>

--- a/apps/web/src/domains/account/pages/account-page.tsx
+++ b/apps/web/src/domains/account/pages/account-page.tsx
@@ -49,7 +49,7 @@ export function AccountPage() {
           subtitle="Sign in to get started."
         />
         {errorMessage && (
-          <p className="text-center text-sm text-[var(--content-secondary)]">
+          <p className="text-center text-sm text-[var(--system-negative-strong)]">
             {errorMessage}
           </p>
         )}

--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -113,28 +113,32 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
  * `LoginBackground` — the web login screen is always dark per Figma.
  */
 function WebLoginForm({ returnTo }: { returnTo: string | null }) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
   const callbackUrl = buildProviderCallbackUrl(returnTo);
   const signUpHref = returnTo
     ? `${routes.account.signup}?returnTo=${encodeURIComponent(returnTo)}`
     : routes.account.signup;
 
-  const handleApple = () => {
-    void startAuthFlow(PROVIDER_ID, callbackUrl, {
-      providerHint: "AppleOAuth",
-      returnTo,
-    });
+  const handleProvider = async (providerHint?: string) => {
+    setErrorMessage(null);
+    setLoading(true);
+    try {
+      await startAuthFlow(PROVIDER_ID, callbackUrl, {
+        ...(providerHint ? { providerHint } : {}),
+        returnTo,
+      });
+    } catch (err) {
+      console.error("[web-login] auth flow failed:", err);
+      setErrorMessage("Something went wrong. Please try again.");
+      setLoading(false);
+    }
   };
 
-  const handleGoogle = () => {
-    void startAuthFlow(PROVIDER_ID, callbackUrl, {
-      providerHint: "GoogleOAuth",
-      returnTo,
-    });
-  };
-
-  const handleEmail = () => {
-    void startAuthFlow(PROVIDER_ID, callbackUrl, { returnTo });
-  };
+  const handleApple = () => void handleProvider("AppleOAuth");
+  const handleGoogle = () => void handleProvider("GoogleOAuth");
+  const handleEmail = () => void handleProvider();
 
   return (
     <div className="dark">
@@ -145,12 +149,18 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
             <h1 className="text-title-large text-center text-[var(--content-emphasised)]">
               Sign in to Vellum
             </h1>
+            {errorMessage && (
+              <p className="text-body-small-default text-center text-[var(--content-secondary)]">
+                {errorMessage}
+              </p>
+            )}
             <div className="flex flex-col items-center gap-3">
               <Button
                 type="button"
                 variant="outlined"
                 fullWidth
                 onClick={handleApple}
+                disabled={loading}
                 leftIcon={<AppleLogo />}
                 className="max-w-[300px] gap-3"
               >
@@ -161,6 +171,7 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
                 variant="outlined"
                 fullWidth
                 onClick={handleGoogle}
+                disabled={loading}
                 leftIcon={<GoogleLogo />}
                 className="max-w-[300px] gap-3"
               >
@@ -171,6 +182,7 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
                 variant="outlined"
                 fullWidth
                 onClick={handleEmail}
+                disabled={loading}
                 leftIcon={<Mail />}
                 className="max-w-[300px] gap-3"
               >

--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -84,7 +84,7 @@ function NativeLoginForm({ returnTo }: { returnTo: string | null }) {
     <NativeSplash>
       <div className="z-10 mt-8 flex w-full max-w-[320px] flex-col items-center gap-3">
         {errorMessage && (
-          <p className="text-body-small-default max-w-[280px] text-center text-[var(--content-secondary)]">
+          <p className="text-body-small-default max-w-[280px] text-center text-[var(--system-negative-strong)]">
             {errorMessage}
           </p>
         )}
@@ -150,7 +150,7 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
               Sign in to Vellum
             </h1>
             {errorMessage && (
-              <p className="text-body-small-default text-center text-[var(--content-secondary)]">
+              <p className="text-body-small-default text-center text-[var(--system-negative-strong)]">
                 {errorMessage}
               </p>
             )}

--- a/apps/web/src/domains/account/pages/signup-page.tsx
+++ b/apps/web/src/domains/account/pages/signup-page.tsx
@@ -39,7 +39,7 @@ export function SignupPage() {
   if (error) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-[var(--content-secondary)]">{error}</p>
+        <p className="text-[var(--system-negative-strong)]">{error}</p>
       </div>
     );
   }

--- a/apps/web/src/domains/account/pages/signup-page.tsx
+++ b/apps/web/src/domains/account/pages/signup-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { PROVIDER_CALLBACK_URL, PROVIDER_ID } from "@/lib/account/login-flow.js";
@@ -16,6 +16,7 @@ import { startAuthFlow } from "@/runtime/native-auth.js";
 export function SignupPage() {
   const didRedirect = useRef(false);
   const [searchParams] = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (didRedirect.current) return;
@@ -26,11 +27,22 @@ export function SignupPage() {
       ? `${PROVIDER_CALLBACK_URL}?returnTo=${encodeURIComponent(returnTo)}`
       : PROVIDER_CALLBACK_URL;
 
-    void startAuthFlow(PROVIDER_ID, callbackUrl, {
+    startAuthFlow(PROVIDER_ID, callbackUrl, {
       intent: "signup",
       returnTo,
+    }).catch((err) => {
+      console.error("[signup] auth flow failed:", err);
+      setError("Something went wrong. Please try again.");
     });
   }, [searchParams]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-[var(--content-secondary)]">{error}</p>
+      </div>
+    );
+  }
 
   return null;
 }

--- a/apps/web/src/runtime/native-auth.ts
+++ b/apps/web/src/runtime/native-auth.ts
@@ -163,47 +163,39 @@ export function getSessionTokenFromCookies(): string | null {
  * `startNativeLogin()` (which handles the cookie + navigation
  * internally), otherwise we fall through to the existing web flow.
  *
- * Adding this wrapper means every auth entry point in the app (login,
- * signup, marketing nav, account) gets native routing for free without
- * each having to know about Capacitor.
+ * On the web path, errors propagate to the caller so the UI can display
+ * feedback (e.g. inline error messages on the login form). On the native
+ * path, `USER_CANCELLED` (user tapped cancel on the auth sheet) is
+ * swallowed since it's a routine dismissal, and all other errors are
+ * re-thrown for the caller to handle.
  */
 export async function startAuthFlow(
   providerId: string,
   callbackUrl: string,
   options: ProviderRedirectOptions & { returnTo?: string | null } = {},
 ): Promise<void> {
-  try {
-    if (isNativePlatform()) {
+  if (isNativePlatform()) {
+    try {
       await startNativeLogin({
         returnTo: options.returnTo ?? null,
         loginHint: options.loginHint,
         providerHint: options.providerHint,
       });
-      return;
+    } catch (err) {
+      // Capacitor translates `call.reject(msg, code)` from Swift into a
+      // JS Error whose `message` is the first arg and whose `code` is
+      // the second arg (as an own property, not in `message`). Match the
+      // code exactly rather than substring-matching the message.
+      const errorCode = (err as { code?: unknown } | null | undefined)?.code;
+      if (errorCode === "USER_CANCELLED") return;
+      throw err;
     }
-    // `options` carries an extra `returnTo` field that the web
-    // `startProviderRedirect` doesn't care about — TS's structural typing
-    // accepts the superset, and the web flow plumbs `returnTo` through
-    // `callbackUrl` instead. No need to destructure it out.
-    await startProviderRedirect(providerId, callbackUrl, options);
-  } catch (err) {
-    // USER_CANCELLED is routine (user tapped cancel on the auth sheet);
-    // swallow quietly. Anything else is a real failure — surface it to
-    // the console so it shows up in the Capacitor bridge log and Xcode's
-    // device console, rather than becoming a silent unhandled-rejection.
-    //
-    // Capacitor translates `call.reject(msg, code)` from Swift into a JS
-    // Error whose `message` is the first arg and whose `code` is the
-    // second arg (as an own property, not in `message`). Match the code
-    // exactly rather than substring-matching the message — a substring
-    // check ("cancel") would also swallow unrelated iOS errors that
-    // happen to include the word in their localized description.
-    //
-    // TODO(LUM-1127 follow-up): plumb a visible toast/inline error so
-    // users get feedback on non-cancellation failures.
-    const errorCode = (err as { code?: unknown } | null | undefined)?.code;
-    if (errorCode !== "USER_CANCELLED") {
-      console.error("[native-auth] auth flow failed:", err);
-    }
+    return;
   }
+
+  // Web path: `options` carries an extra `returnTo` field that the web
+  // `startProviderRedirect` doesn't care about — TS's structural typing
+  // accepts the superset, and the web flow plumbs `returnTo` through
+  // `callbackUrl` instead. Errors propagate to the caller.
+  await startProviderRedirect(providerId, callbackUrl, options);
 }


### PR DESCRIPTION
## Prompt / plan

Investigated the broken login flow in the Vite web app. The auth code is correctly ported from the platform, but `startAuthFlow()` silently swallows all errors on the web path, and all callers use fire-and-forget `void startAuthFlow(...)` with no error feedback — users click sign-in buttons and see nothing when auth fails.

### What changed

**1. `startAuthFlow()` now propagates errors on web** (`runtime/native-auth.ts`)

Previously, a single try/catch wrapped both native and web paths, catching all errors and only logging to console. Now:
- **Native path**: try/catch swallows `USER_CANCELLED` (routine dismissal), re-throws everything else
- **Web path**: no try/catch — errors from `startProviderRedirect()` propagate to the caller

**2. All callers now handle errors with user-visible feedback**

- **`login-page.tsx` (`WebLoginForm`)**: Added `errorMessage` and `loading` state. Buttons disabled during auth, inline error on failure. Consolidated three identical handlers into `handleProvider(hint?)`.
- **`signup-page.tsx`**: `.catch()` with error state. Renders a centered error message instead of blank screen on failure.
- **`account-page.tsx`**: try/catch with `errorMessage` state and `signingIn` loading state. Button disabled during auth, inline error on failure.

**3. Error text uses semantic `--system-negative-strong` token**

All auth error messages (including `NativeLoginForm` which was ported with the wrong token) now use `--system-negative-strong` instead of `--content-secondary`.

### Why this is needed

Any failure in the auth flow produced zero user-visible feedback across all auth entry points. The error was only in the console. Acknowledged in the code: `TODO(LUM-1127 follow-up): plumb a visible toast/inline error`.

### Why this is safe

- Native `USER_CANCELLED` still swallowed; `NativeLoginForm` already has try/catch + error state
- All four callers of `startAuthFlow` now handle errors — no unhandled rejections (verified via grep)
- No changes to CSRF bootstrap, provider redirect, or callback logic

### Root cause analysis

1. `startAuthFlow()` was designed for the native Capacitor path; the web path was bolted on inside the same try/catch, inheriting native error-swallowing behavior
2. The `void startAuthFlow(...)` fire-and-forget pattern in all callers made errors architecturally unreachable from the UI layer
3. **Prevention**: When porting code that mixes platform-specific and shared concerns, verify error handling works correctly per platform. Functions changing error contract (swallowing → propagating) must have all callers audited

### Alternatives not taken

- **Toast-based errors**: Rejected — inline errors next to the button are more discoverable and match `NativeLoginForm` pattern
- **Keep swallowing + `onError` callback**: Rejected — adds API complexity without following standard async/await error propagation

### References

- [React useState](https://react.dev/reference/react/useState)
- allauth headless `browser_view` decorator confirms CSRF cookie via `get_token(request)` on every browser-client response

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- `bun run build` — passes
- Grep audit: all 4 callers of `startAuthFlow` handle errors
- CI Test job failure is pre-existing on `main` (DOM test env not set up — LUM-1675)

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->