### PR TITLE
fix(web): redirect native clients to prechat after assistant retire (LUM-1762)

### DIFF
--- a/apps/web/src/domains/settings/components/retire-assistant.tsx
+++ b/apps/web/src/domains/settings/components/retire-assistant.tsx
@@ -6,6 +6,8 @@ import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog"
 import { toast } from "@vellum/design-library/components/toast";
 import { retireAssistantById } from "@/assistant/api.js";
 import { clearOnboardingFlags } from "@/domains/onboarding/prefs.js";
+import { isNativePlatform } from "@/runtime/native-auth.js";
+import { routes } from "@/utils/routes.js";
 
 interface RetireAssistantProps {
   assistantId: string;
@@ -22,7 +24,15 @@ export function RetireAssistant({ assistantId }: RetireAssistantProps) {
       if (result.ok || result.status === 404) {
         clearOnboardingFlags();
         toast.success("Assistant retired.");
-        navigate("/assistant/onboarding/privacy");
+        // Native (iOS) re-onboarding skips the privacy/TOS step — those
+        // are re-shown only when the user explicitly resets prefs.
+        // Web users still see the privacy step to satisfy first-load
+        // consent requirements on a fresh assistant.
+        navigate(
+          isNativePlatform()
+            ? routes.onboarding.prechat
+            : routes.onboarding.privacy,
+        );
       } else {
         const detail =
           typeof result.error?.detail === "string"


### PR DESCRIPTION
Closes [LUM-1762](https://linear.app/vellum/issue/LUM-1762) (partial — see status table).

## Summary

Back-port of [`vellum-ai/vellum-assistant-platform#7442`](https://github.com/vellum-ai/vellum-assistant-platform/pull/7442). After retiring an assistant, native (iOS) clients now land on `/onboarding/prechat` instead of `/onboarding/privacy`. The privacy step is only re-shown to native users when they explicitly reset prefs, so dropping them on it after a retire makes them tap through a redundant screen.

Uses the existing `isNativePlatform()` runtime check and the `routes` helper.

## LUM-1762 status

| Platform PR | Status |
|---|---|
| #7442 (iOS prechat redirect) | ✅ this PR |
| #7431 (workspace browser borders) | ✅ already in OSS (`workspace-browser.tsx:78–90`) |
| #7432 (settings styling) | ✅ already in OSS (`access-consent-setting.tsx:55`, `media-embeds-card.tsx:111`) |
| #7451 (upgrade success message) | ✅ already in OSS (`assistant-upgrades.tsx:57`) |
| #7394 (handle editing) | ⛔ blocked — backend endpoint not in OSS's `platform.yaml`. Defer until the OSS backend ships `/v1/assistants/{id}/handle/` + `/handle-available/`, then port the front-end pieces. |

## Verified locally

- `bun run lint` — 0 errors.
- `bun run typecheck` — clean.

## Test plan

- [ ] CI green
- [ ] Manual (web): retire assistant, verify landing on `/assistant/onboarding/privacy` (existing behavior)
- [ ] Manual (native/iOS): retire assistant, verify landing on `/assistant/onboarding/prechat`

https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2)_