### PR TITLE
fix(web): iOS prechat safe-area + back-nav persistence (LUM-1763)

### DIFF
--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -202,6 +202,17 @@ export function PreChatFlow() {
   // ── iOS native flow: NameStep → VibeStep → Privacy → Hatching → Chat ──
   if (isNative) {
     if (screen === 0) {
+      // Both Continue and Skip advance to the vibe step and persist the
+      // position so the user lands back here on reload — shared closure
+      // keeps the two callsites from drifting.
+      const goToVibeStep = () => {
+        setScreen(1);
+        try {
+          sessionStorage.setItem("prechat_native_screen", "1");
+        } catch {
+          // ignore — see initial-state comment.
+        }
+      };
       return (
         <NameStepScreen
           userName={userName}
@@ -209,22 +220,8 @@ export function PreChatFlow() {
           displayedAssistantNames={displayedAssistantNames}
           onUserNameChange={handleUserNameChange}
           onAssistantNameChange={setAssistantName}
-          onContinue={() => {
-            setScreen(1);
-            try {
-              sessionStorage.setItem("prechat_native_screen", "1");
-            } catch {
-              // ignore — see initial-state comment.
-            }
-          }}
-          onSkip={() => {
-            setScreen(1);
-            try {
-              sessionStorage.setItem("prechat_native_screen", "1");
-            } catch {
-              // ignore — see initial-state comment.
-            }
-          }}
+          onContinue={goToVibeStep}
+          onSkip={goToVibeStep}
           currentStep={0}
           totalSteps={IOS_TOTAL_STEPS}
         />

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -72,7 +72,19 @@ export function PreChatFlow() {
     (isIOSWeb && !readIOSAppDownloaded()) ||
     (isMacOSWeb && !readMacOsAppDownloaded());
 
-  const [screen, setScreen] = useState<Screen>(0);
+  // Native pre-chat restores its position across reloads via sessionStorage
+  // — without this, an iOS user who's tapped through to the vibe step and
+  // hot-reloads (or returns after the OS reclaims memory) is silently
+  // dropped back to the name step.
+  const [screen, setScreen] = useState<Screen>(() => {
+    try {
+      const saved = sessionStorage.getItem("prechat_native_screen");
+      if (saved === "1") return 1;
+    } catch {
+      // sessionStorage can throw under privacy modes — ignore.
+    }
+    return 0;
+  });
   const [selectedTools, setSelectedTools] = useState<Set<string>>(
     () => new Set(),
   );
@@ -197,8 +209,22 @@ export function PreChatFlow() {
           displayedAssistantNames={displayedAssistantNames}
           onUserNameChange={handleUserNameChange}
           onAssistantNameChange={setAssistantName}
-          onContinue={() => setScreen(1)}
-          onSkip={() => setScreen(1)}
+          onContinue={() => {
+            setScreen(1);
+            try {
+              sessionStorage.setItem("prechat_native_screen", "1");
+            } catch {
+              // ignore — see initial-state comment.
+            }
+          }}
+          onSkip={() => {
+            setScreen(1);
+            try {
+              sessionStorage.setItem("prechat_native_screen", "1");
+            } catch {
+              // ignore — see initial-state comment.
+            }
+          }}
           currentStep={0}
           totalSteps={IOS_TOTAL_STEPS}
         />
@@ -223,13 +249,25 @@ export function PreChatFlow() {
       if (trimmedAssistant) {
         setPendingAssistantName(trimmedAssistant);
       }
+      try {
+        sessionStorage.removeItem("prechat_native_screen");
+      } catch {
+        // ignore — see initial-state comment.
+      }
       void navigate(routes.onboarding.privacy);
     };
     return (
       <VibeStepScreen
         selectedGroupId={selectedGroupId}
         onGroupChange={setSelectedGroupId}
-        onBack={() => setScreen(0)}
+        onBack={() => {
+          setScreen(0);
+          try {
+            sessionStorage.removeItem("prechat_native_screen");
+          } catch {
+            // ignore — see initial-state comment.
+          }
+        }}
         onContinue={finishNativePreChat}
         onSkip={finishNativePreChat}
         currentStep={1}

--- a/apps/web/src/domains/onboarding/screens/name-step-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/name-step-screen.tsx
@@ -34,8 +34,15 @@ export function NameStepScreen({
     <OnboardingLayout>
       <div className="mx-auto flex min-h-screen w-full max-w-md flex-col px-6 pb-40 text-[var(--content-default)]">
         <div
-          className="grid w-full grid-cols-[auto_1fr_auto] items-center pb-4 pt-4"
-          style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
+          className="grid w-full grid-cols-[auto_1fr_auto] items-center pb-4"
+          style={{
+            // Respect the iOS safe-area inset on top of the standard
+            // 1rem padding so the header clears the status bar / Dynamic
+            // Island instead of sliding under it.
+            paddingTop:
+              "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)",
+            animation: "fadeInUp 0.3s ease-out 0.1s both",
+          }}
         >
           {onBack ? (
             <Button

--- a/apps/web/src/domains/onboarding/screens/vibe-step-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/vibe-step-screen.tsx
@@ -28,8 +28,14 @@ export function VibeStepScreen({
     <OnboardingLayout>
       <div className="mx-auto flex min-h-screen w-full max-w-md flex-col px-6 pb-40 text-[var(--content-default)]">
         <div
-          className="grid w-full grid-cols-[auto_1fr_auto] items-center pb-4 pt-4"
-          style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
+          className="grid w-full grid-cols-[auto_1fr_auto] items-center pb-4"
+          style={{
+            // Match name-step's safe-area handling — iOS status bar /
+            // Dynamic Island would otherwise overlap the back button row.
+            paddingTop:
+              "calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)",
+            animation: "fadeInUp 0.3s ease-out 0.1s both",
+          }}
         >
           <Button
             variant="ghost"


### PR DESCRIPTION
Closes [LUM-1763](https://linear.app/vellum/issue/LUM-1763) (partial — #7355 Sanity feature deferred, see status note).

## Summary

Back-port of [`vellum-ai/vellum-assistant-platform#7461`](https://github.com/vellum-ai/vellum-assistant-platform/pull/7461). Two iOS prechat polish fixes that landed on platform after the OSS onboarding paths were frozen:

1. **Safe-area top spacing.** `NameStepScreen` and `VibeStepScreen` were using a flat `pt-4`, which on iOS slides the back-button row under the status bar / Dynamic Island. Switch to `calc(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) + 1rem)` so the standard 1rem padding sits on top of the system inset.
2. **Back-nav persistence.** `PreChatFlow` resets to screen 0 on every mount, so an iOS user who taps through to the vibe step and hot-reloads (or returns after the OS reclaims memory) is silently dropped back to the name step. Remember the position in `sessionStorage` under `prechat_native_screen`; restore on mount; clear on back-from-vibe and on `finishNativePreChat`. Storage writes are wrapped in try/catch so private-mode contexts don't throw.

## LUM-1763 status

| Platform PR | Status |
|---|---|
| #7461 (iOS safe-area + back-nav) | ✅ this PR |
| #7355 (Sanity content-automation cohort) | ⏭️ deferred — cohort-specific feature with its own Sanity integration. Wants explicit team decision on whether OSS ships the cohort feature at all before porting. |

## Verified locally

- `bun run lint` — 0 errors.
- `bun run typecheck` — clean.

## Test plan

- [ ] CI green
- [ ] Manual (native/iOS): tap through Name → Vibe step, hot-reload — should land back on Vibe step, not Name step
- [ ] Manual (native/iOS): back from Vibe → Name, hot-reload — should land on Name step (sessionStorage cleared)
- [ ] Manual (native/iOS): visual inspection that the back-button row clears the status bar / Dynamic Island
- [ ] Manual (web): no regression — safe-area inset is 0px on desktop, so padding stays at 1rem

https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2)_