### PR TITLE
fix(web): treat 404 as empty library instead of error state (LUM-1782)

### DIFF
--- a/apps/web/src/domains/intelligence/components/apps/library-view.tsx
+++ b/apps/web/src/domains/intelligence/components/apps/library-view.tsx
@@ -14,6 +14,7 @@ import { type ChangeEvent, type MouseEvent, useCallback, useEffect, useMemo, use
 
 import type { AppSummary } from "@/domains/chat/api/apps.js";
 import type { DocumentSummary } from "@/domains/chat/api/documents.js";
+import { ApiError } from "@/lib/api-errors.js";
 import {
   deleteApp,
   getCachedAppHtml,
@@ -269,7 +270,14 @@ export function LibraryView({
             appsResult.status === "rejected" &&
             docsResult.status === "rejected"
           ) {
-            throw appsResult.reason;
+            const isNotFound = (r: PromiseRejectedResult) =>
+              r.reason instanceof ApiError && r.reason.status === 404;
+            if (isNotFound(appsResult) && isNotFound(docsResult)) {
+              setApps([]);
+              setDocuments([]);
+            } else {
+              throw appsResult.reason;
+            }
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

When the daemon isn't running or the assistant isn't provisioned, both `/v1/apps` and `/v1/documents` return 404. Previously this showed a generic error message ("Not found") with a Retry button. Now it shows the proper "Your library is empty" state with the Import option.

Closes LUM-1782

## Changes

### `library-view.tsx` — fetchLibrary error handling

When both `listApps` and `listDocuments` fail, the existing code throws the first error. The fix adds a check: if both failures are `ApiError` with status 404, treat it as an empty library (set `apps: []`, `documents: []`) rather than entering the error state. Non-404 errors (500, network failures, etc.) still show the error UI with Retry.

### Why 404 specifically

The daemon returns 404 when:
- The assistant isn't provisioned yet (no container running)
- The apps/documents endpoints aren't available (daemon not started)

This is functionally equivalent to "no apps exist" — the correct UX is the empty state with the Import option, not an error message. The platform handles this implicitly because its API layer returns empty arrays rather than 404s.

## Prompt / plan

Visual verification testing (prod vs local) found the Library page showing "Not found" instead of the empty state when the daemon isn't running.

## Test plan

- `bunx tsc --noEmit` — passes
- `bun run lint` — passes
- CI

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->