### PR TITLE
fix(web): iOS onboarding safe-area top spacing and back-nav on privacy screen

### DIFF
--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -308,13 +308,6 @@ export function PreChatFlow() {
       if (trimmedAssistant) {
         setPendingAssistantName(trimmedAssistant);
       }
-      if (screenStorageKey) {
-        try {
-          sessionStorage.removeItem(screenStorageKey);
-        } catch {
-          // ignore — see initial-state comment.
-        }
-      }
       void navigate(routes.onboarding.privacy);
     };
     return (

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -241,6 +241,7 @@ export function PreChatFlow() {
       });
     }
     clearPrivacyConsent();
+    try { sessionStorage.removeItem("prechat_native_screen"); } catch {}
     void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
   }
 


### PR DESCRIPTION
Mirror of vellum-assistant-platform fix. Fixes two iOS onboarding bugs: (1) the back button, progress dots, and title on NameStep and VibeStep screens were clipped by the iOS status bar/notch because the header grid used `pt-4` (16px) without accounting for `--safe-area-inset-top`, and (2) the "Back" button on the privacy screen navigated to the initial NameStep instead of VibeStep because `PreChatFlow`'s screen index was ephemeral React state lost on browser back re-mount.

## Prompt / plan
Fix iOS onboarding spacing and back-nav bugs. Add `paddingTop: calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)` to the header grid in NameStepScreen and VibeStepScreen. Persist PreChatFlow's iOS native screen index in sessionStorage so `router.back()` from privacy restores the correct screen.

## Test plan
- Lint and typecheck pass (`bun run lint`, `bunx tsc --noEmit`)
- Visual verification on iOS device: NameStep and VibeStep header content should be pushed below the status bar/notch
- Navigation verification: "Back" on privacy screen should return to VibeStep, not NameStep
- Web flow unaffected (safe-area resolves to 0, sessionStorage key is scoped to native flow)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/229de90df2654a74a5dbb01fc458d65d

## Root Cause Analysis

**1. How did the code get into this state?**
The iOS-specific onboarding screens were ported from the platform repo where they had the same bugs — `pt-4` (16px) header padding without safe-area compensation, and ephemeral screen state that doesn't survive `router.back()` re-mounts.

**2. What mistakes or decisions led to it?**
The header grid pattern was copied without applying `--safe-area-inset-top` (already used in `Layout.tsx`). Mixed state-based + URL-based navigation didn't persist the screen index needed for back-nav.

**3. Were there warning signs we missed?**
The privacy screen's `py-16` (64px) vs the other screens' `pt-4` was a signal of inconsistent safe-area handling.

**4. What can we do to prevent this pattern from recurring?**
Any full-screen page outside `Layout` should apply safe-area inset padding. Mixed state + URL navigation should persist state for back-nav.

**5. Should we add a guideline to AGENTS.md?**
Consider adding: "All full-screen pages outside the main `Layout` shell must apply `--safe-area-inset-top` padding to their topmost content."
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->