### PR TITLE
feat(agent-wake): add suppressWakeSurface option to skip the "Conversation Woke" card

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1587,4 +1587,130 @@ describe("wakeAgentForOpportunity", () => {
     // No log row was inserted because JSON.stringify threw.
     expect(recordRequestLogCalls).toHaveLength(0);
   });
+
+  describe("suppressWakeSurface option", () => {
+    function makeCheckpointTarget(): {
+      target: WakeTarget;
+      persistedTailCalls: Message[];
+      wakeProducedOutputCalls: string[];
+    } {
+      const firstAssistant: Message = {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu-1", name: "some_tool", input: {} },
+        ],
+      };
+      const toolResult: Message = {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "tu-1", content: "ok" }],
+      };
+      const persistedTailCalls: Message[] = [];
+      const baseline: Message[] = [
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ];
+      const history: Message[] = [...baseline];
+      let processing = false;
+      const wakeProducedOutputCalls: string[] = [];
+
+      const target: WakeTarget = {
+        conversationId: "conv-suppress-surface",
+        agentLoop: {
+          run: async (_input, _onEvent, _signal, _requestId, onCheckpoint) => {
+            const runHistory: Message[] = [..._input];
+            runHistory.push(firstAssistant);
+            runHistory.push(toolResult);
+            await onCheckpoint!({
+              turnIndex: 0,
+              toolCount: 1,
+              hasToolUse: true,
+              history: runHistory,
+            });
+            return runHistory;
+          },
+        },
+        getMessages: () => history,
+        pushMessage: (msg) => {
+          history.push(msg);
+        },
+        emitAgentEvent: () => {},
+        isProcessing: () => processing,
+        markProcessing: (on) => {
+          processing = on;
+        },
+        persistTailMessage: async (msg) => {
+          persistedTailCalls.push(msg);
+        },
+        onWakeProducedOutput: (_source, _hint, surfaceId) => {
+          wakeProducedOutputCalls.push(surfaceId);
+        },
+      };
+      return { target, persistedTailCalls, wakeProducedOutputCalls };
+    }
+
+    test(
+      "default (suppressWakeSurface omitted) still injects the ui_surface " +
+        "card and calls onWakeProducedOutput",
+      async () => {
+        const { target, persistedTailCalls, wakeProducedOutputCalls } =
+          makeCheckpointTarget();
+
+        await wakeAgentForOpportunity(
+          {
+            conversationId: "conv-suppress-surface",
+            hint: "do the thing",
+            source: "memory_v2_consolidation",
+          },
+          { resolveTarget: async () => target },
+        );
+
+        // Existing behavior: card injected, broadcast fired exactly once.
+        expect(wakeProducedOutputCalls).toHaveLength(1);
+        const persistedFirst = persistedTailCalls[0];
+        expect(persistedFirst).toBeDefined();
+        const blocks = Array.isArray(persistedFirst!.content)
+          ? persistedFirst!.content
+          : [];
+        const uiBlock = blocks.find(
+          (b: { type?: string }) => b.type === "ui_surface",
+        );
+        expect(uiBlock).toBeDefined();
+      },
+    );
+
+    test(
+      "suppressWakeSurface: true produces output but skips the ui_surface " +
+        "card injection and the onWakeProducedOutput broadcast",
+      async () => {
+        const { target, persistedTailCalls, wakeProducedOutputCalls } =
+          makeCheckpointTarget();
+
+        await wakeAgentForOpportunity(
+          {
+            conversationId: "conv-suppress-surface",
+            hint: "do the thing",
+            source: "memory_v2_consolidation",
+            suppressWakeSurface: true,
+          },
+          { resolveTarget: async () => target },
+        );
+
+        // Tail still persisted (wake produced real output).
+        const persistedFirst = persistedTailCalls[0];
+        expect(persistedFirst).toBeDefined();
+        // First assistant tail message should NOT have a ui_surface block
+        // prepended at the front.
+        const blocks = Array.isArray(persistedFirst!.content)
+          ? persistedFirst!.content
+          : [];
+        const firstBlock = blocks[0] as { type?: string } | undefined;
+        expect(firstBlock?.type).not.toBe("ui_surface");
+        const uiBlock = blocks.find(
+          (b: { type?: string }) => b.type === "ui_surface",
+        );
+        expect(uiBlock).toBeUndefined();
+        // Live broadcast was suppressed.
+        expect(wakeProducedOutputCalls).toHaveLength(0);
+      },
+    );
+  });
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -229,6 +229,15 @@ export interface WakeOptions {
    * forked conversation before waking). When `true`, `hint` is ignored.
    */
   skipHintInjection?: boolean;
+  /**
+   * Skip injection of the "Conversation Woke" `ui_surface` card into the
+   * first assistant tail message and the corresponding live
+   * `onWakeProducedOutput` broadcast. Default false (existing behavior).
+   * Used by callers whose conversation context already makes it obvious
+   * that the agent's output came from a wake (e.g. fork-based memory
+   * retrospectives whose conversation title already says "(Retrospective)").
+   */
+  suppressWakeSurface?: boolean;
 }
 
 /**
@@ -714,26 +723,28 @@ export async function wakeAgentForOpportunity(
     const goLive = (currentHistory: Message[]): void => {
       if (mode === "live") return;
       if (!surfaceInjected) {
-        const tailStart = baselineLength + wakeHintMessageCount;
-        const tail = currentHistory.slice(tailStart);
-        const firstAssistant = tail.find((m) => m.role === "assistant");
-        if (firstAssistant && Array.isArray(firstAssistant.content)) {
-          firstAssistant.content.unshift({
-            type: "ui_surface",
-            surfaceId: wakeSurfaceId,
-            surfaceType: "card",
-            title: "Conversation Woke",
-            data: {
+        if (!opts.suppressWakeSurface) {
+          const tailStart = baselineLength + wakeHintMessageCount;
+          const tail = currentHistory.slice(tailStart);
+          const firstAssistant = tail.find((m) => m.role === "assistant");
+          if (firstAssistant && Array.isArray(firstAssistant.content)) {
+            firstAssistant.content.unshift({
+              type: "ui_surface",
+              surfaceId: wakeSurfaceId,
+              surfaceType: "card",
               title: "Conversation Woke",
-              body: hint,
-              metadata: [{ label: "Source", value: source }],
-            },
-            display: "inline",
-          } as never);
+              data: {
+                title: "Conversation Woke",
+                body: hint,
+                metadata: [{ label: "Source", value: source }],
+              },
+              display: "inline",
+            } as never);
+          }
         }
         surfaceInjected = true;
       }
-      if (target.onWakeProducedOutput) {
+      if (!opts.suppressWakeSurface && target.onWakeProducedOutput) {
         try {
           target.onWakeProducedOutput(source, hint, wakeSurfaceId);
         } catch (err) {
@@ -959,6 +970,7 @@ export async function wakeAgentForOpportunity(
 
       const durationMs = nowFn() - startedAt;
       const suppressAutoCompaction = opts.suppressAutoCompaction === true;
+      const suppressWakeSurface = opts.suppressWakeSurface === true;
       if (runError) {
         log.error(
           {
@@ -966,6 +978,7 @@ export async function wakeAgentForOpportunity(
             source,
             durationMs,
             suppressAutoCompaction,
+            suppressWakeSurface,
             hintRole,
             err: runError,
           },
@@ -978,6 +991,7 @@ export async function wakeAgentForOpportunity(
             conversationId,
             durationMs,
             suppressAutoCompaction,
+            suppressWakeSurface,
             hintRole,
             producedToolCalls: false,
             toolNamesCalled: [],
@@ -991,6 +1005,7 @@ export async function wakeAgentForOpportunity(
             conversationId,
             durationMs,
             suppressAutoCompaction,
+            suppressWakeSurface,
             hintRole,
             producedToolCalls,
             toolNamesCalled: toolUseNames,


### PR DESCRIPTION
## Summary
- New WakeOptions.suppressWakeSurface flag (default false)
- When true, skips both the ui_surface card injection into the assistant tail and the onWakeProducedOutput broadcast

Part of plan: fix-fork-retro.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->