### PR TITLE
fix(web): set up DOM test environment and fix all test failures (LUM-1675)

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -74,6 +74,10 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -61,8 +61,6 @@ jobs:
 
   test:
     name: Test
-    # Non-blocking until pre-existing failures are fixed (LUM-1687).
-    # The aggregator excludes this job from the gate check.
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -83,7 +81,7 @@ jobs:
         run: bun run openapi-ts
 
       - name: Test
-        run: bun test
+        run: bun run test:ci
 
   build:
     name: Build
@@ -128,11 +126,9 @@ jobs:
         run: |
           echo "Lint:       $LINT"
           echo "Type Check: $TYPECHECK"
-          echo "Test:       $TEST (non-blocking until LUM-1687)"
+          echo "Test:       $TEST"
           echo "Build:      $BUILD"
-          # Test is excluded from the gate until pre-existing failures
-          # are fixed (LUM-1687). Once green, add TEST to this loop.
-          for r in "$LINT" "$TYPECHECK" "$BUILD"; do
+          for r in "$LINT" "$TYPECHECK" "$TEST" "$BUILD"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one web CI job failed."
               exit 1

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -79,6 +79,10 @@ jobs:
         with:
           bun-version: '1.3.11'
 
+      - name: Install design-library dependencies
+        working-directory: packages/design-library
+        run: bun install --frozen-lockfile
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -66,8 +66,6 @@ jobs:
 
   test:
     name: Test
-    # Non-blocking until pre-existing failures are fixed (LUM-1687).
-    # The aggregator excludes this job from the gate check.
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,7 +86,7 @@ jobs:
         run: bun run openapi-ts
 
       - name: Test
-        run: bun test
+        run: bun run test:ci
 
   build:
     name: Build
@@ -136,11 +134,9 @@ jobs:
         run: |
           echo "Lint:       $LINT"
           echo "Type Check: $TYPECHECK"
-          echo "Test:       $TEST (non-blocking until LUM-1687)"
+          echo "Test:       $TEST"
           echo "Build:      $BUILD"
-          # Test is excluded from the gate until pre-existing failures
-          # are fixed (LUM-1687). Once green, add TEST to this loop.
-          for r in "$LINT" "$TYPECHECK" "$BUILD"; do
+          for r in "$LINT" "$TYPECHECK" "$TEST" "$BUILD"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one web CI job failed."
               exit 1

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -38,6 +38,7 @@ cd apps/web && bunx tsc --noEmit      # Type-check
 cd apps/web && bun run lint           # Lint
 cd apps/web && bun run build          # Production build
 cd apps/web && bun test src/path/to/file.test.ts  # Run specific tests
+cd apps/web && bun run test:ci       # Run all tests (isolated, CI)
 ```
 
 ## Migration status

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -893,7 +893,20 @@ If bypassing, add a comment explaining why.
 
 ## Testing
 
-- **Test framework:** `bun:test` (`describe`, `it`, `expect`, `mock`).
+- **Test framework:** [Bun's test runner](https://bun.sh/docs/test)
+  (`describe`, `it`, `expect`, `mock`).
+- **DOM environment:**
+  [happy-dom](https://github.com/nicedoc/happy-dom) provides
+  `window`, `document`, `localStorage`, `sessionStorage`, and `fetch`
+  via a preload script (`test-setup.ts`, referenced in `bunfig.toml`).
+  Component and hook tests can render to the DOM without a real
+  browser.
+- **Component rendering:** Use
+  [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/)
+  `render` for component tests.
+  [`renderToStaticMarkup`](https://react.dev/reference/react-dom/server/renderToStaticMarkup)
+  is SSR-only and does not support Zustand store subscriptions — avoid
+  it for tests that rely on store state.
 - **Colocate tests with source.** `message-handlers.test.ts` lives
   alongside `message-handlers.ts`.
 - **Test reducers and pure functions in isolation.** They are pure
@@ -902,7 +915,17 @@ If bypassing, add a comment explaining why.
 - **Mock at the right boundary.** Mock API clients (`client.get`,
   `client.post`), not `globalThis.fetch`. This catches request-building
   bugs that fetch-level mocks miss.
-- **Run tests:** `bun test src/path/to/file.test.ts`
+- **`mock.module()` is process-global.** Bun's
+  [`mock.module()`](https://bun.sh/docs/test/mocking#mock-module)
+  replaces the module for the entire process — mocks leak across test
+  files. Files pass individually but may fail in a full `bun test` run.
+  CI uses `bun run test:ci` (each file in its own subprocess) to
+  guarantee isolation.
+- **Run tests:**
+  ```bash
+  bun test src/path/to/file.test.ts  # single file (fast)
+  bun run test:ci                    # all files, isolated (CI)
+  ```
 - **Test Zustand stores via their non-React API.** Use `.getState()`
   and `.setState()` directly — no React rendering needed. Reset the
   store in `beforeEach` with `useStore.setState(initialState, true)`

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -79,6 +79,29 @@ bun run typecheck  # bunx tsc --noEmit
 bun run lint       # eslint
 ```
 
+## Testing
+
+```bash
+bun test                         # run all tests (single process, fast)
+bun test src/path/to/file.test.ts  # run one file
+bun run test:ci                  # run each file in its own process (CI)
+```
+
+Tests use [Bun's built-in test runner](https://bun.sh/docs/test) with
+[happy-dom](https://github.com/nicedoc/happy-dom) providing browser
+globals (`window`, `document`, `localStorage`, `fetch`, etc.) so
+component and hook tests run without a real browser.
+
+### Why `test:ci`?
+
+Bun's
+[`mock.module()`](https://bun.sh/docs/test/mocking#mock-module)
+mutates a process-global module registry — mocks set in one test file
+leak into every subsequent file in the same process. `bun run test:ci`
+runs each file in its own subprocess for full isolation. Use it when
+the standard `bun test` shows cross-file contamination, or in CI where
+deterministic results are required.
+
 ## Architecture
 
 See [`CONVENTIONS.md`](./CONVENTIONS.md) for code organization

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -57,6 +57,7 @@
       },
       "devDependencies": {
         "@capacitor/cli": "8.3.4",
+        "@happy-dom/global-registrator": "18.0.1",
         "@hey-api/openapi-ts": "0.97.1",
         "@sentry/vite-plugin": "3.4.0",
         "@tailwindcss/vite": "4.1.8",
@@ -65,6 +66,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
         "eslint": "10.2.0",
+        "happy-dom": "18.0.1",
         "tailwindcss": "4.1.8",
         "typescript": "5.9.3",
         "typescript-eslint": "8.58.1",
@@ -216,6 +218,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^18.0.1" } }, "sha512-xCy/cpEP8xyJ6u0eokYgaQxeUmcKqHx/+aC3R0DLa7/S38efhZAVDQqLJ5zzTguLFS0gvAzZHP40NGaLwRyapQ=="],
 
     "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA=="],
 
@@ -671,7 +675,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+    "@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -684,6 +688,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
@@ -982,6 +988,8 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA=="],
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
@@ -1469,7 +1477,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -1514,6 +1522,8 @@
     "webpack-sources": ["webpack-sources@3.4.1", "", {}, "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.5.0", "", {}, "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -1601,11 +1611,15 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@types/fs-extra/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@vellum/design-library/@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
 
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -1677,11 +1691,15 @@
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "@types/fs-extra/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
     "@vellum/design-library/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
     "@vellum/design-library/@tailwindcss/vite/@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
 
     "@vellum/design-library/@tailwindcss/vite/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 

--- a/apps/web/bunfig.toml
+++ b/apps/web/bunfig.toml
@@ -1,0 +1,8 @@
+[test]
+
+# happy-dom provides window, document, localStorage, sessionStorage, fetch,
+# and other browser APIs so component tests and hooks that touch the DOM can
+# run in Bun's test runner without a real browser.
+#
+# Reference: https://github.com/nicedoc/happy-dom/wiki/GlobalRegistrator
+preload = ["./test-setup.ts"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
-    "postinstall": "rm -rf ../../packages/design-library/node_modules/@types/react ../../packages/design-library/node_modules/@types/react-dom 2>/dev/null; for pkg in react react-dom; do rm -rf ../../packages/design-library/node_modules/$pkg && ln -sf \"$(cd ../.. && pwd)/apps/web/node_modules/$pkg\" ../../packages/design-library/node_modules/$pkg; done 2>/dev/null; true && test -d src/generated || bun run openapi-ts",
+    "postinstall": "mkdir -p ../../packages/design-library/node_modules && rm -rf ../../packages/design-library/node_modules/@types/react ../../packages/design-library/node_modules/@types/react-dom 2>/dev/null; for pkg in react react-dom; do rm -rf ../../packages/design-library/node_modules/$pkg && ln -sf \"$(cd ../.. && pwd)/apps/web/node_modules/$pkg\" ../../packages/design-library/node_modules/$pkg; done 2>/dev/null; true && test -d src/generated || bun run openapi-ts",
     "openapi-ts": "openapi-ts",
     "ios:setup": "bunx cap sync ios && cd ../ios/App && xcodegen generate --spec project.yml",
     "ios:open": "bun run ios:setup && open ../ios/App/App.xcodeproj",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,9 @@
     "postinstall": "rm -rf ../../packages/design-library/node_modules/@types/react ../../packages/design-library/node_modules/@types/react-dom 2>/dev/null; for pkg in react react-dom; do rm -rf ../../packages/design-library/node_modules/$pkg && ln -sf \"$(cd ../.. && pwd)/apps/web/node_modules/$pkg\" ../../packages/design-library/node_modules/$pkg; done 2>/dev/null; true && test -d src/generated || bun run openapi-ts",
     "openapi-ts": "openapi-ts",
     "ios:setup": "bunx cap sync ios && cd ../ios/App && xcodegen generate --spec project.yml",
-    "ios:open": "bun run ios:setup && open ../ios/App/App.xcodeproj"
+    "ios:open": "bun run ios:setup && open ../ios/App/App.xcodeproj",
+    "test": "bun test",
+    "test:ci": "bun scripts/run-tests.ts"
   },
   "dependencies": {
     "@capacitor/app": "8.1.0",
@@ -68,6 +70,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "8.3.4",
+    "@happy-dom/global-registrator": "18.0.1",
     "@hey-api/openapi-ts": "0.97.1",
     "@sentry/vite-plugin": "3.4.0",
     "@tailwindcss/vite": "4.1.8",
@@ -76,6 +79,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
     "eslint": "10.2.0",
+    "happy-dom": "18.0.1",
     "tailwindcss": "4.1.8",
     "typescript": "5.9.3",
     "typescript-eslint": "8.58.1",

--- a/apps/web/scripts/run-tests.ts
+++ b/apps/web/scripts/run-tests.ts
@@ -1,0 +1,73 @@
+/**
+ * Runs each test file in its own Bun subprocess to guarantee mock isolation.
+ *
+ * Bun's `mock.module()` mutates a process-global module registry, so mocks
+ * set in one test file leak into every subsequent file in the same process.
+ * Running each file in its own process is the only reliable workaround.
+ *
+ * Usage:
+ *   bun scripts/run-tests.ts                  # run all test files
+ *   bun scripts/run-tests.ts src/foo.test.ts  # run specific files
+ *
+ * Environment:
+ *   TEST_CONCURRENCY=N  — max parallel processes (default: 8)
+ *
+ * Reference: https://bun.sh/docs/test/mocking#mock-module
+ */
+
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const concurrency = parseInt(process.env.TEST_CONCURRENCY ?? "8", 10);
+
+// Collect test files — from CLI args or by globbing src/.
+const files =
+  args.length > 0
+    ? args
+    : [...new Glob("src/**/*.test.{ts,tsx}").scanSync(".")].sort();
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+async function runFile(file: string): Promise<boolean> {
+  const proc = Bun.spawn(["bun", "test", file], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: import.meta.dir + "/..",
+  });
+  // Read streams concurrently with exit to prevent pipe-buffer deadlock.
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    process.stderr.write(`\n✗ ${file}\n${stdout}${stderr}`);
+    return false;
+  }
+  return true;
+}
+
+// Process files in batches of `concurrency`.
+for (let i = 0; i < files.length; i += concurrency) {
+  const batch = files.slice(i, i + concurrency);
+  await Promise.all(
+    batch.map(async (f) => {
+      if (await runFile(f)) {
+        passed++;
+      } else {
+        failed++;
+        failures.push(f);
+      }
+    }),
+  );
+}
+
+console.log(`\n${passed} passed, ${failed} failed (${files.length} test files)`);
+
+if (failures.length > 0) {
+  console.log("\nFailed:");
+  for (const f of failures) console.log(`  ${f}`);
+  process.exit(1);
+}

--- a/apps/web/scripts/run-tests.ts
+++ b/apps/web/scripts/run-tests.ts
@@ -18,7 +18,7 @@
 import { Glob } from "bun";
 
 const args = process.argv.slice(2);
-const concurrency = parseInt(process.env.TEST_CONCURRENCY ?? "8", 10);
+const concurrency = Math.max(1, parseInt(process.env.TEST_CONCURRENCY ?? "8", 10) || 8);
 
 // Collect test files — from CLI args or by globbing src/.
 const files =

--- a/apps/web/src/domains/chat/api/api.test.ts
+++ b/apps/web/src/domains/chat/api/api.test.ts
@@ -40,7 +40,7 @@ const sentryCaptureMessages: SentryCaptureMessageCall[] = [];
 // Sentry so fleet-wide passive telemetry can answer the L2/L3 question even
 // when users never submit a support snapshot. Capturing every call makes
 // those code paths assertable.
-mock.module("@sentry/nextjs", () => ({
+mock.module("@sentry/browser", () => ({
   addBreadcrumb: (crumb: SentryBreadcrumbCall) => {
     sentryBreadcrumbs.push(crumb);
   },

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1,18 +1,17 @@
 /**
  * Tests for the `ChatComposer` extraction.
  *
- * The web workspace lacks `@testing-library/react` (no jsdom/happy-dom), so
- * we exercise behavior through two channels:
+ * Exercises behavior through two channels:
  *   1. The pure `shouldSubmitOnEnter` policy helper — used by the textarea's
  *      onKeyDown handler in production. Asserting on the helper is equivalent
  *      to asserting on the keyboard handler since the production handler is a
  *      thin shim around it.
- *   2. `renderToStaticMarkup` for HTML surface checks (placeholder, send/stop
- *      button, disabled attribute).
+ *   2. `@testing-library/react` `render` for HTML surface checks (placeholder,
+ *      send/stop button, disabled attribute).
  */
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, render } from "@testing-library/react";
 
 import {
   type ChatAttachment,
@@ -279,8 +278,10 @@ describe("computeGhostSuffix", () => {
 // HTML rendering — placeholder and send/stop button surface
 // ---------------------------------------------------------------------------
 
+afterEach(cleanup);
+
 function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
-  return renderToStaticMarkup(
+  const { container } = render(
     <ChatComposer
       input=""
       setInput={() => {}}
@@ -299,6 +300,7 @@ function renderComposer(props: Partial<Parameters<typeof ChatComposer>[0]> = {})
       {...props}
     />,
   );
+  return container.innerHTML;
 }
 
 describe("ChatComposer — placeholder", () => {

--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -1,0 +1,17 @@
+/**
+ * Test preload — registers happy-dom globals (window, document,
+ * localStorage, sessionStorage, etc.) so component and hook tests
+ * can run in Bun's test runner without a real browser.
+ *
+ * Loaded via `preload` in bunfig.toml.
+ *
+ * Reference: https://github.com/nicedoc/happy-dom/wiki/GlobalRegistrator
+ */
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+
+// Set a base URL so relative fetch requests (e.g. "/v1/assistants/...")
+// resolve correctly instead of failing against "about:blank".
+window.location.href = "http://localhost:3000";


### PR DESCRIPTION
## Why

The web app had 46 test failures that were never caught because there was no Test job in CI until LUM-1545 added one. All failures stem from missing browser globals (`window`, `document`, `localStorage`, `fetch`) — Bun's test runner doesn't provide a DOM environment by default.

## What changed

### DOM environment — happy-dom

- Added [`happy-dom`](https://github.com/nicedoc/happy-dom) + [`@happy-dom/global-registrator`](https://github.com/nicedoc/happy-dom/wiki/GlobalRegistrator) as dev dependencies
- Created `test-setup.ts` preload script that registers browser globals and sets `window.location.href` to `http://localhost:3000` (so relative `fetch()` URLs resolve instead of failing against `about:blank`)
- Configured in `bunfig.toml` via `[test] preload`

### Per-file isolated test runner

- Created `scripts/run-tests.ts` — runs each test file in its own Bun subprocess with configurable concurrency (`TEST_CONCURRENCY` env var, default 8)
- Added `test:ci` script to `package.json`

**Why isolation is needed:** Bun's [`mock.module()`](https://bun.sh/docs/test/mocking#mock-module) mutates a process-global module registry with no `restore()` API. Mocks set in one test file leak into every subsequent file in the same process. Running each file in its own process is the only reliable workaround. This affects 24 of the original 46 failures — files that pass individually but fail in a full `bun test` run due to contamination.

### Test fixes

1. **ChatComposer stop-button tests (2 failures):** Converted `renderToStaticMarkup` → `@testing-library/react` `render`. Root cause: `renderToStaticMarkup` does synchronous SSR where Zustand's `getServerSnapshot` returns initial state, ignoring `setState()` calls. Client-side `render` uses `getSnapshot` which reads the live store.

2. **Sentry watchdog tests (3 failures):** Changed mock path from `@sentry/nextjs` → `@sentry/browser` in `api.test.ts`. Root cause: production code imports `@sentry/browser`, but the test mocked `@sentry/nextjs` (a leftover from when this code lived in the Next.js platform repo). The mock never intercepted calls.

### CI changes

- Changed test step from `bun test` → `bun run test:ci` in both `pr-web.yaml` and `ci-main-web.yaml`
- **Made Test job blocking** — added `TEST` to the aggregator gate check. Previously non-blocking while failures existed.

### Documentation

- `README.md`: Added Testing section with commands and `test:ci` explanation
- `CONVENTIONS.md`: Expanded Testing section with happy-dom setup, `@testing-library/react` guidance, `mock.module()` isolation caveat, and updated run commands
- `AGENTS.md`: Added `test:ci` command

## Alternatives not chosen

- **jsdom**: Heavier (~2MB vs ~500KB), slower startup. happy-dom is purpose-built for test environments and Bun-compatible.
- **Bun's built-in `environment = "happy-dom"` config**: Not supported in Bun 1.3.x. The `preload` + `GlobalRegistrator` approach is the documented workaround.
- **Per-test `mock.restore()`**: Bun's `mock.restore()` doesn't restore module mocks — only function mocks. No API exists to undo `mock.module()`.
- **Restructuring tests to avoid `mock.module()`**: High effort, and the tests legitimately need module mocking. Per-file isolation is the pragmatic solution with zero test code changes.

## Root cause analysis

1. **How did 46 failures accumulate?** Tests were written against component/hook code that requires browser APIs, but no DOM environment was configured and no CI Test job existed to catch failures.
2. **What decisions led to it?** The Test job was deliberately deferred during initial CI setup (LUM-1545), creating a window where tests could be written without validation.
3. **Warning signs missed?** Running `bun test` locally would have shown failures, but without CI enforcement there was no feedback loop.
4. **Prevention:** The Test job is now blocking in CI. New test failures will be caught immediately.

## Test plan

- `bun run test:ci` — 79 files, 0 failures (verified locally)
- Lint and typecheck clean
- CI will validate on this PR

Closes LUM-1675

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->