### PR TITLE
Add sitemap navigation guidance to web_fetch tool

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -976,7 +976,7 @@ export async function executeWebFetch(
 class WebFetchTool implements Tool {
   name = "web_fetch";
   description =
-    "Fetch a webpage and return LLM-friendly extracted text with metadata. Use this after web_search when you need to read a specific result.";
+    "Fetch a webpage and return LLM-friendly extracted text with metadata. Use this after web_search when you need to read a specific result. When navigating a content site for specific pages you weren't given direct URLs to, fetch the sitemap (/sitemap.xml) rather than guessing slugs from titles — it has ground-truth paths, last-modified dates, and full coverage. A page that returns unusually short content or redirects to the homepage is often JS-rendered; the sitemap usually still works even when direct fetches don't.";
   category = "network";
   defaultRiskLevel = RiskLevel.Low;
 

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -976,7 +976,7 @@ export async function executeWebFetch(
 class WebFetchTool implements Tool {
   name = "web_fetch";
   description =
-    "Fetch a webpage and return LLM-friendly extracted text with metadata. Use this after web_search when you need to read a specific result. When navigating a content site for specific pages you weren't given direct URLs to, fetch the sitemap (/sitemap.xml) rather than guessing slugs from titles — it has ground-truth paths, last-modified dates, and full coverage. A page that returns unusually short content or redirects to the homepage is often JS-rendered; the sitemap usually still works even when direct fetches don't.";
+    "Fetch a webpage and return LLM-friendly extracted text with metadata. Use this after web_search when you need to read a specific result. To find pages on a site without guessing slugs, fetch /sitemap.xml first — it has ground-truth paths and works even when pages are JS-rendered.";
   category = "network";
   defaultRiskLevel = RiskLevel.Low;
 


### PR DESCRIPTION
## Summary
- Adds guidance to the `web_fetch` tool description teaching the agent to prefer `/sitemap.xml` over guessing URL slugs when navigating content sites without direct URLs
- Sitemaps provide ground-truth paths, last-modified dates, and full coverage — and work even when pages are JS-rendered and return empty/short content via direct fetch

## Test plan
- [x] Pre-commit hooks pass (lint, typecheck, formatting)
- [ ] Verify the updated description surfaces correctly in tool definitions during inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->