### PR TITLE
Fix transient waking modal flash

### DIFF
--- a/apps/web/src/domains/assistant/use-assistant-reachability.test.ts
+++ b/apps/web/src/domains/assistant/use-assistant-reachability.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  shouldDeferReachabilityOverlay,
+  shouldFailReachabilityImmediately,
+} from "@/domains/assistant/use-assistant-reachability.js";
+import type { ConnectionStatus } from "@/generated/api/index.js";
+
+function fakeResponse(
+  overrides: Partial<ConnectionStatus> = {},
+): ConnectionStatus {
+  return {
+    state: "waking",
+    is_awake: false,
+    pod_status: null,
+    waking_since: null,
+    last_ready_at: null,
+    crash_loop_since: null,
+    detail: null,
+    ...overrides,
+  };
+}
+
+describe("assistant reachability", () => {
+  test("fails immediately for crash-looping pods", () => {
+    expect(shouldFailReachabilityImmediately("crash_loop")).toBe(true);
+  });
+
+  test("does not fail immediately for transient states", () => {
+    expect(shouldFailReachabilityImmediately("ready")).toBe(false);
+    expect(shouldFailReachabilityImmediately("waking")).toBe(false);
+    expect(shouldFailReachabilityImmediately("unreachable")).toBe(false);
+  });
+
+  test("fails immediately when state is waking but crash_loop_since is set", () => {
+    const response = fakeResponse({
+      state: "waking",
+      crash_loop_since: "2026-01-01T00:00:00Z",
+    });
+    expect(shouldFailReachabilityImmediately("waking", response)).toBe(true);
+  });
+
+  test("does not fail for waking when crash_loop_since is null", () => {
+    const response = fakeResponse({ state: "waking", crash_loop_since: null });
+    expect(shouldFailReachabilityImmediately("waking", response)).toBe(false);
+  });
+
+  test("does not fail for unreachable even when crash_loop_since is set", () => {
+    const response = fakeResponse({
+      state: "unreachable",
+      crash_loop_since: "2026-01-01T00:00:00Z",
+    });
+    expect(
+      shouldFailReachabilityImmediately("unreachable", response),
+    ).toBe(false);
+  });
+
+  test("does not fail for not_found even when crash_loop_since is set", () => {
+    const response = fakeResponse({
+      state: "not_found",
+      crash_loop_since: "2026-01-01T00:00:00Z",
+    });
+    expect(
+      shouldFailReachabilityImmediately("not_found", response),
+    ).toBe(false);
+  });
+
+  test("defers only the first silent probe response", () => {
+    expect(
+      shouldDeferReachabilityOverlay({
+        probeResponseCount: 1,
+        silentGracePeriod: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferReachabilityOverlay({
+        probeResponseCount: 2,
+        silentGracePeriod: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferReachabilityOverlay({
+        probeResponseCount: 1,
+        silentGracePeriod: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/domains/assistant/use-assistant-reachability.ts
+++ b/apps/web/src/domains/assistant/use-assistant-reachability.ts
@@ -1,8 +1,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { assistantsConnectionStatus } from "@/generated/api/index.js";
-import type { AssistantsConnectionStatusResponse, ConnectionStatus } from "@/generated/api/index.js";
+import {
+  assistantsConnectionStatus,
+  type AssistantsConnectionStatusResponse,
+  type ConnectionStatus,
+} from "@/generated/api/index.js";
 import { subscribeAssistantUnreachable } from "@/domains/assistant/unreachable-bus.js";
 
 /**
@@ -85,6 +88,16 @@ export function shouldFailReachabilityImmediately(
   return false;
 }
 
+export function shouldDeferReachabilityOverlay({
+  probeResponseCount,
+  silentGracePeriod,
+}: {
+  probeResponseCount: number;
+  silentGracePeriod: boolean;
+}): boolean {
+  return silentGracePeriod && probeResponseCount === 1;
+}
+
 export function useAssistantReachability(
   assistantId: string | null,
 ): UseAssistantReachabilityResult {
@@ -93,6 +106,7 @@ export function useAssistantReachability(
   const startedAtRef = useRef<number>(0);
   const attemptsRef = useRef<number>(0);
   const generationRef = useRef<number>(0);
+  const probeResponsesRef = useRef<number>(0);
   const readyAtRef = useRef<number>(0);
   const dismissedAtRef = useRef<number>(0);
   const activeAssistantIdRef = useRef<string | null>(null);
@@ -118,6 +132,7 @@ export function useAssistantReachability(
     clearTimer();
     generationRef.current += 1;
     attemptsRef.current = 0;
+    probeResponsesRef.current = 0;
     startedAtRef.current = 0;
     readyAtRef.current = 0;
     dismissedAtRef.current = Date.now();
@@ -150,6 +165,8 @@ export function useAssistantReachability(
         return;
       }
 
+      const probeResponseCount = probeResponsesRef.current + 1;
+      probeResponsesRef.current = probeResponseCount;
       const serverState = response?.state ?? "unreachable";
       const isPodWaking = serverState === "waking";
       const elapsed = Date.now() - startedAtRef.current;
@@ -198,12 +215,15 @@ export function useAssistantReachability(
         return;
       }
 
-      // When the probe was triggered by the unreachable bus (silent
-      // grace period), suppress the connecting overlay for the first
-      // probe. This absorbs brief transient blips — e.g. a container
-      // restart that resolves within seconds — so the user is never
-      // shown a "Connecting" modal for a momentary hiccup.
-      if (options.silentGracePeriod && attemptsRef.current <= 1 && !isPodWaking) {
+      // Silent probes are used for proactive/background checks. Suppress the
+      // first non-ready result, including a one-off "waking" response, so a
+      // transient PENDING pod observation does not flash the modal.
+      if (
+        shouldDeferReachabilityOverlay({
+          probeResponseCount,
+          silentGracePeriod: options.silentGracePeriod,
+        })
+      ) {
         timerRef.current = setTimeout(() => {
           void runProbeRef.current(generation, options);
         }, RECHECK_INTERVAL_MS);
@@ -239,6 +259,7 @@ export function useAssistantReachability(
     clearTimer();
     generationRef.current += 1;
     attemptsRef.current = 0;
+    probeResponsesRef.current = 0;
     startedAtRef.current = Date.now();
     activeAssistantIdRef.current = assistantId;
     probingRef.current = true;
@@ -251,9 +272,11 @@ export function useAssistantReachability(
         lastServerState: null,
       });
     }
+    const silentGracePeriod =
+      options?.silentGracePeriod ?? !showConnectingImmediately;
     void runProbe(generationRef.current, {
       keepIdleOnReady: !showConnectingImmediately,
-      silentGracePeriod: options?.silentGracePeriod ?? false,
+      silentGracePeriod,
     });
   }, [assistantId, clearTimer, runProbe]);
 
@@ -265,6 +288,7 @@ export function useAssistantReachability(
       clearTimer();
       generationRef.current += 1;
       attemptsRef.current = 0;
+      probeResponsesRef.current = 0;
       startedAtRef.current = 0;
       activeAssistantIdRef.current = null;
       probingRef.current = false;


### PR DESCRIPTION
## Summary
- Debounce silent reachability probes by one response, including transient `waking` results, before opening the overlay.
- Track probe response count separately from retry attempts so `waking` polls do not bypass the silent grace period.
- Add coverage for the reachability crash-loop and silent-deferral helpers in the migrated web app.

## Original prompt
The user reported in the platform repo that the "assistant is waking up" modal sometimes flashes even when the assistant is not actually asleep or waking. The migrated web app has the same reachability hook, so this companion PR applies the same one-poll silent grace behavior to prevent a transient `PENDING`/`waking` response from flashing the modal before the next ready probe closes it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->