### PR TITLE
Tighten Slack task_progress update gate

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -393,6 +393,32 @@ describe("task_progress surface compatibility", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("blocks Slack ui_update that would convert a plain card to task_progress", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: { title: "Plain", body: "No progress" } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: {
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
   test("blocks Slack ui_update that would change task_progress card template", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent, {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -412,6 +412,7 @@ function isSlackTaskProgressUiException(
     if (typeof surfaceId !== "string") return false;
     const stored = ctx.surfaceState.get(surfaceId);
     if (!stored || stored.surfaceType !== "card") return false;
+    if (!isTaskProgressCardData(stored.data)) return false;
     const rawPatch = isPlainObject(input.data) ? input.data : {};
     const patch = normalizeTaskProgressCardPatch(
       stored.data as CardSurfaceData,


### PR DESCRIPTION
## Summary
- Require Slack ui_update task_progress exceptions to start from an already-stored task_progress card.
- Add regression coverage for attempts to convert a plain card into task_progress while dynamic UI is disabled.

## Test plan
- cd assistant && bun test src/__tests__/conversation-surfaces-task-progress.test.ts
- cd assistant && bunx tsc --noEmit

Addresses final-sweep feedback from #31418.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->