### PR TITLE
feat(web): wire deep-link ?app= auto-open in ChatPage (LUM-1773)

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -578,6 +578,24 @@ export function ChatPage() {
     void sendMessage(prompt);
   }, [searchParams, activeConversationKey, sendMessage]);
 
+  // Deep-link: ?app=<id> auto-opens the app viewer on initial load.
+  const deepLinkAppConsumed = useRef(false);
+  useEffect(() => {
+    if (deepLinkAppConsumed.current) return;
+    const appId = searchParams.get("app");
+    if (!appId || !assistantId) return;
+    deepLinkAppConsumed.current = true;
+    void useViewerStore.getState().loadApp(assistantId, appId);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("app");
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      query ? `${window.location.pathname}?${query}` : window.location.pathname,
+    );
+  }, [searchParams, assistantId]);
+
   // Clear question prompt when conversation changes
   useEffect(() => {
     useInteractionStore.getState().dismissQuestion();


### PR DESCRIPTION
## Prompt / plan

Wire the `?app=<id>` deep-link auto-open in `ChatPage` so that navigating to `/assistant?app=<appId>` (or `/assistant/conversations/<key>?app=<appId>`) automatically opens the app viewer.

### What this does

Adds a single `useEffect` in `ChatPage` that:
1. Reads `?app=<id>` from URL search params
2. When `assistantId` is available, calls `loadApp(assistantId, appId)` — the store action handles all state transitions (`mainView: "app"`, `activeAppId`, HTML fetch) and race-condition guards
3. Strips `?app=` from the URL via `window.history.replaceState` to prevent re-triggering on component remount
4. Guards with a `useRef` to ensure the deep-link fires at most once per mount

### Pattern

Follows the existing `?prompt=` auto-send pattern (line 572) with a consumed-ref guard. The URL cleanup is an improvement over `?prompt=` which doesn't clean its param (not a bug since the ref prevents re-sending, but hygiene-wise `?app=` cleanup matters more because a stale `?app=` would visually confuse the user).

### What renders the app

The desktop app viewer render path (`mainView === "app"`) and mobile overlay portal were already wired in LUM-1774 and LUM-1665, respectively. This PR connects the URL entry point to those existing render paths.

### Architecture decision

This is thin page-level orchestration (reads URL → calls a store action → cleans URL). Per [CONVENTIONS.md § Thin orchestrator hooks](apps/web/docs/CONVENTIONS.md), URL-dependent side effects belong in the page component, not in a store or hook.

### Out of scope

- **`?view=` deep-link** — not needed; library/intelligence/identity are real routes in this repo
- **`?skill=` deep-link** — skills panel is a separate route
- **Hash route forwarding** (`#/settings` → `window.vellum.route`) — `AppViewerContainer` accepts an optional `route` prop but this is a secondary feature
- **`/assistant/library/<slug>` deep-link** — already handled by `LibraryDetailPage` route

Closes [LUM-1773](https://linear.app/vellum/issue/LUM-1773)

## Test plan

- TypeScript: `bunx tsc --noEmit` — clean
- Lint: `bun run lint` — clean
- Cross-domain audit: `bun run audit:cross-domain:check` — clean
- CI: pending

Link to Devin session: https://app.devin.ai/sessions/ad8145e66f7f421d9be339d5f8bd1bd5
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->