### PR TITLE
feat(document-editor): add grep/sed-style find & replace tools (JARVIS-903)

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -664,6 +664,18 @@ export function parseAssistantEvent(
       return { type: rawType as "document_comment_reopened" | "document_comment_deleted", ...base };
     }
 
+    case "document_editor_update": {
+      const surfaceId =
+        typeof data.surfaceId === "string" ? data.surfaceId : "";
+      const markdown =
+        typeof data.markdown === "string" ? data.markdown : "";
+      const mode = typeof data.mode === "string" ? data.mode : "replace";
+      if (!surfaceId) {
+        return { type: "unknown", rawType, data };
+      }
+      return { type: "document_editor_update", surfaceId, markdown, mode };
+    }
+
     default:
       return { type: "unknown", rawType, data };
     }

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -503,6 +503,14 @@ export interface DocumentCommentDeletedSseEvent
   conversationKey?: string;
 }
 
+export interface DocumentEditorUpdateEvent {
+  type: "document_editor_update";
+  surfaceId: string;
+  markdown: string;
+  mode: string;
+  conversationKey?: string;
+}
+
 export interface UnknownEvent {
   type: "unknown";
   rawType: string;
@@ -687,4 +695,5 @@ export type AssistantEvent =
   | DocumentCommentResolvedSseEvent
   | DocumentCommentReopenedSseEvent
   | DocumentCommentDeletedSseEvent
+  | DocumentEditorUpdateEvent
   | UnknownEvent;

--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -18,7 +18,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
   type Ref,
@@ -106,19 +105,15 @@ export function DocumentViewerContainer({
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const commentPanelRef = useRef<DocumentCommentPanelHandle>(null);
-  const initialContentRef = useRef(content);
+  const prevContentRef = useRef(content);
 
-  // Generate the iframe HTML once on mount
-  const editorHTML = useMemo(
-    () => generateEditorHTML(initialContentRef.current),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  // Generate the iframe HTML once on mount; subsequent updates go via postMessage
+  const [editorHTML] = useState(() => generateEditorHTML(content));
 
   // Push content updates to the iframe in-place (preserves scroll position)
   useEffect(() => {
-    if (content === initialContentRef.current) return;
-    initialContentRef.current = content;
+    if (content === prevContentRef.current) return;
+    prevContentRef.current = content;
     iframeRef.current?.contentWindow?.postMessage(
       { type: "set_content", content },
       "*",

--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -106,9 +106,24 @@ export function DocumentViewerContainer({
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const commentPanelRef = useRef<DocumentCommentPanelHandle>(null);
+  const initialContentRef = useRef(content);
 
-  // Generate the iframe HTML once per content change
-  const editorHTML = useMemo(() => generateEditorHTML(content), [content]);
+  // Generate the iframe HTML once on mount
+  const editorHTML = useMemo(
+    () => generateEditorHTML(initialContentRef.current),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Push content updates to the iframe in-place (preserves scroll position)
+  useEffect(() => {
+    if (content === initialContentRef.current) return;
+    initialContentRef.current = content;
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "set_content", content },
+      "*",
+    );
+  }, [content]);
 
   // -------------------------------------------------------------------------
   // postMessage listener for iframe → parent events

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -12,6 +12,7 @@ import { useConversationStore } from "@/domains/conversations/conversation-store
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { useTurnStore } from "@/domains/messaging/turn-store.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
 import type { DiskPressureStatusEventPayload } from "@/assistant/use-disk-pressure-monitor.js";
 import {
   recordChatDiagnostic,
@@ -412,6 +413,13 @@ export function useStreamEventHandler(
           break;
         case "sync_changed":
           dispatchSyncChanged(event);
+          break;
+        case "document_editor_update":
+          useViewerStore.getState().updateDocumentContent(
+            event.surfaceId,
+            event.markdown,
+            event.mode,
+          );
           break;
         case "document_comment_created":
         case "document_comment_resolved":

--- a/apps/web/src/domains/chat/utils/editor-bridge.ts
+++ b/apps/web/src/domains/chat/utils/editor-bridge.ts
@@ -359,6 +359,14 @@ export function generateEditorHTML(content: string): string {
       }
     }
 
+    if (d.type === "set_content") {
+      if (typeof d.content === "string") {
+        rawContent = d.content;
+        clearActiveHighlights();
+        el.innerHTML = mdToHtml(rawContent);
+      }
+    }
+
     if (d.type === "set_comment_anchors") {
       // Remove existing anchor highlights (but keep active highlights)
       var existing = el.querySelectorAll(".comment-anchor-highlight");

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -90,6 +90,7 @@ export interface ViewerActions {
   openDocument: () => void;
   loadDocument: (assistantId: string, documentSurfaceId: string) => Promise<void>;
   setLoadedDocument: (document: OpenedDocumentState) => void;
+  updateDocumentContent: (surfaceId: string, content: string, mode: string) => void;
   handleDocumentLoadFailed: () => void;
   closeDocument: () => void;
 
@@ -289,6 +290,14 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   setLoadedDocument: (document) => {
     set({ openedDocumentState: document });
+  },
+
+  updateDocumentContent: (surfaceId, content, mode) => {
+    const state = get();
+    if (!state.openedDocumentState || state.openedDocumentState.surfaceId !== surfaceId) return;
+    const prev = state.openedDocumentState;
+    const newContent = mode === "append" ? prev.content + content : content;
+    set({ openedDocumentState: { ...prev, content: newContent } });
   },
 
   handleDocumentLoadFailed: () => {

--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { getDocumentById } from "../documents/document-store.js";
 import { getSqlite, resetDb } from "../memory/db-connection.js";
-import { executeDocumentFind } from "../tools/document/document-tool.js";
+import {
+  executeDocumentFind,
+  executeDocumentReplaceText,
+} from "../tools/document/document-tool.js";
 import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
@@ -82,6 +86,10 @@ function seedDocument(params: {
     .run(params.surfaceId, params.conversationId, params.updatedAt);
 }
 
+// ---------------------------------------------------------------------------
+// document_find tests
+// ---------------------------------------------------------------------------
+
 interface FindResultBody {
   success: boolean;
   surface_id?: string;
@@ -133,7 +141,6 @@ describe("document_find", () => {
 
     expect(body.success).toBe(true);
     expect(body.total_matches).toBe(3);
-    // Case-insensitive by default: "Hello" matches "Hello", "hello", "HELLO"
     expect(body.matches![0].line_number).toBe(1);
     expect(body.matches![0].match_text).toBe("Hello");
     expect(body.matches![1].line_number).toBe(3);
@@ -223,7 +230,6 @@ describe("document_find", () => {
   });
 
   test("results are capped at 50 matches", () => {
-    // Create a document with many repeated matches
     const lines = Array.from({ length: 100 }, (_, i) => `match line ${i}`);
     seedDocument({
       surfaceId: "doc-many-matches",
@@ -242,5 +248,224 @@ describe("document_find", () => {
     expect(body.success).toBe(true);
     expect(body.total_matches).toBe(50);
     expect(body.matches!.length).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// document_replace_text tests
+// ---------------------------------------------------------------------------
+
+describe("document_replace_text", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedDocument({
+      surfaceId: "doc-replace",
+      conversationId: "conv-current",
+      title: "Replace Test",
+      content: "foo bar foo baz foo",
+      updatedAt: 1000,
+    });
+    seedDocument({
+      surfaceId: "doc-other",
+      conversationId: "conv-other",
+      title: "Other Doc",
+      content: "other content",
+      updatedAt: 2000,
+    });
+  });
+
+  test("literal replace replaces all occurrences", () => {
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "qux" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(3);
+    expect(body.content_changed).toBe(true);
+    expect(getDocumentById("doc-replace")?.content).toBe("qux bar qux baz qux");
+  });
+
+  test("case-insensitive literal replace (default)", () => {
+    seedDocument({
+      surfaceId: "doc-case",
+      conversationId: "conv-current",
+      title: "Case Test",
+      content: "Foo FOO foo",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-case", find: "foo", replace: "x" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(3);
+    expect(getDocumentById("doc-case")?.content).toBe("x x x");
+  });
+
+  test("case-sensitive literal replace", () => {
+    seedDocument({
+      surfaceId: "doc-case-sensitive",
+      conversationId: "conv-current",
+      title: "Case Sensitive Test",
+      content: "Foo FOO foo",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-case-sensitive",
+        find: "foo",
+        replace: "x",
+        case_sensitive: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(1);
+    expect(getDocumentById("doc-case-sensitive")?.content).toBe("Foo FOO x");
+  });
+
+  test("regex replace with backreferences", () => {
+    seedDocument({
+      surfaceId: "doc-regex",
+      conversationId: "conv-current",
+      title: "Regex Test",
+      content: "user1@example user2@test",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-regex",
+        find: "(\\w+)@(\\w+)",
+        replace: "$2/$1",
+        regex: true,
+        case_sensitive: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(2);
+    expect(getDocumentById("doc-regex")?.content).toBe(
+      "example/user1 test/user2",
+    );
+  });
+
+  test("invalid regex returns clean error", () => {
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-replace",
+        find: "[invalid",
+        replace: "x",
+        regex: true,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{ success: boolean; error: string }>(result);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/Invalid regex/);
+    expect(result.isError).toBe(true);
+  });
+
+  test("max_replacements limits substitutions", () => {
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-replace",
+        find: "foo",
+        replace: "qux",
+        max_replacements: 1,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(1);
+    expect(body.content_changed).toBe(true);
+    expect(getDocumentById("doc-replace")?.content).toBe("qux bar foo baz foo");
+  });
+
+  test("no matches returns success with zero replacements", () => {
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "nonexistent", replace: "x" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(0);
+    expect(body.content_changed).toBe(false);
+    expect(getDocumentById("doc-replace")?.content).toBe("foo bar foo baz foo");
+  });
+
+  test("word_count is recalculated after replacement", () => {
+    const before = getDocumentById("doc-replace");
+    expect(before?.wordCount).toBe(5);
+
+    executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "one two" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const after = getDocumentById("doc-replace");
+    expect(after?.wordCount).toBe(8);
+  });
+
+  test("access control blocks non-guardian from other conversations", () => {
+    const remoteContext = makeContext({
+      trustClass: "trusted_contact",
+      executionChannel: "slack",
+      sendToClient: () => {},
+    });
+    const result = executeDocumentReplaceText(
+      { surface_id: "doc-other", find: "other", replace: "x" },
+      remoteContext,
+    );
+    expect(result.isError).toBe(true);
+    const body = parseResult<{ error: string }>(result);
+    expect(body.error).toBe("Document not found");
+    expect(getDocumentById("doc-other")?.content).toBe("other content");
+  });
+
+  test("client is notified via sendToClient with updated content", () => {
+    const messages: unknown[] = [];
+    const sendToClient = (msg: unknown) => {
+      messages.push(msg);
+    };
+    executeDocumentReplaceText(
+      { surface_id: "doc-replace", find: "foo", replace: "qux" },
+      makeContext({ sendToClient }),
+    );
+    expect(messages).toHaveLength(1);
+    const msg = messages[0] as {
+      type: string;
+      surfaceId: string;
+      markdown: string;
+      mode: string;
+    };
+    expect(msg.type).toBe("document_editor_update");
+    expect(msg.surfaceId).toBe("doc-replace");
+    expect(msg.mode).toBe("replace");
+    expect(msg.markdown).toBe("qux bar qux baz qux");
   });
 });

--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getSqlite, resetDb } from "../memory/db-connection.js";
+import { executeDocumentFind } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDb();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.updatedAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.updatedAt,
+      params.updatedAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.updatedAt);
+}
+
+interface FindResultBody {
+  success: boolean;
+  surface_id?: string;
+  query?: string;
+  total_matches?: number;
+  matches?: Array<{
+    line_number: number;
+    line_content: string;
+    match_start: number;
+    match_end: number;
+    match_text: string;
+  }>;
+  error?: string;
+}
+
+const MULTILINE_CONTENT = [
+  "Hello World",
+  "This is line two with some numbers 42 and 100",
+  "hello again on line three",
+  "HELLO UPPERCASE LINE FOUR",
+  "Final line with special chars: foo-bar_baz",
+].join("\n");
+
+describe("document_find", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+    seedDocument({
+      surfaceId: "doc-find-test",
+      conversationId: "conv-current",
+      title: "Find Test Doc",
+      content: MULTILINE_CONTENT,
+      updatedAt: 1000,
+    });
+    seedDocument({
+      surfaceId: "doc-other-conv",
+      conversationId: "conv-other",
+      title: "Other Conv Doc",
+      content: "secret content here",
+      updatedAt: 2000,
+    });
+  });
+
+  test("literal search finds exact matches with correct line numbers", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "Hello" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(3);
+    // Case-insensitive by default: "Hello" matches "Hello", "hello", "HELLO"
+    expect(body.matches![0].line_number).toBe(1);
+    expect(body.matches![0].match_text).toBe("Hello");
+    expect(body.matches![1].line_number).toBe(3);
+    expect(body.matches![1].match_text).toBe("hello");
+    expect(body.matches![2].line_number).toBe(4);
+    expect(body.matches![2].match_text).toBe("HELLO");
+  });
+
+  test("case-insensitive search (default) matches regardless of case", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "hello" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(3);
+    const lineNumbers = body.matches!.map((m) => m.line_number);
+    expect(lineNumbers).toEqual([1, 3, 4]);
+  });
+
+  test("case-sensitive search only matches exact case", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "Hello", case_sensitive: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(1);
+    expect(body.matches![0].line_number).toBe(1);
+    expect(body.matches![0].match_text).toBe("Hello");
+  });
+
+  test("regex search works", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "\\d+", regex: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(2);
+    expect(body.matches![0].match_text).toBe("42");
+    expect(body.matches![0].line_number).toBe(2);
+    expect(body.matches![1].match_text).toBe("100");
+    expect(body.matches![1].line_number).toBe(2);
+  });
+
+  test("invalid regex returns error gracefully", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "[invalid", regex: true },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(result.isError).toBe(true);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/Invalid regex/);
+  });
+
+  test("no matches returns success with empty array", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-find-test", query: "nonexistent-text-xyz" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(0);
+    expect(body.matches).toEqual([]);
+  });
+
+  test("access control blocks non-guardian from searching documents outside their conversation", () => {
+    const result = executeDocumentFind(
+      { surface_id: "doc-other-conv", query: "secret" },
+      makeContext({
+        trustClass: "trusted_contact",
+        executionChannel: "slack",
+        conversationId: "conv-current",
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    const body = parseResult<FindResultBody>(result);
+    expect(body.error).toBe("Document not found");
+  });
+
+  test("results are capped at 50 matches", () => {
+    // Create a document with many repeated matches
+    const lines = Array.from({ length: 100 }, (_, i) => `match line ${i}`);
+    seedDocument({
+      surfaceId: "doc-many-matches",
+      conversationId: "conv-current",
+      title: "Many Matches",
+      content: lines.join("\n"),
+      updatedAt: 3000,
+    });
+
+    const result = executeDocumentFind(
+      { surface_id: "doc-many-matches", query: "match" },
+      makeContext(),
+    );
+    const body = parseResult<FindResultBody>(result);
+
+    expect(body.success).toBe(true);
+    expect(body.total_matches).toBe(50);
+    expect(body.matches!.length).toBe(50);
+  });
+});

--- a/assistant/src/__tests__/document-find-replace.test.ts
+++ b/assistant/src/__tests__/document-find-replace.test.ts
@@ -246,7 +246,7 @@ describe("document_find", () => {
     const body = parseResult<FindResultBody>(result);
 
     expect(body.success).toBe(true);
-    expect(body.total_matches).toBe(50);
+    expect(body.total_matches).toBe(100);
     expect(body.matches!.length).toBe(50);
   });
 });
@@ -401,6 +401,36 @@ describe("document_replace_text", () => {
     expect(body.replacements_made).toBe(1);
     expect(body.content_changed).toBe(true);
     expect(getDocumentById("doc-replace")?.content).toBe("qux bar foo baz foo");
+  });
+
+  test("max_replacements with regex backreferences replaces correctly", () => {
+    seedDocument({
+      surfaceId: "doc-regex-limit",
+      conversationId: "conv-current",
+      title: "Regex Limit Test",
+      content: "a@b c@d e@f",
+      updatedAt: 3000,
+    });
+    const result = executeDocumentReplaceText(
+      {
+        surface_id: "doc-regex-limit",
+        find: "(\\w+)@(\\w+)",
+        replace: "$2/$1",
+        regex: true,
+        case_sensitive: true,
+        max_replacements: 2,
+      },
+      makeContext({ sendToClient: () => {} }),
+    );
+    const body = parseResult<{
+      success: boolean;
+      replacements_made: number;
+      content_changed: boolean;
+    }>(result);
+    expect(body.success).toBe(true);
+    expect(body.replacements_made).toBe(2);
+    expect(body.content_changed).toBe(true);
+    expect(getDocumentById("doc-regex-limit")?.content).toBe("b/a d/c e@f");
   });
 
   test("no matches returns success with zero replacements", () => {

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -46,8 +46,11 @@ When the user requests changes to a document:
 
 1. Find the `surface_id` from the `<active_documents>` context block.
 2. Use `document_update` with the existing `surface_id` — do NOT call `document_create` again.
-3. Use `mode: "replace"` for full rewrites or `mode: "append"` for additions.
-4. For targeted edits — fixing typos, renaming terms, adjusting formatting — prefer `document_find` + `document_replace_text` over `document_update` with `mode: "replace"`. This avoids rewriting the entire document and reduces the risk of accidentally dropping content.
+3. **Choose the right editing tool:**
+   - `document_update` with `mode: "append"` — adding new content to the end.
+   - `document_update` with `mode: "replace"` — ONLY for full rewrites where the majority of the document is changing.
+   - `document_find` + `document_replace_text` — **for everything else**. Fixing typos, renaming terms, swapping sections, reordering content, adjusting formatting, or any edit that touches only part of the document. This is the default choice for edits. It avoids rewriting the entire document and eliminates the risk of accidentally dropping content.
+4. **Do NOT use `document_update` with `mode: "replace"` for targeted edits.** Rewriting the entire document to change a few words or rearrange sections is wasteful and error-prone.
 
 ## Find & Replace
 
@@ -87,6 +90,7 @@ Returns the number of replacements made and whether the content changed.
 - **Fix a recurring typo**: Find `"recieve"`, replace with `"receive"`.
 - **Rename a term throughout**: Find `"widget"` (case-insensitive), replace with `"component"`.
 - **Reformat dates with regex**: Find `(\d{2})/(\d{2})/(\d{4})` with `regex: true`, replace with `$3-$1-$2` to convert `MM/DD/YYYY` to `YYYY-MM-DD`.
+- **Swap or reorder sections**: Use `document_read` to get the content, identify the sections to swap, then call `document_replace_text` to replace the first section with the second and vice versa. For complex rearrangements, use multiple `document_replace_text` calls with `max_replacements: 1`.
 
 ## Comments
 

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -20,6 +20,8 @@ Create and edit long-form documents using the built-in rich text editor. Documen
 - **document_update** - Updates content in an open document editor by `surface_id`. Supports `replace` (overwrite) and `append` (add to end) modes.
 - **document_read** - Reads the current content of a document by `surface_id` when it belongs to the current conversation, or when the current actor is the guardian/local user. Use to verify content before editing.
 - **document_list** - Lists documents. Without `query`, lists the current conversation's documents. With `query`, searches by title; guardian/local users can search across conversations, while other actors are scoped to the current conversation.
+- **document_find** - Searches a document for text or regex patterns. Returns matching lines with line numbers, match positions, and matched text.
+- **document_replace_text** - Targeted find-and-replace within a document. Supports literal and regex patterns (with backreferences). Optionally limit the number of replacements.
 - **document_delete** - Deletes a document by `surface_id`. Use to clean up unwanted documents.
 
 ## Retrieving existing documents
@@ -45,6 +47,46 @@ When the user requests changes to a document:
 1. Find the `surface_id` from the `<active_documents>` context block.
 2. Use `document_update` with the existing `surface_id` — do NOT call `document_create` again.
 3. Use `mode: "replace"` for full rewrites or `mode: "append"` for additions.
+4. For targeted edits — fixing typos, renaming terms, adjusting formatting — prefer `document_find` + `document_replace_text` over `document_update` with `mode: "replace"`. This avoids rewriting the entire document and reduces the risk of accidentally dropping content.
+
+## Find & Replace
+
+Use `document_find` and `document_replace_text` for surgical edits that target specific text patterns without rewriting the entire document.
+
+### document_find
+
+Search a document for literal text or regex patterns. Parameters:
+
+- `surface_id` (required) — the document to search
+- `query` (required) — the search string or regex pattern
+- `regex` (optional, default `false`) — treat `query` as a regular expression
+- `case_sensitive` (optional, default `false`) — match case exactly
+
+Returns a list of matches with line numbers, line content, match positions, and matched text. Use this to preview what will be affected before making replacements.
+
+### document_replace_text
+
+Targeted find-and-replace within a document. Parameters:
+
+- `surface_id` (required) — the document to modify
+- `find` (required) — the search string or regex pattern
+- `replace` (required) — the replacement string (supports `$1`, `$2` backreferences when `regex` is `true`)
+- `regex` (optional, default `false`) — treat `find` as a regular expression
+- `case_sensitive` (optional, default `false`) — match case exactly
+- `max_replacements` (optional) — limit the number of replacements made
+
+Returns the number of replacements made and whether the content changed.
+
+### Workflow
+
+1. Call `document_find` to preview matches and confirm the pattern is correct.
+2. Call `document_replace_text` to apply the changes.
+
+**Examples:**
+
+- **Fix a recurring typo**: Find `"recieve"`, replace with `"receive"`.
+- **Rename a term throughout**: Find `"widget"` (case-insensitive), replace with `"component"`.
+- **Reformat dates with regex**: Find `(\d{2})/(\d{2})/(\d{4})` with `regex: true`, replace with `$3-$1-$2` to convert `MM/DD/YYYY` to `YYYY-MM-DD`.
 
 ## Comments
 

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -103,6 +103,36 @@
       "execution_target": "host"
     },
     {
+      "name": "document_find",
+      "description": "Search for text or a regex pattern within a document. Returns matching lines with line numbers and context — like grep. Use this to locate specific content before making targeted edits with document_replace_text.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "query": {
+            "type": "string",
+            "description": "Text or regex pattern to search for"
+          },
+          "regex": {
+            "type": "boolean",
+            "description": "Treat query as a regex pattern. Defaults to false (literal match)."
+          },
+          "case_sensitive": {
+            "type": "boolean",
+            "description": "Match case-sensitively. Defaults to false."
+          }
+        },
+        "required": ["surface_id", "query"]
+      },
+      "executor": "tools/document-find.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "comment_list",
       "description": "List open comments on a document. Returns all unresolved comments with their content, anchor text, and thread context so you can address user feedback.",
       "category": "document-editor",

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -133,6 +133,44 @@
       "execution_target": "host"
     },
     {
+      "name": "document_replace_text",
+      "description": "Find and replace text within a document — like sed. Performs targeted replacements without rewriting the entire document. Supports literal text and regex patterns. Use document_find first to preview what will be matched.",
+      "category": "document-editor",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "surface_id": {
+            "type": "string",
+            "description": "The document surface ID"
+          },
+          "find": {
+            "type": "string",
+            "description": "Text or regex pattern to find"
+          },
+          "replace": {
+            "type": "string",
+            "description": "Replacement text. When using regex, supports backreferences ($1, $2, etc.)."
+          },
+          "regex": {
+            "type": "boolean",
+            "description": "Treat find as a regex pattern. Defaults to false (literal match)."
+          },
+          "case_sensitive": {
+            "type": "boolean",
+            "description": "Match case-sensitively. Defaults to false."
+          },
+          "max_replacements": {
+            "type": "number",
+            "description": "Maximum number of replacements to make. Omit to replace all occurrences."
+          }
+        },
+        "required": ["surface_id", "find", "replace"]
+      },
+      "executor": "tools/document-replace-text.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "comment_list",
       "description": "List open comments on a document. Returns all unresolved comments with their content, anchor text, and thread context so you can address user feedback.",
       "category": "document-editor",

--- a/assistant/src/config/bundled-skills/document-editor/tools/document-find.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/document-find.ts
@@ -1,0 +1,12 @@
+import { executeDocumentFind } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentFind(input, context);
+}

--- a/assistant/src/config/bundled-skills/document-editor/tools/document-replace-text.ts
+++ b/assistant/src/config/bundled-skills/document-editor/tools/document-replace-text.ts
@@ -1,0 +1,12 @@
+import { executeDocumentReplaceText } from "../../../../tools/document/document-tool.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDocumentReplaceText(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -59,6 +59,7 @@ import * as documentDelete from "./bundled-skills/document-editor/tools/document
 import * as documentFind from "./bundled-skills/document-editor/tools/document-find.js";
 import * as documentList from "./bundled-skills/document-editor/tools/document-list.js";
 import * as documentRead from "./bundled-skills/document-editor/tools/document-read.js";
+import * as documentReplaceText from "./bundled-skills/document-editor/tools/document-replace-text.js";
 import * as documentUpdate from "./bundled-skills/document-editor/tools/document-update.js";
 // ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
@@ -180,6 +181,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["document-editor:tools/document-list.ts", documentList],
   ["document-editor:tools/document-delete.ts", documentDelete],
   ["document-editor:tools/document-find.ts", documentFind],
+  ["document-editor:tools/document-replace-text.ts", documentReplaceText],
   ["document-editor:tools/comment-list.ts", commentList],
   ["document-editor:tools/comment-resolve.ts", commentResolve],
   ["document-editor:tools/comment-reply.ts", commentReply],

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -50,12 +50,13 @@ import * as computerUseWait from "./bundled-skills/computer-use/tools/computer-u
 import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js";
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
-// ── document-editor ───────────────────────────────────────────────────────────
+// ── document-editor ────────────────────────────────────────────────────────────
 import * as commentList from "./bundled-skills/document-editor/tools/comment-list.js";
 import * as commentReply from "./bundled-skills/document-editor/tools/comment-reply.js";
 import * as commentResolve from "./bundled-skills/document-editor/tools/comment-resolve.js";
 import * as documentCreate from "./bundled-skills/document-editor/tools/document-create.js";
 import * as documentDelete from "./bundled-skills/document-editor/tools/document-delete.js";
+import * as documentFind from "./bundled-skills/document-editor/tools/document-find.js";
 import * as documentList from "./bundled-skills/document-editor/tools/document-list.js";
 import * as documentRead from "./bundled-skills/document-editor/tools/document-read.js";
 import * as documentUpdate from "./bundled-skills/document-editor/tools/document-update.js";
@@ -173,14 +174,15 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/google-contacts.ts", googleContacts],
 
   // document-editor
-  ["document-editor:tools/comment-list.ts", commentList],
-  ["document-editor:tools/comment-reply.ts", commentReply],
-  ["document-editor:tools/comment-resolve.ts", commentResolve],
   ["document-editor:tools/document-create.ts", documentCreate],
-  ["document-editor:tools/document-delete.ts", documentDelete],
-  ["document-editor:tools/document-list.ts", documentList],
-  ["document-editor:tools/document-read.ts", documentRead],
   ["document-editor:tools/document-update.ts", documentUpdate],
+  ["document-editor:tools/document-read.ts", documentRead],
+  ["document-editor:tools/document-list.ts", documentList],
+  ["document-editor:tools/document-delete.ts", documentDelete],
+  ["document-editor:tools/document-find.ts", documentFind],
+  ["document-editor:tools/comment-list.ts", commentList],
+  ["document-editor:tools/comment-resolve.ts", commentResolve],
+  ["document-editor:tools/comment-reply.ts", commentReply],
 
   // followups
   ["followups:tools/followup-create.ts", followupCreate],

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -390,6 +390,109 @@ export function saveDocument(params: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Find-and-replace
+// ---------------------------------------------------------------------------
+
+export interface ReplaceInDocumentOptions {
+  regex?: boolean;
+  caseSensitive?: boolean;
+  maxReplacements?: number;
+}
+
+export type ReplaceInDocumentResult =
+  | { success: true; replacements_made: number; content_changed: boolean }
+  | { success: false; error: string };
+
+function escapeRegExpChars(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Find and replace text within a document — like sed.
+ * Supports literal text and regex patterns with optional backreferences.
+ */
+export function replaceInDocument(
+  surfaceId: string,
+  find: string,
+  replace: string,
+  options: ReplaceInDocumentOptions = {},
+): ReplaceInDocumentResult {
+  try {
+    const row = rawGet<{ content: string }>(
+      /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    if (!row) {
+      return { success: false, error: "Document not found" };
+    }
+
+    const flags = "g" + (options.caseSensitive === true ? "" : "i");
+    const pattern = options.regex
+      ? new RegExp(find, flags)
+      : new RegExp(escapeRegExpChars(find), flags);
+
+    const totalMatches = [...row.content.matchAll(pattern)].length;
+    if (totalMatches === 0) {
+      return { success: true, replacements_made: 0, content_changed: false };
+    }
+
+    let newContent: string;
+    let replacementsMade: number;
+
+    if (
+      options.maxReplacements != null &&
+      options.maxReplacements < totalMatches
+    ) {
+      // Iterative replacement up to maxReplacements using manual exec loop
+      // so backreferences in the replacement string work correctly.
+      const limit = options.maxReplacements;
+      let count = 0;
+      let result = "";
+      let lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = pattern.exec(row.content)) !== null) {
+        if (count >= limit) break;
+        result += row.content.slice(lastIndex, m.index);
+        // Build the replacement for this match using String.replace
+        // so $1, $2, $& backreferences resolve against the match.
+        result += m[0].replace(pattern, replace);
+        lastIndex = m.index + m[0].length;
+        count++;
+      }
+      result += row.content.slice(lastIndex);
+      newContent = result;
+      replacementsMade = count;
+    } else {
+      newContent = row.content.replace(pattern, replace);
+      replacementsMade = totalMatches;
+    }
+
+    const wordCount = newContent
+      .split(/\s+/)
+      .filter((w) => w.length > 0).length;
+    rawRun(
+      /*sql*/ `UPDATE documents SET content = ?, word_count = ?, updated_at = ? WHERE surface_id = ?`,
+      newContent,
+      wordCount,
+      Date.now(),
+      surfaceId,
+    );
+    log.info({ surfaceId, replacementsMade }, "Replaced text in document");
+    return {
+      success: true,
+      replacements_made: replacementsMade,
+      content_changed: true,
+    };
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Replace-in-document error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 /** Update persisted document content (append or replace). */
 export function updateDocumentContent(
   surfaceId: string,

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -270,67 +270,67 @@ export function findInDocument(
   query: string,
   options: { regex?: boolean; caseSensitive?: boolean } = {},
 ): FindResult | null {
-  const row = rawGet<{ content: string }>(
-    /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
-    surfaceId,
-  );
-  if (!row) return null;
+  try {
+    const row = rawGet<{ content: string }>(
+      /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    if (!row) return null;
 
-  const lines = row.content.split("\n");
-  const matches: FindMatch[] = [];
+    const lines = row.content.split("\n");
+    const matches: FindMatch[] = [];
+    let uncappedTotal = 0;
 
-  if (options.regex) {
-    const flags = options.caseSensitive ? "g" : "gi";
-    const re = new RegExp(query, flags);
-    for (
-      let i = 0;
-      i < lines.length && matches.length < MAX_FIND_MATCHES;
-      i++
-    ) {
-      const line = lines[i];
-      re.lastIndex = 0;
-      let m: RegExpExecArray | null;
-      while (
-        (m = re.exec(line)) !== null &&
-        matches.length < MAX_FIND_MATCHES
-      ) {
-        matches.push({
-          lineNumber: i + 1,
-          lineContent: line,
-          matchStart: m.index,
-          matchEnd: m.index + m[0].length,
-          matchText: m[0],
-        });
-        // Prevent infinite loops on zero-length matches
-        if (m[0].length === 0) re.lastIndex++;
+    if (options.regex) {
+      const flags = options.caseSensitive ? "g" : "gi";
+      const re = new RegExp(query, flags);
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        re.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(line)) !== null) {
+          uncappedTotal++;
+          if (matches.length < MAX_FIND_MATCHES) {
+            matches.push({
+              lineNumber: i + 1,
+              lineContent: line,
+              matchStart: m.index,
+              matchEnd: m.index + m[0].length,
+              matchText: m[0],
+            });
+          }
+          if (m[0].length === 0) re.lastIndex++;
+        }
+      }
+    } else {
+      const needle = options.caseSensitive ? query : query.toLowerCase();
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const haystack = options.caseSensitive ? line : line.toLowerCase();
+        let startPos = 0;
+        while (startPos <= haystack.length) {
+          const idx = haystack.indexOf(needle, startPos);
+          if (idx === -1) break;
+          uncappedTotal++;
+          if (matches.length < MAX_FIND_MATCHES) {
+            matches.push({
+              lineNumber: i + 1,
+              lineContent: line,
+              matchStart: idx,
+              matchEnd: idx + needle.length,
+              matchText: line.slice(idx, idx + needle.length),
+            });
+          }
+          startPos = idx + Math.max(needle.length, 1);
+        }
       }
     }
-  } else {
-    const needle = options.caseSensitive ? query : query.toLowerCase();
-    for (
-      let i = 0;
-      i < lines.length && matches.length < MAX_FIND_MATCHES;
-      i++
-    ) {
-      const line = lines[i];
-      const haystack = options.caseSensitive ? line : line.toLowerCase();
-      let startPos = 0;
-      while (startPos <= haystack.length && matches.length < MAX_FIND_MATCHES) {
-        const idx = haystack.indexOf(needle, startPos);
-        if (idx === -1) break;
-        matches.push({
-          lineNumber: i + 1,
-          lineContent: line,
-          matchStart: idx,
-          matchEnd: idx + needle.length,
-          matchText: line.slice(idx, idx + needle.length),
-        });
-        startPos = idx + Math.max(needle.length, 1);
-      }
-    }
+
+    return { surfaceId, totalMatches: uncappedTotal, matches };
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Find-in-document error");
+    return null;
   }
-
-  return { surfaceId, totalMatches: matches.length, matches };
 }
 
 // ---------------------------------------------------------------------------
@@ -454,9 +454,11 @@ export function replaceInDocument(
       while ((m = pattern.exec(row.content)) !== null) {
         if (count >= limit) break;
         result += row.content.slice(lastIndex, m.index);
-        // Build the replacement for this match using String.replace
-        // so $1, $2, $& backreferences resolve against the match.
-        result += m[0].replace(pattern, replace);
+        const singleMatchPattern = new RegExp(
+          pattern.source,
+          pattern.flags.replace("g", ""),
+        );
+        result += m[0].replace(singleMatchPattern, replace);
         lastIndex = m.index + m[0].length;
         count++;
       }

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -241,6 +241,99 @@ export function deleteDocument(surfaceId: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// In-document search (grep)
+// ---------------------------------------------------------------------------
+
+export interface FindMatch {
+  lineNumber: number;
+  lineContent: string;
+  matchStart: number;
+  matchEnd: number;
+  matchText: string;
+}
+
+export interface FindResult {
+  surfaceId: string;
+  totalMatches: number;
+  matches: FindMatch[];
+}
+
+const MAX_FIND_MATCHES = 50;
+
+/**
+ * Search for text or a regex pattern within a document's content.
+ * Returns matching lines with line numbers and match positions.
+ * Results are capped at {@link MAX_FIND_MATCHES} to avoid oversized responses.
+ */
+export function findInDocument(
+  surfaceId: string,
+  query: string,
+  options: { regex?: boolean; caseSensitive?: boolean } = {},
+): FindResult | null {
+  const row = rawGet<{ content: string }>(
+    /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+    surfaceId,
+  );
+  if (!row) return null;
+
+  const lines = row.content.split("\n");
+  const matches: FindMatch[] = [];
+
+  if (options.regex) {
+    const flags = options.caseSensitive ? "g" : "gi";
+    const re = new RegExp(query, flags);
+    for (
+      let i = 0;
+      i < lines.length && matches.length < MAX_FIND_MATCHES;
+      i++
+    ) {
+      const line = lines[i];
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while (
+        (m = re.exec(line)) !== null &&
+        matches.length < MAX_FIND_MATCHES
+      ) {
+        matches.push({
+          lineNumber: i + 1,
+          lineContent: line,
+          matchStart: m.index,
+          matchEnd: m.index + m[0].length,
+          matchText: m[0],
+        });
+        // Prevent infinite loops on zero-length matches
+        if (m[0].length === 0) re.lastIndex++;
+      }
+    }
+  } else {
+    const needle = options.caseSensitive ? query : query.toLowerCase();
+    for (
+      let i = 0;
+      i < lines.length && matches.length < MAX_FIND_MATCHES;
+      i++
+    ) {
+      const line = lines[i];
+      const haystack = options.caseSensitive ? line : line.toLowerCase();
+      let startPos = 0;
+      while (startPos <= haystack.length && matches.length < MAX_FIND_MATCHES) {
+        const idx = haystack.indexOf(needle, startPos);
+        if (idx === -1) break;
+        matches.push({
+          lineNumber: i + 1,
+          lineContent: line,
+          matchStart: idx,
+          matchEnd: idx + needle.length,
+          matchText: line.slice(idx, idx + needle.length),
+        });
+        startPos = idx + Math.max(needle.length, 1);
+      }
+    }
+  }
+
+  return { surfaceId, totalMatches: matches.length, matches };
+}
+
+// ---------------------------------------------------------------------------
 // Document persistence
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -461,6 +461,7 @@ export function replaceInDocument(
         result += m[0].replace(singleMatchPattern, replace);
         lastIndex = m.index + m[0].length;
         count++;
+        if (m[0].length === 0) pattern.lastIndex++;
       }
       result += row.content.slice(lastIndex);
       newContent = result;

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -433,7 +433,10 @@ export function replaceInDocument(
       : new RegExp(escapeRegExpChars(find), flags);
 
     const totalMatches = [...row.content.matchAll(pattern)].length;
-    if (totalMatches === 0) {
+    if (
+      totalMatches === 0 ||
+      (options.maxReplacements != null && options.maxReplacements <= 0)
+    ) {
       return { success: true, replacements_made: 0, content_changed: false };
     }
 

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -6,6 +6,7 @@ import {
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
+  replaceInDocument,
   saveDocument,
   searchDocumentsByTitle,
   updateDocumentContent,
@@ -291,6 +292,76 @@ export function executeDocumentFind(
         match_end: m.matchEnd,
         match_text: m.matchText,
       })),
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentReplaceText(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const find = input.find as string;
+  const replace = (input.replace as string) ?? "";
+  const regex = (input.regex as boolean | undefined) ?? false;
+  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
+  const maxReplacements = input.max_replacements as number | undefined;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  if (regex) {
+    try {
+      new RegExp(find);
+    } catch (err) {
+      return {
+        content: JSON.stringify({
+          success: false,
+          error: `Invalid regex: ${err instanceof Error ? err.message : String(err)}`,
+        }),
+        isError: true,
+      };
+    }
+  }
+
+  const result = replaceInDocument(surfaceId, find, replace, {
+    regex,
+    caseSensitive,
+    maxReplacements,
+  });
+
+  if (!result.success) {
+    return {
+      content: JSON.stringify({
+        success: false,
+        surface_id: surfaceId,
+        error: result.error,
+      }),
+      isError: true,
+    };
+  }
+
+  if (context.sendToClient && result.content_changed) {
+    const doc = getDocumentById(surfaceId);
+    if (doc) {
+      context.sendToClient({
+        type: "document_editor_update",
+        conversationId: context.conversationId,
+        surfaceId,
+        markdown: doc.content,
+        mode: "replace",
+      });
+    }
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: surfaceId,
+      replacements_made: result.replacements_made,
+      content_changed: result.content_changed,
     }),
     isError: false,
   };

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   deleteDocument,
+  findInDocument,
   getDocumentById,
   getDocumentsForConversation,
   isDocumentAssociatedWithConversation,
@@ -239,6 +240,57 @@ export function executeDocumentDelete(
       success: true,
       surface_id: surfaceId,
       message: "Document deleted",
+    }),
+    isError: false,
+  };
+}
+
+export function executeDocumentFind(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult {
+  const surfaceId = input.surface_id as string;
+  const query = input.query as string;
+  const regex = (input.regex as boolean | undefined) ?? false;
+  const caseSensitive = (input.case_sensitive as boolean | undefined) ?? false;
+
+  if (!canAccessDocument(surfaceId, context)) {
+    return documentNotFound(surfaceId);
+  }
+
+  if (regex) {
+    try {
+      new RegExp(query);
+    } catch (e) {
+      return {
+        content: JSON.stringify({
+          success: false,
+          surface_id: surfaceId,
+          error: `Invalid regex: ${e instanceof Error ? e.message : String(e)}`,
+        }),
+        isError: true,
+      };
+    }
+  }
+
+  const result = findInDocument(surfaceId, query, { regex, caseSensitive });
+  if (!result) {
+    return documentNotFound(surfaceId);
+  }
+
+  return {
+    content: JSON.stringify({
+      success: true,
+      surface_id: result.surfaceId,
+      query,
+      total_matches: result.totalMatches,
+      matches: result.matches.map((m) => ({
+        line_number: m.lineNumber,
+        line_content: m.lineContent,
+        match_start: m.matchStart,
+        match_end: m.matchEnd,
+        match_text: m.matchText,
+      })),
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary
Add `document_find` and `document_replace_text` tools to the document-editor skill, giving the assistant grep/sed-style capabilities for surgical document editing without rewriting entire documents.

- **`document_find`** — Search for text or regex patterns within a document. Returns matching lines with line numbers, match positions, and matched text. Supports case-sensitive/insensitive and regex modes. Results capped at 50 with true total count reported.
- **`document_replace_text`** — Targeted find-and-replace within a document. Supports literal and regex patterns with backreferences ($1, $2). Optional `max_replacements` to limit substitutions. Recalculates word count and notifies connected clients.

### Implementation PRs
1. #31397 — `document_find` store function, executor, tests
2. #31398 — `document_replace_text` store function, executor, tests
3. #31419 — SKILL.md documentation and workflow guidance
4. #31421 — Self-review fixes (backreference bug, try/catch, total_matches accuracy)

## Test plan
- [x] 19 tests covering both tools: literal/regex search, case sensitivity, access control, result capping, backreferences, max_replacements, word_count recalculation, client notification
- [x] All tests pass locally
- [x] Type-check and lint pass

Closes JARVIS-903
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->