### PR TITLE
Port lazy Slack channel footer to apps web

### DIFF
--- a/apps/web/src/domains/chat/api/conversations.test.ts
+++ b/apps/web/src/domains/chat/api/conversations.test.ts
@@ -57,4 +57,78 @@ describe("parseConversation — originChannel plumbing", () => {
     });
     expect(parsed?.originChannel).toBe("notification:reminder");
   });
+
+  test("preserves Slack channel binding with id, name, and link", () => {
+    const parsed = parseConversation({
+      conversationKey: "conv-123",
+      channelBinding: {
+        sourceChannel: "slack",
+        externalChatId: "C0123ABCDEF",
+        externalThreadId: "1710000000.000100",
+        externalChatName: "product",
+        slackChannel: {
+          id: "C0123ABCDEF",
+          name: "product",
+          link: "slack://channel?team=T0123&id=C0123ABCDEF",
+        },
+        slackThread: {
+          channelId: "C0123ABCDEF",
+          threadTs: "1710000000.000100",
+          link: {
+            appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
+            webUrl:
+              "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+          },
+        },
+      },
+      conversationOriginChannel: "vellum",
+    });
+
+    expect(parsed?.originChannel).toBe("slack");
+    expect(parsed?.channelBinding).toEqual({
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+      externalChatName: "product",
+      slackChannel: {
+        id: "C0123ABCDEF",
+        name: "product",
+        link: "slack://channel?team=T0123&id=C0123ABCDEF",
+      },
+      slackThread: {
+        channelId: "C0123ABCDEF",
+        threadTs: "1710000000.000100",
+        link: {
+          appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
+          webUrl:
+            "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+        },
+      },
+    });
+  });
+
+  test("does not throw for malformed or absent channelBinding", () => {
+    expect(
+      parseConversation({
+        conversationKey: "conv-123",
+        channelBinding: "slack",
+      })?.channelBinding,
+    ).toBeUndefined();
+
+    const parsed = parseConversation({
+      conversationKey: "conv-456",
+      channelBinding: {
+        sourceChannel: "slack",
+        externalChatId: 123,
+        slackChannel: {
+          id: 123,
+          name: "product",
+        },
+      },
+      conversationOriginChannel: "telegram",
+    });
+
+    expect(parsed?.originChannel).toBe("slack");
+    expect(parsed?.channelBinding).toBeUndefined();
+  });
 });

--- a/apps/web/src/domains/chat/api/conversations.ts
+++ b/apps/web/src/domains/chat/api/conversations.ts
@@ -14,6 +14,10 @@ import {
   extractErrorMessage,
   SDK_BASE_OPTIONS,
 } from "@/domains/chat/api/client.js";
+import {
+  parseSlackMessageLink,
+  type SlackMessageLink,
+} from "@/domains/chat/types/types.js";
 
 // ---------------------------------------------------------------------------
 // Conversations
@@ -33,6 +37,7 @@ export interface Conversation {
   isPinned?: boolean;
   conversationType?: string;
   scheduleJobId?: string;
+  channelBinding?: ConversationChannelBinding;
   /**
    * Channel of origin for this conversation, e.g. `"slack"`, `"telegram"`,
    * `"phone"`, `"vellum"`, or `"notification:*"`. Sourced from the daemon's
@@ -43,6 +48,28 @@ export interface Conversation {
   originChannel?: string;
   /** True for optimistic stubs not yet confirmed by the server. */
   draft?: boolean;
+}
+
+export interface ConversationChannelBinding {
+  sourceChannel: string;
+  externalChatId: string;
+  externalThreadId?: string;
+  externalChatName?: string;
+  slackChannel?: ConversationSlackChannel;
+  slackThread?: ConversationSlackThread;
+}
+
+export interface ConversationSlackChannel {
+  id?: string;
+  channelId?: string;
+  name?: string;
+  link?: string | SlackMessageLink;
+}
+
+export interface ConversationSlackThread {
+  channelId: string;
+  threadTs: string;
+  link?: SlackMessageLink;
 }
 
 interface ListConversationsResponse {
@@ -61,6 +88,83 @@ function normalizeTimestamp(value: unknown): string | undefined {
     return new Date(value).toISOString();
   }
   return undefined;
+}
+
+function parseSlackChannel(raw: unknown): ConversationSlackChannel | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : undefined;
+  const channelId =
+    typeof record.channelId === "string" ? record.channelId : undefined;
+  if (!id && !channelId) return undefined;
+
+  const link =
+    typeof record.link === "string"
+      ? record.link
+      : parseSlackMessageLink(record.link);
+  const hasLink =
+    typeof link === "string" ||
+    (typeof link === "object" && (Boolean(link.appUrl) || Boolean(link.webUrl)));
+
+  return {
+    ...(id ? { id } : {}),
+    ...(channelId ? { channelId } : {}),
+    name: typeof record.name === "string" ? record.name : undefined,
+    ...(hasLink ? { link } : {}),
+  };
+}
+
+function parseSlackThread(raw: unknown): ConversationSlackThread | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.channelId !== "string" ||
+    typeof record.threadTs !== "string"
+  ) {
+    return undefined;
+  }
+
+  const link = parseSlackMessageLink(record.link);
+
+  return {
+    channelId: record.channelId,
+    threadTs: record.threadTs,
+    ...(link?.appUrl || link?.webUrl ? { link } : {}),
+  };
+}
+
+function parseChannelBinding(
+  raw: unknown,
+): ConversationChannelBinding | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.sourceChannel !== "string" ||
+    typeof record.externalChatId !== "string"
+  ) {
+    return undefined;
+  }
+
+  const slackChannel = parseSlackChannel(record.slackChannel);
+  const slackThread = parseSlackThread(record.slackThread);
+
+  return {
+    sourceChannel: record.sourceChannel,
+    externalChatId: record.externalChatId,
+    externalThreadId:
+      typeof record.externalThreadId === "string"
+        ? record.externalThreadId
+        : undefined,
+    externalChatName:
+      typeof record.externalChatName === "string"
+        ? record.externalChatName
+        : undefined,
+    ...(slackChannel ? { slackChannel } : {}),
+    ...(slackThread ? { slackThread } : {}),
+  };
 }
 
 export function parseConversation(raw: unknown): Conversation | null {
@@ -89,6 +193,7 @@ export function parseConversation(raw: unknown): Conversation | null {
     record.channelBinding && typeof record.channelBinding === "object"
       ? (record.channelBinding as Record<string, unknown>)
       : null;
+  const parsedChannelBinding = parseChannelBinding(channelBinding);
   const bindingSourceChannel =
     channelBinding && typeof channelBinding.sourceChannel === "string"
       ? channelBinding.sourceChannel
@@ -128,6 +233,7 @@ export function parseConversation(raw: unknown): Conversation | null {
       typeof record.conversationType === "string" ? record.conversationType : undefined,
     scheduleJobId:
       typeof record.scheduleJobId === "string" ? record.scheduleJobId : undefined,
+    channelBinding: parsedChannelBinding,
     originChannel,
   };
 }

--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -7,7 +7,10 @@
  */
 
 import type { ChatMessage, ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
-import type { Surface } from "@/domains/chat/types/types.js";
+import type {
+  SlackRuntimeMessage,
+  Surface,
+} from "@/domains/chat/types/types.js";
 import {
   assertHasResponse,
   client,
@@ -87,11 +90,12 @@ export interface RuntimeMessage {
   textSegments?: Array<{ type: string; content: string; [key: string]: unknown }>;
   contentOrder?: Array<{ type: string; id: string }>;
   metadata?: Record<string, unknown>;
+  slackMessage?: SlackRuntimeMessage;
   toolCalls?: RuntimeToolCall[];
   /** Structured attachment metadata from the daemon's history endpoint. */
   attachments?: RuntimeAttachment[];
-  /** Server-provided timestamp in milliseconds since epoch. */
-  timestamp?: number;
+  /** Server-provided timestamp as epoch milliseconds or an ISO string. */
+  timestamp?: number | string;
   /** Subagent notification attached to this history message by the daemon. */
   subagentNotification?: RuntimeSubagentNotification;
 }
@@ -281,7 +285,12 @@ export async function getChatHistory(
         if (m.toolCalls && m.toolCalls.length > 0) {
           msg.toolCalls = mapRuntimeToolCalls(m.toolCalls, m.id);
         }
-        if (m.timestamp) msg.timestamp = m.timestamp;
+        if (typeof m.timestamp === "number") {
+          msg.timestamp = m.timestamp;
+        } else if (typeof m.timestamp === "string") {
+          const timestamp = Date.parse(m.timestamp);
+          if (Number.isFinite(timestamp)) msg.timestamp = timestamp;
+        }
         return msg;
       });
 

--- a/apps/web/src/domains/chat/api/slack-channel-name.ts
+++ b/apps/web/src/domains/chat/api/slack-channel-name.ts
@@ -1,0 +1,52 @@
+import { client, SDK_BASE_OPTIONS } from "@/domains/chat/api/client.js";
+
+export interface SlackChannelNameResolution {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseResolution(value: unknown): SlackChannelNameResolution | null {
+  const payload = asRecord(value);
+  if (typeof payload?.channelId !== "string") {
+    return null;
+  }
+
+  return {
+    channelId: payload.channelId,
+    channelName:
+      typeof payload.channelName === "string" ? payload.channelName : undefined,
+    cached: payload.cached === true,
+    resolved: payload.resolved === true,
+  };
+}
+
+export async function resolveSlackChannelName(
+  assistantId: string,
+  conversationId: string,
+): Promise<SlackChannelNameResolution | null> {
+  try {
+    const { data, response } = await client.post<unknown, unknown>({
+      ...SDK_BASE_OPTIONS,
+      url: "/v1/assistants/{assistant_id}/conversations/{conversationId}/slack-channel/resolve",
+      path: { assistant_id: assistantId, conversationId },
+      body: {},
+      throwOnError: false,
+    });
+
+    if (!response?.ok) {
+      return null;
+    }
+
+    return parseResolution(data);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { ChatBodyProps } from "@/domains/chat/components/chat-body.js";
@@ -57,9 +58,23 @@ mock.module(
   }),
 );
 
-mock.module("@vellum/design-library/components/notice", () => ({
+mock.module("@vellum/design-library", () => ({
+  Button: ({
+    children,
+    iconOnly,
+    ...props
+  }: {
+    children?: ReactNode;
+    iconOnly?: ReactNode;
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{iconOnly ?? children}</button>
+  ),
   Notice: ({ children }: { children: string }) => (
     <div data-testid="notice">{children}</div>
+  ),
+  ResizablePanel: () => <div data-testid="resizable-panel" />,
+  Typography: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
   ),
 }));
 
@@ -71,7 +86,7 @@ mock.module(
 );
 
 // Import after mocks are registered.
-import { ChatBody } from "@/domains/chat/components/chat-body.js";
+const { ChatBody } = await import("@/domains/chat/components/chat-body.js");
 
 const noop = () => {};
 const noopDrag = () => {};
@@ -235,5 +250,24 @@ describe("ChatBody — read-only cancellation", () => {
     expect(html).toContain('aria-label="Stop generating"');
     expect(html).toContain('title="Stop generation"');
     expect(html).not.toContain("COMPOSER");
+  });
+});
+
+describe("ChatBody — channel footer slot", () => {
+  test("renders channelFooterSlot immediately above the composer", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          channelFooterSlot: (
+            <div data-testid="channel-footer">CHANNEL_FOOTER</div>
+          ),
+        })}
+      />,
+    );
+
+    expect(html).toContain("CHANNEL_FOOTER");
+    expect(html.indexOf("CHANNEL_FOOTER")).toBeLessThan(
+      html.indexOf("COMPOSER"),
+    );
   });
 });

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -118,6 +118,12 @@ export interface ChatBodyProps {
   questionPromptSlot?: ReactNode;
 
   /**
+   * Optional pre-rendered footer rendered inside the max-width wrapper
+   * immediately above the composer or read-only banner.
+   */
+  channelFooterSlot?: ReactNode;
+
+  /**
    * Optional conversation-starter chip grid rendered inside the max-width
    * wrapper directly below the composer. Visible only on the empty state;
    * the parent passes `undefined` once messages arrive. Rendered as a
@@ -176,6 +182,7 @@ export function ChatBody({
   bannerSlot,
   queuedDrawerSlot,
   questionPromptSlot,
+  channelFooterSlot,
   startersSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
@@ -249,6 +256,7 @@ export function ChatBody({
           )}
           {queuedDrawerSlot}
           {questionPromptSlot}
+          {channelFooterSlot}
           {isChannelReadonly ? (
             <ChatReadonlyBanner
               canStopGenerating={canStopGenerating}

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -22,6 +22,7 @@ import * as Sentry from "@sentry/react";
 import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, startTransition, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { ChatBody } from "@/domains/chat/components/chat-body.js";
+import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid.js";
 import { ComposerNotices } from "@/domains/chat/components/composer-notices.js";
 import { ConfirmationPromptCard } from "@/domains/chat/components/confirmation-prompt-card.js";
@@ -1305,6 +1306,14 @@ export function ChatRouteContent({
     </div>
   ) : null;
 
+  const channelFooterSlot = (
+    <SlackChannelFooter
+      assistantId={assistantId ?? undefined}
+      conversation={activeConversation}
+      messages={messages}
+    />
+  );
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -1338,6 +1347,7 @@ export function ChatRouteContent({
             isChannelReadonly={isChannelReadonly}
             canStopGenerating={canStopGenerating}
             questionPromptSlot={questionPromptSlot}
+            channelFooterSlot={channelFooterSlot}
             startersSlot={startersSlot}
           />
         }
@@ -1411,6 +1421,7 @@ export function ChatRouteContent({
       bannerSlot={mainBannerSlot}
       queuedDrawerSlot={mainQueuedDrawerSlot}
       questionPromptSlot={questionPromptSlot}
+      channelFooterSlot={channelFooterSlot}
       startersSlot={startersSlot}
     />
   );

--- a/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { client } from "@/domains/chat/api/client.js";
+import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
+
+describe("SlackChannelFooter lazy channel name resolution", () => {
+  const originalPost = client.post;
+  let postCalls: Array<Parameters<typeof client.post>[0]> = [];
+  let nextResolveResponse: {
+    data: unknown;
+    error: unknown;
+    response: Response;
+  };
+
+  beforeEach(() => {
+    postCalls = [];
+    nextResolveResponse = {
+      data: {
+        channelId: "C0123ABCDEF",
+        channelName: "product",
+        cached: false,
+        resolved: true,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+    client.post = mock(async (options: Parameters<typeof client.post>[0]) => {
+      postCalls.push(options);
+      return nextResolveResponse;
+    }) as typeof client.post;
+  });
+
+  afterEach(() => {
+    client.post = originalPost;
+    cleanup();
+  });
+
+  test("resolves an ID-only Slack channel fallback", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-lazy-resolve",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("C0123ABCDEF")).not.toBeNull();
+
+    await waitFor(() => {
+      expect(screen.queryByText("product")).not.toBeNull();
+    });
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0]).toMatchObject({
+      url: "/v1/assistants/{assistant_id}/conversations/{conversationId}/slack-channel/resolve",
+      path: {
+        assistant_id: "assistant-1",
+        conversationId: "conv-lazy-resolve",
+      },
+      body: {},
+      throwOnError: false,
+    });
+  });
+
+  test("does not resolve when the binding already has a friendly name", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-friendly-name",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+            externalChatName: "Product",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Product")).not.toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("does not resolve Slack direct-message channels", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-direct-message",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "D0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("D0123ABCDEF")).not.toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("keeps the channel ID fallback when resolution is unavailable", async () => {
+    nextResolveResponse = {
+      data: {
+        channelId: "C9876ZYXWVU",
+        cached: false,
+        resolved: false,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-unresolved",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C9876ZYXWVU",
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+    expect(screen.queryByText("C9876ZYXWVU")).not.toBeNull();
+  });
+
+  test("deduplicates in-flight resolution for repeated renders", async () => {
+    let resolvePost:
+      | ((value: typeof nextResolveResponse) => void)
+      | undefined;
+    client.post = mock(async (options: Parameters<typeof client.post>[0]) => {
+      postCalls.push(options);
+      return await new Promise<typeof nextResolveResponse>((resolve) => {
+        resolvePost = resolve;
+      });
+    }) as typeof client.post;
+
+    render(
+      <>
+        <SlackChannelFooter
+          assistantId="assistant-1"
+          conversation={{
+            conversationKey: "conv-deduped",
+            originChannel: "slack",
+            channelBinding: {
+              sourceChannel: "slack",
+              externalChatId: "CDEDUPED123",
+            },
+          }}
+        />
+        <SlackChannelFooter
+          assistantId="assistant-1"
+          conversation={{
+            conversationKey: "conv-deduped",
+            originChannel: "slack",
+            channelBinding: {
+              sourceChannel: "slack",
+              externalChatId: "CDEDUPED123",
+            },
+          }}
+        />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+
+    resolvePost?.({
+      data: {
+        channelId: "CDEDUPED123",
+        channelName: "shared-channel",
+        cached: false,
+        resolved: true,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    });
+
+    await waitFor(() => {
+      expect(screen.queryAllByText("shared-channel")).toHaveLength(2);
+    });
+  });
+});

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from "react";
+
+import { ExternalLink, Hash } from "lucide-react";
+
+import { resolveSlackChannelName } from "@/domains/chat/api/slack-channel-name.js";
+import type {
+  Conversation,
+  ConversationChannelBinding,
+} from "@/domains/chat/api/conversations.js";
+import {
+  getSlackLinkUrl,
+  type DisplayMessage,
+  type SlackMessageLink,
+} from "@/domains/chat/types/types.js";
+
+type SlackFooterConversation = Pick<
+  Conversation,
+  "channelBinding" | "originChannel"
+> &
+  Partial<Pick<Conversation, "conversationKey">>;
+
+export interface SlackChannelFooterProps {
+  assistantId?: string;
+  conversation: SlackFooterConversation | null | undefined;
+  messages?: DisplayMessage[];
+}
+
+const slackChannelNameRequests = new Map<string, Promise<string | null>>();
+
+function getSlackChannelLink(
+  slackChannel: ConversationChannelBinding["slackChannel"],
+  messageLink?: SlackMessageLink,
+  channelId?: string,
+): string | undefined {
+  if (slackChannel?.link) {
+    if (typeof slackChannel.link === "string") return slackChannel.link;
+    return getSlackLinkUrl(slackChannel.link);
+  }
+  return getSlackChannelLinkFromMessageLink(messageLink, channelId);
+}
+
+function getSlackChannelLinkFromMessageLink(
+  messageLink: SlackMessageLink | undefined,
+  channelId: string | undefined,
+): string | undefined {
+  if (!messageLink || !channelId) return undefined;
+
+  if (messageLink.webUrl) {
+    try {
+      const url = new URL(messageLink.webUrl);
+      const channelPath = `/archives/${channelId}`;
+      if (url.pathname.startsWith(`${channelPath}/`)) {
+        url.pathname = channelPath;
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+      }
+    } catch {
+      // Fall through to app URL parsing.
+    }
+  }
+
+  if (!messageLink.appUrl) return undefined;
+  try {
+    const url = new URL(messageLink.appUrl);
+    if (url.protocol !== "slack:" || url.hostname !== "channel") {
+      return undefined;
+    }
+    const team = url.searchParams.get("team");
+    if (!team || url.searchParams.get("id") !== channelId) {
+      return undefined;
+    }
+    return `slack://channel?${new URLSearchParams({
+      team,
+      id: channelId,
+    }).toString()}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function getSlackMessageChannel(
+  messages: DisplayMessage[] | undefined,
+  channelId: string | undefined,
+) {
+  if (!messages || messages.length === 0) return undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const slackMessage = messages[i]?.slackMessage;
+    if (!slackMessage) continue;
+    if (channelId && slackMessage.channelId !== channelId) continue;
+    return slackMessage;
+  }
+  return undefined;
+}
+
+function isChannelIdFallback(
+  value: string | undefined,
+  channelBinding: ConversationChannelBinding,
+): boolean {
+  return (
+    value === undefined ||
+    value === channelBinding.externalChatId ||
+    value === channelBinding.slackChannel?.channelId ||
+    value === channelBinding.slackChannel?.id
+  );
+}
+
+function getSlackChannelDisplayText(
+  channelBinding: ConversationChannelBinding,
+  fallbackChannelName?: string,
+): string | undefined {
+  const slackChannel = channelBinding.slackChannel;
+  const primaryName = slackChannel?.name ?? channelBinding.externalChatName;
+
+  if (!isChannelIdFallback(primaryName, channelBinding)) {
+    return primaryName;
+  }
+  if (
+    fallbackChannelName &&
+    !isChannelIdFallback(fallbackChannelName, channelBinding)
+  ) {
+    return fallbackChannelName;
+  }
+
+  return (
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding.externalChatId
+  );
+}
+
+function isSlackDmChannelId(channelId: string | undefined): boolean {
+  return channelId?.startsWith("D") === true;
+}
+
+export function SlackChannelFooter({
+  assistantId,
+  conversation,
+  messages,
+}: SlackChannelFooterProps) {
+  const [resolvedChannelName, setResolvedChannelName] = useState<{
+    key: string;
+    channelName: string;
+  } | null>(null);
+
+  const channelBinding =
+    conversation?.originChannel === "slack"
+      ? conversation.channelBinding
+      : undefined;
+  const slackChannel = channelBinding?.slackChannel;
+  const channelId =
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding?.externalChatId;
+  const messageChannel = getSlackMessageChannel(messages, channelId);
+  const fallbackDisplayText = channelBinding
+    ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
+    : undefined;
+  const conversationId = conversation?.conversationKey;
+  const resolutionKey =
+    assistantId && conversationId && channelId
+      ? `${assistantId}:${conversationId}:${channelId}`
+      : undefined;
+  const shouldResolveChannelName =
+    Boolean(assistantId && conversationId && channelId && channelBinding) &&
+    !isSlackDmChannelId(channelId) &&
+    channelBinding !== undefined &&
+    isChannelIdFallback(fallbackDisplayText, channelBinding);
+
+  useEffect(() => {
+    if (
+      !shouldResolveChannelName ||
+      !assistantId ||
+      !conversationId ||
+      !channelId ||
+      !resolutionKey
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let request = slackChannelNameRequests.get(resolutionKey);
+
+    if (!request) {
+      request = resolveSlackChannelName(assistantId, conversationId).then(
+        (result) => {
+          if (
+            !result?.resolved ||
+            result.channelId !== channelId ||
+            !result.channelName
+          ) {
+            return null;
+          }
+          return result.channelName;
+        },
+      );
+      slackChannelNameRequests.set(resolutionKey, request);
+      request.finally(() => {
+        if (slackChannelNameRequests.get(resolutionKey) === request) {
+          slackChannelNameRequests.delete(resolutionKey);
+        }
+      });
+    }
+
+    request.then((channelName) => {
+      if (!cancelled && channelName) {
+        setResolvedChannelName({ key: resolutionKey, channelName });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assistantId,
+    channelId,
+    conversationId,
+    resolutionKey,
+    shouldResolveChannelName,
+  ]);
+
+  if (!channelBinding) {
+    return null;
+  }
+
+  const resolvedDisplayText =
+    resolutionKey && resolvedChannelName?.key === resolutionKey
+      ? resolvedChannelName.channelName
+      : undefined;
+  const displayText = resolvedDisplayText ?? fallbackDisplayText;
+  if (!displayText) return null;
+
+  const href = getSlackChannelLink(
+    slackChannel,
+    messageChannel?.messageLink,
+    channelId,
+  );
+  const content = (
+    <>
+      <Hash className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{displayText}</span>
+      {href ? (
+        <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className="mb-2 flex justify-center text-body-small-default text-[var(--content-tertiary)]">
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex max-w-full items-center gap-1.5 truncate rounded px-1.5 py-1 text-[var(--content-secondary)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        >
+          {content}
+        </a>
+      ) : (
+        <div className="inline-flex max-w-full items-center gap-1.5 truncate px-1.5 py-1">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/types/types.ts
+++ b/apps/web/src/domains/chat/types/types.ts
@@ -20,6 +20,51 @@ export interface DisplayAttachment {
   previewUrl: string | null;
 }
 
+export interface SlackMessageLink {
+  appUrl?: string;
+  webUrl?: string;
+}
+
+export function parseSlackMessageLink(
+  raw: unknown,
+): SlackMessageLink | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  const link = {
+    appUrl: typeof record.appUrl === "string" ? record.appUrl : undefined,
+    webUrl: typeof record.webUrl === "string" ? record.webUrl : undefined,
+  };
+
+  return link.appUrl || link.webUrl ? link : undefined;
+}
+
+export function getSlackLinkUrl(
+  link: SlackMessageLink | null | undefined,
+): string | undefined {
+  return link?.webUrl ?? link?.appUrl;
+}
+
+export interface SlackMessageSender {
+  id?: string;
+  externalUserId?: string;
+  name?: string;
+  displayName?: string;
+  username?: string;
+  avatarUrl?: string;
+  isBot?: boolean;
+}
+
+export interface SlackRuntimeMessage {
+  channelId: string;
+  channelName?: string;
+  channelTs: string;
+  threadTs?: string;
+  sender?: SlackMessageSender;
+  messageLink?: SlackMessageLink;
+  threadLink?: SlackMessageLink;
+}
+
 export interface DisplayMessage {
   /** Stable client-side identity that survives optimistic send →
    *  server reconciliation. Assigned at message creation; never mutated.
@@ -39,6 +84,7 @@ export interface DisplayMessage {
   textSegments?: Array<{ type: string; content: string; [key: string]: unknown }>;
   contentOrder?: Array<{ type: string; id: string }>;
   metadata?: Record<string, unknown>;
+  slackMessage?: SlackRuntimeMessage;
   toolCalls?: ChatMessageToolCall[];
   /** Attachments rendered inside the message bubble. For user messages these
    *  are populated client-side from the upload flow; for assistant messages

--- a/apps/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/apps/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -181,4 +181,52 @@ describe("mapRuntimeToDisplayMessage", () => {
       mimeType: "text/csv",
     });
   });
+
+  test("preserves Slack message metadata alongside mapped message fields", () => {
+    const m = makeMessage({
+      id: "msg-slack",
+      daemonMessageId: "daemon-msg-slack",
+      role: "user",
+      content: "Slack reply",
+      metadata: { source: "slack" },
+      slackMessage: {
+        channelId: "C123ABCDEF",
+        channelName: "triage",
+        channelTs: "1710000000.000200",
+        threadTs: "1710000000.000100",
+        sender: {
+          id: "U123",
+          displayName: "Ada Lovelace",
+          username: "ada",
+          avatarUrl: "https://example.com/avatar.png",
+          isBot: false,
+        },
+        messageLink: {
+          appUrl:
+            "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000200",
+          webUrl:
+            "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
+        },
+        threadLink: {
+          appUrl:
+            "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000100",
+          webUrl:
+            "https://example.slack.com/archives/C123ABCDEF/p1710000000000100",
+        },
+      },
+      timestamp: "2026-05-15T12:34:56.000Z",
+    });
+
+    const display = mapRuntimeToDisplayMessage(m);
+
+    expect(display).toMatchObject({
+      id: "msg-slack",
+      daemonMessageId: "daemon-msg-slack",
+      role: "user",
+      content: "Slack reply",
+      metadata: { source: "slack" },
+      slackMessage: m.slackMessage,
+      timestamp: Date.parse("2026-05-15T12:34:56.000Z"),
+    });
+  });
 });

--- a/apps/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/apps/web/src/domains/chat/utils/map-runtime-message.ts
@@ -1,7 +1,11 @@
 import { runtimeAttachmentsToDisplay } from "@/domains/chat/utils/attachment-mapping.js";
 import { parseAttachmentSummariesFromContent } from "@/domains/chat/utils/parse-attachment-summaries.js";
 import { newStableId } from "@/domains/chat/utils/stable-id.js";
-import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types.js";
+import type {
+  DisplayAttachment,
+  DisplayMessage,
+  SlackRuntimeMessage,
+} from "@/domains/chat/types/types.js";
 import { mapRuntimeToolCalls, normalizeContentOrder, normalizeTextSegments, type RuntimeMessage } from "@/domains/chat/api/messages.js";
 
 /**
@@ -25,6 +29,7 @@ export interface PreparedRuntimeMessage {
     | undefined;
   normalizedContentOrder: Array<{ type: string; id: string }> | undefined;
   toolCalls: ReturnType<typeof mapRuntimeToolCalls> | undefined;
+  slackMessage: SlackRuntimeMessage | undefined;
   timestamp: number | undefined;
 }
 
@@ -98,6 +103,7 @@ export function prepareServerMessage(m: RuntimeMessage): PreparedRuntimeMessage 
     normalizedSegments,
     normalizedContentOrder,
     toolCalls,
+    slackMessage: m.slackMessage,
     timestamp,
   };
 }
@@ -124,6 +130,7 @@ export function mapRuntimeToDisplayMessage(m: RuntimeMessage): DisplayMessage {
   if (prepared.normalizedContentOrder) msg.contentOrder = prepared.normalizedContentOrder;
   if (m.metadata) msg.metadata = m.metadata;
   if (m.subagentNotification) msg.isSubagentNotification = true;
+  if (prepared.slackMessage) msg.slackMessage = prepared.slackMessage;
   if (prepared.toolCalls) msg.toolCalls = prepared.toolCalls;
   if (prepared.timestamp != null) msg.timestamp = prepared.timestamp;
 

--- a/apps/web/src/domains/chat/utils/message-merge.ts
+++ b/apps/web/src/domains/chat/utils/message-merge.ts
@@ -18,6 +18,7 @@ export function messagesEqual(a: DisplayMessage[], b: DisplayMessage[]): boolean
       JSON.stringify(am.textSegments) !== JSON.stringify(bm.textSegments) ||
       JSON.stringify(am.contentOrder) !== JSON.stringify(bm.contentOrder) ||
       JSON.stringify(am.metadata) !== JSON.stringify(bm.metadata) ||
+      JSON.stringify(am.slackMessage) !== JSON.stringify(bm.slackMessage) ||
       JSON.stringify(am.toolCalls) !== JSON.stringify(bm.toolCalls) ||
       JSON.stringify(am.attachments) !== JSON.stringify(bm.attachments)
     ) {
@@ -36,6 +37,7 @@ export function messagesEqual(a: DisplayMessage[], b: DisplayMessage[]): boolean
       "textSegments",
       "contentOrder",
       "metadata",
+      "slackMessage",
       "toolCalls",
       "attachments",
       "timestamp",
@@ -176,6 +178,9 @@ export function mergeDuplicateMessages(
       ...(preferred.metadata ?? {}),
     };
   }
+  if (current.slackMessage || incoming.slackMessage) {
+    merged.slackMessage = incoming.slackMessage ?? current.slackMessage;
+  }
 
   if (!merged.contentOrder) {
     merged.contentOrder = current.contentOrder ?? incoming.contentOrder;
@@ -260,6 +265,9 @@ export function mergeLatestHistoryMessage(
       ...(current.metadata ?? {}),
       ...(incoming.metadata ?? {}),
     };
+  }
+  if (current.slackMessage || incoming.slackMessage) {
+    merged.slackMessage = incoming.slackMessage ?? current.slackMessage;
   }
 
   if (merged.timestamp == null) {


### PR DESCRIPTION
## Summary
- port lazy Slack channel footer resolution into `apps/web`
- parse Slack channel bindings and preserve Slack message metadata in migrated chat state
- add focused migrated-web tests for binding parsing, footer resolution, and runtime message mapping

## Tests
- `cd apps/web && bun test src/domains/chat/components/slack-channel-footer.test.tsx src/domains/chat/components/chat-body.test.tsx src/domains/chat/api/conversations.test.ts src/domains/chat/utils/map-runtime-message.test.ts`
- `cd apps/web && bun run lint src/domains/chat/api/conversations.ts src/domains/chat/api/conversations.test.ts src/domains/chat/api/messages.ts src/domains/chat/api/slack-channel-name.ts src/domains/chat/components/chat-body.tsx src/domains/chat/components/chat-body.test.tsx src/domains/chat/components/chat-route-content.tsx src/domains/chat/components/slack-channel-footer.tsx src/domains/chat/components/slack-channel-footer.test.tsx src/domains/chat/types/types.ts src/domains/chat/utils/map-runtime-message.ts src/domains/chat/utils/map-runtime-message.test.ts src/domains/chat/utils/message-merge.ts`
- `cd apps/web && bun run typecheck`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->