### PR TITLE
fix(document-editor): guard against zero-length regex matches in replace loop

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -461,6 +461,7 @@ export function replaceInDocument(
         result += m[0].replace(singleMatchPattern, replace);
         lastIndex = m.index + m[0].length;
         count++;
+        if (m[0].length === 0) pattern.lastIndex++;
       }
       result += row.content.slice(lastIndex);
       newContent = result;


### PR DESCRIPTION
## Summary
- Add `if (m[0].length === 0) pattern.lastIndex++` guard to the `maxReplacements` exec loop in `replaceInDocument`, matching the existing guard in `findInDocument`
- Prevents infinite loop when a zero-length regex pattern (e.g. `a*`) is used with `max_replacements`

Addresses review feedback from Devin on #31423.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->