### PR TITLE
feat(memory): allow forkConversation to override conversationType and groupId

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -49,6 +49,7 @@ import {
   getRetrospectiveState,
   upsertRetrospectiveState,
 } from "../memory/memory-retrospective-state.js";
+import { rawGet, rawRun } from "../memory/raw-query.js";
 import {
   activationState,
   channelInboundEvents,
@@ -659,6 +660,58 @@ describe("forkConversation", () => {
 
     expect(await hydrateActivationState(db, fork.id)).toBeNull();
     expect(loadGraphMemoryState(fork.id)).toBeNull();
+  });
+
+  test("defaults conversationType to standard and inherits the parent's group", async () => {
+    const source = createConversation("Default inheritance thread");
+    await addMessage(source.id, "user", "first message", undefined, {
+      skipIndexing: true,
+    });
+    rawRun(
+      "UPDATE conversations SET group_id = ? WHERE id = ?",
+      "system:pinned",
+      source.id,
+    );
+
+    const fork = forkConversation({ conversationId: source.id });
+    const row = getDb()
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, fork.id))
+      .get();
+    const groupIdRow = rawGet<{ group_id: string | null }>(
+      "SELECT group_id FROM conversations WHERE id = ?",
+      fork.id,
+    );
+
+    expect(row?.conversationType).toBe("standard");
+    expect(groupIdRow?.group_id).toBe("system:pinned");
+  });
+
+  test("honors conversationType and groupId overrides on the fork", async () => {
+    const source = createConversation("Override thread");
+    await addMessage(source.id, "user", "first message", undefined, {
+      skipIndexing: true,
+    });
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      conversationType: "background",
+      groupId: "system:background",
+    });
+
+    const row = getDb()
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, fork.id))
+      .get();
+    const groupIdRow = rawGet<{ group_id: string | null }>(
+      "SELECT group_id FROM conversations WHERE id = ?",
+      fork.id,
+    );
+
+    expect(row?.conversationType).toBe("background");
+    expect(groupIdRow?.group_id).toBe("system:background");
   });
 
   test("copies memory state when throughMessageId points at the last message", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -547,6 +547,20 @@ export function forkConversation(params: {
    * Optional title for the fork. Defaults to `<parent title> (Fork)`.
    */
   title?: string;
+  /**
+   * Override the fork's `conversationType` column. Defaults to `"standard"`.
+   * Used by fork-based memory retrospectives to bucket the fork as a
+   * `"background"` conversation so it doesn't surface in the user's
+   * conversation list.
+   */
+  conversationType?: ConversationCreateType;
+  /**
+   * Override the fork's `groupId`. Defaults to the parent conversation's
+   * group (or `"system:all"` when the parent has none). Used by fork-based
+   * memory retrospectives to route the fork into a dedicated background
+   * group.
+   */
+  groupId?: string;
 }): ConversationRow {
   const { conversationId, throughMessageId } = params;
   const db = getDb();
@@ -610,8 +624,8 @@ export function forkConversation(params: {
   const forkedConversation = db.transaction(() => {
     const fc = createConversation({
       title: forkTitle,
-      conversationType: "standard",
-      groupId: parentGroupId ?? "system:all",
+      conversationType: params.conversationType ?? "standard",
+      groupId: params.groupId ?? parentGroupId ?? "system:all",
       ...(params.source != null ? { source: params.source } : {}),
     });
 


### PR DESCRIPTION
## Summary
- Extend forkConversation params with optional conversationType and groupId
- Defaults preserve existing behavior (standard / inherited parent group)

Part of plan: fix-fork-retro.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->