### PR TITLE
feat(web): port inspector page from platform (LUM-1766)

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -312,7 +312,9 @@ export async function fetchConversationMessages(
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to fetch conversation messages");
-  if (!response.ok) return [];
+  if (!response.ok) {
+    throw new Error(`Failed to fetch conversation messages (HTTP ${response.status})`);
+  }
   return Array.isArray(data?.messages) ? data.messages : [];
 }
 

--- a/apps/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/apps/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -1,0 +1,131 @@
+import { type ReactNode } from "react";
+import { Link } from "react-router";
+
+import {
+  displayProvider,
+  displayText,
+  formattedCreatedAt,
+  MISSING_VALUE,
+} from "@/domains/chat/inspector/inspector-formatters.js";
+import type { LLMRequestLogEntry } from "@/domains/chat/types/inspector-types.js";
+
+interface CallRailProps {
+  logs: LLMRequestLogEntry[];
+  selectedLogId: string | undefined;
+  buildCallHref: (logId: string) => string;
+}
+
+/**
+ * Left rail listing every LLM call captured for the inspected message.
+ *
+ * Sort order: newest call on top, oldest on the bottom. The `Call N`
+ * label tracks chronological order — Call 1 is the first call made
+ * for this message, Call N is the most recent.
+ */
+export function CallRail({
+  logs,
+  selectedLogId,
+  buildCallHref,
+}: CallRailProps): ReactNode {
+  if (!logs.length) {
+    return (
+      <div
+        className="flex h-full items-center justify-center p-4 text-label-default"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        No LLM calls recorded.
+      </div>
+    );
+  }
+
+  const orderedLogs = [...logs].reverse();
+
+  return (
+    <nav className="flex flex-col gap-2 p-3" aria-label="LLM calls">
+      <div
+        className="px-1 text-label-default"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        {logs.length === 1 ? "1 LLM call" : `${logs.length} LLM calls`}
+      </div>
+      {orderedLogs.map((entry, displayIndex) => (
+        <CallRow
+          key={entry.id}
+          entry={entry}
+          callNumber={logs.length - displayIndex}
+          isSelected={entry.id === selectedLogId}
+          isLatest={displayIndex === 0}
+          href={buildCallHref(entry.id)}
+        />
+      ))}
+    </nav>
+  );
+}
+
+interface CallRowProps {
+  entry: LLMRequestLogEntry;
+  callNumber: number;
+  isSelected: boolean;
+  isLatest: boolean;
+  href: string;
+}
+
+function CallRow({
+  entry,
+  callNumber,
+  isSelected,
+  isLatest,
+  href,
+}: CallRowProps): ReactNode {
+  const provider = displayProvider(entry.summary?.provider ?? null);
+  const model = entry.summary?.model ? displayText(entry.summary.model) : null;
+  const subtitle =
+    [provider !== MISSING_VALUE ? provider : null, model]
+      .filter((value): value is string => Boolean(value))
+      .join(" · ") || "Unrecognized call";
+
+  return (
+    <Link
+      to={href}
+      aria-current={isSelected ? "page" : undefined}
+      className="flex flex-col gap-1 rounded-md p-3 text-left no-underline transition-colors hover:opacity-90"
+      style={{
+        background: isSelected
+          ? "var(--surface-active)"
+          : "var(--surface-overlay)",
+        border: `1px solid ${
+          isSelected ? "var(--border-active)" : "var(--border-base)"
+        }`,
+      }}
+    >
+      <div className="flex items-baseline gap-2">
+        <span
+          className="line-clamp-1 flex-1 text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          Call {callNumber}
+        </span>
+        {isLatest ? (
+          <span
+            className="text-label-default"
+            style={{ color: "var(--primary-default, var(--content-default))" }}
+          >
+            Latest
+          </span>
+        ) : null}
+      </div>
+      <div
+        className="line-clamp-2 text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {subtitle}
+      </div>
+      <div
+        className="text-label-default"
+        style={{ color: "var(--content-tertiary)" }}
+      >
+        {formattedCreatedAt(entry.createdAt)}
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/components/message-inspector-view.tsx
+++ b/apps/web/src/domains/chat/inspector/components/message-inspector-view.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, ArrowLeft, Download } from "lucide-react";
-import { useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { useMemo, useState, type ReactNode } from "react";
 
 import { Button } from "@vellum/design-library";
@@ -172,12 +172,12 @@ function Header({
         size="compact"
         leftIcon={<ArrowLeft size={16} aria-hidden />}
       >
-        <a
-          href={routes.conversation(conversationKey)}
+        <Link
+          to={routes.conversation(conversationKey)}
           aria-label="Back to conversation"
         >
           Back
-        </a>
+        </Link>
       </Button>
       <div className="flex flex-1 flex-col">
         <h1

--- a/apps/web/src/domains/chat/inspector/components/message-inspector-view.tsx
+++ b/apps/web/src/domains/chat/inspector/components/message-inspector-view.tsx
@@ -1,0 +1,400 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertCircle, ArrowLeft, Download } from "lucide-react";
+import { useSearchParams } from "react-router";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { Button } from "@vellum/design-library";
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import {
+  buildInspectorExportFilename,
+  buildInspectorExportZipBlob,
+  downloadBlob,
+} from "@/domains/chat/inspector/inspector-export.js";
+import { useLlmContext } from "@/domains/chat/inspector/inspector-api.js";
+import {
+  llmLogPayloadQueryOptions,
+  type LlmLogPayload,
+} from "@/domains/chat/inspector/inspector-payload-api.js";
+import type {
+  LlmContextResponse,
+  LLMRequestLogEntry,
+} from "@/domains/chat/types/inspector-types.js";
+import { routes } from "@/utils/routes.js";
+
+import { CallRail } from "./call-rail.js";
+import { TabBar, type InspectorTab } from "./tab-bar.js";
+import { MemoryTab } from "./tabs/memory-tab.js";
+import { OverviewTab } from "./tabs/overview-tab.js";
+import { PromptTab } from "./tabs/prompt-tab.js";
+import { RawTab } from "./tabs/raw-tab.js";
+import { ResponseTab } from "./tabs/response-tab.js";
+
+interface MessageInspectorViewProps {
+  conversationKey: string;
+  messageId: string;
+}
+
+/**
+ * Three-region inspector layout: header with back nav and call count,
+ * a left call rail listing every LLM call captured for this message,
+ * and a tabbed detail pane for the selected call.
+ *
+ * The selected call is encoded as `?callId=...` in the URL so each
+ * row in the rail is a real hyperlink — sharable, right-click-openable,
+ * and back/forward navigable.
+ */
+export function MessageInspectorView({
+  conversationKey,
+  messageId,
+}: MessageInspectorViewProps): ReactNode {
+  const { assistantId } = useAssistantContext();
+  const {
+    data,
+    isLoading: isLoadingContext,
+    isError,
+    error,
+    refetch,
+  } = useLlmContext(assistantId ?? undefined, messageId);
+
+  const logs = useMemo(() => data?.logs ?? [], [data?.logs]);
+  const [searchParams] = useSearchParams();
+  const callIdParam = searchParams.get("callId");
+
+  const selectedLogId = useMemo<string | undefined>(() => {
+    if (!logs.length) return undefined;
+    if (callIdParam && logs.some((log) => log.id === callIdParam)) {
+      return callIdParam;
+    }
+    return logs[logs.length - 1]!.id;
+  }, [logs, callIdParam]);
+
+  const selectedLog = useMemo<LLMRequestLogEntry | null>(
+    () => logs.find((log) => log.id === selectedLogId) ?? null,
+    [logs, selectedLogId],
+  );
+
+  const buildCallHref = useMemo(
+    () =>
+      (logId: string): string => {
+        const params = new URLSearchParams();
+        params.set("conversationKey", conversationKey);
+        params.set("messageId", messageId);
+        params.set("callId", logId);
+        return `${routes.inspect}?${params.toString()}`;
+      },
+    [conversationKey, messageId],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <Header
+        assistantId={assistantId}
+        conversationKey={conversationKey}
+        context={data}
+        messageId={messageId}
+        callCount={data ? logs.length : null}
+      />
+      <div
+        className="flex min-h-0 flex-1"
+        style={{ borderTop: "1px solid var(--border-base)" }}
+      >
+        {isLoadingContext ? (
+          <CenteredMessage tone="muted">Loading…</CenteredMessage>
+        ) : isError ? (
+          <ErrorState error={error} onRetry={() => void refetch()} />
+        ) : !logs.length ? (
+          <EmptyState />
+        ) : (
+          <Loaded
+            logs={logs}
+            context={data}
+            selectedLog={selectedLog}
+            selectedLogId={selectedLogId}
+            buildCallHref={buildCallHref}
+            assistantId={assistantId}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface HeaderProps {
+  assistantId: string | null;
+  conversationKey: string;
+  context: LlmContextResponse | undefined;
+  messageId: string;
+  callCount: number | null;
+}
+
+function Header({
+  assistantId,
+  conversationKey,
+  context,
+  messageId,
+  callCount,
+}: HeaderProps): ReactNode {
+  const queryClient = useQueryClient();
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const canExport = Boolean(assistantId && context && context.logs.length > 0);
+
+  async function handleExport(): Promise<void> {
+    if (!assistantId || !context || isExporting) return;
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const payloads = await Promise.all(
+        context.logs.map((log): Promise<LlmLogPayload> => {
+          const options = llmLogPayloadQueryOptions(assistantId, log.id);
+          return queryClient.fetchQuery(options);
+        }),
+      );
+      const blob = await buildInspectorExportZipBlob(context, payloads);
+      downloadBlob(blob, buildInspectorExportFilename(messageId));
+    } catch (err) {
+      setExportError(
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message: unknown }).message)
+          : "Failed to export inspector data",
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <Button
+        asChild
+        variant="ghost"
+        size="compact"
+        leftIcon={<ArrowLeft size={16} aria-hidden />}
+      >
+        <a
+          href={routes.conversation(conversationKey)}
+          aria-label="Back to conversation"
+        >
+          Back
+        </a>
+      </Button>
+      <div className="flex flex-1 flex-col">
+        <h1
+          className="text-title-medium"
+          style={{ color: "var(--content-default)" }}
+        >
+          LLM Context Inspector
+        </h1>
+        <p
+          className="text-label-default"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          Select a call to inspect provider, model, and usage details.
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outlined"
+          size="compact"
+          leftIcon={<Download size={16} aria-hidden />}
+          disabled={!canExport || isExporting}
+          onClick={() => void handleExport()}
+          aria-label="Export inspector data as ZIP"
+        >
+          {isExporting ? "Exporting…" : "Export ZIP"}
+        </Button>
+        <div className="flex flex-col items-end gap-0.5">
+          {callCount != null ? (
+            <span
+              className="text-label-default"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              {callCount === 1 ? "1 LLM call" : `${callCount} LLM calls`}
+            </span>
+          ) : null}
+          <code
+            className="select-text text-body-small-default"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            {messageId}
+          </code>
+          {exportError ? (
+            <span
+              className="max-w-72 text-right text-body-small-default"
+              role="alert"
+              style={{ color: "var(--system-negative-strong)" }}
+            >
+              {exportError}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface LoadedProps {
+  logs: LLMRequestLogEntry[];
+  context: LlmContextResponse | undefined;
+  selectedLog: LLMRequestLogEntry | null;
+  selectedLogId: string | undefined;
+  buildCallHref: (logId: string) => string;
+  assistantId: string | null;
+}
+
+function Loaded({
+  logs,
+  context,
+  selectedLog,
+  selectedLogId,
+  buildCallHref,
+  assistantId,
+}: LoadedProps): ReactNode {
+  const [tab, setTab] = useState<InspectorTab>("overview");
+
+  return (
+    <>
+      <aside
+        className="hidden w-64 shrink-0 overflow-y-auto md:block"
+        style={{
+          background: "var(--surface-base)",
+          borderRight: "1px solid var(--border-base)",
+        }}
+      >
+        <CallRail
+          logs={logs}
+          selectedLogId={selectedLogId}
+          buildCallHref={buildCallHref}
+        />
+      </aside>
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <TabBar selected={tab} onSelect={setTab} />
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+          {tab === "memory" ? (
+            <MemoryTab context={context} />
+          ) : selectedLog ? (
+            <TabContent
+              tab={tab}
+              entry={selectedLog}
+              assistantId={assistantId}
+              conversationTotalEstimatedCostUsd={
+                context?.conversationTotalEstimatedCostUsd
+              }
+            />
+          ) : (
+            <CenteredMessage tone="muted">
+              Choose a call from the rail to inspect its context.
+            </CenteredMessage>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}
+
+interface TabContentProps {
+  tab: Exclude<InspectorTab, "memory">;
+  entry: LLMRequestLogEntry;
+  assistantId: string | null;
+  conversationTotalEstimatedCostUsd: number | null | undefined;
+}
+
+function TabContent({
+  tab,
+  entry,
+  assistantId,
+  conversationTotalEstimatedCostUsd,
+}: TabContentProps): ReactNode {
+  switch (tab) {
+    case "overview":
+      return (
+        <OverviewTab
+          entry={entry}
+          conversationTotalEstimatedCostUsd={conversationTotalEstimatedCostUsd}
+        />
+      );
+    case "prompt":
+      return <PromptTab entry={entry} />;
+    case "response":
+      return <ResponseTab entry={entry} />;
+    case "raw":
+      return <RawTab entry={entry} assistantId={assistantId ?? undefined} />;
+  }
+}
+
+function CenteredMessage({
+  children,
+  tone = "default",
+}: {
+  children: ReactNode;
+  tone?: "muted" | "default";
+}): ReactNode {
+  const color =
+    tone === "muted" ? "var(--content-tertiary)" : "var(--content-secondary)";
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center p-8 text-label-default"
+      style={{ color }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EmptyState(): ReactNode {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        No LLM calls recorded for this message.
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Either the message wasn&rsquo;t produced by an LLM call or its
+        request logs were trimmed by retention.
+      </p>
+    </div>
+  );
+}
+
+function ErrorState({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry: () => void;
+}): ReactNode {
+  const message =
+    error && typeof error === "object" && "message" in error
+      ? String((error as { message: unknown }).message)
+      : "Failed to load LLM context.";
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <AlertCircle
+        size={32}
+        aria-hidden
+        style={{ color: "var(--content-secondary)" }}
+      />
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        Failed to load
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {message}
+      </p>
+      <Button variant="outlined" size="compact" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/components/tab-bar.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tab-bar.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@/utils/misc.js";
+
+export type InspectorTab = "overview" | "prompt" | "response" | "raw" | "memory";
+
+const TABS: { id: InspectorTab; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "prompt", label: "Prompt" },
+  { id: "response", label: "Response" },
+  { id: "raw", label: "Raw" },
+  { id: "memory", label: "Memory" },
+];
+
+interface TabBarProps {
+  selected: InspectorTab;
+  onSelect: (tab: InspectorTab) => void;
+}
+
+export function TabBar({ selected, onSelect }: TabBarProps): ReactNode {
+  return (
+    <div
+      className="flex shrink-0 px-4"
+      style={{ borderBottom: "1px solid var(--border-base)" }}
+    >
+      {TABS.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => onSelect(tab.id)}
+          className={cn(
+            "-mb-px border-b-2 px-3 py-2 text-label-medium-default transition-colors",
+            selected === tab.id
+              ? "border-[var(--primary-base)] text-[var(--content-default)]"
+              : "border-transparent text-[var(--content-secondary)] hover:text-[var(--content-default)]",
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -1,0 +1,740 @@
+import { ChevronDown, ChevronRight, Copy } from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+
+import { Card } from "@vellum/design-library";
+import type {
+  LlmContextResponse,
+  MemoryCandidate,
+  MemoryRecallLog,
+  MemoryV2ActivationLog,
+  MemoryV2ConceptRow,
+} from "@/domains/chat/types/inspector-types.js";
+
+/**
+ * Memory tab rendering V1 recall and/or V2 activation data. When both
+ * are present a pill switcher lets the user toggle between the two
+ * views; when only one is present it renders directly.
+ */
+export function MemoryTab({
+  context,
+}: {
+  context: LlmContextResponse | undefined;
+}): ReactNode {
+  const recall = context?.memoryRecall ?? null;
+  const v2 = context?.memoryV2Activation ?? null;
+  const hasRecall = recall !== null;
+  const hasV2 = v2 !== null;
+
+  type MemoryView = "recall" | "v2";
+  const defaultView: MemoryView = hasV2 ? "v2" : "recall";
+  const [view, setView] = useState<MemoryView>(defaultView);
+
+  useEffect(() => {
+    setView(hasV2 ? "v2" : "recall");
+  }, [hasV2, hasRecall]);
+
+  if (!hasRecall && !hasV2) {
+    return <NoDataState />;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {hasRecall && hasV2 && (
+        <div
+          className="flex gap-1 px-4 py-2"
+          style={{ borderBottom: "1px solid var(--border-base)" }}
+        >
+          <ViewPill
+            label="Memory V2"
+            active={view === "v2"}
+            onClick={() => setView("v2")}
+          />
+          <ViewPill
+            label="Recall (v1)"
+            active={view === "recall"}
+            onClick={() => setView("recall")}
+          />
+        </div>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {view === "v2" && hasV2 ? (
+          <MemoryV2Section activation={v2} />
+        ) : hasRecall ? (
+          <MemoryRecallSection recall={recall} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ViewPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}): ReactNode {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-full px-3 py-1 text-label-default transition-colors"
+      style={{
+        background: active
+          ? "var(--surface-active)"
+          : "var(--surface-overlay)",
+        color: active ? "var(--content-default)" : "var(--content-secondary)",
+        border: "none",
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function MemoryRecallSection({
+  recall,
+}: {
+  recall: MemoryRecallLog;
+}): ReactNode {
+  if (!recall.enabled) {
+    return (
+      <div className="p-4">
+        <SectionCard
+          title="Memory disabled"
+          subtitle={recall.reason ?? "Memory recall was disabled for this turn."}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <ScopeBanner
+        title="Turn-level recall"
+        body="Memory recall runs once per turn. This data applies to all LLM calls for this message."
+      />
+
+      <SectionCard
+        title="Status"
+        subtitle="Provider, model, and latency for this recall."
+      >
+        <MetaGrid
+          rows={[
+            { label: "Status", value: recall.degraded ? "Degraded" : "Active" },
+            { label: "Provider", value: recall.provider ?? "Unavailable" },
+            { label: "Model", value: recall.model ?? "Unavailable" },
+            {
+              label: "Total latency",
+              value: recall.latencyMs != null ? `${recall.latencyMs} ms` : "—",
+            },
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard
+        title="Retrieval funnel"
+        subtitle="How memories were filtered from semantic search to injection."
+      >
+        <MetaGrid
+          rows={[
+            {
+              label: "Semantic hits",
+              value: recall.semanticHits != null ? fmt(recall.semanticHits) : "—",
+            },
+            {
+              label: "After merge",
+              value: recall.mergedCount != null ? fmt(recall.mergedCount) : "—",
+            },
+            {
+              label: "Tier 1",
+              value: recall.tier1Count != null ? fmt(recall.tier1Count) : "—",
+            },
+            {
+              label: "Tier 2",
+              value: recall.tier2Count != null ? fmt(recall.tier2Count) : "—",
+            },
+            {
+              label: "Selected",
+              value: recall.selectedCount != null ? fmt(recall.selectedCount) : "—",
+            },
+            {
+              label: "Injected tokens",
+              value: recall.injectedTokens != null ? fmt(recall.injectedTokens) : "—",
+            },
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard title="Search details">
+        <MetaGrid
+          rows={[
+            {
+              label: "Hybrid search",
+              value:
+                recall.hybridSearchLatencyMs != null
+                  ? `${recall.hybridSearchLatencyMs} ms`
+                  : "—",
+            },
+            {
+              label: "Sparse vectors",
+              value:
+                recall.sparseVectorUsed != null
+                  ? recall.sparseVectorUsed
+                    ? "Used"
+                    : "Dense only"
+                  : "—",
+            },
+          ]}
+        />
+      </SectionCard>
+
+      {recall.queryContext != null && (
+        <SectionCard
+          title="Query context"
+          subtitle="The text embedded as the search vector for semantic retrieval."
+          copyText={recall.queryContext}
+        >
+          <CodeBlock text={recall.queryContext} />
+        </SectionCard>
+      )}
+
+      {recall.topCandidates.length > 0 && (
+        <SectionCard
+          title="Top candidates"
+          subtitle={`${recall.topCandidates.length} candidate(s) ranked by final score.`}
+        >
+          <div className="flex flex-col gap-2">
+            {[...recall.topCandidates]
+              .sort((a, b) => b.score - a.score)
+              .map((c, i) => (
+                <CandidateRow key={`${i}-${c.nodeId}`} candidate={c} />
+              ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {recall.injectedText != null && (
+        <SectionCard
+          title="Injected memory context"
+          copyText={recall.injectedText}
+        >
+          <CodeBlock text={recall.injectedText} />
+        </SectionCard>
+      )}
+
+      {recall.degraded && recall.degradation != null && (
+        <SectionCard title="Degradation">
+          <MetaGrid
+            rows={[
+              {
+                label: "Reason",
+                value: recall.degradation.reason ?? "Unknown",
+              },
+              {
+                label: "Semantic unavailable",
+                value: recall.degradation.semanticUnavailable ? "Yes" : "No",
+              },
+              ...(recall.degradation.fallbackSources?.length
+                ? [
+                    {
+                      label: "Fallback sources",
+                      value: recall.degradation.fallbackSources.join(", "),
+                    },
+                  ]
+                : []),
+            ]}
+          />
+        </SectionCard>
+      )}
+    </div>
+  );
+}
+
+function CandidateRow({ candidate }: { candidate: MemoryCandidate }): ReactNode {
+  return (
+    <div
+      className="flex items-start justify-between gap-3 rounded-md px-3 py-2"
+      style={{ background: "var(--surface-base)" }}
+    >
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <code
+          className="truncate text-body-small-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {candidate.nodeId}
+        </code>
+        {candidate.type != null && (
+          <TypeChip label={candidate.type} />
+        )}
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {fmtScore(candidate.score)}
+        </span>
+        <span
+          className="text-label-small"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          sem {fmtScore(candidate.semanticSimilarity)} · rec{" "}
+          {fmtScore(candidate.recencyBoost)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function MemoryV2Section({
+  activation,
+}: {
+  activation: MemoryV2ActivationLog;
+}): ReactNode {
+  const sorted = useMemo(
+    () =>
+      [...activation.concepts].sort(
+        (a, b) => b.finalActivation - a.finalActivation,
+      ),
+    [activation.concepts],
+  );
+
+  const inContextCount = sorted.filter((c) => c.status === "in_context").length;
+  const injectedCount = sorted.filter((c) => c.status === "injected").length;
+  const notInjectedCount = sorted.filter(
+    (c) => c.status === "not_injected",
+  ).length;
+
+  const cfg = activation.config;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <SectionCard title="Run">
+        <MetaGrid
+          rows={[
+            { label: "Mode", value: activation.mode },
+            { label: "Turn", value: String(activation.turn) },
+            {
+              label: "Concepts evaluated",
+              value: fmt(activation.concepts.length),
+            },
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard title="Outcome">
+        <MetaGrid
+          rows={[
+            { label: "In context", value: fmt(inContextCount) },
+            { label: "Injected", value: fmt(injectedCount) },
+            { label: "Not injected", value: fmt(notInjectedCount) },
+          ]}
+        />
+      </SectionCard>
+
+      {sorted.length > 0 && (
+        <SectionCard
+          title="Concepts"
+          subtitle={`${sorted.length} concept(s) ranked by final activation.`}
+        >
+          <div className="flex flex-col gap-1">
+            {sorted.map((concept) => (
+              <ConceptRow key={concept.slug} concept={concept} config={cfg} />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      <SectionCard title="Config" subtitle="Hyperparameters used for this activation run.">
+        <MetaGrid
+          rows={[
+            { label: "d (decay)", value: fmtAct(cfg.d) },
+            { label: "c_user", value: fmtAct(cfg.c_user) },
+            { label: "c_assistant", value: fmtAct(cfg.c_assistant) },
+            { label: "c_now", value: fmtAct(cfg.c_now) },
+            { label: "k", value: fmtAct(cfg.k) },
+            { label: "hops", value: String(cfg.hops) },
+            { label: "top_k", value: String(cfg.top_k) },
+            { label: "epsilon", value: fmtAct(cfg.epsilon) },
+          ]}
+        />
+      </SectionCard>
+    </div>
+  );
+}
+
+function ConceptRow({
+  concept,
+  config,
+}: {
+  concept: MemoryV2ConceptRow;
+  config: MemoryV2ActivationLog["config"];
+}): ReactNode {
+  const [expanded, setExpanded] = useState(false);
+
+  const isCustomSource = concept.source !== "ann_top50";
+  const statusColor = v2StatusColor(concept.status);
+  const statusText = v2StatusLabel(concept.status);
+
+  const breakdownRows: { label: string; value: string }[] = [
+    { label: "A_o (own)", value: fmtAct(concept.ownActivation) },
+    { label: "spread Δ", value: fmtAct(concept.spreadContribution) },
+    { label: "prior · d", value: fmtAct(concept.priorActivation) },
+    {
+      label: `sim_user (×${fmtAct(config.c_user)})`,
+      value: fmtAct(concept.simUser),
+    },
+    {
+      label: `sim_asst (×${fmtAct(config.c_assistant)})`,
+      value: fmtAct(concept.simAssistant),
+    },
+    {
+      label: `sim_now (×${fmtAct(config.c_now)})`,
+      value: fmtAct(concept.simNow),
+    },
+  ];
+
+  if ((concept.simUserRerankBoost ?? 0) !== 0) {
+    breakdownRows.push({
+      label: "rerank user Δ",
+      value: fmtAct(concept.simUserRerankBoost ?? 0),
+    });
+  }
+  if ((concept.simAssistantRerankBoost ?? 0) !== 0) {
+    breakdownRows.push({
+      label: "rerank asst Δ",
+      value: fmtAct(concept.simAssistantRerankBoost ?? 0),
+    });
+  }
+  if (concept.inRerankPool != null) {
+    breakdownRows.push({
+      label: "in rerank pool",
+      value: concept.inRerankPool ? "Yes" : "No",
+    });
+  }
+  if (isCustomSource) {
+    breakdownRows.push({ label: "source", value: concept.source });
+  }
+  breakdownRows.push({ label: "status", value: statusText });
+
+  const barWidth = Math.max(0, Math.min(concept.finalActivation, 1));
+
+  return (
+    <div
+      className="overflow-hidden rounded-md"
+      style={{ background: "var(--surface-base)" }}
+    >
+      <button
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+        style={{ background: "none", border: "none", cursor: "pointer" }}
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span
+          className="mt-0.5 shrink-0 rounded-full"
+          style={{
+            width: 8,
+            height: 8,
+            background: statusColor,
+          }}
+          aria-hidden
+        />
+        <code
+          className="flex-1 truncate text-body-small-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {concept.slug}
+        </code>
+        {isCustomSource && <TypeChip label={concept.source} />}
+        <div
+          className="shrink-0 overflow-hidden rounded-full"
+          style={{
+            width: 60,
+            height: 6,
+            background: "var(--surface-active)",
+          }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${barWidth * 100}%`,
+              background: "var(--primary-base)",
+            }}
+          />
+        </div>
+        <span
+          className="w-12 shrink-0 text-right text-body-medium-default tabular-nums"
+          style={{ color: "var(--content-default)" }}
+        >
+          {fmtAct(concept.finalActivation)}
+        </span>
+        <span
+          className="shrink-0"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {expanded ? (
+            <ChevronDown size={14} aria-hidden />
+          ) : (
+            <ChevronRight size={14} aria-hidden />
+          )}
+        </span>
+      </button>
+
+      {expanded && (
+        <div
+          className="flex flex-col gap-1 px-3 pb-3"
+          style={{ paddingLeft: "1.5rem" }}
+        >
+          {breakdownRows.map(({ label, value }) => (
+            <BreakdownRow key={label} label={label} value={value} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScopeBanner({
+  title,
+  body,
+}: {
+  title: string;
+  body: string;
+}): ReactNode {
+  return (
+    <div
+      className="rounded-lg px-4 py-3"
+      style={{ background: "var(--surface-overlay)" }}
+    >
+      <p
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {title}
+      </p>
+      <p
+        className="mt-1 text-body-medium-lighter"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {body}
+      </p>
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  subtitle,
+  copyText,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  copyText?: string;
+  children?: ReactNode;
+}): ReactNode {
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-col gap-0.5">
+            <span
+              className="text-body-medium-default"
+              style={{ color: "var(--content-default)" }}
+            >
+              {title}
+            </span>
+            {subtitle != null && subtitle !== "" && (
+              <span
+                className="text-label-default"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                {subtitle}
+              </span>
+            )}
+          </div>
+          {copyText != null && (
+            <CopyButton text={copyText} />
+          )}
+        </div>
+        {children}
+      </div>
+    </Card>
+  );
+}
+
+function MetaGrid({
+  rows,
+}: {
+  rows: { label: string; value: string }[];
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map(({ label, value }) => (
+        <div
+          key={label}
+          className="flex items-baseline justify-between gap-3"
+        >
+          <span
+            className="shrink-0 text-label-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            {label}
+          </span>
+          <span
+            className="text-right text-body-medium-lighter"
+            style={{ color: "var(--content-default)" }}
+          >
+            {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BreakdownRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): ReactNode {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span
+        className="text-label-small"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {label}
+      </span>
+      <span
+        className="tabular-nums text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function CodeBlock({ text }: { text: string }): ReactNode {
+  return (
+    <pre
+      className="overflow-x-auto rounded-md p-3 text-body-small-default"
+      style={{
+        background: "var(--surface-base)",
+        color: "var(--content-default)",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+      }}
+    >
+      {text}
+    </pre>
+  );
+}
+
+function TypeChip({ label }: { label: string }): ReactNode {
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-label-small"
+      style={{
+        background: "var(--surface-base)",
+        color: "var(--content-secondary)",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function CopyButton({ text }: { text: string }): ReactNode {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      title={copied ? "Copied!" : "Copy"}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-label-default transition-colors"
+      style={{
+        background: "var(--surface-overlay)",
+        color: copied ? "var(--system-positive-strong)" : "var(--content-secondary)",
+        border: "none",
+        cursor: "pointer",
+      }}
+    >
+      <Copy size={12} aria-hidden />
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+function NoDataState(): ReactNode {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <p
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        No memory data
+      </p>
+      <p
+        className="max-w-sm text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Memory recall information is not available for this message.
+      </p>
+    </div>
+  );
+}
+
+function fmt(n: number): string {
+  return new Intl.NumberFormat().format(n);
+}
+
+function fmtScore(n: number): string {
+  return n.toFixed(3);
+}
+
+function fmtAct(n: number): string {
+  return n.toFixed(3);
+}
+
+function v2StatusColor(status: string): string {
+  switch (status) {
+    case "in_context":
+      return "var(--content-secondary)";
+    case "injected":
+      return "var(--system-positive-strong)";
+    case "not_injected":
+      return "var(--content-disabled)";
+    default:
+      return "var(--content-tertiary)";
+  }
+}
+
+function v2StatusLabel(status: string): string {
+  switch (status) {
+    case "in_context":
+      return "In context";
+    case "injected":
+      return "Injected";
+    case "not_injected":
+      return "Not injected";
+    case "page_missing":
+      return "Page missing";
+    default:
+      return status;
+  }
+}

--- a/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight, Copy } from "lucide-react";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { Card } from "@vellum/design-library";
 import type {
@@ -15,6 +15,8 @@ import type {
  * are present a pill switcher lets the user toggle between the two
  * views; when only one is present it renders directly.
  */
+type MemoryView = "recall" | "v2";
+
 export function MemoryTab({
   context,
 }: {
@@ -25,7 +27,6 @@ export function MemoryTab({
   const hasRecall = recall !== null;
   const hasV2 = v2 !== null;
 
-  type MemoryView = "recall" | "v2";
   const defaultView: MemoryView = hasV2 ? "v2" : "recall";
   const [view, setView] = useState<MemoryView>(defaultView);
 
@@ -653,11 +654,15 @@ function TypeChip({ label }: { label: string }): ReactNode {
 
 function CopyButton({ text }: { text: string }): ReactNode {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => () => { clearTimeout(timerRef.current!); }, []);
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      clearTimeout(timerRef.current!);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
     });
   };
 

--- a/apps/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
@@ -1,0 +1,275 @@
+import { type ReactNode } from "react";
+
+import { Card } from "@vellum/design-library";
+import {
+  compactToolNames,
+  displayProvider,
+  displayText,
+  formatCacheTokens,
+  formatCost,
+  formatCount,
+  formattedCreatedAt,
+  isProviderOnlySummary,
+  MISSING_VALUE,
+  summaryFallbackMessage,
+  truncatedResponsePreview,
+} from "@/domains/chat/inspector/inspector-formatters.js";
+import type {
+  LLMCallSummary,
+  LLMRequestLogEntry,
+} from "@/domains/chat/types/inspector-types.js";
+
+interface OverviewTabProps {
+  entry: LLMRequestLogEntry;
+  conversationTotalEstimatedCostUsd?: number | null;
+}
+
+interface MetadataRow {
+  label: string;
+  value: string;
+}
+
+/**
+ * Overview tab rendering the normalized summary as a stack of cards:
+ * optional conversation totals, identity (provider/model/created-at),
+ * usage (token + cost rows), response preview, and tool-call list.
+ * Falls back to a single explanatory card when the daemon couldn't
+ * normalize the call.
+ */
+export function OverviewTab({
+  entry,
+  conversationTotalEstimatedCostUsd,
+}: OverviewTabProps): ReactNode {
+  const summary = entry.summary;
+  const showFallback = !summary || isProviderOnlySummary(summary);
+  const conversationTotals = renderConversationTotalsCard(
+    conversationTotalEstimatedCostUsd,
+  );
+
+  if (showFallback) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        {conversationTotals}
+        <FallbackCard
+          message={summaryFallbackMessage(
+            entry.createdAt,
+            summary?.provider ?? null,
+          )}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {conversationTotals}
+      <MetadataCard
+        title="Normalized metadata"
+        subtitle="Provider, model, timestamps, and usage counts."
+        rows={buildIdentityRows(
+          summary,
+          entry.createdAt,
+          entry.agentLoopExitReason,
+        )}
+      />
+      <MetadataCard
+        title="Usage"
+        subtitle="Token and call counts normalized by the assistant route."
+        rows={buildUsageRows(summary)}
+      />
+      <SecondaryCard
+        title="Response preview"
+        body={truncatedResponsePreview(summary.responsePreview ?? null)}
+      />
+      <SecondaryCard
+        title="Tool calls"
+        body={compactToolNames(summary.toolCallNames ?? null)}
+      />
+    </div>
+  );
+}
+
+function renderConversationTotalsCard(
+  conversationTotalEstimatedCostUsd: number | null | undefined,
+): ReactNode {
+  if (
+    conversationTotalEstimatedCostUsd == null ||
+    !Number.isFinite(conversationTotalEstimatedCostUsd)
+  ) {
+    return null;
+  }
+  return (
+    <MetadataCard
+      title="Conversation"
+      subtitle="Running totals across every priced LLM call so far."
+      rows={[
+        {
+          label: "Total cost so far",
+          value: formatCost(conversationTotalEstimatedCostUsd),
+        },
+      ]}
+    />
+  );
+}
+
+function buildIdentityRows(
+  summary: LLMCallSummary,
+  createdAt: number | null | undefined,
+  agentLoopExitReason: string | null | undefined,
+): MetadataRow[] {
+  const rows: MetadataRow[] = [
+    { label: "Provider", value: displayProvider(summary.provider ?? null) },
+    { label: "Model", value: displayText(summary.model ?? null) },
+    { label: "Created", value: formattedCreatedAt(createdAt) },
+    { label: "Status", value: displayText(summary.status ?? null) },
+    { label: "Stop reason", value: displayText(summary.stopReason ?? null) },
+  ];
+  if (agentLoopExitReason != null && agentLoopExitReason.trim().length > 0) {
+    rows.push({
+      label: "Loop exit reason",
+      value: displayText(agentLoopExitReason),
+    });
+  }
+  return rows;
+}
+
+function buildUsageRows(summary: LLMCallSummary): MetadataRow[] {
+  const rows: MetadataRow[] = [
+    { label: "Input tokens", value: formatCount(summary.inputTokens) },
+    { label: "Output tokens", value: formatCount(summary.outputTokens) },
+    {
+      label: "Cache tokens",
+      value: formatCacheTokens(
+        summary.cacheCreationInputTokens,
+        summary.cacheReadInputTokens,
+      ),
+    },
+    { label: "Estimated cost", value: formatCost(summary.estimatedCostUsd) },
+    {
+      label: "Request messages",
+      value: formatCount(summary.requestMessageCount),
+    },
+    { label: "Tools available", value: formatCount(summary.requestToolCount) },
+    { label: "Tool calls", value: formatCount(summary.responseToolCallCount) },
+  ];
+  if (
+    summary.durationMs != null &&
+    Number.isFinite(summary.durationMs)
+  ) {
+    rows.splice(4, 0, {
+      label: "Duration",
+      value: `${formatCount(Math.round(summary.durationMs))} ms`,
+    });
+  }
+  return rows;
+}
+
+function CardHeader({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle?: string;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <span
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        {title}
+      </span>
+      {subtitle ? (
+        <span
+          className="text-label-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {subtitle}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function MetadataCard({
+  title,
+  subtitle,
+  rows,
+}: {
+  title: string;
+  subtitle: string;
+  rows: MetadataRow[];
+}): ReactNode {
+  return (
+    <Card padding="md">
+      <div className="flex flex-col gap-3">
+        <CardHeader title={title} subtitle={subtitle} />
+        <div className="flex flex-col gap-2">
+          {rows.map((row) => (
+            <MetadataRowItem key={row.label} row={row} />
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function SecondaryCard({
+  title,
+  body,
+}: {
+  title: string;
+  body: string;
+}): ReactNode {
+  return (
+    <Card padding="md">
+      <div className="flex flex-col gap-2">
+        <CardHeader title={title} />
+        <p
+          className="select-text whitespace-pre-wrap break-words text-body-medium-lighter"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {body || MISSING_VALUE}
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function FallbackCard({ message }: { message: string }): ReactNode {
+  return (
+    <Card padding="md">
+      <div className="flex flex-col gap-2">
+        <CardHeader
+          title="Normalized summary unavailable"
+          subtitle="This call still has raw request and response payloads."
+        />
+        <p
+          className="select-text whitespace-pre-wrap break-words text-body-medium-lighter"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          {message}
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function MetadataRowItem({ row }: { row: MetadataRow }): ReactNode {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span
+        className="shrink-0 text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {row.label}
+      </span>
+      <span
+        className="ml-auto select-text break-words text-right text-body-medium-lighter"
+        style={{ color: "var(--content-default)" }}
+      >
+        {row.value}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
@@ -1,0 +1,239 @@
+import { Copy } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { Button, Card, SegmentControl } from "@vellum/design-library";
+import type {
+  LLMContextSection,
+  LLMRequestLogEntry,
+} from "@/domains/chat/types/inspector-types.js";
+import { FileMarkdown } from "@/domains/intelligence/components/file-markdown.js";
+
+interface PromptTabProps {
+  entry: LLMRequestLogEntry;
+}
+
+type ViewMode = "markdown" | "raw";
+
+/**
+ * Prompt tab rendering each normalized request section as a card.
+ * Text sections render as Markdown by default; a Markdown/Raw segmented
+ * control flips the entire tab to plain `<pre>` text. Structured
+ * payloads always render as `<pre>` regardless of mode.
+ */
+export function PromptTab({ entry }: PromptTabProps): ReactNode {
+  const sections = entry.requestSections ?? [];
+  const [viewMode, setViewMode] = useState<ViewMode>("markdown");
+
+  const bannerText =
+    sections.length === 0
+      ? "This call has no normalized prompt sections yet."
+      : `${sections.length} normalized request section${sections.length === 1 ? "" : "s"} shown in the order returned by the assistant route.`;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Card>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p
+              className="text-body-medium-default"
+              style={{ color: "var(--content-default)" }}
+            >
+              Prompt sections
+            </p>
+            <p
+              className="mt-1 text-body-medium-lighter"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              {bannerText}
+            </p>
+          </div>
+          {sections.length > 0 && (
+            <SegmentControl<ViewMode>
+              ariaLabel="Prompt rendering mode"
+              value={viewMode}
+              onChange={setViewMode}
+              items={[
+                { value: "markdown", label: "Markdown" },
+                { value: "raw", label: "Raw" },
+              ]}
+            />
+          )}
+        </div>
+      </Card>
+
+      {sections.length === 0 ? (
+        <EmptyState />
+      ) : (
+        sections.map((section, i) => (
+          <SectionCard
+            key={i}
+            section={section}
+            index={i}
+            viewMode={viewMode}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function EmptyState(): ReactNode {
+  return (
+    <Card>
+      <p
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        No normalized prompt sections
+      </p>
+      <p
+        className="mt-1 text-body-medium-lighter"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        This call has no normalized prompt sections. Use the Raw tab to inspect
+        the full request payload.
+      </p>
+    </Card>
+  );
+}
+
+interface SectionCardProps {
+  section: LLMContextSection;
+  index: number;
+  viewMode: ViewMode;
+}
+
+function SectionCard({
+  section,
+  index,
+  viewMode,
+}: SectionCardProps): ReactNode {
+  const title = sectionTitle(section, index);
+  const kind = humanKindLabel(section.kind);
+  const formatLabel = languageFormatLabel(section.language ?? null);
+  const { text, isStructured } = renderContent(section);
+  const renderAsMarkdown = !isStructured && viewMode === "markdown";
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p
+            className="truncate text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {title}
+          </p>
+          <div className="mt-0.5 flex items-center gap-2">
+            <span
+              className="text-label-default"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              {kind}
+            </span>
+            {formatLabel && (
+              <span
+                className="text-label-default"
+                style={{ color: "var(--content-secondary)" }}
+              >
+                {formatLabel}
+              </span>
+            )}
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="compact"
+          iconOnly
+          leftIcon={<Copy size={14} aria-hidden />}
+          aria-label={`Copy ${title}`}
+          onClick={() => void navigator.clipboard.writeText(text)}
+        />
+      </div>
+
+      {isStructured ? (
+        <pre
+          className="mt-3 overflow-auto rounded-md p-3 text-body-small-default"
+          style={{
+            background: "var(--surface-base)",
+            color: "var(--content-default)",
+            maxHeight: "320px",
+          }}
+        >
+          {text}
+        </pre>
+      ) : renderAsMarkdown ? (
+        <div
+          className="mt-3 min-w-0 break-words"
+          style={{ color: "var(--content-default)" }}
+        >
+          <FileMarkdown content={text} stripFrontmatter={false} />
+        </div>
+      ) : (
+        <p
+          className="mt-3 select-text whitespace-pre-wrap break-words text-body-medium-lighter"
+          style={{ color: "var(--content-default)" }}
+        >
+          {text}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function sectionTitle(section: LLMContextSection, index: number): string {
+  const lbl = section.label?.trim();
+  if (lbl) return lbl;
+  return `${humanKindLabel(section.kind)} ${index + 1}`;
+}
+
+function humanKindLabel(kind: string): string {
+  return kind
+    .replace(/_/g, " ")
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function languageFormatLabel(language: string | null): string | null {
+  if (!language) return null;
+  switch (language.toLowerCase()) {
+    case "json":
+    case "application/json":
+      return "JSON";
+    case "markdown":
+    case "md":
+    case "text/markdown":
+      return "Markdown";
+    case "javascript":
+    case "application/javascript":
+    case "text/javascript":
+      return "JavaScript";
+    case "typescript":
+    case "application/typescript":
+    case "text/typescript":
+      return "TypeScript";
+    default:
+      return null;
+  }
+}
+
+function renderContent(section: LLMContextSection): {
+  text: string;
+  isStructured: boolean;
+} {
+  if (section.text != null) {
+    return { text: section.text, isStructured: false };
+  }
+  if (section.data != null) {
+    try {
+      return {
+        text: JSON.stringify(section.data, null, 2),
+        isStructured: true,
+      };
+    } catch {
+      return { text: String(section.data), isStructured: false };
+    }
+  }
+  return { text: "No content available.", isStructured: false };
+}

--- a/apps/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
@@ -1,0 +1,182 @@
+import { AlertCircle, Copy, Download, RefreshCw } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import { Button, Card } from "@vellum/design-library";
+import { useLlmLogPayload } from "@/domains/chat/inspector/inspector-payload-api.js";
+import type { LLMRequestLogEntry } from "@/domains/chat/types/inspector-types.js";
+
+type RawPane = "request" | "response";
+
+interface RawTabProps {
+  entry: LLMRequestLogEntry;
+  assistantId: string | undefined;
+}
+
+/**
+ * Raw tab — lazily fetches the full provider JSON for the selected call.
+ * Exposes a Request/Response toggle, copy action, and download action
+ * for each pane. Payloads are cached for 5 minutes (immutable).
+ */
+export function RawTab({ entry, assistantId }: RawTabProps): ReactNode {
+  const [pane, setPane] = useState<RawPane>("request");
+  const { data, isLoading, isError, error, refetch } = useLlmLogPayload(
+    assistantId,
+    entry.id,
+  );
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (isError) {
+    const msg =
+      error && typeof error === "object" && "message" in error
+        ? String((error as { message: unknown }).message)
+        : "The payload request failed. Try again.";
+    return <ErrorState message={msg} onRetry={() => void refetch()} />;
+  }
+
+  const rawValue = pane === "request" ? data?.requestPayload : data?.responsePayload;
+  const displayText = formatPayload(rawValue);
+  const downloadFilename = buildRawPayloadFilename(entry.id, pane);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center gap-2">
+        {(["request", "response"] as RawPane[]).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPane(p)}
+            className="rounded-md px-3 py-1 text-label-medium-default transition-colors"
+            style={{
+              background: pane === p ? "var(--surface-overlay)" : "transparent",
+              color:
+                pane === p ? "var(--content-default)" : "var(--content-secondary)",
+              border: "1px solid var(--border-base)",
+            }}
+          >
+            {p === "request" ? "Request" : "Response"}
+          </button>
+        ))}
+      </div>
+
+      <Card>
+        <div className="flex items-center justify-between gap-3">
+          <span
+            className="text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {pane === "request" ? "Request payload" : "Response payload"}
+          </span>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="compact"
+              iconOnly
+              leftIcon={<Download size={14} aria-hidden />}
+              aria-label={`Download ${pane} payload`}
+              onClick={() => downloadRawPayload(displayText, downloadFilename)}
+            />
+            <Button
+              variant="ghost"
+              size="compact"
+              iconOnly
+              leftIcon={<Copy size={14} aria-hidden />}
+              aria-label={`Copy ${pane} payload`}
+              onClick={() => void navigator.clipboard.writeText(displayText)}
+            />
+          </div>
+        </div>
+        <pre
+          className="mt-3 overflow-auto rounded-md p-3 text-body-small-default"
+          style={{
+            background: "var(--surface-base)",
+            color: "var(--content-default)",
+            maxHeight: "calc(100vh - 320px)",
+            minHeight: "120px",
+          }}
+        >
+          {displayText}
+        </pre>
+      </Card>
+    </div>
+  );
+}
+
+export function formatPayload(value: unknown): string {
+  if (value == null) return "null";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function buildRawPayloadFilename(logId: string, pane: RawPane): string {
+  const safeLogId = logId.replace(/[^A-Za-z0-9._-]+/g, "_");
+  return `llm-${safeLogId}-${pane}.json`;
+}
+
+function downloadRawPayload(text: string, filename: string): void {
+  const blob = new Blob([text], { type: "application/json;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function LoadingState(): ReactNode {
+  return (
+    <div className="flex h-48 w-full flex-col items-center justify-center gap-2">
+      <p
+        className="text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Loading raw payloads…
+      </p>
+    </div>
+  );
+}
+
+interface ErrorStateProps {
+  message: string;
+  onRetry: () => void;
+}
+
+function ErrorState({ message, onRetry }: ErrorStateProps): ReactNode {
+  return (
+    <div className="flex h-48 w-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <AlertCircle
+        size={28}
+        aria-hidden
+        style={{ color: "var(--content-secondary)" }}
+      />
+      <p
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        Couldn&rsquo;t load raw payloads
+      </p>
+      <p
+        className="max-w-xs text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {message}
+      </p>
+      <Button
+        variant="outlined"
+        size="compact"
+        leftIcon={<RefreshCw size={14} aria-hidden />}
+        onClick={onRetry}
+      >
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
@@ -1,0 +1,326 @@
+import { Copy, FileCode } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Button, Card } from "@vellum/design-library";
+import type {
+  LLMCallSummary,
+  LLMContextSection,
+  LLMRequestLogEntry,
+} from "@/domains/chat/types/inspector-types.js";
+
+interface ResponseTabProps {
+  entry: LLMRequestLogEntry;
+}
+
+/**
+ * Response tab rendering a metadata card (stop reason + mode label)
+ * followed by per-section cards keyed on presentation kind.
+ */
+export function ResponseTab({ entry }: ResponseTabProps): ReactNode {
+  const sections = buildSectionModels(entry.responseSections ?? []);
+  const stopReason = deriveStopReason(entry.summary);
+  const modeLabel = deriveModeLabel(entry.summary, sections);
+  const hasMetadata = stopReason != null || modeLabel != null;
+
+  if (!sections.length && !hasMetadata) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <FallbackCard message={null} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {hasMetadata && (
+        <Card>
+          <p
+            className="text-body-medium-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            Response metadata
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {stopReason && <MetadataChip label={`Stop reason: ${stopReason}`} />}
+            {modeLabel && <MetadataChip label={modeLabel} />}
+          </div>
+        </Card>
+      )}
+
+      {sections.length > 0 ? (
+        sections.map((s) => <ResponseSectionCard key={s.id} section={s} />)
+      ) : (
+        <FallbackCard message={null} />
+      )}
+    </div>
+  );
+}
+
+interface ResponseSectionCardProps {
+  section: ResponseSectionModel;
+}
+
+function ResponseSectionCard({ section }: ResponseSectionCardProps): ReactNode {
+  switch (section.kind) {
+    case "toolCall":
+      return <ToolCallCard section={section} />;
+    default:
+      return <TextCard section={section} />;
+  }
+}
+
+function TextCard({ section }: ResponseSectionCardProps): ReactNode {
+  return (
+    <Card>
+      <SectionHeader section={section} />
+      {section.bodyText ? (
+        <p
+          className="mt-3 select-text whitespace-pre-wrap text-body-medium-lighter"
+          style={{ color: "var(--content-default)" }}
+        >
+          {section.bodyText}
+        </p>
+      ) : (
+        <p
+          className="mt-3 text-body-medium-lighter"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          No assistant text was captured for this section.
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function ToolCallCard({ section }: ResponseSectionCardProps): ReactNode {
+  return (
+    <Card>
+      <SectionHeader section={section} />
+      {section.toolName && (
+        <div className="mt-2">
+          <MetadataChip label={`Tool: ${section.toolName}`} />
+        </div>
+      )}
+      {section.bodyText ? (
+        <div className="mt-3">
+          <p
+            className="mb-1 text-label-default"
+            style={{ color: "var(--content-secondary)" }}
+          >
+            Arguments preview
+          </p>
+          <p
+            className="select-text whitespace-pre-wrap text-body-small-default"
+            style={{ color: "var(--content-default)" }}
+          >
+            {section.bodyText}
+          </p>
+        </div>
+      ) : (
+        <p
+          className="mt-3 text-body-medium-lighter"
+          style={{ color: "var(--content-secondary)" }}
+        >
+          No structured arguments preview is available for this tool call.
+        </p>
+      )}
+      <div
+        className="mt-3 rounded-md px-3 py-2 text-label-default"
+        style={{
+          background: "var(--surface-overlay)",
+          color: "var(--content-secondary)",
+        }}
+      >
+        Need the full provider payload? Open the Raw tab for request and
+        response JSON.
+      </div>
+    </Card>
+  );
+}
+
+function FallbackCard({ message }: { message: string | null }): ReactNode {
+  return (
+    <Card>
+      <div className="flex items-center gap-2">
+        <FileCode
+          size={14}
+          aria-hidden
+          style={{ color: "var(--content-tertiary)" }}
+        />
+        <span
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          Section rendering unavailable
+        </span>
+      </div>
+      <p
+        className="mt-2 text-body-medium-lighter"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        {message ??
+          "This response has no rendered sections. Raw payloads remain available in the Raw tab, and any normalized response metadata will still be shown when present."}
+      </p>
+    </Card>
+  );
+}
+
+function SectionHeader({
+  section,
+}: {
+  section: ResponseSectionModel;
+}): ReactNode {
+  return (
+    <div className="flex items-start gap-4">
+      <div className="min-w-0 flex-1">
+        <p
+          className="text-body-medium-default"
+          style={{ color: "var(--content-default)" }}
+        >
+          {section.title}
+        </p>
+        <div className="mt-0.5">
+          <MetadataChip label={section.kindLabel} />
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="compact"
+        iconOnly
+        leftIcon={<Copy size={14} aria-hidden />}
+        aria-label="Copy section content"
+        onClick={() =>
+          void navigator.clipboard.writeText(section.copyText)
+        }
+      />
+    </div>
+  );
+}
+
+function MetadataChip({ label }: { label: string }): ReactNode {
+  return (
+    <span
+      className="inline-block rounded px-2 py-0.5 text-label-default"
+      style={{
+        background: "var(--surface-overlay)",
+        color: "var(--content-secondary)",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+type PresentationKind = "assistantText" | "reasoning" | "toolCall" | "result" | "other";
+
+interface ResponseSectionModel {
+  id: number;
+  kind: PresentationKind;
+  title: string;
+  kindLabel: string;
+  bodyText: string | null;
+  toolName: string | null;
+  copyText: string;
+}
+
+const TEXT_KINDS = new Set([
+  "assistant",
+  "message",
+  "text",
+  "output",
+  "completion",
+  "markdown",
+  "code",
+  "json",
+]);
+
+const TOOL_CALL_KINDS = new Set(["tool", "tool_use", "function_call"]);
+
+const RESULT_KINDS = new Set(["tool_result", "function_response"]);
+
+function toPresentationKind(kind: string): PresentationKind {
+  const k = kind.toLowerCase();
+  if (TOOL_CALL_KINDS.has(k)) return "toolCall";
+  if (RESULT_KINDS.has(k)) return "result";
+  if (k === "reasoning") return "reasoning";
+  if (TEXT_KINDS.has(k)) return "assistantText";
+  return "other";
+}
+
+function kindDisplayLabel(kind: string, presentationKind: PresentationKind): string {
+  switch (presentationKind) {
+    case "toolCall":
+      return "Tool call";
+    case "result":
+      return kind.toLowerCase() === "function_response"
+        ? "Function response"
+        : "Tool result";
+    case "reasoning":
+      return "Reasoning";
+    case "assistantText":
+      return "Assistant text";
+    default:
+      return kind;
+  }
+}
+
+function sectionBodyText(section: LLMContextSection): string | null {
+  if (section.text != null) return section.text;
+  if (section.data != null) {
+    try {
+      return JSON.stringify(section.data, null, 2);
+    } catch {
+      return String(section.data);
+    }
+  }
+  return null;
+}
+
+function buildSectionModels(sections: LLMContextSection[]): ResponseSectionModel[] {
+  return sections.map((section, index) => {
+    const pKind = toPresentationKind(section.kind);
+    const rawTitle = section.label?.trim() ?? "";
+    const title = rawTitle || `Section ${index + 1}`;
+    const body = sectionBodyText(section);
+    return {
+      id: index,
+      kind: pKind,
+      title,
+      kindLabel: kindDisplayLabel(section.kind, pKind),
+      bodyText: body,
+      toolName: section.toolName ?? null,
+      copyText: body ?? title,
+    };
+  });
+}
+
+function deriveStopReason(summary?: LLMCallSummary | null): string | null {
+  const raw = summary?.stopReason?.trim();
+  return raw || null;
+}
+
+function isToolCallingStop(stopReason: string | null): boolean {
+  if (!stopReason) return false;
+  return ["tool_calls", "tool_use", "function_call", "function_calls"].includes(
+    stopReason.toLowerCase().trim(),
+  );
+}
+
+function deriveModeLabel(
+  summary: LLMCallSummary | null | undefined,
+  sections: ResponseSectionModel[],
+): string | null {
+  if (summary?.responseToolCallCount && summary.responseToolCallCount > 0) {
+    return "Tool-calling response";
+  }
+  if (isToolCallingStop(summary?.stopReason ?? null)) {
+    return "Tool-calling response";
+  }
+  if (!sections.length) return null;
+  if (sections.some((s) => s.kind === "toolCall")) return "Tool-calling response";
+  const hasText = sections.some((s) => s.kind === "assistantText");
+  const hasResult = sections.some((s) => s.kind === "result");
+  if (hasText && !hasResult) return "Text-only response";
+  if (hasResult && !hasText) return "Result-only response";
+  return null;
+}

--- a/apps/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.tsx
@@ -1,0 +1,152 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router";
+import { type ReactNode } from "react";
+
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { fetchConversationMessages } from "@/domains/chat/api/messages.js";
+import { MessageInspectorView } from "@/domains/chat/inspector/components/message-inspector-view.js";
+
+/**
+ * `/assistant/inspect` page. Reads `?conversationKey=...&messageId=...`
+ * from the query string and mounts the inspector view. When `messageId`
+ * is omitted, resolves the latest assistant message for the given
+ * conversation.
+ */
+export function InspectPage(): ReactNode {
+  const [searchParams] = useSearchParams();
+  const conversationKey = searchParams.get("conversationKey");
+  const messageId = searchParams.get("messageId");
+
+  if (!conversationKey) {
+    return <MissingConversationKeyState />;
+  }
+
+  if (messageId) {
+    return (
+      <MessageInspectorView
+        conversationKey={conversationKey}
+        messageId={messageId}
+      />
+    );
+  }
+
+  return <ResolveLatestMessage conversationKey={conversationKey} />;
+}
+
+function ResolveLatestMessage({
+  conversationKey,
+}: {
+  conversationKey: string;
+}): ReactNode {
+  const { assistantId } = useAssistantContext();
+
+  const {
+    data: latestAssistantMessageId,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: [
+      "assistants",
+      assistantId,
+      "conversations",
+      conversationKey,
+      "latest-assistant-message-id",
+    ] as const,
+    queryFn: async (): Promise<string | null> => {
+      if (!assistantId) return null;
+      const messages = await fetchConversationMessages(
+        assistantId,
+        conversationKey,
+      );
+      for (let i = messages.length - 1; i >= 0; i -= 1) {
+        const msg = messages[i]!;
+        if (msg.role !== "assistant") continue;
+        const id = msg.daemonMessageId ?? msg.id;
+        if (id) return id;
+      }
+      return null;
+    },
+    enabled: Boolean(assistantId),
+    staleTime: 30_000,
+  });
+
+  if (isLoading) {
+    return <CenteredMessage tone="muted">Loading…</CenteredMessage>;
+  }
+  if (isError) {
+    return (
+      <CenteredMessage tone="muted">
+        Failed to load conversation messages.
+      </CenteredMessage>
+    );
+  }
+  if (!latestAssistantMessageId) {
+    return <NoAssistantMessageState />;
+  }
+
+  return (
+    <MessageInspectorView
+      conversationKey={conversationKey}
+      messageId={latestAssistantMessageId}
+    />
+  );
+}
+
+function MissingConversationKeyState(): ReactNode {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        Missing inspector parameters
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        Open the inspector from a conversation&rsquo;s overflow menu — direct
+        navigation requires a <code>conversationKey</code>.
+      </p>
+    </div>
+  );
+}
+
+function NoAssistantMessageState(): ReactNode {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <h2
+        className="text-body-medium-default"
+        style={{ color: "var(--content-default)" }}
+      >
+        Nothing to inspect yet
+      </h2>
+      <p
+        className="max-w-md text-label-default"
+        style={{ color: "var(--content-secondary)" }}
+      >
+        This conversation has no assistant messages — the inspector needs at
+        least one assistant turn to show LLM context.
+      </p>
+    </div>
+  );
+}
+
+function CenteredMessage({
+  children,
+  tone = "default",
+}: {
+  children: ReactNode;
+  tone?: "muted" | "default";
+}): ReactNode {
+  const color =
+    tone === "muted" ? "var(--content-tertiary)" : "var(--content-secondary)";
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center p-8 text-label-default"
+      style={{ color }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/types/inspector-types.ts
+++ b/apps/web/src/domains/chat/types/inspector-types.ts
@@ -71,6 +71,7 @@ export interface LLMRequestLogEntry {
   summary?: LLMCallSummary | null;
   requestSections?: LLMContextSection[] | null;
   responseSections?: LLMContextSection[] | null;
+  agentLoopExitReason?: string | null;
 }
 
 /**

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -11,6 +11,7 @@ import { IdentityPage } from "@/domains/intelligence/identity-page.js";
 import { ConnectPage } from "@/domains/contacts/connect-page.js";
 import { ContactsPage } from "@/domains/contacts/contacts-page.js";
 import { WorkspacePage } from "@/domains/workspace/workspace-page.js";
+import { InspectPage } from "@/domains/chat/inspector/inspect-page.js";
 import { NotFound } from "@/components/not-found.js";
 import { SettingsLayout } from "@/domains/settings/settings-layout.js";
 import { GeneralPage } from "@/domains/settings/pages/general-page.js";
@@ -182,6 +183,7 @@ export const router = createBrowserRouter([
           { path: "workspace", element: <WorkspacePage /> },
           { path: "contacts", element: <ContactsPage /> },
           { path: "connect", element: <ConnectPage /> },
+          { path: "inspect", element: <InspectPage /> },
         ],
       },
 


### PR DESCRIPTION
## Prompt / plan

Port the `/assistant/inspect` page and full `MessageInspectorView` component tree from `vellum-assistant-platform` to `vellum-assistant`. The route constant and navigation action already exist (`use-conversation-secondary-actions.ts` navigates to `routes.inspect` with `?conversationKey=&messageId=`), but there was no matching route in `routes.tsx` — clicking "Inspect" in the conversation menu resulted in a 404.

The inspector data-fetching layer (`domains/chat/inspector/`) was already ported in a prior PR. Only the view components and route were missing.

### What's ported

| File | Lines | What it does |
|------|-------|-------------|
| `inspect-page.tsx` | 143 | Page reading `?conversationKey` + `?messageId`, resolves latest assistant message when messageId omitted |
| `message-inspector-view.tsx` | 312 | Three-region layout: header with back nav + export, call rail, tabbed detail pane. URL-driven call selection via `?callId` |
| `call-rail.tsx` | 139 | Left rail listing LLM calls as real hyperlinks (newest first) |
| `tab-bar.tsx` | 50 | Horizontal tab bar (overview / prompt / response / raw / memory) |
| `overview-tab.tsx` | 305 | Normalized summary cards: identity rows, usage rows, cost |
| `prompt-tab.tsx` | 246 | Request sections with markdown / raw view toggle |
| `response-tab.tsx` | 338 | Response sections with metadata card and copy actions |
| `raw-tab.tsx` | 191 | Full provider JSON with lazy fetch, copy, download |
| `memory-tab.tsx` | 773 | Memory recall v1 + v2 activation data display |
| `inspector-types.ts` | +1 | Added `agentLoopExitReason` field to `LLMRequestLogEntry` |
| `routes.tsx` | +2 | Added `inspect` route under ChatLayout children |

### Convention adaptations from platform

- `useSearchParams` from `react-router` (not `next/navigation`)
- `Link` from `react-router` (not `AppLink`) — all internal navigation uses `<Link to>` for SPA transitions
- `useAssistantContext()` (not `useResolvedAssistantId`)
- Removed all `"use client"` directives
- kebab-case filenames, `.js` extensions on imports, `@/` aliases
- No barrel files — direct imports from source files
- `Button`, `Card`, `SegmentControl` from `@vellum/design-library`

### Bugs fixed (not carried from platform)

1. **`fetchConversationMessages` silently swallows HTTP errors** — The function returned `[]` for non-OK responses, so backend/auth failures appeared as "no assistant messages" instead of an error state. Now throws on non-OK responses so TanStack Query's `isError` catches it. Both existing callers (`use-send-message.ts`, `use-message-reconciliation.ts`) already wrap calls in try/catch with best-effort semantics.
2. **Back button caused full page reload** — Used `<a href>` instead of `<Link to>` from react-router, losing all client state (Zustand stores, query cache). Fixed to use `<Link to>` consistent with `call-rail.tsx`.
3. **CopyButton timer leak on unmount** — `setTimeout` in `CopyButton` had no cleanup, risking setState-on-unmounted. Added `useRef` + `useEffect` cleanup.
4. **Type alias inside component body** — `MemoryView` type was declared inside the `MemoryTab` function body. Moved above the component for clarity and reusability.

### What this does NOT change

- No changes to existing inspector API layer (`inspector-api.ts`, `inspector-payload-api.ts`, `inspector-export.ts`)
- No changes to navigation action in `use-conversation-secondary-actions.ts`
- No changes to route constants in `utils/routes.ts`

### Alternatives not taken

- **Stub page**: Could have added a simple placeholder page to fix the 404. Rejected because the full inspector is needed for debugging LLM calls — a stub provides no value.
- **Mobile call switcher**: The call rail is hidden below `md` breakpoint with no alternate mobile control. This matches the platform behavior and is a follow-up UX improvement, not a port concern.

Closes LUM-1766

## Test plan

- `bunx tsc --noEmit` — 0 errors
- `bun run lint` — 0 errors (1 pre-existing warning in unrelated file)
- `bun run build` — succeeds (6,393 modules)
- CI — 7/7 checks pass
- Route wiring verified: `inspect` route added under ChatLayout children, matches existing `routes.inspect` constant
- All imports verified against existing exports in the codebase

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->