### PR TITLE
feat(providers): per-model reasoning_effort ceiling for Fireworks

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1744,4 +1744,109 @@ describe("OpenAIProvider reasoning_effort", () => {
     });
     expect(lastCreateParams!.reasoning_effort).toBe("medium");
   });
+
+  test('maxReasoningEffort: "max" passes "max" through unclamped', async () => {
+    const uncapped = new OpenAIProvider("test-key", "gpt-5", {
+      maxReasoningEffort: "max",
+    });
+    await uncapped.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "max" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("max");
+    await uncapped.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "xhigh" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("xhigh");
+  });
+});
+
+describe("FireworksProvider reasoning_effort ceiling", () => {
+  beforeEach(() => {
+    fakeChunks = [];
+    lastCreateParams = null;
+  });
+
+  test('DeepSeek V4 Pro accepts "max" unclamped', async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/deepseek-v4-pro",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "max" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("max");
+  });
+
+  test('DeepSeek V4 Pro accepts "xhigh" unclamped', async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/deepseek-v4-pro",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "xhigh" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("xhigh");
+  });
+
+  test('Kimi K2.6 clamps "xhigh"/"max" down to "high"', async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/kimi-k2p6",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "xhigh" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "max" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+  });
+
+  test('unknown Fireworks model falls back to "high" ceiling', async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/some-future-model",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "max" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("high");
+  });
+
+  test("effort below ceiling is forwarded verbatim", async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/deepseek-v4-pro",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "medium" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("medium");
+  });
+
+  test('effort: "none" passes through regardless of ceiling', async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/kimi-k2p6",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: { effort: "none" },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("none");
+  });
+
+  test("model override picks ceiling from runtime model, not constructor model", async () => {
+    const fw = new FireworksProvider(
+      "fw-key",
+      "accounts/fireworks/models/kimi-k2p6",
+    );
+    await fw.sendMessage([userMsg("hi")], undefined, "system", {
+      config: {
+        effort: "max",
+        model: "accounts/fireworks/models/deepseek-v4-pro",
+      },
+    });
+    expect(lastCreateParams!.reasoning_effort).toBe("max");
+  });
 });

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 
 export interface FireworksProviderOptions {
@@ -7,6 +8,15 @@ export interface FireworksProviderOptions {
 }
 
 const DEFAULT_FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+
+const FIREWORKS_MODEL_EFFORT_CEILINGS: ReadonlyMap<
+  string,
+  "high" | "xhigh" | "max"
+> = new Map(
+  PROVIDER_CATALOG.find((p) => p.id === "fireworks")?.models.flatMap((m) =>
+    m.maxEffort ? ([[m.id, m.maxEffort]] as const) : [],
+  ) ?? [],
+);
 
 export class FireworksProvider extends OpenAIChatCompletionsProvider {
   constructor(
@@ -19,9 +29,17 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
       providerName: "fireworks",
       providerLabel: "Fireworks",
       streamTimeoutMs: options.streamTimeoutMs,
-      // Fireworks' OpenAI-compatible chat-completions API documents only
-      // low|medium|high for reasoning_effort; sending "xhigh" 4xxs upstream.
+      // Fallback for models not declared in the catalog. Most Fireworks
+      // chat-completions models only document `low|medium|high`; per-model
+      // overrides (e.g. DeepSeek V4 → "max") come from
+      // {@link resolveMaxReasoningEffort}.
       maxReasoningEffort: "high",
     });
+  }
+
+  protected override resolveMaxReasoningEffort(
+    model: string,
+  ): "high" | "xhigh" | "max" {
+    return FIREWORKS_MODEL_EFFORT_CEILINGS.get(model) ?? "high";
   }
 }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -45,6 +45,13 @@ export interface CatalogModel {
   supportsVision?: boolean;
   supportsToolUse?: boolean;
   pricing?: CatalogModelPricing;
+  /**
+   * Upper bound for `reasoning_effort` accepted by this model's upstream API.
+   * Used by providers (e.g. Fireworks) to clamp Vellum's `xhigh`/`max` tiers
+   * down to whatever the model documents. Omit to inherit the provider
+   * default.
+   */
+  maxEffort?: "high" | "xhigh" | "max";
   /** When set, this model is only visible when the named feature flag is enabled. */
   featureFlag?: string;
 }
@@ -589,6 +596,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        maxEffort: "high",
         pricing: {
           inputPer1mTokens: 0.95,
           outputPer1mTokens: 4.0,
@@ -636,10 +644,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         displayName: "DeepSeek V4 Pro",
         contextWindowTokens: 1040000,
         maxOutputTokens: 131072,
-        supportsThinking: false,
+        supportsThinking: true,
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
+        maxEffort: "max",
         pricing: { inputPer1mTokens: 1.74, outputPer1mTokens: 3.48 },
       },
     ],

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -66,33 +66,55 @@ export interface OpenAIChatCompletionsProviderOptions {
   extraCreateParams?: Record<string, unknown>;
   /** Upper bound for `reasoning_effort` sent on the wire. Defaults to "xhigh"
    *  (OpenAI's current ceiling). Compatibility providers whose APIs only
-   *  document `low|medium|high` (e.g. Fireworks) should set this to "high" so
-   *  Vellum's `xhigh`/`max` tiers don't 4xx upstream. */
-  maxReasoningEffort?: "high" | "xhigh";
+   *  document `low|medium|high` should set this to "high" so Vellum's
+   *  `xhigh`/`max` tiers don't 4xx upstream. Set to "max" for providers like
+   *  Fireworks DeepSeek V4 that accept the full effort range. Subclasses can
+   *  override {@link OpenAIChatCompletionsProvider.resolveMaxReasoningEffort}
+   *  for per-model ceilings. */
+  maxReasoningEffort?: "high" | "xhigh" | "max";
   /** Parse `<think>...</think>` tags from the content stream into thinking
    *  blocks. MiniMax and similar providers embed reasoning inside XML-style
    *  tags in the regular content field rather than using `reasoning_content`. */
   parseThinkTags?: boolean;
 }
 
-/** Map our internal effort values to OpenAI's reasoning_effort parameter.
- *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". `"none"` is
- *  passed through explicitly because OpenAI defaults `reasoning_effort` to
- *  "medium" when the field is omitted — the user's opt-out is only honored
- *  when we send it on the wire. */
-export const EFFORT_TO_REASONING_EFFORT: Record<
-  string,
-  NonNullable<
-    OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"]
-  >
-> = {
+/** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
+ *  `"max"`, but Fireworks accepts it for DeepSeek V4; the assignment to
+ *  `params.reasoning_effort` casts through this union. */
+type ReasoningEffortWire = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+
+const REASONING_EFFORT_RANK: Record<ReasoningEffortWire, number> = {
+  none: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  xhigh: 4,
+  max: 5,
+};
+
+/** Map our internal effort values to a reasoning_effort wire value. `"max"`
+ *  is emitted raw — providers cap it down to their own ceiling
+ *  ({@link OpenAIChatCompletionsProviderOptions.maxReasoningEffort}) at send
+ *  time. `"none"` is passed through explicitly because OpenAI-compatible APIs
+ *  default `reasoning_effort` to `"medium"` when the field is omitted, so the
+ *  user's opt-out is only honored when we send it on the wire. */
+export const EFFORT_TO_REASONING_EFFORT: Record<string, ReasoningEffortWire> = {
   none: "none",
   low: "low",
   medium: "medium",
   high: "high",
   xhigh: "xhigh",
-  max: "xhigh",
+  max: "max",
 };
+
+export function clampReasoningEffort(
+  value: ReasoningEffortWire,
+  ceiling: "high" | "xhigh" | "max",
+): ReasoningEffortWire {
+  return REASONING_EFFORT_RANK[value] > REASONING_EFFORT_RANK[ceiling]
+    ? ceiling
+    : value;
+}
 
 const OPENAI_SUPPORTED_IMAGE_TYPES = new Set([
   "image/jpeg",
@@ -122,7 +144,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private model: string;
   private streamTimeoutMs: number;
   private extraCreateParams: Record<string, unknown>;
-  private maxReasoningEffort: "high" | "xhigh";
+  private maxReasoningEffort: "high" | "xhigh" | "max";
   private requestHeaders: Record<string, string>;
   private parseThinkTags: boolean;
 
@@ -187,10 +209,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
         ? EFFORT_TO_REASONING_EFFORT[effort]
         : undefined;
       if (reasoningEffort && typeof nestedReasoningEffort !== "string") {
-        params.reasoning_effort =
-          reasoningEffort === "xhigh" && this.maxReasoningEffort === "high"
-            ? "high"
-            : reasoningEffort;
+        const ceiling = this.resolveMaxReasoningEffort(
+          modelOverride ?? this.model,
+        );
+        params.reasoning_effort = clampReasoningEffort(
+          reasoningEffort,
+          ceiling,
+        ) as OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"];
       }
 
       if (tools && tools.length > 0) {
@@ -544,6 +569,18 @@ export class OpenAIChatCompletionsProvider implements Provider {
     _options?: SendMessageOptions,
   ): Record<string, unknown> {
     return this.extraCreateParams;
+  }
+
+  /**
+   * Per-request reasoning_effort ceiling. Defaults to the provider-wide
+   * `maxReasoningEffort` from constructor options. Subclasses (e.g. Fireworks)
+   * override to consult the model catalog so per-model accepted ranges are
+   * respected.
+   */
+  protected resolveMaxReasoningEffort(
+    _model: string,
+  ): "high" | "xhigh" | "max" {
+    return this.maxReasoningEffort;
   }
 
   /** Convert neutral messages + system prompt to OpenAI message format. */

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "../../util/errors.js";
 import { AnthropicProvider } from "../anthropic/client.js";
 import {
+  clampReasoningEffort,
   EFFORT_TO_REASONING_EFFORT,
   OpenAIChatCompletionsProvider,
 } from "../openai/chat-completions-provider.js";
@@ -200,7 +201,10 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
     const summaryOverride = extractReasoningSummaryOverride(config);
     const reasoning: Record<string, unknown> = { enabled: thinkingEnabled };
     if (mappedEffort) {
-      reasoning.effort = mappedEffort;
+      reasoning.effort = clampReasoningEffort(
+        mappedEffort,
+        this.resolveMaxReasoningEffort(this.resolveEffectiveModel(options)),
+      );
     }
     if (thinkingEnabled) {
       reasoning.summary = summaryOverride ?? "detailed";


### PR DESCRIPTION
## Summary

- Add `maxEffort` to `CatalogModel` so each model can declare the upper
  reasoning_effort tier its upstream API accepts.
- Replace the static `maxReasoningEffort` cap in `FireworksProvider` with
  a per-request `resolveMaxReasoningEffort` hook backed by the catalog;
  default is still `"high"` for models without an explicit `maxEffort`.
- Mark `accounts/fireworks/models/deepseek-v4-pro` as `supportsThinking:
  true` with `maxEffort: "max"`; mark Kimi K2.6 with `maxEffort: "high"`.
- Extend the shared `EFFORT_TO_REASONING_EFFORT` map to emit `"max"` raw
  and route both flat (`reasoning_effort`) and nested
  (`reasoning.effort`, used by OpenRouter) wire forms through one
  `clampReasoningEffort` helper. OpenAI and OpenRouter keep their
  effective `"xhigh"` ceiling.

## Original prompt

The user asked to add support for Fireworks reasoning effort, pointing
at the Fireworks API reference. The plumbing already existed (Fireworks
extends `OpenAIChatCompletionsProvider`, which forwards
`reasoning_effort`) but a hard `"high"` cap blocked Vellum's `xhigh` and
`max` tiers from reaching reasoning-capable Fireworks models that
document the full range — notably DeepSeek V4 Pro. The user asked to
both lift the cap (per-model, since gpt-oss / Kimi / MiniMax / GLM cap
at `"high"`) and mark existing reasoning-capable models thinking-capable
so the resolver actually feeds them an effort value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->