### PR TITLE
silence pkb-reminder injector under memory v2

### DIFF
--- a/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
+++ b/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
@@ -3,8 +3,8 @@
  *
  * When `getConfig().memory.v2.enabled` is true:
  *   - `pkb-context` silences itself (concept pages own retrieval).
- *   - `pkb-reminder` still fires (its body is generic recall/remember
- *     guidance) but skips the PKB-search hints — those name PKB paths.
+ *   - `pkb-reminder` silences itself (the v2 static `<memory>` block
+ *     supplants the generic recall/remember nudge).
  *   - `now-md` fires unchanged (workspace state, independent of PKB).
  *
  * Mocks `getConfig` at the module level so each test can flip the effective
@@ -85,7 +85,7 @@ describe("PKB injector v2 cutover behavior", () => {
     expect(texts.some((t) => t.includes("<NOW.md"))).toBe(true);
   });
 
-  test("v2 active → pkb-context silenced; pkb-reminder + now-md still fire", async () => {
+  test("v2 active → pkb-context and pkb-reminder silenced; now-md still fires", async () => {
     v2Active = true;
     const result = await applyRuntimeInjections(RUN_MESSAGES, {
       turnContext: makeTurnContext(),
@@ -99,29 +99,8 @@ describe("PKB injector v2 cutover behavior", () => {
 
     const texts = tailTexts(result.messages);
     expect(texts.some((t) => t.includes("<knowledge_base>"))).toBe(false);
-    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(true);
+    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(false);
     expect(texts.some((t) => t.includes("<NOW.md"))).toBe(true);
     expect(texts).toContain("What next?");
-  });
-
-  test("v2 active → pkb-reminder body fires without the hybrid-search hints", async () => {
-    v2Active = true;
-    const result = await applyRuntimeInjections(RUN_MESSAGES, {
-      turnContext: makeTurnContext(),
-      pkbActive: true,
-      pkbScopeId: "scope-default",
-      pkbRoot: "/tmp/pkb",
-      pkbConversation: { messages: [] },
-      // Provide a query vector so the v1 path WOULD have called searchPkbFiles
-      // and rendered hints. Under v2, the call is skipped and the reminder
-      // is rendered with empty hints — i.e. no "files look especially
-      // relevant" line.
-      pkbQueryVector: [0.1, 0.2, 0.3],
-    });
-
-    const texts = tailTexts(result.messages);
-    const reminder = texts.find((t) => t.includes("<system_reminder>"));
-    expect(reminder).toBeDefined();
-    expect(reminder).not.toContain("files look especially relevant");
   });
 });

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -133,12 +133,11 @@ const diskPressureWarningInjector: Injector = {
 };
 
 /**
- * v2 read-side cutover guard. The `pkb-context` injector silences itself
- * under v2 because the `<knowledge_base>` block surfaces PKB content the v2
- * activation block already covers. The `pkb-reminder` injector still fires
- * (its body is generic recall/remember guidance) but skips the hybrid-search
- * hints — those name PKB paths v2 is moving away from. NOW.md is workspace
- * state independent of PKB and fires unchanged.
+ * v2 read-side cutover guard. Under v2 both `pkb-context` and `pkb-reminder`
+ * silence themselves entirely — the `<knowledge_base>` content and the
+ * generic recall/remember nudge are both supplanted by the v2 static
+ * `<memory>` block. NOW.md is workspace state independent of PKB and fires
+ * unchanged.
  */
 function isPkbInjectionSilencedByV2(): boolean {
   return getConfig().memory.v2.enabled;
@@ -287,9 +286,8 @@ const pkbReminderInjector: Injector = {
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
     if (!inputs.pkbActive) return null;
-    const reminder = isPkbInjectionSilencedByV2()
-      ? buildPkbReminder([])
-      : await buildPkbReminderWithHints(inputs);
+    if (isPkbInjectionSilencedByV2()) return null;
+    const reminder = await buildPkbReminderWithHints(inputs);
     return {
       id: "pkb-reminder",
       text: reminder,


### PR DESCRIPTION
## Summary
- \`pkbReminderInjector\` now returns null when \`isPkbInjectionSilencedByV2()\` is true, suppressing the \`<system_reminder>\` block entirely on v2 installs (matching how \`pkbContextInjector\` already behaves). v1 installs are unchanged.
- Drops the now-redundant \`buildPkbReminder([])\` fallback that rendered an empty-hints reminder under v2.
- \`injector-pkb-v2-silenced.test.ts\` collapsed: under v2-active, neither \`<knowledge_base>\` nor \`<system_reminder>\` fires; NOW.md still does.

## Original prompt
Sidd asked to remove the \`<system_reminder>\` user-message injection. After exploring the injection pipeline, we shifted scope: rather than rip out the injector, builder, hint search, persistence, and rehydrate paths, we gate the existing injector on the v2 memory router. v2 installs no longer see the block (the v2 static \`<memory>\` block already supplants the generic recall/remember nudge), while v1 installs are untouched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->