### PR TITLE
feat(web): wire mobile overlays into ChatPage via portal (LUM-1665)

### DIFF
--- a/apps/web/src/components/layout/root-layout.tsx
+++ b/apps/web/src/components/layout/root-layout.tsx
@@ -69,6 +69,12 @@ export function RootLayout() {
       >
         <Outlet />
       </div>
+
+      {/* Portal target for mobile overlays that use `position: fixed`.
+          Lives outside the inner wrapper so the keyboard-following
+          `translate3d(...)` doesn't shift the overlay's containing block.
+          See: https://www.w3.org/TR/css-transforms-1/#transform-rendering */}
+      <div id="viewport-overlays" />
     </div>
   );
 }

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -18,6 +18,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { ChevronDown } from "lucide-react";
 
@@ -76,6 +77,9 @@ import { ConversationAssetsPill } from "@/domains/chat/components/conversation-a
 import { CommandPalette } from "@/components/command-palette/command-palette.js";
 import { shouldHandleShortcut } from "@/domains/chat/chat-layout.js";
 import { abortSubagent } from "@/domains/chat/api/conversations.js";
+import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay.js";
+import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay.js";
+import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay.js";
 import { routes } from "@/utils/routes.js";
 import { haptic } from "@/utils/haptics.js";
 import type { AssistantIdentity } from "@/domains/chat/api/assistant.js";
@@ -158,6 +162,8 @@ export function ChatPage() {
     viewBeforeSubagentDetail: s.viewBeforeSubagentDetail,
   })));
   const subagentState = useSubagentStore(useShallow((s) => ({ byId: s.byId, orderedIds: s.orderedIds })));
+  const isSharing = useDeployStore.use.isSharing();
+  const isDeploying = useDeployStore.use.isDeploying();
   const subagentEntries = useMemo(
     () => subagentState.orderedIds.map((id) => subagentState.byId[id]!).filter(Boolean),
     [subagentState.byId, subagentState.orderedIds],
@@ -1100,6 +1106,13 @@ export function ChatPage() {
     isChannelReadonly,
   };
 
+  // -------------------------------------------------------------------------
+  // Mobile overlay portal
+  // -------------------------------------------------------------------------
+  const overlayTarget = isMobile
+    ? document.getElementById("viewport-overlays")
+    : null;
+
   return (
     <>
       <ChatRouteContent {...chatRouteProps} />
@@ -1114,6 +1127,69 @@ export function ChatPage() {
         onItemSelect={handleItemSelect}
         onKeyDown={commandPalette.handleKeyDown}
       />
+      {overlayTarget &&
+        createPortal(
+          <>
+            <MobileAppOverlay
+              openedAppState={
+                viewerState.mainView === "app" ? viewerState.openedAppState : null
+              }
+              isAppMinimized={viewerState.isAppMinimized}
+              assistantId={assistantId}
+              onToggleMinimized={() => {
+                useViewerStore.getState().toggleAppMinimized();
+              }}
+              onClose={() => {
+                useViewerStore.getState().closeApp();
+                useViewerStore.getState().setMainView("chat");
+              }}
+              onShare={() => {
+                useDeployStore.getState().startSharing();
+              }}
+              isSharing={isSharing}
+              onDeploy={
+                deployToVercel
+                  ? () => {
+                      useDeployStore.getState().startDeploying();
+                    }
+                  : undefined
+              }
+              isDeploying={isDeploying}
+            />
+            <MobileDocumentOverlay
+              openedDocumentState={
+                viewerState.mainView === "document"
+                  ? viewerState.openedDocumentState
+                  : null
+              }
+              assistantId={assistantId}
+              onClose={() => {
+                useViewerStore.getState().closeDocument();
+              }}
+            />
+            <MobileSubagentDetailOverlay
+              entry={
+                viewerState.mainView === "subagent-detail" &&
+                viewerState.activeSubagentId
+                  ? subagentState.byId[viewerState.activeSubagentId] ?? null
+                  : null
+              }
+              onClose={() => {
+                useViewerStore.getState().closeSubagentDetail();
+              }}
+              onStop={async (subagentId: string) => {
+                if (!assistantId || !activeConversationKey) return;
+                try {
+                  await abortSubagent(assistantId, activeConversationKey, subagentId);
+                } catch {
+                  // Best-effort — the daemon may have already completed
+                }
+              }}
+              onRequestDetail={async () => {}}
+            />
+          </>,
+          overlayTarget,
+        )}
     </>
   );
 }

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -1107,11 +1107,14 @@ export function ChatPage() {
   };
 
   // -------------------------------------------------------------------------
-  // Mobile overlay portal
+  // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
   // -------------------------------------------------------------------------
-  const overlayTarget = isMobile
-    ? document.getElementById("viewport-overlays")
-    : null;
+  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setOverlayTarget(
+      isMobile ? document.getElementById("viewport-overlays") : null,
+    );
+  }, [isMobile]);
 
   return (
     <>


### PR DESCRIPTION
## Prompt / plan

Wire the three mobile overlay components (`MobileAppOverlay`, `MobileDocumentOverlay`, `MobileSubagentDetailOverlay`) into the chat surface. These components were ported in #31317 but left unwired pending LUM-1663 (AssistantSideMenu), which is now complete.

**Problem**: On mobile, opening an app, document, or subagent detail has no UI — the desktop path uses `ResizablePanel` split-views (guarded by `!isMobile`), but nothing renders the mobile full-screen overlays.

**Solution**: Render the overlays from `ChatPage` via `createPortal` into a target div in `RootLayout` that sits outside the keyboard-following `translate3d(...)` wrapper. This preserves correct `position: fixed` viewport anchoring per [CSS Transforms spec §6](https://www.w3.org/TR/css-transforms-1/#transform-rendering).

### Changes

- **`root-layout.tsx`**: Add `<div id="viewport-overlays" />` as a sibling of the inner transform wrapper
- **`chat-page.tsx`**: Import the 3 overlay components, read `isSharing`/`isDeploying` from deploy store at the top level (Rules of Hooks compliance), and portal the overlays conditioned on `isMobile` + the relevant `mainView` state. Portal target resolved via `useState` + `useEffect` (not synchronous render) per CONVENTIONS.md §SSR.

### Divergences from platform

- Platform passes overlays to `AssistantShell` via a `viewportOverlays` prop; the assistant repo uses a portal target since `RootLayout` doesn't accept children props for this purpose
- Deep-link `route` prop is omitted from `MobileAppOverlay` — `ChatPage` doesn't use `useAppViewerActions` yet (the hook exists but isn't wired); can be added when app deep-linking is ported

### References

- [CSS Transforms spec §6 — transform rendering](https://www.w3.org/TR/css-transforms-1/#transform-rendering): why `position: fixed` inside a transformed container anchors to the transform origin
- [React createPortal](https://react.dev/reference/react-dom/createPortal): portal pattern for rendering outside the component tree
- [CONVENTIONS.md §SSR](apps/web/CONVENTIONS.md): route components must not access `document` during synchronous render

## Test plan

- TypeScript: `bunx tsc --noEmit` — clean (exit 0)
- Lint: `bun run lint` — clean (only pre-existing unrelated warning)
- CI checks: all green

Closes LUM-1665

Link to Devin session: https://app.devin.ai/sessions/ad8145e66f7f421d9be339d5f8bd1bd5
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->