### PR TITLE
feat(macos): add queue steering button to macOS queue drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessageRow.swift
@@ -20,6 +20,8 @@ struct QueuedMessageRow: View {
     let positionLabel: String
     let isTail: Bool
     let isComposerEmpty: Bool
+    let showSteer: Bool
+    let onSteer: () -> Void
     let onEdit: () -> Void
     let onCancel: () -> Void
 
@@ -54,10 +56,14 @@ struct QueuedMessageRow: View {
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            // (d) Trailing icon cluster: pencil only when tail, xmark always.
+            // (d) Trailing icon cluster: steer, pencil (tail only), xmark.
             // Pencil is disabled when the composer has content so we don't
             // clobber the user's in-progress draft.
             HStack(spacing: VSpacing.xs) {
+                if showSteer {
+                    QueuedRowIconButton(icon: .arrowUp, accessibilityLabel: "Push to agent now", action: onSteer)
+                        .help("Push to agent now")
+                }
                 if isTail {
                     QueuedRowIconButton(icon: .pencil, accessibilityLabel: "Edit queued message", action: onEdit)
                         .disabled(!isComposerEmpty)

--- a/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/QueuedMessagesDrawer.swift
@@ -14,6 +14,7 @@ struct QueuedMessagesDrawer: View {
     @Bindable var viewModel: ChatViewModel
     @Binding var composerText: String
     @Binding var composerAttachments: [ChatAttachment]
+    @Environment(AssistantFeatureFlagStore.self) private var featureFlagStore: AssistantFeatureFlagStore?
 
     var body: some View {
         // Cache `queuedMessages` and `tailQueuedMessageId` once per render —
@@ -71,6 +72,7 @@ struct QueuedMessagesDrawer: View {
         // the source of truth, but the disabled state gives visual feedback.
         let isComposerEmpty = composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && composerAttachments.isEmpty
+        let showSteer = featureFlagStore?.isEnabled("queue-steering") ?? false
         return VStack(alignment: .leading, spacing: VSpacing.xs) {
             ForEach(Array(queuedMessages.enumerated()), id: \.element.id) { index, message in
                 QueuedMessageRow(
@@ -78,6 +80,10 @@ struct QueuedMessagesDrawer: View {
                     positionLabel: "#\(index + 1)",
                     isTail: message.id == tailId,
                     isComposerEmpty: isComposerEmpty,
+                    showSteer: showSteer,
+                    onSteer: {
+                        viewModel.steerQueuedMessage(messageId: message.id)
+                    },
                     onEdit: {
                         viewModel.editQueuedTail(
                             into: $composerText,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -3878,6 +3878,15 @@ final class MockConversationQueueClient: ConversationQueueClientProtocol, @unche
         }
         return deleteResult
     }
+
+    var steerResult: Bool = true
+
+    func steerQueuedMessage(conversationId: String, requestId: String) async -> Bool {
+        queue.sync {
+            _calls.append(Call(conversationId: conversationId, requestId: requestId))
+        }
+        return steerResult
+    }
 }
 
 private struct FakeSubagentClient: SubagentClientProtocol {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -215,6 +215,10 @@ final class ChatActionHandler {
             guard belongsToConversation(msg.conversationId) else { return }
             vm.applyQueuedMessageDeletion(requestId: msg.requestId)
 
+        case .messageSteered(let msg):
+            guard belongsToConversation(msg.conversationId) else { return }
+            vm.applyMessageSteered(requestId: msg.requestId)
+
         case .messageDequeued(let msg):
             handleMessageDequeued(msg, vm: vm)
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1762,6 +1762,39 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         sendCoordinator.sendDirectQueuedMessage(messageId: messageId)
     }
 
+    /// Steer the agent to a queued message via the HTTP steer endpoint.
+    /// Promotes the message to the head of the queue and aborts the current generation.
+    public func steerQueuedMessage(messageId: UUID) {
+        guard let conversationId else { return }
+
+        // Find the requestId for this message
+        guard let entry = requestIdToMessageId.first(where: { $0.value == messageId }) else {
+            log.warning("Cannot steer: no requestId for message \(messageId)")
+            return
+        }
+
+        Task {
+            let success = await conversationQueueClient.steerQueuedMessage(
+                conversationId: conversationId,
+                requestId: entry.key
+            )
+            if !success {
+                log.error("Failed to steer queued message")
+            }
+        }
+    }
+
+    /// Update local queue positions after the server confirms a message was steered.
+    /// The steered message is promoted to position 1; it will be dequeued shortly
+    /// when the abort triggers queue drain.
+    func applyMessageSteered(requestId: String) {
+        guard let messageId = requestIdToMessageId[requestId] else { return }
+        // Set the steered message to position 1 (head of queue)
+        if let idx = messages.firstIndex(where: { $0.id == messageId }) {
+            messages[idx].status = .queued(position: 1)
+        }
+    }
+
     /// If a send-direct is pending, populate the composer and fire sendMessage.
     /// Called from all cancel-completion paths (generationCancelled, timeout, disconnected, etc.).
     func dispatchPendingSendDirect() {

--- a/clients/shared/Network/ConversationQueueClient.swift
+++ b/clients/shared/Network/ConversationQueueClient.swift
@@ -6,6 +6,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Conve
 /// Focused client for message queue operations routed through the gateway.
 public protocol ConversationQueueClientProtocol {
     func deleteQueuedMessage(conversationId: String, requestId: String) async -> Bool
+    func steerQueuedMessage(conversationId: String, requestId: String) async -> Bool
 }
 
 /// Gateway-backed implementation of ``ConversationQueueClientProtocol``.
@@ -26,6 +27,24 @@ public struct ConversationQueueClient: ConversationQueueClientProtocol {
             return true
         } catch {
             log.error("deleteQueuedMessage error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func steerQueuedMessage(conversationId: String, requestId: String) async -> Bool {
+        do {
+            let encoded = requestId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? requestId
+            let response = try await GatewayHTTPClient.post(
+                path: "messages/queued/\(encoded)/steer?conversationId=\(conversationId)",
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("steerQueuedMessage failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("steerQueuedMessage error: \(error.localizedDescription)")
             return false
         }
     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2838,6 +2838,18 @@ public struct MessageQueuedDeleted: Codable, Sendable {
     }
 }
 
+public struct MessageSteered: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let requestId: String
+
+    public init(type: String, conversationId: String, requestId: String) {
+        self.type = type
+        self.conversationId = conversationId
+        self.requestId = requestId
+    }
+}
+
 /// Request-level terminal signal for a user message lifecycle.
 /// 
 /// Unlike `message_complete`, this does not imply the active assistant turn

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -973,6 +973,16 @@ extension MessageQueuedDeleted {
     }
 }
 
+/// Notifies client that a queued message was steered (promoted to head of queue).
+/// Backed by generated `MessageSteered`.
+public typealias MessageSteeredMessage = MessageSteered
+
+extension MessageSteered {
+    public init(conversationId: String, requestId: String) {
+        self.init(type: "message_steered", conversationId: conversationId, requestId: requestId)
+    }
+}
+
 /// Client → Server request to delete a specific queued message.
 /// Backed by generated `DeleteQueuedMessage`.
 public typealias DeleteQueuedMessageMessage = DeleteQueuedMessage
@@ -2935,6 +2945,7 @@ public enum ServerMessage: Decodable, Sendable {
     case messageDequeued(MessageDequeuedMessage)
     case messageRequestComplete(MessageRequestCompleteMessage)
     case messageQueuedDeleted(MessageQueuedDeletedMessage)
+    case messageSteered(MessageSteeredMessage)
     case skillsListResponse(SkillsListResponseMessage)
     case skillDetailResponse(SkillDetailResponseMessage)
     case skillStateChanged(SkillStateChangedMessage)
@@ -3221,6 +3232,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "message_queued_deleted":
             let message = try MessageQueuedDeletedMessage(from: decoder)
             self = .messageQueuedDeleted(message)
+        case "message_steered":
+            let message = try MessageSteeredMessage(from: decoder)
+            self = .messageSteered(message)
         case "skills_list_response":
             let message = try SkillsListResponseMessage(from: decoder)
             self = .skillsListResponse(message)


### PR DESCRIPTION
## Summary

- Adds "Push to agent now" steer button to each queued message row in the macOS queue drawer, matching the web UI implementation
- Adds `message_steered` SSE event handling so the client updates queue positions when a steer occurs
- Gated behind the `queue-steering` assistant-scoped feature flag via `AssistantFeatureFlagStore`

## Changes

| Layer | File | What |
|-------|------|------|
| Generated types | `GeneratedAPITypes.swift` | Add `MessageSteered` Codable struct |
| Message types | `MessageTypes.swift` | Add `MessageSteeredMessage` typealias, enum case, and decoder |
| Network | `ConversationQueueClient.swift` | Add `steerQueuedMessage()` POST to `/messages/queued/:id/steer` |
| ViewModel | `ChatViewModel.swift` | Add `steerQueuedMessage()` and `applyMessageSteered()` |
| Action handler | `ChatActionHandler.swift` | Route `messageSteered` SSE event to view model |
| UI | `QueuedMessageRow.swift` | Add ArrowUp steer button (conditionally shown) |
| UI | `QueuedMessagesDrawer.swift` | Read `queue-steering` flag, pass `showSteer`/`onSteer` to rows |
| Tests | `ChatViewModelTests.swift` | Add `steerQueuedMessage()` to mock queue client |

Part of #31307

## Test plan

- [ ] Enable `queue-steering` feature flag
- [ ] Queue multiple messages while the assistant is processing
- [ ] Verify ArrowUp button appears on each queued message row
- [ ] Click the steer button and verify the message is promoted and processed next
- [ ] Verify the button is hidden when the feature flag is disabled
- [ ] Verify existing cancel and edit buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->