### PR TITLE
feat(web): wire chat UI slots — header actions, assets pill, preferences, search, assistant name (LUM-1704–1708)

### DIFF
--- a/apps/web/src/domains/chat/assistant-context.ts
+++ b/apps/web/src/domains/chat/assistant-context.ts
@@ -1,14 +1,22 @@
 /**
- * Typed outlet context for the assistant lifecycle.
+ * Typed outlet context for the assistant lifecycle and layout slot
+ * registration.
  *
  * `ChatLayout` owns `useAssistantLifecycle` and passes the resolved
  * assistant state to all child routes via React Router's outlet context.
  * Child routes consume it through `useAssistantContext()`.
  *
+ * Layout slot setters (`setTopBarCenter`, `setTopBarRightSlot`) allow
+ * child routes to register content for the header without prop drilling.
+ * `ChatLayout` holds the slot state and passes it to `ChatLayoutHeader`;
+ * child routes call the setters (typically via `useEffect`) to fill them.
+ * When a child route unmounts its cleanup effect clears the slots.
+ *
  * References:
  * - https://reactrouter.com/start/framework/outlet
  * - https://reactrouter.com/start/framework/routing#layout-routes
  */
+import type { ReactNode } from "react";
 import { useOutletContext } from "react-router";
 
 import type {
@@ -24,6 +32,9 @@ export interface AssistantContextValue {
   hatchVersion: UseAssistantLifecycleReturn["hatchVersion"];
   setAssistantId: UseAssistantLifecycleReturn["setAssistantId"];
   autoGreetRef: UseAssistantLifecycleReturn["autoGreetRef"];
+  setTopBarCenter: (node: ReactNode) => void;
+  setTopBarRightSlot: (node: ReactNode) => void;
+  setOnSearchClick: (cb: (() => void) | null) => void;
 }
 
 export function useAssistantContext(): AssistantContextValue {

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -19,6 +19,8 @@ import { useConversationListStore } from "@/domains/conversations/conversation-l
 
 import { OfflineBanner } from "@/components/offline-banner.js";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu.js";
+import { PreferencesMenu } from "@/domains/chat/components/preferences-menu.js";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
 import { ChatLayoutHeader } from "./chat-layout-header.js";
 
 /**
@@ -113,6 +115,18 @@ export function ChatLayout() {
     onRedirect: navigate,
   });
 
+  // --- Layout slot state for child route content ---
+  const [topBarCenter, setTopBarCenter] = useState<ReactNode>(null);
+  const [topBarRightSlot, setTopBarRightSlot] = useState<ReactNode>(null);
+  const onSearchClickRef = useRef<(() => void) | null>(null);
+  const setOnSearchClick = useCallback((cb: (() => void) | null) => {
+    onSearchClickRef.current = cb;
+  }, []);
+
+  // --- Assistant identity from store (written by ChatPage) ---
+  const assistantName = useAssistantIdentityStore.use.name();
+  const assistantVersion = useAssistantIdentityStore.use.version();
+
   const assistantContext = useMemo<AssistantContextValue>(
     () => ({
       assistantId: lifecycle.assistantId,
@@ -122,6 +136,9 @@ export function ChatLayout() {
       hatchVersion: lifecycle.hatchVersion,
       setAssistantId: lifecycle.setAssistantId,
       autoGreetRef: lifecycle.autoGreetRef,
+      setTopBarCenter,
+      setTopBarRightSlot,
+      setOnSearchClick,
     }),
     [
       lifecycle.assistantId,
@@ -131,6 +148,7 @@ export function ChatLayout() {
       lifecycle.hatchVersion,
       lifecycle.setAssistantId,
       lifecycle.autoGreetRef,
+      setOnSearchClick,
     ],
   );
 
@@ -217,9 +235,6 @@ export function ChatLayout() {
       window.removeEventListener("keydown", onKeyDown);
     };
   }, [toggleSidebar]);
-
-  // Ctrl/Cmd+K shortcut for command palette — listener is only installed
-  // when a handler exists to avoid swallowing the browser's default behavior.
 
   // Ctrl/Cmd+[ and Ctrl/Cmd+] shortcuts for back/forward navigation
   useEffect(() => {
@@ -323,6 +338,7 @@ export function ChatLayout() {
     (args: SideMenuRenderArgs): ReactNode => (
       <AssistantSideMenu
         assistantId={lifecycle.assistantId ?? ""}
+        assistantName={assistantName}
         collapsed={args.collapsed}
         variant={args.variant}
         conversations={conversations}
@@ -336,12 +352,20 @@ export function ChatLayout() {
         onOpenIntelligence={handleOpenHome}
         isLibraryActive={isLibraryActive}
         onOpenLibrary={handleOpenLibrary}
+        footerAction={
+          <PreferencesMenu
+            assistantId={lifecycle.assistantId}
+            assistantVersion={assistantVersion}
+          />
+        }
         onClose={args.onClose}
         onSearchClick={args.onSearch}
       />
     ),
     [
       lifecycle.assistantId,
+      assistantName,
+      assistantVersion,
       conversations,
       conversationGroups,
       activeConversationKey,
@@ -363,6 +387,8 @@ export function ChatLayout() {
         drawerOpen={drawerOpen}
         collapsed={collapsed}
         toggleSidebar={toggleSidebar}
+        topBarCenter={topBarCenter}
+        topBarRightSlot={topBarRightSlot}
         onStartNewConversation={handleStartNewConversation}
         canGoBack={canGoBack}
         canGoForward={canGoForward}
@@ -370,6 +396,7 @@ export function ChatLayout() {
         onGoForward={handleGoForward}
         onOpenHome={handleOpenHome}
         isHomeActive={isHomeActive}
+        onSearchClick={() => onSearchClickRef.current?.()}
       />
 
       <OfflineBanner />
@@ -405,6 +432,7 @@ export function ChatLayout() {
                   collapsed: false,
                   variant: "overlay",
                   onClose: () => setDrawerOpen(false),
+                  onSearch: () => onSearchClickRef.current?.(),
                 })}
               </aside>
             </div>
@@ -417,7 +445,7 @@ export function ChatLayout() {
             className="shrink-0"
             aria-label="Navigation"
           >
-            {renderSideMenu({ collapsed, variant: "rail" })}
+            {renderSideMenu({ collapsed, variant: "rail", onSearch: () => onSearchClickRef.current?.() })}
           </aside>
           <main className="flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
             <Outlet context={assistantContext} />

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -637,7 +637,16 @@ export function ChatPage() {
     [navigate],
   );
 
-  const conversationActions = useConversationActions({
+  const {
+    handleArchiveConversation,
+    handleUnarchiveConversation,
+    handleMarkConversationUnread,
+    handleMarkConversationRead,
+    handleTogglePinConversation,
+    handleMoveToGroup,
+    handleRemoveFromGroup,
+    handleRenameConversation,
+  } = useConversationActions({
     assistantId,
     activeConversationKey,
     conversations,
@@ -647,7 +656,14 @@ export function ChatPage() {
     prePinGroupIdsRef,
   });
 
-  const secondaryActions = useConversationSecondaryActions({
+  const {
+    handleForkConversation,
+    handleForkConversationFromMenu,
+    handleAnalyzeConversation,
+    handleOpenInNewWindow,
+    handleInspectConversation,
+    handleCopyConversation,
+  } = useConversationSecondaryActions({
     assistantId,
     activeConversationKey,
     activeConversation: activeConversation ?? null,
@@ -724,50 +740,50 @@ export function ChatPage() {
         isPinned={isPinned}
         isArchived={isArchived}
         isReadonly={isChannelReadonly}
-        onPinToggle={() => conversationActions.handleTogglePinConversation(activeConversation)}
-        onRename={() => conversationActions.handleRenameConversation(activeConversation)}
-        onArchive={() => conversationActions.handleArchiveConversation(activeConversation)}
-        onUnarchive={() => conversationActions.handleUnarchiveConversation(activeConversation)}
+        onPinToggle={() => handleTogglePinConversation(activeConversation)}
+        onRename={() => handleRenameConversation(activeConversation)}
+        onArchive={() => handleArchiveConversation(activeConversation)}
+        onUnarchive={() => handleUnarchiveConversation(activeConversation)}
         onAnalyze={
           !isChannelReadonly && activeConversation.conversationKey
-            ? () => secondaryActions.handleAnalyzeConversation(activeConversation)
+            ? () => handleAnalyzeConversation(activeConversation)
             : undefined
         }
         onForkConversation={
           !isChannelReadonly && hasPersistedMessage
-            ? secondaryActions.handleForkConversationFromMenu
+            ? handleForkConversationFromMenu
             : undefined
         }
         onOpenInNewWindow={
           activeConversation.conversationKey
-            ? () => secondaryActions.handleOpenInNewWindow(activeConversation)
+            ? () => handleOpenInNewWindow(activeConversation)
             : undefined
         }
         onInspect={
           activeConversation.conversationKey
-            ? () => secondaryActions.handleInspectConversation(activeConversation)
+            ? () => handleInspectConversation(activeConversation)
             : undefined
         }
         onCopyConversation={
           messages.length > 0
-            ? secondaryActions.handleCopyConversation
+            ? handleCopyConversation
             : undefined
         }
         moveToGroups={moveToGroups}
-        onMoveToGroup={(groupId) => conversationActions.handleMoveToGroup(activeConversation, groupId)}
+        onMoveToGroup={(groupId) => handleMoveToGroup(activeConversation, groupId)}
         onRemoveFromGroup={
           activeConversation.groupId && !activeConversation.groupId.startsWith("system:")
-            ? () => conversationActions.handleRemoveFromGroup(activeConversation)
+            ? () => handleRemoveFromGroup(activeConversation)
             : undefined
         }
         onMarkUnread={
           !isChannelReadonly && activeConversation.hasUnseenLatestAssistantMessage === false
-            ? () => conversationActions.handleMarkConversationUnread(activeConversation)
+            ? () => handleMarkConversationUnread(activeConversation)
             : undefined
         }
         onMarkRead={
           activeConversation.hasUnseenLatestAssistantMessage
-            ? () => conversationActions.handleMarkConversationRead(activeConversation)
+            ? () => handleMarkConversationRead(activeConversation)
             : undefined
         }
         side="bottom"
@@ -797,8 +813,19 @@ export function ChatPage() {
     assistantId,
     isChannelReadonly,
     conversationGroups,
-    conversationActions,
-    secondaryActions,
+    handleTogglePinConversation,
+    handleRenameConversation,
+    handleArchiveConversation,
+    handleUnarchiveConversation,
+    handleAnalyzeConversation,
+    handleForkConversationFromMenu,
+    handleOpenInNewWindow,
+    handleInspectConversation,
+    handleCopyConversation,
+    handleMoveToGroup,
+    handleRemoveFromGroup,
+    handleMarkConversationUnread,
+    handleMarkConversationRead,
     hasPersistedMessage,
     messages.length,
   ]);
@@ -894,8 +921,6 @@ export function ChatPage() {
   };
 
   const pushToAiSettings = () => { void navigate(routes.settings.ai); };
-
-  const handleForkConversation = secondaryActions.handleForkConversation;
 
   const chatRouteProps: ChatRouteContentProps = {
     assistantId,

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -698,8 +698,12 @@ export function ChatPage() {
       navigateToSettings,
     });
 
+  // Guard: command palette should only be togglable once the page is fully loaded
+  const isPageReady = !authLoading && assistantState.kind !== "loading" && assistantState.kind !== "error";
+
   // Ctrl/Cmd+K shortcut for command palette
   useEffect(() => {
+    if (!isPageReady) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (!shouldHandleShortcut(event, document.activeElement, "k")) return;
       event.preventDefault();
@@ -707,13 +711,14 @@ export function ChatPage() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => { window.removeEventListener("keydown", onKeyDown); };
-  }, [commandPalette.toggle]);
+  }, [commandPalette.toggle, isPageReady]);
 
   // Register command palette toggle as the search callback for the layout
   useEffect(() => {
+    if (!isPageReady) return;
     setOnSearchClick(commandPalette.toggle);
     return () => { setOnSearchClick(null); };
-  }, [commandPalette.toggle, setOnSearchClick]);
+  }, [commandPalette.toggle, setOnSearchClick, isPageReady]);
 
   // -------------------------------------------------------------------------
   // Layout header slot registration — topBarCenter + topBarRightSlot

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -707,11 +707,7 @@ export function ChatPage() {
     [messages],
   );
 
-  const mainView = viewerState.mainView;
-  const isNonChatView = mainView === "intelligence" || mainView === "library" || mainView === "home";
-
   const topBarCenterContent = useMemo(() => {
-    if (isNonChatView) return null;
     if (!activeConversation) {
       return assistantId ? (
         <span className="text-sm font-medium text-[var(--content-default)]">
@@ -800,7 +796,6 @@ export function ChatPage() {
     activeConversation,
     assistantId,
     isChannelReadonly,
-    isNonChatView,
     conversationGroups,
     conversationActions,
     secondaryActions,
@@ -814,7 +809,6 @@ export function ChatPage() {
   }, [topBarCenterContent, setTopBarCenter]);
 
   const topBarRightContent = useMemo(() => {
-    if (isNonChatView) return null;
     if (!activeConversation?.conversationKey || !assistantId) return null;
     return (
       <ConversationAssetsPill
@@ -831,7 +825,7 @@ export function ChatPage() {
         }}
       />
     );
-  }, [activeConversation?.conversationKey, assistantId, assetsRefreshKey, isNonChatView]);
+  }, [activeConversation?.conversationKey, assistantId, assetsRefreshKey]);
 
   useEffect(() => {
     setTopBarRightSlot(topBarRightContent);

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -19,6 +19,7 @@ import {
   useState,
 } from "react";
 import { useNavigate, useSearchParams } from "react-router";
+import { ChevronDown } from "lucide-react";
 
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
@@ -30,6 +31,7 @@ import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
 import { useIsNativePlatform } from "@/runtime/native-auth.js";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
 
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import type { ChatError } from "@/domains/chat/types.js";
@@ -40,6 +42,7 @@ import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
 import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
 
+import { Button } from "@vellum/design-library";
 import { useSyncChatStore } from "@/domains/chat/chat-store.js";
 import { useChatAttachments } from "@/domains/chat/components/chat-attachments/use-chat-attachments.js";
 import { useVoiceInput } from "@/domains/chat/hooks/use-voice-input.js";
@@ -50,6 +53,9 @@ import { useDiskPressureMonitor } from "@/domains/assistant/use-disk-pressure-mo
 import { getDiskPressureChatBlockReason } from "@/domains/assistant/disk-pressure.js";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges.js";
 import { useConversationLoader } from "@/domains/chat/hooks/use-conversation-loader.js";
+import { useConversationActions } from "@/domains/chat/hooks/use-conversation-actions.js";
+import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions.js";
+import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-palette-sections.js";
 import { useMessageReconciliation } from "@/domains/chat/hooks/use-message-reconciliation.js";
 import { useStreamEventHandler } from "@/domains/chat/hooks/use-stream-event-handler.js";
 import { useSendMessage } from "@/domains/chat/hooks/use-send-message.js";
@@ -63,6 +69,11 @@ import { hasPendingAssistantResponse } from "@/domains/chat/utils/chat-utils.js"
 import { isSurfaceInteractive } from "@/domains/chat/types/types.js";
 import type { UIContext } from "@/domains/chat/utils/turn-selectors.js";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel.js";
+import { buildMoveToGroupTargets } from "@/domains/chat/utils/groupConversations.js";
+import { ConversationActionsMenu } from "@/domains/chat/components/conversation-actions-menu.js";
+import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill.js";
+import { CommandPalette } from "@/components/command-palette/command-palette.js";
+import { shouldHandleShortcut } from "@/domains/chat/chat-layout.js";
 import { abortSubagent } from "@/domains/chat/api/conversations.js";
 import { routes } from "@/utils/routes.js";
 import { haptic } from "@/utils/haptics.js";
@@ -84,7 +95,15 @@ export function ChatPage() {
   const isNative = useIsNativePlatform();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { assistantId, assistantState, checkAssistant, setAssistantId } = useAssistantContext();
+  const {
+    assistantId,
+    assistantState,
+    checkAssistant,
+    setAssistantId,
+    setTopBarCenter,
+    setTopBarRightSlot,
+    setOnSearchClick,
+  } = useAssistantContext();
   const chatPullToRefresh = useFeatureFlagStore.use.chatPullToRefresh();
   const deployToVercel = useFeatureFlagStore.use.deployToVercel();
   const doctor = useFeatureFlagStore.use.doctor();
@@ -113,8 +132,8 @@ export function ChatPage() {
     isPinnedToLatest: true,
   });
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
-  void assetsRefreshKey;
   const [assistantIdentity, setAssistantIdentity] = useState<AssistantIdentity | null>(null);
+  const prePinGroupIdsRef = useRef<Map<string, string | undefined>>(new Map());
 
   // -------------------------------------------------------------------------
   // Zustand store selectors
@@ -591,6 +610,235 @@ export function ChatPage() {
   });
 
   // -------------------------------------------------------------------------
+  // Sync assistant identity to the global store (read by ChatLayout)
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (assistantIdentity) {
+      useAssistantIdentityStore.getState().setIdentity(
+        assistantIdentity.name ?? null,
+        assistantIdentity.version ?? null,
+      );
+    } else {
+      useAssistantIdentityStore.getState().clearIdentity();
+    }
+  }, [assistantIdentity]);
+
+  useEffect(() => {
+    return () => { useAssistantIdentityStore.getState().clearIdentity(); };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Conversation actions (archive, pin, rename, etc.)
+  // -------------------------------------------------------------------------
+  const conversationGroups = useConversationListStore.use.conversationGroups();
+
+  const pushConversationKeyParam = useCallback(
+    (key: string) => { void navigate(`${routes.assistant}?conversationKey=${encodeURIComponent(key)}`); },
+    [navigate],
+  );
+
+  const conversationActions = useConversationActions({
+    assistantId,
+    activeConversationKey,
+    conversations,
+    refreshConversations,
+    switchConversation,
+    startNewConversation,
+    prePinGroupIdsRef,
+  });
+
+  const secondaryActions = useConversationSecondaryActions({
+    assistantId,
+    activeConversationKey,
+    activeConversation: activeConversation ?? null,
+    assistantIdentityName: assistantIdentity?.name ?? undefined,
+    messagesRef,
+    refreshConversations,
+    switchConversation,
+    setError,
+    pushConversationKeyParam,
+    pushRoute,
+  });
+
+  // -------------------------------------------------------------------------
+  // Command palette
+  // -------------------------------------------------------------------------
+  const navigateToSettings = useCallback(() => {
+    void navigate(routes.settings.root);
+  }, [navigate]);
+
+  const { commandPalette, mergedSections, handleItemSelect } =
+    useCommandPaletteSections({
+      assistantId,
+      assistantName: assistantIdentity?.name ?? undefined,
+      conversations,
+      activeConversationKey: activeConversationKey ?? undefined,
+      startNewConversation: () => startNewConversation(),
+      switchConversation,
+      navigate: (to: string | number) => {
+        if (typeof to === "number") navigate(to);
+        else void navigate(to);
+      },
+      navigateToSettings,
+    });
+
+  // Ctrl/Cmd+K shortcut for command palette
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldHandleShortcut(event, document.activeElement, "k")) return;
+      event.preventDefault();
+      commandPalette.toggle();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => { window.removeEventListener("keydown", onKeyDown); };
+  }, [commandPalette.toggle]);
+
+  // Register command palette toggle as the search callback for the layout
+  useEffect(() => {
+    setOnSearchClick(commandPalette.toggle);
+    return () => { setOnSearchClick(null); };
+  }, [commandPalette.toggle, setOnSearchClick]);
+
+  // -------------------------------------------------------------------------
+  // Layout header slot registration — topBarCenter + topBarRightSlot
+  // -------------------------------------------------------------------------
+  const hasPersistedMessage = useMemo(
+    () => messages.some((m) => m.daemonMessageId != null || m.id != null),
+    [messages],
+  );
+
+  const mainView = viewerState.mainView;
+  const isNonChatView = mainView === "intelligence" || mainView === "library" || mainView === "home";
+
+  const topBarCenterContent = useMemo(() => {
+    if (isNonChatView) return null;
+    if (!activeConversation) {
+      return assistantId ? (
+        <span className="text-sm font-medium text-[var(--content-default)]">
+          New conversation
+        </span>
+      ) : null;
+    }
+    const moveToGroups = buildMoveToGroupTargets(activeConversation, conversationGroups);
+    const isPinned = activeConversation.isPinned || activeConversation.groupId === "system:pinned";
+    const isArchived = activeConversation.archivedAt != null;
+    return (
+      <ConversationActionsMenu
+        variant="header"
+        isPinned={isPinned}
+        isArchived={isArchived}
+        isReadonly={isChannelReadonly}
+        onPinToggle={() => conversationActions.handleTogglePinConversation(activeConversation)}
+        onRename={() => conversationActions.handleRenameConversation(activeConversation)}
+        onArchive={() => conversationActions.handleArchiveConversation(activeConversation)}
+        onUnarchive={() => conversationActions.handleUnarchiveConversation(activeConversation)}
+        onAnalyze={
+          !isChannelReadonly && activeConversation.conversationKey
+            ? () => secondaryActions.handleAnalyzeConversation(activeConversation)
+            : undefined
+        }
+        onForkConversation={
+          !isChannelReadonly && hasPersistedMessage
+            ? secondaryActions.handleForkConversationFromMenu
+            : undefined
+        }
+        onOpenInNewWindow={
+          activeConversation.conversationKey
+            ? () => secondaryActions.handleOpenInNewWindow(activeConversation)
+            : undefined
+        }
+        onInspect={
+          activeConversation.conversationKey
+            ? () => secondaryActions.handleInspectConversation(activeConversation)
+            : undefined
+        }
+        onCopyConversation={
+          messages.length > 0
+            ? secondaryActions.handleCopyConversation
+            : undefined
+        }
+        moveToGroups={moveToGroups}
+        onMoveToGroup={(groupId) => conversationActions.handleMoveToGroup(activeConversation, groupId)}
+        onRemoveFromGroup={
+          activeConversation.groupId && !activeConversation.groupId.startsWith("system:")
+            ? () => conversationActions.handleRemoveFromGroup(activeConversation)
+            : undefined
+        }
+        onMarkUnread={
+          !isChannelReadonly && activeConversation.hasUnseenLatestAssistantMessage === false
+            ? () => conversationActions.handleMarkConversationUnread(activeConversation)
+            : undefined
+        }
+        onMarkRead={
+          activeConversation.hasUnseenLatestAssistantMessage
+            ? () => conversationActions.handleMarkConversationRead(activeConversation)
+            : undefined
+        }
+        side="bottom"
+        align="center"
+        sideOffset={8}
+        trigger={
+          <Button
+            variant="ghost"
+            rightIcon={<ChevronDown />}
+            aria-haspopup="menu"
+            className="min-w-0"
+          >
+            <span className="min-w-0 max-w-[240px] truncate">
+              {isArchived && (
+                <span className="mr-1 text-[var(--content-tertiary)]">
+                  [Archived]
+                </span>
+              )}
+              {activeConversation.title ?? "Untitled"}
+            </span>
+          </Button>
+        }
+      />
+    );
+  }, [
+    activeConversation,
+    assistantId,
+    isChannelReadonly,
+    isNonChatView,
+    conversationGroups,
+    conversationActions,
+    secondaryActions,
+    hasPersistedMessage,
+    messages.length,
+  ]);
+
+  useEffect(() => {
+    setTopBarCenter(topBarCenterContent);
+    return () => { setTopBarCenter(null); };
+  }, [topBarCenterContent, setTopBarCenter]);
+
+  const topBarRightContent = useMemo(() => {
+    if (isNonChatView) return null;
+    if (!activeConversation?.conversationKey || !assistantId) return null;
+    return (
+      <ConversationAssetsPill
+        assistantId={assistantId}
+        conversationId={activeConversation.conversationKey}
+        refreshKey={assetsRefreshKey}
+        onOpenApp={(appId) => {
+          haptic.light();
+          useViewerStore.getState().openApp(appId);
+        }}
+        onOpenDocument={() => {
+          haptic.light();
+          useViewerStore.getState().openDocument();
+        }}
+      />
+    );
+  }, [activeConversation?.conversationKey, assistantId, assetsRefreshKey, isNonChatView]);
+
+  useEffect(() => {
+    setTopBarRightSlot(topBarRightContent);
+    return () => { setTopBarRightSlot(null); };
+  }, [topBarRightContent, setTopBarRightSlot]);
+
+  // -------------------------------------------------------------------------
   // Derived UI state
   // -------------------------------------------------------------------------
   const hasUncompletedVisibleSurface = useMemo(() => {
@@ -653,9 +901,7 @@ export function ChatPage() {
 
   const pushToAiSettings = () => { void navigate(routes.settings.ai); };
 
-  const handleForkConversation = async (_throughMessageId: string) => {
-    // Fork is not yet implemented in the OSS app
-  };
+  const handleForkConversation = secondaryActions.handleForkConversation;
 
   const chatRouteProps: ChatRouteContentProps = {
     assistantId,
@@ -839,5 +1085,20 @@ export function ChatPage() {
     isChannelReadonly,
   };
 
-  return <ChatRouteContent {...chatRouteProps} />;
+  return (
+    <>
+      <ChatRouteContent {...chatRouteProps} />
+      <CommandPalette
+        isOpen={commandPalette.isOpen}
+        onClose={commandPalette.close}
+        query={commandPalette.query}
+        onQueryChange={commandPalette.setQuery}
+        selectedIndex={commandPalette.selectedIndex}
+        sections={mergedSections}
+        isSearching={commandPalette.isSearching}
+        onItemSelect={handleItemSelect}
+        onKeyDown={commandPalette.handleKeyDown}
+      />
+    </>
+  );
 }

--- a/apps/web/src/stores/assistant-identity-store.ts
+++ b/apps/web/src/stores/assistant-identity-store.ts
@@ -1,0 +1,43 @@
+/**
+ * Zustand store for the active assistant's identity (name, version).
+ *
+ * `ChatPage` writes to this store when it fetches the assistant identity
+ * from the daemon. `ChatLayout` reads from it to display the assistant
+ * name in the sidebar header and pass the version to `PreferencesMenu`.
+ *
+ * This store bridges the layout↔page boundary: `ChatLayout` owns the
+ * sidebar and header chrome but the identity fetch lives in `ChatPage`
+ * (which owns the full chat lifecycle). A Zustand store avoids prop
+ * drilling through the React Router outlet context for simple scalar
+ * values.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components}
+ */
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors.js";
+
+interface AssistantIdentityState {
+  name: string | null;
+  version: string | null;
+}
+
+interface AssistantIdentityActions {
+  setIdentity: (name: string | null, version: string | null) => void;
+  clearIdentity: () => void;
+}
+
+type AssistantIdentityStore = AssistantIdentityState & AssistantIdentityActions;
+
+const useAssistantIdentityStoreBase = create<AssistantIdentityStore>(
+  (set) => ({
+    name: null,
+    version: null,
+    setIdentity: (name, version) => set({ name, version }),
+    clearIdentity: () => set({ name: null, version: null }),
+  }),
+);
+
+export const useAssistantIdentityStore = createSelectors(
+  useAssistantIdentityStoreBase,
+);


### PR DESCRIPTION
## Prompt / plan

Wire the 5 remaining chat UI parity items identified during the localhost-vs-staging comparison (LUM-1704 through LUM-1708). All components were already ported; they just needed to be connected in the correct layout slots.

**Why needed:** The web app had all chat UI components ported but none wired into the layout chrome — the header showed no conversation title, no assets pill, and no search button; the sidebar showed a fallback name and no preferences menu. This PR achieves feature parity with the deployed platform for the chat page chrome.

**What changed (4 files, 1 new):**

1. **`assistant-identity-store.ts`** (new) — Zustand store bridging assistant identity from `ChatPage` (fetcher) to `ChatLayout` (displayer). Uses `createSelectors` for atomic subscriptions.

2. **`assistant-context.ts`** — Extended outlet context with `setTopBarCenter`, `setTopBarRightSlot`, `setOnSearchClick`.

3. **`chat-layout.tsx`** — Reads assistant name/version from identity store. Passes `assistantName`, `PreferencesMenu` as `footerAction`, `onSearchClick`, and header slots.

4. **`chat-page.tsx`** — Main wiring hub: syncs identity to store, destructures stable callbacks from action hooks, registers `ConversationActionsMenu`/`ConversationAssetsPill`/`CommandPalette` in layout slots, adds Ctrl/Cmd+K shortcut with `isPageReady` guard.

**Safety:** Additive-only, cleanup on all effects, stable `useMemo` deps (individual callbacks, not wrapper objects), loading guard on command palette toggle.

**Review feedback addressed:**
- Unstable `useMemo` deps (Codex P1 + vex-bot + Devin Review) — destructured stable callbacks
- Command palette loading guard (Devin Review) — `isPageReady` check
- Invalid `MainView` comparisons (CI typecheck) — removed non-existent enum values

**References:** [Zustand outside React](https://zustand.docs.pmnd.rs/guides/practice-with-no-store-actions) · [React Router outlet context](https://reactrouter.com/start/framework/outlet) · [useMemo dep stability](https://react.dev/reference/react/useMemo#troubleshooting)

Closes LUM-1704, Closes LUM-1705, Closes LUM-1706, Closes LUM-1707, Closes LUM-1708

## Test plan

- CI: lint, typecheck, build, test — all green (7/7)
- Manual: compare localhost chat header/sidebar to staging for feature parity

Link to Devin session: https://app.devin.ai/sessions/5c400920d2b745bc84401cd020820f22
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->