### PR TITLE
test(providers): add gemini-3.5-flash to gemini-3 regression list

### DIFF
--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -65,6 +65,7 @@ describe("projectProviderForWire", () => {
     const wire = projectProviderForWire(gemini!);
     const modelIds = wire.models.map((model) => model.id);
     const expectedGemini3ModelIds = [
+      "gemini-3.5-flash",
       "gemini-3.1-pro-preview",
       "gemini-3.1-pro-preview-customtools",
       "gemini-3-flash-preview",


### PR DESCRIPTION
## Summary
- `config-model.test.ts` filters Gemini wire models by `id.startsWith("gemini-3")` and compares the result against an explicit list. PR #31400 added `gemini-3.5-flash` to the catalog without updating this list, so CI on main is now failing.
- Adds `gemini-3.5-flash` as the first entry of `expectedGemini3ModelIds` to match the catalog order in `assistant/src/providers/model-catalog.ts`.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/26198533313/job/77083204911 — the \`test:stable\` job failed on \`config-model.test.ts\` because the new \`gemini-3.5-flash\` model isn't accounted for in the regression guard. Scope strictly to that test; do not retune the catalog or touch unrelated providers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->