### PR TITLE
Fix lazy Slack channel resolution follow-ups

### DIFF
--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -175,10 +175,10 @@ export function upsertOutboundBinding(input: {
 export function updateExternalChatName(
   conversationId: string,
   externalChatName: string,
-): ExternalConversationBinding | null {
+): void {
   const db = getDb();
   const trimmedName = externalChatName.trim();
-  if (!trimmedName) return getBindingByConversation(conversationId);
+  if (!trimmedName) return;
 
   db.update(externalConversationBindings)
     .set({
@@ -187,8 +187,6 @@ export function updateExternalChatName(
     })
     .where(eq(externalConversationBindings.conversationId, conversationId))
     .run();
-
-  return getBindingByConversation(conversationId);
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+
+const BOT_TOKEN = "xoxb-test";
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => BOT_TOKEN,
+}));
+
+const { getSlackConversationInfo } = await import("./api.js");
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("getSlackConversationInfo", () => {
+  test("calls conversations.info with GET query params", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = mock(async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          channel: {
+            id: "C123",
+            name: "engineering",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const info = await getSlackConversationInfo("C123");
+
+    expect(info).toEqual({ id: "C123", name: "engineering" });
+    expect(capturedUrl).toBeDefined();
+    const url = new URL(capturedUrl!);
+    expect(url.pathname).toBe("/api/conversations.info");
+    expect(url.searchParams.get("channel")).toBe("C123");
+    expect(capturedInit?.method).toBe("GET");
+    expect(capturedInit?.body).toBeUndefined();
+    expect(capturedInit?.headers).toEqual({
+      Authorization: `Bearer ${BOT_TOKEN}`,
+    });
+  });
+});

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -190,6 +190,83 @@ export async function callSlackApi(
   );
 }
 
+/**
+ * Call a Slack Web API read method with query parameters.
+ */
+async function callSlackApiGet(
+  method: string,
+  params: URLSearchParams,
+): Promise<SlackApiResponse> {
+  const botToken = await resolveBotToken();
+  const query = params.toString();
+  const url = `${SLACK_API_BASE}/${method}${query ? `?${query}` : ""}`;
+
+  let lastError: string | undefined;
+
+  for (let attempt = 0; attempt <= SLACK_MAX_RATE_LIMIT_RETRIES; attempt++) {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+      },
+    });
+
+    if (response.status === 429) {
+      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
+        throw new Error("Slack rate limit exceeded after retries");
+      }
+      const retryAfter =
+        parseInt(response.headers.get("Retry-After") ?? "", 10) ||
+        SLACK_DEFAULT_RETRY_AFTER_S;
+      log.warn({ method, retryAfter, attempt }, "Slack rate limited, retrying");
+      await new Promise((r) => setTimeout(r, retryAfter * 1000));
+      continue;
+    }
+
+    if (response.status >= 500) {
+      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
+        throw new Error(
+          `Slack ${method} failed with status ${response.status} after retries`,
+        );
+      }
+      log.warn(
+        { method, status: response.status, attempt },
+        "Slack 5xx error, retrying",
+      );
+      await new Promise((r) =>
+        setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
+      );
+      continue;
+    }
+
+    const data = (await response.json()) as SlackApiResponse;
+
+    if (!data.ok) {
+      lastError = data.error;
+      const category = classifySlackError(data.error);
+
+      if (category === "rate_limit" && attempt < SLACK_MAX_RATE_LIMIT_RETRIES) {
+        log.warn(
+          { method, slackError: data.error, attempt },
+          "Slack rate limited (body), retrying",
+        );
+        await new Promise((r) =>
+          setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
+        );
+        continue;
+      }
+
+      throw new SlackApiError(data.error);
+    }
+
+    return data;
+  }
+
+  throw new Error(
+    `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
+  );
+}
+
 function normalizeSlackString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -199,9 +276,10 @@ function normalizeSlackString(value: unknown): string | undefined {
 export async function getSlackConversationInfo(
   channelId: string,
 ): Promise<SlackConversationInfo | null> {
-  const data = (await callSlackApi("conversations.info", {
-    channel: channelId,
-  })) as SlackConversationsInfoResponse;
+  const data = (await callSlackApiGet(
+    "conversations.info",
+    new URLSearchParams({ channel: channelId }),
+  )) as SlackConversationsInfoResponse;
 
   const id = normalizeSlackString(data.channel?.id);
   if (!id) return null;

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -6,38 +6,28 @@ type MockSlackInfo = {
   nameNormalized?: string;
 } | null;
 
-type MockSlackCategory =
-  | "auth"
-  | "channel_not_found"
-  | "not_found"
-  | "permission"
-  | "rate_limit"
-  | "unknown";
-
-class MockSlackApiError extends Error {
-  readonly slackError: string | undefined;
-  readonly category: MockSlackCategory;
-
-  constructor(slackError: string | undefined, category: MockSlackCategory) {
-    super(`Slack API error: ${slackError ?? "unknown"}`);
-    this.name = "SlackApiError";
-    this.slackError = slackError;
-    this.category = category;
-  }
-}
+type MockSlackResult = MockSlackInfo | { slackError: string };
 
 const slackInfoCalls: string[] = [];
-let slackInfoImpl: (channelId: string) => Promise<MockSlackInfo> = async () =>
+let slackInfoImpl: (channelId: string) => Promise<MockSlackResult> = async () =>
   null;
+const syncInvalidations: string[][] = [];
+const originalFetch = globalThis.fetch;
 
-mock.module("../../../messaging/providers/slack/api.js", () => ({
-  SlackApiError: MockSlackApiError,
-  getSlackConversationInfo: async (channelId: string) => {
-    slackInfoCalls.push(channelId);
-    return slackInfoImpl(channelId);
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "xoxb-test",
+}));
+
+mock.module("../../sync/sync-publisher.js", () => ({
+  publishSyncInvalidation: async (tags: string[]) => {
+    syncInvalidations.push([...tags]);
   },
 }));
 
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../../../daemon/message-types/sync.js";
 import { createConversation } from "../../../memory/conversation-crud.js";
 import { getDb, resetDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
@@ -103,13 +93,43 @@ async function resolve(conversationId: string): Promise<ResolveResponse> {
   })) as ResolveResponse;
 }
 
+function mockSlackFetch(): void {
+  globalThis.fetch = mock(async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname !== "/api/conversations.info") {
+      throw new Error(`Unexpected Slack API request: ${url.pathname}`);
+    }
+
+    const channelId = url.searchParams.get("channel") ?? "";
+    slackInfoCalls.push(channelId);
+    const result = await slackInfoImpl(channelId);
+    if (result && "slackError" in result) {
+      return Response.json({ ok: false, error: result.slackError });
+    }
+
+    return Response.json({
+      ok: true,
+      channel: result
+        ? {
+            id: result.id,
+            name: result.name,
+            name_normalized: result.nameNormalized,
+          }
+        : undefined,
+    });
+  }) as unknown as typeof fetch;
+}
+
 beforeEach(() => {
   clearTables();
   slackInfoCalls.length = 0;
+  syncInvalidations.length = 0;
   slackInfoImpl = async () => null;
+  mockSlackFetch();
 });
 
 afterAll(() => {
+  globalThis.fetch = originalFetch;
   resetDb();
   mock.restore();
 });
@@ -164,6 +184,30 @@ describe("slack_channel_name_resolve", () => {
     expect(updated?.username).toBe("alice");
   });
 
+  test("publishes conversation sync tags after persisting a returned name", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CSYNC123",
+      externalChatName: "CSYNC123",
+    });
+    slackInfoImpl = async (channelId) => ({
+      id: channelId,
+      nameNormalized: "team-sync",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CSYNC123",
+      channelName: "team-sync",
+      cached: false,
+      resolved: true,
+    });
+    expect(syncInvalidations).toContainEqual([
+      SYNC_TAGS.conversationsList,
+      conversationMetadataSyncTag(conversationId),
+    ]);
+  });
+
   test("does not call Slack for DM bindings", async () => {
     const conversationId = createBoundConversation({
       externalChatId: "D123",
@@ -203,9 +247,7 @@ describe("slack_channel_name_resolve", () => {
       externalChatName: "CFAIL123",
     });
     const before = getBindingByConversation(conversationId);
-    slackInfoImpl = async () => {
-      throw new MockSlackApiError("missing_scope", "permission");
-    };
+    slackInfoImpl = async () => ({ slackError: "missing_scope" });
 
     const result = await resolve(conversationId);
 

--- a/assistant/src/runtime/routes/slack-channel-routes.ts
+++ b/assistant/src/runtime/routes/slack-channel-routes.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
 import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../../daemon/message-types/sync.js";
+import {
   getBindingByConversation,
   updateExternalChatName,
 } from "../../memory/external-conversation-store.js";
@@ -8,6 +12,7 @@ import {
   getSlackConversationInfo,
   SlackApiError,
 } from "../../messaging/providers/slack/api.js";
+import { publishSyncInvalidation } from "../sync/sync-publisher.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -120,30 +125,9 @@ async function handleSlackChannelNameResolve({
     };
   }
 
+  let info;
   try {
-    const info = await getSlackConversationInfo(channelId);
-    const channelName = usableResolvedName(
-      channelId,
-      info?.name,
-      info?.nameNormalized,
-    );
-    if (!channelName) {
-      return {
-        channelId,
-        cached: false,
-        resolved: false,
-        reason: "no_name",
-      };
-    }
-
-    updateExternalChatName(conversationId, channelName);
-
-    return {
-      channelId,
-      channelName,
-      cached: false,
-      resolved: true,
-    };
+    info = await getSlackConversationInfo(channelId);
   } catch (err) {
     return {
       channelId,
@@ -152,6 +136,33 @@ async function handleSlackChannelNameResolve({
       reason: reasonForSlackError(err),
     };
   }
+
+  const channelName = usableResolvedName(
+    channelId,
+    info?.name,
+    info?.nameNormalized,
+  );
+  if (!channelName) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: "no_name",
+    };
+  }
+
+  updateExternalChatName(conversationId, channelName);
+  await publishSyncInvalidation([
+    SYNC_TAGS.conversationsList,
+    conversationMetadataSyncTag(conversationId),
+  ]);
+
+  return {
+    channelId,
+    channelName,
+    cached: false,
+    resolved: true,
+  };
 }
 
 export const ROUTES: RouteDefinition[] = [


### PR DESCRIPTION
## Summary
- call Slack `conversations.info` with GET query params for lazy channel name resolution
- let persistence/sync failures surface instead of being reported as Slack lookup failures
- publish conversation sync invalidations after persisting a resolved Slack channel name
- simplify `updateExternalChatName` to avoid an unused follow-up read

## Tests
- `cd assistant && bun test src/messaging/providers/slack/api.test.ts src/runtime/routes/__tests__/slack-channel-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bunx eslint src/memory/external-conversation-store.ts src/messaging/providers/slack/api.ts src/messaging/providers/slack/api.test.ts src/runtime/routes/slack-channel-routes.ts src/runtime/routes/__tests__/slack-channel-routes.test.ts`
