### PR TITLE
fix(web): remove vestigial className="app-root" tokens

### DIFF
--- a/apps/web/src/components/native-splash.tsx
+++ b/apps/web/src/components/native-splash.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from "react";
  */
 export function NativeSplash({ children }: { children?: ReactNode }) {
   return (
-    <div className="app-root fixed inset-0 z-50 flex flex-col items-center justify-center bg-[var(--surface-base)] text-[var(--content-default)]">
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-[var(--surface-base)] text-[var(--content-default)]">
       <img
         src="/vellum-logo.svg"
         alt="Vellum"

--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -142,7 +142,7 @@ function WebLoginForm({ returnTo }: { returnTo: string | null }) {
 
   return (
     <div className="dark">
-      <div className="app-root relative min-h-screen overflow-x-hidden bg-[var(--surface-base)] text-[var(--content-default)]">
+      <div className="relative min-h-screen overflow-x-hidden bg-[var(--surface-base)] text-[var(--content-default)]">
         <LoginBackground />
         <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-4">
           <LoginCard>

--- a/packages/design-library/src/utils/portal-container.tsx
+++ b/packages/design-library/src/utils/portal-container.tsx
@@ -28,22 +28,25 @@ export interface PortalContainerProviderProps {
  * Provides a portal target element to all descendant design library
  * components that render overlays (Popover, Modal, Menu, etc.).
  *
- * Mount this at the top of your app shell, passing the element that has
- * your theme's CSS variables in scope. Overlay components read this
- * context internally and fall back to `document.body` when no provider
- * is mounted.
+ * Overlay components read this context internally and fall back to
+ * `document.body` when no provider is mounted. Because theme tokens are
+ * defined on `:root` (scoped via `data-theme` on `<html>`), the default
+ * `document.body` target already has access to design tokens, so most
+ * apps don't need to mount this provider at the top level.
  *
- * Nestable — an inner provider overrides the outer one for its subtree,
- * which is useful for rendering overlays inside dialogs or shadow DOM.
+ * The primary use case is nesting — an inner provider overrides the
+ * outer one for its subtree, which is useful for rendering overlays
+ * inside dialogs (so menus opened from within a modal portal into the
+ * modal rather than escaping to `document.body`) or shadow DOM.
  *
  * ```tsx
- * function AppShell({ children }: { children: ReactNode }) {
+ * function Dialog({ children }: { children: ReactNode }) {
  *   const ref = useRef<HTMLDivElement>(null);
  *   const [container, setContainer] = useState<HTMLElement | null>(null);
  *   useEffect(() => { setContainer(ref.current); }, []);
  *
  *   return (
- *     <div ref={ref} className="app-root">
+ *     <div ref={ref} role="dialog">
  *       <PortalContainerProvider container={container}>
  *         {children}
  *       </PortalContainerProvider>


### PR DESCRIPTION
## Summary

PR #31324 deleted `AppRootProvider` after confirming **zero CSS rules target `.app-root`** in this repo — theme tokens now live on `:root` and apply via `data-theme` on `<html>`. Two `className="app-root"` strings survived that cleanup and have been dead ever since (they target no CSS rule). A docstring example in `portal-container.tsx` also still illustrated the old `.app-root` wrapper pattern.

This PR removes the dead tokens and updates the docstring to reflect post-#31324 conventions.

## Changes

- `apps/web/src/components/native-splash.tsx` — drop `app-root` from className (other classes preserved).
- `apps/web/src/domains/account/pages/login-page.tsx` — drop `app-root` from className (other classes preserved).
- `packages/design-library/src/utils/portal-container.tsx` — rewrite docstring example. The provider is no longer needed at the app shell (overlays fall back to `document.body`, which now has access to design tokens via `:root`). The example now shows the provider's primary remaining use case: nesting overlays inside a dialog so menus opened from within a modal portal into the modal rather than escaping to `document.body`.

No runtime behavior changes — only dead className tokens removed and a docstring updated.

## Verification

- `grep -rn "app-root" apps/web/src packages/design-library/src` returns no matches.
- `cd apps/web && bunx tsc --noEmit` passes cleanly.

## Links

- Linear: [LUM-1769](https://linear.app/vellum/issue/LUM-1769)
- Precedent: #31324 (AppRootProvider deletion)

Closes LUM-1769

https://claude.ai/code/session_01DGgkooyEB8d6v9fpDj7UxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGgkooyEB8d6v9fpDj7UxN)_