### PR TITLE
Slack status task_progress updates

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -337,6 +337,36 @@ describe("injectChannelCapabilityContext", () => {
     expect(text).toContain("emoji reactions");
   });
 
+  test("allows only task_progress ui_show/ui_update guidance for Slack", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain(
+      'Only use ui_show/ui_update for card surfaces with template: "task_progress"',
+    );
+    expect(text).not.toContain("Do NOT use ui_show, ui_update, or app_create");
+  });
+
+  test("keeps blanket ui_show/ui_update prohibition for other non-dynamic channels", () => {
+    const caps: ChannelCapabilities = {
+      channel: "phone",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Do NOT use ui_show, ui_update, or app_create");
+    expect(text).not.toContain("Only use ui_show/ui_update");
+  });
+
   test("still injects for group chats even when all capabilities are true", () => {
     const caps: ChannelCapabilities = {
       channel: "slack",
@@ -611,7 +641,7 @@ describe("trust-gating via channel capabilities", () => {
   });
 
   test("non-dashboard channel adds constraint rules preventing UI references", () => {
-    const caps = resolveChannelCapabilities("slack");
+    const caps = resolveChannelCapabilities("telegram");
     const message: Message = {
       role: "user",
       content: [{ type: "text", text: "Show me a chart" }],
@@ -1248,6 +1278,24 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(vellumText).not.toContain("response_discretion:");
     expect(telegramText).toContain("response_discretion:");
     expect(telegramText).toContain("<no_response/>");
+  });
+
+  test("adds task_progress hint only for Slack turns", () => {
+    const slackText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "slack",
+      channelName: "slack",
+    });
+    const telegramText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "telegram",
+      channelName: "telegram",
+    });
+
+    expect(slackText).toContain(
+      "if you are going to do work, use task_progress",
+    );
+    expect(telegramText).not.toContain("use task_progress");
   });
 
   test("dedup logic: fields matching canonical_actor_identity are omitted", () => {

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -84,6 +84,95 @@ describe("task_progress surface compatibility", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("allows Slack ui_show for task_progress card when dynamic UI is otherwise disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Working",
+      template: "task_progress",
+      templateData: {
+        status: "in_progress",
+        steps: [{ label: "Start", status: "in_progress" }],
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "card") return;
+    expect((showMessage.data as CardSurfaceData).template).toBe(
+      "task_progress",
+    );
+  });
+
+  test("blocks Slack ui_show for non-task_progress card when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Blocked",
+      data: { title: "Blocked", body: "not progress" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_show when normalized card data is not task_progress", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Blocked",
+      template: "task_progress",
+      data: { title: "Blocked", body: "not progress", template: "plain" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_show for non-card task_progress input when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "dynamic_page",
+      title: "Blocked",
+      data: { template: "task_progress", html: "<p>Blocked</p>" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_show is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
   test("ui_show maps legacy top-level task_progress fields into card data", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);
@@ -247,6 +336,111 @@ describe("task_progress surface compatibility", () => {
     const templateData = updatedCard.templateData as Record<string, unknown>;
     expect(templateData.status).toBe("completed");
     expect(Array.isArray(templateData.steps)).toBe(true);
+  });
+
+  test("allows Slack ui_update for stored task_progress card when dynamic UI is disabled", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: {
+        title: "Working",
+        body: "",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { status: "completed" },
+    });
+
+    expect(result.isError).toBe(false);
+    const updateMessage = sent.find(
+      (msg): msg is UiSurfaceUpdate => msg.type === "ui_surface_update",
+    );
+    expect(updateMessage).toBeDefined();
+    if (!updateMessage) return;
+    const templateData = (updateMessage.data as CardSurfaceData)
+      .templateData as Record<string, unknown>;
+    expect(templateData.status).toBe("completed");
+  });
+
+  test("blocks Slack ui_update when stored surface is not a task_progress card", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: { title: "Plain", body: "No progress" } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { body: "still blocked" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  test("blocks Slack ui_update that would change task_progress card template", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: {
+        title: "Working",
+        body: "",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: { template: "plain", body: "now a plain card" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+    expect(
+      (ctx.surfaceState.get("surface-1")?.data as CardSurfaceData).template,
+    ).toBe("task_progress");
+  });
+
+  test("blocks Slack ui_update when the surface is not already stored", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "missing-surface",
+      data: { status: "completed" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
   });
 
   test("ui_show rejects new interactive surface when a non-dynamic_page pending surface exists", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -393,6 +393,32 @@ describe("task_progress surface compatibility", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("blocks Slack ui_update that would convert a plain card to task_progress", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+    ctx.surfaceState.set("surface-1", {
+      surfaceType: "card",
+      data: { title: "Plain", body: "No progress" } satisfies CardSurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "surface-1",
+      data: {
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'ui_update is unavailable on channel "slack"',
+    );
+    expect(sent).toHaveLength(0);
+  });
+
   test("blocks Slack ui_update that would change task_progress card template", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent, {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -680,9 +680,15 @@ export function injectChannelCapabilityContext(
       "- Do NOT reference the dashboard UI, settings panels, or visual preference pickers.",
     );
     if (!caps.supportsDynamicUi) {
-      lines.push(
-        "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
-      );
+      if (caps.channel === "slack") {
+        lines.push(
+          '- Do NOT use app_create. Only use ui_show/ui_update for card surfaces with template: "task_progress"; present all other information as text.',
+        );
+      } else {
+        lines.push(
+          "- Do NOT use ui_show, ui_update, or app_create — this channel cannot render them.",
+        );
+      }
       lines.push(
         "- Present information as well-formatted text instead of dynamic UI.",
       );
@@ -973,6 +979,9 @@ export function buildUnifiedTurnContextBlock(
     lines.push(
       `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
     );
+    if (options.channelName === "slack") {
+      lines.push("if you are going to do work, use task_progress");
+    }
   }
 
   lines.push("</turn_context>");

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -412,6 +412,7 @@ function isSlackTaskProgressUiException(
     if (typeof surfaceId !== "string") return false;
     const stored = ctx.surfaceState.get(surfaceId);
     if (!stored || stored.surfaceType !== "card") return false;
+    if (!isTaskProgressCardData(stored.data)) return false;
     const rawPatch = isPlainObject(input.data) ? input.data : {};
     const patch = normalizeTaskProgressCardPatch(
       stored.data as CardSurfaceData,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -390,6 +390,39 @@ function normalizeTaskProgressCardPatch(
   return normalizedPatch;
 }
 
+function isTaskProgressCardData(data: SurfaceData | Record<string, unknown>) {
+  return (data as Record<string, unknown>).template === "task_progress";
+}
+
+function isSlackTaskProgressUiException(
+  ctx: SurfaceConversationContext,
+  toolName: string,
+  input: Record<string, unknown>,
+): boolean {
+  if (ctx.channelCapabilities?.channel !== "slack") return false;
+  if (toolName === "ui_show") {
+    const surfaceType = input.surface_type as SurfaceType;
+    if (surfaceType !== "card") return false;
+    const rawData = isPlainObject(input.data) ? input.data : {};
+    const data = normalizeCardShowData(input, rawData);
+    return isTaskProgressCardData(data);
+  }
+  if (toolName === "ui_update") {
+    const surfaceId = input.surface_id;
+    if (typeof surfaceId !== "string") return false;
+    const stored = ctx.surfaceState.get(surfaceId);
+    if (!stored || stored.surfaceType !== "card") return false;
+    const rawPatch = isPlainObject(input.data) ? input.data : {};
+    const patch = normalizeTaskProgressCardPatch(
+      stored.data as CardSurfaceData,
+      rawPatch,
+    );
+    const mergedData = { ...stored.data, ...patch } as SurfaceData;
+    return isTaskProgressCardData(mergedData);
+  }
+  return false;
+}
+
 /**
  * Subset of Conversation state that surface helpers need access to.
  * The Conversation class implements this interface so its instances can be
@@ -2140,7 +2173,11 @@ export async function surfaceProxyResolver(
 
   if (toolName === "ui_show" || toolName === "ui_update") {
     const caps = ctx.channelCapabilities;
-    if (caps && !caps.supportsDynamicUi) {
+    if (
+      caps &&
+      !caps.supportsDynamicUi &&
+      !isSlackTaskProgressUiException(ctx, toolName, input)
+    ) {
       log.info(
         { toolName, channel: caps.channel, conversationId: ctx.conversationId },
         "Blocked UI surface tool on channel without dynamic UI support",

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -174,8 +174,14 @@ async function deliverSlack(
       channel,
       threadTs: statusThreadTs,
       status,
+      loadingMessages,
     } = payload.assistantThreadStatus;
-    await sendSlackAssistantThreadStatus(channel, statusThreadTs, status);
+    await sendSlackAssistantThreadStatus(
+      channel,
+      statusThreadTs,
+      status,
+      loadingMessages,
+    );
     return { ok: true };
   }
 

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type CallSlackApi = (
+  method: string,
+  body: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+const callSlackApiMock = mock<CallSlackApi>(async () => ({ ok: true }));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("./api.js", () => ({
+  callSlackApi: (method: string, body: Record<string, unknown>) =>
+    callSlackApiMock(method, body),
+  callSlackApiForm: async () => ({}),
+  completeSlackUpload: async () => {},
+  SlackApiError: class SlackApiError extends Error {
+    slackError?: string;
+  },
+  uploadToSlackUrl: async () => {},
+}));
+
+import { sendSlackAssistantThreadStatus } from "./send.js";
+
+describe("sendSlackAssistantThreadStatus", () => {
+  beforeEach(() => {
+    callSlackApiMock.mockReset();
+    callSlackApiMock.mockImplementation(async () => ({ ok: true }));
+  });
+
+  test("serializes loading messages for Slack assistant thread status", async () => {
+    await sendSlackAssistantThreadStatus(
+      "C123",
+      "1700000000.000100",
+      "is working...",
+      ["Reading files", "Running tests"],
+    );
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+    expect(callSlackApiMock).toHaveBeenCalledWith(
+      "assistant.threads.setStatus",
+      {
+        channel_id: "C123",
+        thread_ts: "1700000000.000100",
+        status: "is working...",
+        loading_messages: ["Reading files", "Running tests"],
+      },
+    );
+  });
+
+  test("falls back to the reaction path when status API delivery fails", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new Error("missing_scope");
+      })
+      .mockImplementationOnce(async () => ({ ok: true }));
+
+    await sendSlackAssistantThreadStatus(
+      "C123",
+      "1700000000.000100",
+      "is working...",
+      ["Reading files"],
+    );
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "reactions.add", {
+      channel: "C123",
+      name: "eyes",
+      timestamp: "1700000000.000100",
+    });
+  });
+});

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -275,13 +275,19 @@ export async function sendSlackAssistantThreadStatus(
   channel: string,
   threadTs: string,
   status: string,
+  loadingMessages?: string[],
 ): Promise<void> {
   try {
-    await callSlackApi("assistant.threads.setStatus", {
+    const body: Record<string, unknown> = {
       channel_id: channel,
       thread_ts: threadTs,
       status,
-    });
+    };
+    if (loadingMessages !== undefined) {
+      body.loading_messages = loadingMessages;
+    }
+
+    await callSlackApi("assistant.threads.setStatus", body);
     return;
   } catch {
     log.warn(

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -174,6 +174,8 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 });
 
 describe("Slack thinking status timing", () => {
+  const slackStatusLabels = ["is grinding", "is working", "is touching grass"];
+
   const trustCtx: TrustContext = {
     trustClass: "guardian",
     guardianExternalUserId: "guardian-1",
@@ -281,9 +283,13 @@ describe("Slack thinking status timing", () => {
         {
           channel: channelId,
           threadTs,
-          status: "is thinking...",
+          status: expect.any(String),
+          loadingMessages: ["Working on it..."],
         },
       );
+      const threadStatus = deliveredChannelReplies[0]!.payload
+        .assistantThreadStatus as { status: string };
+      expect(slackStatusLabels).toContain(threadStatus.status);
       return { messageId: "user-msg-mention-immediate" };
     };
 
@@ -309,7 +315,8 @@ describe("Slack thinking status timing", () => {
         | undefined;
       return status?.status;
     });
-    expect(statuses).toEqual(["is thinking...", ""]);
+    expect(slackStatusLabels).toContain(statuses[0]!);
+    expect(statuses[1]).toBe("");
   });
 
   test("does not set Slack thinking status for no_response text deltas", async () => {
@@ -396,6 +403,226 @@ describe("Slack thinking status timing", () => {
         | undefined;
       return status?.status;
     });
-    expect(statuses).toEqual(["is thinking...", ""]);
+    expect(slackStatusLabels).toContain(statuses[0]!);
+    expect(statuses[1]).toBe("");
+  });
+
+  test("buffers task_progress for ambiguous Slack turns until deliverable text appears", async () => {
+    const conversationId = "conv-progress-buffered";
+    const channelId = "C-PROGRESS-BUFFERED";
+    const threadTs = "1700000000.000012";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [
+              { label: "Search docs", status: "in_progress" },
+              { label: "Summarize", status: "pending" },
+            ],
+          },
+        },
+      });
+      expect(deliveredChannelReplies).toEqual([]);
+
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "I found the answer.",
+        conversationId,
+      });
+      return { messageId: "user-msg-progress-buffered" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-buffered",
+      content: "ambient request",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map(
+      (entry) => entry.payload.assistantThreadStatus,
+    );
+    expect(statuses).toEqual([
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (1/2): Search docs"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: "",
+      },
+    ]);
+    expect(slackStatusLabels).toContain(
+      (statuses[0] as { status: string }).status,
+    );
+  });
+
+  test("keeps ambiguous Slack no_response turns quiet even with task_progress", async () => {
+    const conversationId = "conv-progress-no-response";
+    const channelId = "C-PROGRESS-NO-RESPONSE";
+    const threadTs = "1700000000.000013";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress-no-response",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [{ label: "Inspect", status: "in_progress" }],
+          },
+        },
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "<no_response/>",
+        conversationId,
+      });
+      return { messageId: "user-msg-progress-no-response" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-no-response",
+      content: "ambient chatter",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    expect(deliveredChannelReplies).toEqual([]);
+  });
+
+  test("updates Slack loading message when task_progress changes", async () => {
+    const conversationId = "conv-progress-update";
+    const channelId = "C-PROGRESS-UPDATE";
+    const threadTs = "1700000000.000014";
+
+    const processMessage: MessageProcessor = async (
+      _conversationId,
+      _content,
+      _attachmentIds,
+      options,
+    ) => {
+      options?.onEvent?.({
+        type: "ui_surface_show",
+        conversationId,
+        surfaceId: "surface-progress-update",
+        surfaceType: "card",
+        data: {
+          title: "Task progress",
+          body: "Working",
+          template: "task_progress",
+          templateData: {
+            steps: [
+              { label: "Read request", status: "in_progress" },
+              { label: "Write answer", status: "pending" },
+            ],
+          },
+        },
+      });
+      options?.onEvent?.({
+        type: "assistant_text_delta",
+        text: "On it.",
+        conversationId,
+      });
+      options?.onEvent?.({
+        type: "ui_surface_update",
+        conversationId,
+        surfaceId: "surface-progress-update",
+        data: {
+          templateData: {
+            steps: [
+              { label: "Read request", status: "completed" },
+              { label: "Write answer", status: "in_progress" },
+            ],
+          },
+        },
+      });
+      return { messageId: "user-msg-progress-update" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-progress-update",
+      content: "please respond",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
+    });
+
+    await flush();
+
+    const statuses = deliveredChannelReplies.map(
+      (entry) => entry.payload.assistantThreadStatus,
+    );
+    expect(statuses).toEqual([
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (1/2): Read request"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["In progress (2/2): Write answer"],
+      },
+      {
+        channel: channelId,
+        threadTs,
+        status: "",
+      },
+    ]);
+    expect(slackStatusLabels).toContain(
+      (statuses[0] as { status: string }).status,
+    );
+    expect(slackStatusLabels).toContain(
+      (statuses[1] as { status: string }).status,
+    );
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -364,6 +364,20 @@ type SlackThinkingStatusController = {
   stop: () => void;
 };
 
+type SlackThinkingStatusHandle = {
+  updateLoadingMessages: (loadingMessages?: string[]) => void;
+  clear: () => void;
+};
+
+type TaskProgressStep = {
+  label: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+};
+
+type TaskProgressData = {
+  steps: TaskProgressStep[];
+};
+
 const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/i;
 const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
 const NO_RESPONSE_SENTINEL_FORMS = [
@@ -432,16 +446,51 @@ function createSlackThinkingStatusController(params: {
   const callbackUrl = replyCallbackUrl;
 
   let stopped = false;
-  let clearSlackThinkingStatus: (() => void) | undefined;
+  let slackThinkingStatus: SlackThinkingStatusHandle | undefined;
   let observedAssistantText = "";
+  let currentLoadingMessages: string[] | undefined = startImmediately
+    ? [...SLACK_GENERIC_LOADING_MESSAGES]
+    : undefined;
+  let lastSentLoadingMessageKey: string | undefined;
+  const taskProgressBySurfaceId = new Map<string, TaskProgressData>();
 
   const start = (): void => {
-    if (stopped || clearSlackThinkingStatus) return;
-    clearSlackThinkingStatus = setSlackThinkingStatus(
+    if (stopped || slackThinkingStatus) return;
+    slackThinkingStatus = setSlackThinkingStatus(
       callbackUrl,
       chatId,
       assistantId,
+      currentLoadingMessages,
     );
+    lastSentLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
+  };
+
+  const maybeUpdateLoadingMessages = (): void => {
+    const nextLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
+    if (nextLoadingMessageKey === lastSentLoadingMessageKey) return;
+    lastSentLoadingMessageKey = nextLoadingMessageKey;
+    slackThinkingStatus?.updateLoadingMessages(currentLoadingMessages);
+  };
+
+  const observeTaskProgress = (msg: ServerMessage): void => {
+    if (msg.type === "ui_surface_show") {
+      const progress = getTaskProgressDataFromSurfaceData(msg.data);
+      if (!progress) return;
+      taskProgressBySurfaceId.set(msg.surfaceId, progress);
+    } else if (msg.type === "ui_surface_update") {
+      const existing = taskProgressBySurfaceId.get(msg.surfaceId);
+      const progress = mergeTaskProgressData(existing, msg.data);
+      if (!progress) return;
+      taskProgressBySurfaceId.set(msg.surfaceId, progress);
+    } else {
+      return;
+    }
+
+    currentLoadingMessages =
+      getTaskProgressLoadingMessage(
+        taskProgressBySurfaceId.get(msg.surfaceId),
+      ) ?? [];
+    maybeUpdateLoadingMessages();
   };
 
   if (startImmediately) {
@@ -450,8 +499,14 @@ function createSlackThinkingStatusController(params: {
 
   return {
     observeEvent(msg) {
-      if (stopped || clearSlackThinkingStatus) return;
-      if (msg.type !== "assistant_text_delta") return;
+      if (stopped) return;
+
+      if (msg.type === "ui_surface_show" || msg.type === "ui_surface_update") {
+        observeTaskProgress(msg);
+        return;
+      }
+
+      if (slackThinkingStatus || msg.type !== "assistant_text_delta") return;
 
       observedAssistantText += msg.text;
       if (shouldStartSlackThinkingStatusForText(observedAssistantText)) {
@@ -460,16 +515,95 @@ function createSlackThinkingStatusController(params: {
     },
     stop() {
       stopped = true;
-      clearSlackThinkingStatus?.();
+      slackThinkingStatus?.clear();
     },
   };
 }
 
 const SLACK_THINKING_MAX_DURATION_MS = 120_000;
+const SLACK_GENERIC_LOADING_MESSAGES = ["Working on it..."] as const;
+const SLACK_THINKING_STATUSES = [
+  "is grinding",
+  "is working",
+  "is touching grass",
+] as const;
+
+function getRandomSlackThinkingStatus(): string {
+  return SLACK_THINKING_STATUSES[
+    Math.floor(Math.random() * SLACK_THINKING_STATUSES.length)
+  ]!;
+}
+
+function getLoadingMessagesKey(loadingMessages?: string[]): string | undefined {
+  return loadingMessages?.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getTaskProgressDataFromSurfaceData(
+  data: unknown,
+): TaskProgressData | undefined {
+  if (!isRecord(data)) return undefined;
+  if (data.template !== "task_progress") return undefined;
+  return parseTaskProgressData(data.templateData);
+}
+
+function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
+  if (!isRecord(value) || !Array.isArray(value.steps)) return undefined;
+
+  const steps = value.steps.flatMap((step): TaskProgressStep[] => {
+    if (!isRecord(step)) return [];
+    if (typeof step.label !== "string") return [];
+    if (
+      step.status !== "pending" &&
+      step.status !== "in_progress" &&
+      step.status !== "completed" &&
+      step.status !== "failed"
+    ) {
+      return [];
+    }
+    return [{ label: step.label, status: step.status }];
+  });
+
+  return steps.length > 0 ? { steps } : undefined;
+}
+
+function mergeTaskProgressData(
+  existing: TaskProgressData | undefined,
+  data: unknown,
+): TaskProgressData | undefined {
+  if (!isRecord(data)) return existing;
+  const update = getTaskProgressDataFromSurfaceData(data);
+  if (update) return update;
+  if (!existing || !("templateData" in data)) return existing;
+
+  return parseTaskProgressData({
+    steps: existing.steps,
+    ...(isRecord(data.templateData) ? data.templateData : {}),
+  });
+}
+
+function getTaskProgressLoadingMessage(
+  progress: TaskProgressData | undefined,
+): string[] | undefined {
+  if (!progress) return undefined;
+
+  const activeStepIndex = progress.steps.findIndex(
+    (step) => step.status === "in_progress",
+  );
+  if (activeStepIndex < 0) return undefined;
+
+  const activeStep = progress.steps[activeStepIndex]!;
+  return [
+    `In progress (${activeStepIndex + 1}/${progress.steps.length}): ${activeStep.label}`,
+  ];
+}
 
 /**
- * Set the Slack Assistants API "is thinking..." status on the thread and
- * return a cleanup function that clears it. Both operations are fire-and-forget.
+ * Set Slack Assistants API status on the thread and return a handle for
+ * updating loading messages or clearing the indicator.
  *
  * A safety timer auto-clears the status after {@link SLACK_THINKING_MAX_DURATION_MS}
  * to prevent a stuck indicator when `processMessage` hangs.
@@ -478,7 +612,8 @@ function setSlackThinkingStatus(
   callbackUrl: string,
   chatId: string,
   assistantId?: string,
-): () => void {
+  loadingMessages?: string[],
+): SlackThinkingStatusHandle {
   let cleared = false;
 
   // Extract the thread timestamp from the callback URL so we can target
@@ -488,7 +623,12 @@ function setSlackThinkingStatus(
   // For non-threaded DMs, fall back to emoji reaction on the original message.
   if (!threadTs) {
     const messageTs = extractMessageTsFromCallbackUrl(callbackUrl);
-    if (!messageTs) return () => {};
+    if (!messageTs) {
+      return {
+        updateLoadingMessages: () => {},
+        clear: () => {},
+      };
+    }
 
     const addPromise = deliverChannelReply(callbackUrl, {
       chatId,
@@ -501,7 +641,7 @@ function setSlackThinkingStatus(
       );
     });
 
-    const clearReaction = () => {
+    const clearReaction = (): void => {
       if (cleared) return;
       cleared = true;
       clearTimeout(safetyTimer);
@@ -525,28 +665,55 @@ function setSlackThinkingStatus(
     );
     (safetyTimer as { unref?: () => void }).unref?.();
 
-    return clearReaction;
+    return {
+      updateLoadingMessages: () => {},
+      clear: clearReaction,
+    };
   }
 
   // Track the set promise so clear waits for it to settle first,
   // preventing a race where clear arrives at Slack before set.
-  const setPromise = deliverChannelReply(callbackUrl, {
+  let statusPromise = deliverChannelReply(callbackUrl, {
     chatId,
     assistantId,
     assistantThreadStatus: {
       channel: chatId,
       threadTs,
-      status: "is thinking...",
+      status: getRandomSlackThinkingStatus(),
+      ...(loadingMessages ? { loadingMessages } : {}),
     },
   }).catch((err) => {
     log.debug({ err, chatId, threadTs }, "Failed to set Slack thinking status");
   });
 
-  const clearStatus = () => {
+  const updateLoadingMessages = (nextLoadingMessages?: string[]): void => {
+    if (cleared) return;
+    statusPromise = statusPromise.then(() =>
+      deliverChannelReply(callbackUrl, {
+        chatId,
+        assistantId,
+        assistantThreadStatus: {
+          channel: chatId,
+          threadTs,
+          status: getRandomSlackThinkingStatus(),
+          ...(nextLoadingMessages
+            ? { loadingMessages: nextLoadingMessages }
+            : {}),
+        },
+      }).catch((err) => {
+        log.debug(
+          { err, chatId, threadTs },
+          "Failed to update Slack thinking status",
+        );
+      }),
+    );
+  };
+
+  const clearStatus = (): void => {
     if (cleared) return;
     cleared = true;
     clearTimeout(safetyTimer);
-    void setPromise.then(() =>
+    void statusPromise.then(() =>
       deliverChannelReply(callbackUrl, {
         chatId,
         assistantId,
@@ -567,7 +734,10 @@ function setSlackThinkingStatus(
   const safetyTimer = setTimeout(clearStatus, SLACK_THINKING_MAX_DURATION_MS);
   (safetyTimer as { unref?: () => void }).unref?.();
 
-  return clearStatus;
+  return {
+    updateLoadingMessages,
+    clear: clearStatus,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway-client/src/types.ts
+++ b/packages/gateway-client/src/types.ts
@@ -79,6 +79,8 @@ export interface ChannelReplyPayload {
     channel: string;
     threadTs: string;
     status: string;
+    /** Serialized to Slack as `loading_messages`. */
+    loadingMessages?: string[];
   };
 }
 


### PR DESCRIPTION
## Summary
Make Slack status updates reflect assistant task progress while preserving the existing quiet gate for ambiguous channel messages. Direct-addressed Slack turns still show an immediate generic indicator, and group/channel turns stay quiet until deliverable assistant text proves the assistant will respond.

## Changes
- Thread Slack `loading_messages` through the status API payload.
- Add Slack-only prompt guidance to use `task_progress` when doing work.
- Allow Slack `task_progress` card surfaces while keeping unrelated dynamic UI blocked.
- Bridge `task_progress` show/update events into Slack status loading messages.
- Tighten the Slack `ui_update` exception so only already-stored `task_progress` cards can be updated through the Slack-only gate.

## Milestone PRs (merged into feature branch)
- #31414: Add Slack status loading message plumbing
- #31418: Allow Slack task_progress status surfaces
- #31424: Bridge Slack task progress into status
- #31428: Tighten Slack task_progress update gate

## Project issue
Closes #31408

## Test plan
- [x] cd assistant && bun test src/messaging/providers/slack/send.test.ts
- [x] cd assistant && bun test src/__tests__/conversation-runtime-assembly.test.ts src/__tests__/conversation-surfaces-task-progress.test.ts
- [x] cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts
- [x] cd assistant && bunx tsc --noEmit
