### PR TITLE
fix(memory): hide retrospective instruction message from UI

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -38,6 +38,15 @@ let bootstrappedConversationId = "bg-conv-new";
 let bootstrapCalls: Array<{ forkParentConversationId?: string }> = [];
 let deletedConversationIds: string[] = [];
 
+// Fork-path mocks. Flag off by default so legacy-path tests stay untouched.
+let forkFlagEnabled = false;
+let forkedConversationId = "fork-conv-1";
+let addMessageCalls: Array<{
+  conversationId: string;
+  role: string;
+  metadata: unknown;
+}> = [];
+
 mock.module("../memory-retrospective-state.js", () => ({
   getRetrospectiveState: (_id: string) => mockState,
   upsertRetrospectiveState: (args: {
@@ -67,18 +76,23 @@ mock.module("../conversation-crud.js", () => ({
     source: "memory-retrospective",
     forkParentMessageId: null,
   }),
-  // Imported by `runForkBasedRetrospective`; legacy-path tests never hit it.
-  forkConversation: (_params: unknown) => {
-    throw new Error(
-      "forkConversation should not be called in legacy-path tests",
-    );
-  },
-  addMessage: async () => {
-    throw new Error("addMessage should not be called in legacy-path tests");
+  forkConversation: (_params: unknown) => ({ id: forkedConversationId }),
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    _content: string,
+    metadata: unknown,
+  ) => {
+    addMessageCalls.push({ conversationId, role, metadata });
   },
   deleteConversation: (id: string) => {
     deletedConversationIds.push(id);
   },
+}));
+
+mock.module("../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (flag: string) =>
+    flag === "memory-retrospective-fork" && forkFlagEnabled,
 }));
 
 let transcriptFormatterCalls: Array<{
@@ -216,6 +230,9 @@ describe("memoryRetrospectiveJob", () => {
     transcriptFormatterCalls = [];
     mockAssistantName = "Bob";
     mockUserName = "Alice";
+    forkFlagEnabled = false;
+    forkedConversationId = "fork-conv-1";
+    addMessageCalls = [];
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -423,5 +440,18 @@ describe("memoryRetrospectiveJob", () => {
 
     const hint = wakeCalls[0]!.hint;
     expect(hint).toContain("<\u200B/already_remembered>");
+  });
+
+  test("fork path: persisted instruction is stamped with hidden: true so the UI list serializer drops it", async () => {
+    forkFlagEnabled = true;
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0]!.conversationId).toBe("fork-conv-1");
+    expect(addMessageCalls[0]!.role).toBe("user");
+    expect(addMessageCalls[0]!.metadata).toEqual({
+      kind: "memory_retrospective_instruction",
+      hidden: true,
+    });
   });
 });

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -368,7 +368,7 @@ async function runForkBasedRetrospective(
       forkId,
       "user",
       JSON.stringify([{ type: "text", text: instruction }]),
-      { kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND },
+      { kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND, hidden: true },
       { skipIndexing: true },
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
- Stamp hidden: true on the persisted retrospective instruction metadata
- UI list serializer (from PR 6) now drops it; LLM still sees it as the last user message

Part of plan: fix-fork-retro.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->