### PR TITLE
fix(catalog): sync DeepSeek V4 Pro supportsThinking to clients

### DIFF
--- a/apps/web/src/domains/assistant/llm-model-catalog.ts
+++ b/apps/web/src/domains/assistant/llm-model-catalog.ts
@@ -214,6 +214,7 @@ export const MODELS_BY_PROVIDER = {
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
+      supportsThinking: true,
     },
   ],
   openrouter: [

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -567,7 +567,7 @@
           "maxOutputTokens": 131072,
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
-          "supportsThinking": false,
+          "supportsThinking": true,
           "supportsCaching": false,
           "supportsVision": false,
           "supportsToolUse": true,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -567,7 +567,7 @@
           "maxOutputTokens": 131072,
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
-          "supportsThinking": false,
+          "supportsThinking": true,
           "supportsCaching": false,
           "supportsVision": false,
           "supportsToolUse": true,


### PR DESCRIPTION
## Summary

- Set \`supportsThinking: true\` for \`accounts/fireworks/models/deepseek-v4-pro\` in \`meta/llm-provider-catalog.json\`, the SwiftPM mirror at \`clients/shared/Resources/llm-provider-catalog.json\`, and the web vendored catalog at \`apps/web/src/domains/assistant/llm-model-catalog.ts\`.
- Restores \`llm-catalog-parity.test.ts\` (red on main after #31381 merged with \`--skip-ci\`).
- Profile editor's reasoning-effort selector now shows for DeepSeek V4 Pro on web and macOS (visibility logic gates on \`supportsThinking\`).

## Original prompt

Follow-up to #31381. The user asked whether the prior PR made reasoning
effort configurable in the models UI. The wire plumbing landed but the
visibility rule in \`profile-param-visibility.ts\` (and the macOS
equivalent) reads \`supportsThinking\` from the client catalog — which
the prior PR didn't update — so the effort selector was still hidden
for DeepSeek V4 Pro and the parity guard test was red on \`main\`. This
PR closes that gap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->