### PR TITLE
Bridge Slack task progress into status

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -174,6 +174,8 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 });
 
 describe("Slack thinking status timing", () => {
+  const slackStatusLabels = ["is grinding", "is working", "is touching grass"];
+
   const trustCtx: TrustContext = {
     trustClass: "guardian",
     guardianExternalUserId: "guardian-1",
@@ -281,9 +283,13 @@ describe("Slack thinking status timing", () => {
         {
           channel: channelId,
           threadTs,
-          status: "is thinking...",
+          status: expect.any(String),
+          loadingMessages: ["Working on it..."],
         },
       );
+      const threadStatus = deliveredChannelReplies[0]!.payload
+        .assistantThreadStatus as { status: string };
+      expect(slackStatusLabels).toContain(threadStatus.status);
       return { messageId: "user-msg-mention-immediate" };
     };
 
@@ -309,7 +315,8 @@ describe("Slack thinking status timing", () => {
         | undefined;
       return status?.status;
     });
-    expect(statuses).toEqual(["is thinking...", ""]);
+    expect(slackStatusLabels).toContain(statuses[0]!);
+    expect(statuses[1]).toBe("");
   });
 
   test("does not set Slack thinking status for no_response text deltas", async () => {
@@ -396,6 +403,226 @@ describe("Slack thinking status timing", () => {
         | undefined;
       return status?.status;
     });
-    expect(statuses).toEqual(["is thinking...", ""]);
+    expect(slackStatusLabels).toContain(statuses[0]!);
+    expect(statuses[1]).toBe("");
+  });
+
+  test("buffers task_progress for ambiguous Slack turns until deliverable text appears", async () => {
+    const conversationId = "conv-progress-buffered";
+    const channelId = "C-PROGRESS-BUFFERED";
+    const threadTs = "1700000000.000012";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [
+              { label: "Search docs", status: "in_progress" },
+              { label: "Summarize", status: "pending" },
+            ],
+          },
+        },
+      });
+      expect(deliveredChannelReplies).toEqual([]);
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "I found the answer.",
+        conversationId,
+      });
+      return { messageId: "user-msg-progress-buffered" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-buffered",
+      content: "ambient request",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map(
+      (entry) => entry.payload.assistantThreadStatus,
+    );
+    expect(statuses).toEqual([
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (1/2): Search docs"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: "",
+      },
+    ]);
+    expect(slackStatusLabels).toContain(
+      (statuses[0] as { status: string }).status,
+    );
+  });
+
+  test("keeps ambiguous Slack no_response turns quiet even with task_progress", async () => {
+    const conversationId = "conv-progress-no-response";
+    const channelId = "C-PROGRESS-NO-RESPONSE";
+    const threadTs = "1700000000.000013";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress-no-response",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [{ label: "Inspect", status: "in_progress" }],
+          },
+        },
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<no_response/>",
+        conversationId,
+      });
+      return { messageId: "user-msg-progress-no-response" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-no-response",
+      content: "ambient chatter",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    expect(deliveredChannelReplies).toEqual([]);
+  });
+
+  test("updates Slack loading message when task_progress changes", async () => {
+    const conversationId = "conv-progress-update";
+    const channelId = "C-PROGRESS-UPDATE";
+    const threadTs = "1700000000.000014";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress-update",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [
+              { label: "Read request", status: "in_progress" },
+              { label: "Write answer", status: "pending" },
+            ],
+          },
+        },
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "On it.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "ui_surface_update",
+        conversationId,
+        surfaceId: "surface-progress-update",
+        data: {
+          templateData: {
+            steps: [
+              { label: "Read request", status: "completed" },
+              { label: "Write answer", status: "in_progress" },
+            ],
+          },
+        },
+      });
+      return { messageId: "user-msg-progress-update" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-update",
+      content: "please respond",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map(
+      (entry) => entry.payload.assistantThreadStatus,
+    );
+    expect(statuses).toEqual([
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (1/2): Read request"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (2/2): Write answer"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: "",
+      },
+    ]);
+    expect(slackStatusLabels).toContain(
+      (statuses[0] as { status: string }).status,
+    );
+    expect(slackStatusLabels).toContain(
+      (statuses[1] as { status: string }).status,
+    );
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -363,6 +363,20 @@ type SlackThinkingStatusController = {
   stop: () => void;
 };
 
+type SlackThinkingStatusHandle = {
+  updateLoadingMessages: (loadingMessages?: string[]) => void;
+  clear: () => void;
+};
+
+type TaskProgressStep = {
+  label: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+};
+
+type TaskProgressData = {
+  steps: TaskProgressStep[];
+};
+
 const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/i;
 const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
 const NO_RESPONSE_SENTINEL_FORMS = [
@@ -431,16 +445,51 @@ function createSlackThinkingStatusController(params: {
   const callbackUrl = replyCallbackUrl;
 
   let stopped = false;
-  let clearSlackThinkingStatus: (() => void) | undefined;
+  let slackThinkingStatus: SlackThinkingStatusHandle | undefined;
   let observedAssistantText = "";
+  let currentLoadingMessages: string[] | undefined = startImmediately
+    ? [...SLACK_GENERIC_LOADING_MESSAGES]
+    : undefined;
+  let lastSentLoadingMessageKey: string | undefined;
+  const taskProgressBySurfaceId = new Map<string, TaskProgressData>();
 
   const start = (): void => {
-    if (stopped || clearSlackThinkingStatus) return;
-    clearSlackThinkingStatus = setSlackThinkingStatus(
+    if (stopped || slackThinkingStatus) return;
+    slackThinkingStatus = setSlackThinkingStatus(
       callbackUrl,
       chatId,
       assistantId,
+      currentLoadingMessages,
     );
+    lastSentLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
+  };
+
+  const maybeUpdateLoadingMessages = (): void => {
+    const nextLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
+    if (nextLoadingMessageKey === lastSentLoadingMessageKey) return;
+    lastSentLoadingMessageKey = nextLoadingMessageKey;
+    slackThinkingStatus?.updateLoadingMessages(currentLoadingMessages);
+  };
+
+  const observeTaskProgress = (msg: ServerMessage): void => {
+    if (msg.type === "ui_surface_show") {
+      const progress = getTaskProgressDataFromSurfaceData(msg.data);
+      if (!progress) return;
+      taskProgressBySurfaceId.set(msg.surfaceId, progress);
+    } else if (msg.type === "ui_surface_update") {
+      const existing = taskProgressBySurfaceId.get(msg.surfaceId);
+      const progress = mergeTaskProgressData(existing, msg.data);
+      if (!progress) return;
+      taskProgressBySurfaceId.set(msg.surfaceId, progress);
+    } else {
+      return;
+    }
+
+    currentLoadingMessages =
+      getTaskProgressLoadingMessage(
+        taskProgressBySurfaceId.get(msg.surfaceId),
+      ) ?? [];
+    maybeUpdateLoadingMessages();
   };
 
   if (startImmediately) {
@@ -449,8 +498,14 @@ function createSlackThinkingStatusController(params: {
 
   return {
     observeEvent(msg) {
-      if (stopped || clearSlackThinkingStatus) return;
-      if (msg.type !== "assistant_text_delta") return;
+      if (stopped) return;
+
+      if (msg.type === "ui_surface_show" || msg.type === "ui_surface_update") {
+        observeTaskProgress(msg);
+        return;
+      }
+
+      if (slackThinkingStatus || msg.type !== "assistant_text_delta") return;
 
       observedAssistantText += msg.text;
       if (shouldStartSlackThinkingStatusForText(observedAssistantText)) {
@@ -459,12 +514,91 @@ function createSlackThinkingStatusController(params: {
     },
     stop() {
       stopped = true;
-      clearSlackThinkingStatus?.();
+      slackThinkingStatus?.clear();
     },
   };
 }
 
 const SLACK_THINKING_MAX_DURATION_MS = 120_000;
+const SLACK_GENERIC_LOADING_MESSAGES = ["Working on it..."] as const;
+const SLACK_THINKING_STATUSES = [
+  "is grinding",
+  "is working",
+  "is touching grass",
+] as const;
+
+function getRandomSlackThinkingStatus(): string {
+  return SLACK_THINKING_STATUSES[
+    Math.floor(Math.random() * SLACK_THINKING_STATUSES.length)
+  ]!;
+}
+
+function getLoadingMessagesKey(loadingMessages?: string[]): string | undefined {
+  return loadingMessages?.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getTaskProgressDataFromSurfaceData(
+  data: unknown,
+): TaskProgressData | undefined {
+  if (!isRecord(data)) return undefined;
+  if (data.template !== "task_progress") return undefined;
+  return parseTaskProgressData(data.templateData);
+}
+
+function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
+  if (!isRecord(value) || !Array.isArray(value.steps)) return undefined;
+
+  const steps = value.steps.flatMap((step): TaskProgressStep[] => {
+    if (!isRecord(step)) return [];
+    if (typeof step.label !== "string") return [];
+    if (
+      step.status !== "pending" &&
+      step.status !== "in_progress" &&
+      step.status !== "completed" &&
+      step.status !== "failed"
+    ) {
+      return [];
+    }
+    return [{ label: step.label, status: step.status }];
+  });
+
+  return steps.length > 0 ? { steps } : undefined;
+}
+
+function mergeTaskProgressData(
+  existing: TaskProgressData | undefined,
+  data: unknown,
+): TaskProgressData | undefined {
+  if (!isRecord(data)) return existing;
+  const update = getTaskProgressDataFromSurfaceData(data);
+  if (update) return update;
+  if (!existing || !("templateData" in data)) return existing;
+
+  return parseTaskProgressData({
+    steps: existing.steps,
+    ...(isRecord(data.templateData) ? data.templateData : {}),
+  });
+}
+
+function getTaskProgressLoadingMessage(
+  progress: TaskProgressData | undefined,
+): string[] | undefined {
+  if (!progress) return undefined;
+
+  const activeStepIndex = progress.steps.findIndex(
+    (step) => step.status === "in_progress",
+  );
+  if (activeStepIndex < 0) return undefined;
+
+  const activeStep = progress.steps[activeStepIndex]!;
+  return [
+    `In progress (${activeStepIndex + 1}/${progress.steps.length}): ${activeStep.label}`,
+  ];
+}
 
 /**
  * Set the Slack Assistants API "is thinking..." status on the thread and
@@ -477,7 +611,8 @@ function setSlackThinkingStatus(
   callbackUrl: string,
   chatId: string,
   assistantId?: string,
-): () => void {
+  loadingMessages?: string[],
+): SlackThinkingStatusHandle {
   let cleared = false;
 
   // Extract the thread timestamp from the callback URL so we can target
@@ -487,7 +622,12 @@ function setSlackThinkingStatus(
   // For non-threaded DMs, fall back to emoji reaction on the original message.
   if (!threadTs) {
     const messageTs = extractMessageTsFromCallbackUrl(callbackUrl);
-    if (!messageTs) return () => {};
+    if (!messageTs) {
+      return {
+        updateLoadingMessages: () => {},
+        clear: () => {},
+      };
+    }
 
     const addPromise = deliverChannelReply(callbackUrl, {
       chatId,
@@ -500,7 +640,7 @@ function setSlackThinkingStatus(
       );
     });
 
-    const clearReaction = () => {
+    const clearReaction = (): void => {
       if (cleared) return;
       cleared = true;
       clearTimeout(safetyTimer);
@@ -524,28 +664,55 @@ function setSlackThinkingStatus(
     );
     (safetyTimer as { unref?: () => void }).unref?.();
 
-    return clearReaction;
+    return {
+      updateLoadingMessages: () => {},
+      clear: clearReaction,
+    };
   }
 
   // Track the set promise so clear waits for it to settle first,
   // preventing a race where clear arrives at Slack before set.
-  const setPromise = deliverChannelReply(callbackUrl, {
+  let statusPromise = deliverChannelReply(callbackUrl, {
     chatId,
     assistantId,
     assistantThreadStatus: {
       channel: chatId,
       threadTs,
-      status: "is thinking...",
+      status: getRandomSlackThinkingStatus(),
+      ...(loadingMessages ? { loadingMessages } : {}),
     },
   }).catch((err) => {
     log.debug({ err, chatId, threadTs }, "Failed to set Slack thinking status");
   });
 
-  const clearStatus = () => {
+  const updateLoadingMessages = (nextLoadingMessages?: string[]): void => {
+    if (cleared) return;
+    statusPromise = statusPromise.then(() =>
+      deliverChannelReply(callbackUrl, {
+        chatId,
+        assistantId,
+        assistantThreadStatus: {
+          channel: chatId,
+          threadTs,
+          status: getRandomSlackThinkingStatus(),
+          ...(nextLoadingMessages
+            ? { loadingMessages: nextLoadingMessages }
+            : {}),
+        },
+      }).catch((err) => {
+        log.debug(
+          { err, chatId, threadTs },
+          "Failed to update Slack thinking status",
+        );
+      }),
+    );
+  };
+
+  const clearStatus = (): void => {
     if (cleared) return;
     cleared = true;
     clearTimeout(safetyTimer);
-    void setPromise.then(() =>
+    void statusPromise.then(() =>
       deliverChannelReply(callbackUrl, {
         chatId,
         assistantId,
@@ -566,7 +733,10 @@ function setSlackThinkingStatus(
   const safetyTimer = setTimeout(clearStatus, SLACK_THINKING_MAX_DURATION_MS);
   (safetyTimer as { unref?: () => void }).unref?.();
 
-  return clearStatus;
+  return {
+    updateLoadingMessages,
+    clear: clearStatus,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -601,8 +601,8 @@ function getTaskProgressLoadingMessage(
 }
 
 /**
- * Set the Slack Assistants API "is thinking..." status on the thread and
- * return a cleanup function that clears it. Both operations are fire-and-forget.
+ * Set Slack Assistants API status on the thread and return a handle for
+ * updating loading messages or clearing the indicator.
  *
  * A safety timer auto-clears the status after {@link SLACK_THINKING_MAX_DURATION_MS}
  * to prevent a stuck indicator when `processMessage` hangs.


### PR DESCRIPTION
## Summary
- observe Slack task_progress surfaces in the background status controller
- show immediate generic status for DMs/direct mentions while keeping ambiguous group turns quiet until response certainty
- update Slack loading messages from active task_progress steps

## Project issue
Part of #31408

## Test plan
- cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts
- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->