### PR TITLE
fix(web): wire edit-from-chat and desktop app viewer (LUM-1774)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -53,9 +53,6 @@
   "src/domains/chat/hooks/use-app-nudges.ts": [
     "nudges"
   ],
-  "src/domains/chat/hooks/use-app-viewer-actions.ts": [
-    "conversations"
-  ],
   "src/domains/chat/hooks/use-assistant-lifecycle.ts": [
     "onboarding"
   ],

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -1088,13 +1088,7 @@ export function ChatPage() {
       if (!openedAppState || !assistantId) return;
 
       const appId = openedAppState.appId;
-      const stored = getEditChatKey(assistantId, appId);
-      const storedStillExists =
-        stored !== null &&
-        (conversations.length === 0 ||
-          conversations.some((c) => c.conversationKey === stored));
-
-      const conversationKey = storedStillExists ? stored! : crypto.randomUUID();
+      const conversationKey = getEditChatKey(assistantId, appId) ?? crypto.randomUUID();
       setEditChatKey(assistantId, appId, conversationKey);
       useConversationStore.getState().setEditingKey(conversationKey);
       useViewerStore.getState().enterAppEditing();

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -85,6 +85,7 @@ import { abortSubagent } from "@/domains/chat/api/conversations.js";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay.js";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay.js";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay.js";
+import { getEditChatKey, setEditChatKey } from "@/domains/chat/utils/edit-chat-session.js";
 import { routes } from "@/utils/routes.js";
 import { haptic } from "@/utils/haptics.js";
 import type { AssistantIdentity } from "@/domains/chat/api/assistant.js";
@@ -1081,6 +1082,26 @@ export function ChatPage() {
     handleCloseEditPanel: () => {
       useConversationStore.getState().setEditingKey(null);
       useViewerStore.getState().exitAppEditing();
+    },
+    handleEditApp: () => {
+      const { openedAppState } = useViewerStore.getState();
+      if (!openedAppState || !assistantId) return;
+
+      const appId = openedAppState.appId;
+      const stored = getEditChatKey(assistantId, appId);
+      const storedStillExists =
+        stored !== null &&
+        (conversations.length === 0 ||
+          conversations.some((c) => c.conversationKey === stored));
+
+      const conversationKey = storedStillExists ? stored! : crypto.randomUUID();
+      setEditChatKey(assistantId, appId, conversationKey);
+      useConversationStore.getState().setEditingKey(conversationKey);
+      useViewerStore.getState().enterAppEditing();
+
+      if (activeConversationKey !== conversationKey) {
+        navigateToConversation(conversationKey);
+      }
     },
     handleShareApp: () => {
       const app = useViewerStore.getState().openedAppState;

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -46,6 +46,7 @@ import { DiscordNudgeBanner } from "@/domains/nudges/components/discord-nudge-ba
 import { GitHubNudgeBanner } from "@/domains/nudges/components/github-nudge-banner.js";
 import { IOSAppBanner } from "@/domains/nudges/components/ios-app-banner.js";
 import { MacOSAppBanner } from "@/domains/nudges/components/macos-app-banner.js";
+import { Loader2 } from "lucide-react";
 import { Button, Notice, ResizablePanel } from "@vellum/design-library";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner.js";
 import { QueuedMessagesDrawer } from "@/domains/chat/components/queued-messages-drawer.js";
@@ -327,6 +328,7 @@ export interface ChatRouteContentProps {
   handleCloseDocument: () => void;
   handleCloseApp: () => void;
   handleCloseEditPanel: () => void;
+  handleEditApp: () => void;
   handleShareApp: () => void;
   handleDeployApp: (() => void) | undefined;
 
@@ -411,6 +413,7 @@ export function ChatRouteContent({
   handleCloseDocument,
   handleCloseApp,
   handleCloseEditPanel,
+  handleEditApp,
   handleShareApp,
   handleDeployApp,
   handleForkConversation,
@@ -1353,6 +1356,32 @@ export function ChatRouteContent({
             isEditing
           />
         }
+      />
+    );
+  }
+
+  // Desktop full-width app viewer (non-editing). Mobile uses the portal-based
+  // MobileAppOverlay instead — this branch is desktop-only.
+  if (mainView === "app" && !isMobile) {
+    if (!openedAppState) {
+      return (
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+        </div>
+      );
+    }
+    return (
+      <AppViewerContainer
+        appId={openedAppState.appId}
+        appName={openedAppState.name}
+        html={openedAppState.html}
+        assistantId={assistantId ?? ""}
+        onClose={handleCloseApp}
+        onEdit={handleEditApp}
+        onShare={handleShareApp}
+        isSharing={isSharing}
+        onDeploy={deployToVercel ? handleDeployApp : undefined}
+        isDeploying={isDeploying}
       />
     );
   }


### PR DESCRIPTION
## Prompt / plan

Fixes two bugs in the app viewer flow, plus a pre-existing platform bug caught during review:

### Bug 1: Desktop `mainView === "app"` had no render path

When a user clicked an app from a chat transcript, `loadApp` set `mainView: "app"`, but `ChatRouteContent` had no branch for this state on desktop. The app viewer was invisible — it fell through to the default chat content. Added a full-width `AppViewerContainer` render branch with a `Loader2` spinner fallback while the app HTML loads.

### Bug 2: No `handleEditApp` callback

The Edit button in `AppNavBar` had no working callback from the chat flow. Implemented the full edit-mode entry:
- Resolves or creates an editing conversation key via `edit-chat-session.ts` (sessionStorage with 4h TTL) — so subsequent Edit clicks on the same app land in the same chat thread
- Sets `editingConversationKey` in conversation store
- Enters `app-editing` view in viewer store
- Navigates to the editing conversation

### Bug 3: Draft edit sessions lost on re-entry (pre-existing platform bug)

The platform's `useAppViewerActions` checked `conversations.some(c => c.conversationKey === stored)` before trusting a stored edit-chat session key. But draft conversations (unsent) are not in the server-side conversation list — they only appear after first send. So clicking Edit → closing → clicking Edit again would mint a new UUID instead of returning to the same thread.

Fixed by trusting the stored key directly (the 4h sessionStorage TTL is the staleness guard). This matches `DocumentViewerPage`'s existing pattern.

The `app-editing` split panel (chat left, app right) was already implemented and working. This PR connects the missing entry points to reach it.

### Architecture decision

The `handleEditApp` callback lives in `ChatPage` as thin orchestration rather than a store action because:
- It coordinates two stores (viewer + conversation) plus React Router navigation
- Per [CONVENTIONS.md § Thin orchestrator hooks](apps/web/docs/CONVENTIONS.md), store-bridging + navigation callbacks belong in the page component
- No API calls involved — purely local UI state transitions

### Out of scope

`handleEditAppFromDetached` (editing from the library grid at `/assistant/library`) requires cross-route state coordination since the library is a separate route in this repo. This is significantly more complex and warrants its own issue.

### Root cause analysis

1. **How did the code get into this state?** PR #31265 (LUM-1677, ChatPage orchestration) wired 15+ hooks but skipped `useAppViewerActions`, creating inline one-liner stubs for the handler callbacks. The stubs set viewer state but never implemented edit-mode entry or the desktop `mainView === "app"` render path. PR #31383 (LUM-1765) moved API logic into stores but focused on load/share/deploy, not the edit flow.

2. **What mistakes led to it?** The port from the platform's `AssistantPageClient` was incremental — each PR covered a subset of the handlers. The desktop `mainView === "app"` render path lived in `AssistantPageClient` (outside `ChatRouteContent`), so it was easy to miss when porting only the `ChatRouteContent` piece.

3. **Warning signs missed?** The platform's `AssistantPageClient` has an explicit `mainView === "app"` branch at line 2305 that renders `AppViewerContainer` full-width. This wasn't flagged as missing during the port because the platform renders it outside `ChatRouteContent`.

4. **Prevention?** When porting a component, trace all `mainView` branches in the source to ensure each has a render path in the target.

5. **Bug 3 (draft loss):** The platform's `conversations.some()` check was never correct for unsent drafts — `DocumentViewerPage` already uses the simpler pattern of trusting the stored key. The inconsistency wasn't caught because the two code paths were written at different times.

Closes [LUM-1774](https://linear.app/vellum/issue/LUM-1774)

## Test plan

- TypeScript: `bunx tsc --noEmit` — clean
- Lint: `bun run lint` — clean
- Cross-domain audit: `bun run audit:cross-domain:check` — clean (regenerated allowlist after `use-app-viewer-actions.ts` deletion from prior PR)
- CI: all checks passing

Link to Devin session: https://app.devin.ai/sessions/ad8145e66f7f421d9be339d5f8bd1bd5
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->