### PR TITLE
feat(home): add LLM-generated personalized greeting and suggestion prompts

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -102,4 +102,17 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  homeGreeting: {
+    profile: "cost-optimized",
+    maxTokens: 60,
+    effort: "low",
+    thinking: { enabled: false },
+    temperature: 0.7,
+  },
+  homeSuggestedPrompts: {
+    profile: "cost-optimized",
+    maxTokens: 512,
+    effort: "low",
+    thinking: { enabled: false },
+  },
 };

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -300,6 +300,20 @@ const CATALOG_RECORD: CatalogRecord = {
       "Builds the personalized artifact in a background conversation with tool access.",
     domain: "agentLoop",
   },
+  homeGreeting: {
+    id: "homeGreeting",
+    displayName: "Home Greeting",
+    description:
+      "Generates the personalized greeting shown on the Home page in the assistant's tone/persona.",
+    domain: "ui",
+  },
+  homeSuggestedPrompts: {
+    id: "homeSuggestedPrompts",
+    displayName: "Home Suggested Prompts",
+    description:
+      "Generates contextual conversation-starter suggestions for the Home page.",
+    domain: "ui",
+  },
 };
 
 // Source of truth for call-site display metadata. API responses and usage

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -76,6 +76,8 @@ export const LLMCallSiteEnum = z.enum([
   "trustRuleSuggestion",
   "proactiveArtifactDecision",
   "proactiveArtifactBuild",
+  "homeGreeting",
+  "homeSuggestedPrompts",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,6 +32,7 @@ import {
 } from "../credential-execution/startup-timeout.js";
 import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import { startHomeContentRefresh } from "../home/home-content-refresh.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
 import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
@@ -471,6 +472,10 @@ export async function runDaemon(): Promise<void> {
           ),
         );
       });
+
+      // Pre-warm LLM-generated home page content (greeting + suggestion
+      // prompts) so the GET handler never triggers LLM calls.
+      startHomeContentRefresh();
 
       // Backfill injection templates on Slack bot token credentials so the
       // credential proxy can inject Authorization headers. Safe on every startup.

--- a/assistant/src/home/__tests__/suggested-prompts.test.ts
+++ b/assistant/src/home/__tests__/suggested-prompts.test.ts
@@ -5,8 +5,6 @@ import { describe, expect, mock, test } from "bun:test";
 let mockConnectedProviders = new Set<string>();
 
 mock.module("../../oauth/oauth-store.js", () => ({
-  isProviderConnected: async (provider: string) =>
-    mockConnectedProviders.has(provider),
   listProviders: () => [
     { provider: "google" },
     { provider: "slack" },
@@ -14,6 +12,11 @@ mock.module("../../oauth/oauth-store.js", () => ({
     { provider: "linear" },
     { provider: "github" },
   ],
+}));
+
+mock.module("../../schedule/integration-status.js", () => ({
+  isOAuthProviderConnected: async (provider: string) =>
+    mockConnectedProviders.has(provider),
 }));
 
 mock.module("../../util/logger.js", () => ({

--- a/assistant/src/home/__tests__/suggested-prompts.test.ts
+++ b/assistant/src/home/__tests__/suggested-prompts.test.ts
@@ -23,6 +23,34 @@ mock.module("../../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ llm: {} }),
+}));
+
+mock.module("../../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => ({ provider: "mock" }),
+}));
+
+mock.module("../../providers/registry.js", () => ({
+  getProvider: () => ({}),
+}));
+
+mock.module("../../prompts/persona-resolver.js", () => ({
+  resolvePersonaContext: () => ({
+    userPersona: null,
+    userSlug: null,
+    channelPersona: null,
+  }),
+}));
+
+mock.module("../../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "mock system prompt",
+}));
+
+mock.module("../../runtime/btw-sidechain.js", () => ({
+  runBtwSidechain: async () => ({ text: "" }),
+}));
+
 const { getSuggestedPrompts } = await import("../suggested-prompts.js");
 
 // ─── Tests ─────────────────────────────────────────────────────────────

--- a/assistant/src/home/__tests__/suggested-prompts.test.ts
+++ b/assistant/src/home/__tests__/suggested-prompts.test.ts
@@ -31,8 +31,8 @@ mock.module("../../config/llm-resolver.js", () => ({
   resolveCallSiteConfig: () => ({ provider: "mock" }),
 }));
 
-mock.module("../../providers/registry.js", () => ({
-  getProvider: () => ({}),
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => ({}),
 }));
 
 mock.module("../../prompts/persona-resolver.js", () => ({

--- a/assistant/src/home/home-content-refresh.ts
+++ b/assistant/src/home/home-content-refresh.ts
@@ -1,0 +1,52 @@
+/**
+ * Background refresh timer for LLM-generated home page content.
+ *
+ * Keeps the personalized greeting and assistant-generated suggestion
+ * prompts warm in their caches so the GET handler never triggers LLM
+ * calls or database writes (see `src/runtime/AGENTS.md` — GET handler
+ * idempotency rule).
+ *
+ * Call `startHomeContentRefresh()` once during daemon startup; the
+ * timer handles periodic re-generation automatically.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { refreshPersonalizedGreeting } from "./home-greeting.js";
+import { refreshAssistantSuggestedPrompts } from "./suggested-prompts.js";
+
+const log = getLogger("home-content-refresh");
+
+const REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+async function refreshAll(): Promise<void> {
+  await Promise.all([
+    refreshPersonalizedGreeting(),
+    refreshAssistantSuggestedPrompts(),
+  ]);
+}
+
+/**
+ * Start periodic background refresh of home page LLM content.
+ * Runs an initial generation immediately (fire-and-forget) and
+ * schedules re-generation every 30 minutes.
+ */
+export function startHomeContentRefresh(): void {
+  void refreshAll().catch((err) =>
+    log.warn({ err }, "Initial home content refresh failed"),
+  );
+
+  refreshTimer = setInterval(() => {
+    void refreshAll().catch((err) =>
+      log.warn({ err }, "Periodic home content refresh failed"),
+    );
+  }, REFRESH_INTERVAL_MS);
+}
+
+export function stopHomeContentRefresh(): void {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}

--- a/assistant/src/home/home-greeting-cache.ts
+++ b/assistant/src/home/home-greeting-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Caching layer for the LLM-generated personalized home greeting.
+ *
+ * The greeting (a short persona-flavored "here's what's been going on" line)
+ * is generated via `runBtwSidechain` and displayed at the top of the Home
+ * page. To avoid redundant LLM calls on every feed fetch, we cache the
+ * result for 4 hours with content-hash-based invalidation: when IDENTITY.md,
+ * SOUL.md, or the guardian persona change, the cache is busted.
+ *
+ * Storage uses the existing `memory_checkpoints` table (simple key-value store).
+ */
+
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../memory/checkpoints.js";
+import { computeIdentityContentHash } from "../runtime/routes/identity-intro-cache.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const CHECKPOINT_KEY_TEXT = "home:greeting:text";
+const CHECKPOINT_KEY_HASH = "home:greeting:content_hash";
+const CHECKPOINT_KEY_TIMESTAMP = "home:greeting:cached_at";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function getCachedHomeGreeting(): string | null {
+  try {
+    const text = getMemoryCheckpoint(CHECKPOINT_KEY_TEXT);
+    const hash = getMemoryCheckpoint(CHECKPOINT_KEY_HASH);
+    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
+
+    if (!text || !hash || !timestampStr) {
+      return null;
+    }
+
+    const cachedAt = Number(timestampStr);
+    if (isNaN(cachedAt) || Date.now() - cachedAt > CACHE_TTL_MS) {
+      return null;
+    }
+
+    const currentHash = computeIdentityContentHash();
+    if (currentHash !== hash) {
+      return null;
+    }
+
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+export function setCachedHomeGreeting(text: string): void {
+  try {
+    const hash = computeIdentityContentHash();
+    const now = String(Date.now());
+    setMemoryCheckpoint(CHECKPOINT_KEY_TEXT, text);
+    setMemoryCheckpoint(CHECKPOINT_KEY_HASH, hash);
+    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, now);
+  } catch {
+    // Cache write failure is non-fatal — next request will regenerate.
+  }
+}

--- a/assistant/src/home/home-greeting.ts
+++ b/assistant/src/home/home-greeting.ts
@@ -1,0 +1,80 @@
+/**
+ * Personalized home-page greeting generator.
+ *
+ * Produces a short greeting in the assistant's tone/persona for the
+ * Home page header. Uses the BTW side-chain for LLM generation and
+ * caches the result for 4 hours (busted when identity files change).
+ *
+ * Falls back to a generic time-of-day greeting when the LLM call
+ * fails or when no provider is available.
+ */
+
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
+import { resolvePersonaContext } from "../prompts/persona-resolver.js";
+import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { getProvider } from "../providers/registry.js";
+import { runBtwSidechain } from "../runtime/btw-sidechain.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getCachedHomeGreeting,
+  setCachedHomeGreeting,
+} from "./home-greeting-cache.js";
+
+const log = getLogger("home-greeting");
+
+const GENERATION_TIMEOUT_MS = 5_000;
+
+/**
+ * Return a personalized greeting if cached or generatable within the
+ * timeout. Falls back to `null` so the caller can use the generic
+ * time-of-day greeting.
+ */
+export async function getPersonalizedGreeting(): Promise<string | null> {
+  const cached = getCachedHomeGreeting();
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const config = getConfig();
+    const resolved = resolveCallSiteConfig("homeGreeting", config.llm);
+    const provider = getProvider(resolved.provider);
+    const { userPersona, userSlug, channelPersona } = resolvePersonaContext(
+      undefined,
+      undefined,
+    );
+
+    const systemPrompt = buildSystemPrompt({
+      excludeBootstrap: true,
+      excludeCustomPrefix: true,
+      userPersona,
+      channelPersona,
+      userSlug,
+    });
+
+    const result = await runBtwSidechain({
+      content:
+        "Generate a short, casual greeting for the home page (max 10 words). " +
+        "It should convey the meaning of 'here's what's been going on' but in " +
+        "your unique tone and personality. Just output the greeting text, nothing else. " +
+        "No quotes, no preamble.",
+      provider,
+      systemPrompt,
+      messages: [],
+      tools: [],
+      callSite: "homeGreeting",
+      timeoutMs: GENERATION_TIMEOUT_MS,
+    });
+
+    const text = result.text.trim();
+    if (text) {
+      setCachedHomeGreeting(text);
+      return text;
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to generate personalized home greeting");
+  }
+
+  return null;
+}

--- a/assistant/src/home/home-greeting.ts
+++ b/assistant/src/home/home-greeting.ts
@@ -5,15 +5,17 @@
  * Home page header. Uses the BTW side-chain for LLM generation and
  * caches the result for 4 hours (busted when identity files change).
  *
- * Falls back to a generic time-of-day greeting when the LLM call
- * fails or when no provider is available.
+ * The GET handler reads only from cache (`getPersonalizedGreeting`).
+ * Generation runs in the background via `refreshPersonalizedGreeting`,
+ * called at daemon startup and periodically by the home-content
+ * refresh timer.
  */
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
-import { getProvider } from "../providers/registry.js";
+import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -26,20 +28,34 @@ const log = getLogger("home-greeting");
 const GENERATION_TIMEOUT_MS = 5_000;
 
 /**
- * Return a personalized greeting if cached or generatable within the
- * timeout. Falls back to `null` so the caller can use the generic
- * time-of-day greeting.
+ * Return the cached personalized greeting, or `null` when none is
+ * available yet. This is a synchronous cache read — safe for GET
+ * handlers.
  */
-export async function getPersonalizedGreeting(): Promise<string | null> {
+export function getPersonalizedGreeting(): string | null {
+  return getCachedHomeGreeting();
+}
+
+/**
+ * Generate a personalized greeting via LLM and write it to cache.
+ * No-ops when the cache is still fresh. Intended for background
+ * invocation (daemon startup / periodic refresh), not the GET path.
+ */
+export async function refreshPersonalizedGreeting(): Promise<void> {
   const cached = getCachedHomeGreeting();
   if (cached) {
-    return cached;
+    return;
   }
 
   try {
     const config = getConfig();
     const resolved = resolveCallSiteConfig("homeGreeting", config.llm);
-    const provider = getProvider(resolved.provider);
+
+    const provider = await getConfiguredProvider("homeGreeting");
+    if (!provider) {
+      return;
+    }
+
     const { userPersona, userSlug, channelPersona } = resolvePersonaContext(
       undefined,
       undefined,
@@ -64,17 +80,15 @@ export async function getPersonalizedGreeting(): Promise<string | null> {
       messages: [],
       tools: [],
       callSite: "homeGreeting",
+      maxTokens: resolved.maxTokens,
       timeoutMs: GENERATION_TIMEOUT_MS,
     });
 
     const text = result.text.trim();
     if (text) {
       setCachedHomeGreeting(text);
-      return text;
     }
   } catch (err) {
     log.warn({ err }, "Failed to generate personalized home greeting");
   }
-
-  return null;
 }

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -16,11 +16,11 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { listProviders } from "../oauth/oauth-store.js";
-import { isOAuthProviderConnected } from "../schedule/integration-status.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import { runBtwSidechain } from "../runtime/btw-sidechain.js";
+import { isOAuthProviderConnected } from "../schedule/integration-status.js";
 import { getLogger } from "../util/logger.js";
 import type { SuggestedPrompt } from "./feed-types.js";
 

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -15,7 +15,8 @@
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
-import { isProviderConnected, listProviders } from "../oauth/oauth-store.js";
+import { listProviders } from "../oauth/oauth-store.js";
+import { isOAuthProviderConnected } from "../schedule/integration-status.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { getConfiguredProvider } from "../providers/provider-send-message.js";
@@ -115,6 +116,21 @@ export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
 }
 
 /**
+ * Drops the in-memory LLM suggestion cache so the next call to
+ * `getSuggestedPrompts()` returns only the fresh deterministic list (and
+ * a follow-up background refresh repopulates the LLM half).
+ *
+ * Called from OAuth connect/disconnect paths so a freshly-connected
+ * provider stops surfacing as a "Connect X" pill within one reload — the
+ * 30-minute TTL would otherwise pin a stale suggestion until the next
+ * periodic refresh.
+ */
+export function invalidateAssistantSuggestedPromptsCache(): void {
+  cachedLLMPrompts = [];
+  cachedLLMPromptsAt = 0;
+}
+
+/**
  * Generate LLM-based suggestion prompts and write them to the in-memory
  * cache. No-ops when the cache is still fresh. Intended for background
  * invocation (daemon startup / periodic refresh), not the GET path.
@@ -148,7 +164,7 @@ async function getDeterministicPrompts(): Promise<SuggestedPrompt[]> {
     const meta = CONNECT_PROMPT_META[provider.provider];
     if (!meta) continue;
 
-    const connected = await isProviderConnected(provider.provider);
+    const connected = await isOAuthProviderConnected(provider.provider);
 
     if (!connected) {
       prompts.push({

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -7,10 +7,16 @@
  * Two sources of prompts:
  *   - **Deterministic** — derived from missing OAuth connections.
  *   - **Assistant-generated** — contextual suggestions from the LLM
- *     (placeholder; not yet implemented).
+ *     based on what's relevant to the user.
  */
 
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
 import { isProviderConnected, listProviders } from "../oauth/oauth-store.js";
+import { resolvePersonaContext } from "../prompts/persona-resolver.js";
+import { buildSystemPrompt } from "../prompts/system-prompt.js";
+import { getProvider } from "../providers/registry.js";
+import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { getLogger } from "../util/logger.js";
 import type { SuggestedPrompt } from "./feed-types.js";
 
@@ -72,23 +78,30 @@ const CONNECT_PROMPT_META: Record<
   },
 };
 
+const LLM_SUGGESTIONS_TIMEOUT_MS = 5_000;
+
 /**
- * Produce deterministic suggested prompts based on missing OAuth
- * connections and (in the future) assistant-generated conversation
- * starters.
+ * Produce suggested prompts from both deterministic and LLM sources.
+ * Deterministic prompts always come first; LLM-generated prompts are
+ * appended when available.
  */
 export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
   const prompts: SuggestedPrompt[] = [];
 
+  let deterministicPrompts: SuggestedPrompt[] = [];
   try {
-    const deterministicPrompts = await getDeterministicPrompts();
+    deterministicPrompts = await getDeterministicPrompts();
     prompts.push(...deterministicPrompts);
   } catch (err) {
     log.warn({ err }, "Failed to compute deterministic suggested prompts");
   }
 
-  // Placeholder: assistant-generated prompts will be added here once
-  // the LLM producer is implemented.
+  try {
+    const llmPrompts = await getAssistantGeneratedPrompts(deterministicPrompts);
+    prompts.push(...llmPrompts);
+  } catch (err) {
+    log.warn({ err }, "Failed to generate assistant suggested prompts");
+  }
 
   return prompts;
 }
@@ -134,4 +147,93 @@ async function getDeterministicPrompts(): Promise<SuggestedPrompt[]> {
   }
 
   return prompts;
+}
+
+// ---------------------------------------------------------------------------
+// LLM-generated suggestions
+// ---------------------------------------------------------------------------
+
+interface LLMSuggestion {
+  label: string;
+  prompt: string;
+}
+
+/**
+ * Ask the LLM to generate contextual conversation-starter suggestions
+ * based on the assistant's persona and the user's connected services.
+ * Returns an empty array on failure so deterministic prompts still show.
+ */
+async function getAssistantGeneratedPrompts(
+  deterministicPrompts: SuggestedPrompt[],
+): Promise<SuggestedPrompt[]> {
+  const config = getConfig();
+  const resolved = resolveCallSiteConfig("homeSuggestedPrompts", config.llm);
+  const provider = getProvider(resolved.provider);
+  const { userPersona, userSlug, channelPersona } = resolvePersonaContext(
+    undefined,
+    undefined,
+  );
+
+  const systemPrompt = buildSystemPrompt({
+    excludeBootstrap: true,
+    excludeCustomPrefix: true,
+    userPersona,
+    channelPersona,
+    userSlug,
+  });
+
+  const existingLabels = deterministicPrompts.map((p) => p.label).join(", ");
+  const contextNote = existingLabels
+    ? `The user already has these suggestions: ${existingLabels}. Do NOT duplicate them.`
+    : "";
+
+  const result = await runBtwSidechain({
+    content:
+      "Suggest 2-3 short, actionable conversation starters for the home page. " +
+      "Each should be something specific and helpful you can do for the user right now. " +
+      `${contextNote} ` +
+      'Return ONLY a JSON array of objects with "label" (max 5 words) and "prompt" (the full message to send). ' +
+      "No markdown fences, no explanation.",
+    provider,
+    systemPrompt,
+    messages: [],
+    tools: [],
+    callSite: "homeSuggestedPrompts",
+    timeoutMs: LLM_SUGGESTIONS_TIMEOUT_MS,
+  });
+
+  const text = result.text.trim();
+  if (!text) {
+    return [];
+  }
+
+  const parsed = parseLLMSuggestions(text);
+  return parsed.map((s, i) => ({
+    id: `assistant-${i}-${s.label.toLowerCase().replace(/\s+/g, "-")}`,
+    label: s.label,
+    prompt: s.prompt,
+    source: "assistant" as const,
+  }));
+}
+
+function parseLLMSuggestions(text: string): LLMSuggestion[] {
+  try {
+    const cleaned = text
+      .replace(/^```(?:json)?\n?/m, "")
+      .replace(/\n?```$/m, "");
+    const parsed = JSON.parse(cleaned);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (item): item is LLMSuggestion =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof item.label === "string" &&
+        typeof item.prompt === "string",
+    );
+  } catch {
+    log.warn("Failed to parse LLM suggestions response");
+    return [];
+  }
 }

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -6,8 +6,11 @@
  *
  * Two sources of prompts:
  *   - **Deterministic** — derived from missing OAuth connections.
+ *     Computed inline (read-only, safe for GET).
  *   - **Assistant-generated** — contextual suggestions from the LLM
- *     based on what's relevant to the user.
+ *     based on what's relevant to the user. Read from an in-memory
+ *     cache in the GET path; generation runs in the background via
+ *     `refreshAssistantSuggestedPrompts`.
  */
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
@@ -15,7 +18,7 @@ import { getConfig } from "../config/loader.js";
 import { isProviderConnected, listProviders } from "../oauth/oauth-store.js";
 import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
-import { getProvider } from "../providers/registry.js";
+import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import { runBtwSidechain } from "../runtime/btw-sidechain.js";
 import { getLogger } from "../util/logger.js";
 import type { SuggestedPrompt } from "./feed-types.js";
@@ -79,11 +82,19 @@ const CONNECT_PROMPT_META: Record<
 };
 
 const LLM_SUGGESTIONS_TIMEOUT_MS = 5_000;
+const LLM_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+// ---------------------------------------------------------------------------
+// In-memory cache for LLM-generated suggestions
+// ---------------------------------------------------------------------------
+
+let cachedLLMPrompts: SuggestedPrompt[] = [];
+let cachedLLMPromptsAt = 0;
 
 /**
- * Produce suggested prompts from both deterministic and LLM sources.
- * Deterministic prompts always come first; LLM-generated prompts are
- * appended when available.
+ * Produce suggested prompts from both deterministic and cached LLM sources.
+ * Deterministic prompts always come first; cached LLM-generated prompts are
+ * appended when available. No LLM calls happen in this path — safe for GET.
  */
 export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
   const prompts: SuggestedPrompt[] = [];
@@ -96,14 +107,31 @@ export async function getSuggestedPrompts(): Promise<SuggestedPrompt[]> {
     log.warn({ err }, "Failed to compute deterministic suggested prompts");
   }
 
-  try {
-    const llmPrompts = await getAssistantGeneratedPrompts(deterministicPrompts);
-    prompts.push(...llmPrompts);
-  } catch (err) {
-    log.warn({ err }, "Failed to generate assistant suggested prompts");
+  if (Date.now() - cachedLLMPromptsAt < LLM_CACHE_TTL_MS) {
+    prompts.push(...cachedLLMPrompts);
   }
 
   return prompts;
+}
+
+/**
+ * Generate LLM-based suggestion prompts and write them to the in-memory
+ * cache. No-ops when the cache is still fresh. Intended for background
+ * invocation (daemon startup / periodic refresh), not the GET path.
+ */
+export async function refreshAssistantSuggestedPrompts(): Promise<void> {
+  if (Date.now() - cachedLLMPromptsAt < LLM_CACHE_TTL_MS) {
+    return;
+  }
+
+  try {
+    const deterministicPrompts = await getDeterministicPrompts();
+    const llmPrompts = await generateAssistantPrompts(deterministicPrompts);
+    cachedLLMPrompts = llmPrompts;
+    cachedLLMPromptsAt = Date.now();
+  } catch (err) {
+    log.warn({ err }, "Failed to refresh assistant suggested prompts");
+  }
 }
 
 /**
@@ -163,12 +191,17 @@ interface LLMSuggestion {
  * based on the assistant's persona and the user's connected services.
  * Returns an empty array on failure so deterministic prompts still show.
  */
-async function getAssistantGeneratedPrompts(
+async function generateAssistantPrompts(
   deterministicPrompts: SuggestedPrompt[],
 ): Promise<SuggestedPrompt[]> {
   const config = getConfig();
   const resolved = resolveCallSiteConfig("homeSuggestedPrompts", config.llm);
-  const provider = getProvider(resolved.provider);
+
+  const provider = await getConfiguredProvider("homeSuggestedPrompts");
+  if (!provider) {
+    return [];
+  }
+
   const { userPersona, userSlug, channelPersona } = resolvePersonaContext(
     undefined,
     undefined,
@@ -199,6 +232,7 @@ async function getAssistantGeneratedPrompts(
     messages: [],
     tools: [],
     callSite: "homeSuggestedPrompts",
+    maxTokens: resolved.maxTokens,
     timeoutMs: LLM_SUGGESTIONS_TIMEOUT_MS,
   });
 

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -20,6 +20,7 @@
  */
 
 import { emitPostConnectNudge } from "../home/post-connect-feed.js";
+import { invalidateAssistantSuggestedPromptsCache } from "../home/suggested-prompts.js";
 import type { TokenEndpointAuthMethod } from "../security/oauth2.js";
 import { prepareOAuth2Flow, startOAuth2Flow } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";
@@ -252,6 +253,7 @@ export async function orchestrateOAuthConnect(
               },
               "Deferred OAuth2 flow completed — tokens stored",
             );
+            invalidateAssistantSuggestedPromptsCache();
             void emitPostConnectNudge(options.service);
             options.onDeferredComplete?.({
               success: true,
@@ -375,6 +377,7 @@ export async function orchestrateOAuthConnect(
       "orchestrateOAuthConnect: tokens stored, connect complete",
     );
 
+    invalidateAssistantSuggestedPromptsCache();
     void emitPostConnectNudge(options.service);
 
     return {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -1100,5 +1100,17 @@ export async function disconnectOAuthProvider(
 
   deleteConnection(conn.id);
 
+  // Dynamic import: `suggested-prompts.ts` imports from this module, so a
+  // static import here would create a cycle. The cache invalidation is
+  // best-effort — failures must not block disconnect.
+  void import("../home/suggested-prompts.js")
+    .then((m) => m.invalidateAssistantSuggestedPromptsCache())
+    .catch((err) => {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to invalidate suggested-prompts cache after disconnect",
+      );
+    });
+
   return "disconnected";
 }

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -29,6 +29,7 @@ import {
   suggestedPromptSchema,
 } from "../../home/feed-types.js";
 import { patchFeedItemStatus, readHomeFeed } from "../../home/feed-writer.js";
+import { getPersonalizedGreeting } from "../../home/home-greeting.js";
 import { getSuggestedPrompts } from "../../home/suggested-prompts.js";
 import {
   addMessage,
@@ -123,13 +124,17 @@ export async function handleGetHomeFeed({
   const filtered = feed.items;
 
   const now = new Date();
+
+  const [personalizedGreeting, suggestedPrompts] = await Promise.all([
+    getPersonalizedGreeting().catch(() => null),
+    getSuggestedPrompts(),
+  ]);
+
   const contextBanner = {
-    greeting: computeGreeting(now),
+    greeting: personalizedGreeting ?? computeGreeting(now),
     timeAwayLabel: formatRelativeTime(timeAwaySeconds),
     newCount: filtered.filter((i) => i.status === "new").length,
   };
-
-  const suggestedPrompts = await getSuggestedPrompts();
 
   log.debug(
     {

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -125,10 +125,8 @@ export async function handleGetHomeFeed({
 
   const now = new Date();
 
-  const [personalizedGreeting, suggestedPrompts] = await Promise.all([
-    getPersonalizedGreeting().catch(() => null),
-    getSuggestedPrompts(),
-  ]);
+  const personalizedGreeting = getPersonalizedGreeting();
+  const suggestedPrompts = await getSuggestedPrompts();
 
   const contextBanner = {
     greeting: personalizedGreeting ?? computeGreeting(now),

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -10,7 +10,9 @@ import {
  * Check whether a provider has an active connection, handling both BYO
  * (local SQLite) and managed (platform) modes.
  */
-async function isOAuthProviderConnected(provider: string): Promise<boolean> {
+export async function isOAuthProviderConnected(
+  provider: string,
+): Promise<boolean> {
   const providerRow = getProvider(provider);
   const managedKey = providerRow?.managedServiceConfigKey;
 

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -162,31 +162,42 @@ struct HomeDetailPanel<Content: View>: View {
 
     /// Overflow menu behind a vertical ellipsis button, containing
     /// mark-read/unread and dismiss actions.
+    ///
+    /// The outlined chrome is painted on a `RoundedRectangle` sibling that
+    /// sits *outside* the `Menu`. SwiftUI's `.borderlessButton` menu style
+    /// flattens any shape modifiers nested inside the label, so the border
+    /// has to live on a wrapping view to survive.
     private var overflowMenu: some View {
-        Menu {
-            if let onMarkReadUnread {
-                Button(action: onMarkReadUnread) {
-                    Label(
-                        isRead ? "Mark as unread" : "Mark as read",
-                        systemImage: isRead ? "envelope.badge" : "envelope.open"
-                    )
+        RoundedRectangle(cornerRadius: VRadius.md)
+            .stroke(VColor.borderElement, lineWidth: 1)
+            .frame(width: 32, height: 32)
+            .overlay {
+                Menu {
+                    if let onMarkReadUnread {
+                        Button(action: onMarkReadUnread) {
+                            Label(
+                                isRead ? "Mark as unread" : "Mark as read",
+                                systemImage: isRead ? "envelope.badge" : "envelope.open"
+                            )
+                        }
+                    }
+                    if let onDismissItem {
+                        Button(action: onDismissItem) {
+                            Label("Dismiss", systemImage: "xmark.circle")
+                        }
+                    }
+                } label: {
+                    VIconView(.ellipsis, size: 16)
+                        .foregroundStyle(VColor.primaryBase)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
                 }
-            }
-            if let onDismissItem {
-                Button(action: onDismissItem) {
-                    Label("Dismiss", systemImage: "xmark.circle")
-                }
-            }
-        } label: {
-            VIconView(.ellipsis, size: 16)
-                .foregroundStyle(VColor.primaryBase)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
                 .frame(width: 32, height: 32)
-                .contentShape(Rectangle())
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .frame(width: 32)
-        .accessibilityLabel("More options")
+            }
+            .pointerCursor()
+            .accessibilityLabel("More options")
     }
 
     /// 32pt persona avatar rendered into the header's leading slot for

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift
@@ -5,13 +5,13 @@ import VellumAssistantShared
 ///
 /// Matches Figma nodes 3216:63021 (email editor) and 3216:63117 (invoice
 /// preview) — a 601pt solid-white chrome with its own 16pt-rounded card
-/// border, a header that hosts an optional icon chip + title + a single
-/// trailing "Go to Thread" action + optional dismiss, and a scrolling
+/// border, a header that hosts an optional icon chip + title + trailing
+/// actions ("Go to Convo" button, overflow menu, close), and a scrolling
 /// content area below a hairline divider.
 ///
 /// The chrome is intentionally solid (not glass) so the panel reads as a
 /// distinct work surface next to the floating glass recap cards on the
-/// Home page. The header "Go to Thread" button uses `VButton.Size.regular`
+/// Home page. The header "Go to Convo" button uses `VButton.Size.regular`
 /// (32pt tall, 8pt corners, 10pt horizontal padding) with the `.outlined`
 /// style — a deliberate break from the fully-pill buttons used inside the
 /// recap cards.
@@ -31,11 +31,22 @@ struct HomeDetailPanel<Content: View>: View {
     /// Optional background fill for the icon chip. Falls back to
     /// `VColor.surfaceBase` when `nil`.
     var iconBackground: Color? = nil
-    /// Tap handler for the trailing "Go to Thread" button in the header.
-    /// Pass `nil` to hide the button (e.g. previews that don't surface a
-    /// thread affordance).
-    var onGoToThread: (() -> Void)? = nil
-    var onDismiss: (() -> Void)? = nil
+    /// Tap handler for the trailing "Go to Convo" button in the header.
+    /// Pass `nil` to hide the button (e.g. when no conversation is
+    /// associated with the feed item).
+    var onGoToConvo: (() -> Void)? = nil
+    /// Toggles the item between read and unread. Shown in the overflow
+    /// menu; pass `nil` to hide the overflow menu entirely.
+    var onMarkReadUnread: (() -> Void)? = nil
+    /// Whether the item is currently in a "read" state (`seen` or
+    /// `actedOn`). Drives the overflow menu label: "Mark as unread"
+    /// when `true`, "Mark as read" when `false`.
+    var isRead: Bool = false
+    /// Dismisses the feed item. Shown in the overflow menu alongside
+    /// mark-read/unread; pass `nil` to omit it from the menu.
+    var onDismissItem: (() -> Void)? = nil
+    /// Closes the detail panel without modifying the feed item.
+    var onClose: (() -> Void)? = nil
     /// When `true` (default), the content area is wrapped in a vertical
     /// `ScrollView` so tall content like invoice images scrolls naturally.
     /// Pass `false` for bodies that want to fill the panel height and
@@ -83,8 +94,9 @@ struct HomeDetailPanel<Content: View>: View {
 
     // MARK: - Header
 
-    /// Header row: optional icon chip + title on the leading edge, and a
-    /// single "Go to Thread" action + optional dismiss on the trailing edge.
+    /// Header row: optional icon chip + title on the leading edge, and
+    /// trailing actions — "Go to Convo" button, an overflow menu (ellipsis)
+    /// with mark-read/unread and dismiss, and a close button.
     private var header: some View {
         HStack(spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
@@ -114,24 +126,29 @@ struct HomeDetailPanel<Content: View>: View {
             Spacer(minLength: 0)
 
             HStack(spacing: VSpacing.sm) {
-                if let onGoToThread {
+                if let onGoToConvo {
                     VButton(
-                        label: "Go to Thread",
+                        label: "Go to Convo",
                         style: .outlined,
                         size: .regular,
-                        action: onGoToThread
+                        action: onGoToConvo
                     )
                 }
 
-                if let onDismiss {
+                if onMarkReadUnread != nil || onDismissItem != nil {
+                    overflowMenu
+                }
+
+                if let onClose {
                     VButton(
-                        label: "Dismiss",
+                        label: "Close",
                         iconOnly: VIcon.x.rawValue,
                         style: .outlined,
                         size: .regular,
                         iconColor: VColor.primaryBase,
-                        action: onDismiss
+                        action: onClose
                     )
+                    .accessibilityLabel("Close detail panel")
                 }
             }
         }
@@ -141,6 +158,35 @@ struct HomeDetailPanel<Content: View>: View {
             bottom: VSpacing.md,
             trailing: VSpacing.lg
         ))
+    }
+
+    /// Overflow menu behind a vertical ellipsis button, containing
+    /// mark-read/unread and dismiss actions.
+    private var overflowMenu: some View {
+        Menu {
+            if let onMarkReadUnread {
+                Button(action: onMarkReadUnread) {
+                    Label(
+                        isRead ? "Mark as unread" : "Mark as read",
+                        systemImage: isRead ? "envelope.badge" : "envelope.open"
+                    )
+                }
+            }
+            if let onDismissItem {
+                Button(action: onDismissItem) {
+                    Label("Dismiss", systemImage: "xmark.circle")
+                }
+            }
+        } label: {
+            VIconView(.ellipsis, size: 16)
+                .foregroundStyle(VColor.primaryBase)
+                .frame(width: 32, height: 32)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 32)
+        .accessibilityLabel("More options")
     }
 
     /// 32pt persona avatar rendered into the header's leading slot for

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeMarkdownContent.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeMarkdownContent.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Renders a markdown string as styled `Text` in the Home detail panel.
+///
+/// Uses SwiftUI's native `AttributedString(markdown:)` for inline formatting
+/// (bold, italic, links, code). Falls back to plain text when the markdown
+/// parse fails so the UI never blanks on malformed input.
+struct HomeMarkdownContent: View {
+    let text: String
+
+    var body: some View {
+        Text(rendered)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentSecondary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    /// Parses the source text as markdown into an `AttributedString`,
+    /// falling back to a plain-text `AttributedString` on failure.
+    private var rendered: AttributedString {
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            return attributed
+        }
+        return AttributedString(text)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeMarkdownContent.swift
+++ b/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeMarkdownContent.swift
@@ -10,11 +10,13 @@ struct HomeMarkdownContent: View {
     let text: String
 
     var body: some View {
-        Text(rendered)
-            .font(VFont.bodyMediumDefault)
-            .foregroundStyle(VColor.contentSecondary)
-            .textSelection(.enabled)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+        HStack {
+            Text(rendered)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
     }
 
     /// Parses the source text as markdown into an `AttributedString`,

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -146,15 +146,17 @@ struct HomeGallerySection: View {
 
                 GallerySectionHeader(
                     title: "HomeDetailPanel",
-                    description: "Reusable white right-side panel container with a standardized header (icon + title + \"Go to Thread\" action + dismiss)."
+                    description: "Reusable white right-side panel container with a standardized header (icon + title + \"Go to Convo\" action + overflow menu + close)."
                 )
 
                 VStack(spacing: VSpacing.lg) {
                     HomeDetailPanel(
                         icon: .file,
                         title: "Panel title",
-                        onGoToThread: {},
-                        onDismiss: {}
+                        onGoToConvo: {},
+                        onMarkReadUnread: {},
+                        onDismissItem: {},
+                        onClose: {}
                     ) {
                         Text("Detail content goes here.")
                             .padding(VSpacing.lg)
@@ -164,8 +166,11 @@ struct HomeGallerySection: View {
                     HomeDetailPanel(
                         icon: .bell,
                         title: "Assistant-initiated",
-                        onGoToThread: {},
-                        onDismiss: {},
+                        onGoToConvo: {},
+                        onMarkReadUnread: {},
+                        isRead: true,
+                        onDismissItem: {},
+                        onClose: {},
                         showsPersonaAvatar: true
                     ) {
                         Text("Persona avatar replaces the category chip when the row originated from the assistant.")

--- a/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGallerySection.swift
@@ -255,6 +255,7 @@ struct HomeGallerySection: View {
                 VCard(background: VColor.surfaceBase) {
                     HomeGreetingHeader(
                         onStartNewChat: {},
+                        greeting: nil,
                         name: "Example Assistant"
                     ) {
                         if let image = NSImage(systemSymbolName: "person.circle.fill", accessibilityDescription: nil) {

--- a/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeGreetingHeader.swift
@@ -3,14 +3,17 @@ import VellumAssistantShared
 
 /// Greeting header for the Home feed.
 ///
-/// Displays a caller-provided avatar on the leading edge and an optional
-/// display name next to it, with a primary "New Chat" pill CTA on the
+/// Displays a caller-provided avatar on the leading edge, a greeting or
+/// display name next to it, and a primary "New Chat" pill CTA on the
 /// trailing edge.
 ///
+/// When a personalized `greeting` is available (daemon-generated in the
+/// assistant's tone/persona), it takes precedence over the plain `name`.
 /// The caller is responsible for sizing the avatar and for any outer padding
 /// around the header.
 struct HomeGreetingHeader<Avatar: View>: View {
     let onStartNewChat: () -> Void
+    let greeting: String?
     let name: String?
     @ViewBuilder let avatar: () -> Avatar
 
@@ -18,11 +21,11 @@ struct HomeGreetingHeader<Avatar: View>: View {
         HStack(alignment: .center, spacing: VSpacing.md) {
             avatar()
 
-            if let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !trimmed.isEmpty {
-                Text(trimmed)
+            if let headline = effectiveHeadline {
+                Text(headline)
                     .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentEmphasized)
+                    .lineLimit(2)
             }
 
             Spacer()
@@ -35,5 +38,19 @@ struct HomeGreetingHeader<Avatar: View>: View {
                 action: onStartNewChat
             )
         }
+    }
+
+    /// Personalized greeting takes precedence; falls back to the
+    /// assistant's display name.
+    private var effectiveHeadline: String? {
+        if let g = greeting?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !g.isEmpty {
+            return g
+        }
+        if let n = name?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !n.isEmpty {
+            return n
+        }
+        return nil
     }
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -67,6 +67,7 @@ struct HomePageView: View {
 
                 HomeGreetingHeader(
                     onStartNewChat: onStartNewChat,
+                    greeting: feedStore.contextBanner?.greeting,
                     name: store.state?.assistantName
                 ) {
                     greetingAvatar

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -260,7 +260,11 @@ extension MainWindowView {
     func homeDetailPanelContent() -> some View {
         switch activeHomeDetailPanel {
         case .toolPermission(let item):
-            HomeDetailPanel(icon: nil, title: item.title, onDismiss: { activeHomeDetailPanel = nil }) {
+            HomeDetailPanel(
+                icon: nil,
+                title: item.title,
+                onClose: { activeHomeDetailPanel = nil }
+            ) {
                 HomePermissionDetailCard(item: item)
             }
         case .generic(let item):
@@ -279,18 +283,39 @@ extension MainWindowView {
                 title: headerTitle,
                 iconForeground: iconForegroundForFeedItem(item),
                 iconBackground: iconBackgroundForFeedItem(item),
-                onGoToThread: goToThreadHandler(for: item),
-                onDismiss: { activeHomeDetailPanel = nil },
+                onGoToConvo: goToConvoHandler(for: item),
+                onMarkReadUnread: {
+                    Task {
+                        let nextStatus: FeedItemStatus = isItemRead(item) ? .new : .seen
+                        await feedStore.updateStatus(itemId: item.id, status: nextStatus)
+                    }
+                },
+                isRead: isItemRead(item),
+                onDismissItem: {
+                    Task {
+                        await feedStore.dismiss(itemId: item.id)
+                    }
+                    activeHomeDetailPanel = nil
+                },
+                onClose: { activeHomeDetailPanel = nil },
                 showsPersonaAvatar: item.fromAssistant == true
             ) {
-                Text(item.summary).font(VFont.bodyMediumDefault).foregroundStyle(VColor.contentSecondary).padding(VSpacing.lg)
+                HomeMarkdownContent(text: item.summary)
+                    .padding(VSpacing.lg)
             }
         case nil:
             EmptyView()
         }
     }
 
-    /// Builds the "Go to Thread" handler for the home detail panel.
+    /// Whether the feed item is in a "read" state (`seen` or `actedOn`).
+    private func isItemRead(_ item: FeedItem) -> Bool {
+        let current = feedStore.items.first(where: { $0.id == item.id })
+        let status = current?.status ?? item.status
+        return status == .seen || status == .actedOn
+    }
+
+    /// Builds the "Go to Convo" handler for the home detail panel.
     ///
     /// `FeedItem.conversationId` carries the **daemon-side** conversation
     /// ID (mirrored from `notification_intent.deepLinkMetadata.conversationId`
@@ -305,14 +330,14 @@ extension MainWindowView {
     ///
     /// Returns `nil` when the feed item has no associated conversation —
     /// `HomeDetailPanel` hides the button when the handler is `nil`.
-    private func goToThreadHandler(for item: FeedItem) -> (() -> Void)? {
+    private func goToConvoHandler(for item: FeedItem) -> (() -> Void)? {
         guard let daemonConversationId = item.conversationId else { return nil }
         return {
             Task { @MainActor in
                 let found = await conversationManager.selectConversationByConversationIdAsync(daemonConversationId)
                 let activeLocalId = conversationManager.activeConversationId
                 panelCoordinatorLog.info(
-                    "Go to Thread: daemonConversationId=\(daemonConversationId, privacy: .public) feedItemId=\(item.id, privacy: .public) found=\(found, privacy: .public) activeLocalId=\(activeLocalId?.uuidString ?? "<nil>", privacy: .public)"
+                    "Go to Convo: daemonConversationId=\(daemonConversationId, privacy: .public) feedItemId=\(item.id, privacy: .public) found=\(found, privacy: .public) activeLocalId=\(activeLocalId?.uuidString ?? "<nil>", privacy: .public)"
                 )
                 guard found, let id = activeLocalId else {
                     windowState.showToast(message: "Couldn't open the conversation.", style: .error)


### PR DESCRIPTION
Adds LLM-generated personalized greeting and suggestion prompts to the home feed, and ports the homepage UI improvements (dynamic greeting, overflow menu, markdown panel, "Go to Convo" text) to the macOS SwiftUI client to match the web implementation.

**Daemon changes:**
- `homeGreeting` call site: generates a persona-aware greeting via BTW sidechain with 4h TTL cache and content-hash invalidation
- `homeSuggestedPrompts` call site: produces deterministic + LLM-generated suggestion prompts with 30min in-memory cache, deduplicating against deterministic prompts
- Background refresh timer (`startHomeContentRefresh`) pre-warms both caches at startup and every 30 minutes — GET handler reads cached values only (no LLM calls, no side effects)
- Uses `getConfiguredProvider()` for connection-aware credential resolution and passes `maxTokens` from call-site config

**macOS changes:**
- `HomeGreetingHeader`: displays `contextBanner.greeting` (daemon-generated in assistant's tone/persona) with fallback to assistant name
- `HomeDetailPanel`: "Go to Thread" → "Go to Convo", standalone dismiss button replaced with overflow menu (ellipsis) containing "Mark as read/unread" and "Dismiss" actions, separate close button
- `HomeMarkdownContent`: renders feed item summary as styled markdown using native `AttributedString(markdown:)` with plain-text fallback
- `PanelCoordinator`: wires mark-read/unread and dismiss through `feedStore.updateStatus`/`feedStore.dismiss`

**Backwards compatibility:** Wire format is additive — `contextBanner.greeting` and `suggestedPrompts` are new optional fields that older clients ignore. macOS changes are client-only UI with no wire-format impact.

Note: CI does not have a macOS build environment, so Swift changes need local Xcode verification.

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/4fe82b5ad3184121b3bd855b83f613b9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->