### PR TITLE
chore(web): remove manual route hierarchy comment, add grep hint

### DIFF
--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -69,52 +69,13 @@ function HomePageRoute() {
   );
 }
 
-/**
- * Route hierarchy (no basename — routes are absolute browser paths):
- *
- *   /account/*   — standalone auth pages, no app chrome
- *   │  ├── AccountPage (/account)
- *   │  ├── LoginPage (/account/login)
- *   │  ├── SignupPage (/account/signup)
- *   │  ├── ProviderCallbackPage (/account/provider/callback)
- *   │  ├── ProviderSignupPage (/account/provider/signup)
- *   │  ├── OAuthPopupCompletePage (/account/oauth/popup-complete)
- *   │  ├── DesktopOAuthCompletePage (/account/oauth/desktop-complete)
- *   │  ├── PasswordResetPage (/account/password/reset → redirects to login)
- *   │  └── PasswordResetPage (/account/password/reset/key/:key → redirects to login)
- *   │
- *   /logout        — standalone logout (calls API, redirects to login)
- *   │
- *   /assistant/* — auth-protected app with RootLayout
- *   │  middleware: [authMiddleware] — redirects to login when auth required
- *   │  ├── Onboarding (full-screen, no app chrome)
- *   │  │   ├── PrivacyScreen (/assistant/onboarding/privacy)
- *   │  │   ├── PreChatFlow (/assistant/onboarding/prechat)
- *   │  │   └── HatchingScreen (/assistant/onboarding/hatching)
- *   │  ├── SettingsLayout (full-screen overlay panel, no ChatLayout sidebar)
- *   │  │   ├── GeneralPage (/assistant/settings/general)
- *   │  │   ├── AiPage (/assistant/settings/ai)
- *   │  │   ├── IntegrationsPage, SchedulesPage, VoicePage, ...
- *   │  │   ├── BillingPage (/assistant/settings/billing)
- *   │  │   │   ├── onboarding, upgrade/cancel, upgrade/success
- *   │  │   └── AdvancedPage, DeveloperPage, DebugPage
- *   │  ├── LogsLayout (full-screen overlay panel, like SettingsLayout)
- *   │  │   ├── TracePage (/assistant/logs/trace)
- *   │  │   ├── UsagePage (/assistant/logs/usage)
- *   │  │   ├── SystemEventsPage (/assistant/logs/system-events)
- *   │  │   └── EmailsPage (/assistant/logs/emails)
- *   │  └── ChatLayout — sidebar rail, drawer, shortcuts
- *   │       ├── ChatPage (index, /assistant)
- *   │       ├── HomePageRoute (/assistant/home)
- *   │       ├── LibraryPage / LibraryDetailPage
- *   │       ├── ContactsPage (/assistant/contacts)
- *   │       └── ConnectPage (/assistant/connect)
- *
- * References:
- * - React Router data mode routing: https://reactrouter.com/start/data/routing
- * - React Router prefix routes: https://reactrouter.com/start/data/routing#prefix-route
- * - React Router middleware: https://reactrouter.com/how-to/middleware
- */
+// Route tree — no basename, routes are absolute browser paths.
+// To view the full hierarchy at a glance:
+//   grep -n 'path:' apps/web/src/routes.tsx
+//
+// References:
+// - React Router data mode routing: https://reactrouter.com/start/data/routing
+// - React Router middleware: https://reactrouter.com/how-to/middleware
 export const router = createBrowserRouter([
   // Account routes — standalone auth pages, no app chrome
   {


### PR DESCRIPTION
## Prompt / plan

Remove the manually-maintained ASCII route hierarchy comment from `routes.tsx`. This comment duplicated the route tree and required updating every time a route was added — a maintenance burden with no functional value since the `createBrowserRouter()` call below it is already well-structured with inline section comments.

Replaced with a concise note and a `grep` command (`grep -n 'path:' apps/web/src/routes.tsx`) that generates an equivalent view on demand from the source of truth.

**Why:** The comment drifted out of sync on every route change and was pure documentation overhead. The route config itself, with its inline comments (`// Account routes`, `// Settings routes`, `// Logs routes`, etc.), is self-documenting. The grep command gives the same at-a-glance view without manual maintenance.

**Safety:** Comment-only change — no functional code modified.

## Test plan

- Lint + typecheck via CI
- Verified `grep -n 'path:' apps/web/src/routes.tsx` produces a clear route listing

Link to Devin session: https://app.devin.ai/sessions/565d827296144ac9bf12bd108169e5ef
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->