### PR TITLE
fix(security): gate base_url to openai-compatible and add SSRF protection (ATL-611)

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -179,6 +179,7 @@ import {
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateSlackCompactionWatermark,
+  migrateStripBaseUrlNonOpenaiCompatible,
   migrateStripIntegrationPrefixFromProviderKeys,
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
@@ -446,6 +447,7 @@ export function initializeDb(): void {
     migrateChannelInboundDeliveryAttempts,
     migrateMemoryV2InjectionEvents,
     migrateConversationLastNotifiedProfile,
+    migrateStripBaseUrlNonOpenaiCompatible,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/257-strip-base-url-non-openai-compatible.ts
+++ b/assistant/src/memory/migrations/257-strip-base-url-non-openai-compatible.ts
@@ -1,0 +1,22 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Strip `base_url` from provider connections whose provider is NOT
+ * `openai-compatible`. These values should never have been accepted — the
+ * route layer now rejects them, but existing rows may still carry one from
+ * before the validation was added. Setting it to NULL prevents
+ * API-key exfiltration via a redirected base URL.
+ *
+ * Idempotent — re-running is a no-op once all non-openai-compatible rows
+ * already have NULL base_url.
+ */
+export function migrateStripBaseUrlNonOpenaiCompatible(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Only clear base_url on rows where provider is NOT openai-compatible.
+  raw.exec(
+    `UPDATE provider_connections SET base_url = NULL WHERE provider != 'openai-compatible' AND base_url IS NOT NULL`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -217,6 +217,7 @@ export {
 export { migrateProviderConnectionBaseUrlAndModels } from "./250-provider-connection-base-url-and-models.js";
 export { downA2ATasks, migrateA2ATasks } from "./251-a2a-tasks.js";
 export { migrateLlmRequestLogAgentLoopExitReason } from "./252-llm-request-log-agent-loop-exit-reason.js";
+export { migrateConversationLastNotifiedProfile } from "./253-conversation-last-notified-profile.js";
 export { migrateCreateDocumentComments } from "./253-document-comments.js";
 export {
   downExternalConversationBindingChatName,
@@ -227,7 +228,6 @@ export {
   downMemoryV2InjectionEvents,
   migrateMemoryV2InjectionEvents,
 } from "./256-memory-v2-injection-events.js";
-export { migrateConversationLastNotifiedProfile } from "./253-conversation-last-notified-profile.js";
 export { migrateStripBaseUrlNonOpenaiCompatible } from "./257-strip-base-url-non-openai-compatible.js";
 export {
   MIGRATION_REGISTRY,

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -228,6 +228,7 @@ export {
   migrateMemoryV2InjectionEvents,
 } from "./256-memory-v2-injection-events.js";
 export { migrateConversationLastNotifiedProfile } from "./253-conversation-last-notified-profile.js";
+export { migrateStripBaseUrlNonOpenaiCompatible } from "./257-strip-base-url-non-openai-compatible.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-route-validation.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Route-level validation tests for base_url provider-type gate and SSRF
+ * protection on inference provider connections.
+ *
+ * These tests exercise the POST (create) and PATCH (update) route handlers
+ * with mocked DB, config, and DNS resolution.
+ */
+import { Database } from "bun:sqlite";
+import { describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateCreateProviderConnections } from "../../../memory/migrations/243-provider-connections.js";
+import { migrateProviderConnectionStatusLabel } from "../../../memory/migrations/244-provider-connection-status-label.js";
+import { migrateProviderConnectionBaseUrlAndModels } from "../../../memory/migrations/250-provider-connection-base-url-and-models.js";
+import * as schema from "../../../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  return drizzle(sqlite, { schema });
+}
+
+function bootDb() {
+  const db = createTestDb();
+  migrateCreateProviderConnections(db);
+  migrateProviderConnectionStatusLabel(db);
+  migrateProviderConnectionBaseUrlAndModels(db);
+  return db;
+}
+
+// Create and hold a test DB; the mock returns it from getDb().
+const testDb = bootDb();
+
+mock.module("../../../memory/db-connection.js", () => ({
+  getDb: () => testDb,
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (flag: string) =>
+    flag === "openai-compatible-endpoints",
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({ llm: {} }),
+  getConfigReadOnly: () => ({ llm: {} }),
+}));
+
+// Mock DNS resolution: all hostnames resolve to a public IP by default.
+// Tests that need private-IP resolution override this per-test.
+let mockResolvedAddresses: string[] = ["93.184.216.34"];
+
+// Import the real url-safety module for use inside the mock.
+const {
+  isPrivateOrLocalHost: realIsPrivateOrLocalHost,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  isIPv4,
+  isIPv6,
+  parseUrl,
+  unwrapBracketedHostname,
+  extractEmbeddedIPv4FromIPv6,
+  looksLikeHostPortShorthand,
+  looksLikePathOnlyInput,
+  buildHostHeader,
+  stripUrlUserinfo,
+  sanitizeUrlForOutput,
+  sanitizeUrlStringForOutput,
+} = await import("../../../tools/network/url-safety.js");
+
+mock.module("../../../tools/network/url-safety.js", () => ({
+  isPrivateOrLocalHost: realIsPrivateOrLocalHost,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  isIPv4,
+  isIPv6,
+  parseUrl,
+  unwrapBracketedHostname,
+  extractEmbeddedIPv4FromIPv6,
+  looksLikeHostPortShorthand,
+  looksLikePathOnlyInput,
+  buildHostHeader,
+  stripUrlUserinfo,
+  sanitizeUrlForOutput,
+  sanitizeUrlStringForOutput,
+  resolveHostAddresses: async () => mockResolvedAddresses,
+  resolveRequestAddress: async (
+    hostname: string,
+    _resolveHost: unknown,
+    allowPrivateNetwork: boolean,
+  ) => {
+    if (!allowPrivateNetwork && realIsPrivateOrLocalHost(hostname)) {
+      return { addresses: [], blockedAddress: hostname };
+    }
+    const addresses = mockResolvedAddresses;
+    if (!allowPrivateNetwork) {
+      for (const addr of addresses) {
+        if (realIsPrivateOrLocalHost(addr)) {
+          return { addresses: [], blockedAddress: addr };
+        }
+      }
+    }
+    return { addresses };
+  },
+}));
+
+const { ROUTES } = await import(
+  "../../../runtime/routes/inference-provider-connection-routes.js"
+);
+
+const handleCreate = ROUTES.find(
+  (r) => r.operationId === "inference_provider_connections_create",
+)!.handler;
+
+const handleUpdate = ROUTES.find(
+  (r) => r.operationId === "inference_provider_connections_update",
+)!.handler;
+
+// ---------------------------------------------------------------------------
+// Provider-type gate: base_url rejected for non-openai-compatible providers
+// ---------------------------------------------------------------------------
+
+describe("base_url provider-type gate (create)", () => {
+  test("rejects base_url on anthropic provider", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "exfil-anthropic",
+          provider: "anthropic",
+          auth: { type: "api_key", credential: "cred-exfil" },
+          base_url: "https://evil.example.com/v1",
+        },
+      }),
+    ).rejects.toThrow(/base_url is only valid for openai-compatible/);
+  });
+
+  test("rejects base_url on openai provider", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "exfil-openai",
+          provider: "openai",
+          auth: { type: "api_key", credential: "cred-exfil" },
+          base_url: "https://evil.example.com/v1",
+        },
+      }),
+    ).rejects.toThrow(/base_url is only valid for openai-compatible/);
+  });
+
+  test("rejects base_url on gemini provider", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "exfil-gemini",
+          provider: "gemini",
+          auth: { type: "api_key", credential: "cred-exfil" },
+          base_url: "https://evil.example.com/v1",
+        },
+      }),
+    ).rejects.toThrow(/base_url is only valid for openai-compatible/);
+  });
+
+  test("accepts base_url on openai-compatible provider", async () => {
+    mockResolvedAddresses = ["93.184.216.34"];
+    const result = await handleCreate({
+      body: {
+        name: "valid-oai-compat",
+        provider: "openai-compatible",
+        auth: { type: "api_key", credential: "cred-vllm" },
+        base_url: "https://my-vllm.example.com/v1",
+        models: [{ id: "my-model" }],
+      },
+    });
+    expect(result).toBeDefined();
+    expect((result as { baseUrl: string }).baseUrl).toBe(
+      "https://my-vllm.example.com/v1",
+    );
+  });
+
+  test("allows null base_url on non-openai-compatible provider", async () => {
+    // Setting base_url to null is always allowed (it's a no-op clear).
+    const result = await handleCreate({
+      body: {
+        name: "null-baseurl-anthropic",
+        provider: "anthropic",
+        auth: { type: "api_key", credential: "cred-test" },
+        base_url: null,
+      },
+    });
+    expect(result).toBeDefined();
+    expect((result as { baseUrl: string | null }).baseUrl).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF protection: private/local network addresses blocked
+// ---------------------------------------------------------------------------
+
+describe("base_url SSRF protection (create)", () => {
+  test("rejects private IP (192.168.x.x)", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-private-ip",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://192.168.1.1/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects localhost", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-localhost",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://localhost:8080/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects 0.0.0.0", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-zero",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://0.0.0.0:8080/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects 10.x.x.x", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-ten",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://10.0.0.1/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects 127.0.0.1", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-loopback",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://127.0.0.1:8080/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects metadata.google.internal", async () => {
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-metadata",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "http://metadata.google.internal/computeMetadata/v1/",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/private or local network/);
+  });
+
+  test("rejects hostname that resolves to a private IP", async () => {
+    mockResolvedAddresses = ["10.0.0.5"];
+    await expect(
+      handleCreate({
+        body: {
+          name: "ssrf-dns-rebind",
+          provider: "openai-compatible",
+          auth: { type: "api_key", credential: "cred-ssrf" },
+          base_url: "https://dns-rebind.example.com/v1",
+          models: [{ id: "m" }],
+        },
+      }),
+    ).rejects.toThrow(/resolves to a private network/);
+  });
+
+  test("accepts a valid public URL", async () => {
+    mockResolvedAddresses = ["93.184.216.34"];
+    const result = await handleCreate({
+      body: {
+        name: "valid-public-url",
+        provider: "openai-compatible",
+        auth: { type: "api_key", credential: "cred-valid" },
+        base_url: "https://api.example.com/v1",
+        models: [{ id: "my-model" }],
+      },
+    });
+    expect(result).toBeDefined();
+    expect((result as { baseUrl: string }).baseUrl).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Update handler: base_url validation on existing connections
+// ---------------------------------------------------------------------------
+
+describe("base_url provider-type gate (update)", () => {
+  test("rejects adding base_url to an existing anthropic connection", async () => {
+    // Seed a connection first.
+    await handleCreate({
+      body: {
+        name: "update-test-anthropic",
+        provider: "anthropic",
+        auth: { type: "api_key", credential: "cred-update" },
+      },
+    });
+
+    await expect(
+      handleUpdate({
+        pathParams: { name: "update-test-anthropic" },
+        body: {
+          auth: { type: "api_key", credential: "cred-update" },
+          base_url: "https://evil.example.com/v1",
+        },
+      }),
+    ).rejects.toThrow(/base_url is only valid for openai-compatible/);
+  });
+});

--- a/assistant/src/providers/inference/__tests__/base-url-security.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-security.test.ts
@@ -1,0 +1,189 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateCreateProviderConnections } from "../../../memory/migrations/243-provider-connections.js";
+import { migrateProviderConnectionStatusLabel } from "../../../memory/migrations/244-provider-connection-status-label.js";
+import { migrateProviderConnectionBaseUrlAndModels } from "../../../memory/migrations/250-provider-connection-base-url-and-models.js";
+import { migrateStripBaseUrlNonOpenaiCompatible } from "../../../memory/migrations/257-strip-base-url-non-openai-compatible.js";
+import * as schema from "../../../memory/schema.js";
+import { providerConnections } from "../../../memory/schema/inference.js";
+import { createConnection, getConnection } from "../connections.js";
+import { resolveAuth } from "../resolve-auth.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  return drizzle(sqlite, { schema });
+}
+
+function bootDb() {
+  const db = createTestDb();
+  migrateCreateProviderConnections(db);
+  migrateProviderConnectionStatusLabel(db);
+  migrateProviderConnectionBaseUrlAndModels(db);
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Migration: strip base_url from non-openai-compatible connections
+// ---------------------------------------------------------------------------
+
+describe("migration 257: strip base_url from non-openai-compatible connections", () => {
+  test("clears base_url on anthropic connection", () => {
+    const db = bootDb();
+
+    // Manually insert a row with a base_url on an anthropic provider (simulating
+    // a row created before the validation was added).
+    const now = Date.now();
+    db.insert(providerConnections)
+      .values({
+        name: "bad-anthropic",
+        provider: "anthropic",
+        auth: JSON.stringify({ type: "api_key", credential: "cred-abc" }),
+        status: "active",
+        baseUrl: "https://evil.example.com/v1",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    migrateStripBaseUrlNonOpenaiCompatible(db);
+
+    const conn = getConnection(db, "bad-anthropic");
+    expect(conn).not.toBeNull();
+    expect(conn!.baseUrl).toBeNull();
+  });
+
+  test("preserves base_url on openai-compatible connection", () => {
+    const db = bootDb();
+
+    const now = Date.now();
+    db.insert(providerConnections)
+      .values({
+        name: "good-vllm",
+        provider: "openai-compatible",
+        auth: JSON.stringify({ type: "api_key", credential: "cred-vllm" }),
+        status: "active",
+        baseUrl: "https://my-vllm.example.com/v1",
+        models: JSON.stringify([{ id: "my-model" }]),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    migrateStripBaseUrlNonOpenaiCompatible(db);
+
+    const conn = getConnection(db, "good-vllm");
+    expect(conn).not.toBeNull();
+    expect(conn!.baseUrl).toBe("https://my-vllm.example.com/v1");
+  });
+
+  test("is idempotent", () => {
+    const db = bootDb();
+
+    const now = Date.now();
+    db.insert(providerConnections)
+      .values({
+        name: "bad-openai",
+        provider: "openai",
+        auth: JSON.stringify({ type: "api_key", credential: "cred-abc" }),
+        status: "active",
+        baseUrl: "https://evil.example.com/v1",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    migrateStripBaseUrlNonOpenaiCompatible(db);
+    migrateStripBaseUrlNonOpenaiCompatible(db);
+
+    const conn = getConnection(db, "bad-openai");
+    expect(conn).not.toBeNull();
+    expect(conn!.baseUrl).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuth defense-in-depth: strip baseUrl for non-openai-compatible
+// ---------------------------------------------------------------------------
+
+describe("resolveAuth defense-in-depth", () => {
+  // Mock the secure key store to return a predictable value.
+  mock.module("../../../security/secure-keys.js", () => ({
+    getSecureKeyAsync: async (credential: string) =>
+      credential === "cred-test" ? "sk-test-key" : null,
+  }));
+
+  // Mock the platform proxy context to avoid real platform calls.
+  mock.module("../../../providers/platform-proxy/context.js", () => ({
+    buildManagedBaseUrl: async () => null,
+    resolveManagedProxyContext: async () => ({
+      assistantApiKey: "platform-key",
+    }),
+  }));
+
+  test("strips baseUrl for anthropic provider", async () => {
+    const result = await resolveAuth(
+      { type: "api_key", credential: "cred-test" },
+      "anthropic",
+      { baseUrl: "https://evil.example.com/v1" },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved.kind).toBe("header");
+      if (result.resolved.kind === "header") {
+        expect(result.resolved.baseUrl).toBeUndefined();
+      }
+    }
+  });
+
+  test("strips baseUrl for openai provider", async () => {
+    const result = await resolveAuth(
+      { type: "api_key", credential: "cred-test" },
+      "openai",
+      { baseUrl: "https://evil.example.com/v1" },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.kind === "header") {
+      expect(result.resolved.baseUrl).toBeUndefined();
+    }
+  });
+
+  test("strips baseUrl for gemini provider", async () => {
+    const result = await resolveAuth(
+      { type: "api_key", credential: "cred-test" },
+      "gemini",
+      { baseUrl: "https://evil.example.com/v1" },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.kind === "header") {
+      expect(result.resolved.baseUrl).toBeUndefined();
+    }
+  });
+
+  test("preserves baseUrl for openai-compatible provider", async () => {
+    const result = await resolveAuth(
+      { type: "api_key", credential: "cred-test" },
+      "openai-compatible",
+      { baseUrl: "https://my-vllm.example.com/v1" },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.kind === "header") {
+      expect(result.resolved.baseUrl).toBe("https://my-vllm.example.com/v1");
+    }
+  });
+
+  test("handles null baseUrl gracefully for any provider", async () => {
+    const result = await resolveAuth(
+      { type: "api_key", credential: "cred-test" },
+      "anthropic",
+      { baseUrl: null },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.kind === "header") {
+      expect(result.resolved.baseUrl).toBeUndefined();
+    }
+  });
+});

--- a/assistant/src/providers/inference/__tests__/base-url-security.test.ts
+++ b/assistant/src/providers/inference/__tests__/base-url-security.test.ts
@@ -9,7 +9,7 @@ import { migrateProviderConnectionBaseUrlAndModels } from "../../../memory/migra
 import { migrateStripBaseUrlNonOpenaiCompatible } from "../../../memory/migrations/257-strip-base-url-non-openai-compatible.js";
 import * as schema from "../../../memory/schema.js";
 import { providerConnections } from "../../../memory/schema/inference.js";
-import { createConnection, getConnection } from "../connections.js";
+import { getConnection } from "../connections.js";
 import { resolveAuth } from "../resolve-auth.js";
 
 function createTestDb() {

--- a/assistant/src/providers/inference/resolve-auth.ts
+++ b/assistant/src/providers/inference/resolve-auth.ts
@@ -14,7 +14,11 @@ import {
   resolveManagedProxyContext,
 } from "../../providers/platform-proxy/context.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
 import type { Auth, ResolvedAuth } from "./auth.js";
+import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "./connections.js";
+
+const log = getLogger("resolve-auth");
 
 export type ResolveAuthError =
   | { code: "credential_not_found"; credential: string }
@@ -28,6 +32,19 @@ export async function resolveAuth(
 ): Promise<
   { ok: true; resolved: ResolvedAuth } | { ok: false; error: ResolveAuthError }
 > {
+  // Defense-in-depth: strip baseUrl for providers that should not accept one.
+  // The route layer rejects base_url for non-openai-compatible providers, but
+  // this guard catches any code path that bypasses route validation (e.g.
+  // corrupted DB rows, direct calls from internal code).
+  let safeBaseUrl = opts.baseUrl;
+  if (safeBaseUrl && !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
+    log.warn(
+      { provider, baseUrl: safeBaseUrl },
+      `Stripping baseUrl for provider "${provider}" — base_url is only valid for openai-compatible providers.`,
+    );
+    safeBaseUrl = null;
+  }
+
   switch (auth.type) {
     case "api_key": {
       const value = await getSecureKeyAsync(auth.credential);
@@ -42,7 +59,7 @@ export async function resolveAuth(
         resolved: {
           kind: "header",
           headers: { Authorization: `Bearer ${value}` },
-          ...(opts.baseUrl ? { baseUrl: opts.baseUrl } : {}),
+          ...(safeBaseUrl ? { baseUrl: safeBaseUrl } : {}),
         },
       };
     }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -28,8 +28,14 @@ import {
   getConnection,
   listConnections,
   MANAGED_CONNECTION_NAMES,
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   updateConnection,
 } from "../../providers/inference/connections.js";
+import {
+  isPrivateOrLocalHost,
+  resolveHostAddresses,
+  resolveRequestAddress,
+} from "../../tools/network/url-safety.js";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -59,10 +65,26 @@ function rejectDisabledOpenAICompatibleProvider(provider: string): void {
 // Custom provider field parsing (openai-compatible base_url + models)
 // ---------------------------------------------------------------------------
 
-function parseCustomProviderFields(body: Record<string, unknown>): {
+/**
+ * Parse and validate `base_url` and `models` from the request body.
+ *
+ * `base_url` is only accepted for providers in
+ * `PROVIDERS_REQUIRING_BASE_URL_AND_MODELS` (currently `openai-compatible`).
+ * For all other providers, supplying `base_url` returns a 400. This prevents
+ * API-key exfiltration: an attacker cannot create an `anthropic` connection
+ * with a `base_url` pointing to their own server, which would redirect all
+ * LLM calls (and the API key) to the attacker.
+ *
+ * Even for `openai-compatible`, the `base_url` must not point to private
+ * networks or cloud metadata endpoints (SSRF protection).
+ */
+async function parseCustomProviderFields(
+  body: Record<string, unknown>,
+  provider: string,
+): Promise<{
   baseUrl?: string | null;
   models?: ConnectionModel[] | null;
-} {
+}> {
   const out: {
     baseUrl?: string | null;
     models?: ConnectionModel[] | null;
@@ -70,11 +92,24 @@ function parseCustomProviderFields(body: Record<string, unknown>): {
 
   if ("base_url" in body) {
     const raw = body.base_url;
+
+    // Gate: base_url is only valid for openai-compatible providers.
+    if (
+      raw !== null &&
+      raw !== undefined &&
+      !PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)
+    ) {
+      throw new BadRequestError(
+        `base_url is only valid for openai-compatible providers. Remove base_url or use the openai-compatible provider type.`,
+      );
+    }
+
     if (raw === null) {
       out.baseUrl = null;
     } else if (typeof raw === "string" && raw.length > 0) {
+      let parsed: URL;
       try {
-        const parsed = new URL(raw);
+        parsed = new URL(raw);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
           throw new BadRequestError(`Invalid base_url: must be an http(s) URL`);
         }
@@ -84,6 +119,27 @@ function parseCustomProviderFields(body: Record<string, unknown>): {
           `Invalid base_url: must be a valid http(s) URL`,
         );
       }
+
+      // SSRF protection: reject private IPs, localhost, cloud metadata endpoints.
+      const hostname = parsed.hostname;
+      if (isPrivateOrLocalHost(hostname)) {
+        throw new BadRequestError(
+          `Invalid base_url: must not point to a private or local network address.`,
+        );
+      }
+
+      // DNS resolution check: hostname may resolve to a private IP.
+      const resolved = await resolveRequestAddress(
+        hostname,
+        resolveHostAddresses,
+        /* allowPrivateNetwork */ false,
+      );
+      if (resolved.blockedAddress) {
+        throw new BadRequestError(
+          `Invalid base_url: hostname resolves to a private network address.`,
+        );
+      }
+
       out.baseUrl = raw;
     } else {
       throw new BadRequestError(
@@ -145,7 +201,7 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
   return conn;
 }
 
-function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
+async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   const name = body.name;
   const provider = body.provider;
   const auth = body.auth;
@@ -186,7 +242,7 @@ function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const customFields = parseCustomProviderFields(body);
+  const customFields = await parseCustomProviderFields(body, providerResult.data);
 
   const result = createConnection(getDb(), {
     name,
@@ -224,7 +280,7 @@ function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   return result.connection;
 }
 
-function handleUpdateConnection({
+async function handleUpdateConnection({
   pathParams = {},
   body = {},
 }: RouteHandlerArgs) {
@@ -278,7 +334,7 @@ function handleUpdateConnection({
     );
   }
 
-  const customFields = parseCustomProviderFields(body);
+  const customFields = await parseCustomProviderFields(body, existing.provider);
 
   const result = updateConnection(getDb(), name, {
     auth: authResult.data,


### PR DESCRIPTION
## Summary

Closes a BYOK security vulnerability where `base_url` was accepted for all provider types, enabling two attack vectors:

- **API key exfiltration**: An attacker creates e.g. an `anthropic` connection with `base_url` pointing to their server — all LLM calls (and the API key) get redirected there.
- **SSRF**: Setting `base_url` to private-network or cloud-metadata addresses lets an attacker probe internal infrastructure from the runtime.

### Fix (three defense layers)

- **Route layer**: `parseCustomProviderFields()` rejects `base_url` with 400 for any provider other than `openai-compatible`. Even for `openai-compatible`, validates against private IPs, localhost, and cloud metadata endpoints via `isPrivateOrLocalHost()` + DNS resolution.
- **resolve-auth defense-in-depth**: Strips `baseUrl` with a warning log if the provider isn't `openai-compatible`, catching any code path that bypasses route validation (corrupted DB rows, internal calls).
- **DB migration 253**: NULLs out `base_url` on all existing non-`openai-compatible` connection rows.

Part of [ATL-611](https://linear.app/vellum/issue/ATL-611)

## Test plan

### Automated (22 new tests)

- [x] `base-url-route-validation.test.ts` — Provider-type gate:
  - Rejects `base_url` on `anthropic`, `openai`, `gemini` providers (400)
  - Accepts `base_url` on `openai-compatible` provider
  - Allows `null` / omitted `base_url` for any provider
  - Same validation on PATCH (update) path
- [x] `base-url-route-validation.test.ts` — SSRF protection:
  - Rejects `192.168.x.x`, `10.x.x.x`, `127.0.0.1`, `localhost`, `0.0.0.0`, `metadata.google.internal`
  - Rejects hostnames that DNS-resolve to private IPs
  - Accepts valid public URLs
- [x] `base-url-security.test.ts` — DB migration 253:
  - Strips `base_url` from `anthropic` connection rows
  - Preserves `base_url` on `openai-compatible` rows
  - Idempotent on re-run
- [x] `base-url-security.test.ts` — resolve-auth defense-in-depth:
  - Strips `baseUrl` for `anthropic`, `openai`, `gemini` providers
  - Preserves `baseUrl` for `openai-compatible`
  - Handles `null` gracefully

### Manual

- [ ] Start assistant locally (`velup`), create an `anthropic` provider connection with a `base_url` via the API — verify 400 response
- [ ] Create an `openai-compatible` connection with a valid public `base_url` — verify accepted
- [ ] Create an `openai-compatible` connection with `base_url: "http://localhost:1234"` — verify rejected
- [ ] Verify existing connections without `base_url` are unaffected after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)