### PR TITLE
feat(providers): add Gemini 3.5 Flash

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -401,6 +401,21 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "gemini-3.5-flash",
+        displayName: "Gemini 3.5 Flash",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 65536,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 1.5,
+          outputPer1mTokens: 9.0,
+          cacheReadPer1mTokens: 0.15,
+        },
+      },
+      {
         id: "gemini-3.1-pro-preview",
         displayName: "Gemini 3.1 Pro Preview",
         contextWindowTokens: 1048576,

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -292,6 +292,23 @@
       "defaultModel": "gemini-2.5-flash",
       "models": [
         {
+          "id": "gemini-3.5-flash",
+          "displayName": "Gemini 3.5 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.5,
+            "outputPer1mTokens": 9,
+            "cacheReadPer1mTokens": 0.15
+          }
+        },
+        {
           "id": "gemini-3.1-pro-preview",
           "displayName": "Gemini 3.1 Pro Preview",
           "contextWindowTokens": 1048576,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -292,6 +292,23 @@
       "defaultModel": "gemini-2.5-flash",
       "models": [
         {
+          "id": "gemini-3.5-flash",
+          "displayName": "Gemini 3.5 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.5,
+            "outputPer1mTokens": 9,
+            "cacheReadPer1mTokens": 0.15
+          }
+        },
+        {
           "id": "gemini-3.1-pro-preview",
           "displayName": "Gemini 3.1 Pro Preview",
           "contextWindowTokens": 1048576,


### PR DESCRIPTION
## Summary

- Adds \`gemini-3.5-flash\` to the Gemini provider in the model catalog.
- 1M context, 64k max output, thinking + caching + vision + tool use.
- Pricing: \$1.50 input / \$9.00 output / \$0.15 cache read per 1M tokens. No context-length tiers (Flash models don't have the 200k step that the Pro tier has).
- Specs from \`ai.google.dev/gemini-api/docs/models/gemini-3.5-flash\` and pricing from \`ai.google.dev/gemini-api/docs/pricing\` on 2026-05-20.
- Placed at the top of the Gemini \`models\` array as the newest stable Gemini Flash variant.

## Test plan

- [x] \`bunx tsc --noEmit\` clean in \`assistant/\`
- [x] \`bun test src/__tests__/llm-catalog-parity.test.ts\` (16/16 pass, 60 models total)
- [x] Pre-commit hooks: secrets, generic-examples, formatting, lint, typecheck all green
- [ ] Manual smoke (post-merge): Gemini provider dropdown shows "Gemini 3.5 Flash"; thinking and tool use work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->