### PR TITLE
fix(daemon): use SOUL.md greetings in identity/intro endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9062,8 +9062,8 @@ paths:
       operationId: identity_intro_get
       summary: Get identity intro text
       description:
-        Returns a deterministic greeting derived from the assistant name in IDENTITY.md, falling back to
-        LLM-generated cache.
+        "Returns a greeting for the empty-state hero. Priority: SOUL.md ## Greetings (random pick), ## Identity
+        Intro section, 'Hi, I'm {name}!' from IDENTITY.md, then LLM-generated cache."
       tags:
         - identity
       responses:

--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -60,6 +60,7 @@ mock.module("../prompts/persona-resolver.js", () => ({
 import {
   computeIdentityContentHash,
   getCachedIntro,
+  parseSoulGreetings,
   readWorkspaceIdentityIntro,
   setCachedIntro,
 } from "../runtime/routes/identity-intro-cache.js";
@@ -260,5 +261,72 @@ describe("identity intro cache", () => {
     checkpointStore.set("identity:intro:content_hash", "abc");
     // Missing timestamp — should return null
     expect(getCachedIntro()).toBeNull();
+  });
+});
+
+describe("parseSoulGreetings", () => {
+  test("parses greeting lines from ## Greetings section", () => {
+    workspaceFiles["SOUL.md"] = [
+      "# Soul",
+      "",
+      "## Greetings",
+      "- Hey there!",
+      "- What's cooking?",
+      "- Ready to roll.",
+    ].join("\n");
+
+    expect(parseSoulGreetings()).toEqual([
+      "Hey there!",
+      "What's cooking?",
+      "Ready to roll.",
+    ]);
+  });
+
+  test("strips surrounding quotes from greetings", () => {
+    workspaceFiles["SOUL.md"] = [
+      "## Greetings",
+      '- "Hello, friend!"',
+      "- 'Yo!'",
+    ].join("\n");
+
+    expect(parseSoulGreetings()).toEqual(["Hello, friend!", "Yo!"]);
+  });
+
+  test("stops collecting at the next heading", () => {
+    workspaceFiles["SOUL.md"] = [
+      "## Greetings",
+      "- First",
+      "- Second",
+      "## Other Section",
+      "- Not a greeting",
+    ].join("\n");
+
+    expect(parseSoulGreetings()).toEqual(["First", "Second"]);
+  });
+
+  test("returns empty array when no SOUL.md exists", () => {
+    expect(parseSoulGreetings()).toEqual([]);
+  });
+
+  test("returns empty array when no Greetings section exists", () => {
+    workspaceFiles["SOUL.md"] = [
+      "# Soul",
+      "",
+      "## Personality",
+      "Be cheerful.",
+    ].join("\n");
+
+    expect(parseSoulGreetings()).toEqual([]);
+  });
+
+  test("skips empty bullet items", () => {
+    workspaceFiles["SOUL.md"] = [
+      "## Greetings",
+      "- Hello!",
+      "- ",
+      "- Bye!",
+    ].join("\n");
+
+    expect(parseSoulGreetings()).toEqual(["Hello!", "Bye!"]);
   });
 });

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -38,7 +38,7 @@ const IDENTITY_FILES = ["IDENTITY.md", "SOUL.md"] as const;
 // ---------------------------------------------------------------------------
 
 /** Read a workspace prompt file, returning empty string if missing. */
-function readWorkspaceFile(name: string): string {
+export function readWorkspaceFile(name: string): string {
   try {
     const path = getWorkspacePromptPath(name);
     if (!existsSync(path)) return "";
@@ -76,6 +76,45 @@ export function readWorkspaceIdentityIntro(): string | null {
     parseIdentityIntroSection(readWorkspaceFile("IDENTITY.md")) ??
     parseIdentityIntroSection(readWorkspaceFile("SOUL.md"))
   );
+}
+
+/**
+ * Parse greeting lines from the `## Greetings` section of SOUL.md.
+ *
+ * Mirrors the macOS client's `IdentityData.parseGreetings(from:)` logic:
+ * looks for a markdown heading containing "greetings", then collects
+ * bullet-list items until the next heading. Strips surrounding quotes.
+ */
+export function parseSoulGreetings(): string[] {
+  const content = readWorkspaceFile("SOUL.md");
+  if (!content) return [];
+
+  const greetings: string[] = [];
+  let inSection = false;
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (/^#+\s/.test(trimmed)) {
+      inSection = trimmed.toLowerCase().includes("greetings");
+      continue;
+    }
+    if (inSection && trimmed.startsWith("- ")) {
+      let greeting = trimmed.slice(2).trim();
+      // Strip surrounding quotes
+      if (
+        greeting.length >= 2 &&
+        ((greeting.startsWith('"') && greeting.endsWith('"')) ||
+          (greeting.startsWith("'") && greeting.endsWith("'")))
+      ) {
+        greeting = greeting.slice(1, -1);
+      }
+      if (greeting) {
+        greetings.push(greeting);
+      }
+    }
+  }
+
+  return greetings;
 }
 
 /** Compute a SHA-256 hex hash of the concatenated identity file contents. */

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -21,7 +21,11 @@ import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { NotFoundError } from "./errors.js";
-import { getCachedIntro } from "./identity-intro-cache.js";
+import {
+  getCachedIntro,
+  parseSoulGreetings,
+  readWorkspaceIdentityIntro,
+} from "./identity-intro-cache.js";
 import type { RouteDefinition } from "./types.js";
 
 interface MemoryInfo {
@@ -376,6 +380,21 @@ function resolveIdentityCreatedAt(identityPath: string): string | undefined {
 }
 
 function getIdentityIntro() {
+  // 1. SOUL.md greetings — custom per-assistant greetings (matches macOS client)
+  const soulGreetings = parseSoulGreetings();
+  if (soulGreetings.length > 0) {
+    const greeting =
+      soulGreetings[Math.floor(Math.random() * soulGreetings.length)]!;
+    return { text: greeting };
+  }
+
+  // 2. Explicit ## Identity Intro section in IDENTITY.md or SOUL.md
+  const identityIntro = readWorkspaceIdentityIntro();
+  if (identityIntro) {
+    return { text: identityIntro };
+  }
+
+  // 3. Default "Hi, I'm {name}!" from IDENTITY.md
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   if (existsSync(identityPath)) {
     const content = readFileSync(identityPath, "utf-8");
@@ -385,6 +404,7 @@ function getIdentityIntro() {
     }
   }
 
+  // 4. Cached LLM-generated intro
   const cached = getCachedIntro();
   if (!cached) {
     throw new NotFoundError("No cached identity intro available");
@@ -493,7 +513,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: getIdentityIntro,
     summary: "Get identity intro text",
     description:
-      "Returns a deterministic greeting derived from the assistant name in IDENTITY.md, falling back to LLM-generated cache.",
+      "Returns a greeting for the empty-state hero. Priority: SOUL.md ## Greetings (random pick), ## Identity Intro section, 'Hi, I'm {name}!' from IDENTITY.md, then LLM-generated cache.",
     tags: ["identity"],
     responseBody: z.object({
       text: z.string(),


### PR DESCRIPTION
## Summary
- The identity/intro endpoint always returned "Hi, I'm {name}!" from IDENTITY.md, ignoring custom greetings configured in SOUL.md
- The macOS client worked around this by separately loading SOUL.md greetings via the workspace API, but the web app only calls identity/intro and showed the static greeting
- Updated `getIdentityIntro()` to check sources in the same priority order as the macOS client: SOUL.md `## Greetings` (random pick) → `## Identity Intro` section → "Hi, I'm {name}!" fallback → cached LLM intro

## Test plan
- [x] Existing identity-intro-cache tests pass (18 tests)
- [x] Added 6 new tests for `parseSoulGreetings` covering: basic parsing, quote stripping, section boundary, missing file, missing section, empty items
- [ ] Verify web app empty state shows a SOUL.md greeting when `## Greetings` section exists
- [ ] Verify fallback to "Hi, I'm {name}!" when no SOUL.md greetings are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->