### PR TITLE
feat(document-editor): live-update editor when document content changes

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -664,6 +664,18 @@ export function parseAssistantEvent(
       return { type: rawType as "document_comment_reopened" | "document_comment_deleted", ...base };
     }
 
+    case "document_editor_update": {
+      const surfaceId =
+        typeof data.surfaceId === "string" ? data.surfaceId : "";
+      const markdown =
+        typeof data.markdown === "string" ? data.markdown : "";
+      const mode = typeof data.mode === "string" ? data.mode : "replace";
+      if (!surfaceId) {
+        return { type: "unknown", rawType, data };
+      }
+      return { type: "document_editor_update", surfaceId, markdown, mode };
+    }
+
     default:
       return { type: "unknown", rawType, data };
     }

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -503,6 +503,14 @@ export interface DocumentCommentDeletedSseEvent
   conversationKey?: string;
 }
 
+export interface DocumentEditorUpdateEvent {
+  type: "document_editor_update";
+  surfaceId: string;
+  markdown: string;
+  mode: string;
+  conversationKey?: string;
+}
+
 export interface UnknownEvent {
   type: "unknown";
   rawType: string;
@@ -687,4 +695,5 @@ export type AssistantEvent =
   | DocumentCommentResolvedSseEvent
   | DocumentCommentReopenedSseEvent
   | DocumentCommentDeletedSseEvent
+  | DocumentEditorUpdateEvent
   | UnknownEvent;

--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -106,9 +106,24 @@ export function DocumentViewerContainer({
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const commentPanelRef = useRef<DocumentCommentPanelHandle>(null);
+  const initialContentRef = useRef(content);
 
-  // Generate the iframe HTML once per content change
-  const editorHTML = useMemo(() => generateEditorHTML(content), [content]);
+  // Generate the iframe HTML once on mount
+  const editorHTML = useMemo(
+    () => generateEditorHTML(initialContentRef.current),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Push content updates to the iframe in-place (preserves scroll position)
+  useEffect(() => {
+    if (content === initialContentRef.current) return;
+    initialContentRef.current = content;
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "set_content", content },
+      "*",
+    );
+  }, [content]);
 
   // -------------------------------------------------------------------------
   // postMessage listener for iframe → parent events

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -12,6 +12,7 @@ import { useConversationStore } from "@/domains/conversations/conversation-store
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
 import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { useTurnStore } from "@/domains/messaging/turn-store.js";
+import { useViewerStore } from "@/stores/viewer-store.js";
 import type { DiskPressureStatusEventPayload } from "@/assistant/use-disk-pressure-monitor.js";
 import {
   recordChatDiagnostic,
@@ -412,6 +413,13 @@ export function useStreamEventHandler(
           break;
         case "sync_changed":
           dispatchSyncChanged(event);
+          break;
+        case "document_editor_update":
+          useViewerStore.getState().updateDocumentContent(
+            event.surfaceId,
+            event.markdown,
+            event.mode,
+          );
           break;
         case "document_comment_created":
         case "document_comment_resolved":

--- a/apps/web/src/domains/chat/utils/editor-bridge.ts
+++ b/apps/web/src/domains/chat/utils/editor-bridge.ts
@@ -359,6 +359,14 @@ export function generateEditorHTML(content: string): string {
       }
     }
 
+    if (d.type === "set_content") {
+      if (typeof d.content === "string") {
+        rawContent = d.content;
+        clearActiveHighlights();
+        el.innerHTML = mdToHtml(rawContent);
+      }
+    }
+
     if (d.type === "set_comment_anchors") {
       // Remove existing anchor highlights (but keep active highlights)
       var existing = el.querySelectorAll(".comment-anchor-highlight");

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -90,6 +90,7 @@ export interface ViewerActions {
   openDocument: () => void;
   loadDocument: (assistantId: string, documentSurfaceId: string) => Promise<void>;
   setLoadedDocument: (document: OpenedDocumentState) => void;
+  updateDocumentContent: (surfaceId: string, content: string, mode: string) => void;
   handleDocumentLoadFailed: () => void;
   closeDocument: () => void;
 
@@ -289,6 +290,14 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   setLoadedDocument: (document) => {
     set({ openedDocumentState: document });
+  },
+
+  updateDocumentContent: (surfaceId, content, mode) => {
+    const state = get();
+    if (!state.openedDocumentState || state.openedDocumentState.surfaceId !== surfaceId) return;
+    const prev = state.openedDocumentState;
+    const newContent = mode === "append" ? prev.content + content : content;
+    set({ openedDocumentState: { ...prev, content: newContent } });
   },
 
   handleDocumentLoadFailed: () => {


### PR DESCRIPTION
## Summary
- Add `document_editor_update` SSE event parsing and handling so the document editor rerenders when tools like `document_replace_text` or `document_update` modify content
- Add `set_content` postMessage handler in the editor bridge iframe for in-place content updates (preserves scroll position)
- Add `updateDocumentContent` action to the viewer store that handles both replace and append modes

Previously, tool-driven content changes (e.g. `document_replace_text`) were persisted to the database and an SSE event was emitted, but the frontend silently dropped the event. The editor only showed the original content until the page was refreshed.

Part of JARVIS-903
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->