### PR TITLE
feat(daemon): inject model profile into turn context on profile change

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -31,7 +31,10 @@ import {
   type EffectiveContextWindow,
   resolveEffectiveContextWindow,
 } from "../config/llm-context-resolution.js";
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  resolveDefaultProfileKey,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ContextWindowConfig } from "../config/types.js";
@@ -62,6 +65,7 @@ import {
   getConversationOriginInterface,
   getConversationOverrideProfileFromRow,
   getLastUserTimestampBefore,
+  setLastNotifiedInferenceProfile,
   getMessageById,
   provenanceFromTrustContext,
   updateConversationContextWindow,
@@ -1519,6 +1523,31 @@ export async function runAgentLoopImpl(
       }
     }
 
+    // Resolve the effective profile key for this turn and detect changes.
+    // Only inject model_profile into the turn context when the profile
+    // changed since the last turn (or on the first turn of a conversation)
+    // to avoid per-turn token cost.
+    const effectiveProfileKey =
+      turnOverrideProfile ??
+      config.llm.activeProfile ??
+      resolveDefaultProfileKey("mainAgent", config.llm);
+    const lastNotified = turnStartConversation?.lastNotifiedInferenceProfile;
+    let modelProfileStr: string | null = null;
+    if (effectiveProfileKey != null && effectiveProfileKey !== lastNotified) {
+      const profileEntry = config.llm.profiles?.[effectiveProfileKey];
+      const resolved = resolveCallSiteConfig(turnCallSite, config.llm, {
+        overrideProfile: turnOverrideProfile ?? undefined,
+      });
+      const label = profileEntry?.label ?? effectiveProfileKey;
+      modelProfileStr = resolved.model
+        ? `${label} (${resolved.model})`
+        : label;
+      setLastNotifiedInferenceProfile(
+        ctx.conversationId,
+        effectiveProfileKey,
+      );
+    }
+
     const baseTurnContext = {
       timestamp,
       interfaceName,
@@ -1527,6 +1556,7 @@ export async function runAgentLoopImpl(
       clientTimezone: timezoneContext.clientTimezone,
       detectedTimezone: timezoneContext.detectedTimezone,
       timeSinceLastMessage,
+      modelProfile: modelProfileStr,
     };
     const unifiedTurnContextStr = buildUnifiedTurnContextBlock(
       isGuardian

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -804,6 +804,13 @@ export interface UnifiedTurnContextOptions {
    * the model can acknowledge long absences; otherwise omitted.
    */
   timeSinceLastMessage?: string | null;
+  /**
+   * Human-readable model profile description. Only populated when the active
+   * inference profile changed since the last turn (or on the first turn of a
+   * conversation) so the model knows which profile/model it is using without
+   * paying per-turn token cost.
+   */
+  modelProfile?: string | null;
 }
 
 /**
@@ -861,6 +868,9 @@ export function buildUnifiedTurnContextBlock(
   }
   if (options.timeSinceLastMessage) {
     lines.push(`time_since_last_message: ${options.timeSinceLastMessage}`);
+  }
+  if (options.modelProfile) {
+    lines.push(`model_profile: ${options.modelProfile}`);
   }
   if (options.interfaceName) {
     lines.push(`interface: ${options.interfaceName}`);

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -206,6 +206,7 @@ export interface ConversationRow {
   inferenceProfile: string | null;
   inferenceProfileSessionId: string | null;
   inferenceProfileExpiresAt: number | null;
+  lastNotifiedInferenceProfile: string | null;
 }
 
 export const parseConversation = createRowMapper<
@@ -238,6 +239,7 @@ export const parseConversation = createRowMapper<
   inferenceProfile: "inferenceProfile",
   inferenceProfileSessionId: "inferenceProfileSessionId",
   inferenceProfileExpiresAt: "inferenceProfileExpiresAt",
+  lastNotifiedInferenceProfile: "lastNotifiedInferenceProfile",
 });
 
 export interface MessageRow {
@@ -1614,6 +1616,17 @@ export function getConversationOverrideProfile(
   conversationId: string,
 ): string | undefined {
   return getConversationOverrideProfileFromRow(getConversation(conversationId));
+}
+
+export function setLastNotifiedInferenceProfile(
+  conversationId: string,
+  profileKey: string | null,
+): void {
+  rawRun(
+    "UPDATE conversations SET last_notified_inference_profile = ? WHERE id = ?",
+    profileKey,
+    conversationId,
+  );
 }
 
 /**

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -69,6 +69,7 @@ import {
   migrateConversationForkLineage,
   migrateConversationHostAccess,
   migrateConversationInferenceProfileSession,
+  migrateConversationLastNotifiedProfile,
   migrateConversationsArchivedAt,
   migrateConversationsLastMessageAt,
   migrateConversationsThreadTypeIndex,
@@ -444,6 +445,7 @@ export function initializeDb(): void {
     migrateExternalConversationBindingChatName,
     migrateChannelInboundDeliveryAttempts,
     migrateMemoryV2InjectionEvents,
+    migrateConversationLastNotifiedProfile,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/253-conversation-last-notified-profile.ts
+++ b/assistant/src/memory/migrations/253-conversation-last-notified-profile.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateConversationLastNotifiedProfile(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN last_notified_inference_profile TEXT DEFAULT NULL`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -227,6 +227,7 @@ export {
   downMemoryV2InjectionEvents,
   migrateMemoryV2InjectionEvents,
 } from "./256-memory-v2-injection-events.js";
+export { migrateConversationLastNotifiedProfile } from "./253-conversation-last-notified-profile.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -41,6 +41,7 @@ export const conversations = sqliteTable(
     inferenceProfile: text("inference_profile"),
     inferenceProfileSessionId: text("inference_profile_session_id"),
     inferenceProfileExpiresAt: integer("inference_profile_expires_at"),
+    lastNotifiedInferenceProfile: text("last_notified_inference_profile"),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),


### PR DESCRIPTION
## Summary

- When a user switches inference profiles mid-conversation, the assistant now knows about it. A `model_profile` line is injected into the `<turn_context>` block on the first turn of a conversation and whenever the effective profile changes.
- Zero extra tokens on steady-state turns — only fires when the profile actually changes, per Sidd's suggestion to avoid per-turn cost.
- New `last_notified_inference_profile` column on conversations tracks what the model was last told.

Fixes the bug reported in [Slack](https://vellumai.slack.com/archives/C0AE1L81FS8/p1779193508459959) where the assistant reports the wrong active profile after a mid-conversation switch.

## Test plan

- [ ] **First turn notification**: Start a new conversation and ask "What model profile are you using?" — the assistant should correctly report the active profile (e.g. "Balanced (claude-sonnet-4-6)")
- [ ] **Steady state (no extra tokens)**: Send several messages in the same conversation without changing the profile. Inspect the LLM context via `/v1/messages/:id/llm-context` — `model_profile` should NOT appear in `<turn_context>` on subsequent turns
- [ ] **Mid-conversation switch**: In an active conversation, use the profile picker (⋮ menu / chat input dropdown) to switch to a different profile (e.g. "Quality"). On the next message, ask what model/profile is being used — the assistant should report the new profile. Verify `model_profile` appears in that turn's `<turn_context>`
- [ ] **Workspace default change**: Change the workspace-wide active profile in Settings → Models & Services. Start a new message in an existing conversation (that was on the old default). The assistant should report the new default profile
- [ ] **Session-based profile override**: Use a profile session (TTL-based override) and verify the notification fires when the session opens and when it expires (reverting to the previous profile)
- [ ] **Migration idempotency**: Restart the daemon twice — the migration should not error on the second boot (column already exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)