### PR TITLE
fix(tools): surface 'Unknown tool' before 'load the skill' gate

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -271,6 +271,54 @@ describe("ToolExecutor allowedToolNames gating", () => {
     expect(result.content).toContain("file_read");
     expect(result.content).toContain("not currently active");
   });
+
+  test("unknown tool name reports 'Unknown tool' even when allowedToolNames is set", async () => {
+    // Regression: a hallucinated tool name with allowedToolNames set used to
+    // hit the "not currently active. Load the skill that provides this tool
+    // first." gate, which sent the model chasing a nonexistent skill. The
+    // registry-lookup gate runs first now so the model sees the real list.
+    const executor = new ToolExecutor(makePrompter());
+    const allowed = new Set(["file_read"]);
+    const result = await executor.execute(
+      "unknown_tool",
+      { foo: "bar" },
+      makeContext({ allowedToolNames: allowed }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown tool: unknown_tool");
+    expect(result.content).not.toContain("not currently active");
+  });
+
+  test("inactive skill tool names the owning skill in the load hint", async () => {
+    const executor = new ToolExecutor(makePrompter());
+    getToolOverride = (name: string) => {
+      if (name !== "skill_tool_x") return undefined;
+      return {
+        name,
+        description: "tool from a skill",
+        category: "skill",
+        defaultRiskLevel: RiskLevel.Low,
+        origin: "skill" as const,
+        ownerSkillId: "my-skill",
+        getDefinition: () => ({
+          name,
+          description: "tool from a skill",
+          input_schema: { type: "object" as const, properties: {} },
+        }),
+        execute: async () => fakeToolResult,
+      };
+    };
+    const allowed = new Set(["file_read"]);
+    const result = await executor.execute(
+      "skill_tool_x",
+      {},
+      makeContext({ allowedToolNames: allowed }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(
+      'Tool "skill_tool_x" is not currently active. Load the "my-skill" skill that provides this tool first.',
+    );
+  });
 });
 
 describe("ToolExecutor policy context plumbing", () => {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -334,9 +334,17 @@ export class ToolApprovalHandler {
       return { allowed: false, result: { content: msg, isError: true } };
     }
 
-    // Gate tools not active for the current turn
-    if (context.allowedToolNames && !context.allowedToolNames.has(name)) {
-      const msg = `Tool "${name}" is not currently active. Load the skill that provides this tool first.`;
+    // Look up the tool before the allowedToolNames gate so a name no skill
+    // provides surfaces as "Unknown tool" (with the real list) instead of
+    // the misleading "load the skill" hint.
+    const tool = getTool(name);
+    if (!tool) {
+      const available = getAllTools()
+        .filter((t) => t.executionMode !== "proxy" || context.proxyToolResolver)
+        .map((t) => t.name)
+        .sort()
+        .join(", ");
+      const msg = `Unknown tool: ${name}. Available tools: ${available}`;
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({
         type: "error",
@@ -356,15 +364,12 @@ export class ToolApprovalHandler {
       return { allowed: false, result: { content: msg, isError: true } };
     }
 
-    // Resolve the tool from the registry
-    const tool = getTool(name);
-    if (!tool) {
-      const available = getAllTools()
-        .filter((t) => t.executionMode !== "proxy" || context.proxyToolResolver)
-        .map((t) => t.name)
-        .sort()
-        .join(", ");
-      const msg = `Unknown tool: ${name}. Available tools: ${available}`;
+    // Gate tools not active for the current turn
+    if (context.allowedToolNames && !context.allowedToolNames.has(name)) {
+      const loadHint = tool.ownerSkillId
+        ? `Load the "${tool.ownerSkillId}" skill that provides this tool first.`
+        : `Load the skill that provides this tool first.`;
+      const msg = `Tool "${name}" is not currently active. ${loadHint}`;
       const durationMs = Date.now() - startTime;
       emitLifecycleEvent({
         type: "error",


### PR DESCRIPTION
## Summary

- Reorder the two error gates in `ToolApprovalHandler.checkPreExecutionGates()` so the registry lookup runs before the `allowedToolNames` check. Hallucinated tool names (e.g. `app_update`, removed in a prior refactor) now return `Unknown tool: X. Available tools: ...` instead of the misleading `Tool "X" is not currently active. Load the skill that provides this tool first.` — the model can see the real list and self-correct.
- When a tool *is* in the registry but isn't loaded this turn, the "not currently active" message now names the owning skill (`Load the "my-skill" skill that provides this tool first.`) when `tool.ownerSkillId` is set, so the model loads the right one.
- Added two regression tests covering both branches.

## Original prompt

Sidd hit "Tool 'app_update' is not currently active. Load the skill that provides this tool first." while iterating on a food-tracker Vellum app. `app_update` was removed in the `simplify-app-builder-tools` refactor — the workflow is now `file_edit` on the metadata json + `app_refresh` — so no skill provides `app_update`. The misleading error came from the order of gates in `tool-approval-handler.ts`: the allowedToolNames check fired before the registry lookup, so genuinely unknown names looked like "skill not loaded" rather than "no such tool." This PR fixes the feedback loop so the model self-corrects on the next turn.