### PR TITLE
fix(document-editor): fix CI — remove invalid eslint-disable directive

### DIFF
--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -18,7 +18,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
   type Ref,
@@ -106,19 +105,15 @@ export function DocumentViewerContainer({
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const commentPanelRef = useRef<DocumentCommentPanelHandle>(null);
-  const initialContentRef = useRef(content);
+  const prevContentRef = useRef(content);
 
-  // Generate the iframe HTML once on mount
-  const editorHTML = useMemo(
-    () => generateEditorHTML(initialContentRef.current),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  // Generate the iframe HTML once on mount; subsequent updates go via postMessage
+  const [editorHTML] = useState(() => generateEditorHTML(content));
 
   // Push content updates to the iframe in-place (preserves scroll position)
   useEffect(() => {
-    if (content === initialContentRef.current) return;
-    initialContentRef.current = content;
+    if (content === prevContentRef.current) return;
+    prevContentRef.current = content;
     iframeRef.current?.contentWindow?.postMessage(
       { type: "set_content", content },
       "*",


### PR DESCRIPTION
## Summary
- Replace `useMemo` with eslint-disable for `react-hooks/exhaustive-deps` (rule doesn't exist in this project) with `useState` initializer, which is the idiomatic way to compute a value once on mount

Part of JARVIS-903
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->