### PR TITLE
chore(web): replace React.* namespace types with destructured imports (LUM-1699)

### DIFF
--- a/apps/web/src/components/account/account-form.tsx
+++ b/apps/web/src/components/account/account-form.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type FormEvent, type InputHTMLAttributes, type ReactNode } from "react";
 
 import { Notice } from "@vellum/design-library";
 
@@ -21,7 +21,7 @@ const ARROW_ICON = (
 );
 
 interface AccountFormProps {
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
   error?: string | null;
   children: ReactNode;
   submitLabel: string;
@@ -62,7 +62,7 @@ export function AccountForm({
 }
 
 export function AccountInput(
-  props: React.InputHTMLAttributes<HTMLInputElement>,
+  props: InputHTMLAttributes<HTMLInputElement>,
 ) {
   return (
     <input

--- a/apps/web/src/components/avatar/chat-avatar.tsx
+++ b/apps/web/src/components/avatar/chat-avatar.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from "motion/react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type CSSProperties } from "react";
 
 import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
 import { AnimatedAvatar } from "./animated-avatar.js";
@@ -61,7 +61,7 @@ export function ChatAvatar({
   const hasCharacter = !!components && !!effectiveTraits;
   const preferCharacter = hasCharacter && (!!traits || !customImageUrl);
 
-  const wrapperStyle: React.CSSProperties = {
+  const wrapperStyle: CSSProperties = {
     width: size,
     height: size,
     flexShrink: 0,

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useRef,
   type FC,
+  type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
 } from "react";
@@ -53,7 +54,7 @@ export interface CommandPaletteProps {
   /** Called when an item is selected (clicked or Enter pressed). */
   onItemSelect?: (item: CommandPaletteItemData, index: number) => void;
   /** Key-down handler from useCommandPalette for keyboard navigation. */
-  onKeyDown: (e: React.KeyboardEvent) => void;
+  onKeyDown: (e: KeyboardEvent) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/command-palette/use-command-palette.ts
+++ b/apps/web/src/components/command-palette/use-command-palette.ts
@@ -1,5 +1,5 @@
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 
 import type { GlobalSearchResponse } from "@/domains/chat/api/global-search.js";
 import { searchGlobal } from "@/domains/chat/api/global-search.js";
@@ -26,7 +26,7 @@ export interface UseCommandPaletteReturn {
   toggle: () => void;
   setQuery: (value: string) => void;
   /** Key-down handler to attach to the palette container or input. */
-  handleKeyDown: (e: React.KeyboardEvent) => void;
+  handleKeyDown: (e: KeyboardEvent) => void;
 }
 
 const DEBOUNCE_MS = 150;
@@ -151,7 +151,7 @@ export function useCommandPalette({
   }, []);
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       // Cmd+K / Ctrl+K toggles the palette closed even when input is focused.
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();

--- a/apps/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-signup-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
 import {
@@ -55,7 +55,7 @@ export function ProviderSignupPage() {
     })();
   }, [navigate]);
 
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
     setIsSubmitting(true);

--- a/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
+++ b/apps/web/src/domains/chat/components/collapsed-conversations-button.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactNode } from "react";
+import { createElement, type FC, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 // Mock design library components
@@ -36,7 +36,7 @@ const mockPanelItem = ({
       ...rest,
     },
     Icon
-      ? createElement(Icon as React.FC<Record<string, unknown>>, { size: 14 })
+      ? createElement(Icon as FC<Record<string, unknown>>, { size: 14 })
       : null,
     label as string,
     badge != null ? createElement("span", { "data-testid": "badge" }, String(badge)) : null,

--- a/apps/web/src/domains/chat/components/document-comment-form.tsx
+++ b/apps/web/src/domains/chat/components/document-comment-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import { Send } from "lucide-react";
 import { Button } from "@vellum/design-library";
 
@@ -23,7 +23,7 @@ export function DocumentCommentForm({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSubmit = useCallback(
-    async (event: React.FormEvent) => {
+    async (event: FormEvent) => {
       event.preventDefault();
       const trimmed = content.trim();
       if (!trimmed || submitting) return;
@@ -41,7 +41,7 @@ export function DocumentCommentForm({
   );
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         void handleSubmit(event);

--- a/apps/web/src/domains/chat/components/onboarding-choice-card.tsx
+++ b/apps/web/src/domains/chat/components/onboarding-choice-card.tsx
@@ -10,7 +10,7 @@
  */
 
 import { Check, MessageSquare } from "lucide-react";
-import { useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 
 import { Button, Card } from "@vellum/design-library";
 import { TASK_ICONS } from "@/components/prechat-task-icons.js";
@@ -180,7 +180,7 @@ export function OnboardingChoiceCard({
                     rows={1}
                     placeholder="What do you need help with?"
                     className="mt-0.5 w-full resize-none overflow-hidden border-none bg-transparent p-0 text-body-small-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:outline-none"
-                    style={{ fieldSizing: "content" } as React.CSSProperties}
+                    style={{ fieldSizing: "content" } as CSSProperties}
                   />
                 ) : (
                   <div>

--- a/apps/web/src/domains/chat/components/subagent-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/subagent-progress-card.tsx
@@ -7,7 +7,7 @@ import {
   ChevronUp,
   Square,
 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 
 import { BusyIndicator } from "@/domains/chat/components/busy-indicator.js";
 import { AvatarRenderer } from "@/components/avatar-renderer.js";
@@ -129,7 +129,7 @@ function SubagentRow({
   );
 
   const handleStop = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       e.stopPropagation();
       onStopSubagent?.(entry.subagentId);
     },
@@ -189,7 +189,7 @@ function SubagentRow({
             tabIndex={0}
             aria-label={`Stop ${entry.label}`}
             onClick={handleStop}
-            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleStop(e as unknown as React.MouseEvent); } }}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleStop(e as unknown as MouseEvent); } }}
             className="flex shrink-0 cursor-pointer items-center justify-center p-1 text-[var(--content-tertiary)] hover:text-[var(--system-negative-strong)] transition-colors"
           >
             <Square className="h-2.5 w-2.5" fill="currentColor" />

--- a/apps/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/file-upload-surface.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax -- LUM-1768: file contains dark: pairs pending semantic-token migration */
 
 import { AlertTriangle, File, Loader2, Upload, X } from "lucide-react";
-import { type DragEvent, useCallback, useRef, useState } from "react";
+import { type ChangeEvent, type DragEvent, useCallback, useRef, useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types.js";
 
@@ -200,7 +200,7 @@ export function FileUploadSurface({ surface, onAction }: FileUploadSurfaceProps)
   }, []);
 
   const handleFileChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       const files = Array.from(e.target.files ?? []);
       if (files.length > 0) addFiles(files);
       // Reset the input so the same file can be re-selected

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -1,5 +1,5 @@
 
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
 
 import {
   type VoiceInputButtonHandle,
@@ -21,14 +21,14 @@ export interface UseVoiceInputOptions {
   /** Current assistant ID — required for dictation cleanup via the daemon. */
   assistantId: string | null;
   /** Ref to the composer textarea for cursor-position reads and resize. */
-  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
   /** State setter for the composer input value (React useState dispatch). */
   setInput: Dispatch<SetStateAction<string>>;
 }
 
 export interface UseVoiceInputReturn {
   /** Imperative handle ref passed to `VoiceInputButton`. */
-  voiceInputRef: React.RefObject<VoiceInputButtonHandle | null>;
+  voiceInputRef: RefObject<VoiceInputButtonHandle | null>;
   /** Interim (partial) transcript shown while recording is in progress. */
   voiceInterim: string;
   /** Current voice error code, or null if no error. */

--- a/apps/web/src/domains/home/detail-panel/home-markdown-content.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-markdown-content.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -17,7 +18,7 @@ interface HomeMarkdownContentProps {
 // user actually sees the destination. Web keeps the default new-tab behavior
 // (right-click → copy link still works because the `href` is preserved).
 function handleAnchorClick(
-  event: React.MouseEvent<HTMLAnchorElement>,
+  event: MouseEvent<HTMLAnchorElement>,
   href: string | undefined,
 ): void {
   if (!href || !isNativePlatform()) return;

--- a/apps/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/apps/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 
 import { Button } from "@vellum/design-library/components/button";
 import { Input, Textarea } from "@vellum/design-library/components/input";
@@ -90,7 +90,7 @@ function CreateScheduleModalInner({
     trimmedMessage.length > 0 &&
     !submitting;
 
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!canSubmit) return;
     setSubmitting(true);

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -6,7 +6,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { Card } from "@vellum/design-library/components/card";
 import { ConfirmDialog } from "@vellum/design-library/components/confirm-dialog";
@@ -780,7 +780,7 @@ function TabButton({
 }: {
   active: boolean;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button

--- a/apps/web/src/domains/settings/components/nudge-settings-card.tsx
+++ b/apps/web/src/domains/settings/components/nudge-settings-card.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from "react";
+import type { ComponentType, CSSProperties, ReactNode } from "react";
 
 import { Button } from "@vellum/design-library/components/button";
 import { SettingsCard } from "@/domains/settings/components/settings-card.js";
@@ -6,7 +6,7 @@ import { SettingsCard } from "@/domains/settings/components/settings-card.js";
 export interface NudgeBenefit {
   icon: ComponentType<{
     size?: number;
-    style?: React.CSSProperties;
+    style?: CSSProperties;
     "aria-hidden"?: boolean;
   }>;
   text: string;

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -17,7 +17,7 @@ import {
   Pencil,
   Video,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { Button } from "@vellum/design-library/components/button";
 import { client } from "@/generated/api/client.gen.js";
@@ -143,7 +143,7 @@ function FileHeader({
   name: string;
   mimeType: string;
   size?: number;
-  rightContent?: React.ReactNode;
+  rightContent?: ReactNode;
 }) {
   return (
     <div


### PR DESCRIPTION
Closes [LUM-1699](https://linear.app/vellum/issue/LUM-1699).

## Summary

Mechanical convention-compliance pass: replace `React.ReactNode` / `React.ChangeEvent` / `React.MouseEvent` / etc. with destructured type imports per [`STYLE_GUIDE.md`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/STYLE_GUIDE.md):

```ts
// before
function foo(e: React.ChangeEvent<HTMLInputElement>) { ... }

// after
import { type ChangeEvent } from "react";
function foo(e: ChangeEvent<HTMLInputElement>) { ... }
```

## Scope expansion

The issue listed 5 files. A `grep -rE "React\.[A-Z]"` found **11 more** with the same anti-pattern. Fixing all 16 in one pass — the convention applies uniformly, and partial cleanup invites drift.

## Files touched (16)

- `src/components/account/account-form.tsx`
- `src/components/avatar/chat-avatar.tsx`
- `src/components/command-palette/command-palette.tsx`
- `src/components/command-palette/use-command-palette.ts`
- `src/domains/account/pages/provider-signup-page.tsx`
- `src/domains/chat/components/collapsed-conversations-button.test.tsx`
- `src/domains/chat/components/document-comment-form.tsx`
- `src/domains/chat/components/onboarding-choice-card.tsx`
- `src/domains/chat/components/subagent-progress-card.tsx`
- `src/domains/chat/components/surfaces/file-upload-surface.tsx`
- `src/domains/chat/hooks/use-voice-input.ts`
- `src/domains/home/detail-panel/home-markdown-content.tsx`
- `src/domains/settings/components/create-schedule-modal.tsx`
- `src/domains/settings/components/integration-detail-modal.tsx`
- `src/domains/settings/components/nudge-settings-card.tsx`
- `src/domains/workspace/components/workspace-file-viewer.tsx`

## Verified locally

- `grep -rE "React\.[A-Z]" src` — zero matches.
- `bun run typecheck` — clean.
- `bun run lint` — 0 errors.

## Test plan

- [ ] CI green
- No behavior change — pure type renames.

https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPGu4yGPTL4JoLaPuqpEW2)_