### PR TITLE
refactor(stores): convert sse-connected-store to real Zustand (LUM-1714)

### DIFF
--- a/apps/web/src/stores/sse-connected-store.ts
+++ b/apps/web/src/stores/sse-connected-store.ts
@@ -1,77 +1,50 @@
-
-import { useSyncExternalStore } from "react";
-
 /**
- * Minimal module-level store tracking whether the always-on SSE stream is
- * currently connected. Implemented as a plain JS observable so it can be read
- * both inside React (via `useSSEConnectedStore`) and outside the render cycle
- * (via `getSSEConnectedSnapshot`) — for example from push notification event
- * handlers that need to decide whether to suppress an OS banner.
+ * Zustand store tracking whether the always-on SSE stream is currently
+ * connected. Used by push notification handlers that need to decide whether
+ * to suppress an OS banner (when SSE is connected, the in-app stream already
+ * delivered the event).
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
 
-type Listener = () => void;
+import { create } from "zustand";
 
-interface SSEConnectedState {
+import { createSelectors } from "@/utils/create-selectors.js";
+
+// ---------------------------------------------------------------------------
+// State & Actions
+// ---------------------------------------------------------------------------
+
+export interface SSEConnectedState {
   isConnected: boolean;
 }
 
-let state: SSEConnectedState = { isConnected: false };
-const listeners = new Set<Listener>();
-
-function notifyListeners(): void {
-  for (const listener of listeners) {
-    listener();
-  }
-}
-
-function subscribe(listener: Listener): () => void {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
-}
-
-function getSnapshot(): boolean {
-  return state.isConnected;
-}
-
-function getServerSnapshot(): boolean {
-  return false;
-}
-
-/**
- * Compatibility shim that mirrors the Zustand `create()` store shape so
- * consumers can call `useSSEConnectedStore.getState()` in the same style
- * as a real Zustand store, and the hook form works via `useSyncExternalStore`.
- */
-function useSSEConnectedStoreHook(): SSEConnectedState {
-  const isConnected = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  return { isConnected };
-}
-
-useSSEConnectedStoreHook.getState = (): SSEConnectedState & {
+export interface SSEConnectedActions {
   setConnected: (value: boolean) => void;
-} => ({
-  ...state,
-  setConnected: (value: boolean) => {
-    if (state.isConnected !== value) {
-      state = { isConnected: value };
-      notifyListeners();
+}
+
+export type SSEConnectedStore = SSEConnectedState & SSEConnectedActions;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useSSEConnectedStoreBase = create<SSEConnectedStore>()((set, get) => ({
+  isConnected: false,
+
+  setConnected: (value) => {
+    if (get().isConnected !== value) {
+      set({ isConnected: value });
     }
   },
-});
+}));
 
-// For testing: allow resetting state
-useSSEConnectedStoreHook.setState = (partial: Partial<SSEConnectedState>): void => {
-  state = { ...state, ...partial };
-  notifyListeners();
-};
-
-export const useSSEConnectedStore = useSSEConnectedStoreHook;
+export const useSSEConnectedStore = createSelectors(useSSEConnectedStoreBase);
 
 /**
- * Non-hook accessor for use in push notification event handlers (outside
- * React render cycle). Returns the current SSE connection state without
- * subscribing to updates.
+ * Non-hook accessor for use outside the React render cycle (e.g. push
+ * notification event handlers). Returns the current SSE connection state
+ * without subscribing to updates.
  */
-export const getSSEConnectedSnapshot = (): boolean => state.isConnected;
+export const getSSEConnectedSnapshot = (): boolean =>
+  useSSEConnectedStore.getState().isConnected;


### PR DESCRIPTION
## Summary

Converts `apps/web/src/stores/sse-connected-store.ts` from a hand-rolled `useSyncExternalStore` shim to a real Zustand store wrapped with `createSelectors()`. The shim's file docstring literally called itself a *"compatibility shim that mirrors the Zustand `create()` store shape"* — so this just makes the file what it was already pretending to be.

Closes the cleanup tracked under LUM-1714.

## API surface — preserved

| Call site | Before | After |
|---|---|---|
| Read inside React | `useSSEConnectedStore().isConnected` | `useSSEConnectedStore.use.isConnected()` *(or the same `useSSEConnectedStore()` for the object)* |
| Read outside React | `useSSEConnectedStore.getState().isConnected` | `useSSEConnectedStore.getState().isConnected` *(same)* |
| Write outside React | `useSSEConnectedStore.getState().setConnected(value)` | `useSSEConnectedStore.getState().setConnected(value)` *(same)* |
| Convenience snapshot | `getSSEConnectedSnapshot()` | `getSSEConnectedSnapshot()` — now a one-line wrapper around `.getState().isConnected` |

No consumers exist outside the test today (`grep` confirms), so no breakage to manage.

## What changed in the file

- Removed: module-level `state` + `listeners: Set<Listener>` + `notifyListeners()` + `subscribe()` + `getSnapshot()` + `getServerSnapshot()` + the bolted-on `.getState()` / `.setState()` methods on the hook function.
- Added: standard `create<SSEConnectedStore>()` definition + `createSelectors(useSSEConnectedStoreBase)` wrapper.
- `setConnected` keeps the "no-op if unchanged" guard inline (compares via `get()` before calling `set()`).
- Type exports added: `SSEConnectedState`, `SSEConnectedActions`, `SSEConnectedStore`.

Net diff: −58 / +31, lots of boilerplate gone.

## Test plan

- [x] `bun test src/stores/sse-connected-store.test.ts` — 3/3 pass, unchanged (test calls `.getState().setConnected(...)`, `.setState(...)`, and `getSSEConnectedSnapshot()` — all still work)
- [x] `bun run lint` — clean (pre-existing warning on `lib/errors/report.ts`)
- [x] `bun run typecheck` — clean
- [x] Future consumers (push-notification handlers, SSE transport) will use the canonical `.use.isConnected()` selector inside React and `.getState().isConnected` outside — no migration needed in this PR since no consumers exist yet

## Divergences from platform

None — this is a state-management refactor that doesn't have a platform analog (platform uses Context for similar state).

## Acceptance criteria (from LUM-1714)

- [x] Standard Zustand store with `createSelectors()`
- [x] No hand-rolled `useSyncExternalStore` or manual listener management
- [x] Non-React consumers still work via `.getState()`
- [x] `bunx tsc --noEmit` and `bun run lint` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWERLgh2s54Vi5NiSWShn2)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->