### PR TITLE
fix(home-feed): point "Go to Thread" at the source conversation

### DIFF
--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -106,7 +106,12 @@ export interface FeedItem {
   actions?: FeedAction[];
   /** Visual urgency treatment — controls badge color independently of sort priority. */
   urgency?: FeedItemUrgency;
-  /** Optional conversation this feed item is associated with. */
+  /**
+   * Source conversation that emitted this notification, when known. Used by
+   * the "Go to Thread" affordance in the detail panel. Omitted when the
+   * source context is not a navigable conversation (scheduler job ids,
+   * watcher event ids, CLI tool-call ids).
+   */
   conversationId?: string;
   /** Server-driven detail panel descriptor; when present, the client opens this panel kind. */
   detailPanel?: FeedItemDetailPanel;

--- a/assistant/src/notifications/__tests__/emit-signal-home-feed.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-home-feed.test.ts
@@ -159,7 +159,10 @@ describe("emitNotificationSignal home-feed wire-up", () => {
     expect(appended.id).toBe(`notif:${result.signalId}`);
     expect(appended.title).toBe("Background job done");
     expect(appended.summary).toBe("Summary of what happened.");
-    expect(appended.conversationId).toBe("conv-vellum-1");
+    // The feed item's conversationId points to the source conversation
+    // that emitted the signal, not the conversation the notification
+    // pipeline spawned to handle it.
+    expect(appended.conversationId).toBe("conv-source-1");
   });
 
   test("interactive standard conversation does NOT trigger appendFeedItem", async () => {

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { FeedItem } from "../../home/feed-types.js";
 import type { NotificationSignal } from "../signal.js";
-import type {
-  NotificationDecision,
-  NotificationDeliveryResult,
-} from "../types.js";
+import type { NotificationDecision } from "../types.js";
 
 // ── Module mocks ───────────────────────────────────────────────────────
 //
@@ -97,7 +94,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(conversationLookups).toEqual(["conv-source-1"]);
     expect(item).not.toBeNull();
@@ -114,6 +111,10 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appended.title).toBe("Background job done");
     expect(appended.summary).toBe("Summary of what happened.");
     expect(appended.urgency).toBe("medium");
+    // The button in the home detail panel navigates to the source
+    // conversation that emitted the notification, not the conversation the
+    // notification pipeline spawned to handle it.
+    expect(appended.conversationId).toBe("conv-source-1");
     expect(typeof appended.timestamp).toBe("string");
     expect(appended.createdAt).toBe(appended.timestamp);
   });
@@ -129,15 +130,16 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).toBeNull();
     expect(appendCalls).toHaveLength(0);
   });
 
   test("isAsyncBackground hint writes even when sourceContextId does not resolve", async () => {
-    // No conversation row matches; the conversation lookup is bypassed
-    // entirely because the hint short-circuits the filter.
+    // Source lookup throws — treated as non-navigable, so the item lands
+    // without a `conversationId` and the "Go to Thread" button hides on the
+    // client. The async-background hint still forces the mirror.
     conversationLookupShouldThrow = true;
     const signal = makeSignal({
       sourceContextId: "not-a-conversation-id",
@@ -154,21 +156,22 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
     expect(appendCalls[0]!.urgency).toBe("high");
-    // The async-background short-circuit must not consult the conversation store.
-    expect(conversationLookups).toHaveLength(0);
+    expect(appendCalls[0]!.conversationId).toBeUndefined();
+    expect(conversationLookups).toEqual(["not-a-conversation-id"]);
   });
 
   test("assistant_tool source mirrors to the home feed even without a background conversation or async hint", async () => {
     // Regression: the `notifications send` CLI/skill emits with
     // `sourceChannel: "assistant_tool"`, a synthetic `cli-<ts>` source
     // context id that does not resolve to a conversation, and
-    // `isAsyncBackground: false`. Before the fix, `shouldMirrorToHomeFeed`
-    // returned `false` for this shape and the Inbox stayed empty.
+    // `isAsyncBackground: false`. The assistant_tool channel forces the
+    // mirror; the source-id lookup misses so the item lands without a
+    // `conversationId` and the "Go to Thread" button hides on the client.
     conversationRow = null;
     const signal = makeSignal({
       sourceChannel: "assistant_tool",
@@ -188,47 +191,42 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
     expect(appendCalls[0]!.title).toBe("Shared from CLI");
     expect(appendCalls[0]!.noteworthy).toBe(true);
-    // The assistant_tool short-circuit must not consult the conversation store.
-    expect(conversationLookups).toHaveLength(0);
+    expect(appendCalls[0]!.conversationId).toBeUndefined();
+    expect(conversationLookups).toEqual(["cli-12345"]);
   });
 
-  test("vellum delivery result conversationId propagates onto the feed item", async () => {
-    conversationRow = { conversationType: "background" };
-    const signal = makeSignal();
+  test("source conversation id does not propagate when the lookup misses", async () => {
+    // When `sourceContextId` does not resolve to a real conversation row
+    // (e.g. scheduler job id, watcher event id), the item is still mirrored
+    // via the `isAsyncBackground` hint but `conversationId` stays undefined
+    // so the client hides the "Go to Thread" affordance.
+    conversationRow = null;
+    const signal = makeSignal({
+      sourceContextId: "scheduler-job-42",
+      attentionHints: {
+        requiresAction: false,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+    });
     const decision = makeDecision({
       renderedCopy: {
         vellum: { title: "Routed title", body: "Routed body" },
       },
     });
-    const deliveryResults: NotificationDeliveryResult[] = [
-      {
-        channel: "telegram",
-        destination: "chat-1",
-        status: "sent",
-        conversationId: "conv-telegram-1",
-      },
-      {
-        channel: "vellum",
-        destination: "vellum-client",
-        status: "sent",
-        conversationId: "conv-vellum-1",
-      },
-    ];
 
-    const item = await writeHomeFeedItemForSignal(
-      signal,
-      decision,
-      deliveryResults,
-    );
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
-    expect(item?.conversationId).toBe("conv-vellum-1");
-    expect(appendCalls[0]!.conversationId).toBe("conv-vellum-1");
+    expect(item?.conversationId).toBeUndefined();
+    expect(appendCalls[0]!.conversationId).toBeUndefined();
+    expect(conversationLookups).toEqual(["scheduler-job-42"]);
   });
 
   test("returns null and does not write when no rendered copy or payload title/body is present", async () => {
@@ -238,7 +236,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: {},
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).toBeNull();
     expect(appendCalls).toHaveLength(0);
@@ -251,7 +249,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Real title" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).toBeNull();
     expect(appendCalls).toHaveLength(0);
@@ -268,7 +266,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { body: "Real body" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -294,7 +292,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -314,7 +312,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).toBeNull();
     expect(appendCalls).toHaveLength(0);
@@ -340,7 +338,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -372,7 +370,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -400,7 +398,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+    const item = await writeHomeFeedItemForSignal(signal, decision);
 
     expect(item).toBeNull();
     expect(appendCalls).toHaveLength(0);
@@ -423,7 +421,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
@@ -438,7 +436,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Payload title", body: "Payload body" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item).not.toBeNull();
     expect(item?.title).toBe("Payload title");
@@ -456,7 +454,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Tool share", body: "Body" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(true);
     expect(appendCalls[0]!.noteworthy).toBe(true);
@@ -470,7 +468,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Tool share", body: "Body" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.fromAssistant).toBe(true);
     expect(appendCalls[0]!.fromAssistant).toBe(true);
@@ -484,7 +482,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Reminder", body: "Time to do thing" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.fromAssistant).toBe(false);
     expect(appendCalls[0]!.fromAssistant).toBe(false);
@@ -498,7 +496,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Reminder", body: "Time to do thing" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(false);
     expect(appendCalls[0]!.noteworthy).toBe(false);
@@ -512,7 +510,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Question", body: "Approve?" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(true);
     expect(appendCalls[0]!.noteworthy).toBe(true);
@@ -532,7 +530,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(true);
     expect(appendCalls[0]!.noteworthy).toBe(true);
@@ -552,7 +550,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(false);
     expect(appendCalls[0]!.noteworthy).toBe(false);
@@ -578,7 +576,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(false);
     expect(appendCalls[0]!.noteworthy).toBe(false);
@@ -600,7 +598,7 @@ describe("writeHomeFeedItemForSignal", () => {
       },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(true);
     expect(appendCalls[0]!.noteworthy).toBe(true);
@@ -614,7 +612,7 @@ describe("writeHomeFeedItemForSignal", () => {
       contextPayload: { title: "Credential expired", body: "Reconnect" },
     });
 
-    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
 
     expect(item?.noteworthy).toBe(true);
     expect(appendCalls[0]!.noteworthy).toBe(true);

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -388,11 +388,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     // Step 5: Mirror background-origin signals into the home activity feed.
     // The helper itself decides whether to write (background filter); we
     // catch and log so a feed-write failure cannot poison the dispatch result.
-    await writeHomeFeedItemForSignal(
-      signal,
-      decision,
-      dispatchResult.deliveryResults,
-    ).catch((err) => {
+    await writeHomeFeedItemForSignal(signal, decision).catch((err) => {
       log.warn({ err, signalId }, "writeHomeFeedItemForSignal threw");
     });
 

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -22,11 +22,7 @@ import { getConversation } from "../memory/conversation-crud.js";
 import { isBackgroundConversationType } from "../memory/conversation-types.js";
 import { getLogger } from "../util/logger.js";
 import type { NotificationSignal } from "./signal.js";
-import type {
-  NotificationDecision,
-  NotificationDeliveryResult,
-  RenderedChannelCopy,
-} from "./types.js";
+import type { NotificationDecision, RenderedChannelCopy } from "./types.js";
 
 const log = getLogger("home-feed-side-effect");
 
@@ -48,9 +44,9 @@ const FEED_ITEM_URGENCIES: ReadonlySet<string> = new Set<FeedItemUrgency>([
 export async function writeHomeFeedItemForSignal(
   signal: NotificationSignal,
   decision: NotificationDecision,
-  deliveryResults: NotificationDeliveryResult[],
 ): Promise<FeedItem | null> {
-  if (!shouldMirrorToHomeFeed(signal)) return null;
+  const { mirror, sourceConversationId } = resolveHomeFeedMirror(signal);
+  if (!mirror) return null;
 
   const renderedCopy =
     decision.renderedCopy.vellum ??
@@ -77,9 +73,6 @@ export async function writeHomeFeedItemForSignal(
     return null;
   }
 
-  const conversationId = deliveryResults.find(
-    (r) => r.channel === "vellum",
-  )?.conversationId;
   const urgency = FEED_ITEM_URGENCIES.has(signal.attentionHints.urgency)
     ? (signal.attentionHints.urgency as FeedItemUrgency)
     : undefined;
@@ -107,7 +100,7 @@ export async function writeHomeFeedItemForSignal(
     noteworthy: deriveNoteworthy(signal),
     fromAssistant: signal.sourceChannel === "assistant_tool",
     ...(urgency ? { urgency } : {}),
-    ...(conversationId ? { conversationId } : {}),
+    ...(sourceConversationId ? { conversationId: sourceConversationId } : {}),
     ...(panelKind ? { detailPanel: { kind: panelKind } } : {}),
     ...(metadata ? { metadata } : {}),
   };
@@ -166,28 +159,41 @@ function deriveDetailPanelKind(
 }
 
 /**
- * `sourceContextId` is best-effort — it may not be a conversation id
- * (e.g. scheduler job id, watcher event id), so a lookup failure
- * falls through to "not a background conversation" rather than throwing.
+ * The lookup is best-effort and unified: a single `getConversation` call
+ * both gates the "background conversation" mirror branch and populates
+ * `sourceConversationId` for the "Go to Thread" navigation target. Misses
+ * (scheduler job ids, watcher event ids, CLI tool-call ids) leave
+ * `sourceConversationId` undefined so the client hides the affordance.
  *
- * `assistant_tool` is the source channel used by the `notifications send`
- * skill (and by background-job failure emits). These signals represent
- * the assistant actively choosing to share, so we mirror them into the
- * home feed without requiring a background-typed conversation or the
- * `isAsyncBackground` hint — the documented (SKILL.md) CLI surface
- * intentionally does not expose either; internal call sites that still set
- * the hint keep working unchanged.
+ * `assistant_tool` mirrors unconditionally because the documented
+ * `notifications send` skill (and background-job failure emits) deliberately
+ * does not require a background-typed conversation or the
+ * `isAsyncBackground` hint.
  */
-function shouldMirrorToHomeFeed(signal: NotificationSignal): boolean {
-  if (signal.sourceChannel === "assistant_tool") return true;
-  if (signal.attentionHints.isAsyncBackground) return true;
-  if (!signal.sourceContextId) return false;
-  try {
-    const row = getConversation(signal.sourceContextId);
-    return isBackgroundConversationType(row?.conversationType);
-  } catch {
-    return false;
+function resolveHomeFeedMirror(signal: NotificationSignal): {
+  mirror: boolean;
+  sourceConversationId?: string;
+} {
+  let sourceRow: { conversationType?: string } | null = null;
+  if (signal.sourceContextId) {
+    try {
+      sourceRow = getConversation(signal.sourceContextId) ?? null;
+    } catch {
+      sourceRow = null;
+    }
   }
+  const sourceConversationId = sourceRow ? signal.sourceContextId : undefined;
+
+  if (signal.sourceChannel === "assistant_tool") {
+    return { mirror: true, sourceConversationId };
+  }
+  if (signal.attentionHints.isAsyncBackground) {
+    return { mirror: true, sourceConversationId };
+  }
+  if (isBackgroundConversationType(sourceRow?.conversationType)) {
+    return { mirror: true, sourceConversationId };
+  }
+  return { mirror: false };
 }
 
 function readPayloadString(payload: unknown, key: string): string | undefined {

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -129,7 +129,10 @@ public struct FeedItem: Codable, Sendable, Identifiable {
     public let actions: [FeedAction]?
     /// Visual urgency treatment — controls badge color independently of sort priority.
     public let urgency: FeedItemUrgency?
-    /// Optional conversation this feed item is associated with.
+    /// Source conversation that emitted this notification, when known. Used
+    /// by the "Go to Thread" affordance in the detail panel. Nil when the
+    /// source context is not a navigable conversation (scheduler job ids,
+    /// watcher event ids, CLI tool-call ids).
     public let conversationId: String?
     /// Server-driven detail panel descriptor; when present, the client opens this panel kind.
     public let detailPanel: FeedItemDetailPanel?


### PR DESCRIPTION
## Summary

- `writeHomeFeedItemForSignal` now stores `signal.sourceContextId` in `FeedItem.conversationId` (instead of the spawned-thread id from the vellum delivery result), so the "Go to Thread" button in the home detail panel jumps back to the conversation that emitted the notification.
- The `getConversation` lookup that already gated the background-conversation branch is unified into a single `resolveHomeFeedMirror` pass that also populates `sourceConversationId`; misses (scheduler job ids, watcher event ids, CLI tool-call ids) leave the field undefined so the client hides the affordance.
- JSDoc/Swift-mirror comments updated to reflect the new semantics; tests flipped to expect the source id and verify undefined-on-miss behavior.

## Original prompt

The "Go to Thread" button in the home-feed detail panel was navigating to the wrong conversation — the notification-handler thread the pipeline spawned, instead of the source conversation that emitted the notification. The fix needed to be surgical: change what `FeedItem.conversationId` means at the writer (no schema or wire-contract change), and let the button hide automatically for signals whose `sourceContextId` isn't a navigable conversation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->