### PR TITLE
fix(design-library): restore missing theme tokens, animations, and scrollbars

### DIFF
--- a/apps/web/src/domains/chat/components/busy-indicator.tsx
+++ b/apps/web/src/domains/chat/components/busy-indicator.tsx
@@ -4,7 +4,7 @@
  *
  * A filled circle that gently pulses in opacity (1→0.3) and scale (1→0.85)
  * over 1s easeInOut. Respects prefers-reduced-motion via the
- * `.busy-indicator` CSS class defined in appTheme.css.
+ * `.busy-indicator` CSS class defined in `apps/web/src/index.css`.
  *
  * Size guide (matching macOS usage):
  *   - 8px  — card-header status icon (ToolCallProgressCard CardStatusIcon)

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -162,7 +162,7 @@ export function HomePage({
         minLeftWidth={400}
         minRightWidth={320}
         left={
-          <div className="flex h-full flex-col gap-[var(--app-spacing-xl)] overflow-y-auto px-[var(--app-spacing-xl)] py-[var(--app-spacing-2xl)]">
+          <div className="flex h-full flex-col gap-[var(--app-spacing-xl)] overflow-y-auto px-[var(--app-spacing-xl)] py-[var(--app-spacing-xxl)]">
             {feedContent}
           </div>
         }
@@ -180,7 +180,7 @@ export function HomePage({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <div className="mx-auto w-full max-w-[960px] px-[var(--app-spacing-xl)] py-[var(--app-spacing-2xl)]">
+      <div className="mx-auto w-full max-w-[960px] px-[var(--app-spacing-xl)] py-[var(--app-spacing-xxl)]">
         <div className="flex flex-col gap-[var(--app-spacing-xl)]">
           {feedContent}
         </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,7 +2,9 @@
 @import "@vellum/design-library/tokens.css";
 @source "../node_modules/@vellum/design-library/src/**/*.tsx";
 
-/* Functional keyframes — ported from platform appTheme.css */
+/* Functional keyframes — app-only animations. Animations consumed by
+ * design-library primitives (popoverIn, bottomSheetIn, panelitem-marquee,
+ * collapsible-slide-*) live in the library's tokens.css. */
 
 @keyframes indeterminate {
   0% { width: 0%; margin-left: 0%; }
@@ -39,4 +41,154 @@
   25% { transform: rotate(0.86deg); }
   50% { transform: rotate(0deg); }
   75% { transform: rotate(-0.86deg); }
+}
+
+/* BusyIndicator — mirrors macOS VBusyIndicator. A filled circle pulsing in
+ * opacity (1→0.3) and scale (1→0.85) over 1s easeInOut. Used in
+ * ToolCallProgressCard for active/thinking phases. */
+@keyframes busy-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.3; transform: scale(0.85); }
+}
+
+.busy-indicator {
+  animation: busy-pulse 1s ease-in-out infinite;
+}
+
+/* Onboarding hatching avatar pulse. Mirrors the macOS HatchingStepView
+ * character animation: scales between 0.9 and 1.0 on ease-in-out, 1.2s
+ * cycle, infinite alternate. Opacity dimmed to 0.6 so the creature reads
+ * as "asleep" during hatching. When the assistant becomes active, swap
+ * the class for `.onboarding-avatar-awake`. */
+@keyframes morphPulse {
+  0% { transform: scale(0.9); }
+  100% { transform: scale(1.0); }
+}
+
+.onboarding-avatar-pulse {
+  animation: morphPulse 1.2s ease-in-out infinite alternate;
+  opacity: 0.6;
+  will-change: transform, opacity;
+}
+
+.onboarding-avatar-awake {
+  transform: scale(1.1);
+  opacity: 1;
+  transition:
+    transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.4s ease-out;
+}
+
+/* Failed hatch — tilt the creature ~45° and desaturate toward gray.
+ * No `transition`: the error branch mounts a fresh MorphAvatar rather than
+ * swapping classes on a persistent node. */
+.onboarding-avatar-failed {
+  transform: rotate(45deg);
+  filter: grayscale(1) brightness(0.55);
+  opacity: 1;
+}
+
+/* App shell sizing guards: keep routed pages from collapsing inside flex
+ * main containers. */
+.app-shell {
+  width: 100%;
+  min-width: 0;
+}
+
+.app-shell-main > * {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Themed scrollbars — subtle, replacing the default OS gray. Applied to
+ * the root and all descendants. Theme-aware via the `data-theme` attribute
+ * on <html>. */
+:root {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(113, 128, 142, 0.35) transparent;
+}
+
+:root *,
+:root *::before,
+:root *::after {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(113, 128, 142, 0.35) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(113, 128, 142, 0.35);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(113, 128, 142, 0.6);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+[data-theme="dark"] {
+  scrollbar-color: rgba(169, 178, 187, 0.25) transparent;
+}
+
+[data-theme="dark"] *,
+[data-theme="dark"] *::before,
+[data-theme="dark"] *::after {
+  scrollbar-color: rgba(169, 178, 187, 0.25) transparent;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background: rgba(169, 178, 187, 0.25);
+  background-clip: padding-box;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(169, 178, 187, 0.5);
+  background-clip: padding-box;
+}
+
+[data-theme="velvet"] {
+  scrollbar-color: rgba(232, 63, 91, 0.28) transparent;
+}
+
+[data-theme="velvet"] *,
+[data-theme="velvet"] *::before,
+[data-theme="velvet"] *::after {
+  scrollbar-color: rgba(232, 63, 91, 0.28) transparent;
+}
+
+[data-theme="velvet"] ::-webkit-scrollbar-thumb {
+  background: rgba(232, 63, 91, 0.28);
+  background-clip: padding-box;
+}
+
+[data-theme="velvet"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(232, 63, 91, 0.5);
+  background-clip: padding-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .busy-indicator {
+    animation: none;
+    opacity: 0.6;
+  }
+  .typing-dot {
+    animation: none !important;
+    opacity: 0.7 !important;
+  }
 }

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -17,8 +17,6 @@
  * Source of truth: Figma cCGBcpVDbn22kj3OPU58W8
  *   Light: node 2674:20625
  *   Dark:  node 2674:20730
- *
- * Keep in sync with platform's web/src/app/(app)/appTheme.css.
  * --------------------------------------------------------------------------- */
 
 /* ---------------------------------------------------------------------------
@@ -47,9 +45,104 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
 
-  --font-sans: "Inter", system-ui, sans-serif;
+  /* Moss (cool neutral — synced with macOS Figma tokens) */
+  --color-moss-950: #111214;
+  --color-moss-900: #17191C;
+  --color-moss-800: #1C2024;
+  --color-moss-700: #24292E;
+  --color-moss-600: #2D3339;
+  --color-moss-500: #444D56;
+  --color-moss-400: #71808E;
+  --color-moss-300: #A9B2BB;
+  --color-moss-200: #CFCCC9;
+  --color-moss-100: #E9E6E2;
+  --color-moss-50:  #F6F5F4;
 
-  /* Border-radius scale — matches platform globals.css */
+  /* Stone (warm neutral — synced with macOS Figma tokens; overrides
+   * Tailwind v4's default stone scale to match the assistant palette) */
+  --color-stone-950: #111214;
+  --color-stone-900: #17191C;
+  --color-stone-800: #24292E;
+  --color-stone-700: #5A6672;
+  --color-stone-600: #71808E;
+  --color-stone-500: #8D99A5;
+  --color-stone-400: #A9B2BB;
+  --color-stone-300: #CFCCC9;
+  --color-stone-200: #E9E6E2;
+  --color-stone-100: #F2F0EE;
+  --color-stone-50:  #F6F5F4;
+
+  /* Forest (green accent — synced with macOS system-positive) */
+  --color-forest-950: #0D2818;
+  --color-forest-900: #1C251F;
+  --color-forest-800: #1B5E30;
+  --color-forest-700: #277E41;
+  --color-forest-600: #2E9A4E;
+  --color-forest-500: #3DB85E;
+  --color-forest-400: #6ECF87;
+  --color-forest-300: #A4E2B5;
+  --color-forest-200: #D0F0DA;
+  --color-forest-100: #E9F2EC;
+
+  /* Emerald (success — synced with macOS system-positive; overrides
+   * Tailwind v4's default emerald scale) */
+  --color-emerald-950: #0D2818;
+  --color-emerald-900: #1C251F;
+  --color-emerald-800: #1B5E30;
+  --color-emerald-700: #277E41;
+  --color-emerald-600: #2E9A4E;
+  --color-emerald-500: #3DB85E;
+  --color-emerald-400: #6ECF87;
+  --color-emerald-300: #A4E2B5;
+  --color-emerald-200: #D0F0DA;
+  --color-emerald-100: #E9F2EC;
+
+  /* Danger (error/destructive) */
+  --color-danger-950: #4E281D;
+  --color-danger-900: #803017;
+  --color-danger-800: #AB3F1C;
+  --color-danger-700: #DA491A;
+  --color-danger-600: #E86B40;
+  --color-danger-500: #F39B74;
+  --color-danger-400: #F9C0A2;
+  --color-danger-300: #F7DAC9;
+  --color-danger-200: #FFE4D5;
+  --color-danger-100: #FFF3EE;
+
+  /* Amber (warning — synced with macOS system-mid; overrides Tailwind v4's
+   * default amber scale) */
+  --color-amber-950: #4B3D1E;
+  --color-amber-900: #6B5520;
+  --color-amber-800: #8C7225;
+  --color-amber-700: #C9990F;
+  --color-amber-600: #F1B21E;
+  --color-amber-500: #F5C94E;
+  --color-amber-400: #F9D978;
+  --color-amber-300: #FCE9A0;
+  --color-amber-200: #FCF3DD;
+  --color-amber-100: #FDF8EE;
+
+  /* Font tokens */
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-serif: "Instrument Serif", serif;
+
+  /* App spacing tokens. The `--app-spacing-*` prefix avoids collisions with
+   * Tailwind's `--spacing-*` namespace (which generates the default spacing
+   * scale used by `p-*`, `m-*`, `gap-*`, etc.). Consumed via `var()` in
+   * arbitrary-value utilities like `gap-[var(--app-spacing-sm)]`. */
+  --app-spacing-xxs: 2px;
+  --app-spacing-xs: 4px;
+  --app-spacing-sm: 8px;
+  --app-spacing-md: 12px;
+  --app-spacing-lg: 16px;
+  --app-spacing-xl: 24px;
+  --app-spacing-xxl: 32px;
+  --app-spacing-xxxl: 48px;
+
+  /* Border-radius scale */
   --radius-xs: 2px;
   --radius-sm: 4px;
   --radius-md: 8px;
@@ -57,6 +150,19 @@
   --radius-xl: 16px;
   --radius-xxl: 20px;
   --radius-pill: 999px;
+
+  /* Shadow scale — synced with macOS design system. `--shadow-popover` is
+   * theme-aware (defined per-mode below); the rest are mode-agnostic. */
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
+  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.16);
+  --shadow-glow: 0 0 12px rgba(241, 178, 30, 0.3);
+  --shadow-accent-glow: 0 0 8px rgba(39, 126, 65, 0.3);
+
+  /* Layout: shared max-width for the chat surface (transcript + composer +
+   * panel surfaces). The chat column is centered and clamped to this width
+   * while the surrounding scroll container remains full-bleed. */
+  --chat-max-width: 800px;
 }
 
 /* ===== Light mode (default) — Figma node 2674:20625 ===== */
@@ -187,7 +293,10 @@
   /* Shadow */
   --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 4px 12px 0 rgba(0, 0, 0, 0.25);
 
-  /* Derived */
+  /* Derived. Re-declared (rather than inherited from the light block) so
+   * --ring tracks the dark --system-positive-strong even when data-theme is
+   * applied to a non-root ancestor. */
+  --ring: color-mix(in srgb, var(--system-positive-strong) 30%, transparent);
   --border-overlay: var(--border-hover);
   --ghost-hover: var(--border-base);
   --ghost-pressed: var(--primary-active);
@@ -239,6 +348,18 @@
   --system-negative-weak: #3A2024;
   --system-mid-strong: #F1B21E;
   --system-mid-weak: #42321C;
+  --system-info-strong: #467CC8;
+  --system-info-weak: #2A3A50;
+
+  /* Feed identifier — reuses the dark palette; velvet's accent colors
+   * apply at the chrome level (primary, surface) rather than swapping
+   * the feed glyph colors. */
+  --feed-nudge-strong: #DB4B77;
+  --feed-nudge-weak: #432B33;
+  --feed-digest-strong: #0E9B8B;
+  --feed-digest-weak: #293D3B;
+  --feed-thread-strong: #E9C91A;
+  --feed-thread-weak: #464125;
 
   /* Aux */
   --aux-white: #FFFFFF;
@@ -246,7 +367,8 @@
   /* Shadow */
   --shadow-popover: 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 4px 12px 0 rgba(0, 0, 0, 0.25);
 
-  /* Derived */
+  /* Derived. --ring re-declared so it tracks velvet's positive accent. */
+  --ring: color-mix(in srgb, var(--system-positive-strong) 30%, transparent);
   --border-overlay: var(--border-hover);
   --ghost-hover: var(--border-base);
   --ghost-pressed: var(--primary-active);


### PR DESCRIPTION
## Summary

Theme audit follow-up to #31324. That PR fixed the `dark:` selector wiring (was `.dark` class, expected `[data-theme=dark]`); after the fix, all 304 `dark:` utilities activated — but a chunk of the underlying color and layout tokens they reference were never carried over from the platform's `appTheme.css` + `globals.css`. Roughly 500 utility uses across `apps/web/` and the design library silently resolved to undefined variables or fell back to Tailwind v4's default palette instead of the Figma-aligned values.

Concretely, the bridge in `packages/design-library/src/tokens.css` only registered `--color-background`, `--color-foreground`, `--font-sans`, and the radius scale. But components reference:

| scale | usages | prior state |
|---|---|---|
| `stone-*` | 320 | Tailwind v4 default oklch (wrong hue) |
| `moss-*` | 95 | undefined — no CSS emitted |
| `forest-*` | 78 | undefined — no CSS emitted |
| `amber-*` | 7 | Tailwind default |
| `danger-*` | 5 | undefined — no CSS emitted |

Verified by reading the storybook-compiled CSS bundle before/after:
```
# before
$ grep -c 'color-moss\|color-forest\|color-danger' preview.css
0
# after
$ grep -oE '\.(bg|text|border)-(moss|forest|danger|amber)-[0-9]+' preview.css | sort -u
.bg-moss-500    .bg-moss-600   .bg-moss-800
.bg-stone-100   .bg-stone-200   .bg-stone-50
.border-moss-600    .text-forest-600    .text-stone-500   ...
```

## What's in this PR

**Tier 1 — `packages/design-library/src/tokens.css`** (the published source of truth):
- Color scales (moss/stone/forest/emerald/danger/amber) with Figma hex values inside `@theme inline` so Tailwind generates utilities
- Font tokens (`--font-mono`, `--font-serif`, `--font-display`, `--font-body`)
- Shadow scale (`--shadow-sm/md/lg/glow/accent-glow`)
- `--app-spacing-xxs..xxxl`
- `--chat-max-width: 800px`
- Missing velvet tokens (`--system-info-*`, `--feed-*`)
- Explicit dark/velvet `--ring` (defensive — currently resolves correctly only because `data-theme` is on `<html>`; locks to light if that ever moves to a wrapper)

**Tier 2 — `apps/web/src/index.css`** (app-level classes referenced by code but not defined anywhere):
- `.busy-indicator` + `busy-pulse` keyframe (referenced by `domains/chat/components/busy-indicator.tsx`, mounted in `tool-call-progress-card`, `subagent-progress-card`, `tool-call-chip`)
- `.onboarding-avatar-pulse/awake/failed` + `morphPulse` keyframe (referenced by `hatching-screen.tsx`)
- `.app-shell` / `.app-shell-main` layout guards (referenced by `components/layout/root-layout.tsx`)
- Themed scrollbars rekeyed from `.dark .app-root` to `data-theme` (was inert before — scrollbars defaulted to OS gray)
- `prefers-reduced-motion` overrides for busy + typing indicators

**Misc**:
- Fix `--app-spacing-2xl` → `--app-spacing-xxl` typo in `home-page.tsx:165,183` (platform exposes `xxl`, not `2xl`)
- Fix stale "defined in appTheme.css" comment in `busy-indicator.tsx` (`appTheme.css` isn't imported here)
- Drop "Keep in sync with platform appTheme.css" header in `tokens.css` — direction reversed post-cutover

## Architectural follow-up (NOT in this PR)

A chunk of the now-restored color-scale utilities could collapse to semantic surface tokens — `bg-stone-100 dark:bg-moss-700` reduces to a single `bg-[var(--surface-lift)]` because the semantic token already switches on `data-theme`. That's a ~500-site refactor with real mapping decisions (some pairs don't have a clean 1:1 to existing semantic tokens), worth tracking separately. The bridge added here is the prerequisite either way: components must render correctly today, and an opinionated migration later is a separate conversation.

## Test plan

- [ ] `bun run storybook` in `packages/design-library/` and step through Light → Dark → Velvet
- [ ] `bun run dev` in `apps/web/` and check: home feed spacing, chat composer max-width, tool-call progress card pulse, hatching/onboarding pulse, scrollbar color
- [ ] Compare against `vellum.ai/assistant` (prod) for each theme
- [ ] `bunx tsc --noEmit` from `apps/web/`

https://claude.ai/code/session_01DGgkooyEB8d6v9fpDj7UxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGgkooyEB8d6v9fpDj7UxN)_