### PR TITLE
fix(design-library): default storybook manager to light theme

### DIFF
--- a/packages/design-library/.storybook/manager.ts
+++ b/packages/design-library/.storybook/manager.ts
@@ -1,21 +1,23 @@
 import { addons } from "storybook/manager-api";
 import { create } from "storybook/theming";
 
-const brand = {
+// Storybook 10 only applies the manager theme once at bootup — calling
+// `addons.setConfig` again after init does not swap the theme live. So we
+// pick a single theme here that matches the canvas's default (`light`,
+// per preview.tsx) and accept that switching the toolbar theme only
+// re-themes the canvas/docs, not the sidebar.
+const lightManagerTheme = create({
+  base: "light",
+
   brandTitle: "Vellum Design Library",
   brandUrl: "https://github.com/vellum-ai/vellum-assistant",
   appBorderRadius: 8,
-};
-
-const lightManagerTheme = create({
-  base: "light",
-  ...brand,
 
   appBg: "#F6F5F4",
   appContentBg: "#FFFFFF",
-  appBorderColor: "#F2F0EE",
+  appBorderColor: "#E9E6E2",
 
-  textColor: "#24292E",
+  textColor: "#17191C",
   textMutedColor: "#5A6672",
 
   colorPrimary: "#17191C",
@@ -23,42 +25,15 @@ const lightManagerTheme = create({
 
   barBg: "#FFFFFF",
   barTextColor: "#5A6672",
-  barSelectedColor: "#24292E",
+  barSelectedColor: "#17191C",
 
   inputBg: "#FFFFFF",
   inputBorder: "#CFCCC9",
-  inputTextColor: "#24292E",
+  inputTextColor: "#17191C",
 });
-
-const darkManagerTheme = create({
-  base: "dark",
-  ...brand,
-
-  appBg: "#17191C",
-  appContentBg: "#1C2024",
-  appBorderColor: "#24292E",
-
-  textColor: "#F6F5F4",
-  textMutedColor: "#A9B2BB",
-
-  colorPrimary: "#F6F5F4",
-  colorSecondary: "#F6F5F4",
-
-  barBg: "#17191C",
-  barTextColor: "#A9B2BB",
-  barSelectedColor: "#F6F5F4",
-
-  inputBg: "#2D3339",
-  inputBorder: "#5A6672",
-  inputTextColor: "#F6F5F4",
-});
-
-const prefersDark =
-  typeof window !== "undefined" &&
-  window.matchMedia?.("(prefers-color-scheme: dark)").matches;
 
 addons.setConfig({
-  theme: prefersDark ? darkManagerTheme : lightManagerTheme,
+  theme: lightManagerTheme,
   sidebar: {
     showRoots: true,
   },


### PR DESCRIPTION
## Summary

The storybook sidebar (manager UI) was rendering in dark colors with very low-contrast text on a dark-mode OS, even when the canvas toolbar showed "light". Investigation found two issues:

- `manager.ts` picked the manager theme from `prefers-color-scheme` at module load — independent of the canvas toolbar selection, which always defaults to `"light"` (per `preview.tsx`).
- Storybook 10 only applies `addons.setConfig({ theme })` once at bootup; calling it again on a `GLOBALS_UPDATED` event does **not** swap the manager UI theme at runtime. So the sidebar can't be made to follow the toolbar's light/dark/velvet selector.

## Fix

Drop the `prefers-color-scheme` branching and ship a single light manager theme that matches the canvas's default. Also tighten a few colors to brighter design-token values (`#17191C` text, `#E9E6E2` border) so the sidebar reads cleanly against the `#F6F5F4` app background.

## Test plan

- [ ] `bun run storybook` from `packages/design-library` — sidebar is light, text is high contrast
- [ ] Toolbar theme switcher in the canvas still toggles the canvas between light/dark/velvet (sidebar stays light, as expected given the SB10 limitation)
- [ ] No regression on a dark-mode OS (sidebar no longer mismatches the canvas)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCMKrvEAdYyZe5eBcMhcFe)_