### PR TITLE
fix(skills): use --file flag instead of stdin pipe for cache writes

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -190,7 +190,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-20T20:02:42-04:00"
+      "updatedAt": "2026-05-20T20:24:11-04:00"
     },
     {
       "id": "google-calendar",
@@ -482,7 +482,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-20T20:02:42-04:00"
+      "updatedAt": "2026-05-20T20:15:36-04:00"
     },
     {
       "id": "outlook-calendar",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -190,7 +190,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-01T13:55:47-04:00"
+      "updatedAt": "2026-05-20T20:02:42-04:00"
     },
     {
       "id": "google-calendar",
@@ -482,7 +482,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-18T18:44:36-04:00"
+      "updatedAt": "2026-05-20T20:02:42-04:00"
     },
     {
       "id": "outlook-calendar",
@@ -636,7 +636,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-19T14:46:12Z"
+      "updatedAt": "2026-05-19T10:59:54-04:00"
     },
     {
       "id": "start-the-day",

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -34,7 +34,7 @@ All operations use CLI scripts that return JSON:
 | `gmail-scan.ts`    | `outreach-scan`         | Identify cold outreach senders (no List-Unsubscribe header)                  |
 | `gmail-archive.ts` | `archive`               | Archive messages (single, batch message_ids, cache_key+sender-emails, query) |
 | `gmail-archive.ts` | `archive --dry-run`     | Preview what would be archived without executing (writes staged ops to log)  |
-| `gmail-archive.ts` | `archive --resume`      | Resume an interrupted archive run from its last checkpoint                    |
+| `gmail-archive.ts` | `archive --resume`      | Resume an interrupted archive run from its last checkpoint                   |
 | `gmail-commit.ts`  | `commit`                | Execute all staged ops from a dry-run                                        |
 | `gmail-commit.ts`  | `cancel`                | Delete a run log without executing anything                                  |
 | `gmail-runs.ts`    | `list`                  | List recent operation runs with status summaries                             |
@@ -161,6 +161,7 @@ bun run scripts/gmail-commit.ts cancel --run-id "<run-id>"
 ```
 
 Label and filter operations also support `--dry-run`:
+
 ```bash
 bun run scripts/gmail-manage.ts label --message-ids "..." --add-labels "..." --dry-run
 bun run scripts/gmail-manage.ts filters --action create --from "..." --remove-labels "INBOX" --dry-run
@@ -191,6 +192,7 @@ bun run scripts/gmail-reverse.ts --run-id "run_20260420_a1b2c3d4" --thread "18f.
 ```
 
 Reversal semantics:
+
 - **archive** → adds INBOX label back (un-archives)
 - **label_add** → removes the labels that were added
 - **label_remove** → adds back the labels that were removed

--- a/skills/gmail/scripts/gmail-archive.ts
+++ b/skills/gmail/scripts/gmail-archive.ts
@@ -13,7 +13,11 @@ import {
   optionalArg,
   parseCsv,
 } from "./lib/common.js";
-import { gmailGet, gmailPost, DailyQuotaExceededError } from "./lib/gmail-client.js";
+import {
+  gmailGet,
+  gmailPost,
+  DailyQuotaExceededError,
+} from "./lib/gmail-client.js";
 import { addToBlocklist } from "./gmail-prefs.js";
 import {
   generateRunId,
@@ -102,7 +106,12 @@ async function batchArchive(
   messageIds: string[],
   account?: string,
   opts?: { runId?: string; phase?: string; reason?: string; dryRun?: boolean },
-): Promise<{ runId: string; committed: number; failed: number; staged: number }> {
+): Promise<{
+  runId: string;
+  committed: number;
+  failed: number;
+  staged: number;
+}> {
   const runId = opts?.runId ?? generateRunId();
   let committed = 0;
   let failed = 0;
@@ -466,10 +475,7 @@ async function archiveSingleMessage(
  * Loads the op log, finds pending (staged but not committed/failed) ops,
  * and re-executes them.
  */
-async function resumeRun(
-  resumeRunId: string,
-  account?: string,
-): Promise<void> {
+async function resumeRun(resumeRunId: string, account?: string): Promise<void> {
   if (!runExists(resumeRunId)) {
     printError(`Run not found: ${resumeRunId}`);
     return;
@@ -575,7 +581,14 @@ async function main(): Promise<void> {
     );
   } else if (messageIdsRaw) {
     const messageIds = parseCsv(messageIdsRaw);
-    await archiveByMessageIds(messageIds, account, skipConfirm, runId, phase, dryRun);
+    await archiveByMessageIds(
+      messageIds,
+      account,
+      skipConfirm,
+      runId,
+      phase,
+      dryRun,
+    );
   } else if (messageId) {
     await archiveSingleMessage(messageId, account);
   } else {

--- a/skills/gmail/scripts/gmail-auto-filters.ts
+++ b/skills/gmail/scripts/gmail-auto-filters.ts
@@ -13,16 +13,8 @@
  *   preview   — show what filters would be created without creating them
  */
 
-import {
-  parseArgs,
-  printError,
-  ok,
-  optionalArg,
-} from "./lib/common.js";
-import {
-  gmailGet,
-  gmailPost,
-} from "./lib/gmail-client.js";
+import { parseArgs, printError, ok, optionalArg } from "./lib/common.js";
+import { gmailGet, gmailPost } from "./lib/gmail-client.js";
 import {
   readLog,
   generateRunId,
@@ -170,20 +162,14 @@ function deriveFilterCandidates(entries: OpEntry[]): FilterCandidate[] {
     if (phase.includes("sketchy") || phase.includes("tld")) {
       const domain = extractDomain(from);
       if (domain && isSketchyTld(domain)) {
-        sketchyTldDomains.set(
-          domain,
-          (sketchyTldDomains.get(domain) ?? 0) + 1,
-        );
+        sketchyTldDomains.set(domain, (sketchyTldDomains.get(domain) ?? 0) + 1);
       }
     }
 
     // Track newsletters (Pass 4)
     if (phase.includes("newsletter") || phase.includes("digest")) {
       if (from) {
-        newsletterSenders.set(
-          from,
-          (newsletterSenders.get(from) ?? 0) + 1,
-        );
+        newsletterSenders.set(from, (newsletterSenders.get(from) ?? 0) + 1);
       }
     }
   }
@@ -291,9 +277,7 @@ function isDuplicateFilter(
 
 /** Format filter candidates into a human-readable confirmation message. */
 function formatFilterPlan(candidates: FilterCandidate[]): string {
-  const lines: string[] = [
-    `${candidates.length} filter(s) will be created:\n`,
-  ];
+  const lines: string[] = [`${candidates.length} filter(s) will be created:\n`];
   for (const c of candidates) {
     const criteria = c.criteria.from
       ? `from: ${c.criteria.from}`
@@ -369,8 +353,7 @@ async function handleGenerate(
   const account = optionalArg(args, "account");
   const dryRun = args["dry-run"] === true;
   const skipConfirm = args["skip-confirm"] === true;
-  const sourceRunId =
-    optionalArg(args, "run-id") ?? findLatestCleanupRun();
+  const sourceRunId = optionalArg(args, "run-id") ?? findLatestCleanupRun();
 
   if (!sourceRunId) {
     printError(
@@ -402,9 +385,7 @@ async function handleGenerate(
     account,
   );
   if (!existingRes.ok) {
-    printError(
-      `Failed to list existing filters (HTTP ${existingRes.status})`,
-    );
+    printError(`Failed to list existing filters (HTTP ${existingRes.status})`);
   }
   const existingFilters = existingRes.data.filter ?? [];
 

--- a/skills/gmail/scripts/gmail-commit.ts
+++ b/skills/gmail/scripts/gmail-commit.ts
@@ -9,12 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import {
-  parseArgs,
-  printError,
-  ok,
-  optionalArg,
-} from "./lib/common.js";
+import { parseArgs, printError, ok, optionalArg } from "./lib/common.js";
 import { gmailPost, DailyQuotaExceededError } from "./lib/gmail-client.js";
 import {
   readLog,
@@ -38,10 +33,7 @@ const OPS_DIR = path.join(SKILL_ROOT, "data", "ops");
 // Commit
 // ---------------------------------------------------------------------------
 
-async function commitRun(
-  runId: string,
-  account?: string,
-): Promise<void> {
+async function commitRun(runId: string, account?: string): Promise<void> {
   if (!runExists(runId)) {
     printError(`Run not found: ${runId}`);
     return;
@@ -118,9 +110,7 @@ async function commitRun(
         }
       } else if (entry.op === "filter_create") {
         // Filter ops store criteria in the reason field as JSON
-        const filterData = entry.reason
-          ? JSON.parse(entry.reason)
-          : null;
+        const filterData = entry.reason ? JSON.parse(entry.reason) : null;
         if (filterData) {
           const resp = await gmailPost(
             "/settings/filters",
@@ -150,7 +140,9 @@ async function commitRun(
           run_id: runId,
           committed,
           failed,
-          note: "Daily quota exceeded. Resume with: bun run scripts/gmail-commit.ts commit " + runId,
+          note:
+            "Daily quota exceeded. Resume with: bun run scripts/gmail-commit.ts commit " +
+            runId,
         });
         return;
       }

--- a/skills/gmail/scripts/gmail-manage.ts
+++ b/skills/gmail/scripts/gmail-manage.ts
@@ -27,11 +27,7 @@ import {
   type GmailMessage,
   type GmailMessagePart,
 } from "./lib/gmail-client.js";
-import {
-  generateRunId,
-  writeStaged,
-  type OpType,
-} from "./lib/op-log.js";
+import { generateRunId, writeStaged, type OpType } from "./lib/op-log.js";
 
 // ---------------------------------------------------------------------------
 // label
@@ -60,7 +56,9 @@ async function handleLabel(
     if (dryRun) {
       const rid = runId ?? generateRunId();
       const opType: OpType = addLabelIds?.length ? "label_add" : "label_remove";
-      const labelIds = addLabelIds?.length ? addLabelIds : (removeLabelIds ?? []);
+      const labelIds = addLabelIds?.length
+        ? addLabelIds
+        : (removeLabelIds ?? []);
       writeStaged({
         run_id: rid,
         phase,
@@ -93,7 +91,9 @@ async function handleLabel(
     if (dryRun) {
       const rid = runId ?? generateRunId();
       const opType: OpType = addLabelIds?.length ? "label_add" : "label_remove";
-      const labelIds = addLabelIds?.length ? addLabelIds : (removeLabelIds ?? []);
+      const labelIds = addLabelIds?.length
+        ? addLabelIds
+        : (removeLabelIds ?? []);
       writeStaged({
         run_id: rid,
         phase,

--- a/skills/gmail/scripts/gmail-reverse.ts
+++ b/skills/gmail/scripts/gmail-reverse.ts
@@ -9,12 +9,7 @@
  *   reverse --run-id <id> --thread <id>      — Reverse a specific thread only
  */
 
-import {
-  parseArgs,
-  printError,
-  ok,
-  optionalArg,
-} from "./lib/common.js";
+import { parseArgs, printError, ok, optionalArg } from "./lib/common.js";
 import { gmailPost, DailyQuotaExceededError } from "./lib/gmail-client.js";
 import {
   generateRunId,
@@ -158,7 +153,11 @@ async function reverseOp(
           account,
         );
         if (!resp.ok) {
-          writeFailed(reversalRunId, chunkIndex, `reverse label_add failed (status ${resp.status})`);
+          writeFailed(
+            reversalRunId,
+            chunkIndex,
+            `reverse label_add failed (status ${resp.status})`,
+          );
           return false;
         }
       }
@@ -173,7 +172,11 @@ async function reverseOp(
           account,
         );
         if (!resp.ok) {
-          writeFailed(reversalRunId, chunkIndex, `reverse label_remove failed (status ${resp.status})`);
+          writeFailed(
+            reversalRunId,
+            chunkIndex,
+            `reverse label_remove failed (status ${resp.status})`,
+          );
           return false;
         }
       }
@@ -190,11 +193,19 @@ async function reverseOp(
       // Inverse of trash: remove TRASH label, add INBOX
       const resp = await gmailPost(
         "/messages/batchModify",
-        { ids: op.message_ids, removeLabelIds: ["TRASH"], addLabelIds: ["INBOX"] },
+        {
+          ids: op.message_ids,
+          removeLabelIds: ["TRASH"],
+          addLabelIds: ["INBOX"],
+        },
         account,
       );
       if (!resp.ok) {
-        writeFailed(reversalRunId, chunkIndex, `untrash batchModify failed (status ${resp.status})`);
+        writeFailed(
+          reversalRunId,
+          chunkIndex,
+          `untrash batchModify failed (status ${resp.status})`,
+        );
         return false;
       }
     }
@@ -313,7 +324,9 @@ async function main(): Promise<void> {
 
   const runId = optionalArg(args, "run-id");
   if (!runId) {
-    printError("Usage: gmail-reverse.ts --run-id <run-id> [--thread <message-id>]");
+    printError(
+      "Usage: gmail-reverse.ts --run-id <run-id> [--thread <message-id>]",
+    );
     return;
   }
 

--- a/skills/gmail/scripts/gmail-runs.ts
+++ b/skills/gmail/scripts/gmail-runs.ts
@@ -30,9 +30,7 @@ function listCmd(args: Record<string, string | boolean>) {
     return;
   }
 
-  const runs = runIds
-    .map((id) => summarizeRun(id))
-    .filter((s) => s !== null);
+  const runs = runIds.map((id) => summarizeRun(id)).filter((s) => s !== null);
 
   ok({ runs });
 }

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -77,7 +77,16 @@ async function cacheStore(data: unknown): Promise<string> {
   try {
     await Bun.write(tmpFile, JSON.stringify(data));
     const proc = Bun.spawn(
-      ["assistant", "cache", "set", "--ttl", "30m", "--json", "--file", tmpFile],
+      [
+        "assistant",
+        "cache",
+        "set",
+        "--ttl",
+        "30m",
+        "--json",
+        "--file",
+        tmpFile,
+      ],
       { stdout: "pipe", stderr: "pipe" },
     );
 

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -71,25 +71,38 @@ interface OutreachSenderAggregation {
  * out of the LLM conversation context.
  */
 async function cacheStore(data: unknown): Promise<string> {
-  const proc = Bun.spawn(
-    ["assistant", "cache", "set", "--ttl", "30m", "--json"],
-    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
-  );
-  proc.stdin.write(JSON.stringify(data));
-  proc.stdin.end();
+  // Use a temp file instead of stdin piping — in containerized environments
+  // /dev/stdin may be unavailable (ENXIO), which silently breaks the spawn.
+  const tmpFile = `/tmp/gmail-scan-cache-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+  try {
+    await Bun.write(tmpFile, JSON.stringify(data));
+    const proc = Bun.spawn(
+      ["assistant", "cache", "set", "--ttl", "30m", "--json", "--file", tmpFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
 
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
 
-  if (exitCode !== 0) {
-    throw new Error(`assistant cache set failed (exit ${exitCode}): ${stdout}`);
+    if (exitCode !== 0) {
+      throw new Error(
+        `assistant cache set failed (exit ${exitCode}): ${stdout}`,
+      );
+    }
+
+    const result = JSON.parse(stdout);
+    if (!result.ok) {
+      throw new Error(`assistant cache set error: ${result.error}`);
+    }
+    return result.key;
+  } finally {
+    try {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(tmpFile);
+    } catch {
+      // Best-effort cleanup
+    }
   }
-
-  const result = JSON.parse(stdout);
-  if (!result.ok) {
-    throw new Error(`assistant cache set error: ${result.error}`);
-  }
-  return result.key;
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/gmail/scripts/lib/op-log.ts
+++ b/skills/gmail/scripts/lib/op-log.ts
@@ -257,9 +257,7 @@ export function getCommittedChunks(runId: string): Set<number> {
 }
 
 /** Get the latest checkpoint from a run log. */
-export function getLatestCheckpoint(
-  runId: string,
-): CheckpointData | undefined {
+export function getLatestCheckpoint(runId: string): CheckpointData | undefined {
   const entries = readLog(runId);
   let latest: CheckpointData | undefined;
   for (const entry of entries) {

--- a/skills/outlook/scripts/outlook-scan.ts
+++ b/skills/outlook/scripts/outlook-scan.ts
@@ -48,25 +48,38 @@ interface SenderAgg {
  * out of the LLM conversation context.
  */
 async function cacheStore(data: unknown): Promise<string> {
-  const proc = Bun.spawn(
-    ["assistant", "cache", "set", "--ttl", "30m", "--json"],
-    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
-  );
-  proc.stdin.write(JSON.stringify(data));
-  proc.stdin.end();
+  // Use a temp file instead of stdin piping — in containerized environments
+  // /dev/stdin may be unavailable (ENXIO), which silently breaks the spawn.
+  const tmpFile = `/tmp/outlook-scan-cache-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+  try {
+    await Bun.write(tmpFile, JSON.stringify(data));
+    const proc = Bun.spawn(
+      ["assistant", "cache", "set", "--ttl", "30m", "--json", "--file", tmpFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
 
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
 
-  if (exitCode !== 0) {
-    throw new Error(`assistant cache set failed (exit ${exitCode}): ${stdout}`);
+    if (exitCode !== 0) {
+      throw new Error(
+        `assistant cache set failed (exit ${exitCode}): ${stdout}`,
+      );
+    }
+
+    const result = JSON.parse(stdout);
+    if (!result.ok) {
+      throw new Error(`assistant cache set error: ${result.error}`);
+    }
+    return result.key;
+  } finally {
+    try {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(tmpFile);
+    } catch {
+      // Best-effort cleanup
+    }
   }
-
-  const result = JSON.parse(stdout);
-  if (!result.ok) {
-    throw new Error(`assistant cache set error: ${result.error}`);
-  }
-  return result.key;
 }
 
 interface PaginateOptions {

--- a/skills/outlook/scripts/outlook-scan.ts
+++ b/skills/outlook/scripts/outlook-scan.ts
@@ -54,7 +54,16 @@ async function cacheStore(data: unknown): Promise<string> {
   try {
     await Bun.write(tmpFile, JSON.stringify(data));
     const proc = Bun.spawn(
-      ["assistant", "cache", "set", "--ttl", "30m", "--json", "--file", tmpFile],
+      [
+        "assistant",
+        "cache",
+        "set",
+        "--ttl",
+        "30m",
+        "--json",
+        "--file",
+        tmpFile,
+      ],
       { stdout: "pipe", stderr: "pipe" },
     );
 


### PR DESCRIPTION
## Summary
- Fix `cacheStore()` in `gmail-scan.ts` and `outlook-scan.ts` to use temp file + `--file` flag instead of `Bun.spawn({ stdin: "pipe" })`
- In containerized environments, `/dev/stdin` is unavailable, causing `ENXIO` errors that silently abort inbox scans after successfully fetching results
- Temp files are cleaned up in a `finally` block after the cache key is extracted

## Test plan
- [ ] Run `gmail-scan.ts sender-digest` in a containerized assistant and verify scan results are cached and returned
- [ ] Run `outlook-scan.ts sender-digest` in a containerized assistant and verify the same
- [ ] Verify temp files in `/tmp/` are cleaned up after cache write completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->