### PR TITLE
fix(nudges): re-subscribe Discord prereq fields after Zustand migration

### DIFF
--- a/apps/web/src/domains/nudges/discord-prefs.ts
+++ b/apps/web/src/domains/nudges/discord-prefs.ts
@@ -123,6 +123,16 @@ export function useDiscordNudgeState(
   const bannerDismissed = useNudgeStore.use.discordBannerDismissed();
   const sidebarDismissed = useNudgeStore.use.discordSidebarDismissed();
 
+  // The Discord prereq cascade reads GitHub nudge state via `getState()`
+  // inside `areDiscordPrerequisitesMet`. Subscribe to those fields here too
+  // so the Discord nudge re-evaluates the moment a GitHub action flips one
+  // of them — otherwise this component would only re-render when one of
+  // its own three Discord fields changes.
+  useNudgeStore.use.githubStarred();
+  useNudgeStore.use.githubBannerDismissed();
+  useNudgeStore.use.githubSidebarDismissed();
+  useNudgeStore.use.discordFirstSeenAt();
+
   const prerequisitesMet = areDiscordPrerequisitesMet(
     platformNudgeResolved,
     conversationCount,


### PR DESCRIPTION
## Summary

Fixes a reactivity regression introduced by [#31341 (LUM-1716)](https://github.com/vellum-ai/vellum-assistant/pull/31341) — flagged by Vex review on the original PR but landed after that PR was already merged.

## The regression

In `discord-prefs.ts`, `useDiscordNudgeState` calls `areDiscordPrerequisitesMet()` which reads three GitHub-nudge fields (`githubStarred`, `githubBannerDismissed`, `githubSidebarDismissed`) plus `discordFirstSeenAt` via `useNudgeStore.getState()` — a non-reactive read.

Before the Zustand migration, the previous `useSyncExternalStore` implementation subscribed to **each** pref key individually, so the Discord nudge re-evaluated `prerequisitesMet` the moment any of those flipped. After the migration, the Discord nudge component only re-renders when one of its own three Discord fields changes — meaning a user who clicks the GitHub star while the Discord nudge component is mounted won't see the Discord nudge appear until something else (a different prop, another state change) triggers a render.

## The fix

Add four side-effect subscriptions inside `useDiscordNudgeState` for the fields `areDiscordPrerequisitesMet` reads non-reactively:

```ts
useNudgeStore.use.githubStarred();
useNudgeStore.use.githubBannerDismissed();
useNudgeStore.use.githubSidebarDismissed();
useNudgeStore.use.discordFirstSeenAt();
```

The values aren't destructured — only the subscription matters. An explanatory comment names the cascade so future readers don't think these are dead reads.

## Test plan

- [x] `bun run lint` — clean (pre-existing warning)
- [x] `bun run typecheck` — clean
- [ ] Manual: with the Discord nudge mounted (banner or sidebar surface), click the GitHub star button in another visible nudge surface — confirm the Discord nudge re-evaluates its `bannerShouldShow` / `sidebarEntryVisible` in the same render cycle.

## Divergences from platform

None — this restores parity with the pre-migration behavior, which already had per-key reactive subscriptions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWERLgh2s54Vi5NiSWShn2)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->