### PR TITLE
fix(slack): deliver prior text for tool-only final replies

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -34,7 +34,7 @@ const updateMessageMetadataCalls: UpdateMessageMetadataCall[] = [];
 /** Per-test override for the synthetic Slack `ts` returned by deliverChannelReply. */
 let nextDeliveryTs: string | null = null;
 
-let renderedHistoryContent: {
+type RenderedHistoryStub = {
   text: string;
   textSegments: string[];
   toolCalls: unknown[];
@@ -42,7 +42,9 @@ let renderedHistoryContent: {
   contentOrder: string[];
   surfaces: unknown[];
   thinkingSegments: string[];
-} = {
+};
+
+let renderedHistoryContent: RenderedHistoryStub = {
   text: "",
   textSegments: [],
   toolCalls: [],
@@ -51,6 +53,7 @@ let renderedHistoryContent: {
   surfaces: [],
   thinkingSegments: [],
 };
+const renderedHistoryContentQueue: RenderedHistoryStub[] = [];
 
 let deliveryFailAtIndex = -1;
 
@@ -100,6 +103,16 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
   getMessages: () => conversationMessages,
+  getMessagesAfter: (
+    _conversationId: string,
+    afterMessageId: string | null,
+  ) => {
+    if (!afterMessageId) return conversationMessages;
+    const index = conversationMessages.findIndex(
+      (message) => message.id === afterMessageId,
+    );
+    return index === -1 ? [] : conversationMessages.slice(index + 1);
+  },
   getMessageById: (messageId: string) =>
     conversationMessages.find((m) => m.id === messageId) ?? null,
   updateMessageMetadata: (
@@ -123,7 +136,8 @@ mock.module("../memory/attachments-store.js", () => ({
 }));
 
 mock.module("../daemon/handlers/shared.js", () => ({
-  renderHistoryContent: () => renderedHistoryContent,
+  renderHistoryContent: () =>
+    renderedHistoryContentQueue.shift() ?? renderedHistoryContent,
 }));
 
 const { deliverRenderedReplyViaCallback, deliverReplyViaCallback } =
@@ -137,6 +151,7 @@ describe("channel-reply-delivery", () => {
     attachmentsByMessageId.clear();
     updateMessageMetadataCalls.length = 0;
     nextDeliveryTs = null;
+    renderedHistoryContentQueue.length = 0;
     renderedHistoryContent = {
       text: "",
       textSegments: [],
@@ -259,6 +274,137 @@ describe("channel-reply-delivery", () => {
       ],
       assistantId: "assistant-2",
     });
+  });
+
+  it("falls back to current-turn assistant text when the newest assistant row is tool-only", async () => {
+    conversationMessages.push(
+      { id: "msg-old-user", role: "user", content: "old prompt" },
+      {
+        id: "msg-old-assistant",
+        role: "assistant",
+        content: '[{"type":"text","text":"old answer"}]',
+      },
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer"}]',
+      },
+      {
+        id: "msg-current-tool-result",
+        role: "user",
+        content: '[{"type":"tool_result","tool_use_id":"tu-1","content":"ok"}]',
+      },
+      {
+        id: "msg-current-tool-only",
+        role: "assistant",
+        content:
+          '[{"type":"tool_use","id":"tu-2","name":"remember","input":{}}]',
+      },
+    );
+    renderedHistoryContentQueue.push(
+      {
+        text: "",
+        textSegments: [],
+        toolCalls: [{ name: "remember", input: {} }],
+        toolCallsBeforeText: true,
+        contentOrder: ["tool:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      },
+      {
+        text: "Current answer.",
+        textSegments: ["Current answer."],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      },
+    );
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Current answer.");
+  });
+
+  it("does not cross the current user boundary when no current-turn assistant text exists", async () => {
+    conversationMessages.push(
+      { id: "msg-old-user", role: "user", content: "old prompt" },
+      {
+        id: "msg-old-assistant",
+        role: "assistant",
+        content: '[{"type":"text","text":"old answer"}]',
+      },
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-tool-only",
+        role: "assistant",
+        content:
+          '[{"type":"tool_use","id":"tu-1","name":"remember","input":{}}]',
+      },
+    );
+    renderedHistoryContentQueue.push({
+      text: "",
+      textSegments: [],
+      toolCalls: [{ name: "remember", input: {} }],
+      toolCallsBeforeText: true,
+      contentOrder: ["tool:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    });
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("treats a current-turn no_response marker as terminal instead of falling back", async () => {
+    conversationMessages.push(
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer"}]',
+      },
+      {
+        id: "msg-current-silent",
+        role: "assistant",
+        content: '[{"type":"text","text":"<no_response/>"}]',
+      },
+    );
+    renderedHistoryContentQueue.push({
+      text: "<no_response/>",
+      textSegments: ["<no_response/>"],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    });
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(0);
   });
 
   it("skips already-delivered segments when startFromSegment is set", async () => {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,8 +1,12 @@
-import { renderHistoryContent } from "../daemon/handlers/shared.js";
+import {
+  type RenderedHistoryContent,
+  renderHistoryContent,
+} from "../daemon/handlers/shared.js";
 import { getAttachmentMetadataForMessage } from "../memory/attachments-store.js";
 import {
   getMessageById,
   getMessages,
+  getMessagesAfter,
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
@@ -74,6 +78,18 @@ function toDeliverableTextSegments(
     return [fallbackText];
   }
   return [];
+}
+
+function hasDeliverableReply(
+  rendered: RenderedHistoryContent,
+  attachments: RuntimeAttachmentMetadata[],
+): boolean {
+  return (
+    toDeliverableTextSegments(rendered.textSegments, rendered.text).length >
+      0 ||
+    attachments.length > 0 ||
+    hasNoResponseMarker(rendered.textSegments)
+  );
 }
 
 export async function deliverRenderedReplyViaCallback(
@@ -169,6 +185,11 @@ export async function deliverRenderedReplyViaCallback(
 }
 
 export type DeliverReplyOptions = {
+  /**
+   * Internal conversation message id for the user row that started this
+   * delivery. When set, fallback scans never cross into older turns.
+   */
+  sinceMessageId?: string;
   startFromSegment?: number;
   onSegmentDelivered?: (deliveredCount: number) => void;
   /** Deliver as ephemeral (visible only to `user`). Fire-and-forget. */
@@ -188,7 +209,11 @@ export async function deliverReplyViaCallback(
   assistantId?: string,
   options?: DeliverReplyOptions,
 ): Promise<void> {
-  const msgs = getMessages(conversationId);
+  const msgs =
+    options?.sinceMessageId === undefined
+      ? getMessages(conversationId)
+      : getMessagesAfter(conversationId, options.sinceMessageId);
+
   for (let i = msgs.length - 1; i >= 0; i--) {
     if (msgs[i].role !== "assistant") continue;
 
@@ -208,6 +233,10 @@ export async function deliverReplyViaCallback(
       sizeBytes: a.sizeBytes,
       kind: a.kind,
     }));
+
+    if (!hasDeliverableReply(rendered, replyAttachments)) {
+      continue;
+    }
 
     // Compose an `onMessageTs` that reconciles `slackMeta.channelTs` on the
     // persisted assistant row once Slack returns the authoritative ts. The

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -292,6 +292,7 @@ export async function sweepFailedEvents(
             replyCallbackUrl,
             assistantId,
             {
+              sinceMessageId: userMessageId,
               startFromSegment: 0,
               onSegmentDelivered: (count) =>
                 updateDeliveredSegmentCount(event.id, count),

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -257,6 +257,7 @@ export function processChannelMessageInBackground(
           replyCallbackUrl,
           assistantId,
           {
+            sinceMessageId: userMessageId,
             onSegmentDelivered: (count) =>
               updateDeliveredSegmentCount(eventId, count),
           },


### PR DESCRIPTION
## Summary
- Bound channel reply delivery to the internal user message that started the turn.
- Fall back to the newest deliverable assistant text within that turn when the final assistant row is tool-only.
- Add regression coverage for current-turn fallback, turn-boundary safety, and `<no_response/>` suppression.

## Original prompt
The user reported that Slack updates are not sent when the assistant loop ends with a final assistant message that only contains tool calls. We discussed sending the last text block before that final tool-call chunk, but only within the current turn so older channel replies are never reused. The fix should generalize across supported channels by using our internal conversation message id, not Slack-specific ids like `ts` or `thread_ts`.

Local verification: `git diff --check` only; per `/do` instructions, I did not run tests locally unless specifically required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->