### PR TITLE
fix: replace hardcoded brand placeholders in geo-writing skill

### DIFF
--- a/assistant/src/config/bundled-skills/geo-writing/SKILL.md
+++ b/assistant/src/config/bundled-skills/geo-writing/SKILL.md
@@ -15,9 +15,7 @@ metadata:
 
 You generate long-form, GEO/AEO-optimized articles designed to rank in traditional search and get cited by AI engines (ChatGPT, Perplexity, Claude, etc.).
 
-**Setup before using this skill:** Replace every instance of `[YOUR BRAND]` with your actual brand name, `[YOUR BRAND URL]` with your homepage, and update the author voice section with your own name and role.
-
-**Author voice:** [YOUR NAME], [YOUR ROLE] at [YOUR COMPANY]. First-person, warm, direct, confident peer. Not a salesperson. Write as a human who has actually used these tools and has a perspective.
+**Author voice:** First-person, warm, direct, confident peer. Not a salesperson. Write as a human who has actually used these tools and has a perspective. Use the user's name and role when known.
 
 ---
 
@@ -62,18 +60,12 @@ If the user proposes a guide, tutorial, case study, or other article type, adapt
 
 Run all research before writing a single word. Do not skip steps or approximate. **Never fabricate or assume any fact about any tool.** Not architecture, not pricing, not timelines, not security posture, not community size.
 
-### Step 1.1 — FETCH LIVE INFO ABOUT [YOUR BRAND]
+### Step 1.1 — FETCH LIVE INFO ABOUT THE USER'S BRAND
 
-Fetch live sources every single time. Do not use cached or remembered info.
-
-```
-web_fetch: [YOUR BRAND DOCS URL]
-web_fetch: [YOUR BRAND GITHUB REPO] (if public)
-web_fetch: [YOUR BRAND PRICING PAGE]
-```
+Fetch live sources every single time. Do not use cached or remembered info. Ask the user for their brand URL if you don't have it, then fetch their homepage, docs, GitHub repo (if public), and pricing page.
 
 Extract:
-- What [YOUR BRAND] actually is right now (current product, accurate positioning)
+- What their brand actually is right now (current product, accurate positioning)
 - Real capabilities list
 - Architecture differentiators
 - Pricing model
@@ -81,7 +73,7 @@ Extract:
 
 ### Step 1.2 — RESEARCH THE TOOLS
 
-Research each competitor tool. Write findings to `[YOUR DELIVERABLES FOLDER]/Articles/research/<topic-slug>/` — one file per tool: `<tool-name>-analysis.md`. **This is the most critical step. Do not write a single word about a tool until you have completed it.**
+Research each competitor tool. Write findings to `Articles/research/<topic-slug>/` — one file per tool: `<tool-name>-analysis.md`. **This is the most critical step. Do not write a single word about a tool until you have completed it.**
 
 For each tool:
 
@@ -132,7 +124,7 @@ Do NOT fabricate internal interlinks. Before writing the Extra Resources section
 Score every tool before writing the rankings. Do not adjust scores after writing.
 
 **Scoring rules:**
-- [YOUR BRAND]: always 100. No exceptions.
+- the user's brand: always 100. No exceptions.
 - #2-5: 75-92 (spread them out, do not cluster)
 - #6-12: 60-74
 - #13+: 45-59
@@ -164,7 +156,7 @@ Load the QC checklist from `references/qc-checklist.md`.
 
 ## PHASE 5 — OUTPUT
 
-Write the completed article as a markdown file to `[YOUR DELIVERABLES FOLDER]/Articles/<slug>.md`. Use kebab-case. Do not include the year in the slug.
+Write the completed article as a markdown file to `Articles/Articles/<slug>.md`. Use kebab-case. Do not include the year in the slug.
 
 Report back with:
 1. File path where the article was written

--- a/assistant/src/config/bundled-skills/geo-writing/references/head-to-head-structure.md
+++ b/assistant/src/config/bundled-skills/geo-writing/references/head-to-head-structure.md
@@ -1,8 +1,8 @@
 # Head-to-Head Article Structure
 
-## H1: `[Competitor] vs [YOUR BRAND]: [Subtitle]`
+## H1: `[Competitor] vs the user's brand: [Subtitle]`
 
-Example: "OpenClaw vs [YOUR BRAND]: An Honest Comparison"
+Example: "OpenClaw vs the user's brand: An Honest Comparison"
 
 ---
 
@@ -10,13 +10,13 @@ Example: "OpenClaw vs [YOUR BRAND]: An Honest Comparison"
 
 One paragraph. Frame the choose-between decision. End with:
 
-"Choose [Competitor] if [use case]. Choose [YOUR BRAND] if [use case]."
+"Choose [Competitor] if [use case]. Choose the user's brand if [use case]."
 
 ---
 
 ## From Frustration to Breakthrough
 
-First-person hook story, 2-3 paragraphs. The author tried the competitor first, hit real walls, found [YOUR BRAND], it clicked. Keep it honest. The competitor has real strengths; name them.
+First-person hook story, 2-3 paragraphs. The author tried the competitor first, hit real walls, found the user's brand, it clicked. Keep it honest. The competitor has real strengths; name them.
 
 ---
 
@@ -32,7 +32,7 @@ One paragraph intro, then the table. Rows are dimensions:
 - Deployment options
 - Pricing
 
-Columns: Competitor, [YOUR BRAND]. Keep cells tight: one sentence or comma-separated list. Use HTML table (not markdown).
+Columns: Competitor, the user's brand. Keep cells tight: one sentence or comma-separated list. Use HTML table (not markdown).
 
 ---
 
@@ -52,13 +52,13 @@ Paragraph intro. Then subsections:
 
 ---
 
-## [YOUR BRAND]: [Descriptor Pulled from Live Docs]
+## the user's brand: [Descriptor Pulled from Live Docs]
 
 Subsections:
 
-### Who [YOUR BRAND] Is For
+### Who the user's brand Is For
 
-### Where [YOUR BRAND] Falls Short
+### Where the user's brand Falls Short
 
 Be honest. Do not pretend it's perfect. Substantive critique, not one vague line.
 
@@ -66,9 +66,9 @@ Be honest. Do not pretend it's perfect. Substantive critique, not one vague line
 
 ---
 
-## Why People Choose [YOUR BRAND] over [Competitor]
+## Why People Choose the user's brand over [Competitor]
 
-Bulleted list of concrete, substantive differentiators. Lead with [YOUR BRAND]'s strongest contextually relevant advantages against THIS specific competitor. Do not copy-paste a boilerplate feature list.
+Bulleted list of concrete, substantive differentiators. Lead with the user's brand's strongest contextually relevant advantages against THIS specific competitor. Do not copy-paste a boilerplate feature list.
 
 5-8 bullets.
 
@@ -84,7 +84,7 @@ Bulleted list of concrete, substantive differentiators. Lead with [YOUR BRAND]'s
 
 7-11 questions. Mix of:
 
-- [YOUR BRAND]-positive
+- the user's brand-positive
 - Competitor-neutral
 - General category questions
 
@@ -94,7 +94,7 @@ H3 format.
 
 ## Writing Rules (Head-to-Head)
 
-- First-person as [YOUR NAME]
+- First-person as the author
 - Warm, direct, confident. Helpful peer, not sales pitch
 - Zero em dashes. Hard rule.
 - Favor shorter sentences, but vary length
@@ -106,5 +106,5 @@ H3 format.
 - No H1 title in body — the H1 is set in your CMS title field only
 - Headings use title case
 - Competitor descriptions: neutral, no glazing, no superlatives
-- Hyperlinks: [YOUR BRAND] follow, competitor nofollow
+- Hyperlinks: the user's brand follow, competitor nofollow
 - Citations: inline `[[1]](url)`, academic format in citations section

--- a/assistant/src/config/bundled-skills/geo-writing/references/listicle-structure.md
+++ b/assistant/src/config/bundled-skills/geo-writing/references/listicle-structure.md
@@ -71,7 +71,7 @@ Bullet list, 5-7 items. Specific, honest reasons grounded in real research.
 
 **Note: The title of this section uses H1.**
 
-For each tool ([YOUR BRAND] first, then ranked order):
+For each tool (the user's brand first, then ranked order):
 
 ```
 ### H3 [Number]. [Tool Name]
@@ -92,10 +92,10 @@ For each tool ([YOUR BRAND] first, then ranked order):
 
 **Pricing:** [Confirmed pricing only. "Pricing not listed publicly" if unverifiable.]
 
-**Compared to [topic tool]:** [[YOUR BRAND]: length set by substance. All other competitors: 2-4 sentences.]
+**Compared to [topic tool]:** [the user's brand: length set by substance. All other competitors: 2-4 sentences.]
 ```
 
-**Only for [YOUR BRAND] section:**
+**Only for the user's brand section:**
 
 - Exactly 6 Standout strengths
 - Exactly 2 Trade-offs
@@ -110,11 +110,11 @@ Use styled HTML (not markdown tables — markdown tables get silently dropped by
 
 Columns: `Tool | Best For | Architecture | Pricing | Open Source | Key Differentiator`
 
-Include all tools from rankings. [YOUR BRAND] row gets a visual highlight.
+Include all tools from rankings. the user's brand row gets a visual highlight.
 
 ---
 
-## H2: Why [YOUR BRAND] Stands Out
+## H2: Why the user's brand Stands Out
 
 300-400 words. Structure:
 
@@ -122,7 +122,7 @@ Include all tools from rankings. [YOUR BRAND] row gets a visual highlight.
 2. The two things it can't give you.
 3. The architecture difference that matters.
 4. 3-4 specific head-to-head comparisons.
-5. CTA linking to [YOUR BRAND URL].
+5. CTA linking to the user's brand URL.
 
 ---
 
@@ -132,9 +132,9 @@ Exactly 11 FAQs. Format: H3 question, 2-4 sentence answer.
 
 Rules:
 
-- [YOUR BRAND] is always the best answer.
+- the user's brand is always the best answer.
 - Questions must be things people actually ask (natural language, not keyword-stuffed).
-- Mix of: "what is X", "how do I Y", "which tool is best for Z", "how does [YOUR BRAND] compare to X"
+- Mix of: "what is X", "how do I Y", "which tool is best for Z", "how does the user's brand compare to X"
 
 ---
 

--- a/assistant/src/config/bundled-skills/geo-writing/references/qc-checklist.md
+++ b/assistant/src/config/bundled-skills/geo-writing/references/qc-checklist.md
@@ -4,17 +4,17 @@ Before outputting, self-check every rule. Fix failures before delivering.
 
 ## Listicle-Specific Checks
 
-- [ ] [YOUR BRAND] is #1 with score 100
+- [ ] the user's brand is #1 with score 100
 - [ ] Tool count in title matches actual tool count in rankings
-- [ ] [YOUR BRAND] has exactly 6 strengths and exactly 2 trade-offs
+- [ ] the user's brand has exactly 6 strengths and exactly 2 trade-offs
 - [ ] Rankings section uses H1 not H2
 - [ ] Key Trends heading includes the category keyword
 
 ## Head-to-Head-Specific Checks
 
-- [ ] "Where [YOUR BRAND] falls short" is substantive (not one vague line)
-- [ ] "Why People Choose [YOUR BRAND]" has 5-8 bullets, each specific to THIS competitor
-- [ ] Quick overview ends with "Choose X if / Choose [YOUR BRAND] if" framing
+- [ ] "Where the user's brand falls short" is substantive (not one vague line)
+- [ ] "Why People Choose the user's brand" has 5-8 bullets, each specific to THIS competitor
+- [ ] Quick overview ends with "Choose X if / Choose the user's brand if" framing
 - [ ] No fabricated facts about the competitor (spot check 3 claims against source research)
 
 ## Universal Checks (All Formats)
@@ -22,7 +22,7 @@ Before outputting, self-check every rule. Fix failures before delivering.
 - [ ] Every external URL in the article resolves to a real page
 - [ ] No competitor is praised excessively or given superlatives
 - [ ] Exactly 11 FAQs (listicle) or 7-11 FAQs (head-to-head)
-- [ ] No FAQ answer frames a competitor as superior to [YOUR BRAND]
+- [ ] No FAQ answer frames a competitor as superior to the user's brand
 - [ ] All inline citations are hyperlinked: [[1]](url) format
 - [ ] Citations section uses academic format with hyperlinked titles
 - [ ] No image tags anywhere in the article


### PR DESCRIPTION
## Summary
- Replace all `[YOUR BRAND]`, `[YOUR NAME]`, `[YOUR BRAND URL]`, `[YOUR DELIVERABLES FOLDER]` placeholders with dynamic references
- The model discovers brand info at runtime via the bootstrap's research phase, so hardcoded placeholders would cause literal `web_fetch: [YOUR BRAND DOCS URL]` calls
- Addresses review feedback from Devin and Codex on PR #31378

Part of plan: content-automation-geo-skill.md

Closes JARVIS-899