### PR TITLE
feat(providers): add Owl Alpha via OpenRouter

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1066,6 +1066,18 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         pricing: { inputPer1mTokens: 0.8, outputPer1mTokens: 3.2 },
       },
+      // Owl (OpenRouter first-party)
+      {
+        id: "openrouter/owl-alpha",
+        displayName: "Owl Alpha",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 262144,
+        supportsThinking: false,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 0, outputPer1mTokens: 0 },
+      },
     ],
     defaultModel: "x-ai/grok-4.20-beta",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -1120,6 +1120,22 @@
             "inputPer1mTokens": 0.8,
             "outputPer1mTokens": 3.2
           }
+        },
+        {
+          "id": "openrouter/owl-alpha",
+          "displayName": "Owl Alpha",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 262144,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0,
+            "outputPer1mTokens": 0
+          }
         }
       ]
     },

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1120,6 +1120,22 @@
             "inputPer1mTokens": 0.8,
             "outputPer1mTokens": 3.2
           }
+        },
+        {
+          "id": "openrouter/owl-alpha",
+          "displayName": "Owl Alpha",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 262144,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0,
+            "outputPer1mTokens": 0
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Adds `openrouter/owl-alpha` to the OpenRouter provider in the model catalog.
- 1M context, 262k max output, tool use; free during alpha.
- Specs sourced from `openrouter.ai/api/v1/models` on 2026-05-20.
- `supportsThinking`/`supportsVision`/`supportsCaching` all `false` — matches what OpenRouter advertises in `supported_parameters`/`input_modalities`, and matches our precedent for non-Anthropic OpenRouter entries (e.g. DeepSeek V4 Pro, commit bdc31a7287).
- Three files updated together (daemon catalog + two byte-identical client mirrors) via \`bun run sync:llm-catalog\`.

## Test plan

- [x] \`bunx tsc --noEmit\` clean in \`assistant/\`
- [x] \`bun test src/__tests__/llm-catalog-parity.test.ts\` (16/16 pass)
- [x] Pre-commit hooks: secrets, generic-examples, formatting, lint, typecheck all green
- [ ] Manual smoke (post-merge): OpenRouter provider dropdown shows "Owl Alpha"; tool use works in a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->