### PR TITLE
fix: show persistent success message after assistant upgrade completes

### DIFF
--- a/apps/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/apps/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -148,6 +148,7 @@ export function AssistantUpgrades({
 
   const handleUpgrade = async () => {
     setShowConfirmation(false);
+    setSuccessMessage(null);
     const targetVersion = selectedVersion ?? undefined;
     try {
       if (isRollback) {

--- a/apps/web/src/domains/settings/components/assistant-upgrades.tsx
+++ b/apps/web/src/domains/settings/components/assistant-upgrades.tsx
@@ -54,6 +54,7 @@ export function AssistantUpgrades({
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [isPollingRollback, setIsPollingRollback] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const pollRefetchInterval = (version: string | null | undefined) => {
     if (
@@ -62,6 +63,10 @@ export function AssistantUpgrades({
       version === targetVersionRef.current
     ) {
       queueMicrotask(() => {
+        const msg = isPollingRollback
+          ? `Successfully rolled back to version ${targetVersionRef.current}.`
+          : `Successfully updated to version ${targetVersionRef.current}.`;
+        setSuccessMessage(msg);
         setIsPollingUpgrade(false);
         targetVersionRef.current = null;
         setSelectedVersion(null);
@@ -286,7 +291,7 @@ export function AssistantUpgrades({
         effectiveSelectedVersion &&
         !releasesLoading && (
           <p className="text-body-medium-lighter text-[var(--system-positive-strong)]">
-            You are already on this version.
+            {successMessage ?? "You are already on this version."}
           </p>
         )}
 


### PR DESCRIPTION
After a successful upgrade/rollback, the component now displays a persistent success message (e.g., "Successfully updated to version X.Y.Z.") instead of the generic "You are already on this version." message. The previous behavior was confusing because the only success feedback was a transient toast that auto-dismissed, leaving the user with no lasting confirmation that their upgrade succeeded.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/4b5895e4913b44e096929156c073d378
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->