### PR TITLE
refactor(web): add createSelectors() to chat-store and turn-store

### DIFF
--- a/apps/web/src/domains/chat/chat-store.ts
+++ b/apps/web/src/domains/chat/chat-store.ts
@@ -1,29 +1,32 @@
 /**
  * Zustand store for chat state shared across deeply-nested components.
  *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
  * Selector-based subscriptions let each consumer re-render only when
  * its slice changes — critical during streaming where `messages`
  * updates at ~50 ms cadence.
  *
- * **Primary API** — selector-based (finest granularity):
+ * **Primary API** — per-field selectors (finest granularity):
  * ```ts
- * const messages = useChatStore((s) => s.messages);
+ * const messages = useChatStore.use.messages();
  * ```
  *
- * **Convenience hooks** — grouped slices for common patterns:
- * - `useChatState()` — state slice (messages, conversation key, assistant ID)
- * - `useChatActions()` — stable action refs (sendMessage)
+ * **Non-React code** — use `.getState()` in callbacks, effects, handlers:
+ * ```ts
+ * const { messages } = useChatStore.getState();
+ * ```
  *
  * Interaction state lives in its own store (`useInteractionStore`).
  * Turn state lives in its own store (`useTurnStore`).
  *
- * Reference: {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/learn/guides/auto-generating-selectors}
  */
 
 import { useEffect } from "react";
 import { create } from "zustand";
-import { useShallow } from "zustand/shallow";
 
+import { createSelectors } from "@/utils/create-selectors.js";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 
 // ---------------------------------------------------------------------------
@@ -52,12 +55,14 @@ export type ChatStore = ChatState & ChatActions;
 
 const NOOP_SEND: ChatActions["sendMessage"] = async () => {};
 
-export const useChatStore = create<ChatStore>()(() => ({
+const useChatStoreBase = create<ChatStore>()(() => ({
   messages: [],
   activeConversationKey: null,
   assistantId: null,
   sendMessage: NOOP_SEND,
 }));
+
+export const useChatStore = createSelectors(useChatStoreBase);
 
 // ---------------------------------------------------------------------------
 // Sync hook — bridges parent-owned state into the store
@@ -98,41 +103,4 @@ export function useSyncChatStore(props: ChatStoreSyncProps): void {
   }, [sendMessage]);
 }
 
-// ---------------------------------------------------------------------------
-// Consumer hooks
-// ---------------------------------------------------------------------------
 
-/**
- * Read-only chat state (messages, active conversation, assistant ID).
- * Re-renders only when one of these three values changes.
- * Use `useChatActions()` if you only need to dispatch.
- */
-export function useChatState(): ChatState {
-  return useChatStore(
-    useShallow((s) => ({
-      messages: s.messages,
-      activeConversationKey: s.activeConversationKey,
-      assistantId: s.assistantId,
-    })),
-  );
-}
-
-/**
- * Stable action refs (sendMessage).
- * Does **not** re-render when messages or active conversation change.
- */
-export function useChatActions(): ChatActions {
-  return useChatStore(
-    useShallow((s) => ({
-      sendMessage: s.sendMessage,
-    })),
-  );
-}
-
-/**
- * Full store snapshot. Prefer `useChatState()` or `useChatActions()`
- * to minimize re-renders — this hook re-renders on any store change.
- */
-export function useChatSnapshot(): ChatStore {
-  return useChatStore(useShallow((s) => s));
-}

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -23,7 +23,7 @@ import {
   VoiceInputButton,
   type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button.js";
-import { isSending, useTurnStore } from "@/domains/messaging/turn-store.js";
+import { type TurnPhase, useTurnStore } from "@/domains/messaging/turn-store.js";
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 import { useAudioAmplitude } from "@/domains/voice/use-audio-amplitude.js";
@@ -357,9 +357,9 @@ export function ChatComposer({
     [emojiState, input, inputRef, setInput, onTextChange],
   );
 
-  const turnState = useTurnStore();
+  const phase: TurnPhase = useTurnStore.use.phase();
   const isGenerating =
-    isSending(turnState) && turnState.phase !== "awaiting_user_input";
+    phase === "queued" || phase === "thinking" || phase === "streaming";
 
   const ghostSuffix = useMemo(
     () =>

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -82,7 +82,7 @@ import { haptic } from "@/utils/haptics.js";
 import { isChannelConversation as _isChannelConversation } from "@/domains/chat/utils/conversation-channel.js";
 import { getDiskPressureChatBlockReason } from "@/domains/assistant/disk-pressure.js";
 import type { DiskPressureStatusEventPayload } from "@/domains/assistant/use-disk-pressure-monitor.js";
-import { useTurnStore } from "@/domains/messaging/turn-store.js";
+import { type TurnState, useTurnStore } from "@/domains/messaging/turn-store.js";
 import type { QuestionResponseEntry, AllowlistOption, ScopeOption, DirectoryScopeOption, ConfirmationDecision } from "@/domains/chat/api/event-types.js";
 import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
 import { DiskPressureBanner, type DiskPressureBannerMode } from "@/domains/chat/components/disk-pressure-banner.js";
@@ -504,7 +504,13 @@ export function ChatRouteContent({
   // -------------------------------------------------------------------------
   // Turn state (read from Zustand store)
   // -------------------------------------------------------------------------
-  const turnState = useTurnStore();
+  const phase = useTurnStore.use.phase();
+  const pendingQueuedCount = useTurnStore.use.pendingQueuedCount();
+  const activeToolCallCount = useTurnStore.use.activeToolCallCount();
+  const activeTurnId = useTurnStore.use.activeTurnId();
+  const lastTerminalReason = useTurnStore.use.lastTerminalReason();
+  const statusText = useTurnStore.use.statusText();
+  const turnState: TurnState = { phase, pendingQueuedCount, activeToolCallCount, activeTurnId, lastTerminalReason, statusText };
 
   // -------------------------------------------------------------------------
   // Deploy / share state (from Zustand store)

--- a/apps/web/src/domains/messaging/turn-store.ts
+++ b/apps/web/src/domains/messaging/turn-store.ts
@@ -5,18 +5,20 @@
  * count, and current turn identity. Direct named actions call `set()` to
  * apply pure transitions so render decisions can be derived deterministically.
  *
+ * Wrapped with `createSelectors` for auto-generated per-field hooks.
  * Selector-based subscriptions let each consumer re-render only when its
  * slice changes — critical during streaming where state updates at ~50 ms
  * cadence. Non-React code (stream handlers, reconciliation) reads the
  * latest state synchronously via `useTurnStore.getState()`.
  *
- * References:
- * - {@link https://zustand.docs.pmnd.rs/}
- * - {@link https://zustand.docs.pmnd.rs/learn/guides/flux-inspired-practice}
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://zustand.docs.pmnd.rs/learn/guides/flux-inspired-practice}
+ * @see {@link https://zustand.docs.pmnd.rs/learn/guides/auto-generating-selectors}
  */
 
 import { create } from "zustand";
-import { useShallow } from "zustand/shallow";
+
+import { createSelectors } from "@/utils/create-selectors.js";
 
 // ---------------------------------------------------------------------------
 // State
@@ -261,7 +263,7 @@ function isStale(s: TurnState): boolean {
 // Store
 // ---------------------------------------------------------------------------
 
-export const useTurnStore = create<TurnStore>()((set, get) => ({
+const useTurnStoreBase = create<TurnStore>()((set, get) => ({
   ...INITIAL_TURN_STATE,
 
   // ----- Send flow -----
@@ -514,61 +516,7 @@ export const useTurnStore = create<TurnStore>()((set, get) => ({
   },
 }));
 
-// ---------------------------------------------------------------------------
-// Convenience hooks
-// ---------------------------------------------------------------------------
-
-/**
- * Read-only turn state. Re-renders only when one of the state fields
- * changes. Use `useTurnActions()` if you only need to dispatch.
- */
-export function useTurnState(): TurnState {
-  return useTurnStore(
-    useShallow((s) => ({
-      phase: s.phase,
-      pendingQueuedCount: s.pendingQueuedCount,
-      activeToolCallCount: s.activeToolCallCount,
-      activeTurnId: s.activeTurnId,
-      lastTerminalReason: s.lastTerminalReason,
-      statusText: s.statusText,
-    })),
-  );
-}
-
-/**
- * Stable action references. Does **not** re-render when turn state changes.
- */
-export function useTurnActions(): TurnActions {
-  return useTurnStore(
-    useShallow((s) => ({
-      requestSend: s.requestSend,
-      acceptSend: s.acceptSend,
-      onTextDelta: s.onTextDelta,
-      onToolUseStart: s.onToolUseStart,
-      onToolResult: s.onToolResult,
-      onActivityThinking: s.onActivityThinking,
-      showSurface: s.showSurface,
-      updateSurface: s.updateSurface,
-      dismissSurface: s.dismissSurface,
-      completeSurface: s.completeSurface,
-      onSecretRequest: s.onSecretRequest,
-      onConfirmationRequest: s.onConfirmationRequest,
-      onQuestionRequest: s.onQuestionRequest,
-      onContactRequest: s.onContactRequest,
-      completeTurn: s.completeTurn,
-      handoffGeneration: s.handoffGeneration,
-      cancelGeneration: s.cancelGeneration,
-      onStreamError: s.onStreamError,
-      onSessionError: s.onSessionError,
-      onPollReconciled: s.onPollReconciled,
-      onTurnTimeout: s.onTurnTimeout,
-      resetTurn: s.resetTurn,
-      enqueueMessage: s.enqueueMessage,
-      dequeueMessage: s.dequeueMessage,
-      deleteQueuedMessage: s.deleteQueuedMessage,
-    })),
-  );
-}
+export const useTurnStore = createSelectors(useTurnStoreBase);
 
 // ---------------------------------------------------------------------------
 // Pure reducer (used by tests to verify state transitions in isolation)


### PR DESCRIPTION
## Summary

Wraps `chat-store` and `turn-store` with `createSelectors()` per [CONVENTIONS.md — Auto-generated selectors](apps/web/CONVENTIONS.md#auto-generated-selectors-via-createselectors), enabling auto-generated `.use.field()` per-field selector hooks. These were the only two Zustand stores in the app not following the convention.

Net −78 lines (32 added, 110 removed).

## Why needed

All other Zustand stores (`auth`, `organization`, `viewer`, `conversation-list`, `interaction`, `subagent`, `pinned-apps`, `feature-flag`) already use `createSelectors()`. `chat-store` and `turn-store` were the two holdouts — they used manual `useShallow` convenience hooks instead of the auto-generated `.use.field()` pattern required by CONVENTIONS.md.

## Changes

**chat-store.ts:**
- Rename base store to `useChatStoreBase`, wrap with `createSelectors`
- Delete dead convenience hooks (`useChatState`, `useChatActions`, `useChatSnapshot`) — defined but never imported by any consumer
- Remove `useShallow` import (only used by deleted hooks)

**turn-store.ts:**
- Rename base store to `useTurnStoreBase`, wrap with `createSelectors`
- Delete dead convenience hooks (`useTurnState`, `useTurnActions`) — defined but never imported by any consumer
- Remove `useShallow` import (only used by deleted hooks)

**chat-composer.tsx:**
- Replace `useTurnStore()` (full-store subscription) with `useTurnStore.use.phase()` — the component only needs `phase` to derive `isGenerating`
- Remove `isSending` import (replaced by direct phase checks equivalent to `isSending(state) && phase !== 'awaiting_user_input'`)

**chat-route-content.tsx:**
- Replace `useTurnStore()` (full-store subscription) with per-field `.use.*()` selectors for all 6 `TurnState` fields — targeted re-render subscriptions instead of subscribing to the entire store including actions

## Safety

- `createSelectors` returns a store with the same API (`.getState()`, `.setState()`, hook call) plus the `.use` property — all existing `useChatStore.getState()`, `useChatStore.setState()`, `useTurnStore.getState()`, `useTurnStore.setState()` calls continue to work unchanged
- All 163 tests pass (120 turn-store tests, 43 chat-composer tests)
- Typecheck and lint clean

## Root cause analysis

These stores were created during the initial migration from React Context to Zustand. The `createSelectors()` convention was documented in CONVENTIONS.md but wasn't applied to these two stores at creation time. The dead convenience hooks (`useChatState`, `useChatActions`, etc.) were written as an intermediate pattern before the team settled on `createSelectors()` as the standard.

**Prevention:** The convention is now consistently applied across all stores. The dead code deletion removes the pattern from the codebase so it doesn't serve as a template for future stores.

## References

- [Zustand — Auto Generating Selectors](https://zustand.docs.pmnd.rs/learn/guides/auto-generating-selectors)
- [Zustand — Prevent rerenders with useShallow](https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow)
- [CONVENTIONS.md — Auto-generated selectors via createSelectors](apps/web/CONVENTIONS.md#auto-generated-selectors-via-createselectors)

## Prompt / plan

Closes LUM-1715 — chat-store + turn-store missing `createSelectors()`.

## Test plan

- All 120 turn-store tests pass
- All 43 chat-composer tests pass
- TypeScript typecheck clean (`bunx tsc --noEmit`)
- ESLint clean (`bun run lint`)
- CI verification

Link to Devin session: https://app.devin.ai/sessions/0a7470e554b2479db3dd1f2bb8f5a53d
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->