### PR TITLE
feat(memory-v2): track injection frequency EMA for router v4 tier 2

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -125,6 +125,7 @@ import {
   migrateMemoryRecallLogsQueryContext,
   migrateMemoryRetrospectiveState,
   migrateMemoryV2ActivationLogs,
+  migrateMemoryV2InjectionEvents,
   migrateMessageBookmarks,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
@@ -442,6 +443,7 @@ export function initializeDb(): void {
     migrateCreateDocumentComments,
     migrateExternalConversationBindingChatName,
     migrateChannelInboundDeliveryAttempts,
+    migrateMemoryV2InjectionEvents,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/256-memory-v2-injection-events.ts
+++ b/assistant/src/memory/migrations/256-memory-v2-injection-events.ts
@@ -1,0 +1,113 @@
+import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_memory_v2_injection_events_v1";
+const log = getLogger("memory-v2-injection-events-migration");
+
+/**
+ * Create the memory_v2_injection_events table — an append-only event log of
+ * (slug, injected_at) tuples capturing every router selection.
+ *
+ * This is the data source for the time-decayed injection frequency score
+ * that drives tier 2 assignment in memory router v4. Score is computed on
+ * read as `Σ exp(-λ × (now - tᵢ))` with `λ = ln(2) / 3 days`, so the table
+ * just accumulates raw events; the formula or half-life can change later
+ * without losing signal.
+ *
+ * Backfill: walks existing `memory_v2_activation_logs` and replays each
+ * row's router-sourced slugs as historical events. Without backfill the
+ * scores would take ~3 half-lives (≈9 days) to reach steady state; with
+ * backfill tier 2 assignment has signal from day one.
+ *
+ * Indexes:
+ * - `(slug, injected_at)` for per-slug score reads (the hot path).
+ * - `(injected_at)` for time-range pruning later.
+ */
+export function migrateMemoryV2InjectionEvents(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS memory_v2_injection_events (
+        id INTEGER PRIMARY KEY,
+        slug TEXT NOT NULL,
+        injected_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v2_injection_events_slug_time
+        ON memory_v2_injection_events (slug, injected_at)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v2_injection_events_time
+        ON memory_v2_injection_events (injected_at)
+    `);
+
+    // Bail before backfill on databases that predate memory_v2_activation_logs
+    // (migration 234) — there's no historical signal to replay.
+    const logsTable = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_activation_logs'`,
+      )
+      .get();
+    if (!logsTable) return;
+
+    // Re-run safety net independent of the checkpoint: if events already
+    // exist, do not append duplicates. The checkpoint normally short-circuits
+    // re-runs in withCrashRecovery; this guards the manual-clear path.
+    const existing = raw
+      .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
+      .get() as { n: number };
+    if (existing.n > 0) return;
+
+    const rows = raw
+      .query(
+        `SELECT concepts_json, created_at FROM memory_v2_activation_logs ORDER BY created_at ASC`,
+      )
+      .all() as Array<{ concepts_json: string; created_at: number }>;
+    if (rows.length === 0) return;
+
+    const insert = raw.prepare(
+      `INSERT INTO memory_v2_injection_events (slug, injected_at) VALUES (?, ?)`,
+    );
+    const replay = raw.transaction(
+      (events: ReadonlyArray<{ slug: string; t: number }>) => {
+        for (const e of events) insert.run(e.slug, e.t);
+      },
+    );
+
+    const buffer: Array<{ slug: string; t: number }> = [];
+    let parseFailures = 0;
+    for (const row of rows) {
+      let concepts: Array<{ slug?: unknown; source?: unknown }>;
+      try {
+        concepts = JSON.parse(row.concepts_json) as Array<{
+          slug?: unknown;
+          source?: unknown;
+        }>;
+      } catch {
+        parseFailures += 1;
+        continue;
+      }
+      if (!Array.isArray(concepts)) continue;
+      for (const c of concepts) {
+        if (typeof c.slug !== "string") continue;
+        // Carry-over entries were not router-selected this turn — exclude.
+        if (c.source !== "router") continue;
+        buffer.push({ slug: c.slug, t: row.created_at });
+      }
+    }
+
+    if (buffer.length > 0) replay(buffer);
+    log.info(
+      { inserted: buffer.length, rowsScanned: rows.length, parseFailures },
+      `Backfilled ${buffer.length} injection events from ${rows.length} activation log rows`,
+    );
+  });
+}
+
+export function downMemoryV2InjectionEvents(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_v2_injection_events`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -224,6 +224,10 @@ export {
 } from "./254-external-conversation-binding-chat-name.js";
 export { migrateChannelInboundDeliveryAttempts } from "./255-channel-inbound-delivery-attempts.js";
 export {
+  downMemoryV2InjectionEvents,
+  migrateMemoryV2InjectionEvents,
+} from "./256-memory-v2-injection-events.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -51,6 +51,7 @@ import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
 import { downNormalizeSlackExternalContent } from "./249-normalize-slack-external-content.js";
 import { downA2ATasks } from "./251-a2a-tasks.js";
 import { downExternalConversationBindingChatName } from "./254-external-conversation-binding-chat-name.js";
+import { downMemoryV2InjectionEvents } from "./256-memory-v2-injection-events.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -435,6 +436,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add external_chat_name to external conversation bindings for channel footer metadata",
     down: downExternalConversationBindingChatName,
+  },
+  {
+    key: "migration_memory_v2_injection_events_v1",
+    version: 51,
+    dependsOn: ["migration_memory_v2_activation_logs_v1"],
+    description:
+      "Create memory_v2_injection_events table and backfill from activation logs for EMA-based tier 2 routing",
+    down: downMemoryV2InjectionEvents,
   },
 ];
 

--- a/assistant/src/memory/v2/__tests__/injection-events.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection-events.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for `assistant/src/memory/v2/injection-events.ts` and its sibling
+ * migration `256-memory-v2-injection-events.ts`.
+ *
+ * Coverage matrix:
+ *   - Migration creates the table + both indexes; safe to re-run.
+ *   - Backfill replays router-sourced concepts from memory_v2_activation_logs
+ *     and is idempotent on a forced re-run with cleared checkpoint.
+ *   - Backfill is a no-op when the activation-logs table doesn't exist
+ *     (pre-234 DB).
+ *   - recordInjectionEvents appends one row per slug per call; empty list
+ *     is a no-op.
+ *   - computeInjectionScore matches the closed-form decay at known deltas
+ *     (0d ≈ 1, 3d ≈ 0.5, 6d ≈ 0.25) and sums multiple events linearly.
+ *   - computeInjectionScores returns the same per-slug values in batch and
+ *     omits slugs with no events.
+ *
+ * Uses an in-memory bun:sqlite database — no real workspace DB.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+import type { DrizzleDb } from "../../db-connection.js";
+import { getSqliteFrom } from "../../db-connection.js";
+import { migrateMemoryV2ActivationLogs } from "../../migrations/234-memory-v2-activation-logs.js";
+import {
+  downMemoryV2InjectionEvents,
+  migrateMemoryV2InjectionEvents,
+} from "../../migrations/256-memory-v2-injection-events.js";
+import * as schema from "../../schema.js";
+import {
+  computeInjectionScore,
+  computeInjectionScores,
+  INJECTION_SCORE_HALF_LIFE_MS,
+  recordInjectionEvents,
+} from "../injection-events.js";
+
+// memory_checkpoints is required by withCrashRecovery and is normally
+// created by an early core migration. Stand it up by hand so we can run
+// the v2 migrations in isolation against a fresh in-memory DB.
+const CHECKPOINTS_DDL = /*sql*/ `
+  CREATE TABLE memory_checkpoints (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  )
+`;
+
+let sqlite: Database;
+let database: DrizzleDb;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  database = drizzle(sqlite, { schema });
+  getSqliteFrom(database).exec(CHECKPOINTS_DDL);
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function insertActivationLog(
+  rawDb: Database,
+  args: {
+    id: string;
+    concepts: Array<{ slug: string; source: string; status?: string }>;
+    createdAt: number;
+  },
+): void {
+  rawDb
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+        id, conversation_id, message_id, turn, mode,
+        concepts_json, skills_json, config_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      args.id,
+      "conv-1",
+      `msg-${args.id}`,
+      1,
+      "router",
+      JSON.stringify(args.concepts),
+      "[]",
+      "{}",
+      args.createdAt,
+    );
+}
+
+describe("migrateMemoryV2InjectionEvents", () => {
+  test("creates table and both indexes; safe to re-run", () => {
+    migrateMemoryV2InjectionEvents(database);
+    migrateMemoryV2InjectionEvents(database);
+
+    const raw = getSqliteFrom(database);
+    const table = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_injection_events'`,
+      )
+      .get();
+    expect(table).toBeTruthy();
+
+    const indexNames = new Set(
+      (
+        raw
+          .query(
+            `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_v2_injection_events'`,
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name),
+    );
+    expect(indexNames.has("idx_memory_v2_injection_events_slug_time")).toBe(
+      true,
+    );
+    expect(indexNames.has("idx_memory_v2_injection_events_time")).toBe(true);
+  });
+
+  test("backfill replays router-sourced concepts and ignores carry_over", () => {
+    migrateMemoryV2ActivationLogs(database);
+    const raw = getSqliteFrom(database);
+    insertActivationLog(raw, {
+      id: "log-1",
+      concepts: [
+        { slug: "alice", source: "router", status: "injected" },
+        { slug: "bob", source: "router", status: "in_context" },
+        { slug: "ghost", source: "carry_over", status: "not_injected" },
+      ],
+      createdAt: 1_000_000,
+    });
+    insertActivationLog(raw, {
+      id: "log-2",
+      concepts: [{ slug: "alice", source: "router", status: "injected" }],
+      createdAt: 2_000_000,
+    });
+
+    migrateMemoryV2InjectionEvents(database);
+
+    const rows = raw
+      .query(
+        `SELECT slug, injected_at FROM memory_v2_injection_events ORDER BY injected_at, slug`,
+      )
+      .all() as Array<{ slug: string; injected_at: number }>;
+    expect(rows).toEqual([
+      { slug: "alice", injected_at: 1_000_000 },
+      { slug: "bob", injected_at: 1_000_000 },
+      { slug: "alice", injected_at: 2_000_000 },
+    ]);
+  });
+
+  test("backfill is a no-op when memory_v2_activation_logs is absent", () => {
+    // No activation-logs migration applied first.
+    expect(() => migrateMemoryV2InjectionEvents(database)).not.toThrow();
+    const { n } = getSqliteFrom(database)
+      .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
+      .get() as { n: number };
+    expect(n).toBe(0);
+  });
+
+  test("forced re-run does not double-insert existing events", () => {
+    migrateMemoryV2ActivationLogs(database);
+    const raw = getSqliteFrom(database);
+    insertActivationLog(raw, {
+      id: "log-1",
+      concepts: [{ slug: "alice", source: "router", status: "injected" }],
+      createdAt: 1_000_000,
+    });
+
+    migrateMemoryV2InjectionEvents(database);
+    // Simulate someone manually clearing the checkpoint — the in-table
+    // guard should still prevent re-backfill.
+    raw
+      .prepare(
+        `DELETE FROM memory_checkpoints WHERE key = 'migration_memory_v2_injection_events_v1'`,
+      )
+      .run();
+    migrateMemoryV2InjectionEvents(database);
+
+    const { n } = raw
+      .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
+  test("downMemoryV2InjectionEvents drops the table", () => {
+    migrateMemoryV2InjectionEvents(database);
+    downMemoryV2InjectionEvents(database);
+    const table = getSqliteFrom(database)
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_injection_events'`,
+      )
+      .get();
+    expect(table).toBeFalsy();
+  });
+});
+
+describe("recordInjectionEvents", () => {
+  beforeEach(() => {
+    migrateMemoryV2InjectionEvents(database);
+  });
+
+  test("appends one row per slug at the same timestamp", () => {
+    const t = 1_000_000;
+    recordInjectionEvents(database, ["alice", "bob", "alice"], t);
+    const rows = getSqliteFrom(database)
+      .query(
+        `SELECT slug, injected_at FROM memory_v2_injection_events ORDER BY id`,
+      )
+      .all();
+    expect(rows).toEqual([
+      { slug: "alice", injected_at: t },
+      { slug: "bob", injected_at: t },
+      { slug: "alice", injected_at: t },
+    ]);
+  });
+
+  test("empty list is a no-op", () => {
+    recordInjectionEvents(database, [], 1_000_000);
+    const { n } = getSqliteFrom(database)
+      .query(`SELECT COUNT(*) as n FROM memory_v2_injection_events`)
+      .get() as { n: number };
+    expect(n).toBe(0);
+  });
+});
+
+describe("computeInjectionScore", () => {
+  beforeEach(() => {
+    migrateMemoryV2InjectionEvents(database);
+  });
+
+  test("returns 0 for a slug with no events", () => {
+    expect(computeInjectionScore(database, "missing", Date.now())).toBe(0);
+  });
+
+  test("single event 0 days ago → score ≈ 1", () => {
+    const now = 10_000_000_000;
+    recordInjectionEvents(database, ["alice"], now);
+    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(1, 5);
+  });
+
+  test("single event 3 days (one half-life) ago → score ≈ 0.5", () => {
+    const now = 10_000_000_000;
+    recordInjectionEvents(
+      database,
+      ["alice"],
+      now - INJECTION_SCORE_HALF_LIFE_MS,
+    );
+    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(0.5, 5);
+  });
+
+  test("single event 6 days (two half-lives) ago → score ≈ 0.25", () => {
+    const now = 10_000_000_000;
+    recordInjectionEvents(
+      database,
+      ["alice"],
+      now - 2 * INJECTION_SCORE_HALF_LIFE_MS,
+    );
+    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(0.25, 5);
+  });
+
+  test("multiple events sum independently", () => {
+    const now = 10_000_000_000;
+    recordInjectionEvents(database, ["alice"], now);
+    recordInjectionEvents(
+      database,
+      ["alice"],
+      now - INJECTION_SCORE_HALF_LIFE_MS,
+    );
+    recordInjectionEvents(
+      database,
+      ["alice"],
+      now - 2 * INJECTION_SCORE_HALF_LIFE_MS,
+    );
+    expect(computeInjectionScore(database, "alice", now)).toBeCloseTo(1.75, 5);
+  });
+});
+
+describe("computeInjectionScores", () => {
+  beforeEach(() => {
+    migrateMemoryV2InjectionEvents(database);
+  });
+
+  test("returns the same per-slug values as the single-slug helper", () => {
+    const now = 10_000_000_000;
+    recordInjectionEvents(database, ["alice", "bob"], now);
+    recordInjectionEvents(
+      database,
+      ["alice"],
+      now - INJECTION_SCORE_HALF_LIFE_MS,
+    );
+
+    const scores = computeInjectionScores(
+      database,
+      ["alice", "bob", "ghost"],
+      now,
+    );
+    expect(scores.get("alice")).toBeCloseTo(1.5, 5);
+    expect(scores.get("bob")).toBeCloseTo(1, 5);
+    // ghost has no events — omitted from the result, not present as 0.
+    expect(scores.has("ghost")).toBe(false);
+    expect(scores.get("alice")).toBeCloseTo(
+      computeInjectionScore(database, "alice", now),
+      5,
+    );
+  });
+
+  test("empty slug list returns empty map", () => {
+    expect(computeInjectionScores(database, [], Date.now()).size).toBe(0);
+  });
+});

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -388,6 +388,8 @@ import type { SkillEntry } from "../types.js";
 const { getSqliteFrom } = await import("../../db-connection.js");
 const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
+const { migrateMemoryV2InjectionEvents } =
+  await import("../../migrations/256-memory-v2-injection-events.js");
 const schema = await import("../../schema.js");
 const { clearEverInjected, hydrate, save } =
   await import("../activation-store.js");
@@ -409,6 +411,7 @@ function createTestDb(): DrizzleDb {
     )
   `);
   migrateActivationState(db);
+  migrateMemoryV2InjectionEvents(db);
   return db;
 }
 

--- a/assistant/src/memory/v2/injection-events.ts
+++ b/assistant/src/memory/v2/injection-events.ts
@@ -1,0 +1,101 @@
+import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const log = getLogger("memory-v2-injection-events");
+
+/**
+ * Half-life of the injection-frequency decay, in milliseconds.
+ *
+ * Per the memory router v4 spec: a +1 from 3 days ago contributes 0.5; from
+ * 6 days ago 0.25. Decoupled from turn volume — busy and quiet days decay
+ * at the same wall-clock rate.
+ */
+export const INJECTION_SCORE_HALF_LIFE_MS = 3 * 24 * 60 * 60 * 1000;
+
+export const INJECTION_SCORE_LAMBDA =
+  Math.log(2) / INJECTION_SCORE_HALF_LIFE_MS;
+
+// Events past 6 half-lives contribute <1.6% each. Reads bound the scan to
+// this window so per-slug score computation stays cheap as history grows.
+const READ_WINDOW_MS = 6 * INJECTION_SCORE_HALF_LIFE_MS;
+
+function decayContribution(elapsedMs: number): number {
+  return Math.exp(-INJECTION_SCORE_LAMBDA * elapsedMs);
+}
+
+/**
+ * Append one event per slug. Best-effort — a SQLite write must never abort
+ * the agent turn on top of a successful routing decision the rest of the
+ * caller depends on.
+ */
+export function recordInjectionEvents(
+  database: DrizzleDb,
+  slugs: readonly string[],
+  injectedAt: number,
+): void {
+  if (slugs.length === 0) return;
+  try {
+    const raw = getSqliteFrom(database);
+    const insert = raw.prepare(
+      `INSERT INTO memory_v2_injection_events (slug, injected_at) VALUES (?, ?)`,
+    );
+    const append = raw.transaction((items: readonly string[]) => {
+      for (const slug of items) insert.run(slug, injectedAt);
+    });
+    append(slugs);
+  } catch (err) {
+    log.warn(
+      { err, slugCount: slugs.length },
+      "failed to record injection events; continuing",
+    );
+  }
+}
+
+/** `score(now) = Σᵢ exp(-λ × (now - tᵢ))` over events within READ_WINDOW_MS. */
+export function computeInjectionScore(
+  database: DrizzleDb,
+  slug: string,
+  now: number,
+): number {
+  const cutoff = now - READ_WINDOW_MS;
+  const raw = getSqliteFrom(database);
+  const rows = raw
+    .query(
+      `SELECT injected_at FROM memory_v2_injection_events
+        WHERE slug = ? AND injected_at >= ?`,
+    )
+    .all(slug, cutoff) as Array<{ injected_at: number }>;
+  let score = 0;
+  for (const row of rows) score += decayContribution(now - row.injected_at);
+  return score;
+}
+
+/**
+ * Batch variant of `computeInjectionScore` — single SQL pass scoped to the
+ * requested slugs so tier assignment doesn't issue O(M) queries. Slugs
+ * with no events in the read window are omitted from the result; callers
+ * should treat a missing entry as score 0.
+ */
+export function computeInjectionScores(
+  database: DrizzleDb,
+  slugs: readonly string[],
+  now: number,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  if (slugs.length === 0) return out;
+  const cutoff = now - READ_WINDOW_MS;
+  const raw = getSqliteFrom(database);
+  const placeholders = slugs.map(() => "?").join(",");
+  const rows = raw
+    .query(
+      `SELECT slug, injected_at FROM memory_v2_injection_events
+        WHERE slug IN (${placeholders}) AND injected_at >= ?`,
+    )
+    .all(...slugs, cutoff) as Array<{ slug: string; injected_at: number }>;
+  for (const row of rows) {
+    const prev = out.get(row.slug) ?? 0;
+    out.set(row.slug, prev + decayContribution(now - row.injected_at));
+  }
+  return out;
+}

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -43,6 +43,7 @@ import {
   isCliCommandSlug,
 } from "./cli-command-store.js";
 import { getEdgeIndex } from "./edge-index.js";
+import { recordInjectionEvents } from "./injection-events.js";
 import { readPage, renderPageContent } from "./page-store.js";
 import { runRouter } from "./router.js";
 import { getSkillCapability, isSkillSlug } from "./skill-store.js";
@@ -554,6 +555,15 @@ async function injectViaRouter(args: {
     config,
     ...(signal ? { signal } : {}),
   });
+
+  // Record router selections to the EMA event log. The router decided these
+  // slugs are relevant THIS turn (regardless of whether they're newly
+  // rendered or re-picked from prior context). The helper swallows its own
+  // errors — a SQLite write must not abort the turn on top of a successful
+  // routing decision the rest of this function depends on.
+  if (routerResult.failureReason === null) {
+    recordInjectionEvents(database, routerResult.selectedSlugs, Date.now());
+  }
 
   if (routerResult.failureReason !== null) {
     log.warn(


### PR DESCRIPTION
## Summary
- Add `memory_v2_injection_events` table (append-only `(slug, injected_at)` log) with backfill from existing `memory_v2_activation_logs` router-sourced selections.
- Add `recordInjectionEvents` / `computeInjectionScore` / `computeInjectionScores` helpers in `assistant/src/memory/v2/injection-events.ts` using a 3-day half-life decay (`score = Σ exp(-λ × Δt)`).
- Hook `injectViaRouter` to record `routerResult.selectedSlugs` on every successful router turn (best-effort, swallows SQLite errors so a logging hiccup never aborts the turn).

## Original prompt
Step 1 of the memory router v4 spec (`~/.vellum/workspace/scratch/memory-router-v4-spec.md`) — track time-decayed injection frequencies per concept page so the future tier 2 of the parallel router can pick the top-M-by-EMA pages. Pure instrumentation; routing decisions are unchanged. Recording the router's selection (not post-dedup renders) captures the \"router said this is relevant THIS turn\" signal that drives tier 2 graduation. Backfilling from existing activation logs avoids waiting days for meaningful scores.

## Test plan
- [x] \`bun test src/memory/v2/__tests__/injection-events.test.ts\` — 14 new tests covering migration, backfill (with and without prior activation logs), idempotent re-run, decay math at 0d/3d/6d, multi-event sums, and batch parity.
- [x] \`bun test src/memory/v2/__tests__/injection.test.ts\` — existing 38 tests still pass with the new migration wired into the test DB setup.
- [x] \`bunx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->