### PR TITLE
Lazy Slack channel names

### DIFF
--- a/apps/web/src/domains/chat/api/conversations.test.ts
+++ b/apps/web/src/domains/chat/api/conversations.test.ts
@@ -57,4 +57,78 @@ describe("parseConversation — originChannel plumbing", () => {
     });
     expect(parsed?.originChannel).toBe("notification:reminder");
   });
+
+  test("preserves Slack channel binding with id, name, and link", () => {
+    const parsed = parseConversation({
+      conversationKey: "conv-123",
+      channelBinding: {
+        sourceChannel: "slack",
+        externalChatId: "C0123ABCDEF",
+        externalThreadId: "1710000000.000100",
+        externalChatName: "product",
+        slackChannel: {
+          id: "C0123ABCDEF",
+          name: "product",
+          link: "slack://channel?team=T0123&id=C0123ABCDEF",
+        },
+        slackThread: {
+          channelId: "C0123ABCDEF",
+          threadTs: "1710000000.000100",
+          link: {
+            appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
+            webUrl:
+              "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+          },
+        },
+      },
+      conversationOriginChannel: "vellum",
+    });
+
+    expect(parsed?.originChannel).toBe("slack");
+    expect(parsed?.channelBinding).toEqual({
+      sourceChannel: "slack",
+      externalChatId: "C0123ABCDEF",
+      externalThreadId: "1710000000.000100",
+      externalChatName: "product",
+      slackChannel: {
+        id: "C0123ABCDEF",
+        name: "product",
+        link: "slack://channel?team=T0123&id=C0123ABCDEF",
+      },
+      slackThread: {
+        channelId: "C0123ABCDEF",
+        threadTs: "1710000000.000100",
+        link: {
+          appUrl: "slack://channel?team=T0123&id=C0123ABCDEF",
+          webUrl:
+            "https://example.slack.com/archives/C0123ABCDEF/p1710000000000100",
+        },
+      },
+    });
+  });
+
+  test("does not throw for malformed or absent channelBinding", () => {
+    expect(
+      parseConversation({
+        conversationKey: "conv-123",
+        channelBinding: "slack",
+      })?.channelBinding,
+    ).toBeUndefined();
+
+    const parsed = parseConversation({
+      conversationKey: "conv-456",
+      channelBinding: {
+        sourceChannel: "slack",
+        externalChatId: 123,
+        slackChannel: {
+          id: 123,
+          name: "product",
+        },
+      },
+      conversationOriginChannel: "telegram",
+    });
+
+    expect(parsed?.originChannel).toBe("slack");
+    expect(parsed?.channelBinding).toBeUndefined();
+  });
 });

--- a/apps/web/src/domains/chat/api/conversations.ts
+++ b/apps/web/src/domains/chat/api/conversations.ts
@@ -14,6 +14,10 @@ import {
   extractErrorMessage,
   SDK_BASE_OPTIONS,
 } from "@/domains/chat/api/client.js";
+import {
+  parseSlackMessageLink,
+  type SlackMessageLink,
+} from "@/domains/chat/types/types.js";
 
 // ---------------------------------------------------------------------------
 // Conversations
@@ -33,6 +37,7 @@ export interface Conversation {
   isPinned?: boolean;
   conversationType?: string;
   scheduleJobId?: string;
+  channelBinding?: ConversationChannelBinding;
   /**
    * Channel of origin for this conversation, e.g. `"slack"`, `"telegram"`,
    * `"phone"`, `"vellum"`, or `"notification:*"`. Sourced from the daemon's
@@ -43,6 +48,28 @@ export interface Conversation {
   originChannel?: string;
   /** True for optimistic stubs not yet confirmed by the server. */
   draft?: boolean;
+}
+
+export interface ConversationChannelBinding {
+  sourceChannel: string;
+  externalChatId: string;
+  externalThreadId?: string;
+  externalChatName?: string;
+  slackChannel?: ConversationSlackChannel;
+  slackThread?: ConversationSlackThread;
+}
+
+export interface ConversationSlackChannel {
+  id?: string;
+  channelId?: string;
+  name?: string;
+  link?: string | SlackMessageLink;
+}
+
+export interface ConversationSlackThread {
+  channelId: string;
+  threadTs: string;
+  link?: SlackMessageLink;
 }
 
 interface ListConversationsResponse {
@@ -61,6 +88,83 @@ function normalizeTimestamp(value: unknown): string | undefined {
     return new Date(value).toISOString();
   }
   return undefined;
+}
+
+function parseSlackChannel(raw: unknown): ConversationSlackChannel | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : undefined;
+  const channelId =
+    typeof record.channelId === "string" ? record.channelId : undefined;
+  if (!id && !channelId) return undefined;
+
+  const link =
+    typeof record.link === "string"
+      ? record.link
+      : parseSlackMessageLink(record.link);
+  const hasLink =
+    typeof link === "string" ||
+    (typeof link === "object" && (Boolean(link.appUrl) || Boolean(link.webUrl)));
+
+  return {
+    ...(id ? { id } : {}),
+    ...(channelId ? { channelId } : {}),
+    name: typeof record.name === "string" ? record.name : undefined,
+    ...(hasLink ? { link } : {}),
+  };
+}
+
+function parseSlackThread(raw: unknown): ConversationSlackThread | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.channelId !== "string" ||
+    typeof record.threadTs !== "string"
+  ) {
+    return undefined;
+  }
+
+  const link = parseSlackMessageLink(record.link);
+
+  return {
+    channelId: record.channelId,
+    threadTs: record.threadTs,
+    ...(link?.appUrl || link?.webUrl ? { link } : {}),
+  };
+}
+
+function parseChannelBinding(
+  raw: unknown,
+): ConversationChannelBinding | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.sourceChannel !== "string" ||
+    typeof record.externalChatId !== "string"
+  ) {
+    return undefined;
+  }
+
+  const slackChannel = parseSlackChannel(record.slackChannel);
+  const slackThread = parseSlackThread(record.slackThread);
+
+  return {
+    sourceChannel: record.sourceChannel,
+    externalChatId: record.externalChatId,
+    externalThreadId:
+      typeof record.externalThreadId === "string"
+        ? record.externalThreadId
+        : undefined,
+    externalChatName:
+      typeof record.externalChatName === "string"
+        ? record.externalChatName
+        : undefined,
+    ...(slackChannel ? { slackChannel } : {}),
+    ...(slackThread ? { slackThread } : {}),
+  };
 }
 
 export function parseConversation(raw: unknown): Conversation | null {
@@ -89,6 +193,7 @@ export function parseConversation(raw: unknown): Conversation | null {
     record.channelBinding && typeof record.channelBinding === "object"
       ? (record.channelBinding as Record<string, unknown>)
       : null;
+  const parsedChannelBinding = parseChannelBinding(channelBinding);
   const bindingSourceChannel =
     channelBinding && typeof channelBinding.sourceChannel === "string"
       ? channelBinding.sourceChannel
@@ -128,6 +233,7 @@ export function parseConversation(raw: unknown): Conversation | null {
       typeof record.conversationType === "string" ? record.conversationType : undefined,
     scheduleJobId:
       typeof record.scheduleJobId === "string" ? record.scheduleJobId : undefined,
+    channelBinding: parsedChannelBinding,
     originChannel,
   };
 }

--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -7,7 +7,10 @@
  */
 
 import type { ChatMessage, ChatMessageToolCall } from "@/domains/chat/api/event-types.js";
-import type { Surface } from "@/domains/chat/types/types.js";
+import type {
+  SlackRuntimeMessage,
+  Surface,
+} from "@/domains/chat/types/types.js";
 import {
   assertHasResponse,
   client,
@@ -87,11 +90,12 @@ export interface RuntimeMessage {
   textSegments?: Array<{ type: string; content: string; [key: string]: unknown }>;
   contentOrder?: Array<{ type: string; id: string }>;
   metadata?: Record<string, unknown>;
+  slackMessage?: SlackRuntimeMessage;
   toolCalls?: RuntimeToolCall[];
   /** Structured attachment metadata from the daemon's history endpoint. */
   attachments?: RuntimeAttachment[];
-  /** Server-provided timestamp in milliseconds since epoch. */
-  timestamp?: number;
+  /** Server-provided timestamp as epoch milliseconds or an ISO string. */
+  timestamp?: number | string;
   /** Subagent notification attached to this history message by the daemon. */
   subagentNotification?: RuntimeSubagentNotification;
 }
@@ -281,7 +285,12 @@ export async function getChatHistory(
         if (m.toolCalls && m.toolCalls.length > 0) {
           msg.toolCalls = mapRuntimeToolCalls(m.toolCalls, m.id);
         }
-        if (m.timestamp) msg.timestamp = m.timestamp;
+        if (typeof m.timestamp === "number") {
+          msg.timestamp = m.timestamp;
+        } else if (typeof m.timestamp === "string") {
+          const timestamp = Date.parse(m.timestamp);
+          if (Number.isFinite(timestamp)) msg.timestamp = timestamp;
+        }
         return msg;
       });
 

--- a/apps/web/src/domains/chat/api/slack-channel-name.ts
+++ b/apps/web/src/domains/chat/api/slack-channel-name.ts
@@ -1,0 +1,52 @@
+import { client, SDK_BASE_OPTIONS } from "@/domains/chat/api/client.js";
+
+export interface SlackChannelNameResolution {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseResolution(value: unknown): SlackChannelNameResolution | null {
+  const payload = asRecord(value);
+  if (typeof payload?.channelId !== "string") {
+    return null;
+  }
+
+  return {
+    channelId: payload.channelId,
+    channelName:
+      typeof payload.channelName === "string" ? payload.channelName : undefined,
+    cached: payload.cached === true,
+    resolved: payload.resolved === true,
+  };
+}
+
+export async function resolveSlackChannelName(
+  assistantId: string,
+  conversationId: string,
+): Promise<SlackChannelNameResolution | null> {
+  try {
+    const { data, response } = await client.post<unknown, unknown>({
+      ...SDK_BASE_OPTIONS,
+      url: "/v1/assistants/{assistant_id}/conversations/{conversationId}/slack-channel/resolve",
+      path: { assistant_id: assistantId, conversationId },
+      body: {},
+      throwOnError: false,
+    });
+
+    if (!response?.ok) {
+      return null;
+    }
+
+    return parseResolution(data);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { ChatBodyProps } from "@/domains/chat/components/chat-body.js";
@@ -57,9 +58,23 @@ mock.module(
   }),
 );
 
-mock.module("@vellum/design-library/components/notice", () => ({
+mock.module("@vellum/design-library", () => ({
+  Button: ({
+    children,
+    iconOnly,
+    ...props
+  }: {
+    children?: ReactNode;
+    iconOnly?: ReactNode;
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{iconOnly ?? children}</button>
+  ),
   Notice: ({ children }: { children: string }) => (
     <div data-testid="notice">{children}</div>
+  ),
+  ResizablePanel: () => <div data-testid="resizable-panel" />,
+  Typography: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
   ),
 }));
 
@@ -71,7 +86,7 @@ mock.module(
 );
 
 // Import after mocks are registered.
-import { ChatBody } from "@/domains/chat/components/chat-body.js";
+const { ChatBody } = await import("@/domains/chat/components/chat-body.js");
 
 const noop = () => {};
 const noopDrag = () => {};
@@ -235,5 +250,24 @@ describe("ChatBody — read-only cancellation", () => {
     expect(html).toContain('aria-label="Stop generating"');
     expect(html).toContain('title="Stop generation"');
     expect(html).not.toContain("COMPOSER");
+  });
+});
+
+describe("ChatBody — channel footer slot", () => {
+  test("renders channelFooterSlot immediately above the composer", () => {
+    const html = renderToStaticMarkup(
+      <ChatBody
+        {...baseProps({
+          channelFooterSlot: (
+            <div data-testid="channel-footer">CHANNEL_FOOTER</div>
+          ),
+        })}
+      />,
+    );
+
+    expect(html).toContain("CHANNEL_FOOTER");
+    expect(html.indexOf("CHANNEL_FOOTER")).toBeLessThan(
+      html.indexOf("COMPOSER"),
+    );
   });
 });

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -118,6 +118,12 @@ export interface ChatBodyProps {
   questionPromptSlot?: ReactNode;
 
   /**
+   * Optional pre-rendered footer rendered inside the max-width wrapper
+   * immediately above the composer or read-only banner.
+   */
+  channelFooterSlot?: ReactNode;
+
+  /**
    * Optional conversation-starter chip grid rendered inside the max-width
    * wrapper directly below the composer. Visible only on the empty state;
    * the parent passes `undefined` once messages arrive. Rendered as a
@@ -176,6 +182,7 @@ export function ChatBody({
   bannerSlot,
   queuedDrawerSlot,
   questionPromptSlot,
+  channelFooterSlot,
   startersSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
@@ -249,6 +256,7 @@ export function ChatBody({
           )}
           {queuedDrawerSlot}
           {questionPromptSlot}
+          {channelFooterSlot}
           {isChannelReadonly ? (
             <ChatReadonlyBanner
               canStopGenerating={canStopGenerating}

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -22,6 +22,7 @@ import * as Sentry from "@sentry/react";
 import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, startTransition, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { ChatBody } from "@/domains/chat/components/chat-body.js";
+import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid.js";
 import { ComposerNotices } from "@/domains/chat/components/composer-notices.js";
 import { ConfirmationPromptCard } from "@/domains/chat/components/confirmation-prompt-card.js";
@@ -1305,6 +1306,14 @@ export function ChatRouteContent({
     </div>
   ) : null;
 
+  const channelFooterSlot = (
+    <SlackChannelFooter
+      assistantId={assistantId ?? undefined}
+      conversation={activeConversation}
+      messages={messages}
+    />
+  );
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -1338,6 +1347,7 @@ export function ChatRouteContent({
             isChannelReadonly={isChannelReadonly}
             canStopGenerating={canStopGenerating}
             questionPromptSlot={questionPromptSlot}
+            channelFooterSlot={channelFooterSlot}
             startersSlot={startersSlot}
           />
         }
@@ -1411,6 +1421,7 @@ export function ChatRouteContent({
       bannerSlot={mainBannerSlot}
       queuedDrawerSlot={mainQueuedDrawerSlot}
       questionPromptSlot={questionPromptSlot}
+      channelFooterSlot={channelFooterSlot}
       startersSlot={startersSlot}
     />
   );

--- a/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { client } from "@/domains/chat/api/client.js";
+import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
+
+describe("SlackChannelFooter lazy channel name resolution", () => {
+  const originalPost = client.post;
+  let postCalls: Array<Parameters<typeof client.post>[0]> = [];
+  let nextResolveResponse: {
+    data: unknown;
+    error: unknown;
+    response: Response;
+  };
+
+  beforeEach(() => {
+    postCalls = [];
+    nextResolveResponse = {
+      data: {
+        channelId: "C0123ABCDEF",
+        channelName: "product",
+        cached: false,
+        resolved: true,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+    client.post = mock(async (options: Parameters<typeof client.post>[0]) => {
+      postCalls.push(options);
+      return nextResolveResponse;
+    }) as typeof client.post;
+  });
+
+  afterEach(() => {
+    client.post = originalPost;
+    cleanup();
+  });
+
+  test("resolves an ID-only Slack channel fallback", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-lazy-resolve",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("C0123ABCDEF")).not.toBeNull();
+
+    await waitFor(() => {
+      expect(screen.queryByText("product")).not.toBeNull();
+    });
+
+    expect(postCalls).toHaveLength(1);
+    expect(postCalls[0]).toMatchObject({
+      url: "/v1/assistants/{assistant_id}/conversations/{conversationId}/slack-channel/resolve",
+      path: {
+        assistant_id: "assistant-1",
+        conversationId: "conv-lazy-resolve",
+      },
+      body: {},
+      throwOnError: false,
+    });
+  });
+
+  test("does not resolve when the binding already has a friendly name", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-friendly-name",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+            externalChatName: "Product",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Product")).not.toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("does not resolve Slack direct-message channels", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-direct-message",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "D0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("D0123ABCDEF")).not.toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("keeps the channel ID fallback when resolution is unavailable", async () => {
+    nextResolveResponse = {
+      data: {
+        channelId: "C9876ZYXWVU",
+        cached: false,
+        resolved: false,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-unresolved",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C9876ZYXWVU",
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+    expect(screen.queryByText("C9876ZYXWVU")).not.toBeNull();
+  });
+
+  test("deduplicates in-flight resolution for repeated renders", async () => {
+    let resolvePost:
+      | ((value: typeof nextResolveResponse) => void)
+      | undefined;
+    client.post = mock(async (options: Parameters<typeof client.post>[0]) => {
+      postCalls.push(options);
+      return await new Promise<typeof nextResolveResponse>((resolve) => {
+        resolvePost = resolve;
+      });
+    }) as typeof client.post;
+
+    render(
+      <>
+        <SlackChannelFooter
+          assistantId="assistant-1"
+          conversation={{
+            conversationKey: "conv-deduped",
+            originChannel: "slack",
+            channelBinding: {
+              sourceChannel: "slack",
+              externalChatId: "CDEDUPED123",
+            },
+          }}
+        />
+        <SlackChannelFooter
+          assistantId="assistant-1"
+          conversation={{
+            conversationKey: "conv-deduped",
+            originChannel: "slack",
+            channelBinding: {
+              sourceChannel: "slack",
+              externalChatId: "CDEDUPED123",
+            },
+          }}
+        />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+
+    resolvePost?.({
+      data: {
+        channelId: "CDEDUPED123",
+        channelName: "shared-channel",
+        cached: false,
+        resolved: true,
+      },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    });
+
+    await waitFor(() => {
+      expect(screen.queryAllByText("shared-channel")).toHaveLength(2);
+    });
+  });
+});

--- a/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
@@ -141,6 +141,44 @@ describe("SlackChannelFooter lazy channel name resolution", () => {
     expect(screen.queryByText("C9876ZYXWVU")).not.toBeNull();
   });
 
+  test("prefers a refreshed binding name over a cached lazy resolution", async () => {
+    const { rerender } = render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-refreshed-name",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("product")).not.toBeNull();
+    });
+
+    rerender(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-refreshed-name",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "C0123ABCDEF",
+            externalChatName: "renamed-product",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("renamed-product")).not.toBeNull();
+    expect(screen.queryByText("product")).toBeNull();
+  });
+
   test("deduplicates in-flight resolution for repeated renders", async () => {
     let resolvePost:
       | ((value: typeof nextResolveResponse) => void)

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -227,7 +227,9 @@ export function SlackChannelFooter({
     resolutionKey && resolvedChannelName?.key === resolutionKey
       ? resolvedChannelName.channelName
       : undefined;
-  const displayText = resolvedDisplayText ?? fallbackDisplayText;
+  const displayText = !isChannelIdFallback(fallbackDisplayText, channelBinding)
+    ? fallbackDisplayText
+    : (resolvedDisplayText ?? fallbackDisplayText);
   if (!displayText) return null;
 
   const href = getSlackChannelLink(

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from "react";
+
+import { ExternalLink, Hash } from "lucide-react";
+
+import { resolveSlackChannelName } from "@/domains/chat/api/slack-channel-name.js";
+import type {
+  Conversation,
+  ConversationChannelBinding,
+} from "@/domains/chat/api/conversations.js";
+import {
+  getSlackLinkUrl,
+  type DisplayMessage,
+  type SlackMessageLink,
+} from "@/domains/chat/types/types.js";
+
+type SlackFooterConversation = Pick<
+  Conversation,
+  "channelBinding" | "originChannel"
+> &
+  Partial<Pick<Conversation, "conversationKey">>;
+
+export interface SlackChannelFooterProps {
+  assistantId?: string;
+  conversation: SlackFooterConversation | null | undefined;
+  messages?: DisplayMessage[];
+}
+
+const slackChannelNameRequests = new Map<string, Promise<string | null>>();
+
+function getSlackChannelLink(
+  slackChannel: ConversationChannelBinding["slackChannel"],
+  messageLink?: SlackMessageLink,
+  channelId?: string,
+): string | undefined {
+  if (slackChannel?.link) {
+    if (typeof slackChannel.link === "string") return slackChannel.link;
+    return getSlackLinkUrl(slackChannel.link);
+  }
+  return getSlackChannelLinkFromMessageLink(messageLink, channelId);
+}
+
+function getSlackChannelLinkFromMessageLink(
+  messageLink: SlackMessageLink | undefined,
+  channelId: string | undefined,
+): string | undefined {
+  if (!messageLink || !channelId) return undefined;
+
+  if (messageLink.webUrl) {
+    try {
+      const url = new URL(messageLink.webUrl);
+      const channelPath = `/archives/${channelId}`;
+      if (url.pathname.startsWith(`${channelPath}/`)) {
+        url.pathname = channelPath;
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+      }
+    } catch {
+      // Fall through to app URL parsing.
+    }
+  }
+
+  if (!messageLink.appUrl) return undefined;
+  try {
+    const url = new URL(messageLink.appUrl);
+    if (url.protocol !== "slack:" || url.hostname !== "channel") {
+      return undefined;
+    }
+    const team = url.searchParams.get("team");
+    if (!team || url.searchParams.get("id") !== channelId) {
+      return undefined;
+    }
+    return `slack://channel?${new URLSearchParams({
+      team,
+      id: channelId,
+    }).toString()}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function getSlackMessageChannel(
+  messages: DisplayMessage[] | undefined,
+  channelId: string | undefined,
+) {
+  if (!messages || messages.length === 0) return undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const slackMessage = messages[i]?.slackMessage;
+    if (!slackMessage) continue;
+    if (channelId && slackMessage.channelId !== channelId) continue;
+    return slackMessage;
+  }
+  return undefined;
+}
+
+function isChannelIdFallback(
+  value: string | undefined,
+  channelBinding: ConversationChannelBinding,
+): boolean {
+  return (
+    value === undefined ||
+    value === channelBinding.externalChatId ||
+    value === channelBinding.slackChannel?.channelId ||
+    value === channelBinding.slackChannel?.id
+  );
+}
+
+function getSlackChannelDisplayText(
+  channelBinding: ConversationChannelBinding,
+  fallbackChannelName?: string,
+): string | undefined {
+  const slackChannel = channelBinding.slackChannel;
+  const primaryName = slackChannel?.name ?? channelBinding.externalChatName;
+
+  if (!isChannelIdFallback(primaryName, channelBinding)) {
+    return primaryName;
+  }
+  if (
+    fallbackChannelName &&
+    !isChannelIdFallback(fallbackChannelName, channelBinding)
+  ) {
+    return fallbackChannelName;
+  }
+
+  return (
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding.externalChatId
+  );
+}
+
+function isSlackDmChannelId(channelId: string | undefined): boolean {
+  return channelId?.startsWith("D") === true;
+}
+
+export function SlackChannelFooter({
+  assistantId,
+  conversation,
+  messages,
+}: SlackChannelFooterProps) {
+  const [resolvedChannelName, setResolvedChannelName] = useState<{
+    key: string;
+    channelName: string;
+  } | null>(null);
+
+  const channelBinding =
+    conversation?.originChannel === "slack"
+      ? conversation.channelBinding
+      : undefined;
+  const slackChannel = channelBinding?.slackChannel;
+  const channelId =
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding?.externalChatId;
+  const messageChannel = getSlackMessageChannel(messages, channelId);
+  const fallbackDisplayText = channelBinding
+    ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
+    : undefined;
+  const conversationId = conversation?.conversationKey;
+  const resolutionKey =
+    assistantId && conversationId && channelId
+      ? `${assistantId}:${conversationId}:${channelId}`
+      : undefined;
+  const shouldResolveChannelName =
+    Boolean(assistantId && conversationId && channelId && channelBinding) &&
+    !isSlackDmChannelId(channelId) &&
+    channelBinding !== undefined &&
+    isChannelIdFallback(fallbackDisplayText, channelBinding);
+
+  useEffect(() => {
+    if (
+      !shouldResolveChannelName ||
+      !assistantId ||
+      !conversationId ||
+      !channelId ||
+      !resolutionKey
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let request = slackChannelNameRequests.get(resolutionKey);
+
+    if (!request) {
+      request = resolveSlackChannelName(assistantId, conversationId).then(
+        (result) => {
+          if (
+            !result?.resolved ||
+            result.channelId !== channelId ||
+            !result.channelName
+          ) {
+            return null;
+          }
+          return result.channelName;
+        },
+      );
+      slackChannelNameRequests.set(resolutionKey, request);
+      request.finally(() => {
+        if (slackChannelNameRequests.get(resolutionKey) === request) {
+          slackChannelNameRequests.delete(resolutionKey);
+        }
+      });
+    }
+
+    request.then((channelName) => {
+      if (!cancelled && channelName) {
+        setResolvedChannelName({ key: resolutionKey, channelName });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assistantId,
+    channelId,
+    conversationId,
+    resolutionKey,
+    shouldResolveChannelName,
+  ]);
+
+  if (!channelBinding) {
+    return null;
+  }
+
+  const resolvedDisplayText =
+    resolutionKey && resolvedChannelName?.key === resolutionKey
+      ? resolvedChannelName.channelName
+      : undefined;
+  const displayText = resolvedDisplayText ?? fallbackDisplayText;
+  if (!displayText) return null;
+
+  const href = getSlackChannelLink(
+    slackChannel,
+    messageChannel?.messageLink,
+    channelId,
+  );
+  const content = (
+    <>
+      <Hash className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{displayText}</span>
+      {href ? (
+        <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className="mb-2 flex justify-center text-body-small-default text-[var(--content-tertiary)]">
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex max-w-full items-center gap-1.5 truncate rounded px-1.5 py-1 text-[var(--content-secondary)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        >
+          {content}
+        </a>
+      ) : (
+        <div className="inline-flex max-w-full items-center gap-1.5 truncate px-1.5 py-1">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/types/types.ts
+++ b/apps/web/src/domains/chat/types/types.ts
@@ -20,6 +20,51 @@ export interface DisplayAttachment {
   previewUrl: string | null;
 }
 
+export interface SlackMessageLink {
+  appUrl?: string;
+  webUrl?: string;
+}
+
+export function parseSlackMessageLink(
+  raw: unknown,
+): SlackMessageLink | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const record = raw as Record<string, unknown>;
+  const link = {
+    appUrl: typeof record.appUrl === "string" ? record.appUrl : undefined,
+    webUrl: typeof record.webUrl === "string" ? record.webUrl : undefined,
+  };
+
+  return link.appUrl || link.webUrl ? link : undefined;
+}
+
+export function getSlackLinkUrl(
+  link: SlackMessageLink | null | undefined,
+): string | undefined {
+  return link?.webUrl ?? link?.appUrl;
+}
+
+export interface SlackMessageSender {
+  id?: string;
+  externalUserId?: string;
+  name?: string;
+  displayName?: string;
+  username?: string;
+  avatarUrl?: string;
+  isBot?: boolean;
+}
+
+export interface SlackRuntimeMessage {
+  channelId: string;
+  channelName?: string;
+  channelTs: string;
+  threadTs?: string;
+  sender?: SlackMessageSender;
+  messageLink?: SlackMessageLink;
+  threadLink?: SlackMessageLink;
+}
+
 export interface DisplayMessage {
   /** Stable client-side identity that survives optimistic send →
    *  server reconciliation. Assigned at message creation; never mutated.
@@ -39,6 +84,7 @@ export interface DisplayMessage {
   textSegments?: Array<{ type: string; content: string; [key: string]: unknown }>;
   contentOrder?: Array<{ type: string; id: string }>;
   metadata?: Record<string, unknown>;
+  slackMessage?: SlackRuntimeMessage;
   toolCalls?: ChatMessageToolCall[];
   /** Attachments rendered inside the message bubble. For user messages these
    *  are populated client-side from the upload flow; for assistant messages

--- a/apps/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/apps/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -181,4 +181,52 @@ describe("mapRuntimeToDisplayMessage", () => {
       mimeType: "text/csv",
     });
   });
+
+  test("preserves Slack message metadata alongside mapped message fields", () => {
+    const m = makeMessage({
+      id: "msg-slack",
+      daemonMessageId: "daemon-msg-slack",
+      role: "user",
+      content: "Slack reply",
+      metadata: { source: "slack" },
+      slackMessage: {
+        channelId: "C123ABCDEF",
+        channelName: "triage",
+        channelTs: "1710000000.000200",
+        threadTs: "1710000000.000100",
+        sender: {
+          id: "U123",
+          displayName: "Ada Lovelace",
+          username: "ada",
+          avatarUrl: "https://example.com/avatar.png",
+          isBot: false,
+        },
+        messageLink: {
+          appUrl:
+            "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000200",
+          webUrl:
+            "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
+        },
+        threadLink: {
+          appUrl:
+            "slack://channel?team=T123&id=C123ABCDEF&message=1710000000.000100",
+          webUrl:
+            "https://example.slack.com/archives/C123ABCDEF/p1710000000000100",
+        },
+      },
+      timestamp: "2026-05-15T12:34:56.000Z",
+    });
+
+    const display = mapRuntimeToDisplayMessage(m);
+
+    expect(display).toMatchObject({
+      id: "msg-slack",
+      daemonMessageId: "daemon-msg-slack",
+      role: "user",
+      content: "Slack reply",
+      metadata: { source: "slack" },
+      slackMessage: m.slackMessage,
+      timestamp: Date.parse("2026-05-15T12:34:56.000Z"),
+    });
+  });
 });

--- a/apps/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/apps/web/src/domains/chat/utils/map-runtime-message.ts
@@ -1,7 +1,11 @@
 import { runtimeAttachmentsToDisplay } from "@/domains/chat/utils/attachment-mapping.js";
 import { parseAttachmentSummariesFromContent } from "@/domains/chat/utils/parse-attachment-summaries.js";
 import { newStableId } from "@/domains/chat/utils/stable-id.js";
-import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types.js";
+import type {
+  DisplayAttachment,
+  DisplayMessage,
+  SlackRuntimeMessage,
+} from "@/domains/chat/types/types.js";
 import { mapRuntimeToolCalls, normalizeContentOrder, normalizeTextSegments, type RuntimeMessage } from "@/domains/chat/api/messages.js";
 
 /**
@@ -25,6 +29,7 @@ export interface PreparedRuntimeMessage {
     | undefined;
   normalizedContentOrder: Array<{ type: string; id: string }> | undefined;
   toolCalls: ReturnType<typeof mapRuntimeToolCalls> | undefined;
+  slackMessage: SlackRuntimeMessage | undefined;
   timestamp: number | undefined;
 }
 
@@ -98,6 +103,7 @@ export function prepareServerMessage(m: RuntimeMessage): PreparedRuntimeMessage 
     normalizedSegments,
     normalizedContentOrder,
     toolCalls,
+    slackMessage: m.slackMessage,
     timestamp,
   };
 }
@@ -124,6 +130,7 @@ export function mapRuntimeToDisplayMessage(m: RuntimeMessage): DisplayMessage {
   if (prepared.normalizedContentOrder) msg.contentOrder = prepared.normalizedContentOrder;
   if (m.metadata) msg.metadata = m.metadata;
   if (m.subagentNotification) msg.isSubagentNotification = true;
+  if (prepared.slackMessage) msg.slackMessage = prepared.slackMessage;
   if (prepared.toolCalls) msg.toolCalls = prepared.toolCalls;
   if (prepared.timestamp != null) msg.timestamp = prepared.timestamp;
 

--- a/apps/web/src/domains/chat/utils/message-merge.ts
+++ b/apps/web/src/domains/chat/utils/message-merge.ts
@@ -18,6 +18,7 @@ export function messagesEqual(a: DisplayMessage[], b: DisplayMessage[]): boolean
       JSON.stringify(am.textSegments) !== JSON.stringify(bm.textSegments) ||
       JSON.stringify(am.contentOrder) !== JSON.stringify(bm.contentOrder) ||
       JSON.stringify(am.metadata) !== JSON.stringify(bm.metadata) ||
+      JSON.stringify(am.slackMessage) !== JSON.stringify(bm.slackMessage) ||
       JSON.stringify(am.toolCalls) !== JSON.stringify(bm.toolCalls) ||
       JSON.stringify(am.attachments) !== JSON.stringify(bm.attachments)
     ) {
@@ -36,6 +37,7 @@ export function messagesEqual(a: DisplayMessage[], b: DisplayMessage[]): boolean
       "textSegments",
       "contentOrder",
       "metadata",
+      "slackMessage",
       "toolCalls",
       "attachments",
       "timestamp",
@@ -176,6 +178,9 @@ export function mergeDuplicateMessages(
       ...(preferred.metadata ?? {}),
     };
   }
+  if (current.slackMessage || incoming.slackMessage) {
+    merged.slackMessage = incoming.slackMessage ?? current.slackMessage;
+  }
 
   if (!merged.contentOrder) {
     merged.contentOrder = current.contentOrder ?? incoming.contentOrder;
@@ -260,6 +265,9 @@ export function mergeLatestHistoryMessage(
       ...(current.metadata ?? {}),
       ...(incoming.metadata ?? {}),
     };
+  }
+  if (current.slackMessage || incoming.slackMessage) {
+    merged.slackMessage = incoming.slackMessage ?? current.slackMessage;
   }
 
   if (merged.timestamp == null) {

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4391,6 +4391,51 @@ paths:
               required:
                 - conversationKey
               additionalProperties: false
+  /v1/conversations/{conversationId}/slack-channel/resolve:
+    post:
+      operationId: conversations_by_conversationId_slackchannel_resolve_post
+      summary: Resolve Slack channel name
+      description: Resolve and persist a friendly Slack channel name for an external conversation binding.
+      tags:
+        - conversations
+        - slack
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  channelId:
+                    type: string
+                  channelName:
+                    type: string
+                  cached:
+                    type: boolean
+                  resolved:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - auth
+                      - dm
+                      - no_name
+                      - not_found
+                      - permission
+                      - rate_limit
+                      - slack_error
+                required:
+                  - channelId
+                  - cached
+                  - resolved
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}:
     delete:
       operationId: conversations_by_id_delete

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -172,6 +172,25 @@ export function upsertOutboundBinding(input: {
     .run();
 }
 
+export function updateExternalChatName(
+  conversationId: string,
+  externalChatName: string,
+): ExternalConversationBinding | null {
+  const db = getDb();
+  const trimmedName = externalChatName.trim();
+  if (!trimmedName) return getBindingByConversation(conversationId);
+
+  db.update(externalConversationBindings)
+    .set({
+      externalChatName: trimmedName,
+      updatedAt: Date.now(),
+    })
+    .where(eq(externalConversationBindings.conversationId, conversationId))
+    .run();
+
+  return getBindingByConversation(conversationId);
+}
+
 /**
  * Look up an external binding by conversation ID.
  */

--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -175,10 +175,10 @@ export function upsertOutboundBinding(input: {
 export function updateExternalChatName(
   conversationId: string,
   externalChatName: string,
-): ExternalConversationBinding | null {
+): void {
   const db = getDb();
   const trimmedName = externalChatName.trim();
-  if (!trimmedName) return getBindingByConversation(conversationId);
+  if (!trimmedName) return;
 
   db.update(externalConversationBindings)
     .set({
@@ -187,8 +187,6 @@ export function updateExternalChatName(
     })
     .where(eq(externalConversationBindings.conversationId, conversationId))
     .run();
-
-  return getBindingByConversation(conversationId);
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+
+const BOT_TOKEN = "xoxb-test";
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => BOT_TOKEN,
+}));
+
+const { getSlackConversationInfo } = await import("./api.js");
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("getSlackConversationInfo", () => {
+  test("calls conversations.info with GET query params", async () => {
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = mock(async (input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          channel: {
+            id: "C123",
+            name: "engineering",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const info = await getSlackConversationInfo("C123");
+
+    expect(info).toEqual({ id: "C123", name: "engineering" });
+    expect(capturedUrl).toBeDefined();
+    const url = new URL(capturedUrl!);
+    expect(url.pathname).toBe("/api/conversations.info");
+    expect(url.searchParams.get("channel")).toBe("C123");
+    expect(capturedInit?.method).toBe("GET");
+    expect(capturedInit?.body).toBeUndefined();
+    expect(capturedInit?.headers).toEqual({
+      Authorization: `Bearer ${BOT_TOKEN}`,
+    });
+  });
+});

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -190,6 +190,83 @@ export async function callSlackApi(
   );
 }
 
+/**
+ * Call a Slack Web API read method with query parameters.
+ */
+async function callSlackApiGet(
+  method: string,
+  params: URLSearchParams,
+): Promise<SlackApiResponse> {
+  const botToken = await resolveBotToken();
+  const query = params.toString();
+  const url = `${SLACK_API_BASE}/${method}${query ? `?${query}` : ""}`;
+
+  let lastError: string | undefined;
+
+  for (let attempt = 0; attempt <= SLACK_MAX_RATE_LIMIT_RETRIES; attempt++) {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+      },
+    });
+
+    if (response.status === 429) {
+      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
+        throw new Error("Slack rate limit exceeded after retries");
+      }
+      const retryAfter =
+        parseInt(response.headers.get("Retry-After") ?? "", 10) ||
+        SLACK_DEFAULT_RETRY_AFTER_S;
+      log.warn({ method, retryAfter, attempt }, "Slack rate limited, retrying");
+      await new Promise((r) => setTimeout(r, retryAfter * 1000));
+      continue;
+    }
+
+    if (response.status >= 500) {
+      if (attempt >= SLACK_MAX_RATE_LIMIT_RETRIES) {
+        throw new Error(
+          `Slack ${method} failed with status ${response.status} after retries`,
+        );
+      }
+      log.warn(
+        { method, status: response.status, attempt },
+        "Slack 5xx error, retrying",
+      );
+      await new Promise((r) =>
+        setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
+      );
+      continue;
+    }
+
+    const data = (await response.json()) as SlackApiResponse;
+
+    if (!data.ok) {
+      lastError = data.error;
+      const category = classifySlackError(data.error);
+
+      if (category === "rate_limit" && attempt < SLACK_MAX_RATE_LIMIT_RETRIES) {
+        log.warn(
+          { method, slackError: data.error, attempt },
+          "Slack rate limited (body), retrying",
+        );
+        await new Promise((r) =>
+          setTimeout(r, SLACK_DEFAULT_RETRY_AFTER_S * 1000),
+        );
+        continue;
+      }
+
+      throw new SlackApiError(data.error);
+    }
+
+    return data;
+  }
+
+  throw new Error(
+    `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
+  );
+}
+
 function normalizeSlackString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -199,9 +276,10 @@ function normalizeSlackString(value: unknown): string | undefined {
 export async function getSlackConversationInfo(
   channelId: string,
 ): Promise<SlackConversationInfo | null> {
-  const data = (await callSlackApi("conversations.info", {
-    channel: channelId,
-  })) as SlackConversationsInfoResponse;
+  const data = (await callSlackApiGet(
+    "conversations.info",
+    new URLSearchParams({ channel: channelId }),
+  )) as SlackConversationsInfoResponse;
 
   const id = normalizeSlackString(data.channel?.id);
   if (!id) return null;

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -53,9 +53,7 @@ const SLACK_ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
   invalid_blocks: "client_error",
 };
 
-function classifySlackError(
-  errorCode: string | undefined,
-): SlackErrorCategory {
+function classifySlackError(errorCode: string | undefined): SlackErrorCategory {
   if (!errorCode) return "unknown";
   return SLACK_ERROR_CODE_MAP[errorCode] ?? "unknown";
 }
@@ -96,6 +94,20 @@ interface SlackApiResponse {
   ts?: string;
   upload_url?: string;
   file_id?: string;
+}
+
+interface SlackConversationsInfoResponse extends SlackApiResponse {
+  channel?: {
+    id?: unknown;
+    name?: unknown;
+    name_normalized?: unknown;
+  };
+}
+
+export interface SlackConversationInfo {
+  id: string;
+  name?: string;
+  nameNormalized?: string;
 }
 
 /**
@@ -176,6 +188,32 @@ export async function callSlackApi(
   throw new Error(
     `Slack ${method} failed after retries: ${lastError ?? "unknown"}`,
   );
+}
+
+function normalizeSlackString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export async function getSlackConversationInfo(
+  channelId: string,
+): Promise<SlackConversationInfo | null> {
+  const data = (await callSlackApi("conversations.info", {
+    channel: channelId,
+  })) as SlackConversationsInfoResponse;
+
+  const id = normalizeSlackString(data.channel?.id);
+  if (!id) return null;
+
+  const name = normalizeSlackString(data.channel?.name);
+  const nameNormalized = normalizeSlackString(data.channel?.name_normalized);
+
+  return {
+    id,
+    ...(name ? { name } : {}),
+    ...(nameNormalized ? { nameNormalized } : {}),
+  };
 }
 
 /**

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -153,6 +153,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "conversations/undo", scopes: ["chat.write"] },
   { endpoint: "conversations/regenerate", scopes: ["chat.write"] },
   { endpoint: "conversations/attention", scopes: ["chat.read"] },
+  { endpoint: "conversations/slack-channel/resolve", scopes: ["chat.read"] },
   { endpoint: "conversations/seen", scopes: ["chat.write"] },
   { endpoint: "conversations/unread", scopes: ["chat.write"] },
   { endpoint: "conversations/import", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type MockSlackInfo = {
+  id: string;
+  name?: string;
+  nameNormalized?: string;
+} | null;
+
+type MockSlackCategory =
+  | "auth"
+  | "channel_not_found"
+  | "not_found"
+  | "permission"
+  | "rate_limit"
+  | "unknown";
+
+class MockSlackApiError extends Error {
+  readonly slackError: string | undefined;
+  readonly category: MockSlackCategory;
+
+  constructor(slackError: string | undefined, category: MockSlackCategory) {
+    super(`Slack API error: ${slackError ?? "unknown"}`);
+    this.name = "SlackApiError";
+    this.slackError = slackError;
+    this.category = category;
+  }
+}
+
+const slackInfoCalls: string[] = [];
+let slackInfoImpl: (channelId: string) => Promise<MockSlackInfo> = async () =>
+  null;
+
+mock.module("../../../messaging/providers/slack/api.js", () => ({
+  SlackApiError: MockSlackApiError,
+  getSlackConversationInfo: async (channelId: string) => {
+    slackInfoCalls.push(channelId);
+    return slackInfoImpl(channelId);
+  },
+}));
+
+import { createConversation } from "../../../memory/conversation-crud.js";
+import { getDb, resetDb } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import {
+  getBindingByConversation,
+  upsertBinding,
+} from "../../../memory/external-conversation-store.js";
+import { ROUTES } from "../slack-channel-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+initializeDb();
+
+interface ResolveResponse {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+  reason?: string;
+}
+
+function resolveHandler(): RouteDefinition["handler"] {
+  const route = ROUTES.find(
+    (r) => r.operationId === "slack_channel_name_resolve",
+  );
+  if (!route) throw new Error("slack_channel_name_resolve route not found");
+  return route.handler;
+}
+
+const handler = resolveHandler();
+
+function clearTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM conversations");
+}
+
+function createBoundConversation(input: {
+  sourceChannel?: string;
+  externalChatId: string;
+  externalChatName?: string | null;
+  externalThreadId?: string | null;
+  externalUserId?: string | null;
+  displayName?: string | null;
+  username?: string | null;
+}): string {
+  const conversation = createConversation("Slack route test");
+  upsertBinding({
+    conversationId: conversation.id,
+    sourceChannel: input.sourceChannel ?? "slack",
+    externalChatId: input.externalChatId,
+    externalChatName: input.externalChatName,
+    externalThreadId: input.externalThreadId,
+    externalUserId: input.externalUserId,
+    displayName: input.displayName,
+    username: input.username,
+  });
+  return conversation.id;
+}
+
+async function resolve(conversationId: string): Promise<ResolveResponse> {
+  return (await handler({
+    pathParams: { conversationId },
+  })) as ResolveResponse;
+}
+
+beforeEach(() => {
+  clearTables();
+  slackInfoCalls.length = 0;
+  slackInfoImpl = async () => null;
+});
+
+afterAll(() => {
+  resetDb();
+  mock.restore();
+});
+
+describe("slack_channel_name_resolve", () => {
+  test("returns cached friendly name without calling Slack", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CACHED123",
+      externalChatName: "team-updates",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CACHED123",
+      channelName: "team-updates",
+      cached: true,
+      resolved: true,
+    });
+    expect(slackInfoCalls).toEqual([]);
+  });
+
+  test("resolves an unresolved channel ID and persists the returned name", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CRESOLVE123",
+      externalChatName: "CRESOLVE123",
+      externalThreadId: "1710000000.000100",
+      externalUserId: "U123",
+      displayName: "Alice",
+      username: "alice",
+    });
+    slackInfoImpl = async (channelId) => ({
+      id: channelId,
+      name: "engineering",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(slackInfoCalls).toEqual(["CRESOLVE123"]);
+    expect(result).toEqual({
+      channelId: "CRESOLVE123",
+      channelName: "engineering",
+      cached: false,
+      resolved: true,
+    });
+
+    const updated = getBindingByConversation(conversationId);
+    expect(updated?.externalChatName).toBe("engineering");
+    expect(updated?.externalThreadId).toBe("1710000000.000100");
+    expect(updated?.externalUserId).toBe("U123");
+    expect(updated?.displayName).toBe("Alice");
+    expect(updated?.username).toBe("alice");
+  });
+
+  test("does not call Slack for DM bindings", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "D123",
+      externalChatName: null,
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "D123",
+      cached: false,
+      resolved: false,
+      reason: "dm",
+    });
+    expect(slackInfoCalls).toEqual([]);
+    expect(getBindingByConversation(conversationId)?.externalChatName).toBe(
+      null,
+    );
+  });
+
+  test("rejects non-Slack bindings", async () => {
+    const conversationId = createBoundConversation({
+      sourceChannel: "telegram",
+      externalChatId: "chat-123",
+    });
+
+    await expect(resolve(conversationId)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      statusCode: 404,
+    });
+    expect(slackInfoCalls).toEqual([]);
+  });
+
+  test("returns unresolved on Slack API failure without mutating the binding", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CFAIL123",
+      externalChatName: "CFAIL123",
+    });
+    const before = getBindingByConversation(conversationId);
+    slackInfoImpl = async () => {
+      throw new MockSlackApiError("missing_scope", "permission");
+    };
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CFAIL123",
+      cached: false,
+      resolved: false,
+      reason: "permission",
+    });
+    expect(slackInfoCalls).toEqual(["CFAIL123"]);
+
+    const after = getBindingByConversation(conversationId);
+    expect(after?.externalChatName).toBe("CFAIL123");
+    expect(after?.updatedAt).toBe(before?.updatedAt);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -6,38 +6,28 @@ type MockSlackInfo = {
   nameNormalized?: string;
 } | null;
 
-type MockSlackCategory =
-  | "auth"
-  | "channel_not_found"
-  | "not_found"
-  | "permission"
-  | "rate_limit"
-  | "unknown";
-
-class MockSlackApiError extends Error {
-  readonly slackError: string | undefined;
-  readonly category: MockSlackCategory;
-
-  constructor(slackError: string | undefined, category: MockSlackCategory) {
-    super(`Slack API error: ${slackError ?? "unknown"}`);
-    this.name = "SlackApiError";
-    this.slackError = slackError;
-    this.category = category;
-  }
-}
+type MockSlackResult = MockSlackInfo | { slackError: string };
 
 const slackInfoCalls: string[] = [];
-let slackInfoImpl: (channelId: string) => Promise<MockSlackInfo> = async () =>
+let slackInfoImpl: (channelId: string) => Promise<MockSlackResult> = async () =>
   null;
+const syncInvalidations: string[][] = [];
+const originalFetch = globalThis.fetch;
 
-mock.module("../../../messaging/providers/slack/api.js", () => ({
-  SlackApiError: MockSlackApiError,
-  getSlackConversationInfo: async (channelId: string) => {
-    slackInfoCalls.push(channelId);
-    return slackInfoImpl(channelId);
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "xoxb-test",
+}));
+
+mock.module("../../sync/sync-publisher.js", () => ({
+  publishSyncInvalidation: async (tags: string[]) => {
+    syncInvalidations.push([...tags]);
   },
 }));
 
+import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../../../daemon/message-types/sync.js";
 import { createConversation } from "../../../memory/conversation-crud.js";
 import { getDb, resetDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
@@ -103,13 +93,43 @@ async function resolve(conversationId: string): Promise<ResolveResponse> {
   })) as ResolveResponse;
 }
 
+function mockSlackFetch(): void {
+  globalThis.fetch = mock(async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname !== "/api/conversations.info") {
+      throw new Error(`Unexpected Slack API request: ${url.pathname}`);
+    }
+
+    const channelId = url.searchParams.get("channel") ?? "";
+    slackInfoCalls.push(channelId);
+    const result = await slackInfoImpl(channelId);
+    if (result && "slackError" in result) {
+      return Response.json({ ok: false, error: result.slackError });
+    }
+
+    return Response.json({
+      ok: true,
+      channel: result
+        ? {
+            id: result.id,
+            name: result.name,
+            name_normalized: result.nameNormalized,
+          }
+        : undefined,
+    });
+  }) as unknown as typeof fetch;
+}
+
 beforeEach(() => {
   clearTables();
   slackInfoCalls.length = 0;
+  syncInvalidations.length = 0;
   slackInfoImpl = async () => null;
+  mockSlackFetch();
 });
 
 afterAll(() => {
+  globalThis.fetch = originalFetch;
   resetDb();
   mock.restore();
 });
@@ -164,6 +184,30 @@ describe("slack_channel_name_resolve", () => {
     expect(updated?.username).toBe("alice");
   });
 
+  test("publishes conversation sync tags after persisting a returned name", async () => {
+    const conversationId = createBoundConversation({
+      externalChatId: "CSYNC123",
+      externalChatName: "CSYNC123",
+    });
+    slackInfoImpl = async (channelId) => ({
+      id: channelId,
+      nameNormalized: "team-sync",
+    });
+
+    const result = await resolve(conversationId);
+
+    expect(result).toEqual({
+      channelId: "CSYNC123",
+      channelName: "team-sync",
+      cached: false,
+      resolved: true,
+    });
+    expect(syncInvalidations).toContainEqual([
+      SYNC_TAGS.conversationsList,
+      conversationMetadataSyncTag(conversationId),
+    ]);
+  });
+
   test("does not call Slack for DM bindings", async () => {
     const conversationId = createBoundConversation({
       externalChatId: "D123",
@@ -203,9 +247,7 @@ describe("slack_channel_name_resolve", () => {
       externalChatName: "CFAIL123",
     });
     const before = getBindingByConversation(conversationId);
-    slackInfoImpl = async () => {
-      throw new MockSlackApiError("missing_scope", "permission");
-    };
+    slackInfoImpl = async () => ({ slackError: "missing_scope" });
 
     const result = await resolve(conversationId);
 

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -75,7 +75,7 @@ import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-
 import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-provider-connection-routes.js";
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
 import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
-import { ROUTES as SLACK_CHANNEL_ROUTES } from "./integrations/slack/channel.js";
+import { ROUTES as SLACK_CHANNEL_CONFIG_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_SHARE_ROUTES } from "./integrations/slack/share.js";
 import { ROUTES as TELEGRAM_ROUTES } from "./integrations/telegram.js";
 import { ROUTES as TWILIO_ROUTES } from "./integrations/twilio.js";
@@ -109,6 +109,7 @@ import { ROUTES as SECRET_ROUTES } from "./secret-routes.js";
 import { ROUTES as SEQUENCE_ROUTES } from "./sequence-routes.js";
 import { ROUTES as SETTINGS_ROUTES } from "./settings-routes.js";
 import { ROUTES as SKILL_ROUTES } from "./skills-routes.js";
+import { ROUTES as SLACK_CHANNEL_RESOLVE_ROUTES } from "./slack-channel-routes.js";
 import { ROUTES as STT_ROUTES } from "./stt-routes.js";
 import { ROUTES as SUBAGENT_ROUTES } from "./subagents-routes.js";
 import { ROUTES as SUGGEST_TRUST_RULE_ROUTES } from "./suggest-trust-rule-routes.js";
@@ -229,7 +230,8 @@ export const ROUTES: RouteDefinition[] = [
   ...SETTINGS_ROUTES,
   ...SKILL_ROUTES,
   ...A2A_ROUTES,
-  ...SLACK_CHANNEL_ROUTES,
+  ...SLACK_CHANNEL_CONFIG_ROUTES,
+  ...SLACK_CHANNEL_RESOLVE_ROUTES,
   ...SLACK_SHARE_ROUTES,
   ...STT_ROUTES,
   ...SUGGEST_TRUST_RULE_ROUTES,

--- a/assistant/src/runtime/routes/slack-channel-routes.ts
+++ b/assistant/src/runtime/routes/slack-channel-routes.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
 import {
+  conversationMetadataSyncTag,
+  SYNC_TAGS,
+} from "../../daemon/message-types/sync.js";
+import {
   getBindingByConversation,
   updateExternalChatName,
 } from "../../memory/external-conversation-store.js";
@@ -8,6 +12,7 @@ import {
   getSlackConversationInfo,
   SlackApiError,
 } from "../../messaging/providers/slack/api.js";
+import { publishSyncInvalidation } from "../sync/sync-publisher.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -120,30 +125,9 @@ async function handleSlackChannelNameResolve({
     };
   }
 
+  let info;
   try {
-    const info = await getSlackConversationInfo(channelId);
-    const channelName = usableResolvedName(
-      channelId,
-      info?.name,
-      info?.nameNormalized,
-    );
-    if (!channelName) {
-      return {
-        channelId,
-        cached: false,
-        resolved: false,
-        reason: "no_name",
-      };
-    }
-
-    updateExternalChatName(conversationId, channelName);
-
-    return {
-      channelId,
-      channelName,
-      cached: false,
-      resolved: true,
-    };
+    info = await getSlackConversationInfo(channelId);
   } catch (err) {
     return {
       channelId,
@@ -152,6 +136,33 @@ async function handleSlackChannelNameResolve({
       reason: reasonForSlackError(err),
     };
   }
+
+  const channelName = usableResolvedName(
+    channelId,
+    info?.name,
+    info?.nameNormalized,
+  );
+  if (!channelName) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: "no_name",
+    };
+  }
+
+  updateExternalChatName(conversationId, channelName);
+  await publishSyncInvalidation([
+    SYNC_TAGS.conversationsList,
+    conversationMetadataSyncTag(conversationId),
+  ]);
+
+  return {
+    channelId,
+    channelName,
+    cached: false,
+    resolved: true,
+  };
 }
 
 export const ROUTES: RouteDefinition[] = [

--- a/assistant/src/runtime/routes/slack-channel-routes.ts
+++ b/assistant/src/runtime/routes/slack-channel-routes.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+
+import {
+  getBindingByConversation,
+  updateExternalChatName,
+} from "../../memory/external-conversation-store.js";
+import {
+  getSlackConversationInfo,
+  SlackApiError,
+} from "../../messaging/providers/slack/api.js";
+import { NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+type ResolveReason =
+  | "auth"
+  | "dm"
+  | "no_name"
+  | "not_found"
+  | "permission"
+  | "rate_limit"
+  | "slack_error";
+
+interface SlackChannelResolveResponse {
+  channelId: string;
+  channelName?: string;
+  cached: boolean;
+  resolved: boolean;
+  reason?: ResolveReason;
+}
+
+const SlackChannelResolveResponseSchema = z.object({
+  channelId: z.string(),
+  channelName: z.string().optional(),
+  cached: z.boolean(),
+  resolved: z.boolean(),
+  reason: z
+    .enum([
+      "auth",
+      "dm",
+      "no_name",
+      "not_found",
+      "permission",
+      "rate_limit",
+      "slack_error",
+    ])
+    .optional(),
+});
+
+function friendlyCachedName(
+  externalChatId: string,
+  externalChatName?: string | null,
+): string | undefined {
+  const trimmed = externalChatName?.trim();
+  if (!trimmed || trimmed === externalChatId) return undefined;
+  return trimmed;
+}
+
+function usableResolvedName(
+  externalChatId: string,
+  name?: string,
+  nameNormalized?: string,
+): string | undefined {
+  for (const candidate of [name, nameNormalized]) {
+    const trimmed = candidate?.trim();
+    if (trimmed && trimmed !== externalChatId) return trimmed;
+  }
+  return undefined;
+}
+
+function reasonForSlackError(err: unknown): ResolveReason {
+  if (err instanceof SlackApiError) {
+    switch (err.category) {
+      case "auth":
+        return "auth";
+      case "channel_not_found":
+      case "not_found":
+        return "not_found";
+      case "permission":
+        return "permission";
+      case "rate_limit":
+        return "rate_limit";
+      default:
+        return "slack_error";
+    }
+  }
+  return "slack_error";
+}
+
+async function handleSlackChannelNameResolve({
+  pathParams = {},
+}: RouteHandlerArgs): Promise<SlackChannelResolveResponse> {
+  const conversationId = pathParams.conversationId?.trim();
+  if (!conversationId) {
+    throw new NotFoundError("Conversation not found");
+  }
+
+  const binding = getBindingByConversation(conversationId);
+
+  if (!binding || binding.sourceChannel !== "slack") {
+    throw new NotFoundError("Conversation not found");
+  }
+
+  const channelId = binding.externalChatId;
+  const cachedName = friendlyCachedName(channelId, binding.externalChatName);
+  if (cachedName) {
+    return {
+      channelId,
+      channelName: cachedName,
+      cached: true,
+      resolved: true,
+    };
+  }
+
+  if (channelId.startsWith("D")) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: "dm",
+    };
+  }
+
+  try {
+    const info = await getSlackConversationInfo(channelId);
+    const channelName = usableResolvedName(
+      channelId,
+      info?.name,
+      info?.nameNormalized,
+    );
+    if (!channelName) {
+      return {
+        channelId,
+        cached: false,
+        resolved: false,
+        reason: "no_name",
+      };
+    }
+
+    updateExternalChatName(conversationId, channelName);
+
+    return {
+      channelId,
+      channelName,
+      cached: false,
+      resolved: true,
+    };
+  } catch (err) {
+    return {
+      channelId,
+      cached: false,
+      resolved: false,
+      reason: reasonForSlackError(err),
+    };
+  }
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "slack_channel_name_resolve",
+    endpoint: "conversations/:conversationId/slack-channel/resolve",
+    method: "POST",
+    handler: handleSlackChannelNameResolve,
+    summary: "Resolve Slack channel name",
+    description:
+      "Resolve and persist a friendly Slack channel name for an external conversation binding.",
+    tags: ["conversations", "slack"],
+    pathParams: [
+      {
+        name: "conversationId",
+        type: "string",
+        description: "Conversation ID whose Slack channel name should resolve.",
+      },
+    ],
+    responseBody: SlackChannelResolveResponseSchema,
+  },
+];

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -736,21 +736,25 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("forwards resolved channel name in runtime source metadata", async () => {
+  test("emits a plain app mention without resolving the event channel name", async () => {
     const { rawDb, store } = createSlackStore();
     const config = makeConfig();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
     const ws = makeOpenSocket();
+    const conversationInfoChannels: string[] = [];
 
     fetchMock = mock(async (input) => {
       const url = new URL(String(input));
       if (url.pathname.endsWith("/conversations.info")) {
-        expect(url.searchParams.get("channel")).toBe("C-thread");
+        const channelId = url.searchParams.get("channel");
+        if (channelId) {
+          conversationInfoChannels.push(channelId);
+        }
         return new Response(
           JSON.stringify({
             ok: true,
-            channel: { id: "C-thread", name: "support-triage" },
+            channel: { id: channelId, name: "support-triage" },
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -779,16 +783,15 @@ describe("SlackSocketModeClient thread tracking", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.source.channelName).toBe("support-triage");
+      expect(emitted[0].event.source.channelName).toBeUndefined();
+      expect(conversationInfoChannels).toEqual([]);
 
       await handleInbound(config, emitted[0].event, {
         routingOverride: emitted[0].routing,
       });
 
       expect(runtimePayloads).toHaveLength(1);
-      expect(runtimePayloads[0].sourceMetadata?.channelName).toBe(
-        "support-triage",
-      );
+      expect(runtimePayloads[0].sourceMetadata?.channelName).toBeUndefined();
     } finally {
       rawDb.close();
     }
@@ -843,7 +846,7 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.message.content).toBe(
         "@Example User continue in #visible-name",
       );
-      expect(conversationInfoChannels).toEqual(["C-thread"]);
+      expect(conversationInfoChannels).toEqual([]);
     } finally {
       rawDb.close();
     }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1000,18 +1000,6 @@ export class SlackSocketModeClient {
       this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
     }
 
-    if (channelId) {
-      const channelInfo = await Promise.race([
-        resolveSlackChannel(channelId, this.config.botToken),
-        new Promise<undefined>((resolve) =>
-          setTimeout(resolve, SLACK_RESOLVE_TIMEOUT_MS),
-        ),
-      ]);
-      if (channelInfo?.name) {
-        normalized.event.source.channelName = channelInfo.name;
-      }
-    }
-
     // Enrich actor display name if the sync cache missed.
     // resolveSlackUser is fast on cache hit and deduplicates in-flight fetches,
     // so this adds negligible latency on subsequent messages. A 3s timeout


### PR DESCRIPTION
## Summary
- add a lazy assistant route for resolving Slack channel names outside the Socket Mode event path
- remove event-delivery `conversations.info` lookup for the event channel while preserving explicit Slack channel reference rendering
- port lazy Slack channel footer behavior to the migrated `apps/web` client

## Implementation PRs
- #31413
- #31429
- #31437
- #31444

## Tests
- Assistant route/API tests, gateway Slack Socket Mode tests, and migrated web tests passed in implementation PR CI.
- Final feature branch PR CI will run against the combined branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->