### PR TITLE
Allow Slack task_progress status surfaces

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -337,6 +337,36 @@ describe("injectChannelCapabilityContext", () => {
     expect(text).toContain("emoji reactions");
   });
 
+  test("allows only task_progress ui_show/ui_update guidance for Slack", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain(
+      'Only use ui_show/ui_update for card surfaces with template: "task_progress"',
+    );
+    expect(text).not.toContain("Do NOT use ui_show, ui_update, or app_create");
+  });
+
+  test("keeps blanket ui_show/ui_update prohibition for other non-dynamic channels", () => {
+    const caps: ChannelCapabilities = {
+      channel: "phone",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Do NOT use ui_show, ui_update, or app_create");
+    expect(text).not.toContain("Only use ui_show/ui_update");
+  });
+
   test("still injects for group chats even when all capabilities are true", () => {
     const caps: ChannelCapabilities = {
       channel: "slack",
@@ -611,7 +641,7 @@ describe("trust-gating via channel capabilities", () => {
   });
 
   test("non-dashboard channel adds constraint rules preventing UI references", () => {
-    const caps = resolveChannelCapabilities("slack");
+    const caps = resolveChannelCapabilities("telegram");
     const message: Message = {
       role: "user",
       content: [{ type: "text", text: "Show me a chart" }],
@@ -1248,6 +1278,24 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(vellumText).not.toContain("response_discretion:");
     expect(telegramText).toContain("response_discretion:");
     expect(telegramText).toContain("<no_response/>");
+  });
+
+  test("adds task_progress hint only for Slack turns", () => {
+    const slackText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "slack",
+      channelName: "slack",
+    });
+    const telegramText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "telegram",
+      channelName: "telegram",
+    });
+
+    expect(slackText).toContain(
+      "if you are going to do work, use task_progress",
+    );
+    expect(telegramText).not.toContain("use task_progress");
   });
 
   test("dedup logic: fields matching canonical_actor_identity are omitted", () => {

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -84,6 +84,74 @@ describe("task_progress surface compatibility", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("allows Slack ui_show for task_progress card when dynamic UI is otherwise disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Working",
+      template: "task_progress",
+      templateData: {
+        status: "in_progress",
+        steps: [{ label: "Start", status: "in_progress" }],
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "card") return;
+    expect((showMessage.data as CardSurfaceData).template).toBe(
+      "task_progress",
+    );
+  });
+
+  test("blocks Slack ui_show for non-task_progress card when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Blocked",
+      data: { title: "Blocked", body: "not progress" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_show for non-card task_progress input when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "dynamic_page",
+      title: "Blocked",
+      data: { template: "task_progress", html: "<p>Blocked</p>" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
   test("ui_show maps legacy top-level task_progress fields into card data", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);
@@ -247,6 +315,80 @@ describe("task_progress surface compatibility", () => {
     const templateData = updatedCard.templateData as Record<string, unknown>;
     expect(templateData.status).toBe("completed");
     expect(Array.isArray(templateData.steps)).toBe(true);
+  });
+
+  test("allows Slack ui_update for stored task_progress card when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: {
+        title: "Working",
+        body: "",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { status: "completed" },
+    });
+
+    expect(result.isError).toBe(false);
+    const updateMessage = sent.find(
+      (msg): msg is UiSurfaceUpdate => msg.type === "ui_surface_update",
+    );
+    expect(updateMessage).toBeDefined();
+    if (!updateMessage) return;
+    const templateData = (updateMessage.data as CardSurfaceData)
+      .templateData as Record<string, unknown>;
+    expect(templateData.status).toBe("completed");
+  });
+
+  test("blocks Slack ui_update when stored surface is not a task_progress card", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: { title: "Plain", body: "No progress" } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { body: "still blocked" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_update when the surface is not already stored", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "missing-surface",
+      data: { status: "completed" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
   });
 
   test("ui_show rejects new interactive surface when a non-dynamic_page pending surface exists", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -132,6 +132,27 @@ describe("task_progress surface compatibility", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("blocks Slack ui_show when normalized card data is not task_progress", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Blocked",
+      template: "task_progress",
+      data: { title: "Blocked", body: "not progress", template: "plain" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
   test("blocks Slack ui_show for non-card task_progress input when dynamic UI is disabled", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent, {
@@ -370,6 +391,37 @@ describe("task_progress surface compatibility", () => {
       'ui_update is unavailable on channel "slack"',
     );
     expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_update that would change task_progress card template", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: {
+        title: "Working",
+        body: "",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { template: "plain", body: "now a plain card" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+    expect(
+      (ctx.surfaceState.get("surface-1")?.data as CardSurfaceData).template,
+    ).toBe("task_progress");
   });
 
   test("blocks Slack ui_update when the surface is not already stored", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -680,9 +680,15 @@ export function injectChannelCapabilityContext(
       "- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.",
     );
     if (!caps.supportsDynamicUi) {
-      lines.push(
-        "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
-      );
+      if (caps.channel === "slack") {
+        lines.push(
+          '- Do NOT use app_create. Only use ui_show/ui_update for card surfaces with template: "task_progress"; present all other information as text.',
+        );
+      } else {
+        lines.push(
+          "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
+        );
+      }
       lines.push(
         "- Present information as well-formatted text instead of dynamic UI.",
       );
@@ -973,6 +979,9 @@ export function buildUnifiedTurnContextBlock(
     lines.push(
       `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
     );
+    if (options.channelName === "slack") {
+      lines.push("if you are going to do work, use task_progress");
+    }
   }
 
   lines.push("</turn_context>");

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -390,6 +390,36 @@ function normalizeTaskProgressCardPatch(
   return normalizedPatch;
 }
 
+function isTaskProgressCardData(data: SurfaceData | Record<string, unknown>) {
+  return (data as Record<string, unknown>).template === "task_progress";
+}
+
+function isSlackTaskProgressUiException(
+  ctx: SurfaceConversationContext,
+  toolName: string,
+  input: Record<string, unknown>,
+): boolean {
+  if (ctx.channelCapabilities?.channel !== "slack") return false;
+  if (toolName === "ui_show") {
+    const surfaceType = input.surface_type as SurfaceType;
+    const rawData = isPlainObject(input.data) ? input.data : {};
+    return (
+      surfaceType === "card" &&
+      (input.template === "task_progress" ||
+        rawData.template === "task_progress")
+    );
+  }
+  if (toolName === "ui_update") {
+    const surfaceId = input.surface_id;
+    if (typeof surfaceId !== "string") return false;
+    const stored = ctx.surfaceState.get(surfaceId);
+    return (
+      stored?.surfaceType === "card" && isTaskProgressCardData(stored.data)
+    );
+  }
+  return false;
+}
+
 /**
  * Subset of Conversation state that surface helpers need access to.
  * The Conversation class implements this interface so its instances can be
@@ -2140,7 +2170,11 @@ export async function surfaceProxyResolver(
 
   if (toolName === "ui_show" || toolName === "ui_update") {
     const caps = ctx.channelCapabilities;
-    if (caps && !caps.supportsDynamicUi) {
+    if (
+      caps &&
+      !caps.supportsDynamicUi &&
+      !isSlackTaskProgressUiException(ctx, toolName, input)
+    ) {
       log.info(
         { toolName, channel: caps.channel, conversationId: ctx.conversationId },
         "Blocked UI surface tool on channel without dynamic UI support",

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -402,20 +402,23 @@ function isSlackTaskProgressUiException(
   if (ctx.channelCapabilities?.channel !== "slack") return false;
   if (toolName === "ui_show") {
     const surfaceType = input.surface_type as SurfaceType;
+    if (surfaceType !== "card") return false;
     const rawData = isPlainObject(input.data) ? input.data : {};
-    return (
-      surfaceType === "card" &&
-      (input.template === "task_progress" ||
-        rawData.template === "task_progress")
-    );
+    const data = normalizeCardShowData(input, rawData);
+    return isTaskProgressCardData(data);
   }
   if (toolName === "ui_update") {
     const surfaceId = input.surface_id;
     if (typeof surfaceId !== "string") return false;
     const stored = ctx.surfaceState.get(surfaceId);
-    return (
-      stored?.surfaceType === "card" && isTaskProgressCardData(stored.data)
+    if (!stored || stored.surfaceType !== "card") return false;
+    const rawPatch = isPlainObject(input.data) ? input.data : {};
+    const patch = normalizeTaskProgressCardPatch(
+      stored.data as CardSurfaceData,
+      rawPatch,
     );
+    const mergedData = { ...stored.data, ...patch } as SurfaceData;
+    return isTaskProgressCardData(mergedData);
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- add Slack-only task_progress guidance for work turns
- allow Slack task_progress show/update calls for status observation while keeping other dynamic UI blocked
- cover the Slack hint and surface-tool exception

## Project issue
Part of #31408

## Test plan
- export PATH=\"$HOME/.bun/bin:$PATH\" && bun test src/__tests__/conversation-runtime-assembly.test.ts src/__tests__/conversation-surfaces-task-progress.test.ts
- export PATH=\"$HOME/.bun/bin:$PATH\" && bunx tsc --noEmit --pretty false
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->