### PR TITLE
feat(document-editor): add `document_replace_text` tool for targeted find-and-replace

### DIFF
--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDocumentById } from "../documents/document-store.js";
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { executeDocumentReplaceText } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDb();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.updatedAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.updatedAt,
+      params.updatedAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.updatedAt);
+}
+
+describe("document_replace_text", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedDocument({
+      surfaceId: "doc-replace",
+      conversationId: "conv-current",
+      title: "Replace Test",
+      content: "foo bar foo baz foo",
+      updatedAt: 1000,
+    });
+    seedDocument({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      title: "Other Doc",
+      content: "other content",
+      updatedAt: 2000,
+    });
+  });
+
+  test("literal replace replaces all occurrences", () => {
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "qux" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(3);
+    expect(body.content_changed).toBe(true);
+    expect(getDocumentById("doc-replace")?.content).toBe("qux bar qux baz qux");
+  });
+
+  test("case-insensitive literal replace (default)", () => {
+    seedDocument({
+      surfaceId: "doc-case",
+      conversationId: "conv-current",
+      title: "Case Test",
+      content: "Foo FOO foo",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-case", find: "foo", replace: "x" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(3);
+    expect(getDocumentById("doc-case")?.content).toBe("x x x");
+  });
+
+  test("case-sensitive literal replace", () => {
+    seedDocument({
+      surfaceId: "doc-case-sensitive",
+      conversationId: "conv-current",
+      title: "Case Sensitive Test",
+      content: "Foo FOO foo",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-case-sensitive",
+        find: "foo",
+        replace: "x",
+        case_sensitive: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(1);
+    expect(getDocumentById("doc-case-sensitive")?.content).toBe("Foo FOO x");
+  });
+
+  test("regex replace with backreferences", () => {
+    seedDocument({
+      surfaceId: "doc-regex",
+      conversationId: "conv-current",
+      title: "Regex Test",
+      content: "user1@example user2@test",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-regex",
+        find: "(\\w+)@(\\w+)",
+        replace: "$2/$1",
+        regex: true,
+        case_sensitive: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(2);
+    expect(getDocumentById("doc-regex")?.content).toBe(
+      "example/user1 test/user2",
+    );
+  });
+
+  test("invalid regex returns clean error", () => {
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-replace",
+        find: "[invalid",
+        replace: "x",
+        regex: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{ success: boolean; error: string }>(result);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/Invalid regex/);
+    expect(result.isError).toBe(true);
+  });
+
+  test("max_replacements limits substitutions", () => {
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-replace",
+        find: "foo",
+        replace: "qux",
+        max_replacements: 1,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(1);
+    expect(body.content_changed).toBe(true);
+    // Only the first "foo" should be replaced
+    expect(getDocumentById("doc-replace")?.content).toBe("qux bar foo baz foo");
+  });
+
+  test("no matches returns success with zero replacements", () => {
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "nonexistent", replace: "x" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(0);
+    expect(body.content_changed).toBe(false);
+    // Content should be unchanged
+    expect(getDocumentById("doc-replace")?.content).toBe("foo bar foo baz foo");
+  });
+
+  test("word_count is recalculated after replacement", () => {
+    // Original: "foo bar foo baz foo" = 5 words
+    const before = getDocumentById("doc-replace");
+    expect(before?.wordCount).toBe(5);
+
+    // Replace "foo" with "one two" => "one two bar one two baz one two" = 8 words
+    executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "one two" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const after = getDocumentById("doc-replace");
+    expect(after?.wordCount).toBe(8);
+  });
+
+  test("access control blocks non-guardian from other conversations", () => {
+    const remoteContext = makeContext({
+      trustClass: "trusted_contact",
+      executionChannel: "slack",
+      sendToClient: () => {},
+    });
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-other", find: "other", replace: "x" },
+      remoteContext,
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe("Document not found");
+    // Content should be unchanged
+    expect(getDocumentById("doc-other")?.content).toBe("other content");
+  });
+
+  test("client is notified via sendToClient with updated content", () => {
+    const messages: unknown[] = [];
+    const sendToClient = (msg: unknown) => {
+      messages.push(msg);
+    };
+    executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "qux" },
+      makeContext({ sendToClient }),
+    );
+    expect(messages).toHaveLength(1);
+    const msg = messages[0] as {
+      type: string;
+      surfaceId: string;
+      markdown: string;
+      mode: string;
+    };
+    expect(msg.type).toBe("document_editor_update");
+    expect(msg.surfaceId).toBe("doc-replace");
+    expect(msg.mode).toBe("replace");
+    expect(msg.markdown).toBe("qux bar qux baz qux");
+  });
+});

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -103,6 +103,44 @@
       "execution_target": "host"
     },
     {
+      "name": "document_replace_text",
+      "description": "Find and replace text within a document — like sed. Performs targeted replacements without rewriting the entire document. Supports literal text and regex patterns. Use document_find first to preview what will be matched.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "find": {
+            "type": "string",
+            "description": "Text or regex pattern to find"
+          },
+          "replace": {
+            "type": "string",
+            "description": "Replacement text. When using regex, supports backreferences ($1, $2, etc.)."
+          },
+          "regex": {
+            "type": "boolean",
+            "description": "Treat find as a regex pattern. Defaults to false (literal match)."
+          },
+          "case_sensitive": {
+            "type": "boolean",
+            "description": "Match case-sensitively. Defaults to false."
+          },
+          "max_replacements": {
+            "type": "number",
+            "description": "Maximum number of replacements to make. Omit to replace all occurrences."
+          }
+        },
+        "required": ["surface_id", "find", "replace"]
+      },
+      "executor": "tools/document-replace-text.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "comment_list",
       "description": "List open comments on a document. Returns all unresolved comments with their content, anchor text, and thread context so you can address user feedback.",
       "category": "document-editor",

--- a/assistant/src/config/bundled-skills/document-editor/tools/document-replace-text.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/document-replace-text.ts
@@ -1,0 +1,12 @@
+import { executeDocumentReplaceText } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentReplaceText(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -50,7 +50,7 @@ import * as computerUseWait from "./bundled-skills/computer-use/tools/computer-u
 import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js";
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
-// ── document-editor ───────────────────────────────────────────────────────────
+// ── document-editor ────────────────────────────────────────────────────────────
 import * as commentList from "./bundled-skills/document-editor/tools/comment-list.js";
 import * as commentReply from "./bundled-skills/document-editor/tools/comment-reply.js";
 import * as commentResolve from "./bundled-skills/document-editor/tools/comment-resolve.js";
@@ -58,6 +58,7 @@ import * as documentCreate from "./bundled-skills/document-editor/tools/document
 import * as documentDelete from "./bundled-skills/document-editor/tools/document-delete.js";
 import * as documentList from "./bundled-skills/document-editor/tools/document-list.js";
 import * as documentRead from "./bundled-skills/document-editor/tools/document-read.js";
+import * as documentReplaceText from "./bundled-skills/document-editor/tools/document-replace-text.js";
 import * as documentUpdate from "./bundled-skills/document-editor/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
@@ -173,14 +174,15 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/google-contacts.ts", googleContacts],
 
   // document-editor
-  ["document-editor:tools/comment-list.ts", commentList],
-  ["document-editor:tools/comment-reply.ts", commentReply],
-  ["document-editor:tools/comment-resolve.ts", commentResolve],
   ["document-editor:tools/document-create.ts", documentCreate],
-  ["document-editor:tools/document-delete.ts", documentDelete],
-  ["document-editor:tools/document-list.ts", documentList],
-  ["document-editor:tools/document-read.ts", documentRead],
   ["document-editor:tools/document-update.ts", documentUpdate],
+  ["document-editor:tools/document-read.ts", documentRead],
+  ["document-editor:tools/document-list.ts", documentList],
+  ["document-editor:tools/document-delete.ts", documentDelete],
+  ["document-editor:tools/document-replace-text.ts", documentReplaceText],
+  ["document-editor:tools/comment-list.ts", commentList],
+  ["document-editor:tools/comment-resolve.ts", commentResolve],
+  ["document-editor:tools/comment-reply.ts", commentReply],
 
   // followups
   ["followups:tools/followup-create.ts", followupCreate],

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -297,6 +297,109 @@ export function saveDocument(params: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Find-and-replace
+// ---------------------------------------------------------------------------
+
+export interface ReplaceInDocumentOptions {
+  regex?: boolean;
+  caseSensitive?: boolean;
+  maxReplacements?: number;
+}
+
+export type ReplaceInDocumentResult =
+  | { success: true; replacements_made: number; content_changed: boolean }
+  | { success: false; error: string };
+
+function escapeRegExpChars(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Find and replace text within a document — like sed.
+ * Supports literal text and regex patterns with optional backreferences.
+ */
+export function replaceInDocument(
+  surfaceId: string,
+  find: string,
+  replace: string,
+  options: ReplaceInDocumentOptions = {},
+): ReplaceInDocumentResult {
+  try {
+    const row = rawGet<{ content: string }>(
+      /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    if (!row) {
+      return { success: false, error: "Document not found" };
+    }
+
+    const flags = "g" + (options.caseSensitive === true ? "" : "i");
+    const pattern = options.regex
+      ? new RegExp(find, flags)
+      : new RegExp(escapeRegExpChars(find), flags);
+
+    const totalMatches = [...row.content.matchAll(pattern)].length;
+    if (totalMatches === 0) {
+      return { success: true, replacements_made: 0, content_changed: false };
+    }
+
+    let newContent: string;
+    let replacementsMade: number;
+
+    if (
+      options.maxReplacements != null &&
+      options.maxReplacements < totalMatches
+    ) {
+      // Iterative replacement up to maxReplacements using manual exec loop
+      // so backreferences in the replacement string work correctly.
+      const limit = options.maxReplacements;
+      let count = 0;
+      let result = "";
+      let lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = pattern.exec(row.content)) !== null) {
+        if (count >= limit) break;
+        result += row.content.slice(lastIndex, m.index);
+        // Build the replacement for this match using String.replace
+        // so $1, $2, $& backreferences resolve against the match.
+        result += m[0].replace(pattern, replace);
+        lastIndex = m.index + m[0].length;
+        count++;
+      }
+      result += row.content.slice(lastIndex);
+      newContent = result;
+      replacementsMade = count;
+    } else {
+      newContent = row.content.replace(pattern, replace);
+      replacementsMade = totalMatches;
+    }
+
+    const wordCount = newContent
+      .split(/\s+/)
+      .filter((w) => w.length > 0).length;
+    rawRun(
+      /*sql*/ `UPDATE documents SET content = ?, word_count = ?, updated_at = ? WHERE surface_id = ?`,
+      newContent,
+      wordCount,
+      Date.now(),
+      surfaceId,
+    );
+    log.info({ surfaceId, replacementsMade }, "Replaced text in document");
+    return {
+      success: true,
+      replacements_made: replacementsMade,
+      content_changed: true,
+    };
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Replace-in-document error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 /** Update persisted document content (append or replace). */
 export function updateDocumentContent(
   surfaceId: string,

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -5,6 +5,7 @@ import {
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
+  replaceInDocument,
   saveDocument,
   searchDocumentsByTitle,
   updateDocumentContent,
@@ -239,6 +240,78 @@ export function executeDocumentDelete(
       success: true,
       surface_id: surfaceId,
       message: "Document deleted",
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentReplaceText(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const find = input.find as string;
+  const replace = (input.replace as string) ?? "";
+  const regex = (input.regex as boolean | undefined) ?? false;
+  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
+  const maxReplacements = input.max_replacements as number | undefined;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  // Validate regex before calling the store to surface a clean error
+  if (regex) {
+    try {
+      new RegExp(find);
+    } catch (err) {
+      return {
+        content: JSON.stringify({
+          success: false,
+          error: `Invalid regex: ${err instanceof Error ? err.message : String(err)}`,
+        }),
+        isError: true,
+      };
+    }
+  }
+
+  const result = replaceInDocument(surfaceId, find, replace, {
+    regex,
+    caseSensitive,
+    maxReplacements,
+  });
+
+  if (!result.success) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: result.error,
+      }),
+      isError: true,
+    };
+  }
+
+  // Notify client with the updated content
+  if (context.sendToClient && result.content_changed) {
+    const doc = getDocumentById(surfaceId);
+    if (doc) {
+      context.sendToClient({
+        type: "document_editor_update",
+        conversationId: context.conversationId,
+        surfaceId,
+        markdown: doc.content,
+        mode: "replace",
+      });
+    }
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: surfaceId,
+      replacements_made: result.replacements_made,
+      content_changed: result.content_changed,
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary
- Add `replaceInDocument` store function and `executeDocumentReplaceText` tool executor for sed-style find-and-replace
- Add `document_replace_text` tool definition to TOOLS.json and thin executor wrapper
- Add comprehensive tests covering literal/regex replace, backreferences, max_replacements, word_count recalculation, access control, and client notification

Part of plan: doc-editor-grep-sed.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->