### PR TITLE
feat(web): add IntelligenceLayout with About Assistant tab bar (LUM-1779)

### DIFF
--- a/apps/web/src/domains/intelligence/components/apps/library-view.tsx
+++ b/apps/web/src/domains/intelligence/components/apps/library-view.tsx
@@ -619,11 +619,8 @@ export function LibraryView({
   );
 
   return (
-    <div className="flex h-full flex-col overflow-hidden p-6">
-      <div className="mb-6 flex shrink-0 items-center justify-between">
-        <h1 className="text-title-large text-[var(--content-default)]">
-          Library
-        </h1>
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="mb-4 flex shrink-0 items-center justify-end">
         <div className="flex items-center gap-2">
           <input
             ref={fileInputRef}

--- a/apps/web/src/domains/intelligence/identity-page.tsx
+++ b/apps/web/src/domains/intelligence/identity-page.tsx
@@ -4,9 +4,5 @@ import { IdentityTab } from "@/domains/intelligence/components/identity-tab.js";
 export function IdentityPage() {
   const { assistantId } = useAssistantContext();
   if (!assistantId) return null;
-  return (
-    <div className="h-full overflow-y-auto p-6">
-      <IdentityTab assistantId={assistantId} />
-    </div>
-  );
+  return <IdentityTab assistantId={assistantId} />;
 }

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -1,0 +1,72 @@
+import { NavLink, Outlet, useLocation } from "react-router";
+
+import { cn } from "@vellum/design-library";
+
+import { routes } from "@/utils/routes.js";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
+
+const INTELLIGENCE_TABS = [
+  { label: "Identity", to: routes.identity },
+  { label: "Skills", to: routes.library.root },
+  { label: "Workspace", to: routes.workspace },
+  { label: "Contacts", to: routes.contacts.root },
+] as const;
+
+/**
+ * Shared layout for the "About Assistant" pages (Identity, Skills,
+ * Workspace, Contacts). Renders a heading + tab bar above an
+ * `<Outlet />` for the active tab's content.
+ *
+ * Mounted as a pathless layout route in `routes.tsx` so the child
+ * routes keep their existing URL paths (`/assistant/identity`, etc.)
+ * while inheriting the shared chrome.
+ *
+ * References:
+ * - React Router layout routes: https://reactrouter.com/start/framework/routing#layout-routes
+ * - Platform source: AssistantPageClient.tsx lines 2250-2290
+ */
+export function IntelligenceLayout() {
+  const assistantName = useAssistantIdentityStore.use.name();
+  const { pathname } = useLocation();
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-6 py-5">
+      <h1 className="mb-4 shrink-0 text-title-large text-[var(--content-default)]">
+        About {assistantName || "Assistant"}
+      </h1>
+
+      <nav
+        className="mb-4 flex shrink-0 items-center overflow-x-auto border-b border-[var(--border-base)]"
+        style={{ scrollbarWidth: "none", WebkitOverflowScrolling: "touch" }}
+        aria-label="About assistant sections"
+      >
+        {INTELLIGENCE_TABS.map(({ label, to }) => {
+          const isActive =
+            pathname === to || pathname.startsWith(to + "/");
+          return (
+            <NavLink
+              key={to}
+              to={to}
+              className={cn(
+                "relative -mb-px inline-flex cursor-pointer items-center gap-1.5 border-b-2 border-transparent bg-transparent px-2.5 py-[7px]",
+                "text-body-medium-default whitespace-nowrap",
+                "text-[var(--content-tertiary)] transition-colors",
+                "outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-0",
+                "hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)]",
+                isActive &&
+                  "border-[var(--primary-base)] text-[var(--content-default)]",
+                isActive && "hover:bg-transparent",
+              )}
+            >
+              {label}
+            </NavLink>
+          );
+        })}
+      </nav>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useLocation } from "react-router";
+import { NavLink, Outlet, useLocation, useOutletContext } from "react-router";
 
 import { cn } from "@vellum/design-library";
 
@@ -28,6 +28,7 @@ const INTELLIGENCE_TABS = [
 export function IntelligenceLayout() {
   const assistantName = useAssistantIdentityStore.use.name();
   const { pathname } = useLocation();
+  const outletContext = useOutletContext();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-6 py-5">
@@ -65,7 +66,7 @@ export function IntelligenceLayout() {
       </nav>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <Outlet />
+        <Outlet context={outletContext} />
       </div>
     </div>
   );

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -65,7 +65,7 @@ export function IntelligenceLayout() {
         })}
       </nav>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <Outlet context={outletContext} />
       </div>
     </div>

--- a/apps/web/src/domains/library/library-page.tsx
+++ b/apps/web/src/domains/library/library-page.tsx
@@ -32,12 +32,10 @@ export function LibraryPage() {
   if (!assistantId) return null;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)]">
-      <LibraryView
-        assistantId={assistantId}
-        onNewConversation={handleNewConversation}
-        onOpenDocument={handleOpenDocument}
-      />
-    </div>
+    <LibraryView
+      assistantId={assistantId}
+      onNewConversation={handleNewConversation}
+      onOpenDocument={handleOpenDocument}
+    />
   );
 }

--- a/apps/web/src/domains/workspace/workspace-page.tsx
+++ b/apps/web/src/domains/workspace/workspace-page.tsx
@@ -4,9 +4,5 @@ import { WorkspaceBrowser } from "@/domains/workspace/components/workspace-brows
 export function WorkspacePage() {
   const { assistantId } = useAssistantContext();
   if (!assistantId) return null;
-  return (
-    <div className="h-full overflow-y-auto p-6">
-      <WorkspaceBrowser assistantId={assistantId} />
-    </div>
-  );
+  return <WorkspaceBrowser assistantId={assistantId} />;
 }

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -9,6 +9,7 @@ import { HomePage } from "@/domains/home/home-page.js";
 import { LibraryPage } from "@/domains/library/library-page.js";
 import { LibraryDetailPage } from "@/domains/library/library-detail-page.js";
 import { IdentityPage } from "@/domains/intelligence/identity-page.js";
+import { IntelligenceLayout } from "@/domains/intelligence/intelligence-layout.js";
 import { ConnectPage } from "@/domains/contacts/connect-page.js";
 import { ContactsPage } from "@/domains/contacts/contacts-page.js";
 import { WorkspacePage } from "@/domains/workspace/workspace-page.js";
@@ -179,11 +180,16 @@ export const router = createBrowserRouter([
           { path: "conversations/:conversationKey", element: <ChatPage /> },
           { path: "documents/:surfaceId", element: <DocumentViewerPage /> },
           { path: "home", element: <HomePageRoute /> },
-          { path: "library", element: <LibraryPage /> },
-          { path: "library/:appId", element: <LibraryDetailPage /> },
-          { path: "identity", element: <IdentityPage /> },
-          { path: "workspace", element: <WorkspacePage /> },
-          { path: "contacts", element: <ContactsPage /> },
+          {
+            element: <IntelligenceLayout />,
+            children: [
+              { path: "identity", element: <IdentityPage /> },
+              { path: "library", element: <LibraryPage /> },
+              { path: "library/:appId", element: <LibraryDetailPage /> },
+              { path: "workspace", element: <WorkspacePage /> },
+              { path: "contacts", element: <ContactsPage /> },
+            ],
+          },
           { path: "connect", element: <ConnectPage /> },
           { path: "inspect", element: <InspectPage /> },
         ],

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -185,11 +185,11 @@ export const router = createBrowserRouter([
             children: [
               { path: "identity", element: <IdentityPage /> },
               { path: "library", element: <LibraryPage /> },
-              { path: "library/:appId", element: <LibraryDetailPage /> },
               { path: "workspace", element: <WorkspacePage /> },
               { path: "contacts", element: <ContactsPage /> },
             ],
           },
+          { path: "library/:appId", element: <LibraryDetailPage /> },
           { path: "connect", element: <ConnectPage /> },
           { path: "inspect", element: <InspectPage /> },
         ],


### PR DESCRIPTION
## Summary

Adds the shared "About Assistant" parent layout with heading and tab navigation bar for the Identity, Skills/Library, Workspace, and Contacts pages — matching the platform's intelligence section.

Closes LUM-1779

## Changes

### IntelligenceLayout component (`domains/intelligence/intelligence-layout.tsx`)

New pathless layout route component that renders:
- **Heading**: "About {assistantName}" using `useAssistantIdentityStore`
- **Tab bar**: NavLink-based navigation with 4 tabs (Identity, Skills, Workspace, Contacts)
- **Content area**: `<Outlet />` for the active tab's child route, forwarding ChatLayout's outlet context

Tab styling reuses the design library's `TabsTrigger` visual appearance (border-b-2 active indicator, content-tertiary/content-default color states, surface-hover, ring focus) via NavLink `className` with pathname-based active detection.

### Route restructuring (`routes.tsx`)

The 4 intelligence pages are now nested under a pathless `IntelligenceLayout` route inside `ChatLayout`. `library/:appId` (app viewer) stays as a direct child of `ChatLayout` for full content area. All existing URL paths are preserved:
- `/assistant/identity` → IntelligenceLayout → IdentityPage
- `/assistant/library` → IntelligenceLayout → LibraryPage
- `/assistant/library/:appId` → ChatLayout → LibraryDetailPage (full viewport)
- `/assistant/workspace` → IntelligenceLayout → WorkspacePage
- `/assistant/contacts` → IntelligenceLayout → ContactsPage

Reference: [React Router — Layout Routes](https://reactrouter.com/start/framework/routing#layout-routes)

### Container and heading cleanup

- Removed redundant outer wrappers from IdentityPage, WorkspacePage, and LibraryPage — IntelligenceLayout provides shared container chrome
- Removed duplicate `<h1>Library</h1>` from LibraryView — IntelligenceLayout provides section heading
- Scroll container uses `flex flex-col` so ContactsPage's `flex-1` fills height correctly

### Outlet context forwarding

`IntelligenceLayout` reads the parent context via `useOutletContext()` and passes it through `<Outlet context={outletContext} />` so child routes retain access to `useAssistantContext()` (which reads from the immediate parent's outlet context).

### Why NavLink instead of Radix Tabs

The design library's `Tabs` component uses Radix Tabs, designed for client-side content switching within a single page. Since these tabs navigate between React Router routes, NavLink is idiomatic — each tab is a real link with history entries, browser back/forward support, and direct URL sharing.

### Platform divergence

The platform uses `Tabs.Root` with `onValueChange` in `AssistantPageClient.tsx` because all 4 tabs are rendered inline. The new repo's route-based architecture makes NavLink the correct choice.

## Prompt / plan

Visual verification testing (prod vs local) identified that Identity, Skills/Library, Workspace, and Contacts pages were missing the shared "About Assistant" heading and tab bar. Platform source: `AssistantPageClient.tsx` lines 2250-2290.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- CI

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->