### PR TITLE
fix(risk): cap High → Medium for containerized bash without credentials

### DIFF
--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -425,6 +425,87 @@ describe("credentialed proxied bash", () => {
   });
 });
 
+// ── Containerized bash risk cap ──────────────────────────────────────────────
+
+describe("containerized bash risk cap", () => {
+  test("containerized bash caps high risk to medium", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "rm -rf /",
+      isContainerized: true,
+    });
+    expect(result.risk).toBe("medium");
+  });
+
+  test("containerized bash keeps low risk unchanged", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      isContainerized: true,
+    });
+    expect(result.risk).toBe("low");
+  });
+
+  test("containerized bash keeps medium risk unchanged", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "git push",
+      isContainerized: true,
+    });
+    expect(result.risk).toBe("medium");
+  });
+
+  test("containerized bash with credentials stays high", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "rm -rf /",
+      isContainerized: true,
+      credentialRefCount: 1,
+    });
+    expect(result.risk).toBe("high");
+  });
+
+  test("non-containerized bash stays high", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "rm -rf /",
+      isContainerized: false,
+    });
+    expect(result.risk).toBe("high");
+  });
+
+  test("containerized host_bash is not affected", async () => {
+    const result = await classify({
+      tool: "host_bash",
+      command: "rm -rf /",
+      isContainerized: true,
+    });
+    expect(result.risk).toBe("high");
+  });
+
+  test("containerized proxied bash uses proxied cap (not containerized cap)", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "rm -rf /",
+      isContainerized: true,
+      networkMode: "proxied",
+    });
+    // Proxied cap fires first and already caps to medium
+    expect(result.risk).toBe("medium");
+  });
+
+  test("containerized proxied bash with credentials stays high (proxied credential escalation)", async () => {
+    const result = await classify({
+      tool: "bash",
+      command: "ls",
+      isContainerized: true,
+      networkMode: "proxied",
+      credentialRefCount: 1,
+    });
+    expect(result.risk).toBe("high");
+  });
+});
+
 // ── Unknown tool fallback ───────────────────────────────────────────────────
 
 describe("unknown tool fallback", () => {

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -383,6 +383,22 @@ export async function handleClassifyRisk(
         }
       }
 
+      // Containerized bash risk cap:
+      // When bash runs inside the assistant's own container, high-risk
+      // commands have limited blast radius (only the container itself).
+      // Cap High → Medium to reflect the reduced effective risk.
+      // Credential-attached invocations are excluded because credentials
+      // may affect external systems beyond the container boundary.
+      if (
+        tool === "bash" &&
+        isContainerized &&
+        params.networkMode !== "proxied" &&
+        credentialRefCount === 0 &&
+        finalRisk === "high"
+      ) {
+        finalRisk = "medium";
+      }
+
       // Collect resolved paths for directory-scoped rule enforcement.
       // These are the same resolved args used for scope generation — the
       // assistant threads them into `findHighestPriorityRule` so scoped


### PR DESCRIPTION
When bash runs inside the assistant's own container, the risk classifier reports commands like `rm -rf` as "high" based on inherent destructiveness, but the approval policy auto-approves them via `sandboxAutoApprove` — resulting in a confusing "High · Auto-approved · Sandboxed workspace" badge. This caps High → Medium for containerized bash (matching the existing proxied bash cap) so the displayed risk reflects the reduced blast radius.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/8486baca092f4f8ea10aa13620dee853
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->