### PR TITLE
feat: rewrite wake-up greeting to GEO message for content-automation cohort

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1493,6 +1493,10 @@ export async function handleSendMessage(
       : ("content-source" as const);
     effectiveContent = buildScanFirstMessage(scanUrl, scanVariant);
     // Fall through to normal inference path below
+  } else if (isWakeUp && body.onboarding?.cohort === "content-automation") {
+    effectiveContent = "I want to write articles that rank better in GEO";
+    // Fall through to normal inference path — the bootstrap template
+    // and geo-writing skill handle this message.
   } else if (isWakeUp) {
     const cannedGreeting = getCannedFirstGreeting(body.onboarding ?? undefined);
 


### PR DESCRIPTION
## Summary
- When the content-automation cohort sends the wake-up greeting, rewrite it to "I want to write articles that rank better in GEO" and let the model respond via normal inference
- Follows the same pattern as the scan path rewrite — sets effectiveContent and falls through
- The BOOTSTRAP-CONTENT-AUTOMATION.md + geo-writing skill handle the rest

Part of plan: content-automation-geo-skill.md

Closes JARVIS-899
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->