### PR TITLE
refactor(nudges): consolidate github + discord prefs into a Zustand store (LUM-1716)

### DIFF
--- a/apps/web/src/domains/nudges/discord-prefs.ts
+++ b/apps/web/src/domains/nudges/discord-prefs.ts
@@ -1,114 +1,36 @@
+/**
+ * Discord-nudge public API.
+ *
+ * Backed by `useNudgeStore`; this file exposes the Discord-specific derived
+ * state, click handlers, and prerequisite checks (account age, GitHub-nudge
+ * cascade, conversation count).
+ */
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
 
-import {
-  computeNudgeSidebarVisible,
-  readBooleanPref,
-  writeBooleanPref,
-  readNumberPref,
-  writeNumberPref,
-} from "@/domains/nudges/nudge-prefs.js";
-
+import { computeNudgeSidebarVisible } from "@/domains/nudges/nudge-prefs.js";
+import { useNudgeStore } from "@/domains/nudges/nudge-store.js";
 import {
   readGitHubNudgeStarred,
   readGitHubBannerDismissedAt,
 } from "@/domains/nudges/github-prefs.js";
-
-import {
-  KEY_GITHUB_NUDGE_BANNER_DISMISSED,
-  KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED,
-} from "@/domains/nudges/github-constants.js";
-
 import {
   DISCORD_INVITE_URL,
   DISCORD_MIN_CONVERSATION_COUNT,
   DISCORD_MIN_ACCOUNT_AGE_MS,
   DISCORD_GITHUB_DISMISS_COOLDOWN_MS,
-  KEY_DISCORD_NUDGE_JOINED,
-  KEY_DISCORD_NUDGE_BANNER_DISMISSED,
-  KEY_DISCORD_NUDGE_SIDEBAR_DISMISSED,
-  KEY_DISCORD_NUDGE_FIRST_SEEN_AT,
 } from "@/domains/nudges/discord-constants.js";
-
-// ---------------------------------------------------------------------------
-// External-store subscription (same pattern as github-nudge/prefs.ts)
-// ---------------------------------------------------------------------------
-
-type PrefChangeEvent = CustomEvent<{ key: string; value: string | null }>;
-
-const subscribeCache = new Map<
-  string,
-  (listener: () => void) => () => void
->();
-const snapshotCache = new Map<string, () => boolean>();
-
-function getSubscribeForKey(
-  key: string,
-): (listener: () => void) => () => void {
-  let cached = subscribeCache.get(key);
-  if (!cached) {
-    cached = (listener) => {
-      if (typeof window === "undefined") {
-        return () => {};
-      }
-      const handleSameTab = (event: Event) => {
-        const detail = (event as PrefChangeEvent).detail;
-        if (detail?.key === key) {
-          listener();
-        }
-      };
-      const handleCrossTab = (event: StorageEvent) => {
-        if (event.key === key) {
-          listener();
-        }
-      };
-      window.addEventListener("vellum:pref-changed", handleSameTab);
-      window.addEventListener("storage", handleCrossTab);
-      return () => {
-        window.removeEventListener("vellum:pref-changed", handleSameTab);
-        window.removeEventListener("storage", handleCrossTab);
-      };
-    };
-    subscribeCache.set(key, cached);
-  }
-  return cached;
-}
-
-function getSnapshotForKey(key: string): () => boolean {
-  let cached = snapshotCache.get(key);
-  if (!cached) {
-    cached = () => readBooleanPref(key, false);
-    snapshotCache.set(key, cached);
-  }
-  return cached;
-}
-
-const SERVER_DEFAULT_FALSE = () => false;
-
-function useBooleanPref(key: string): boolean {
-  return useSyncExternalStore(
-    getSubscribeForKey(key),
-    getSnapshotForKey(key),
-    SERVER_DEFAULT_FALSE,
-  );
-}
 
 // ---------------------------------------------------------------------------
 // First-seen timestamp
 // ---------------------------------------------------------------------------
 
 export function ensureFirstSeenAt(): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-  const existing = readNumberPref(KEY_DISCORD_NUDGE_FIRST_SEEN_AT, 0);
-  if (existing === 0) {
-    writeNumberPref(KEY_DISCORD_NUDGE_FIRST_SEEN_AT, Date.now());
-  }
+  useNudgeStore.getState().ensureDiscordFirstSeenAt();
 }
 
 export function readFirstSeenAt(): number {
-  return readNumberPref(KEY_DISCORD_NUDGE_FIRST_SEEN_AT, 0);
+  return useNudgeStore.getState().discordFirstSeenAt;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,13 +38,11 @@ export function readFirstSeenAt(): number {
 // ---------------------------------------------------------------------------
 
 function isGitHubNudgeResolved(): boolean {
-  const starred = readGitHubNudgeStarred();
-  if (starred) {
+  if (readGitHubNudgeStarred()) {
     return true;
   }
-  const bannerDismissed = readBooleanPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED, false);
-  const sidebarDismissed = readBooleanPref(KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED, false);
-  return bannerDismissed && sidebarDismissed;
+  const state = useNudgeStore.getState();
+  return state.githubBannerDismissed && state.githubSidebarDismissed;
 }
 
 function isGitHubDismissCooldownElapsed(): boolean {
@@ -148,47 +68,29 @@ export function areDiscordPrerequisitesMet(
   platformNudgeResolved: boolean,
   conversationCount: number,
 ): boolean {
-  if (!platformNudgeResolved) {
-    return false;
-  }
-  if (!isGitHubNudgeResolved()) {
-    return false;
-  }
-  if (!isAccountAgeEligible()) {
-    return false;
-  }
-  if (conversationCount < DISCORD_MIN_CONVERSATION_COUNT) {
-    return false;
-  }
-  if (!isGitHubDismissCooldownElapsed()) {
-    return false;
-  }
+  if (!platformNudgeResolved) return false;
+  if (!isGitHubNudgeResolved()) return false;
+  if (!isAccountAgeEligible()) return false;
+  if (conversationCount < DISCORD_MIN_CONVERSATION_COUNT) return false;
+  if (!isGitHubDismissCooldownElapsed()) return false;
   return true;
 }
 
 // ---------------------------------------------------------------------------
-// Public readers / writers
+// Public readers
 // ---------------------------------------------------------------------------
 
 export function readDiscordNudgeJoined(): boolean {
-  return readBooleanPref(KEY_DISCORD_NUDGE_JOINED, false);
+  return useNudgeStore.getState().discordJoined;
 }
 
-function writeDiscordNudgeJoined(): void {
-  writeBooleanPref(KEY_DISCORD_NUDGE_JOINED, true);
-}
+// ---------------------------------------------------------------------------
+// Join flow
+// ---------------------------------------------------------------------------
 
 export function joinDiscord(): void {
   openDiscordInvite();
-  writeDiscordNudgeJoined();
-}
-
-function writeDiscordBannerDismissed(): void {
-  writeBooleanPref(KEY_DISCORD_NUDGE_BANNER_DISMISSED, true);
-}
-
-function writeDiscordSidebarDismissed(): void {
-  writeBooleanPref(KEY_DISCORD_NUDGE_SIDEBAR_DISMISSED, true);
+  useNudgeStore.getState().markDiscordJoined();
 }
 
 // ---------------------------------------------------------------------------
@@ -217,9 +119,9 @@ export function useDiscordNudgeState(
   platformNudgeResolved: boolean,
   conversationCount: number,
 ): DiscordNudgeState {
-  const joined = useBooleanPref(KEY_DISCORD_NUDGE_JOINED);
-  const bannerDismissed = useBooleanPref(KEY_DISCORD_NUDGE_BANNER_DISMISSED);
-  const sidebarDismissed = useBooleanPref(KEY_DISCORD_NUDGE_SIDEBAR_DISMISSED);
+  const joined = useNudgeStore.use.discordJoined();
+  const bannerDismissed = useNudgeStore.use.discordBannerDismissed();
+  const sidebarDismissed = useNudgeStore.use.discordSidebarDismissed();
 
   const prerequisitesMet = areDiscordPrerequisitesMet(
     platformNudgeResolved,
@@ -228,24 +130,26 @@ export function useDiscordNudgeState(
 
   const handleJoin = useCallback(() => {
     openDiscordInvite();
-    writeDiscordNudgeJoined();
+    useNudgeStore.getState().markDiscordJoined();
   }, []);
 
   const handleBannerDismiss = useCallback(() => {
-    writeDiscordBannerDismissed();
+    useNudgeStore.getState().dismissDiscordBanner();
   }, []);
 
   const handleSidebarDismiss = useCallback(() => {
-    writeDiscordSidebarDismissed();
+    useNudgeStore.getState().dismissDiscordSidebar();
   }, []);
 
   return {
     bannerShouldShow: prerequisitesMet && !joined && !bannerDismissed,
-    sidebarEntryVisible: prerequisitesMet && computeNudgeSidebarVisible({
-      converted: joined,
-      bannerDismissed,
-      sidebarDismissed,
-    }),
+    sidebarEntryVisible:
+      prerequisitesMet &&
+      computeNudgeSidebarVisible({
+        converted: joined,
+        bannerDismissed,
+        sidebarDismissed,
+      }),
     handleJoin,
     handleBannerDismiss,
     handleSidebarDismiss,
@@ -257,21 +161,6 @@ export function useDiscordNudgeState(
 // ---------------------------------------------------------------------------
 
 export function openDiscordInvite(): void {
-  if (typeof window === "undefined") {
-    return;
-  }
+  if (typeof window === "undefined") return;
   window.open(DISCORD_INVITE_URL, "_blank", "noopener,noreferrer");
 }
-
-// ---------------------------------------------------------------------------
-// Internals exported for tests only. Not part of the public API.
-// ---------------------------------------------------------------------------
-
-export const __testing = {
-  writeDiscordNudgeJoined,
-  writeDiscordBannerDismissed,
-  writeDiscordSidebarDismissed,
-  isGitHubNudgeResolved,
-  isGitHubDismissCooldownElapsed,
-  isAccountAgeEligible,
-};

--- a/apps/web/src/domains/nudges/github-prefs.ts
+++ b/apps/web/src/domains/nudges/github-prefs.ts
@@ -1,120 +1,27 @@
+/**
+ * GitHub-nudge public API.
+ *
+ * Backed by `useNudgeStore`; this file just exposes the GitHub-specific
+ * derived state, click handlers, and a few non-React readers used by the
+ * Discord-nudge prerequisite checks.
+ */
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
 
-import {
-  computeNudgeSidebarVisible,
-  readBooleanPref,
-  writeBooleanPref,
-  writeNumberPref,
-  readNumberPref,
-} from "@/domains/nudges/nudge-prefs.js";
-
-import {
-  GITHUB_REPO_URL,
-  KEY_GITHUB_NUDGE_BANNER_DISMISSED,
-  KEY_GITHUB_NUDGE_BANNER_DISMISSED_AT,
-  KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED,
-  KEY_GITHUB_NUDGE_STARRED,
-} from "@/domains/nudges/github-constants.js";
+import { computeNudgeSidebarVisible } from "@/domains/nudges/nudge-prefs.js";
+import { useNudgeStore } from "@/domains/nudges/nudge-store.js";
+import { GITHUB_REPO_URL } from "@/domains/nudges/github-constants.js";
 
 // ---------------------------------------------------------------------------
-// External-store subscription
-// ---------------------------------------------------------------------------
-//
-// `setLocalSetting` (the underlying writer behind `writeBooleanPref`)
-// dispatches a synthetic `vellum:pref-changed` CustomEvent on `window`
-// after every same-tab write, and the browser dispatches a native
-// `storage` event on cross-tab writes. Both are bridged into
-// `useSyncExternalStore` so every consumer of a given pref key re-renders
-// the instant the flag flips on any surface or tab.
-//
-// The subscribe callback filters on `detail.key` (same-tab) and
-// `event.key` (cross-tab) so unrelated pref flips do not trigger
-// spurious re-renders.
-//
-// `subscribe` and `getSnapshot` are cached at module scope per pref key.
-// `useSyncExternalStore` compares `subscribe` by reference and
-// re-subscribes whenever it receives a fresh function — see
-// https://react.dev/reference/react/useSyncExternalStore#parameters —
-// so creating a new closure on every render would tear down and re-add
-// listeners every render. Same convention as `useIsMobile.ts`.
-
-type PrefChangeEvent = CustomEvent<{ key: string; value: string | null }>;
-
-const subscribeCache = new Map<
-  string,
-  (listener: () => void) => () => void
->();
-const snapshotCache = new Map<string, () => boolean>();
-
-function getSubscribeForKey(
-  key: string,
-): (listener: () => void) => () => void {
-  let cached = subscribeCache.get(key);
-  if (!cached) {
-    cached = (listener) => {
-      if (typeof window === "undefined") return () => {};
-      const handleSameTab = (event: Event) => {
-        const detail = (event as PrefChangeEvent).detail;
-        if (detail?.key === key) listener();
-      };
-      const handleCrossTab = (event: StorageEvent) => {
-        if (event.key === key) listener();
-      };
-      window.addEventListener("vellum:pref-changed", handleSameTab);
-      window.addEventListener("storage", handleCrossTab);
-      return () => {
-        window.removeEventListener("vellum:pref-changed", handleSameTab);
-        window.removeEventListener("storage", handleCrossTab);
-      };
-    };
-    subscribeCache.set(key, cached);
-  }
-  return cached;
-}
-
-function getSnapshotForKey(key: string): () => boolean {
-  let cached = snapshotCache.get(key);
-  if (!cached) {
-    cached = () => readBooleanPref(key, false);
-    snapshotCache.set(key, cached);
-  }
-  return cached;
-}
-
-const SERVER_DEFAULT_FALSE = () => false;
-
-function useBooleanPref(key: string): boolean {
-  return useSyncExternalStore(
-    getSubscribeForKey(key),
-    getSnapshotForKey(key),
-    SERVER_DEFAULT_FALSE,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Public readers / writers
+// Public readers (non-React, for cross-module prerequisite checks)
 // ---------------------------------------------------------------------------
 
 export function readGitHubNudgeStarred(): boolean {
-  return readBooleanPref(KEY_GITHUB_NUDGE_STARRED, false);
-}
-
-function writeGitHubNudgeStarred(): void {
-  writeBooleanPref(KEY_GITHUB_NUDGE_STARRED, true);
-}
-
-function writeGitHubBannerDismissed(): void {
-  writeBooleanPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED, true);
-  writeNumberPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED_AT, Date.now());
+  return useNudgeStore.getState().githubStarred;
 }
 
 export function readGitHubBannerDismissedAt(): number {
-  return readNumberPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED_AT, 0);
-}
-
-function writeGitHubSidebarDismissed(): void {
-  writeBooleanPref(KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED, true);
+  return useNudgeStore.getState().githubBannerDismissedAt;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,21 +47,21 @@ export interface GitHubNudgeState {
 }
 
 export function useGitHubNudgeState(): GitHubNudgeState {
-  const starred = useBooleanPref(KEY_GITHUB_NUDGE_STARRED);
-  const bannerDismissed = useBooleanPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED);
-  const sidebarDismissed = useBooleanPref(KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED);
+  const starred = useNudgeStore.use.githubStarred();
+  const bannerDismissed = useNudgeStore.use.githubBannerDismissed();
+  const sidebarDismissed = useNudgeStore.use.githubSidebarDismissed();
 
   const handleStar = useCallback(() => {
     openGitHubRepo();
-    writeGitHubNudgeStarred();
+    useNudgeStore.getState().markGitHubStarred();
   }, []);
 
   const handleBannerDismiss = useCallback(() => {
-    writeGitHubBannerDismissed();
+    useNudgeStore.getState().dismissGitHubBanner();
   }, []);
 
   const handleSidebarDismiss = useCallback(() => {
-    writeGitHubSidebarDismissed();
+    useNudgeStore.getState().dismissGitHubSidebar();
   }, []);
 
   return {
@@ -178,14 +85,3 @@ export function openGitHubRepo(): void {
   if (typeof window === "undefined") return;
   window.open(GITHUB_REPO_URL, "_blank", "noopener,noreferrer");
 }
-
-// ---------------------------------------------------------------------------
-// Internals exported for tests only. Not part of the public API.
-// ---------------------------------------------------------------------------
-
-export const __testing = {
-  writeGitHubNudgeStarred,
-  writeGitHubBannerDismissed,
-  writeGitHubSidebarDismissed,
-  readGitHubBannerDismissedAt,
-};

--- a/apps/web/src/domains/nudges/nudge-store.ts
+++ b/apps/web/src/domains/nudges/nudge-store.ts
@@ -1,0 +1,157 @@
+/**
+ * Zustand store for GitHub + Discord nudge prefs.
+ *
+ * Replaces the hand-rolled `useSyncExternalStore` + per-key
+ * subscribe/snapshot caches that previously lived in `github-prefs.ts`
+ * and `discord-prefs.ts`. Both pref modules now read/write through this
+ * store; their public hooks (`useGitHubNudgeState`, `useDiscordNudgeState`)
+ * remain as thin selector wrappers so consumers don't change.
+ *
+ * **Storage model:**
+ *
+ * - The persist middleware serialises the whole nudge slice into a
+ *   single localStorage key, `vellum:nudge-prefs`.
+ * - On first load (no `vellum:nudge-prefs` key present), the initial
+ *   state is seeded from the legacy per-key entries the old modules
+ *   wrote (`app.githubNudge.starred`, `app.discordNudge.joined`, etc.),
+ *   so users carrying over from the platform deployment keep their
+ *   dismissals.
+ * - Cross-tab updates: the persist middleware doesn't sync across tabs
+ *   on its own. We listen for `storage` events on `vellum:nudge-prefs`
+ *   and call `persist.rehydrate()` to pull in the other tab's write.
+ *
+ * Reference:
+ * - {@link https://zustand.docs.pmnd.rs/}
+ * - {@link https://zustand.docs.pmnd.rs/integrations/persisting-store-data}
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+import { createSelectors } from "@/utils/create-selectors.js";
+
+import {
+  readBooleanPref,
+  readNumberPref,
+} from "@/domains/nudges/nudge-prefs.js";
+import {
+  KEY_GITHUB_NUDGE_STARRED,
+  KEY_GITHUB_NUDGE_BANNER_DISMISSED,
+  KEY_GITHUB_NUDGE_BANNER_DISMISSED_AT,
+  KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED,
+} from "@/domains/nudges/github-constants.js";
+import {
+  KEY_DISCORD_NUDGE_JOINED,
+  KEY_DISCORD_NUDGE_BANNER_DISMISSED,
+  KEY_DISCORD_NUDGE_SIDEBAR_DISMISSED,
+  KEY_DISCORD_NUDGE_FIRST_SEEN_AT,
+} from "@/domains/nudges/discord-constants.js";
+
+// ---------------------------------------------------------------------------
+// State + Actions
+// ---------------------------------------------------------------------------
+
+export interface NudgeState {
+  githubStarred: boolean;
+  githubBannerDismissed: boolean;
+  /** Epoch ms of the most recent GitHub banner dismiss. 0 = never. */
+  githubBannerDismissedAt: number;
+  githubSidebarDismissed: boolean;
+  discordJoined: boolean;
+  discordBannerDismissed: boolean;
+  discordSidebarDismissed: boolean;
+  /** Epoch ms of the first time the Discord nudge module observed the user. 0 = not yet recorded. */
+  discordFirstSeenAt: number;
+}
+
+export interface NudgeActions {
+  markGitHubStarred: () => void;
+  dismissGitHubBanner: () => void;
+  dismissGitHubSidebar: () => void;
+  markDiscordJoined: () => void;
+  dismissDiscordBanner: () => void;
+  dismissDiscordSidebar: () => void;
+  /** Stamp `discordFirstSeenAt` to `Date.now()` on first observation. No-op afterwards. */
+  ensureDiscordFirstSeenAt: () => void;
+}
+
+export type NudgeStore = NudgeState & NudgeActions;
+
+// ---------------------------------------------------------------------------
+// Initial state — hydrate from legacy per-key localStorage entries
+// ---------------------------------------------------------------------------
+
+function computeInitialFromLegacy(): NudgeState {
+  return {
+    githubStarred: readBooleanPref(KEY_GITHUB_NUDGE_STARRED, false),
+    githubBannerDismissed: readBooleanPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED, false),
+    githubBannerDismissedAt: readNumberPref(KEY_GITHUB_NUDGE_BANNER_DISMISSED_AT, 0),
+    githubSidebarDismissed: readBooleanPref(KEY_GITHUB_NUDGE_SIDEBAR_DISMISSED, false),
+    discordJoined: readBooleanPref(KEY_DISCORD_NUDGE_JOINED, false),
+    discordBannerDismissed: readBooleanPref(KEY_DISCORD_NUDGE_BANNER_DISMISSED, false),
+    discordSidebarDismissed: readBooleanPref(KEY_DISCORD_NUDGE_SIDEBAR_DISMISSED, false),
+    discordFirstSeenAt: readNumberPref(KEY_DISCORD_NUDGE_FIRST_SEEN_AT, 0),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const NUDGE_STORE_KEY = "vellum:nudge-prefs";
+
+const useNudgeStoreBase = create<NudgeStore>()(
+  persist(
+    (set, get) => ({
+      ...computeInitialFromLegacy(),
+
+      markGitHubStarred: () => set({ githubStarred: true }),
+      dismissGitHubBanner: () =>
+        set({
+          githubBannerDismissed: true,
+          githubBannerDismissedAt: Date.now(),
+        }),
+      dismissGitHubSidebar: () => set({ githubSidebarDismissed: true }),
+      markDiscordJoined: () => set({ discordJoined: true }),
+      dismissDiscordBanner: () => set({ discordBannerDismissed: true }),
+      dismissDiscordSidebar: () => set({ discordSidebarDismissed: true }),
+      ensureDiscordFirstSeenAt: () => {
+        if (get().discordFirstSeenAt === 0) {
+          set({ discordFirstSeenAt: Date.now() });
+        }
+      },
+    }),
+    {
+      name: NUDGE_STORE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      // Only persist state, not action functions.
+      partialize: (state) => ({
+        githubStarred: state.githubStarred,
+        githubBannerDismissed: state.githubBannerDismissed,
+        githubBannerDismissedAt: state.githubBannerDismissedAt,
+        githubSidebarDismissed: state.githubSidebarDismissed,
+        discordJoined: state.discordJoined,
+        discordBannerDismissed: state.discordBannerDismissed,
+        discordSidebarDismissed: state.discordSidebarDismissed,
+        discordFirstSeenAt: state.discordFirstSeenAt,
+      }),
+    },
+  ),
+);
+
+export const useNudgeStore = createSelectors(useNudgeStoreBase);
+
+// ---------------------------------------------------------------------------
+// Cross-tab sync
+// ---------------------------------------------------------------------------
+
+// `localStorage.setItem` fires a native `storage` event in *other* tabs.
+// Persist middleware doesn't subscribe to it on its own, so wire a listener
+// that rehydrates this store whenever `vellum:nudge-prefs` changes elsewhere.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === NUDGE_STORE_KEY) {
+      void useNudgeStoreBase.persist.rehydrate();
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `useSyncExternalStore` + per-key subscribe/snapshot caches in `github-prefs.ts` and `discord-prefs.ts` (~150 lines of duplicated boilerplate across the two files) with a single Zustand store backed by the `persist` middleware. Closes LUM-1716.

## What changed

- **New `domains/nudges/nudge-store.ts`** — one store, 8 fields covering both nudge surfaces, 7 actions, `persist` middleware to a single `vellum:nudge-prefs` localStorage key, `createSelectors()` for `.use.field()` atomic subscriptions.
- **`github-prefs.ts`** — drops the `subscribeCache` + `snapshotCache` + `useBooleanPref` boilerplate; `useGitHubNudgeState` is now a thin selector wrapper. Public API surface is preserved (`readGitHubNudgeStarred`, `readGitHubBannerDismissedAt`, `openGitHubRepo`, `useGitHubNudgeState`).
- **`discord-prefs.ts`** — same treatment. Public exports unchanged (`useDiscordNudgeState`, `joinDiscord`, `ensureFirstSeenAt`, `readFirstSeenAt`, `readDiscordNudgeJoined`, `areDiscordPrerequisitesMet`, `openDiscordInvite`).

Net diff: **+219 / −277**.

## Migration behavior — preserves dismissals across cutover

`vellum:nudge-prefs` is a new localStorage key. To avoid re-nudging users who have already starred/joined/dismissed on the current platform deployment (where the per-key entries `app.githubNudge.starred`, `app.discordNudge.joined`, etc. live), the store's initial state is seeded from those legacy keys via `readBooleanPref` / `readNumberPref`. On first load:

1. `vellum:nudge-prefs` is absent → store uses the legacy-hydrated initial state
2. The first `set()` triggers persist to write the new combined key
3. Subsequent loads use the new key authoritatively

Legacy keys aren't deleted (forward-compat in case someone still on a platform-served tab needs them). A future small cleanup can remove them after cutover — happy to file that as a follow-up if desired.

## Cross-tab sync

Zustand's `persist` middleware doesn't auto-sync across tabs. The store registers a `window.addEventListener("storage")` listener that calls `useNudgeStoreBase.persist.rehydrate()` whenever `vellum:nudge-prefs` changes in another tab. Behaviorally equivalent to the previous `storage` event handling.

## Test plan

- [x] `bun run lint` — clean (pre-existing warning on `lib/errors/report.ts`)
- [x] `bun run typecheck` — clean
- [x] `bun test` baseline: **1189 tests, 28 fail / 14 errors — identical to `main`**, zero new failures
- [x] Existing consumers (`use-app-nudges.ts`, `community-page.tsx`) compile unchanged against the preserved public API
- [ ] Manual: with old `app.githubNudge.starred = "true"` in localStorage, load the app, confirm GitHub banner doesn't appear (initial-state seeding works)
- [ ] Manual: open two tabs, dismiss a banner in one, confirm the other refreshes within a few hundred ms (cross-tab sync works)

## Acceptance criteria (from LUM-1716)

- [x] Nudge preferences use a Zustand store with `persist` middleware
- [x] No hand-rolled `useSyncExternalStore`, subscriber sets, or snapshot caches for nudge state
- [x] Cross-tab synchronization preserved
- [x] Store wrapped with `createSelectors()`
- [x] `bunx tsc --noEmit` and `bun run lint` pass

## Out of scope / follow-ups noted

- The `ios-app-prefs.ts` and `mac-app-prefs.ts` modules in the same domain do **not** use the hand-rolled `useSyncExternalStore` pattern (they use `useState` + `useEffect`), so they're not in this PR's scope. If we want them unified into the same nudge-store later, file a separate issue.
- Legacy per-key localStorage entries (`app.githubNudge.*`, `app.discordNudge.*`) are left in place. Cleanup is a one-line `removeLocalSetting` per key in a follow-up after the full deployment cutover.

## Divergences from platform

None — platform doesn't have a Zustand nudge store; this is the new repo's first canonical implementation of nudge prefs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWERLgh2s54Vi5NiSWShn2)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->