### PR TITLE
docs(web): codify "no useReducer, atomic selectors only"

### DIFF
--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -512,32 +512,62 @@ References:
 - [TkDodo — Working with Zustand](https://tkdodo.eu/blog/working-with-zustand) — React Query maintainer's guidance on the boundary between server state (RQ) and client/infrastructure state (Zustand)
 - [Zustand — Reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
 
-### useReducer for component-local state only
+### useReducer is not used for client state
 
-When two or more pieces of **component-local** state change together
-or have interdependent transitions, consolidate them into a
-`useReducer` with typed action events. Reserve `useState` for
-independent, single-value state (a boolean toggle, a text input
-value).
-
-**Do not use `useReducer` for state shared across components.** Shared
-state belongs in a Zustand store with direct named actions (see
-[Direct named actions, not reducers](#direct-named-actions-not-reducers)).
+**Do not use `useReducer` in `apps/web/`.** All client state — including
+single-hook-scoped state with non-trivial transitions — lives in a
+Zustand store with direct named actions (see
+[Direct named actions, not reducers](#direct-named-actions-not-reducers)
+just below). The dispatch/action-type/reducer pattern is not the
+shape we want even inside a Zustand store — Zustand's
+[Flux-inspired practice guide](https://zustand.docs.pmnd.rs/guides/flux-inspired-practice)
+exists for Redux migration paths, not as the recommended idiom.
 
 ```ts
-// Good — related state transitions are atomic and self-documenting
-dispatch({ type: "SHOW_SECRET", requestId, prompt });
+// Good — Zustand store with direct named actions
+const useSecretStore = createSelectors(
+  create<SecretState>((set) => ({
+    requestId: null,
+    prompt: null,
+    showSecret: (requestId: string, prompt: string) =>
+      set({ requestId, prompt }),
+    dismissSecret: () => set({ requestId: null, prompt: null }),
+  })),
+);
 
-// Avoid — multiple setState calls that must stay in sync
-setSecretRequestId(requestId);
-setSecretPrompt(prompt);
-setShowSecretOverlay(true);
+// Avoid — useReducer in any form. Locks state to one component subtree,
+// prevents atomic selectors, no devtools, doesn't survive remount,
+// duplicates the React state primitive we already use Zustand for.
+const [state, dispatch] = useReducer(secretReducer, initialState);
+
+// Avoid — dispatcher pattern inside a Zustand store. Zustand supports
+// this for Redux migrants but it's not idiomatic; named actions are
+// independently testable, discoverable in IDE autocomplete, and don't
+// pay the action-type/switch tax.
+create((set) => ({
+  dispatch: (action: SecretAction) =>
+    set((state) => secretReducer(state, action)),
+}));
 ```
 
-Extract the reducer into its own file so it can be tested as a pure
-function.
+Why no `useReducer` and no in-store reducer pattern:
 
-Reference: [React — Scaling Up with Reducer and Context](https://react.dev/learn/scaling-up-with-reducer-and-context)
+- **Consistency** — the codebase standardizes on Zustand stores with direct named actions as the single client-state primitive.
+- **Cross-component subscribers** — Zustand atomic selectors handle this for free; `useReducer` requires Context wrapping + cross-tree re-renders.
+- **Devtools** — Zustand integrates with Redux DevTools; `useReducer` doesn't.
+- **Persistence across remounts** — module-level Zustand stores survive route remounts; `useReducer` state doesn't.
+- **No prop drilling** — `useReducer` state must be passed down or wrapped in Context. Zustand selectors are accessible everywhere.
+- **No dispatcher boilerplate** — direct named actions skip the action-type union, the switch statement, and the runtime cost of an indirection layer. Each action is a plain function that's testable in isolation.
+
+For state with complex transition rules (state machines), express the
+rules as guards inside the named action itself — e.g. `acceptSend`
+no-ops if `phase !== "thinking"`. The action stays a plain function;
+the rules stay testable in isolation; we don't need a dispatcher
+ceremony to enforce them.
+
+References:
+- [Zustand — Auto Generating Selectors](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
+- [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)
 
 ### Direct named actions, not reducers
 

--- a/apps/web/CONVENTIONS.md
+++ b/apps/web/CONVENTIONS.md
@@ -565,6 +565,14 @@ no-ops if `phase !== "thinking"`. The action stays a plain function;
 the rules stay testable in isolation; we don't need a dispatcher
 ceremony to enforce them.
 
+**Known exceptions** (being migrated):
+
+- `apps/web/src/domains/terminal/use-terminal-state.ts` and
+  `apps/web/src/domains/terminal/use-terminal-session.ts` still use
+  `useReducer` + dispatch. Tracked in
+  [LUM-1748](https://linear.app/vellum/issue/LUM-1748). Do not
+  pattern-match new code on these files.
+
 References:
 - [Zustand — Auto Generating Selectors](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
 - [Zustand — TypeScript guide](https://zustand.docs.pmnd.rs/guides/typescript)


### PR DESCRIPTION
## Summary

Codifies two convention tightenings that the codebase has already been moving toward but the docs hadn't caught up to:

1. **No `useReducer` in `apps/web/`.** All client state — including single-hook-scoped state with non-trivial transitions — lives in a Zustand store with direct named actions. The dispatch/action-type/reducer pattern is not used even inside Zustand stores; [Zustand's Flux-inspired-practice guide](https://zustand.docs.pmnd.rs/guides/flux-inspired-practice) exists for Redux migration paths, not as the recommended idiom. State machines express rules as guards inside named actions (e.g. `acceptSend` no-ops when `phase !== "thinking"`).
2. **Atomic selectors via `createSelectors` are the default.** `useShallow` over object selectors is a band-aid for a pattern we shouldn't write in the first place — call atomic hooks side-by-side and let React 19 batch the renders. Derive composite values with `useMemo` in the consumer, not inside the selector. Existing `useShallow` call sites stay until they're touched; new code doesn't introduce them.

## Why now

Main has already been moving in this direction:

- `turn-state-machine.ts` → `domains/messaging/turn-store.ts` (Zustand)
- `interaction-state-machine.ts` → `domains/interactions/interaction-store.ts` (Zustand)
- Voice recording state → Zustand store (PR #31346)
- Onboarding prefs → Zustand persist store (LUM-1717)

The doc now matches the practice. Future code follows one rule: Zustand stores with direct named actions, atomic selectors via `createSelectors`.

## What changed

- Replaced the "useReducer for component-local state only" section with "useReducer is not used for client state" — explicit ban on both `useReducer` AND the in-store dispatcher pattern. Spells out the drawbacks (no cross-component subscribers, no devtools, doesn't survive remount, prop drilling, action-type/switch tax).
- Rewrote "Selector patterns and `useShallow`" as "Selectors: prefer atomic, avoid `useShallow`". Atomic selectors via `createSelectors` are the recommended default. `useShallow` is documented as legacy-only.

## Cross-references

Linear comments added to the migration tickets that touch state:
[LUM-1731](https://linear.app/vellum/issue/LUM-1731), [LUM-1734](https://linear.app/vellum/issue/LUM-1734), [LUM-1742](https://linear.app/vellum/issue/LUM-1742), [LUM-1743](https://linear.app/vellum/issue/LUM-1743), [LUM-1744](https://linear.app/vellum/issue/LUM-1744).

The two tickets that proposed migrating the existing reducers ([LUM-1745](https://linear.app/vellum/issue/LUM-1745), [LUM-1746](https://linear.app/vellum/issue/LUM-1746)) were closed as already-done — main already did the migrations.

## Test plan

- [x] Doc-only change — no code modifications
- [x] Markdown renders correctly in editor preview
- [ ] PR reviewers verify the policy matches what we want going forward

https://claude.ai/code/session_013dBXRbLF218UhdLq7FEAvv

---
_Generated by [Claude Code](https://claude.ai/code/session_013dBXRbLF218UhdLq7FEAvv)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->