### PR TITLE
feat(document-editor): add `document_find` tool for grep-style search within documents

### DIFF
--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { executeDocumentFind } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDb();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.updatedAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.updatedAt,
+      params.updatedAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.updatedAt);
+}
+
+interface FindResultBody {
+  success: boolean;
+  surface_id?: string;
+  query?: string;
+  total_matches?: number;
+  matches?: Array<{
+    line_number: number;
+    line_content: string;
+    match_start: number;
+    match_end: number;
+    match_text: string;
+  }>;
+  error?: string;
+}
+
+const MULTILINE_CONTENT = [
+  "Hello World",
+  "This is line two with some numbers 42 and 100",
+  "hello again on line three",
+  "HELLO UPPERCASE LINE FOUR",
+  "Final line with special chars: foo-bar_baz",
+].join("\n");
+
+describe("document_find", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedDocument({
+      surfaceId: "doc-find-test",
+      conversationId: "conv-current",
+      title: "Find Test Doc",
+      content: MULTILINE_CONTENT,
+      updatedAt: 1000,
+    });
+    seedDocument({
+      surfaceId: "doc-other-conv",
+      conversationId: "conv-other",
+      title: "Other Conv Doc",
+      content: "secret content here",
+      updatedAt: 2000,
+    });
+  });
+
+  test("literal search finds exact matches with correct line numbers", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "Hello" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(3);
+    // Case-insensitive by default: "Hello" matches "Hello", "hello", "HELLO"
+    expect(body.matches![0].line_number).toBe(1);
+    expect(body.matches![0].match_text).toBe("Hello");
+    expect(body.matches![1].line_number).toBe(3);
+    expect(body.matches![1].match_text).toBe("hello");
+    expect(body.matches![2].line_number).toBe(4);
+    expect(body.matches![2].match_text).toBe("HELLO");
+  });
+
+  test("case-insensitive search (default) matches regardless of case", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "hello" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(3);
+    const lineNumbers = body.matches!.map((m) => m.line_number);
+    expect(lineNumbers).toEqual([1, 3, 4]);
+  });
+
+  test("case-sensitive search only matches exact case", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "Hello", case_sensitive: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(1);
+    expect(body.matches![0].line_number).toBe(1);
+    expect(body.matches![0].match_text).toBe("Hello");
+  });
+
+  test("regex search works", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "\\d+", regex: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(2);
+    expect(body.matches![0].match_text).toBe("42");
+    expect(body.matches![0].line_number).toBe(2);
+    expect(body.matches![1].match_text).toBe("100");
+    expect(body.matches![1].line_number).toBe(2);
+  });
+
+  test("invalid regex returns error gracefully", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "[invalid", regex: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(result.isError).toBe(true);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/Invalid regex/);
+  });
+
+  test("no matches returns success with empty array", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "nonexistent-text-xyz" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(0);
+    expect(body.matches).toEqual([]);
+  });
+
+  test("access control blocks non-guardian from searching documents outside their conversation", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-other-conv", query: "secret" },
+      makeContext({
+        trustClass: "trusted_contact",
+        executionChannel: "slack",
+        conversationId: "conv-current",
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    const body = parseResult<FindResultBody>(result);
+    expect(body.error).toBe("Document not found");
+  });
+
+  test("results are capped at 50 matches", () => {
+    // Create a document with many repeated matches
+    const lines = Array.from({ length: 100 }, (_, i) => `match line ${i}`);
+    seedDocument({
+      surfaceId: "doc-many-matches",
+      conversationId: "conv-current",
+      title: "Many Matches",
+      content: lines.join("\n"),
+      updatedAt: 3000,
+    });
+
+    const result = executeDocumentFind(
+      { surface_id: "doc-many-matches", query: "match" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(50);
+    expect(body.matches!.length).toBe(50);
+  });
+});

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -103,6 +103,36 @@
       "execution_target": "host"
     },
     {
+      "name": "document_find",
+      "description": "Search for text or a regex pattern within a document. Returns matching lines with line numbers and context — like grep. Use this to locate specific content before making targeted edits with document_replace_text.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "query": {
+            "type": "string",
+            "description": "Text or regex pattern to search for"
+          },
+          "regex": {
+            "type": "boolean",
+            "description": "Treat query as a regex pattern. Defaults to false (literal match)."
+          },
+          "case_sensitive": {
+            "type": "boolean",
+            "description": "Match case-sensitively. Defaults to false."
+          }
+        },
+        "required": ["surface_id", "query"]
+      },
+      "executor": "tools/document-find.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "comment_list",
       "description": "List open comments on a document. Returns all unresolved comments with their content, anchor text, and thread context so you can address user feedback.",
       "category": "document-editor",

--- a/assistant/src/config/bundled-skills/document-editor/tools/document-find.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/document-find.ts
@@ -1,0 +1,12 @@
+import { executeDocumentFind } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentFind(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -50,12 +50,13 @@ import * as computerUseWait from "./bundled-skills/computer-use/tools/computer-u
 import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js";
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
-// ── document-editor ───────────────────────────────────────────────────────────
+// ── document-editor ────────────────────────────────────────────────────────────
 import * as commentList from "./bundled-skills/document-editor/tools/comment-list.js";
 import * as commentReply from "./bundled-skills/document-editor/tools/comment-reply.js";
 import * as commentResolve from "./bundled-skills/document-editor/tools/comment-resolve.js";
 import * as documentCreate from "./bundled-skills/document-editor/tools/document-create.js";
 import * as documentDelete from "./bundled-skills/document-editor/tools/document-delete.js";
+import * as documentFind from "./bundled-skills/document-editor/tools/document-find.js";
 import * as documentList from "./bundled-skills/document-editor/tools/document-list.js";
 import * as documentRead from "./bundled-skills/document-editor/tools/document-read.js";
 import * as documentUpdate from "./bundled-skills/document-editor/tools/document-update.js";
@@ -173,14 +174,15 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/google-contacts.ts", googleContacts],
 
   // document-editor
-  ["document-editor:tools/comment-list.ts", commentList],
-  ["document-editor:tools/comment-reply.ts", commentReply],
-  ["document-editor:tools/comment-resolve.ts", commentResolve],
   ["document-editor:tools/document-create.ts", documentCreate],
-  ["document-editor:tools/document-delete.ts", documentDelete],
-  ["document-editor:tools/document-list.ts", documentList],
-  ["document-editor:tools/document-read.ts", documentRead],
   ["document-editor:tools/document-update.ts", documentUpdate],
+  ["document-editor:tools/document-read.ts", documentRead],
+  ["document-editor:tools/document-list.ts", documentList],
+  ["document-editor:tools/document-delete.ts", documentDelete],
+  ["document-editor:tools/document-find.ts", documentFind],
+  ["document-editor:tools/comment-list.ts", commentList],
+  ["document-editor:tools/comment-resolve.ts", commentResolve],
+  ["document-editor:tools/comment-reply.ts", commentReply],
 
   // followups
   ["followups:tools/followup-create.ts", followupCreate],

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -241,6 +241,99 @@ export function deleteDocument(surfaceId: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// In-document search (grep)
+// ---------------------------------------------------------------------------
+
+export interface FindMatch {
+  lineNumber: number;
+  lineContent: string;
+  matchStart: number;
+  matchEnd: number;
+  matchText: string;
+}
+
+export interface FindResult {
+  surfaceId: string;
+  totalMatches: number;
+  matches: FindMatch[];
+}
+
+const MAX_FIND_MATCHES = 50;
+
+/**
+ * Search for text or a regex pattern within a document's content.
+ * Returns matching lines with line numbers and match positions.
+ * Results are capped at {@link MAX_FIND_MATCHES} to avoid oversized responses.
+ */
+export function findInDocument(
+  surfaceId: string,
+  query: string,
+  options: { regex?: boolean; caseSensitive?: boolean } = {},
+): FindResult | null {
+  const row = rawGet<{ content: string }>(
+    /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+    surfaceId,
+  );
+  if (!row) return null;
+
+  const lines = row.content.split("\n");
+  const matches: FindMatch[] = [];
+
+  if (options.regex) {
+    const flags = options.caseSensitive ? "g" : "gi";
+    const re = new RegExp(query, flags);
+    for (
+      let i = 0;
+      i < lines.length && matches.length < MAX_FIND_MATCHES;
+      i++
+    ) {
+      const line = lines[i];
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while (
+        (m = re.exec(line)) !== null &&
+        matches.length < MAX_FIND_MATCHES
+      ) {
+        matches.push({
+          lineNumber: i + 1,
+          lineContent: line,
+          matchStart: m.index,
+          matchEnd: m.index + m[0].length,
+          matchText: m[0],
+        });
+        // Prevent infinite loops on zero-length matches
+        if (m[0].length === 0) re.lastIndex++;
+      }
+    }
+  } else {
+    const needle = options.caseSensitive ? query : query.toLowerCase();
+    for (
+      let i = 0;
+      i < lines.length && matches.length < MAX_FIND_MATCHES;
+      i++
+    ) {
+      const line = lines[i];
+      const haystack = options.caseSensitive ? line : line.toLowerCase();
+      let startPos = 0;
+      while (startPos <= haystack.length && matches.length < MAX_FIND_MATCHES) {
+        const idx = haystack.indexOf(needle, startPos);
+        if (idx === -1) break;
+        matches.push({
+          lineNumber: i + 1,
+          lineContent: line,
+          matchStart: idx,
+          matchEnd: idx + needle.length,
+          matchText: line.slice(idx, idx + needle.length),
+        });
+        startPos = idx + Math.max(needle.length, 1);
+      }
+    }
+  }
+
+  return { surfaceId, totalMatches: matches.length, matches };
+}
+
+// ---------------------------------------------------------------------------
 // Document persistence
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   deleteDocument,
+  findInDocument,
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
@@ -239,6 +240,57 @@ export function executeDocumentDelete(
       success: true,
       surface_id: surfaceId,
       message: "Document deleted",
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentFind(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const query = input.query as string;
+  const regex = (input.regex as boolean | undefined) ?? false;
+  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  if (regex) {
+    try {
+      new RegExp(query);
+    } catch (e) {
+      return {
+        content: JSON.stringify({
+          success: false,
+          surface_id: surfaceId,
+          error: `Invalid regex: ${e instanceof Error ? e.message : String(e)}`,
+        }),
+        isError: true,
+      };
+    }
+  }
+
+  const result = findInDocument(surfaceId, query, { regex, caseSensitive });
+  if (!result) {
+    return documentNotFound(surfaceId);
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: result.surfaceId,
+      query,
+      total_matches: result.totalMatches,
+      matches: result.matches.map((m) => ({
+        line_number: m.lineNumber,
+        line_content: m.lineContent,
+        match_start: m.matchStart,
+        match_end: m.matchEnd,
+        match_text: m.matchText,
+      })),
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary
- Add `findInDocument` store function and `executeDocumentFind` tool executor for grep-style text/regex search within documents
- Add `document_find` tool definition to TOOLS.json and thin executor wrapper
- Add comprehensive tests covering literal/regex search, case sensitivity, access control, and result capping

Part of plan: doc-editor-grep-sed.md (PR 1 of 4)