### PR TITLE
Chat drift: avatar mount, tool timestamp, log export scope, side-by-side editing

### DIFF
--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -134,13 +134,6 @@ function buildTarEntry(filename: string, data: Uint8Array): Uint8Array {
   return buffer;
 }
 
-function isUuid(value: string | null | undefined): value is string {
-  return (
-    typeof value === "string" &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
-  );
-}
-
 async function fetchPlatformLogs(
   assistantId: string,
   opts: {
@@ -166,7 +159,13 @@ async function fetchPlatformLogs(
       body.startTime = opts.window.startTime;
       body.endTime = opts.window.endTime;
     }
-    if (isUuid(opts.activeConversationKey)) {
+    // Forward the active conversation key as `conversationId` so the backend
+    // can scope the export to messages / LLM request logs / usage events /
+    // tool invocations for that conversation. The backend accepts any
+    // non-empty string here — conversation keys take many shapes
+    // (e.g. `slack-thread:C123:1700000000.000000`), so we deliberately do
+    // NOT gate on UUID format.
+    if (opts.activeConversationKey) {
       body.conversationId = opts.activeConversationKey;
     }
     const res = await fetch(`/v1/assistants/${assistantId}/logs/export/`, {

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -414,6 +414,7 @@ export function ChatLayout() {
           <PreferencesMenu
             assistantId={lifecycle.assistantId}
             assistantVersion={assistantVersion}
+            activeConversationKey={activeConversationKey}
           />
         }
         onClose={args.onClose}

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -938,6 +938,25 @@ export function ChatPage() {
     return () => { setTopBarCenter(null); };
   }, [topBarCenterContent, setTopBarCenter]);
 
+  // Open an app from inside a chat (assets pill, "Open App" on a message).
+  // On macOS this enters side-by-side editing mode (chat + app preview);
+  // we mirror that here by transitioning the viewer to `app-editing` once
+  // the load lands, keeping the current conversation as the edit chat.
+  // Bail if the load failed or a newer open superseded this one.
+  const handleOpenAppFromChat = useCallback(
+    async (appId: string) => {
+      if (!assistantId) return;
+      haptic.light();
+      await useViewerStore.getState().loadApp(assistantId, appId);
+      const { activeAppId, openedAppState } = useViewerStore.getState();
+      if (activeConversationKey && openedAppState && activeAppId === appId) {
+        useConversationStore.getState().setEditingKey(activeConversationKey);
+        useViewerStore.getState().enterAppEditing();
+      }
+    },
+    [assistantId, activeConversationKey],
+  );
+
   const topBarRightContent = useMemo(() => {
     if (!activeConversation?.conversationKey || !assistantId) return null;
     return (
@@ -945,17 +964,14 @@ export function ChatPage() {
         assistantId={assistantId}
         conversationId={activeConversation.conversationKey}
         refreshKey={assetsRefreshKey}
-        onOpenApp={(appId) => {
-          haptic.light();
-          if (assistantId) void useViewerStore.getState().loadApp(assistantId, appId);
-        }}
+        onOpenApp={handleOpenAppFromChat}
         onOpenDocument={(surfaceId) => {
           haptic.light();
           if (assistantId) void useViewerStore.getState().loadDocument(assistantId, surfaceId);
         }}
       />
     );
-  }, [activeConversation?.conversationKey, assistantId, assetsRefreshKey]);
+  }, [activeConversation?.conversationKey, assistantId, assetsRefreshKey, handleOpenAppFromChat]);
 
   useEffect(() => {
     setTopBarRightSlot(topBarRightContent);
@@ -1135,10 +1151,7 @@ export function ChatPage() {
       unknownNudgeToolCallIds: interactionActions.unknownNudgeToolCallIds,
       setUnknownNudgeToolCallIds: interactionActions.setUnknownNudgeToolCallIds,
     },
-    handleOpenApp: (appId: string) => {
-      haptic.light();
-      if (assistantId) void useViewerStore.getState().loadApp(assistantId, appId);
-    },
+    handleOpenApp: handleOpenAppFromChat,
     handleOpenDocument: (surfaceId: string) => {
       haptic.light();
       if (assistantId) void useViewerStore.getState().loadDocument(assistantId, surfaceId);

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
+import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions.js";
 
 describe("MessageHoverActions", () => {
   test("renders the timestamp even when no actions are available", () => {

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
+
+describe("MessageHoverActions", () => {
+  test("renders the timestamp even when no actions are available", () => {
+    const html = renderToStaticMarkup(
+      <MessageHoverActions
+        content=""
+        timestamp={Date.UTC(2026, 0, 2, 12, 34)}
+        role="assistant"
+      />,
+    );
+
+    expect(html).toContain("title=");
+    expect(html).toContain("select-none");
+  });
+
+  test("hides while the message is streaming", () => {
+    const html = renderToStaticMarkup(
+      <MessageHoverActions
+        content=""
+        timestamp={Date.UTC(2026, 0, 2, 12, 34)}
+        role="assistant"
+        isStreaming
+      />,
+    );
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -68,7 +68,6 @@ export function MessageHoverActions({
 
   const hasCopyableText = content.trim().length > 0;
   const isAssistant = role === "assistant";
-  const hasAnyAction = hasCopyableText || onFork || (onInspect && isAssistant);
 
   useEffect(() => {
     return () => {
@@ -93,7 +92,7 @@ export function MessageHoverActions({
     });
   }, [content]);
 
-  if (!hasAnyAction || isStreaming) {
+  if (isStreaming) {
     return null;
   }
 

--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -52,11 +52,20 @@ import { ThemeToggle } from "@/components/theme-toggle.js";
 export interface PreferencesMenuProps {
   assistantId?: string | null;
   assistantVersion?: string | null;
+  /**
+   * Key of the currently-open conversation, forwarded into the
+   * `<ShareFeedbackModal>` so the "Include logs" toggle scopes the
+   * exported assistant logs (messages / LLM request logs / usage events
+   * / tool invocations) to that conversation. `null` / `undefined` =
+   * unscoped export across all conversations.
+   */
+  activeConversationKey?: string | null;
 }
 
 export function PreferencesMenu({
   assistantId,
   assistantVersion,
+  activeConversationKey,
 }: PreferencesMenuProps) {
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const isMobile = useIsMobile();
@@ -118,6 +127,7 @@ export function PreferencesMenu({
         onClose={() => setIsFeedbackOpen(false)}
         assistantId={assistantId}
         assistantVersion={assistantVersion}
+        activeConversationKey={activeConversationKey}
       />
 
       <EarnCreditsModal

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.test.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.test.tsx
@@ -182,7 +182,7 @@ describe("LatestTurnRow avatar slot", () => {
     expect(avatarIdx).toBeLessThan(edgeIdx);
   });
 
-  test("with avatarSlot + empty responseItems → no avatar marker is rendered", () => {
+  test("with avatarSlot + empty responseItems → avatar still renders so it persists across the user-send → response boundary without flicker", () => {
     const anchor = userMessageItem("u1", "question");
     const html = renderToStaticMarkup(
       <LatestTurnRow
@@ -192,9 +192,12 @@ describe("LatestTurnRow avatar slot", () => {
         {...sharedProps}
       />,
     );
-    expect(html).not.toContain('data-latest-assistant-avatar="true"');
-    // The avatar contents shouldn't have been rendered either.
-    expect(html).not.toContain("AVATAR_SLOT_MARKER");
+    // After a user sends, the new user message becomes the anchor and
+    // responseItems is empty until V streams. Keeping the avatar
+    // mounted in this window prevents the ChatAvatar entrance spring
+    // from replaying as a visible flicker.
+    expect(html).toContain('data-latest-assistant-avatar="true"');
+    expect(html).toContain("AVATAR_SLOT_MARKER");
   });
 });
 

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -175,7 +175,15 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             )}
         </Fragment>
       ))}
-      {avatarSlot && responseItems.length > 0 && (
+      {avatarSlot && (
+        // Render whenever a slot is provided — including the "user just
+        // sent, response hasn't streamed yet" gap. Gating on
+        // `responseItems.length > 0` here causes the avatar to unmount
+        // and remount across the turn boundary, replaying the
+        // ChatAvatar entrance spring as a visible flicker. Keeping the
+        // slot mounted preserves DOM identity; the avatar's already-
+        // wired `isStreaming` prop drives the "thinking" beat while V
+        // composes a reply.
         <div
           data-latest-assistant-avatar="true"
           className="flex justify-start pl-1 pt-3 pb-2"

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -33,9 +33,9 @@ mock.module(
   }),
 );
 
-import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 
-import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
+import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body.js";
 
 const noop = () => {};
 

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/domains/chat/components/chat-attachments/index.js", () => ({
+  MessageAttachments: () => <div data-testid="attachments" />,
+}));
+
+mock.module("@/domains/chat/components/chat-markdown-message.js", () => ({
+  ChatMarkdownMessage: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+mock.module("@/domains/chat/components/surfaces/index.js", () => ({
+  SurfaceRouter: ({ surface }: { surface: { surfaceId: string } }) => (
+    <div data-testid="surface" data-surface-id={surface.surfaceId} />
+  ),
+}));
+
+mock.module(
+  "@/domains/chat/components/message-hover-actions/message-hover-actions.js",
+  () => ({
+    MessageHoverActions: ({ timestamp }: { timestamp?: number }) => (
+      <div data-testid="hover-actions" data-timestamp={timestamp ?? ""} />
+    ),
+  }),
+);
+
+mock.module(
+  "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js",
+  () => ({
+    ToolCallProgressCard: () => <div data-testid="tool-progress-card" />,
+  }),
+);
+
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile";
+
+import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
+
+const noop = () => {};
+
+function renderMessage(message: DisplayMessage): string {
+  return renderToStaticMarkup(
+    <TranscriptMessageBody
+      message={message}
+      expandedToolCallIds={new Set()}
+      expandedCardIds={new Map()}
+      onSurfaceAction={noop}
+    />,
+  );
+}
+
+describe("TranscriptMessageBody", () => {
+  test("uses the latest tool completion as the message activity timestamp", () => {
+    const html = renderMessage({
+      stableId: "m1",
+      id: "m1",
+      role: "assistant",
+      content: "",
+      timestamp: 1_000,
+      toolCalls: [
+        {
+          id: "tc-1",
+          toolName: "bash",
+          input: {},
+          status: "completed",
+          startedAt: 1_500,
+          completedAt: 2_000,
+        },
+      ],
+    });
+
+    expect(html).toContain('data-testid="hover-actions"');
+    expect(html).toContain('data-timestamp="2000"');
+  });
+
+  test("falls back to the tool start time for active tool-only messages", () => {
+    const html = renderMessage({
+      stableId: "m1",
+      id: "m1",
+      role: "assistant",
+      content: "",
+      timestamp: 1_000,
+      toolCalls: [
+        {
+          id: "tc-1",
+          toolName: "bash",
+          input: {},
+          status: "running",
+          startedAt: 1_500,
+        },
+      ],
+    });
+
+    expect(html).toContain('data-timestamp="1500"');
+  });
+});

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -81,6 +81,31 @@ function isSurfaceToolCallComplete(message: DisplayMessage): boolean {
   return message.isStreaming !== true;
 }
 
+function latestMessageActivityTimestamp(
+  message: DisplayMessage,
+): number | undefined {
+  const latestToolTimestamp = message.toolCalls?.reduce<number | undefined>(
+    (latest, toolCall) => {
+      const toolTimestamp = toolCall.completedAt ?? toolCall.startedAt;
+      if (toolTimestamp == null) {
+        return latest;
+      }
+      return latest == null ? toolTimestamp : Math.max(latest, toolTimestamp);
+    },
+    undefined,
+  );
+
+  if (latestToolTimestamp == null) {
+    return message.timestamp;
+  }
+
+  if (message.timestamp == null) {
+    return latestToolTimestamp;
+  }
+
+  return Math.max(message.timestamp, latestToolTimestamp);
+}
+
 export function TranscriptMessageBody({
   message,
   expandedToolCallIds,
@@ -172,6 +197,7 @@ export function TranscriptMessageBody({
   const isSuppressedUiTool = (tc: ChatMessageToolCall) =>
     !tc.pendingConfirmation &&
     (tc.toolName === "ui_show" || tc.toolName === "ui_update" || tc.toolName === "ui_dismiss");
+  const messageTimestamp = latestMessageActivityTimestamp(message);
 
   if (hasInterleavedToolCalls && message.contentOrder) {
     // Group consecutive entries: merge adjacent toolCall/tool entries into a
@@ -305,7 +331,7 @@ export function TranscriptMessageBody({
           <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
             <MessageHoverActions
               content={message.content}
-              timestamp={message.timestamp}
+              timestamp={messageTimestamp}
               role={message.role}
               isStreaming={message.isStreaming}
               onFork={forkHandler}
@@ -433,7 +459,7 @@ export function TranscriptMessageBody({
         <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
           <MessageHoverActions
             content={message.content}
-            timestamp={message.timestamp}
+            timestamp={messageTimestamp}
             role={message.role}
             isStreaming={message.isStreaming}
             onFork={forkHandler}


### PR DESCRIPTION
Brings four small-surface chat-drift features over from `vellum-assistant-platform` to bring the chat domain closer to parity. Each commit ports one platform PR as a feature spec — the diffs are not 1:1 because the two repos diverged after the May 19 freeze (Zustand turn-store vs reducer, no ChatProvider, kebab-case under `domains/chat/`, etc.).

## Commits

| Commit | Spec | Linear |
|---|---|---|
| `fix(chat): keep avatar mounted across user-send → response boundary` | vellum-ai/vellum-assistant-platform#7329 | LUM-1679 |
| `fix(chat): advance message timestamp for tool activity` | vellum-ai/vellum-assistant-platform#7472 | LUM-1757 |
| `fix(chat): scope shared-feedback log export to active conversation` | vellum-ai/vellum-assistant-platform#7477 | LUM-1758 |
| `fix(chat): open apps in side-by-side editing mode from conversation` | vellum-ai/vellum-assistant-platform#7517 | LUM-1758 |

## Scope

This is the first batch of "smallest wins first" from the chat-drift audit. Six features remain (#7317 tool_progress, #7374 thinking dots on confirm-bypass, #7396 `_vellumDebug.chat`, #7406 task picker surface, #7447 home-unread badge, #6986 Slack channel/sender) — they're bigger ports and pending review of this batch before I take them on.

The 10-PR WebSearchProgressCard cluster (LUM-1757 main body) is **deliberately out of scope** — those PRs sit on the open umbrella PR vellum-ai/vellum-assistant-platform#7430 against platform main, so the spec isn't final yet.

## Test plan

- [x] `bun scripts/run-tests.ts` on the touched test files passes
- [x] `bunx tsc --noEmit` clean
- [ ] Manual verification: avatar no longer flickers on user-send; tool-only message rows show a timestamp; Slack feedback export carries the right `conversationId`; "Open App" from a chat message enters side-by-side

https://claude.ai/code/session_01SEfTiBNj3JQ9Fix4igWbTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEfTiBNj3JQ9Fix4igWbTi)_