### PR TITLE
Add lazy Slack channel name resolution endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4391,6 +4391,51 @@ paths:
               required:
                 - conversationKey
               additionalProperties: false
+  /v1/conversations/{conversationId}/slack-channel/resolve:
+    post:
+      operationId: conversations_by_conversationId_slackchannel_resolve_post
+      summary: Resolve Slack channel name
+      description: Resolve and persist a friendly Slack channel name for an external conversation binding.
+      tags:
+        - conversations
+        - slack
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  channelId:
+                    type: string
+                  channelName:
+                    type: string
+                  cached:
+                    type: boolean
+                  resolved:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - auth
+                      - dm
+                      - no_name
+                      - not_found
+                      - permission
+                      - rate_limit
+                      - slack_error
+                required:
+                  - channelId
+                  - cached
+                  - resolved
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}:
     delete:
       operationId: conversations_by_id_delete

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -172,6 +172,25 @@ export function upsertOutboundBinding(input: {
     .run();
 }
 
+export function updateExternalChatName(
+  conversationId: string,
+  externalChatName: string,
+): ExternalConversationBinding | null {
+  const db = getDb();
+  const trimmedName = externalChatName.trim();
+  if (!trimmedName) return getBindingByConversation(conversationId);
+
+  db.update(externalConversationBindings)
+    .set({
+      externalChatName: trimmedName,
+      updatedAt: Date.now(),
+    })
+    .where(eq(externalConversationBindings.conversationId, conversationId))
+    .run();
+
+  return getBindingByConversation(conversationId);
+}
+
 /**
  * Look up an external binding by conversation ID.
  */

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -53,9 +53,7 @@ const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
   invalid_blocks: "client_error",
 };
 
-function classifySlackError(
-  errorCode: string | undefined,
-): SlackErrorCategory {
+function classifySlackError(errorCode: string | undefined): SlackErrorCategory {
   if (!errorCode) return "unknown";
   return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
 }
@@ -96,6 +94,20 @@ interface SlackApiResponse {
   ts?: string;
   upload_url?: string;
   file_id?: string;
+}
+
+interface SlackConversationsInfoResponse extends SlackApiResponse {
+  channel?: {
+    id?: unknown;
+    name?: unknown;
+    name_normalized?: unknown;
+  };
+}
+
+export interface SlackConversationInfo {
+  id: string;
+  name?: string;
+  nameNormalized?: string;
 }
 
 /**
@@ -176,6 +188,32 @@ export async function callSlackApi(
   throw new Error(
     `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
   );
+}
+
+function normalizeSlackString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export async function getSlackConversationInfo(
+  channelId: string,
+): Promise<SlackConversationInfo | null> {
+  const data = (await callSlackApi("conversations.info", {
+    channel: channelId,
+  })) as SlackConversationsInfoResponse;
+
+  const id = normalizeSlackString(data.channel?.id);
+  if (!id) return null;
+
+  const name = normalizeSlackString(data.channel?.name);
+  const nameNormalized = normalizeSlackString(data.channel?.name_normalized);
+
+  return {
+    id,
+    ...(name ? { name } : {}),
+    ...(nameNormalized ? { nameNormalized } : {}),
+  };
 }
 
 /**

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -153,6 +153,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "conversations/undo", scopes: ["chat.write"] },
   { endpoint: "conversations/regenerate", scopes: ["chat.write"] },
   { endpoint: "conversations/attention", scopes: ["chat.read"] },
+  { endpoint: "conversations/slack-channel/resolve", scopes: ["chat.read"] },
   { endpoint: "conversations/seen", scopes: ["chat.write"] },
   { endpoint: "conversations/unread", scopes: ["chat.write"] },
   { endpoint: "conversations/import", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type MockSlackInfo = {
+  id: string;
+  name?: string;
+  nameNormalized?: string;
+} | null;
+
+type MockSlackCategory =
+  | "auth"
+  | "channel_not_found"
+  | "not_found"
+  | "permission"
+  | "rate_limit"
+  | "unknown";
+
+class MockSlackApiError extends Error {
+  readonly slackError: string | undefined;
+  readonly category: MockSlackCategory;
+
+  constructor(slackError: string | undefined, category: MockSlackCategory) {
+    super(`Slack API error: ${slackError ?? "unknown"}`);
+    this.name = "SlackApiError";
+    this.slackError = slackError;
+    this.category = category;
+  }
+}
+
+const slackInfoCalls: string[] = [];
+let slackInfoImpl: (channelId: string) => Promise<MockSlackInfo> = async () =>
+  null;
+
+mock.module("../../../messaging/providers/slack/api.js", () => ({
+  SlackApiError: MockSlackApiError,
+  getSlackConversationInfo: async (channelId: string) => {
+    slackInfoCalls.push(channelId);
+    return slackInfoImpl(channelId);
+  },
+}));
+
+import { createConversation } from "../../../memory/conversation-crud.js";
+import { getDb, resetDb } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import {
+  getBindingByConversation,
+  upsertBinding,
+} from "../../../memory/external-conversation-store.js";
+import { ROUTES } from "../slack-channel-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+initializeDb();
+
+interface ResolveResponse {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+  reason?: string;
+}
+
+function resolveHandler(): RouteDefinition["handler"] {
+  const route = ROUTES.find(
+    (r) => r.operationId === "slack_channel_name_resolve",
+  );
+  if (!route) throw new Error("slack_channel_name_resolve route not found");
+  return route.handler;
+}
+
+const handler = resolveHandler();
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversations");
+}
+
+function createBoundConversation(input: {
+  sourceChannel?: string;
+  externalChatId: string;
+  externalChatName?: string | null;
+  externalThreadId?: string | null;
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+}): string {
+  const conversation = createConversation("Slack route test");
+  upsertBinding({
+    conversationId: conversation.id,
+    sourceChannel: input.sourceChannel ?? "slack",
+    externalChatId: input.externalChatId,
+    externalChatName: input.externalChatName,
+    externalThreadId: input.externalThreadId,
+    externalUserId: input.externalUserId,
+    displayName: input.displayName,
+    username: input.username,
+  });
+  return conversation.id;
+}
+
+async function resolve(conversationId: string): Promise<ResolveResponse> {
+  return (await handler({
+    pathParams: { conversationId },
+  })) as ResolveResponse;
+}
+
+beforeEach(() => {
+  clearTables();
+  slackInfoCalls.length = 0;
+  slackInfoImpl = async () => null;
+});
+
+afterAll(() => {
+  resetDb();
+  mock.restore();
+});
+
+describe("slack_channel_name_resolve", () => {
+  test("returns cached friendly name without calling Slack", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CACHED123",
+      externalChatName: "team-updates",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CACHED123",
+      channelName: "team-updates",
+      cached: true,
+      resolved: true,
+    });
+    expect(slackInfoCalls).toEqual([]);
+  });
+
+  test("resolves an unresolved channel ID and persists the returned name", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CRESOLVE123",
+      externalChatName: "CRESOLVE123",
+      externalThreadId: "1710000000.000100",
+      externalUserId: "U123",
+      displayName: "Alice",
+      username: "alice",
+    });
+    slackInfoImpl = async (channelId) => ({
+      id: channelId,
+      name: "engineering",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(slackInfoCalls).toEqual(["CRESOLVE123"]);
+    expect(result).toEqual({
+      channelId: "CRESOLVE123",
+      channelName: "engineering",
+      cached: false,
+      resolved: true,
+    });
+
+    const updated = getBindingByConversation(conversationId);
+    expect(updated?.externalChatName).toBe("engineering");
+    expect(updated?.externalThreadId).toBe("1710000000.000100");
+    expect(updated?.externalUserId).toBe("U123");
+    expect(updated?.displayName).toBe("Alice");
+    expect(updated?.username).toBe("alice");
+  });
+
+  test("does not call Slack for DM bindings", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "D123",
+      externalChatName: null,
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "D123",
+      cached: false,
+      resolved: false,
+      reason: "dm",
+    });
+    expect(slackInfoCalls).toEqual([]);
+    expect(getBindingByConversation(conversationId)?.externalChatName).toBe(
+      null,
+    );
+  });
+
+  test("rejects non-Slack bindings", async () => {
+    const conversationId = createBoundConversation({
+      sourceChannel: "telegram",
+      externalChatId: "chat-123",
+    });
+
+    await expect(resolve(conversationId)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      statusCode: 404,
+    });
+    expect(slackInfoCalls).toEqual([]);
+  });
+
+  test("returns unresolved on Slack API failure without mutating the binding", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CFAIL123",
+      externalChatName: "CFAIL123",
+    });
+    const before = getBindingByConversation(conversationId);
+    slackInfoImpl = async () => {
+      throw new MockSlackApiError("missing_scope", "permission");
+    };
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CFAIL123",
+      cached: false,
+      resolved: false,
+      reason: "permission",
+    });
+    expect(slackInfoCalls).toEqual(["CFAIL123"]);
+
+    const after = getBindingByConversation(conversationId);
+    expect(after?.externalChatName).toBe("CFAIL123");
+    expect(after?.updatedAt).toBe(before?.updatedAt);
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -75,7 +75,7 @@ import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-
 import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-provider-connection-routes.js";
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
-import { ROUTES as SLACK_CHANNEL_ROUTES } from "./integrations/slack/channel.js";
+import { ROUTES as SLACK_CHANNEL_CONFIG_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
@@ -109,6 +109,7 @@ import { ROUTES as SECRET_ROUTES } from "./secret-routes.js";
 import { ROUTES as SEQUENCE_ROUTES } from "./sequence-routes.js";
 import { ROUTES as SETTINGS_ROUTES } from "./settings-routes.js";
 import { ROUTES as SKILL_ROUTES } from "./skills-routes.js";
+import { ROUTES as SLACK_CHANNEL_RESOLVE_ROUTES } from "./slack-channel-routes.js";
 import { ROUTES as STT_ROUTES } from "./stt-routes.js";
 import { ROUTES as SUBAGENT_ROUTES } from "./subagents-routes.js";
 import { ROUTES as SUGGEST_TRUST_RULE_ROUTES } from "./suggest-trust-rule-routes.js";
@@ -229,7 +230,8 @@ export const ROUTES: RouteDefinition[] = [
   ...SETTINGS_ROUTES,
   ...SKILL_ROUTES,
   ...A2A_ROUTES,
-  ...SLACK_CHANNEL_ROUTES,
+  ...SLACK_CHANNEL_CONFIG_ROUTES,
+  ...SLACK_CHANNEL_RESOLVE_ROUTES,
   ...SLACK_SHARE_ROUTES,
   ...STT_ROUTES,
   ...SUGGEST_TRUST_RULE_ROUTES,

--- a/assistant/src/runtime/routes/slack-channel-routes.ts
+++ b/assistant/src/runtime/routes/slack-channel-routes.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+
+import {
+  getBindingByConversation,
+  updateExternalChatName,
+} from "../../memory/external-conversation-store.js";
+import {
+  getSlackConversationInfo,
+  SlackApiError,
+} from "../../messaging/providers/slack/api.js";
+import { NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+type ResolveReason =
+  | "auth"
+  | "dm"
+  | "no_name"
+  | "not_found"
+  | "permission"
+  | "rate_limit"
+  | "slack_error";
+
+interface SlackChannelResolveResponse {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+  reason?: ResolveReason;
+}
+
+const SlackChannelResolveResponseSchema = z.object({
+  channelId: z.string(),
+  channelName: z.string().optional(),
+  cached: z.boolean(),
+  resolved: z.boolean(),
+  reason: z
+    .enum([
+      "auth",
+      "dm",
+      "no_name",
+      "not_found",
+      "permission",
+      "rate_limit",
+      "slack_error",
+    ])
+    .optional(),
+});
+
+function friendlyCachedName(
+  externalChatId: string,
+  externalChatName?: string | null,
+): string | undefined {
+  const trimmed = externalChatName?.trim();
+  if (!trimmed || trimmed === externalChatId) return undefined;
+  return trimmed;
+}
+
+function usableResolvedName(
+  externalChatId: string,
+  name?: string,
+  nameNormalized?: string,
+): string | undefined {
+  for (const candidate of [name, nameNormalized]) {
+    const trimmed = candidate?.trim();
+    if (trimmed && trimmed !== externalChatId) return trimmed;
+  }
+  return undefined;
+}
+
+function reasonForSlackError(err: unknown): ResolveReason {
+  if (err instanceof SlackApiError) {
+    switch (err.category) {
+      case "auth":
+        return "auth";
+      case "channel_not_found":
+      case "not_found":
+        return "not_found";
+      case "permission":
+        return "permission";
+      case "rate_limit":
+        return "rate_limit";
+      default:
+        return "slack_error";
+    }
+  }
+  return "slack_error";
+}
+
+async function handleSlackChannelNameResolve({
+  pathParams = {},
+}: RouteHandlerArgs): Promise<SlackChannelResolveResponse> {
+  const conversationId = pathParams.conversationId?.trim();
+  if (!conversationId) {
+    throw new NotFoundError("Conversation not found");
+  }
+
+  const binding = getBindingByConversation(conversationId);
+
+  if (!binding || binding.sourceChannel !== "slack") {
+    throw new NotFoundError("Conversation not found");
+  }
+
+  const channelId = binding.externalChatId;
+  const cachedName = friendlyCachedName(channelId, binding.externalChatName);
+  if (cachedName) {
+    return {
+      channelId,
+      channelName: cachedName,
+      cached: true,
+      resolved: true,
+    };
+  }
+
+  if (channelId.startsWith("D")) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: "dm",
+    };
+  }
+
+  try {
+    const info = await getSlackConversationInfo(channelId);
+    const channelName = usableResolvedName(
+      channelId,
+      info?.name,
+      info?.nameNormalized,
+    );
+    if (!channelName) {
+      return {
+        channelId,
+        cached: false,
+        resolved: false,
+        reason: "no_name",
+      };
+    }
+
+    updateExternalChatName(conversationId, channelName);
+
+    return {
+      channelId,
+      channelName,
+      cached: false,
+      resolved: true,
+    };
+  } catch (err) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: reasonForSlackError(err),
+    };
+  }
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "slack_channel_name_resolve",
+    endpoint: "conversations/:conversationId/slack-channel/resolve",
+    method: "POST",
+    handler: handleSlackChannelNameResolve,
+    summary: "Resolve Slack channel name",
+    description:
+      "Resolve and persist a friendly Slack channel name for an external conversation binding.",
+    tags: ["conversations", "slack"],
+    pathParams: [
+      {
+        name: "conversationId",
+        type: "string",
+        description: "Conversation ID whose Slack channel name should resolve.",
+      },
+    ],
+    responseBody: SlackChannelResolveResponseSchema,
+  },
+];


### PR DESCRIPTION
## Summary
- Adds a runtime endpoint for lazily resolving Slack channel names.
- Persists resolved friendly channel names on external conversation bindings.
- Covers cached, unresolved, DM, non-Slack, and Slack API failure paths with focused tests.

Part of plan: lazy-slack-channel-names.md (assistant PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->