### PR TITLE
Show dismissed notifications in home feed with restore

### DIFF
--- a/apps/web/src/domains/home/home-feed-list.tsx
+++ b/apps/web/src/domains/home/home-feed-list.tsx
@@ -1,6 +1,7 @@
+import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 
-import { Typography } from "@vellum/design-library";
+import { Collapsible, Typography } from "@vellum/design-library";
 import { HomeFeedFilterBar } from "./home-feed-filter-bar.js";
 import { HomeRecapRow } from "./home-recap-row.js";
 import {
@@ -22,12 +23,14 @@ export interface HomeFeedListProps {
   items: FeedItem[];
   onSelectItem: (item: FeedItem) => void;
   onDismissItem: (itemId: string) => void;
+  onRestoreItem: (itemId: string) => void;
 }
 
 export function HomeFeedList({
   items,
   onSelectItem,
   onDismissItem,
+  onRestoreItem,
 }: HomeFeedListProps) {
   const [activeFilter, setActiveFilter] = useState<FeedItemCategory | null>(
     null,
@@ -55,6 +58,13 @@ export function HomeFeedList({
   const filtered = filterByCategory(eligible, effectiveFilter);
   const sorted = sortFeedItems(filtered);
   const grouped = groupByTime(sorted);
+
+  const dismissed = items
+    .filter((item) => item.status === "dismissed")
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
 
   return (
     <div className="flex flex-col gap-[var(--app-spacing-sm)]">
@@ -99,6 +109,34 @@ export function HomeFeedList({
             </div>
           </section>
         ))
+      )}
+
+      {dismissed.length > 0 && (
+        <Collapsible.Root type="single" collapsible>
+          <Collapsible.Item value="dismissed">
+            <Collapsible.Trigger className="group gap-[var(--app-spacing-xs)] text-body-small-default text-[var(--content-tertiary)]">
+              <ChevronRight
+                size={14}
+                aria-hidden
+                className="shrink-0 transition-transform group-data-[state=open]:rotate-90"
+              />
+              <span>Dismissed ({dismissed.length})</span>
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+                {dismissed.map((item) => (
+                  <HomeRecapRow
+                    key={item.id}
+                    item={item}
+                    onSelect={onSelectItem}
+                    onDismiss={onRestoreItem}
+                    trailingAction="restore"
+                  />
+                ))}
+              </div>
+            </Collapsible.Content>
+          </Collapsible.Item>
+        </Collapsible.Root>
       )}
     </div>
   );

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -86,6 +86,13 @@ export function HomePage({
     [feedQuery.updateStatus, selectedItem?.id],
   );
 
+  const handleRestoreItem = useCallback(
+    (itemId: string) => {
+      feedQuery.updateStatus.mutate({ itemId, status: "seen" });
+    },
+    [feedQuery.updateStatus],
+  );
+
   const handleUpdateStatus = useCallback(
     (itemId: string, status: FeedItemStatus) => {
       feedQuery.updateStatus.mutate({ itemId, status });
@@ -129,6 +136,7 @@ export function HomePage({
         items={feedQuery.data?.items ?? []}
         onSelectItem={handleSelectItem}
         onDismissItem={handleDismissItem}
+        onRestoreItem={handleRestoreItem}
       />
     </>
   );

--- a/apps/web/src/domains/home/home-recap-row.tsx
+++ b/apps/web/src/domains/home/home-recap-row.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { RotateCcw, X } from "lucide-react";
 import { useState } from "react";
 
 import { cn } from "@vellum/design-library";
@@ -12,17 +12,28 @@ function resolveStyle(category?: FeedItemCategory) {
   return CATEGORY_STYLES.system;
 }
 
+export type HomeRecapRowTrailingAction = "dismiss" | "restore";
+
 export interface HomeRecapRowProps {
   item: FeedItem;
   onSelect: (item: FeedItem) => void;
   onDismiss: (itemId: string) => void;
+  trailingAction?: HomeRecapRowTrailingAction;
 }
 
-export function HomeRecapRow({ item, onSelect, onDismiss }: HomeRecapRowProps) {
+export function HomeRecapRow({
+  item,
+  onSelect,
+  onDismiss,
+  trailingAction = "dismiss",
+}: HomeRecapRowProps) {
   const [isHovering, setIsHovering] = useState(false);
   const style = resolveStyle(item.category);
   const Icon = style.icon;
   const isUnread = item.status === "new";
+  const isRestore = trailingAction === "restore";
+  const TrailingIcon = isRestore ? RotateCcw : X;
+  const trailingLabel = isRestore ? "Restore" : "Dismiss";
 
   return (
     <button
@@ -69,7 +80,7 @@ export function HomeRecapRow({ item, onSelect, onDismiss }: HomeRecapRowProps) {
         <span
           role="button"
           tabIndex={0}
-          aria-label="Dismiss"
+          aria-label={trailingLabel}
           onClick={(e) => {
             e.stopPropagation();
             onDismiss(item.id);
@@ -86,8 +97,8 @@ export function HomeRecapRow({ item, onSelect, onDismiss }: HomeRecapRowProps) {
             "text-[var(--content-disabled)]",
           )}
         >
-          <X width={7} height={7} aria-hidden="true" />
-          <span className="text-body-small-default">Dismiss</span>
+          <TrailingIcon width={7} height={7} aria-hidden="true" />
+          <span className="text-body-small-default">{trailingLabel}</span>
         </span>
       ) : null}
     </button>

--- a/apps/web/src/domains/home/hooks/use-home-feed-query.ts
+++ b/apps/web/src/domains/home/hooks/use-home-feed-query.ts
@@ -82,12 +82,9 @@ export function useHomeFeedQuery(assistantId: string | null) {
         if (!old) return old;
         return {
           ...old,
-          items:
-            status === "dismissed"
-              ? old.items.filter((item: FeedItem) => item.id !== itemId)
-              : old.items.map((item: FeedItem) =>
-                  item.id === itemId ? { ...item, status } : item,
-                ),
+          items: old.items.map((item: FeedItem) =>
+            item.id === itemId ? { ...item, status } : item,
+          ),
         };
       });
 

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -31,6 +31,7 @@ struct HomePageView: View {
     @AppStorage("homeSuggestionsDismissed") private var suggestionsDismissed: Bool = false
     @State private var activeFilter: FeedItemCategory? = nil
     @State private var isActivityExpanded: Bool = false
+    @State private var isDismissedExpanded: Bool = false
 
     private let maxContentWidth: CGFloat = 960
 
@@ -137,6 +138,26 @@ struct HomePageView: View {
                         .foregroundStyle(VColor.contentTertiary)
                 }
 
+                if !dismissedItems.isEmpty {
+                    DisclosureGroup(isExpanded: $isDismissedExpanded) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            ForEach(dismissedItems, id: \.id) { item in
+                                recapRow(
+                                    for: item,
+                                    showsUrgency: false,
+                                    trailingAction: .restore,
+                                    onTrailing: { restoreItem(item) }
+                                )
+                            }
+                        }
+                        .padding(.top, VSpacing.sm)
+                    } label: {
+                        Text("Dismissed (\(dismissedItems.count))")
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                }
+
                 Spacer(minLength: VSpacing.xxl)
             }
             .frame(maxWidth: maxContentWidth, alignment: .top)
@@ -206,6 +227,15 @@ struct HomePageView: View {
             .sorted { $0.createdAt > $1.createdAt }
     }
 
+    /// Dismissed items across both inbox and background tiers, most-recent
+    /// first. Spans both tiers because once dismissed, the inbox/background
+    /// distinction no longer matters to the user.
+    private var dismissedItems: [FeedItem] {
+        feedStore.items
+            .filter { $0.status == .dismissed }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
     /// Categories present in the inbox (non-dismissed, noteworthy). Drives
     /// the filter bar — only categories with at least one inbox item get a
     /// pill. The Background activity disclosure is unfiltered.
@@ -250,12 +280,17 @@ struct HomePageView: View {
 
     // MARK: - Recap row styling
 
-    /// Shared `HomeRecapRow` builder used by both the inbox feed and the
-    /// Background activity disclosure. `showsUrgency` is `false` for
-    /// activity rows so they never paint the leading red dot — urgent
-    /// items live in the inbox, not the activity section.
+    /// Shared `HomeRecapRow` builder for the inbox, Background activity,
+    /// and Dismissed sections. Urgent items only live in the inbox, so
+    /// activity and dismissed rows pass `showsUrgency: false` to suppress
+    /// the leading red dot.
     @ViewBuilder
-    private func recapRow(for item: FeedItem, showsUrgency: Bool) -> some View {
+    private func recapRow(
+        for item: FeedItem,
+        showsUrgency: Bool,
+        trailingAction: HomeRecapRow.TrailingAction = .dismiss,
+        onTrailing: (() -> Void)? = nil
+    ) -> some View {
         // Fall back to `summary` when `title` is nil — the daemon omits
         // the title when no source title was supplied.
         HomeRecapRow(
@@ -267,7 +302,8 @@ struct HomePageView: View {
             status: item.status,
             isUrgent: showsUrgency && isUrgent(item),
             showsPersonaAvatar: item.fromAssistant == true,
-            onDismiss: { dismissItem(item) },
+            trailingAction: trailingAction,
+            onDismiss: onTrailing ?? { dismissItem(item) },
             onTap: { openItem(item) }
         )
     }
@@ -326,6 +362,14 @@ struct HomePageView: View {
     private func dismissItem(_ item: FeedItem) {
         Task {
             await feedStore.dismiss(itemId: item.id)
+        }
+    }
+
+    /// Restores to `.seen` rather than `.new` — re-promoting an item the
+    /// user has already seen back to unread would be misleading.
+    private func restoreItem(_ item: FeedItem) {
+        Task {
+            await feedStore.updateStatus(itemId: item.id, status: .seen)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeRecapRow.swift
@@ -15,6 +15,17 @@ import VellumAssistantShared
 /// resolves the innermost tappable first. The timestamp uses a fixed
 /// width so the title doesn't reflow when the dismiss affordance appears.
 struct HomeRecapRow: View {
+    /// Hover-only trailing affordance. `.dismiss` is the default (X icon,
+    /// "Dismiss" label); `.restore` is used by the Dismissed disclosure
+    /// to bring a row back into the active feed.
+    enum TrailingAction {
+        case dismiss
+        case restore
+
+        var icon: VIcon { self == .restore ? .rotateCcw : .x }
+        var label: String { self == .restore ? "Restore" : "Dismiss" }
+    }
+
     let icon: VIcon
     /// Foreground color for the icon glyph. Callers pass one of the
     /// feed identifier tokens (e.g. `VColor.feedNudgeStrong`,
@@ -40,6 +51,7 @@ struct HomeRecapRow: View {
     /// feed rows (`FeedItem.fromAssistant == true`) so the surface reads
     /// as "your assistant sent this" rather than a generic system bell.
     var showsPersonaAvatar: Bool = false
+    var trailingAction: TrailingAction = .dismiss
     let onDismiss: () -> Void
     let onTap: () -> Void
 
@@ -90,14 +102,14 @@ struct HomeRecapRow: View {
                     .accessibilityHidden(true)
 
                 if isHovering {
-                    // Wrapping the dismiss in its own Button keeps the tap
-                    // from bubbling to the outer row Button — SwiftUI
-                    // resolves the innermost tappable first.
+                    // Wrapping the trailing affordance in its own Button
+                    // keeps the tap from bubbling to the outer row Button —
+                    // SwiftUI resolves the innermost tappable first.
                     Button(action: onDismiss) {
                         HStack(spacing: VSpacing.xs) {
-                            VIconView(.x, size: 7)
+                            VIconView(trailingAction.icon, size: 7)
                                 .foregroundStyle(VColor.contentDisabled)
-                            Text("Dismiss")
+                            Text(trailingAction.label)
                                 .font(VFont.bodySmallDefault)
                                 .foregroundStyle(VColor.contentDisabled)
                         }
@@ -105,7 +117,7 @@ struct HomeRecapRow: View {
                     }
                     .buttonStyle(.plain)
                     .pointerCursor()
-                    .accessibilityLabel(Text("Dismiss"))
+                    .accessibilityLabel(Text(trailingAction.label))
                 }
             }
             .contentShape(Rectangle())
@@ -120,7 +132,7 @@ struct HomeRecapRow: View {
         .onHover { isHovering = $0 }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(isUrgent ? "Urgent, \(title)" : title))
-        .accessibilityAction(named: Text("Dismiss"), onDismiss)
+        .accessibilityAction(named: Text(trailingAction.label), onDismiss)
     }
 
     /// 26pt leading slot: persona avatar for assistant-initiated rows,


### PR DESCRIPTION
## Summary
- Add a collapsed \"Dismissed (N)\" section at the bottom of the home feed on web (Collapsible) and macOS (DisclosureGroup) — hidden when there are no dismissed items.
- Per-row hover affordance flips from \"Dismiss\" to \"Restore\" inside the section; restore PATCHes status back to \`seen\`.
- Backend was already soft-deleting (\`status: \"dismissed\"\` persisted in \`home-feed.json\`) and the GET endpoint already returned dismissed items — this is purely a client-side change. Also fix the web React Query optimistic update to keep dismissed items in the cache instead of filtering them out, so the disclosure renders them immediately without a refetch.

## Original prompt
Dismissed notifications in the homepage feed were gone forever — there was no way to view or recover them. The ask was to surface them somewhere on the home page so users can see and restore them. Scope: web (apps/web) and macOS (clients/macos); Chrome extension has no notification center. Design choice agreed upfront: collapsed \"Dismissed\" disclosure at the bottom (mirrors the existing \"Background activity\" pattern on macOS) with a per-row Restore action.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->