### PR TITLE
fix(document-editor): fix self-review findings in find/replace tools

### DIFF
--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -246,7 +246,7 @@ describe("document_find", () => {
     const body = parseResult<FindResultBody>(result);
 
     expect(body.success).toBe(true);
-    expect(body.total_matches).toBe(50);
+    expect(body.total_matches).toBe(100);
     expect(body.matches!.length).toBe(50);
   });
 });
@@ -401,6 +401,36 @@ describe("document_replace_text", () => {
     expect(body.replacements_made).toBe(1);
     expect(body.content_changed).toBe(true);
     expect(getDocumentById("doc-replace")?.content).toBe("qux bar foo baz foo");
+  });
+
+  test("max_replacements with regex backreferences replaces correctly", () => {
+    seedDocument({
+      surfaceId: "doc-regex-limit",
+      conversationId: "conv-current",
+      title: "Regex Limit Test",
+      content: "a@b c@d e@f",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-regex-limit",
+        find: "(\\w+)@(\\w+)",
+        replace: "$2/$1",
+        regex: true,
+        case_sensitive: true,
+        max_replacements: 2,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(2);
+    expect(body.content_changed).toBe(true);
+    expect(getDocumentById("doc-regex-limit")?.content).toBe("b/a d/c e@f");
   });
 
   test("no matches returns success with zero replacements", () => {

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -270,67 +270,67 @@ export function findInDocument(
   query: string,
   options: { regex?: boolean; caseSensitive?: boolean } = {},
 ): FindResult | null {
-  const row = rawGet<{ content: string }>(
-    /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
-    surfaceId,
-  );
-  if (!row) return null;
+  try {
+    const row = rawGet<{ content: string }>(
+      /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    if (!row) return null;
 
-  const lines = row.content.split("\n");
-  const matches: FindMatch[] = [];
+    const lines = row.content.split("\n");
+    const matches: FindMatch[] = [];
+    let uncappedTotal = 0;
 
-  if (options.regex) {
-    const flags = options.caseSensitive ? "g" : "gi";
-    const re = new RegExp(query, flags);
-    for (
-      let i = 0;
-      i < lines.length && matches.length < MAX_FIND_MATCHES;
-      i++
-    ) {
-      const line = lines[i];
-      re.lastIndex = 0;
-      let m: RegExpExecArray | null;
-      while (
-        (m = re.exec(line)) !== null &&
-        matches.length < MAX_FIND_MATCHES
-      ) {
-        matches.push({
-          lineNumber: i + 1,
-          lineContent: line,
-          matchStart: m.index,
-          matchEnd: m.index + m[0].length,
-          matchText: m[0],
-        });
-        // Prevent infinite loops on zero-length matches
-        if (m[0].length === 0) re.lastIndex++;
+    if (options.regex) {
+      const flags = options.caseSensitive ? "g" : "gi";
+      const re = new RegExp(query, flags);
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        re.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(line)) !== null) {
+          uncappedTotal++;
+          if (matches.length < MAX_FIND_MATCHES) {
+            matches.push({
+              lineNumber: i + 1,
+              lineContent: line,
+              matchStart: m.index,
+              matchEnd: m.index + m[0].length,
+              matchText: m[0],
+            });
+          }
+          if (m[0].length === 0) re.lastIndex++;
+        }
+      }
+    } else {
+      const needle = options.caseSensitive ? query : query.toLowerCase();
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const haystack = options.caseSensitive ? line : line.toLowerCase();
+        let startPos = 0;
+        while (startPos <= haystack.length) {
+          const idx = haystack.indexOf(needle, startPos);
+          if (idx === -1) break;
+          uncappedTotal++;
+          if (matches.length < MAX_FIND_MATCHES) {
+            matches.push({
+              lineNumber: i + 1,
+              lineContent: line,
+              matchStart: idx,
+              matchEnd: idx + needle.length,
+              matchText: line.slice(idx, idx + needle.length),
+            });
+          }
+          startPos = idx + Math.max(needle.length, 1);
+        }
       }
     }
-  } else {
-    const needle = options.caseSensitive ? query : query.toLowerCase();
-    for (
-      let i = 0;
-      i < lines.length && matches.length < MAX_FIND_MATCHES;
-      i++
-    ) {
-      const line = lines[i];
-      const haystack = options.caseSensitive ? line : line.toLowerCase();
-      let startPos = 0;
-      while (startPos <= haystack.length && matches.length < MAX_FIND_MATCHES) {
-        const idx = haystack.indexOf(needle, startPos);
-        if (idx === -1) break;
-        matches.push({
-          lineNumber: i + 1,
-          lineContent: line,
-          matchStart: idx,
-          matchEnd: idx + needle.length,
-          matchText: line.slice(idx, idx + needle.length),
-        });
-        startPos = idx + Math.max(needle.length, 1);
-      }
-    }
+
+    return { surfaceId, totalMatches: uncappedTotal, matches };
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Find-in-document error");
+    return null;
   }
-
-  return { surfaceId, totalMatches: matches.length, matches };
 }
 
 // ---------------------------------------------------------------------------
@@ -454,9 +454,11 @@ export function replaceInDocument(
       while ((m = pattern.exec(row.content)) !== null) {
         if (count >= limit) break;
         result += row.content.slice(lastIndex, m.index);
-        // Build the replacement for this match using String.replace
-        // so $1, $2, $& backreferences resolve against the match.
-        result += m[0].replace(pattern, replace);
+        const singleMatchPattern = new RegExp(
+          pattern.source,
+          pattern.flags.replace("g", ""),
+        );
+        result += m[0].replace(singleMatchPattern, replace);
         lastIndex = m.index + m[0].length;
         count++;
       }


### PR DESCRIPTION
## Summary
- Fix backreference expansion bug in `replaceInDocument` when `maxReplacements` is set — use non-global regex for single-match replacement
- Add try/catch to `findInDocument` matching the pattern used by all other store functions
- Report true `totalMatches` count before capping returned results at 50, so callers know when results are truncated
- Add test for `max_replacements` with regex backreferences

Part of plan: doc-editor-grep-sed.md (self-review fixes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->