### PR TITLE
feat(web): port workspace page from platform

### DIFF
--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -93,6 +93,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
           <WorkspaceFileViewer
             assistantId={assistantId}
             selectedPath={selectedPath}
+            showHidden={showHidden}
             viewMode={viewMode}
             onChangeViewMode={setViewMode}
             onBrowse={() => setDrawerOpen(true)}

--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -1,0 +1,104 @@
+/**
+ * Top-level workspace browser layout. Renders a file tree sidebar (hidden on
+ * mobile behind a drawer) and a file viewer pane side-by-side.
+ */
+
+import { useCallback, useState } from "react";
+
+import {
+  MobileSidebarDrawer,
+  MobileSidebarTrigger,
+} from "@/components/mobile-sidebar-drawer.js";
+import { WorkspaceFileViewer } from "@/domains/workspace/components/workspace-file-viewer.js";
+import { WorkspaceTree } from "@/domains/workspace/components/workspace-tree.js";
+
+export type WorkspaceViewMode = "preview" | "source";
+
+export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
+  const [viewMode, setViewMode] = useState<WorkspaceViewMode>("preview");
+
+  const handleToggleExpand = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleExpandPath = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  }, []);
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const handleSelectPath = useCallback((path: string) => {
+    setSelectedPath(path);
+    setDrawerOpen(false);
+  }, []);
+
+  const treeProps = {
+    assistantId,
+    expandedPaths,
+    selectedPath,
+    showHidden,
+    onToggleExpand: handleToggleExpand,
+    onExpandPath: handleExpandPath,
+    onSelectPath: handleSelectPath,
+    onToggleShowHidden: () => setShowHidden((v) => !v),
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="flex items-center sm:hidden">
+        <MobileSidebarTrigger onClick={() => setDrawerOpen(true)} />
+      </div>
+
+      <MobileSidebarDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        title="Files"
+      >
+        <WorkspaceTree {...treeProps} />
+      </MobileSidebarDrawer>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-[320px_1fr]">
+        <div
+          className="hidden min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border sm:flex"
+          style={{
+            backgroundColor: "var(--surface-overlay)",
+            borderColor: "var(--border-base)",
+          }}
+        >
+          <WorkspaceTree {...treeProps} />
+        </div>
+        <div
+          className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border"
+          style={{
+            backgroundColor: "var(--surface-overlay)",
+            borderColor: "var(--border-base)",
+          }}
+        >
+          <WorkspaceFileViewer
+            assistantId={assistantId}
+            selectedPath={selectedPath}
+            viewMode={viewMode}
+            onChangeViewMode={setViewMode}
+            onBrowse={() => setDrawerOpen(true)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -1,0 +1,764 @@
+/**
+ * Viewer for individual workspace files. Supports markdown (preview/source
+ * toggle), JSON (pretty-printed preview), plain text, images, video, and a
+ * binary-fallback metadata card. Text-based files can be edited in-place with
+ * Ctrl+S / Cmd+S to save.
+ */
+
+import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  Copy,
+  FileIcon,
+  FileText,
+  FolderOpen,
+  Image as ImageIcon,
+  Loader2,
+  Pencil,
+  Video,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@vellum/design-library/components/button";
+import { client } from "@/generated/api/client.gen.js";
+import { FileMarkdown, isMarkdown } from "@/domains/intelligence/components/file-markdown.js";
+import { isJson, prettifyJson } from "@/domains/workspace/utils/file-json.js";
+
+import type { WorkspaceViewMode } from "@/domains/workspace/components/workspace-browser.js";
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+interface WorkspaceFileResponse {
+  name?: string;
+  path?: string;
+  size?: number;
+  mimeType?: string;
+  modifiedAt?: string;
+  content?: string;
+}
+
+function workspaceFileRetrieveOptions(opts: {
+  path: { assistant_id: string };
+  query: { path: string };
+}) {
+  return queryOptions<WorkspaceFileResponse>({
+    queryFn: async () => {
+      const { data, error } = await client.get<WorkspaceFileResponse, unknown>({
+        url: "/v1/assistants/{assistant_id}/workspace/file/",
+        path: opts.path,
+        query: opts.query,
+      });
+      if (error) throw error;
+      return data!;
+    },
+    queryKey: ["assistantsWorkspaceFileRetrieve", opts],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatFileSize(bytes: number | undefined): string {
+  if (bytes == null) return "Unknown size";
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function FileHeaderIcon({ mimeType }: { mimeType: string }) {
+  const semi = mimeType.indexOf(";");
+  const baseMime = (semi === -1 ? mimeType : mimeType.slice(0, semi)).trim();
+  let Icon = FileText;
+  if (baseMime.startsWith("image/")) Icon = ImageIcon;
+  else if (baseMime.startsWith("video/")) Icon = Video;
+  else if (
+    !baseMime.startsWith("text/") &&
+    baseMime !== "application/json" &&
+    baseMime !== "application/octet-stream"
+  ) {
+    Icon = FileIcon;
+  }
+  return (
+    <span
+      className="flex h-5 w-5 shrink-0 items-center justify-center rounded"
+      style={{
+        backgroundColor: "color-mix(in oklab, var(--content-default) 10%, transparent)",
+      }}
+    >
+      <Icon
+        className="h-3.5 w-3.5"
+        style={{ color: "var(--content-default)" }}
+      />
+    </span>
+  );
+}
+
+function ViewModeToggle({
+  viewMode,
+  onChange,
+}: {
+  viewMode: WorkspaceViewMode;
+  onChange: (mode: WorkspaceViewMode) => void;
+}) {
+  return (
+    <div
+      className="inline-flex rounded-md p-0.5"
+      style={{
+        backgroundColor: "color-mix(in oklab, var(--content-default) 6%, transparent)",
+      }}
+    >
+      {(["preview", "source"] as const).map((mode) => {
+        const active = viewMode === mode;
+        return (
+          <Button
+            key={mode}
+            variant="ghost"
+            onClick={() => onChange(mode)}
+            className="h-auto rounded border-0 px-2.5 py-1 text-body-small-default hover:bg-transparent"
+            style={{
+              backgroundColor: active
+                ? "var(--surface-lift)"
+                : "transparent",
+              color: active
+                ? "var(--content-default)"
+                : "var(--content-tertiary)",
+              boxShadow: active
+                ? "0 1px 2px rgba(0,0,0,0.15)"
+                : undefined,
+            }}
+          >
+            {mode === "preview" ? "Preview" : "Source"}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+function FileHeader({
+  name,
+  mimeType,
+  size,
+  rightContent,
+}: {
+  name: string;
+  mimeType: string;
+  size?: number;
+  rightContent?: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-b px-3 py-2.5"
+      style={{ borderColor: "var(--border-element)" }}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <FileHeaderIcon mimeType={mimeType} />
+        <span
+          className="truncate text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {name}
+        </span>
+        {size != null && (
+          <span
+            className="shrink-0 text-body-small-default"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {formatFileSize(size)}
+          </span>
+        )}
+      </div>
+      {rightContent}
+    </div>
+  );
+}
+
+function BinaryContentViewer({
+  assistantId,
+  path,
+  mimeType,
+}: {
+  assistantId: string;
+  path: string;
+  mimeType: string;
+}) {
+  const { data: blob, isLoading } = useQuery({
+    queryFn: async () => {
+      const res = await client.get<Blob, unknown>({
+        url: "/v1/assistants/{assistant_id}/workspace/file/content/",
+        path: { assistant_id: assistantId },
+        query: { path },
+        parseAs: "blob",
+      });
+      if (res.error) throw res.error;
+      return res.data!;
+    },
+    queryKey: ["assistantsWorkspaceFileContentRetrieve", { assistantId, path }],
+    enabled: !!path,
+  });
+
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    setObjectUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+      setObjectUrl(null);
+    };
+  }, [blob]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2
+          className="h-6 w-6 animate-spin"
+          style={{ color: "var(--content-tertiary)" }}
+        />
+      </div>
+    );
+  }
+
+  if (!objectUrl) return null;
+
+  if (mimeType.startsWith("image/")) {
+    return (
+      <div className="flex items-center justify-center p-4">
+        <img
+          src={objectUrl}
+          alt={path.split("/").pop() ?? "image"}
+          className="max-h-[70vh] max-w-full rounded object-contain"
+        />
+      </div>
+    );
+  }
+
+  if (mimeType.startsWith("video/")) {
+    return (
+      <div className="flex items-center justify-center p-4">
+        <video
+          src={objectUrl}
+          controls
+          className="max-h-[70vh] max-w-full rounded"
+        />
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function isHiddenPath(path: string): boolean {
+  return path.split("/").some((segment) => segment.startsWith("."));
+}
+
+function EditFooter({
+  isDirty,
+  isSaving,
+  onSave,
+  onDiscard,
+}: {
+  isDirty: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center justify-end gap-2 border-t px-3 py-2"
+      style={{ borderColor: "var(--border-element)" }}
+    >
+      <Button
+        variant="ghost"
+        size="compact"
+        disabled={isSaving}
+        onClick={onDiscard}
+      >
+        Discard
+      </Button>
+      {isSaving && (
+        <Loader2
+          className="h-4 w-4 animate-spin"
+          style={{ color: "var(--content-tertiary)" }}
+        />
+      )}
+      <Button
+        variant="primary"
+        size="compact"
+        disabled={!isDirty || isSaving}
+        onClick={onSave}
+      >
+        Save
+      </Button>
+    </div>
+  );
+}
+
+function ContentActionBar({
+  content,
+  showEdit,
+  isEditing,
+  onToggleEdit,
+}: {
+  content: string;
+  showEdit: boolean;
+  isEditing: boolean;
+  onToggleEdit: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(content).then(() => {
+      setCopied(true);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    });
+  }, [content]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  if (isEditing) {
+    return null;
+  }
+
+  return (
+    <div className="absolute right-3 top-3 z-10 flex items-center gap-1 rounded-md bg-[var(--surface-primary)] shadow-sm">
+      {showEdit && (
+        <Button
+          variant="ghost"
+          size="regular"
+          iconOnly={<Pencil aria-hidden />}
+          onClick={onToggleEdit}
+          aria-label="Edit file"
+          className="hover:bg-[var(--surface-base)]"
+        />
+      )}
+      <Button
+        variant="ghost"
+        size="regular"
+        iconOnly={copied ? <Check aria-hidden /> : <Copy aria-hidden />}
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy file contents"}
+        className="hover:bg-[var(--surface-base)]"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Textarea editor — shared across markdown source, JSON source, and plain text
+// ---------------------------------------------------------------------------
+
+const MONO_FONT =
+  "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace";
+
+function FileTextarea({
+  value,
+  onChange,
+  onSave,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+}) {
+  return (
+    <textarea
+      className="m-0 h-full w-full resize-none overflow-auto border-none bg-transparent p-4 text-body-medium-lighter leading-relaxed outline-none"
+      style={{ color: "var(--content-default)", fontFamily: MONO_FONT }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+          e.preventDefault();
+          onSave();
+        }
+      }}
+      spellCheck={false}
+    />
+  );
+}
+
+function SourcePre({
+  content,
+  readOnly,
+  whiteSpace = "pre-wrap",
+  onStartEdit,
+}: {
+  content: string;
+  readOnly: boolean;
+  whiteSpace?: "pre" | "pre-wrap";
+  onStartEdit?: () => void;
+}) {
+  return (
+    <pre
+      className={`m-0 h-full overflow-auto p-4 text-body-medium-lighter leading-relaxed${!readOnly ? " cursor-text" : ""}`}
+      style={{ color: "var(--content-default)", fontFamily: MONO_FONT, whiteSpace }}
+      onClick={!readOnly ? onStartEdit : undefined}
+    >
+      {content}
+    </pre>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function WorkspaceFileViewer({
+  assistantId,
+  selectedPath,
+  viewMode,
+  onChangeViewMode,
+  onBrowse,
+}: {
+  assistantId: string;
+  selectedPath: string | null;
+  viewMode: WorkspaceViewMode;
+  onChangeViewMode: (mode: WorkspaceViewMode) => void;
+  onBrowse?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    ...workspaceFileRetrieveOptions({
+      path: { assistant_id: assistantId },
+      query: { path: selectedPath ?? "" },
+    }),
+    enabled: !!selectedPath,
+  });
+
+  const [editingPath, setEditingPath] = useState<string | null>(null);
+  const [editOverride, setEditOverride] = useState<{
+    path: string;
+    content: string;
+  } | null>(null);
+
+  const isEditing = editingPath != null && editingPath === selectedPath;
+  const originalContent = data?.content ?? "";
+  const editableContent =
+    editOverride?.path === selectedPath
+      ? editOverride.content
+      : originalContent;
+
+  const stopEditing = () => {
+    setEditingPath(null);
+    setEditOverride(null);
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: async ({ path, content }: { path: string; content: string }) => {
+      const { error, response } = await client.post<unknown, unknown>({
+        url: "/v1/assistants/{assistant_id}/workspace/write/",
+        path: { assistant_id: assistantId },
+        body: { path, content, encoding: "utf8" },
+        headers: { "Content-Type": "application/json" },
+        throwOnError: false,
+      });
+      if (!response?.ok || error) {
+        throw new Error("Failed to save file");
+      }
+    },
+    onSuccess: (_data, variables) => {
+      setEditingPath((current) =>
+        current === variables.path ? null : current,
+      );
+      setEditOverride((current) =>
+        current?.path === variables.path ? null : current,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ["assistantsWorkspaceFileRetrieve"],
+      });
+    },
+  });
+
+  const isDirty = editableContent !== originalContent;
+
+  const handleSave = useCallback(() => {
+    if (selectedPath && isDirty && !saveMutation.isPending) {
+      saveMutation.mutate({ path: selectedPath, content: editableContent });
+    }
+  }, [selectedPath, isDirty, saveMutation, editableContent]);
+
+  // --- Empty / loading / error states ---
+
+  if (!selectedPath) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3">
+        <p
+          className="text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          Select a file to view
+        </p>
+        {onBrowse && (
+          <Button
+            type="button"
+            onClick={onBrowse}
+            leftIcon={<FolderOpen aria-hidden />}
+            className="sm:hidden"
+          >
+            Browse files
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2
+          className="h-6 w-6 animate-spin"
+          style={{ color: "var(--content-tertiary)" }}
+        />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p
+          className="text-body-medium-lighter"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          File not found
+        </p>
+      </div>
+    );
+  }
+
+  // --- Render file content ---
+
+  const mimeType = data.mimeType ?? "application/octet-stream";
+  const name = data.name ?? selectedPath.split("/").pop() ?? selectedPath;
+  const markdown = isMarkdown(name, mimeType);
+  const json = isJson(name, mimeType);
+  const isText = mimeType.startsWith("text/") && data.content != null;
+  const readOnly = selectedPath ? isHiddenPath(selectedPath) : true;
+
+  const editFooter = isEditing && (
+    <EditFooter
+      isDirty={isDirty}
+      isSaving={saveMutation.isPending}
+      onSave={handleSave}
+      onDiscard={stopEditing}
+    />
+  );
+
+  // Markdown: Preview/Source toggle
+  if (markdown && data.content != null) {
+    const sourceContent = isEditing ? editableContent : data.content;
+    return (
+      <div className="flex h-full flex-col">
+        <FileHeader
+          name={name}
+          mimeType={mimeType}
+          rightContent={
+            <ViewModeToggle
+              viewMode={viewMode}
+              onChange={(mode) => {
+                if (isEditing) stopEditing();
+                onChangeViewMode(mode);
+              }}
+            />
+          }
+        />
+        <div className="relative flex-1 overflow-hidden">
+          <ContentActionBar
+            content={sourceContent}
+            showEdit={!readOnly && viewMode === "source"}
+            isEditing={isEditing}
+            onToggleEdit={() =>
+              isEditing ? stopEditing() : setEditingPath(selectedPath)
+            }
+          />
+          {viewMode === "preview" ? (
+            <div
+              className="h-full overflow-auto px-6 py-4"
+              style={{ color: "var(--content-default)" }}
+            >
+              <FileMarkdown content={sourceContent} />
+            </div>
+          ) : isEditing ? (
+            <FileTextarea
+              value={editableContent}
+              onChange={(v) => setEditOverride({ path: selectedPath, content: v })}
+              onSave={handleSave}
+            />
+          ) : (
+            <SourcePre
+              content={data.content}
+              readOnly={readOnly}
+              onStartEdit={() => setEditingPath(selectedPath)}
+            />
+          )}
+        </div>
+        {editFooter}
+      </div>
+    );
+  }
+
+  // JSON: Preview (pretty-printed) / Source (raw) toggle
+  if (json && data.content != null) {
+    const sourceContent = isEditing ? editableContent : data.content;
+    const previewContent = prettifyJson(sourceContent);
+    return (
+      <div className="flex h-full flex-col">
+        <FileHeader
+          name={name}
+          mimeType={mimeType}
+          rightContent={
+            <ViewModeToggle
+              viewMode={viewMode}
+              onChange={(mode) => {
+                if (isEditing) stopEditing();
+                onChangeViewMode(mode);
+              }}
+            />
+          }
+        />
+        <div className="relative flex-1 overflow-hidden">
+          <ContentActionBar
+            content={viewMode === "preview" ? previewContent : sourceContent}
+            showEdit={!readOnly && viewMode === "source"}
+            isEditing={isEditing}
+            onToggleEdit={() =>
+              isEditing ? stopEditing() : setEditingPath(selectedPath)
+            }
+          />
+          {viewMode === "preview" ? (
+            <SourcePre content={previewContent} readOnly whiteSpace="pre" />
+          ) : isEditing ? (
+            <FileTextarea
+              value={editableContent}
+              onChange={(v) => setEditOverride({ path: selectedPath, content: v })}
+              onSave={handleSave}
+            />
+          ) : (
+            <SourcePre
+              content={data.content}
+              readOnly={readOnly}
+              onStartEdit={() => setEditingPath(selectedPath)}
+            />
+          )}
+        </div>
+        {editFooter}
+      </div>
+    );
+  }
+
+  // Plain text — source only, consistent header
+  if (isText) {
+    return (
+      <div className="flex h-full flex-col">
+        <FileHeader name={name} mimeType={mimeType} size={data.size} />
+        <div className="relative flex-1 overflow-hidden">
+          <ContentActionBar
+            content={isEditing ? editableContent : (data.content ?? "")}
+            showEdit={!readOnly}
+            isEditing={isEditing}
+            onToggleEdit={() =>
+              isEditing ? stopEditing() : setEditingPath(selectedPath)
+            }
+          />
+          {isEditing ? (
+            <FileTextarea
+              value={editableContent}
+              onChange={(v) => setEditOverride({ path: selectedPath, content: v })}
+              onSave={handleSave}
+            />
+          ) : (
+            <SourcePre
+              content={data.content ?? ""}
+              readOnly={readOnly}
+              onStartEdit={() => setEditingPath(selectedPath)}
+            />
+          )}
+        </div>
+        {editFooter}
+      </div>
+    );
+  }
+
+  // Image / video
+  if (mimeType.startsWith("image/") || mimeType.startsWith("video/")) {
+    return (
+      <div className="flex h-full flex-col">
+        <FileHeader name={name} mimeType={mimeType} size={data.size} />
+        <div className="flex-1 overflow-auto">
+          <BinaryContentViewer
+            assistantId={assistantId}
+            path={selectedPath}
+            mimeType={mimeType}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Binary fallback — metadata card
+  return (
+    <div className="flex h-full flex-col">
+      <FileHeader name={name} mimeType={mimeType} size={data.size} />
+      <div className="flex flex-1 items-center justify-center p-8">
+        <div
+          className="w-full max-w-sm rounded-lg border p-6 text-center"
+          style={{
+            borderColor: "var(--border-base)",
+            backgroundColor: "var(--surface-lift)",
+          }}
+        >
+          <FileIcon
+            className="mx-auto h-10 w-10"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+          <p
+            className="mt-3 text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {name}
+          </p>
+          <div className="mt-2 space-y-1">
+            <p
+              className="text-body-small-default"
+              style={{ color: "var(--content-secondary, var(--content-tertiary))" }}
+            >
+              {mimeType}
+            </p>
+            <p
+              className="text-body-small-default"
+              style={{ color: "var(--content-secondary, var(--content-tertiary))" }}
+            >
+              {formatFileSize(data.size)}
+            </p>
+            {data.modifiedAt && (
+              <p
+                className="text-body-small-default"
+                style={{ color: "var(--content-secondary, var(--content-tertiary))" }}
+              >
+                Modified: {new Date(data.modifiedAt).toLocaleString()}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -23,6 +23,7 @@ import { Button } from "@vellum/design-library/components/button";
 import { client } from "@/generated/api/client.gen.js";
 import { FileMarkdown, isMarkdown } from "@/domains/intelligence/components/file-markdown.js";
 import { isJson, prettifyJson } from "@/domains/workspace/utils/file-json.js";
+import { formatFileSize } from "@/domains/workspace/utils/format-file-size.js";
 
 import type { WorkspaceViewMode } from "@/domains/workspace/components/workspace-browser.js";
 
@@ -41,31 +42,22 @@ interface WorkspaceFileResponse {
 
 function workspaceFileRetrieveOptions(opts: {
   path: { assistant_id: string };
-  query: { path: string };
+  query: { path: string; showHidden?: boolean };
 }) {
   return queryOptions<WorkspaceFileResponse>({
     queryFn: async () => {
+      const query: Record<string, string> = { path: opts.query.path };
+      if (opts.query.showHidden) query.showHidden = "true";
       const { data, error } = await client.get<WorkspaceFileResponse, unknown>({
         url: "/v1/assistants/{assistant_id}/workspace/file/",
         path: opts.path,
-        query: opts.query,
+        query,
       });
       if (error) throw error;
       return data!;
     },
     queryKey: ["assistantsWorkspaceFileRetrieve", opts],
   });
-}
-
-// ---------------------------------------------------------------------------
-// Formatting
-// ---------------------------------------------------------------------------
-
-function formatFileSize(bytes: number | undefined): string {
-  if (bytes == null) return "Unknown size";
-  if (bytes < 1024) return `${bytes} bytes`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,23 +176,27 @@ function BinaryContentViewer({
   assistantId,
   path,
   mimeType,
+  showHidden,
 }: {
   assistantId: string;
   path: string;
   mimeType: string;
+  showHidden?: boolean;
 }) {
   const { data: blob, isLoading } = useQuery({
     queryFn: async () => {
+      const query: Record<string, string> = { path };
+      if (showHidden) query.showHidden = "true";
       const res = await client.get<Blob, unknown>({
         url: "/v1/assistants/{assistant_id}/workspace/file/content/",
         path: { assistant_id: assistantId },
-        query: { path },
+        query,
         parseAs: "blob",
       });
       if (res.error) throw res.error;
       return res.data!;
     },
-    queryKey: ["assistantsWorkspaceFileContentRetrieve", { assistantId, path }],
+    queryKey: ["assistantsWorkspaceFileContentRetrieve", { assistantId, path, showHidden }],
     enabled: !!path,
   });
 
@@ -424,12 +420,14 @@ function SourcePre({
 export function WorkspaceFileViewer({
   assistantId,
   selectedPath,
+  showHidden,
   viewMode,
   onChangeViewMode,
   onBrowse,
 }: {
   assistantId: string;
   selectedPath: string | null;
+  showHidden?: boolean;
   viewMode: WorkspaceViewMode;
   onChangeViewMode: (mode: WorkspaceViewMode) => void;
   onBrowse?: () => void;
@@ -438,7 +436,7 @@ export function WorkspaceFileViewer({
   const { data, isLoading } = useQuery({
     ...workspaceFileRetrieveOptions({
       path: { assistant_id: assistantId },
-      query: { path: selectedPath ?? "" },
+      query: { path: selectedPath ?? "", showHidden },
     }),
     enabled: !!selectedPath,
   });
@@ -550,7 +548,11 @@ export function WorkspaceFileViewer({
   const name = data.name ?? selectedPath.split("/").pop() ?? selectedPath;
   const markdown = isMarkdown(name, mimeType);
   const json = isJson(name, mimeType);
-  const isText = mimeType.startsWith("text/") && data.content != null;
+  // The backend returns inline `content` for all text-renderable files,
+  // including non-text/* MIME types like application/yaml, application/toml,
+  // application/x-sh. Markdown and JSON are checked first in the rendering
+  // cascade, so this catch-all is safe.
+  const isText = data.content != null && !markdown && !json;
   const readOnly = selectedPath ? isHiddenPath(selectedPath) : true;
 
   const editFooter = isEditing && (
@@ -707,6 +709,7 @@ export function WorkspaceFileViewer({
             assistantId={assistantId}
             path={selectedPath}
             mimeType={mimeType}
+            showHidden={showHidden}
           />
         </div>
       </div>
@@ -746,7 +749,7 @@ export function WorkspaceFileViewer({
               className="text-body-small-default"
               style={{ color: "var(--content-secondary, var(--content-tertiary))" }}
             >
-              {formatFileSize(data.size)}
+              {formatFileSize(data.size, "Unknown size")}
             </p>
             {data.modifiedAt && (
               <p

--- a/apps/web/src/domains/workspace/components/workspace-tree.test.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for `WorkspaceTreeCreateMenu`.
+ *
+ * Verifies the mobile vs desktop branch — desktop renders a Radix Popover
+ * with the New File / New Folder rows; mobile renders a BottomSheet (Radix
+ * Dialog). Selecting either row forwards `onSelectKind(kind)` to the parent.
+ *
+ * Uses `renderToStaticMarkup` + `mock.module` for design library compounds
+ * (same pattern as conversation-actions-menu.test.tsx).
+ */
+
+import { describe, expect, mock, test, beforeEach } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+let mockIsMobile = false;
+mock.module("@/hooks/use-is-mobile.js", () => ({
+  useIsMobile: () => mockIsMobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+const passthrough = ({ children, ...props }: Record<string, unknown>) =>
+  createElement("div", props, children as ReactNode);
+
+mock.module("@vellum/design-library/components/bottom-sheet", () => ({
+  BottomSheet: {
+    Root: passthrough,
+    Trigger: ({ children }: Record<string, unknown>) =>
+      createElement("div", { "data-testid": "bs-trigger" }, children as ReactNode),
+    Content: passthrough,
+    Header: passthrough,
+    Title: ({ children }: Record<string, unknown>) =>
+      createElement("span", null, children as ReactNode),
+    Body: passthrough,
+  },
+}));
+
+mock.module("@vellum/design-library/components/popover", () => ({
+  Popover: {
+    Root: passthrough,
+    Trigger: ({ children }: Record<string, unknown>) =>
+      createElement("div", { "data-testid": "pop-trigger" }, children as ReactNode),
+    Content: ({ children, role }: Record<string, unknown>) =>
+      createElement("div", { role }, children as ReactNode),
+  },
+}));
+
+mock.module("@vellum/design-library/components/button", () => ({
+  Button: ({
+    children,
+    role,
+    onClick,
+    iconOnly: _iconOnly,
+    tintColor: _tintColor,
+    leftIcon: _leftIcon,
+    ...rest
+  }: Record<string, unknown>) =>
+    createElement(
+      "button",
+      { role, onClick, "data-testid": "button", ...rest },
+      children as ReactNode,
+    ),
+}));
+
+mock.module("@vellum/design-library/components/panel-item", () => ({
+  PanelItem: ({ label, onSelect }: Record<string, unknown>) =>
+    createElement(
+      "button",
+      { "data-testid": "panel-item", onClick: onSelect as () => void },
+      label as string,
+    ),
+}));
+
+import { WorkspaceTreeCreateMenu } from "./workspace-tree.js";
+
+beforeEach(() => {
+  mockIsMobile = false;
+});
+
+describe("WorkspaceTreeCreateMenu", () => {
+  test("desktop branch renders Popover with New File / New Folder items", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceTreeCreateMenu, {
+        open: true,
+        onOpenChange: () => {},
+        onSelectKind: () => {},
+      }),
+    );
+    expect(html).toContain("New File");
+    expect(html).toContain("New Folder");
+    expect(html).toContain('role="menu"');
+    expect(html).toContain('role="menuitem"');
+  });
+
+  test("mobile branch renders BottomSheet with PanelItem rows", () => {
+    mockIsMobile = true;
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceTreeCreateMenu, {
+        open: true,
+        onOpenChange: () => {},
+        onSelectKind: () => {},
+      }),
+    );
+    expect(html).toContain("New File");
+    expect(html).toContain("New Folder");
+    expect(html).toContain('data-testid="panel-item"');
+  });
+
+  test("desktop branch includes menuitem roles for accessibility", () => {
+    mockIsMobile = false;
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceTreeCreateMenu, {
+        open: true,
+        onOpenChange: () => {},
+        onSelectKind: () => {},
+      }),
+    );
+    const menuitemCount = (html.match(/role="menuitem"/g) ?? []).length;
+    expect(menuitemCount).toBe(2);
+  });
+});

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -1,0 +1,647 @@
+/**
+ * File tree sidebar for the workspace browser. Fetches the assistant's
+ * workspace directory listing, renders a recursive expandable tree, and
+ * provides search filtering plus file/folder creation.
+ */
+
+import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  FilePlus,
+  FileText,
+  Folder,
+  FolderPlus,
+  Image as ImageIcon,
+  Plus,
+  Search,
+  Video,
+  X,
+} from "lucide-react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { BottomSheet } from "@vellum/design-library/components/bottom-sheet";
+import { Button } from "@vellum/design-library/components/button";
+import { Input } from "@vellum/design-library/components/input";
+import { PanelItem } from "@vellum/design-library/components/panel-item";
+import { Popover } from "@vellum/design-library/components/popover";
+import { client } from "@/generated/api/client.gen.js";
+import { useIsMobile } from "@/hooks/use-is-mobile.js";
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+interface WorkspaceTreeEntry {
+  name?: string;
+  path?: string;
+  type?: string;
+  size?: number;
+  mimeType?: string;
+  modifiedAt?: string;
+}
+
+interface WorkspaceTreeResponse {
+  entries?: WorkspaceTreeEntry[];
+}
+
+function workspaceTreeRetrieveOptions(opts: {
+  path: { assistant_id: string };
+  query?: { path?: string; showHidden?: boolean };
+}) {
+  return queryOptions<WorkspaceTreeResponse>({
+    queryFn: async () => {
+      const query: Record<string, string> = {};
+      if (opts.query?.path) query.path = opts.query.path;
+      if (opts.query?.showHidden) query.showHidden = "true";
+      const { data, error } = await client.get<WorkspaceTreeResponse, unknown>({
+        url: "/v1/assistants/{assistant_id}/workspace/tree/",
+        path: opts.path,
+        query,
+      });
+      if (error) throw error;
+      return data!;
+    },
+    queryKey: ["assistantsWorkspaceTreeRetrieve", opts],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function FileIconForEntry({ entry }: { entry: WorkspaceTreeEntry }) {
+  if (entry.type === "directory") {
+    return (
+      <Folder
+        className="h-4 w-4 shrink-0"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    );
+  }
+  if (entry.mimeType?.startsWith("image/")) {
+    return (
+      <ImageIcon
+        className="h-4 w-4 shrink-0"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    );
+  }
+  if (entry.mimeType?.startsWith("video/")) {
+    return (
+      <Video
+        className="h-4 w-4 shrink-0"
+        style={{ color: "var(--content-tertiary)" }}
+      />
+    );
+  }
+  return (
+    <FileText
+      className="h-4 w-4 shrink-0"
+      style={{ color: "var(--content-tertiary)" }}
+    />
+  );
+}
+
+function TreeNode({
+  entry,
+  assistantId,
+  expandedPaths,
+  selectedPath,
+  showHidden,
+  searchLower,
+  onToggleExpand,
+  onSelectPath,
+  depth,
+}: {
+  entry: WorkspaceTreeEntry;
+  assistantId: string;
+  expandedPaths: Set<string>;
+  selectedPath: string | null;
+  showHidden: boolean;
+  searchLower: string;
+  onToggleExpand: (path: string) => void;
+  onSelectPath: (path: string) => void;
+  depth: number;
+}) {
+  const entryPath = entry.path ?? "";
+  const entryName = entry.name ?? "";
+  const isDirectory = entry.type === "directory";
+  const isExpanded = expandedPaths.has(entryPath);
+  const isSelected = selectedPath === entryPath;
+  const isHidden = entryName.startsWith(".");
+
+  // Expand directories whose names match during search so their children are visible.
+  const effectivelyExpanded =
+    isDirectory && (isExpanded || searchLower.length > 0);
+
+  const { data } = useQuery({
+    ...workspaceTreeRetrieveOptions({
+      path: { assistant_id: assistantId },
+      query: { path: entryPath, showHidden },
+    }),
+    enabled: isDirectory && effectivelyExpanded,
+  });
+
+  const children = useMemo(() => data?.entries ?? [], [data?.entries]);
+  const nameMatches =
+    searchLower === "" ||
+    entryName.toLowerCase().includes(searchLower);
+
+  // Filter files by name match. Directories stay visible during search so
+  // their children can mount, fetch, and reveal deeply nested matches.
+  if (searchLower !== "" && !isDirectory && !nameMatches) {
+    return null;
+  }
+
+  const handleClick = () => {
+    if (isDirectory) {
+      onToggleExpand(entryPath);
+    } else {
+      onSelectPath(entryPath);
+    }
+  };
+
+  return (
+    <div>
+      <button
+        onClick={handleClick}
+        className="group flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--ghost-hover)]"
+        style={{
+          paddingLeft: `${depth * 14 + 8}px`,
+          paddingRight: "8px",
+          color: isSelected
+            ? "var(--content-default)"
+            : isHidden
+              ? "var(--content-tertiary)"
+              : "var(--content-default)",
+          backgroundColor: isSelected
+            ? "color-mix(in oklab, var(--primary-base) 12%, transparent)"
+            : undefined,
+          opacity: isHidden && !isSelected ? 0.7 : 1,
+        }}
+      >
+        {isDirectory ? (
+          effectivelyExpanded ? (
+            <ChevronDown
+              className="h-3 w-3 shrink-0"
+              style={{ color: "var(--content-tertiary)" }}
+            />
+          ) : (
+            <ChevronRight
+              className="h-3 w-3 shrink-0"
+              style={{ color: "var(--content-tertiary)" }}
+            />
+          )
+        ) : (
+          <span className="h-3 w-3 shrink-0" />
+        )}
+        <FileIconForEntry entry={entry} />
+        <span className="min-w-0 flex-1 truncate">{entryName}</span>
+        {!isDirectory && entry.size != null && (
+          <span
+            className="shrink-0 text-label-medium-default tabular-nums"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {formatFileSize(entry.size)}
+          </span>
+        )}
+      </button>
+      {isDirectory && effectivelyExpanded && children.length > 0 && (
+        <div>
+          {children.map((child) => (
+            <TreeNode
+              key={child.path}
+              entry={child}
+              assistantId={assistantId}
+              expandedPaths={expandedPaths}
+              selectedPath={selectedPath}
+              showHidden={showHidden}
+              searchLower={searchLower}
+              onToggleExpand={onToggleExpand}
+              onSelectPath={onSelectPath}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create item dialog — portaled to document.body
+// ---------------------------------------------------------------------------
+
+interface CreateItemDialogProps {
+  kind: "file" | "folder";
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+  pending: boolean;
+  error: string | null;
+}
+
+function CreateItemDialog({
+  kind,
+  onCancel,
+  onConfirm,
+  pending,
+  error,
+}: CreateItemDialogProps) {
+  const [name, setName] = useState("");
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && !pending;
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (canSubmit) onConfirm(trimmed);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") onCancel();
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onKeyDown={handleKeyDown}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="mx-4 w-full max-w-sm rounded-xl border p-5 shadow-xl"
+        style={{
+          backgroundColor: "var(--surface-lift)",
+          borderColor: "var(--border-base)",
+        }}
+      >
+        <h2
+          className="mb-3 text-title-small"
+          style={{ color: "var(--content-default)" }}
+        >
+          {kind === "file" ? "New File" : "New Folder"}
+        </h2>
+        <Input
+          autoFocus
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={kind === "file" ? "filename.md" : "folder-name"}
+          errorText={error ?? undefined}
+          fullWidth
+          wrapperClassName="mb-3"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outlined"
+            onClick={onCancel}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!canSubmit}>
+            {pending ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main tree export
+// ---------------------------------------------------------------------------
+
+export function WorkspaceTree({
+  assistantId,
+  expandedPaths,
+  selectedPath,
+  showHidden,
+  onToggleExpand,
+  onExpandPath,
+  onSelectPath,
+  onToggleShowHidden,
+}: {
+  assistantId: string;
+  expandedPaths: Set<string>;
+  selectedPath: string | null;
+  showHidden: boolean;
+  onToggleExpand: (path: string) => void;
+  onExpandPath: (path: string) => void;
+  onSelectPath: (path: string) => void;
+  onToggleShowHidden: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const searchLower = search.trim().toLowerCase();
+
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const [dialogKind, setDialogKind] = useState<"file" | "folder" | null>(null);
+  const [dialogError, setDialogError] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery(
+    workspaceTreeRetrieveOptions({
+      path: { assistant_id: assistantId },
+      query: { showHidden },
+    }),
+  );
+
+  const invalidateTree = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ["assistantsWorkspaceTreeRetrieve"],
+    });
+  }, [queryClient]);
+
+  const createMutation = useMutation({
+    mutationFn: async (input: { kind: "file" | "folder"; name: string }) => {
+      const url =
+        input.kind === "file"
+          ? "/v1/assistants/{assistant_id}/workspace/write/"
+          : "/v1/assistants/{assistant_id}/workspace/mkdir/";
+      const body =
+        input.kind === "file"
+          ? { path: input.name, content: "", encoding: "utf8" }
+          : { path: input.name };
+      const { error, response } = await client.post<unknown, unknown>({
+        url,
+        path: { assistant_id: assistantId },
+        body,
+        headers: { "Content-Type": "application/json" },
+        throwOnError: false,
+      });
+      if (error || !response?.ok) {
+        throw new Error(
+          typeof error === "string"
+            ? error
+            : "Failed to create — check the name and try again.",
+        );
+      }
+      return input;
+    },
+    onSuccess: (input) => {
+      setDialogKind(null);
+      setDialogError(null);
+      invalidateTree();
+      if (input.kind === "file") {
+        onSelectPath(input.name);
+      } else {
+        onExpandPath(input.name);
+      }
+    },
+    onError: (err: unknown) => {
+      setDialogError(err instanceof Error ? err.message : "Failed to create.");
+    },
+  });
+
+  const handleConfirm = useCallback(
+    (name: string) => {
+      if (!dialogKind) return;
+      setDialogError(null);
+      createMutation.mutate({ kind: dialogKind, name });
+    },
+    [dialogKind, createMutation],
+  );
+
+  return (
+    <>
+      <div
+        className="flex items-center justify-between border-b px-3 py-2.5"
+        style={{ borderColor: "var(--border-element)" }}
+      >
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          Files
+        </span>
+        <div className="flex items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            iconOnly={showHidden ? <Eye aria-hidden /> : <EyeOff aria-hidden />}
+            onClick={onToggleShowHidden}
+            aria-label={showHidden ? "Hide hidden files" : "Show hidden files"}
+            title={showHidden ? "Hide hidden files" : "Show hidden files"}
+            tintColor={
+              showHidden ? "var(--content-default)" : "var(--content-tertiary)"
+            }
+          />
+          <WorkspaceTreeCreateMenu
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
+            onSelectKind={(kind) => {
+              setMenuOpen(false);
+              setDialogError(null);
+              setDialogKind(kind);
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="px-3 py-2">
+        <div className="relative">
+          <Input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search files"
+            leftIcon={<Search className="h-3.5 w-3.5" aria-hidden />}
+            fullWidth
+            spellCheck={false}
+            autoComplete="off"
+          />
+          {search && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              iconOnly={<X aria-hidden />}
+              onClick={() => setSearch("")}
+              aria-label="Clear search"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2"
+              tintColor="var(--content-tertiary)"
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <div
+              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+              style={{ color: "var(--content-tertiary)" }}
+            />
+          </div>
+        ) : !data?.entries?.length ? (
+          <p
+            className="px-3 py-4 text-center text-body-medium-lighter"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            No files found
+          </p>
+        ) : (
+          data.entries.map((entry) => (
+            <TreeNode
+              key={entry.path}
+              entry={entry}
+              assistantId={assistantId}
+              expandedPaths={expandedPaths}
+              selectedPath={selectedPath}
+              showHidden={showHidden}
+              searchLower={searchLower}
+              onToggleExpand={onToggleExpand}
+              onSelectPath={onSelectPath}
+              depth={0}
+            />
+          ))
+        )}
+      </div>
+
+      {dialogKind !== null && (
+        <CreateItemDialog
+          key={dialogKind}
+          kind={dialogKind}
+          onCancel={() => {
+            setDialogKind(null);
+            setDialogError(null);
+          }}
+          onConfirm={handleConfirm}
+          pending={createMutation.isPending}
+          error={dialogError}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceTreeCreateMenu — desktop popover / mobile bottom-sheet
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceTreeCreateMenuProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  onSelectKind: (kind: "file" | "folder") => void;
+}
+
+export function WorkspaceTreeCreateMenu({
+  open,
+  onOpenChange,
+  onSelectKind,
+}: WorkspaceTreeCreateMenuProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <BottomSheet.Root open={open} onOpenChange={onOpenChange}>
+        <BottomSheet.Trigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            iconOnly={<Plus aria-hidden />}
+            aria-label="Create new file or folder"
+            title="New file or folder"
+            tintColor="var(--content-tertiary)"
+          />
+        </BottomSheet.Trigger>
+        <BottomSheet.Content>
+          <BottomSheet.Header className="sr-only">
+            <BottomSheet.Title>Create new</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="pt-0">
+            <PanelItem
+              icon={FilePlus}
+              label="New File"
+              onSelect={() => onSelectKind("file")}
+            />
+            <PanelItem
+              icon={FolderPlus}
+              label="New Folder"
+              onSelect={() => onSelectKind("folder")}
+            />
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    );
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="compact"
+          iconOnly={<Plus aria-hidden />}
+          aria-label="Create new file or folder"
+          title="New file or folder"
+          tintColor="var(--content-tertiary)"
+        />
+      </Popover.Trigger>
+      <Popover.Content
+        align="end"
+        sideOffset={4}
+        role="menu"
+        className="w-44 overflow-hidden p-0"
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onSelectKind("file")}
+          className="w-full justify-start rounded-none"
+          leftIcon={
+            <FilePlus aria-hidden style={{ color: "var(--content-tertiary)" }} />
+          }
+          role="menuitem"
+        >
+          New File
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onSelectKind("folder")}
+          className="w-full justify-start rounded-none"
+          leftIcon={
+            <FolderPlus aria-hidden style={{ color: "var(--content-tertiary)" }} />
+          }
+          role="menuitem"
+        >
+          New Folder
+        </Button>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -36,6 +36,7 @@ import { PanelItem } from "@vellum/design-library/components/panel-item";
 import { Popover } from "@vellum/design-library/components/popover";
 import { client } from "@/generated/api/client.gen.js";
 import { useIsMobile } from "@/hooks/use-is-mobile.js";
+import { formatFileSize } from "@/domains/workspace/utils/format-file-size.js";
 
 // ---------------------------------------------------------------------------
 // API helpers
@@ -73,17 +74,6 @@ function workspaceTreeRetrieveOptions(opts: {
     },
     queryKey: ["assistantsWorkspaceTreeRetrieve", opts],
   });
-}
-
-// ---------------------------------------------------------------------------
-// Formatting
-// ---------------------------------------------------------------------------
-
-function formatFileSize(bytes: number | null | undefined): string {
-  if (bytes == null) return "";
-  if (bytes < 1024) return `${bytes} bytes`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 // ---------------------------------------------------------------------------
@@ -186,7 +176,7 @@ function TreeNode({
     <div>
       <button
         onClick={handleClick}
-        className="group flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--ghost-hover)]"
+        className="group flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
         style={{
           paddingLeft: `${depth * 14 + 8}px`,
           paddingRight: "8px",

--- a/apps/web/src/domains/workspace/utils/file-json.ts
+++ b/apps/web/src/domains/workspace/utils/file-json.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared helpers for rendering JSON file content in the workspace file viewer.
+ *
+ * Mirrors the surface of `file-markdown.tsx` — a sniff helper (`isJson`) plus a
+ * content transform (`prettifyJson`) — so the file viewer can branch on JSON
+ * the same way it branches on markdown.
+ */
+
+/**
+ * Strip media-type parameters (e.g. `;charset=utf-8`) from a mime string,
+ * trimming whitespace, so callers can do strict equality against the base type.
+ */
+function baseMediaType(mimeType: string | undefined): string {
+  if (!mimeType) return "";
+  const semi = mimeType.indexOf(";");
+  return (semi === -1 ? mimeType : mimeType.slice(0, semi)).trim();
+}
+
+/**
+ * True if the file looks like JSON by name or mime type.
+ *
+ * Recognised extensions: `.json`.
+ * Recognised mime: `application/json` — with or without parameters such as
+ * `;charset=utf-8`.
+ */
+export function isJson(
+  name: string | undefined,
+  mimeType: string | undefined,
+): boolean {
+  if (baseMediaType(mimeType) === "application/json") return true;
+  const lower = (name ?? "").toLowerCase();
+  return lower.endsWith(".json");
+}
+
+/**
+ * Pretty-print JSON content with 2-space indentation.
+ *
+ * Falls back to the raw content unchanged if it doesn't parse — partial saves,
+ * trailing-comma files, and hand-edited config files should still be viewable
+ * rather than disappearing behind an error state.
+ */
+export function prettifyJson(content: string): string {
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    return content;
+  }
+}

--- a/apps/web/src/domains/workspace/utils/format-file-size.ts
+++ b/apps/web/src/domains/workspace/utils/format-file-size.ts
@@ -1,0 +1,9 @@
+export function formatFileSize(
+  bytes: number | null | undefined,
+  fallback = "",
+): string {
+  if (bytes == null) return fallback;
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/domains/workspace/workspace-page.tsx
+++ b/apps/web/src/domains/workspace/workspace-page.tsx
@@ -1,0 +1,12 @@
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { WorkspaceBrowser } from "@/domains/workspace/components/workspace-browser.js";
+
+export function WorkspacePage() {
+  const { assistantId } = useAssistantContext();
+  if (!assistantId) return null;
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <WorkspaceBrowser assistantId={assistantId} />
+    </div>
+  );
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { LibraryDetailPage } from "@/domains/library/library-detail-page.js";
 import { IdentityPage } from "@/domains/intelligence/identity-page.js";
 import { ConnectPage } from "@/domains/contacts/connect-page.js";
 import { ContactsPage } from "@/domains/contacts/contacts-page.js";
+import { WorkspacePage } from "@/domains/workspace/workspace-page.js";
 import { NotFound } from "@/components/not-found.js";
 import { SettingsLayout } from "@/domains/settings/settings-layout.js";
 import { GeneralPage } from "@/domains/settings/pages/general-page.js";
@@ -178,6 +179,7 @@ export const router = createBrowserRouter([
           { path: "library", element: <LibraryPage /> },
           { path: "library/:appId", element: <LibraryDetailPage /> },
           { path: "identity", element: <IdentityPage /> },
+          { path: "workspace", element: <WorkspacePage /> },
           { path: "contacts", element: <ContactsPage /> },
           { path: "connect", element: <ConnectPage /> },
         ],


### PR DESCRIPTION
## Prompt / plan

Port the workspace browser (file tree + file viewer) from `vellum-assistant-platform` to the new Vite + React Router v7 SPA. Closes [LUM-1655](https://linear.app/vellum/issue/LUM-1655).

**What this adds:**

New domain `domains/workspace/` with 5 files:
- `workspace-page.tsx` — Route component consuming `assistantId` from `ChatLayout` outlet context
- `components/workspace-browser.tsx` — Split-pane layout: file tree sidebar + file viewer (mobile: drawer)
- `components/workspace-tree.tsx` — Recursive file tree with search, expand/collapse, file/folder creation (desktop: Popover, mobile: BottomSheet)
- `components/workspace-file-viewer.tsx` — Markdown (preview/source), JSON (pretty-printed/raw), plain text, image, video, binary-fallback viewer with inline editing and Ctrl+S/Cmd+S save
- `utils/file-json.ts` — `isJson()` and `prettifyJson()` helpers (mirrors `file-markdown.tsx` pattern)

Route added: `/assistant/workspace` nested under `ChatLayout` — matches the platform URL exactly.

**Divergences from platform:**
- Removed `"use client"` directives (Vite SPA, not Next.js)
- Replaced `useAppRootContainer()` portal target with `document.body` — no `AppRootContext` exists in the new repo; existing modals (`command-palette`, `share-feedback-modal`, `trust-rules-modal`) all portal to `document.body`
- Updated all imports to new repo conventions (`@/` aliases, `.js` extensions, `@vellum/design-library/components/` subpath imports)
- Kebab-case filenames per `STYLE_GUIDE.md`
- No `@next/next/no-img-element` eslint-disable comments (no Next.js eslint rules)

**Alternatives not taken:**
- Porting `AppRootContext` / `AppRootProvider` to the new repo — rejected because no other component in the new repo uses it, and `document.body` is the established portal target pattern. Can be added later if theme-scoped portals become necessary.

**Dependencies already present in the new repo (reused, not ported):**
- `MobileSidebarDrawer` / `MobileSidebarTrigger` — `components/mobile-sidebar-drawer.tsx`
- `useIsMobile()` — `hooks/use-is-mobile.ts`
- `FileMarkdown` / `isMarkdown()` — `domains/intelligence/components/file-markdown.tsx`
- `BottomSheet`, `PanelItem`, `Button`, `Input`, `Popover` — `@vellum/design-library`
- `routes.workspace` — already defined in `utils/routes.ts`

## Test plan

- `bunx tsc --noEmit` — 0 errors
- `bun run lint` — 0 errors (1 pre-existing warning in unrelated file)
- `bun test src/domains/workspace/components/workspace-tree.test.tsx` — 3/3 pass (WorkspaceTreeCreateMenu desktop/mobile branch tests)
- Route structure verified: `workspace` nested under ChatLayout alongside `identity`, `library`, `contacts`


Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->