### PR TITLE
docs(chat): drop stale AssistantShell references

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -1,6 +1,6 @@
 /**
  * Chat route content — renders the chat-specific UI (main chat, document panel,
- * app-editing side panel) within the `AssistantShell` layout.
+ * app-editing side panel) inside `ChatLayout`.
  *
  * Extracted from `AssistantPageClient` as Phase 1 of route-level component
  * splitting. This component owns:

--- a/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-app-overlay.tsx
@@ -32,10 +32,13 @@ interface MobileAppOverlayProps {
  * minimized (`isAppMinimized=true`) so the chat behind becomes interactive
  * again.
  *
- * Rendered through the assistant shell's viewport-overlay slot, which places
- * it as a sibling of the shell's transformed inner wrapper. That sibling
- * position keeps `position: fixed` anchored to the viewport's initial
- * containing block rather than the keyboard-following shell transform.
+ * **Mounting constraint**: must render outside `RootLayout`'s inner
+ * transformed wrapper (see `src/components/layout/root-layout.tsx`). When
+ * the soft keyboard opens, `RootLayout` applies a `translate3d(...)` to its
+ * inner div to follow the visual viewport — any `position: fixed` element
+ * inside that transformed wrapper anchors to the transform's origin rather
+ * than the viewport's initial containing block, and the overlay drifts with
+ * the keyboard. Render as a sibling of the inner wrapper instead.
  *
  * https://www.w3.org/TR/css-transforms-1/#transform-rendering
  */

--- a/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-document-overlay.tsx
@@ -12,11 +12,13 @@ interface MobileDocumentOverlayProps {
 
 /**
  * Mobile-only full-screen overlay that hosts the document viewer for a
- * surface referenced from chat. Rendered through the assistant shell's
- * viewport-overlay slot so it lives as a sibling of the shell's transformed
- * inner wrapper — keeping its `position: fixed` box anchored to the
- * viewport's initial containing block rather than the keyboard-following
- * shell transform.
+ * surface referenced from chat.
+ *
+ * **Mounting constraint**: must render outside `RootLayout`'s inner
+ * transformed wrapper (see `src/components/layout/root-layout.tsx`) so
+ * `position: fixed` anchors to the viewport's initial containing block
+ * rather than the keyboard-following transform `RootLayout` applies when
+ * the soft keyboard opens.
  *
  * https://www.w3.org/TR/css-transforms-1/#transform-rendering
  */

--- a/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
+++ b/apps/web/src/domains/chat/components/mobile-subagent-detail-overlay.tsx
@@ -14,10 +14,12 @@ interface MobileSubagentDetailOverlayProps {
 
 /**
  * Mobile-only full-screen overlay that hosts the subagent detail panel.
- * Rendered through the assistant shell's viewport-overlay slot so it lives
- * as a sibling of the shell's transformed inner wrapper — keeping its
- * `position: fixed` box anchored to the viewport's initial containing block
- * rather than the keyboard-following shell transform.
+ *
+ * **Mounting constraint**: must render outside `RootLayout`'s inner
+ * transformed wrapper (see `src/components/layout/root-layout.tsx`) so
+ * `position: fixed` anchors to the viewport's initial containing block
+ * rather than the keyboard-following transform `RootLayout` applies when
+ * the soft keyboard opens.
  *
  * https://www.w3.org/TR/css-transforms-1/#transform-rendering
  */


### PR DESCRIPTION
## Summary

Drops the stale `AssistantShell` references that don't match the new repo's architecture. There's no `AssistantShell` component or `viewportOverlays` slot in `apps/web/` — `RootLayout` (`src/components/layout/root-layout.tsx`) owns the keyboard-following transform, and `ChatLayout` owns the chat-specific layout.

The functional concern the comments were trying to capture is still real — mobile overlays must render outside `RootLayout`'s inner transformed div so `position: fixed` anchors to the viewport's initial containing block instead of the keyboard-following transform — but the named "slot" is platform terminology.

## Changes

| File | Change |
|---|---|
| `mobile-app-overlay.tsx` | JSDoc: drop "assistant shell's viewport-overlay slot", explain the `RootLayout`-inner-transform constraint by name |
| `mobile-document-overlay.tsx` | Same |
| `mobile-subagent-detail-overlay.tsx` | Same |
| `chat-route-content.tsx` | Header comment: "within the `AssistantShell` layout" → "inside `ChatLayout`" |

Pure doc fix — no behavior change.

## Test plan

- [x] `bun run lint` — clean (one pre-existing warning, not mine)
- [x] `bun run typecheck` — clean
- [x] `grep -rn "AssistantShell\|viewportOverlays" apps/web/src` returns nothing


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWERLgh2s54Vi5NiSWShn2)_