### PR TITLE
feat(providers): add Grok 4.3 via OpenRouter

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -800,6 +800,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: { inputPer1mTokens: 3, outputPer1mTokens: 15 },
       },
       {
+        id: "x-ai/grok-4.3",
+        displayName: "Grok 4.3",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 16000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 1.25, outputPer1mTokens: 2.5 },
+      },
+      {
         id: "x-ai/grok-4",
         displayName: "Grok 4",
         contextWindowTokens: 131072,

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -739,6 +739,22 @@
           }
         },
         {
+          "id": "x-ai/grok-4.3",
+          "displayName": "Grok 4.3",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 16000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.25,
+            "outputPer1mTokens": 2.5
+          }
+        },
+        {
           "id": "x-ai/grok-4",
           "displayName": "Grok 4",
           "contextWindowTokens": 131072,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -739,6 +739,22 @@
           }
         },
         {
+          "id": "x-ai/grok-4.3",
+          "displayName": "Grok 4.3",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 16000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.25,
+            "outputPer1mTokens": 2.5
+          }
+        },
+        {
           "id": "x-ai/grok-4",
           "displayName": "Grok 4",
           "contextWindowTokens": 131072,


### PR DESCRIPTION
## Summary

- Adds \`x-ai/grok-4.3\` to the OpenRouter provider in the model catalog.
- 1M context, 16k max output, thinking + vision + tool use.
- Pricing: \$1.25 input / \$2.50 output per 1M tokens.
- \`supportsCaching: false\` matches the two existing OpenRouter Grok entries (and the broader non-Anthropic OpenRouter precedent). OpenRouter does advertise a cache-read rate for this model, but we can revisit caching separately for all Grok entries if we want to opt in.
- Specs from \`openrouter.ai/api/v1/models\` on 2026-05-20.
- Placed between \`grok-4.20-beta\` and \`grok-4\` to keep the xAI subsection roughly newest-first.

## Test plan

- [x] \`bunx tsc --noEmit\` clean in \`assistant/\`
- [x] \`bun test src/__tests__/llm-catalog-parity.test.ts\` (16/16, 61 models total)
- [x] Pre-commit hooks: secrets, generic-examples, formatting, lint, typecheck all green
- [ ] Manual smoke (post-merge): OpenRouter provider shows "Grok 4.3"; thinking + image input work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->