### PR TITLE
feat(messages): hide messages with metadata.hidden from UI list serializer

### DIFF
--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for handleListMessages metadata.hidden filtering.
+ *
+ * Messages persisted with `metadata: { hidden: true }` (e.g. internal
+ * scaffolding like retrospective instructions) must be omitted from the
+ * UI history list while remaining visible to the LLM-side history loader.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  getMessages,
+} from "../memory/conversation-crud.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+interface MessagePayload {
+  role: string;
+  content: string;
+}
+
+describe("handleListMessages metadata.hidden filtering", () => {
+  beforeEach(resetTables);
+
+  test("UI serializer omits hidden messages but LLM-side getMessages includes them", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "first visible" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "internal scaffolding" }]),
+      { hidden: true },
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "second visible" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].content).toBe("first visible");
+    expect(body.messages[1].content).toBe("second visible");
+    expect(
+      body.messages.some((m) => m.content.includes("internal scaffolding")),
+    ).toBe(false);
+
+    // LLM-side loader must include the hidden row so agent context is intact.
+    const llmRows = getMessages(conv.id);
+    expect(llmRows).toHaveLength(3);
+    expect(llmRows[1].metadata).toContain('"hidden":true');
+  });
+
+  test("messages without metadata or with hidden=false are returned", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "no metadata" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "hidden false" }]),
+      { hidden: false },
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(2);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -138,6 +138,21 @@ function isValidRiskThreshold(value: unknown): value is RiskThreshold {
   );
 }
 
+/**
+ * True when a message's persisted metadata explicitly flags it as hidden.
+ * Used to suppress internal scaffolding messages from UI history while
+ * leaving them in the LLM-side context.
+ */
+function isHiddenMessage(metadata: string | null): boolean {
+  if (!metadata) return false;
+  try {
+    const meta = JSON.parse(metadata) as { hidden?: unknown };
+    return meta?.hidden === true;
+  } catch {
+    return false;
+  }
+}
+
 function buildSlackHistoryMessage(
   slackMeta: SlackMessageMetadata | null,
 ): RuntimeMessagePayload["slackMessage"] | undefined {
@@ -458,6 +473,13 @@ export function handleListMessages({
   } else {
     rawMessages = getMessages(resolvedConversationId);
   }
+
+  // Drop messages flagged as hidden in metadata (e.g. internal scaffolding
+  // like retrospective instructions). The LLM-side history loader
+  // (`getMessages` in memory/conversation-crud.ts) intentionally does not
+  // filter — hidden messages remain in agent context but are suppressed from
+  // the UI list.
+  rawMessages = rawMessages.filter((m) => !isHiddenMessage(m.metadata));
 
   // During streaming, tool_use (assistant) and tool_result (user) events are
   // assembled client-side into a single assistant ChatMessage. On reload, they


### PR DESCRIPTION
## Summary
- Message-list HTTP serializer now filters out messages with metadata.hidden === true
- LLM-side getMessages() is unaffected — hidden messages remain in agent context
- Enables UI suppression of internal scaffolding messages (e.g. retrospective instructions)

Part of plan: fix-fork-retro.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->