### PR TITLE
fix(document-editor): handle max_replacements=0 edge case

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -433,7 +433,10 @@ export function replaceInDocument(
       : new RegExp(escapeRegExpChars(find), flags);
 
     const totalMatches = [...row.content.matchAll(pattern)].length;
-    if (totalMatches === 0) {
+    if (
+      totalMatches === 0 ||
+      (options.maxReplacements != null && options.maxReplacements <= 0)
+    ) {
       return { success: true, replacements_made: 0, content_changed: false };
     }
 


### PR DESCRIPTION
## Summary
- Short-circuit `replaceInDocument` when `max_replacements` is 0 or negative, returning `content_changed: false` instead of falling through to the write path

Addresses Codex review feedback on #31423.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->