### PR TITLE
Remove Slack channel lookup from Socket Mode event delivery

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -736,21 +736,25 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("forwards resolved channel name in runtime source metadata", async () => {
+  test("emits a plain app mention without resolving the event channel name", async () => {
     const { rawDb, store } = createSlackStore();
     const config = makeConfig();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
     const ws = makeOpenSocket();
+    const conversationInfoChannels: string[] = [];
 
     fetchMock = mock(async (input) => {
       const url = new URL(String(input));
       if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("C-thread");
+        const channelId = url.searchParams.get("channel");
+        if (channelId) {
+          conversationInfoChannels.push(channelId);
+        }
         return new Response(
           JSON.stringify({
             ok: true,
-            channel: { id: "C-thread", name: "support-triage" },
+            channel: { id: channelId, name: "support-triage" },
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -779,16 +783,15 @@ describe("SlackSocketModeClient thread tracking", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.source.channelName).toBe("support-triage");
+      expect(emitted[0].event.source.channelName).toBeUndefined();
+      expect(conversationInfoChannels).toEqual([]);
 
       await handleInbound(config, emitted[0].event, {
         routingOverride: emitted[0].routing,
       });
 
       expect(runtimePayloads).toHaveLength(1);
-      expect(runtimePayloads[0].sourceMetadata?.channelName).toBe(
-        "support-triage",
-      );
+      expect(runtimePayloads[0].sourceMetadata?.channelName).toBeUndefined();
     } finally {
       rawDb.close();
     }
@@ -843,7 +846,7 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.message.content).toBe(
         "@Example User continue in #visible-name",
       );
-      expect(conversationInfoChannels).toEqual(["C-thread"]);
+      expect(conversationInfoChannels).toEqual([]);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1000,18 +1000,6 @@ export class SlackSocketModeClient {
       this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
     }
 
-    if (channelId) {
-      const channelInfo = await Promise.race([
-        resolveSlackChannel(channelId, this.config.botToken),
-        new Promise<undefined>((resolve) =>
-          setTimeout(resolve, SLACK_RESOLVE_TIMEOUT_MS),
-        ),
-      ]);
-      if (channelInfo?.name) {
-        normalized.event.source.channelName = channelInfo.name;
-      }
-    }
-
     // Enrich actor display name if the sync cache missed.
     // resolveSlackUser is fast on cache hit and deduplicates in-flight fetches,
     // so this adds negligible latency on subsequent messages. A 3s timeout


### PR DESCRIPTION
## Summary
- remove the event-path Slack conversations.info lookup for the inbound conversation channel
- keep embedded Slack channel reference label resolution intact
- update Socket Mode tests to assert sourceMetadata.channelName is no longer set by gateway delivery

## Tests
- cd gateway && bun test src/__tests__/slack-socket-mode-thread-tracking.test.ts src/__tests__/slack-display-name.test.ts
- cd gateway && bunx eslint src/slack/socket-mode.ts src/__tests__/slack-socket-mode-thread-tracking.test.ts src/__tests__/slack-display-name.test.ts
- cd gateway && bunx tsc --noEmit

Part of lazy-slack-channel-names assistant plan. Depends on platform PR #7523 and assistant PR #31413.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->