### PR TITLE
refactor(web): convert current-platform-assistant hook to Zustand store (LUM-1718)

### DIFF
--- a/apps/web/src/domains/settings/current-platform-assistant-store.ts
+++ b/apps/web/src/domains/settings/current-platform-assistant-store.ts
@@ -1,0 +1,168 @@
+/**
+ * Zustand store for the per-organization "current platform assistant"
+ * selection. Persists the selected assistant ID for each org to
+ * localStorage so a reload or new tab restores the prior selection.
+ *
+ * **Storage model — one localStorage key per org:**
+ *
+ * Each org's selection is stored under
+ * `vellum_current_assistant_id__{orgId}`. A custom `StateStorage`
+ * adapter wired into the `persist` middleware reads/writes those keys
+ * directly, so the on-disk format stays compatible with the prior
+ * hand-rolled implementation.
+ *
+ * **Cross-tab sync:**
+ *
+ * The persist middleware doesn't subscribe to `storage` events on its
+ * own. We listen for any `storage` event whose key carries the
+ * per-org prefix and trigger `persist.rehydrate()` so the store
+ * picks up writes from other tabs.
+ *
+ * References:
+ * - {@link https://zustand.docs.pmnd.rs/}
+ * - {@link https://zustand.docs.pmnd.rs/integrations/persisting-store-data}
+ */
+
+import { create } from "zustand";
+import {
+  createJSONStorage,
+  persist,
+  type StateStorage,
+} from "zustand/middleware";
+
+import { createSelectors } from "@/utils/create-selectors.js";
+
+export const PLATFORM_ASSISTANT_STORAGE_PREFIX =
+  "vellum_current_assistant_id__";
+
+export interface CurrentPlatformAssistantState {
+  /** orgId → selected assistant ID. Absent entries mean "no selection yet". */
+  byOrg: Record<string, string>;
+}
+
+export interface CurrentPlatformAssistantActions {
+  setAssistantId: (orgId: string, id: string | null) => void;
+  getAssistantId: (orgId: string) => string | null;
+}
+
+export type CurrentPlatformAssistantStore = CurrentPlatformAssistantState &
+  CurrentPlatformAssistantActions;
+
+function readByOrgFromLocalStorage(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const byOrg: Record<string, string> = {};
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key && key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)) {
+        const orgId = key.slice(PLATFORM_ASSISTANT_STORAGE_PREFIX.length);
+        const value = window.localStorage.getItem(key);
+        if (value != null) byOrg[orgId] = value;
+      }
+    }
+  } catch {
+    // ignore storage failures
+  }
+  return byOrg;
+}
+
+function writeByOrgToLocalStorage(byOrg: Record<string, string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key && key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)) {
+        existing.push(key);
+      }
+    }
+    for (const key of existing) {
+      const orgId = key.slice(PLATFORM_ASSISTANT_STORAGE_PREFIX.length);
+      if (byOrg[orgId] == null) {
+        window.localStorage.removeItem(key);
+      }
+    }
+    for (const [orgId, id] of Object.entries(byOrg)) {
+      window.localStorage.setItem(
+        `${PLATFORM_ASSISTANT_STORAGE_PREFIX}${orgId}`,
+        id,
+      );
+    }
+  } catch {
+    // ignore storage failures
+  }
+}
+
+/**
+ * Translates the single-name `name` view that `persist` expects into
+ * per-org reads and writes against the existing
+ * `vellum_current_assistant_id__{orgId}` localStorage keys.
+ */
+const perOrgStorage: StateStorage = {
+  getItem: () => {
+    const byOrg = readByOrgFromLocalStorage();
+    return JSON.stringify({ state: { byOrg }, version: 0 });
+  },
+  setItem: (_name, value) => {
+    let parsed: { state?: { byOrg?: Record<string, string> } };
+    try {
+      parsed = JSON.parse(value) as typeof parsed;
+    } catch {
+      return;
+    }
+    const byOrg = parsed.state?.byOrg ?? {};
+    writeByOrgToLocalStorage(byOrg);
+  },
+  removeItem: () => {
+    writeByOrgToLocalStorage({});
+  },
+};
+
+const CURRENT_PLATFORM_ASSISTANT_STORE_NAME =
+  "vellum:current-platform-assistant";
+
+const useCurrentPlatformAssistantStoreBase = create<CurrentPlatformAssistantStore>()(
+  persist(
+    (set, get) => ({
+      byOrg: readByOrgFromLocalStorage(),
+
+      setAssistantId: (orgId, id) =>
+        set((state) => {
+          const next = { ...state.byOrg };
+          if (id == null) {
+            delete next[orgId];
+          } else {
+            next[orgId] = id;
+          }
+          return { byOrg: next };
+        }),
+
+      getAssistantId: (orgId) => get().byOrg[orgId] ?? null,
+    }),
+    {
+      name: CURRENT_PLATFORM_ASSISTANT_STORE_NAME,
+      storage: createJSONStorage(() => perOrgStorage),
+      partialize: (state) => ({ byOrg: state.byOrg }),
+    },
+  ),
+);
+
+export const useCurrentPlatformAssistantStore = createSelectors(
+  useCurrentPlatformAssistantStoreBase,
+);
+
+// ---------------------------------------------------------------------------
+// Cross-tab sync
+// ---------------------------------------------------------------------------
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === null) {
+      void useCurrentPlatformAssistantStoreBase.persist.rehydrate();
+      return;
+    }
+    if (event.key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)) {
+      void useCurrentPlatformAssistantStoreBase.persist.rehydrate();
+    }
+  });
+}

--- a/apps/web/src/domains/settings/hooks/use-current-platform-assistant.ts
+++ b/apps/web/src/domains/settings/hooks/use-current-platform-assistant.ts
@@ -1,71 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { useCallback, useEffect } from "react";
 
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen.js";
 import type { Assistant } from "@/generated/api/types.gen.js";
+import { useCurrentPlatformAssistantStore } from "@/domains/settings/current-platform-assistant-store.js";
 import { useOrganizationStore } from "@/stores/organization-store.js";
-
-const PLATFORM_ASSISTANT_STORAGE_PREFIX = "vellum_current_assistant_id__";
 
 const PLATFORM_LIST_OPTIONS = assistantsListOptions({
   query: { hosting: "platform" },
 });
-
-function storageKeyForOrg(orgId: string | null): string | null {
-  if (!orgId) return null;
-  return `${PLATFORM_ASSISTANT_STORAGE_PREFIX}${orgId}`;
-}
-
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
-function notify(): void {
-  for (const listener of listeners) listener();
-}
-
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (event: StorageEvent) => {
-    if (event.key === null) {
-      notify();
-      return;
-    }
-    if (event.key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)) {
-      notify();
-    }
-  });
-}
-
-function subscribe(listener: Listener): () => void {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
-}
-
-function getSnapshot(orgId: string | null): string | null {
-  const key = storageKeyForOrg(orgId);
-  if (!key) return null;
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredId(orgId: string | null, id: string | null): void {
-  const key = storageKeyForOrg(orgId);
-  if (!key) return;
-  try {
-    if (id == null) {
-      window.localStorage.removeItem(key);
-    } else {
-      window.localStorage.setItem(key, id);
-    }
-  } catch {
-    // ignore storage failures
-  }
-  notify();
-}
 
 export interface UseCurrentPlatformAssistantResult {
   assistantId: string | null;
@@ -78,12 +21,11 @@ export interface UseCurrentPlatformAssistantResult {
 
 export function useCurrentPlatformAssistant(): UseCurrentPlatformAssistantResult {
   const orgId = useOrganizationStore.use.currentOrganizationId();
+  const byOrg = useCurrentPlatformAssistantStore.use.byOrg();
+  const setAssistantIdAction =
+    useCurrentPlatformAssistantStore.use.setAssistantId();
 
-  const storedId = useSyncExternalStore(
-    subscribe,
-    useCallback(() => getSnapshot(orgId), [orgId]),
-    () => null,
-  );
+  const storedId = orgId ? (byOrg[orgId] ?? null) : null;
 
   const listQuery = useQuery(PLATFORM_LIST_OPTIONS);
 
@@ -109,16 +51,24 @@ export function useCurrentPlatformAssistant(): UseCurrentPlatformAssistantResult
     if (!isListLoaded) return;
     if (platformAssistants.length === 0) return;
     if (resolvedId === storedId) return;
-    if (resolvedId != null) {
-      writeStoredId(orgId, resolvedId);
+    if (resolvedId != null && orgId) {
+      setAssistantIdAction(orgId, resolvedId);
     }
-  }, [isListLoaded, platformAssistants.length, resolvedId, storedId, orgId]);
+  }, [
+    isListLoaded,
+    platformAssistants.length,
+    resolvedId,
+    storedId,
+    orgId,
+    setAssistantIdAction,
+  ]);
 
   const setAssistantId = useCallback(
     (id: string | null) => {
-      writeStoredId(orgId, id);
+      if (!orgId) return;
+      setAssistantIdAction(orgId, id);
     },
-    [orgId],
+    [orgId, setAssistantIdAction],
   );
 
   return {


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `useSyncExternalStore` + module-level listener set in `use-current-platform-assistant` with a Zustand `persist`-backed store, matching the rest of the codebase.

- **New** `domains/settings/current-platform-assistant-store.ts` — Zustand store with `persist` middleware, wrapped via `createSelectors()`. State is `byOrg: Record<orgId, assistantId>`; actions are `setAssistantId(orgId, id)` / `getAssistantId(orgId)`.
- A custom `StateStorage` adapter keeps writes split across the existing per-org `vellum_current_assistant_id__{orgId}` localStorage keys, so the on-disk format stays backward compatible with the prior implementation.
- Cross-tab sync is preserved: a single `storage` event listener calls `persist.rehydrate()` on any matching key, replacing the previous module-level `listeners` set + `notify()` plumbing.
- React Query still owns the platform assistants list. `useCurrentPlatformAssistant` is now a thin composition of the store + the list query — no `useSyncExternalStore`, no module-level pub/sub.

Linear: https://linear.app/vellum/issue/LUM-1718

## Test plan

- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run lint` passes (no new warnings)
- [ ] Settings → Switch Assistant: selecting a different assistant updates the active row and survives reload
- [ ] Selection scoped per org — switching organizations restores that org's previously selected assistant
- [ ] Open in two tabs: switching in tab A reflects in tab B without a reload
- [ ] Existing `vellum_current_assistant_id__{orgId}` localStorage entries still apply on first load after upgrade


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr5f8uUaAmRTxG77yALrnW)_