### PR TITLE
refactor(web): lift fetchAssistantIdentity into assistant/ (LUM-1753.4)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -192,8 +192,7 @@
     "avatar"
   ],
   "src/domains/intelligence/components/identity-tab.tsx": [
-    "avatar",
-    "chat"
+    "avatar"
   ],
   "src/domains/intelligence/identity-page.tsx": [
     "chat"

--- a/apps/web/src/assistant/identity.ts
+++ b/apps/web/src/assistant/identity.ts
@@ -1,0 +1,49 @@
+/**
+ * Runtime identity for the assistant: name, role, personality, emoji,
+ * home, version, and (optionally) creation timestamp.
+ *
+ * Fetched from the daemon through the wildcard proxy. Returns `null`
+ * when the identity cannot be retrieved (the assistant is still
+ * initializing, the runtime is unreachable, etc.) so the caller can
+ * fall back to a stub.
+ */
+import { client } from "@/generated/api/client.gen.js";
+import { assertHasResponse } from "@/lib/api-errors.js";
+
+// `client.get` needs a baseUrl when there's no `window` (SSR / unit tests).
+const SDK_BASE_OPTIONS =
+  typeof window === "undefined"
+    ? ({ baseUrl: "http://localhost" } as const)
+    : ({} as const);
+
+export interface AssistantIdentity {
+  name: string;
+  role: string;
+  personality: string;
+  emoji: string;
+  home: string;
+  version: string;
+  createdAt?: string;
+}
+
+export async function fetchAssistantIdentity(
+  assistantId: string,
+): Promise<AssistantIdentity | null> {
+  try {
+    const { data, error, response } = await client.get<AssistantIdentity, unknown>({
+      ...SDK_BASE_OPTIONS,
+      url: "/v1/assistants/{assistant_id}/identity/",
+      path: { assistant_id: assistantId },
+      throwOnError: false,
+    });
+    assertHasResponse(response, error, "Failed to fetch assistant identity");
+
+    if (!response.ok || !data || typeof data !== "object") {
+      return null;
+    }
+
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/domains/chat/api/assistant.ts
+++ b/apps/web/src/domains/chat/api/assistant.ts
@@ -1,6 +1,10 @@
 /**
- * Assistant-level operations: discovery, chat context bootstrapping,
- * and runtime identity retrieval.
+ * Chat context bootstrapping: pick an assistant and build the
+ * initial conversation context the chat UI lands on.
+ *
+ * Runtime assistant identity (name, personality, emoji, etc.)
+ * lives at `@/assistant/identity.js` — it's a property of the
+ * assistant itself, not a chat concern.
  */
 
 import {
@@ -89,43 +93,3 @@ export async function getChatContext(): Promise<ChatContext | null> {
   return { assistantId, conversations, conversationKey };
 }
 
-// ---------------------------------------------------------------------------
-// Runtime identity
-// ---------------------------------------------------------------------------
-
-export interface AssistantIdentity {
-  name: string;
-  role: string;
-  personality: string;
-  emoji: string;
-  home: string;
-  version: string;
-  createdAt?: string;
-}
-
-/**
- * Fetch the runtime identity for an assistant via the wildcard proxy.
- * Returns `null` when the identity cannot be retrieved (e.g. assistant
- * is still initializing or the runtime is unreachable).
- */
-export async function fetchAssistantIdentity(
-  assistantId: string,
-): Promise<AssistantIdentity | null> {
-  try {
-    const { data, error, response } = await client.get<AssistantIdentity, unknown>({
-      ...SDK_BASE_OPTIONS,
-      url: "/v1/assistants/{assistant_id}/identity/",
-      path: { assistant_id: assistantId },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch assistant identity");
-
-    if (!response.ok || !data || typeof data !== "object") {
-      return null;
-    }
-
-    return data;
-  } catch {
-    return null;
-  }
-}

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -70,7 +70,7 @@ import { useEventStream } from "@/domains/chat/hooks/use-event-stream.js";
 import { useActiveAppPinSync } from "@/domains/chat/hooks/use-active-app-pin-sync.js";
 
 import { createWebSyncRouter } from "@/lib/sync/web-sync-router.js";
-import { fetchAssistantIdentity } from "@/domains/chat/api/assistant.js";
+import { fetchAssistantIdentity } from "@/assistant/identity.js";
 import { shouldSuppressGenericChatErrorNotice } from "@/domains/chat/utils/error-classification.js";
 import { hasPendingAssistantResponse } from "@/domains/chat/utils/chat-utils.js";
 import { isSurfaceInteractive } from "@/domains/chat/types/types.js";
@@ -88,7 +88,7 @@ import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-su
 import { getEditChatKey, setEditChatKey } from "@/domains/chat/utils/edit-chat-session.js";
 import { routes } from "@/utils/routes.js";
 import { haptic } from "@/utils/haptics.js";
-import type { AssistantIdentity } from "@/domains/chat/api/assistant.js";
+import type { AssistantIdentity } from "@/assistant/identity.js";
 import type { ChatEventStream } from "@/domains/chat/api/stream.js";
 import {
   ChatRouteContent,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -88,7 +88,7 @@ import type { QuestionResponseEntry, AllowlistOption, ScopeOption, DirectoryScop
 import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
 import { DiskPressureBanner, type DiskPressureBannerMode } from "@/domains/chat/components/disk-pressure-banner.js";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button.js";
-import type { AssistantIdentity } from "@/domains/chat/api/assistant.js";
+import type { AssistantIdentity } from "@/assistant/identity.js";
 import type { Conversation } from "@/domains/chat/api/conversations.js";
 import { submitQuestionResponse } from "@/domains/chat/api/interactions.js";
 import type { ChatEventStream } from "@/domains/chat/api/stream.js";

--- a/apps/web/src/domains/chat/utils/chat-utils.ts
+++ b/apps/web/src/domains/chat/utils/chat-utils.ts
@@ -1,5 +1,5 @@
 import type { DisplayMessage } from "@/domains/chat/types/types.js";
-import type { AssistantIdentity } from "@/domains/chat/api/assistant.js";
+import type { AssistantIdentity } from "@/assistant/identity.js";
 import type { Conversation } from "@/domains/chat/api/conversations.js";
 import type { AllowlistOption, AssistantEvent, DirectoryScopeOption, PendingToolConfirmation, ScopeOption } from "@/domains/chat/api/event-types.js";
 

--- a/apps/web/src/domains/contacts/contacts-page.tsx
+++ b/apps/web/src/domains/contacts/contacts-page.tsx
@@ -40,7 +40,7 @@ import type {
   ContactSelection,
 } from "@/domains/contacts/types.js";
 import { useAssistantContext } from "@/domains/chat/assistant-context.js";
-import { fetchAssistantIdentity } from "@/domains/chat/api/assistant.js";
+import { fetchAssistantIdentity } from "@/assistant/identity.js";
 import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
 import { routes } from "@/utils/routes.js";
 

--- a/apps/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/apps/web/src/domains/intelligence/components/identity-tab.tsx
@@ -12,7 +12,7 @@ import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/type
 import { fetchSkills, installSkill, uninstallSkill } from "@/domains/intelligence/skills/api.js";
 import type { SkillInfo } from "@/domains/intelligence/skills/types.js";
 import { getAssistant } from "@/assistant/api.js";
-import { type AssistantIdentity, fetchAssistantIdentity } from "@/domains/chat/api/assistant.js";
+import { type AssistantIdentity, fetchAssistantIdentity } from "@/assistant/identity.js";
 
 export interface IdentityCardProps {
   assistantName: string;

--- a/apps/web/src/hooks/use-assistant-identity-init.ts
+++ b/apps/web/src/hooks/use-assistant-identity-init.ts
@@ -28,7 +28,7 @@
 import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchAssistantIdentity } from "@/domains/chat/api/assistant.js";
+import { fetchAssistantIdentity } from "@/assistant/identity.js";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
 import type { AssistantState } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
 


### PR DESCRIPTION
Closes [LUM-1753.4](https://linear.app/vellum/issue/LUM-1753).

## Summary

Moves `fetchAssistantIdentity` and the `AssistantIdentity` type out of `apps/web/src/domains/chat/api/assistant.ts` and into `apps/web/src/assistant/identity.ts`.

**Why:** the runtime identity of the assistant (name, role, personality, emoji, etc.) has nothing to do with chat. It's a property of the assistant itself, queried by chat, the identity tab, contacts, intelligence, onboarding, the sync router, and several stream handlers. Misplaced since day one — naturally cleaned up now that LUM-1753.3 created the top-level `assistant/` directory.

## What changed

- **New file:** `apps/web/src/assistant/identity.ts` — `fetchAssistantIdentity` + `AssistantIdentity` type. Self-contained (no dependency on `domains/chat/api/client.ts`); inlines the small bit of base-options it needs.
- **`domains/chat/api/assistant.ts`** — header comment retargeted; the file now exclusively owns chat-context bootstrapping (`getChatContext`, `fetchAssistantId`, `ChatContext`). Filename intentionally not renamed in this PR to avoid extra churn — that's a follow-up if anyone wants it.
- **6 import sites updated** to import from `@/assistant/identity.js`:
  - `src/hooks/use-assistant-identity-init.ts`
  - `src/domains/chat/chat-page.tsx` (2 lines)
  - `src/domains/chat/components/chat-route-content.tsx`
  - `src/domains/chat/utils/chat-utils.ts`
  - `src/domains/contacts/contacts-page.tsx`
  - `src/domains/intelligence/components/identity-tab.tsx`
- **Cross-domain allow-list:** 119 → 118 imports. Small numeric drop; the value is structural.

## Verified locally

- `bun run lint` — 0 errors.
- `bun run typecheck` — clean.
- `bun test eslint-rules/no-cross-domain-imports.test.mjs` — 14/14 pass.
- `bun run audit:cross-domain:check` — clean.

## Test plan

- [ ] CI green
- [ ] Spot-check that all 6 import sites still resolve in editor/IDE
- [ ] Manual: assistant identity still loads (name shows in side menu)

https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2)_