### PR TITLE
fix(web): reduce iOS composer-to-keyboard gap from ~24px to 8px

### DIFF
--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -217,6 +217,20 @@ describe("ChatBody — startersSlot rendering", () => {
     );
     expect(html).not.toContain("STARTER_CHIPS");
   });
+
+  test("hides starters when keyboard is open", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...withEmptyState({
+          isKeyboardOpen: true,
+          startersSlot: (
+            <div data-testid="starters">STARTER_CHIPS</div>
+          ),
+        })}
+      />,
+    );
+    expect(html).not.toContain("STARTER_CHIPS");
+  });
 });
 
 describe("ChatBody — read-only cancellation", () => {

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -230,7 +230,7 @@ export function ChatBody({
           on first send (LUM-1506 / LUM-1516). */}
       <div
         className={`relative px-3 pt-2 sm:px-6 sm:pb-0 ${
-          isKeyboardOpen ? "pb-1" : "pb-4"
+          isKeyboardOpen ? "pb-2" : "pb-4"
         }`}
       >
         {refreshFeedback && (
@@ -272,7 +272,7 @@ export function ChatBody({
           ) : (
             <ChatComposer {...composerProps} />
           )}
-          {startersSlot}
+          {!isKeyboardOpen && startersSlot}
         </div>
       </div>
       {isAttachmentDragOver && (


### PR DESCRIPTION
## Prompt / plan
On iOS, the chat composer sits ~24px above the keyboard instead of the expected ~8px. The gap comes from the `startersSlot` (conversation-starter chips) rendered below the composer with `mt-4` (16px margin-top), plus the wrapper's `pb-1` (4px) bottom padding — totaling ~20px+ of dead space when the keyboard is open.

This hides the starters slot when the keyboard is open (they are scrolled off-screen anyway and not useful while typing) and increases the wrapper bottom padding from `pb-1` (4px) to `pb-2` (8px) for a clean 8px gap.

## Test plan
- `bun test` on `chat-body.test.tsx` — all 9 tests pass including new test for keyboard-open starters hiding
- ESLint passes on changed files
- Verify on iOS device that composer sits ~8px above keyboard when focused
- Confirm starters reappear when keyboard is dismissed
- Desktop/web layout unchanged (keyboard detection is mobile-only)

Link to Devin session: https://app.devin.ai/sessions/229de90df2654a74a5dbb01fc458d65d
Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->