### PR TITLE
fix(web): align logs nav with platform + redirect settings/logs index routes

### DIFF
--- a/apps/web/src/domains/logs/logs-layout.tsx
+++ b/apps/web/src/domains/logs/logs-layout.tsx
@@ -21,7 +21,7 @@ export function LogsLayout() {
       (item) =>
         pathname === item.href || pathname.startsWith(item.href + "/"),
     );
-    return match?.label ?? "Logs";
+    return match?.label ?? "Logs & Usage";
   }, [pathname]);
 
   return (

--- a/apps/web/src/domains/logs/logs-layout.tsx
+++ b/apps/web/src/domains/logs/logs-layout.tsx
@@ -21,7 +21,13 @@ export function LogsLayout() {
       (item) =>
         pathname === item.href || pathname.startsWith(item.href + "/"),
     );
-    return match?.label ?? "Logs & Usage";
+    if (match) return match.label;
+    // Index route (/assistant/logs) renders UsagePage but doesn't match
+    // any sidebar href — use the first sidebar item's label.
+    if (pathname === routes.logs.root) {
+      return LOGS_SIDEBAR[0]?.label ?? "Logs & Usage";
+    }
+    return "Logs & Usage";
   }, [pathname]);
 
   return (

--- a/apps/web/src/domains/logs/navigation.ts
+++ b/apps/web/src/domains/logs/navigation.ts
@@ -1,9 +1,9 @@
 import type { LucideIcon } from "lucide-react";
 import {
-  Activity,
   BarChart3,
   Mail,
   MonitorCog,
+  ScrollText,
 } from "lucide-react";
 
 import { routes } from "@/utils/routes.js";
@@ -16,13 +16,13 @@ export interface LogsSidebarItem {
 }
 
 export const LOGS_SIDEBAR: LogsSidebarItem[] = [
-  { id: "trace", label: "Trace", href: routes.logs.trace, icon: Activity },
   { id: "usage", label: "Usage", href: routes.logs.usage, icon: BarChart3 },
+  { id: "logs", label: "Logs", href: routes.logs.trace, icon: ScrollText },
+  { id: "emails", label: "Emails", href: routes.logs.emails, icon: Mail },
   {
     id: "system-events",
     label: "System Events",
     href: routes.logs.systemEvents,
     icon: MonitorCog,
   },
-  { id: "emails", label: "Emails", href: routes.logs.emails, icon: Mail },
 ];

--- a/apps/web/src/domains/settings/components/settings-shell.tsx
+++ b/apps/web/src/domains/settings/components/settings-shell.tsx
@@ -65,8 +65,6 @@ export function SettingsShell({
     </Button>
   );
 
-  const mobileTitle = isMenuRoute ? "Settings" : title;
-
   return (
     <div
       className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 p-4 sm:p-6 md:gap-0"
@@ -84,7 +82,7 @@ export function SettingsShell({
           className="flex-1 truncate text-center"
           style={{ color: "var(--content-tertiary)", lineHeight: 1.4 }}
         >
-          {mobileTitle}
+          {title}
         </Typography>
         <div className="h-10 w-10 shrink-0" aria-hidden="true" />
       </div>

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -52,7 +52,13 @@ export function SettingsLayout() {
       (item) =>
         pathname === item.href || pathname.startsWith(item.href + "/"),
     );
-    return match?.label ?? "Settings";
+    if (match) return match.label;
+    // Index route (/assistant/settings) renders GeneralPage but doesn't
+    // match any sidebar href — use the first sidebar item's label.
+    if (pathname === routes.settings.root) {
+      return SETTINGS_SIDEBAR[0]?.label ?? "Settings";
+    }
+    return "Settings";
   }, [pathname]);
 
   useSettingsSync();

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -134,7 +134,7 @@ export const router = createBrowserRouter([
         path: "settings",
         element: <SettingsLayout />,
         children: [
-          { index: true, element: <Navigate to="general" replace /> },
+          { index: true, element: <GeneralPage /> },
           { path: "general", element: <GeneralPage /> },
           { path: "ai", element: <AiPage /> },
           { path: "integrations", element: <IntegrationsPage /> },
@@ -164,7 +164,7 @@ export const router = createBrowserRouter([
         path: "logs",
         element: <LogsLayout />,
         children: [
-          { index: true, element: <Navigate to="usage" replace /> },
+          { index: true, element: <UsagePage /> },
           { path: "trace", element: <TracePage /> },
           { path: "usage", element: <UsagePage /> },
           { path: "system-events", element: <SystemEventsPage /> },

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -134,7 +134,7 @@ export const router = createBrowserRouter([
         path: "settings",
         element: <SettingsLayout />,
         children: [
-          { index: true, element: <GeneralPage /> },
+          { index: true, element: <Navigate to="general" replace /> },
           { path: "general", element: <GeneralPage /> },
           { path: "ai", element: <AiPage /> },
           { path: "integrations", element: <IntegrationsPage /> },
@@ -164,7 +164,7 @@ export const router = createBrowserRouter([
         path: "logs",
         element: <LogsLayout />,
         children: [
-          { index: true, element: <TracePage /> },
+          { index: true, element: <Navigate to="usage" replace /> },
           { path: "trace", element: <TracePage /> },
           { path: "usage", element: <UsagePage /> },
           { path: "system-events", element: <SystemEventsPage /> },


### PR DESCRIPTION
## Summary

Fixes visual verification findings where the new web app's logs and settings navigation diverged from the platform.

Closes LUM-1780, Closes LUM-1781

## Changes

### Logs nav label/order mismatch (LUM-1780)

The logs sidebar had wrong labels, wrong order, and wrong default tab compared to the platform:

| # | Platform | Before | After |
|---|----------|--------|-------|
| 1 | Usage (default) | Trace | Usage (default) |
| 2 | Logs | Usage | Logs |
| 3 | Emails | System Events | Emails |
| 4 | System Events | Emails | System Events |

- Renamed label `"Trace"` → `"Logs"` (the route path `/logs/trace` is unchanged — only the UI label)
- Changed icon from `Activity` to `ScrollText` (semantically appropriate for log entries)
- Index route now renders `<UsagePage />` directly so Usage is the default tab
- Fallback title changed from `"Logs"` to `"Logs & Usage"` matching platform

### Settings heading shows "Settings" instead of "General" (LUM-1781)

`SettingsLayout` resolves the page heading by matching `pathname` against sidebar item `href` values. The index route renders `<GeneralPage />` at `/assistant/settings`, but the sidebar item's href is `/assistant/settings/general` — no match, falls back to "Settings".

Fix: Updated the title resolution logic in both `settings-layout.tsx` and `logs-layout.tsx` to check for the root pathname as a fallback. When the user is at `/assistant/settings` (index route), the heading now shows the first sidebar item's label ("General") instead of the generic "Settings".

### Mobile SettingsShell title fix (pre-existing)

`SettingsShell` hardcoded `"Settings"` for the mobile header title even when used by `LogsLayout`. Fixed by removing the hardcoded value and using the `title` prop consistently.

### Why NOT `<Navigate replace>` for index routes

The initial approach used `<Navigate to="general" replace />` for settings and `<Navigate to="usage" replace />` for logs. This broke the mobile sidebar flow in `SettingsShell`, which uses a two-page pattern: when `pathname === menuRoute`, it shows the sidebar full-screen; otherwise it shows the content with a back button. The `<Navigate>` redirect makes `pathname === menuRoute` unreachable, trapping mobile users in a redirect loop between the root and sub-path. Rendering the page component directly preserves the mobile flow while the updated title logic handles the heading text.

Reference: [React Router — Index Routes](https://reactrouter.com/start/framework/routing#index-routes)

## Prompt / plan

Visual verification testing (prod vs local) identified these mismatches. Platform source files used as reference: `web/src/lib/logs/navigation.ts`, `web/src/app/(app)/assistant/logs/layout.tsx`.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- `bun run build` — passes
- Bot review findings addressed: mobile sidebar flow preserved, pre-existing mobile title bug fixed
- CI

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->