### PR TITLE
Add Slack status loading message plumbing

### DIFF
--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -174,8 +174,14 @@ async function deliverSlack(
       channel,
       threadTs: statusThreadTs,
       status,
+      loadingMessages,
     } = payload.assistantThreadStatus;
-    await sendSlackAssistantThreadStatus(channel, statusThreadTs, status);
+    await sendSlackAssistantThreadStatus(
+      channel,
+      statusThreadTs,
+      status,
+      loadingMessages,
+    );
     return { ok: true };
   }
 

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type CallSlackApi = (
+  method: string,
+  body: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+const callSlackApiMock = mock<CallSlackApi>(async () => ({ ok: true }));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("./api.js", () => ({
+  callSlackApi: (method: string, body: Record<string, unknown>) =>
+    callSlackApiMock(method, body),
+  callSlackApiForm: async () => ({}),
+  completeSlackUpload: async () => {},
+  SlackApiError: class SlackApiError extends Error {
+    slackError?: string;
+  },
+  uploadToSlackUrl: async () => {},
+}));
+
+import { sendSlackAssistantThreadStatus } from "./send.js";
+
+describe("sendSlackAssistantThreadStatus", () => {
+  beforeEach(() => {
+    callSlackApiMock.mockReset();
+    callSlackApiMock.mockImplementation(async () => ({ ok: true }));
+  });
+
+  test("serializes loading messages for Slack assistant thread status", async () => {
+    await sendSlackAssistantThreadStatus(
+      "C123",
+      "1700000000.000100",
+      "is working...",
+      ["Reading files", "Running tests"],
+    );
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+    expect(callSlackApiMock).toHaveBeenCalledWith(
+      "assistant.threads.setStatus",
+      {
+        channel_id: "C123",
+        thread_ts: "1700000000.000100",
+        status: "is working...",
+        loading_messages: ["Reading files", "Running tests"],
+      },
+    );
+  });
+
+  test("falls back to the reaction path when status API delivery fails", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new Error("missing_scope");
+      })
+      .mockImplementationOnce(async () => ({ ok: true }));
+
+    await sendSlackAssistantThreadStatus(
+      "C123",
+      "1700000000.000100",
+      "is working...",
+      ["Reading files"],
+    );
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "reactions.add", {
+      channel: "C123",
+      name: "eyes",
+      timestamp: "1700000000.000100",
+    });
+  });
+});

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -275,13 +275,19 @@ export async function sendSlackAssistantThreadStatus(
   channel: string,
   threadTs: string,
   status: string,
+  loadingMessages?: string[],
 ): Promise<void> {
   try {
-    await callSlackApi("assistant.threads.setStatus", {
+    const body: Record<string, unknown> = {
       channel_id: channel,
       thread_ts: threadTs,
       status,
-    });
+    };
+    if (loadingMessages !== undefined) {
+      body.loading_messages = loadingMessages;
+    }
+
+    await callSlackApi("assistant.threads.setStatus", body);
     return;
   } catch {
     log.warn(

--- a/packages/gateway-client/src/types.ts
+++ b/packages/gateway-client/src/types.ts
@@ -79,6 +79,8 @@ export interface ChannelReplyPayload {
     channel: string;
     threadTs: string;
     status: string;
+    /** Serialized to Slack as `loading_messages`. */
+    loadingMessages?: string[];
   };
 }
 


### PR DESCRIPTION
## Summary
- add loading message support to Slack assistant thread status payloads
- pass loading messages through direct Slack delivery into assistant.threads.setStatus
- cover the Slack API payload serialization

## Project issue
Part of #31408

## Test plan
- cd assistant && export PATH=\"$HOME/.bun/bin:$PATH\" && bun test src/messaging/providers/slack/send.test.ts
- cd assistant && export PATH=\"$HOME/.bun/bin:$PATH\" && bunx tsc --noEmit