### PR TITLE
feat(memory-v2): parallel batch routing with stable hash-bucketed splitting

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -36,6 +36,7 @@ describe("MemoryV2ConfigSchema", () => {
         enabled: true,
         max_page_ids: 25,
         router_prompt_path: null,
+        batch_size: null,
       },
     });
   });

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -282,8 +282,22 @@ export const MemoryV2ConfigSchema = z
           .describe(
             "Optional path to a file whose contents replace the bundled router prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, and `{{PAGE_INDEX}}`, which are substituted at runtime. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
           ),
+        batch_size: z
+          .number()
+          .int()
+          .min(1)
+          .nullable()
+          .default(null)
+          .describe(
+            "Target batch size for parallel page-index routing. `null` (default) sends the entire page index in one call — identical to v3 behavior. When set, pages are split into `ceil(N / batch_size)` batches by stable FNV-1a hash on slug (so adding/removing a single page only invalidates one batch's KV cache), routed in parallel, and the selected slugs are unioned. A failure in one batch does not abort the turn as long as at least one batch succeeds.",
+          ),
       })
-      .default({ enabled: true, max_page_ids: 25, router_prompt_path: null })
+      .default({
+        enabled: true,
+        max_page_ids: 25,
+        router_prompt_path: null,
+        batch_size: null,
+      })
       .describe(
         "LLM router configuration. When enabled, a single router LLM call replaces spreading activation for per-turn page selection.",
       ),

--- a/assistant/src/memory/v2/__tests__/page-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-index.test.ts
@@ -53,7 +53,8 @@ mock.module("../page-store.js", () => ({
   },
 }));
 
-const { getPageIndex, invalidatePageIndex } = await import("../page-index.js");
+const { getPageIndex, invalidatePageIndex, partitionPageIndex } =
+  await import("../page-index.js");
 const { writePage } = await import("../page-store.js");
 const { invalidateEdgeIndex } = await import("../edge-index.js");
 
@@ -356,5 +357,138 @@ describe("rendered prompt block", () => {
     await writePage(workspaceDir, makePage("alice", { summary: "A page" }));
     const idx = await getPageIndex(workspaceDir);
     expect(idx.rendered).toBe("[1] alice — A page\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// partitionPageIndex — stable batch assignment
+// ---------------------------------------------------------------------------
+
+describe("partitionPageIndex", () => {
+  async function buildIndex(slugs: string[]) {
+    for (const slug of slugs) {
+      await writePage(workspaceDir, makePage(slug, { summary: `${slug} sum` }));
+    }
+    return getPageIndex(workspaceDir);
+  }
+
+  test("batchSize=null returns the same index reference (no work, KV cache safe)", async () => {
+    const idx = await buildIndex(["alice", "bob", "carol"]);
+    const batches = partitionPageIndex(idx, null);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toBe(idx);
+  });
+
+  test("batchSize >= entries.length is a single batch identical to the input", async () => {
+    const idx = await buildIndex(["alice", "bob", "carol"]);
+    const batches = partitionPageIndex(idx, 10);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toBe(idx);
+  });
+
+  test("splits N=5 with batchSize=2 into 3 batches preserving all slugs", async () => {
+    const idx = await buildIndex(["a", "b", "c", "d", "e"]);
+    const batches = partitionPageIndex(idx, 2);
+    expect(batches.length).toBeGreaterThanOrEqual(2);
+    const allSlugs = batches.flatMap((b) => b.entries.map((e) => e.slug));
+    expect(new Set(allSlugs)).toEqual(new Set(["a", "b", "c", "d", "e"]));
+    // Every slug appears in exactly one batch.
+    expect(allSlugs.length).toBe(5);
+  });
+
+  test("re-renders each batch with local 1-based IDs", async () => {
+    const idx = await buildIndex(["a", "b", "c", "d", "e"]);
+    const batches = partitionPageIndex(idx, 2);
+    for (const batch of batches) {
+      expect(batch.entries.map((e) => e.id)).toEqual(
+        batch.entries.map((_, i) => i + 1),
+      );
+      for (const entry of batch.entries) {
+        expect(batch.byId.get(entry.id)).toBe(entry);
+        expect(batch.bySlug.get(entry.slug)).toBe(entry);
+        expect(batch.rendered).toContain(`[${entry.id}] ${entry.slug}`);
+      }
+    }
+  });
+
+  test("KV-cache stability: adding ONE slug only changes the batch it lands in", async () => {
+    // 4 slugs → 2 batches at batchSize=2. Adding a 5th slug should keep
+    // the slug→batch mapping of the original 4 intact except possibly
+    // shifting which 2 of the 3 resulting batches contain them. The
+    // critical invariant: for each ORIGINAL slug, the rendered string of
+    // its containing batch must be byte-identical before and after (so
+    // Anthropic's KV cache hits) — but only when the batch count is
+    // unchanged. When N crosses a ceiling boundary, batch_count grows
+    // and we accept the one-time reshuffle (rare in practice).
+
+    // Pick a slug set that stays at batch_count=3 both before (6 slugs,
+    // ceil(6/2)=3) and after (7 slugs, ceil(7/2)=4) → batch count
+    // changes. Instead, hold batch_count constant by going from 5 to 6
+    // slugs at batchSize=3: ceil(5/3)=2, ceil(6/3)=2.
+    const before = await buildIndex(["a", "b", "c", "d", "e"]);
+    const batchesBefore = partitionPageIndex(before, 3);
+    expect(batchesBefore).toHaveLength(2);
+
+    const renderedBySlug = new Map<string, string>();
+    for (const batch of batchesBefore) {
+      for (const entry of batch.entries) {
+        renderedBySlug.set(entry.slug, batch.rendered);
+      }
+    }
+
+    // Drop the cached global index, write one more page, rebuild.
+    invalidatePageIndex();
+    invalidateEdgeIndex();
+    await writePage(workspaceDir, makePage("f", { summary: "f sum" }));
+    const after = await getPageIndex(workspaceDir);
+    const batchesAfter = partitionPageIndex(after, 3);
+    expect(batchesAfter).toHaveLength(2);
+
+    // Locate each original slug's NEW batch and compare against its OLD
+    // rendered string. We expect exactly one of the two batches'
+    // rendered strings to be byte-identical to the pre-add version (the
+    // batch that didn't gain `f`); the other batch's rendering changed
+    // because `f` was added to it.
+    const renderedAfterBySlug = new Map<string, string>();
+    for (const batch of batchesAfter) {
+      for (const entry of batch.entries) {
+        renderedAfterBySlug.set(entry.slug, batch.rendered);
+      }
+    }
+    let unchangedSlugs = 0;
+    for (const slug of ["a", "b", "c", "d", "e"]) {
+      if (renderedBySlug.get(slug) === renderedAfterBySlug.get(slug)) {
+        unchangedSlugs += 1;
+      }
+    }
+    // At least some slugs must have their batch's rendered string
+    // preserved — index-modulo chunking would change ALL batches when
+    // a slug is added at any position. With hash-bucketing only the
+    // bucket `f` landed in changes.
+    expect(unchangedSlugs).toBeGreaterThan(0);
+  });
+
+  test("edges to pages in other batches drop; edges within a batch remap to local IDs", async () => {
+    // Force `alice → bob` edge. Choose batchSize=1 so alice and bob land
+    // in separate batches → the edge should drop.
+    await writePage(
+      workspaceDir,
+      makePage("alice", { summary: "A", edges: ["bob"] }),
+    );
+    await writePage(workspaceDir, makePage("bob", { summary: "B" }));
+    const idx = await getPageIndex(workspaceDir);
+    const batches = partitionPageIndex(idx, 1);
+
+    for (const batch of batches) {
+      for (const entry of batch.entries) {
+        // Edges must point to IDs that exist in THIS batch's byId map.
+        for (const edgeId of entry.edges) {
+          expect(batch.byId.has(edgeId)).toBe(true);
+        }
+      }
+    }
+    // alice's edge to bob must have dropped (bob is in a different batch).
+    const aliceBatch = batches.find((b) => b.bySlug.has("alice"))!;
+    expect(aliceBatch.bySlug.get("alice")!.edges).toEqual([]);
   });
 });

--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -194,7 +194,10 @@ function makePage(
 // fields the router actually reads. Cast through `as unknown` because the
 // production type is a heavy nested schema; we only exercise the v2.router
 // branch in this test file.
-function makeConfig(overrides?: { maxPageIds?: number }) {
+function makeConfig(overrides?: {
+  maxPageIds?: number;
+  batchSize?: number | null;
+}) {
   return {
     memory: {
       v2: {
@@ -202,6 +205,7 @@ function makeConfig(overrides?: { maxPageIds?: number }) {
         router: {
           enabled: true,
           max_page_ids: overrides?.maxPageIds ?? 25,
+          batch_size: overrides?.batchSize ?? null,
         },
       },
     },
@@ -527,5 +531,166 @@ describe("runRouter — failure modes", () => {
     expect(providerCalls).toHaveLength(1);
     // Signal must be forwarded — otherwise the stub's aborted-check wouldn't fire.
     expect(providerCalls[0].options?.signal).toBe(controller.signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batched routing (config.memory.v2.router.batch_size).
+// ---------------------------------------------------------------------------
+
+describe("runRouter — batched (batch_size set)", () => {
+  beforeEach(async () => {
+    // 5 pages → at batch_size=2 we get ceil(5/2)=3 batches.
+    await writePage(workspaceDir, makePage("alpha", { summary: "A" }));
+    await writePage(workspaceDir, makePage("bravo", { summary: "B" }));
+    await writePage(workspaceDir, makePage("charlie", { summary: "C" }));
+    await writePage(workspaceDir, makePage("delta", { summary: "D" }));
+    await writePage(workspaceDir, makePage("echo", { summary: "E" }));
+  });
+
+  test("fires one provider call per batch in parallel", async () => {
+    // Every batch returns its local id 1 → at most 3 distinct slugs in the
+    // union (one per batch), but we don't assert WHICH slugs the FNV
+    // bucketing picks; just that the provider was called once per batch.
+    providerStub = makeProvider(toolUseResponse([1]));
+
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 2 }),
+    });
+
+    expect(result.failureReason).toBeNull();
+    expect(providerCalls.length).toBeGreaterThan(1);
+    expect(providerCalls.length).toBeLessThanOrEqual(3);
+    // Every batch picked its own local id 1 → distinct slugs in union.
+    expect(result.selectedSlugs.length).toBe(providerCalls.length);
+    expect(new Set(result.selectedSlugs).size).toBe(
+      result.selectedSlugs.length,
+    );
+  });
+
+  test("each batch's system prompt contains only its own subset of slugs", async () => {
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 2 }),
+    });
+
+    // Across all batch calls, every slug appears in exactly one prompt.
+    const allSlugs = ["alpha", "bravo", "charlie", "delta", "echo"];
+    const appearances = new Map<string, number>(allSlugs.map((s) => [s, 0]));
+    for (const call of providerCalls) {
+      for (const slug of allSlugs) {
+        if (call.systemPrompt?.includes(slug)) {
+          appearances.set(slug, (appearances.get(slug) ?? 0) + 1);
+        }
+      }
+    }
+    for (const slug of allSlugs) {
+      expect(appearances.get(slug)).toBe(1);
+    }
+  });
+
+  test("union of selected slugs is deduplicated across batches", async () => {
+    // Every batch returns its local id 1. Same slug could appear in only
+    // one batch (since each slug lives in exactly one batch), so the union
+    // is naturally unique. Sanity-check the dedup path with a 2-call response.
+    providerStub = makeProvider(toolUseResponse([1, 1]));
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 2 }),
+    });
+    expect(result.failureReason).toBeNull();
+    expect(new Set(result.selectedSlugs).size).toBe(
+      result.selectedSlugs.length,
+    );
+  });
+
+  test("priorEverInjected is filtered to the batch's own slugs as local IDs", async () => {
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      priorEverInjected: [
+        { slug: "alpha", turn: 1 },
+        { slug: "echo", turn: 1 },
+      ],
+      config: makeConfig({ batchSize: 2 }),
+    });
+
+    // Exactly the batches containing alpha or echo should mention any
+    // already_injected_id; other batches should have an empty list.
+    for (const call of providerCalls) {
+      const text =
+        (call.messages[0].content as Array<{ text?: string }>)[1]?.text ?? "";
+      const hasAlpha = call.systemPrompt?.includes("alpha");
+      const hasEcho = call.systemPrompt?.includes("echo");
+      const expectsId = hasAlpha || hasEcho;
+      // Block contents: "<already_injected_ids>\n{ids}\n</already_injected_ids>"
+      const match = text.match(
+        /<already_injected_ids>\n([^\n]*)\n<\/already_injected_ids>/,
+      );
+      const idsStr = match?.[1] ?? "";
+      if (expectsId) {
+        expect(idsStr.trim().length).toBeGreaterThan(0);
+      } else {
+        expect(idsStr.trim()).toBe("");
+      }
+    }
+  });
+
+  test("partial failure: one batch fails, others succeed → union returned with success", async () => {
+    let callCount = 0;
+    providerStub = {
+      name: "partial-failure",
+      sendMessage: async (messages, tools, systemPrompt, options) => {
+        callCount += 1;
+        providerCalls.push({ messages, tools, systemPrompt, options });
+        if (callCount === 1) throw new Error("batch 1 boom");
+        return toolUseResponse([1]);
+      },
+    };
+
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 2 }),
+    });
+
+    expect(result.failureReason).toBeNull();
+    expect(result.selectedSlugs.length).toBeGreaterThan(0);
+    expect(providerCalls.length).toBeGreaterThan(1);
+  });
+
+  test("all batches fail → unified failure with first batch's reason", async () => {
+    providerStub = {
+      name: "all-fail",
+      sendMessage: async () => {
+        throw new Error("all batches boom");
+      },
+    };
+
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 2 }),
+    });
+
+    expect(result.failureReason).toBe("api_error");
+    expect(result.selectedSlugs).toEqual([]);
+  });
+
+  test("batch_size larger than index size is single batch (same as v3)", async () => {
+    providerStub = makeProvider(toolUseResponse([1]));
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 1000 }),
+    });
+    expect(result.failureReason).toBeNull();
+    expect(providerCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -244,3 +244,83 @@ function renderIndex(entries: readonly PageIndexEntry[]): string {
   });
   return lines.length > 0 ? `${lines.join("\n")}\n` : "";
 }
+
+// FNV-1a 32-bit. Stable across runtimes — never change the constants or
+// future releases will silently reshuffle batches and torch every batch's
+// KV cache simultaneously.
+function fnv1aHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Split a global `PageIndex` into batches of approximately `batchSize`
+ * entries for parallel routing. Each batch is a self-contained `PageIndex`
+ * with batch-local 1-based IDs and a re-rendered prompt block.
+ *
+ * `batchSize === null` or `entries.length <= batchSize` short-circuits to
+ * `[pageIndex]` (the same object) so single-batch callers send a request
+ * bit-identical to the pre-batching code path and reuse v3's KV cache
+ * untouched.
+ *
+ * Assignment uses FNV-1a on the slug: adding or removing one page only
+ * invalidates the KV cache of the one batch it lands in, instead of
+ * cascading through every batch the way index-modulo chunking would.
+ *
+ * Edges are re-resolved to batch-local IDs — edges pointing to pages in
+ * other batches drop silently (the model can't reference them anyway).
+ */
+export function partitionPageIndex(
+  pageIndex: PageIndex,
+  batchSize: number | null,
+): PageIndex[] {
+  if (batchSize === null || pageIndex.entries.length <= batchSize) {
+    return [pageIndex];
+  }
+  const batchCount = Math.ceil(pageIndex.entries.length / batchSize);
+  const buckets: PageIndexEntry[][] = Array.from(
+    { length: batchCount },
+    () => [],
+  );
+  for (const entry of pageIndex.entries) {
+    buckets[fnv1aHash(entry.slug) % batchCount].push(entry);
+  }
+  return buckets
+    .filter((b) => b.length > 0)
+    .map((entries) => {
+      const localBySlug = new Map<string, PageIndexEntry>();
+      const localById = new Map<number, PageIndexEntry>();
+      const localEntries: PageIndexEntry[] = entries.map((src, i) => {
+        const local: PageIndexEntry = {
+          id: i + 1,
+          slug: src.slug,
+          summary: src.summary,
+          edges: [],
+        };
+        localBySlug.set(local.slug, local);
+        localById.set(local.id, local);
+        return local;
+      });
+      for (let i = 0; i < localEntries.length; i++) {
+        const localEdges: number[] = [];
+        for (const globalEdgeId of entries[i].edges) {
+          const target = pageIndex.byId.get(globalEdgeId);
+          if (!target) continue;
+          const localTarget = localBySlug.get(target.slug);
+          if (localTarget) localEdges.push(localTarget.id);
+        }
+        localEdges.sort((a, b) => a - b);
+        localEntries[i].edges = localEdges;
+      }
+      return {
+        entries: localEntries,
+        bySlug: localBySlug,
+        byId: localById,
+        rendered: renderIndex(localEntries),
+      };
+    });
+}

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -47,7 +47,8 @@ import type {
   ToolDefinition,
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
-import { getPageIndex } from "./page-index.js";
+import type { PageIndex } from "./page-index.js";
+import { getPageIndex, partitionPageIndex } from "./page-index.js";
 import { resolveRouterPrompt } from "./prompts/router.js";
 import type { EverInjectedEntry } from "./types.js";
 
@@ -130,43 +131,32 @@ interface RunRouterParams {
 }
 
 /**
- * Run the router for one turn. The implementation steps (mirroring
- * `sweep-job.ts` end-to-end):
+ * Run the router for one turn.
  *
- *   1. Build the page index. If the workspace has no concept pages and no
- *      seeded skill entries, abstain immediately with `empty_index`.
- *   2. Resolve the configured provider for the `memoryRouter` call site.
- *      Missing → `no_provider` so the caller can fall back to spreading
- *      activation or an empty injection.
- *   3. Build system + user prompts. The system prompt is the rendered
- *      router template with the page index inlined and gets one ephemeral
- *      breakpoint at the end (the page-index block). The user message is
- *      *two* text blocks: the cached `<now>` block and the uncached
- *      already-injected/last-turn block.
- *   4. Force `tool_choice` so the model can only emit `select_pages_to_inject`.
- *   5. Parse the tool input via Zod. Anything off-shape collapses to
- *      `schema_mismatch`.
- *   6. Map IDs to slugs through the page index, dropping IDs outside
- *      `[1, N]` and truncating at `max_page_ids`.
+ * Top-level orchestration. When `config.memory.v2.router.batch_size` is
+ * `null` (default), the entire page index is sent in one call — bit-
+ * identical to the pre-batching code path so v3's KV cache is preserved.
+ * When set, `partitionPageIndex` splits the index into stable hash-bucketed
+ * batches and we fire one provider call per batch in parallel; the selected
+ * slugs are unioned across batches.
  *
- * Any uncaught throw inside the call (network, provider SDK error, abort)
- * collapses to `api_error` and is logged at warn so callers can keep going
- * without crashing the daemon. `AbortSignal.aborted` errors are *not*
- * special-cased; they propagate as `api_error` because the caller treats
- * "router didn't finish" the same regardless of cause.
+ * Per-batch failure does not abort the turn — as long as at least one batch
+ * returns a usable selection, the union is returned with `failureReason:
+ * null`. Only when EVERY batch fails do we surface a failure; in that case
+ * the first batch's reason is returned for parity with the single-batch
+ * v3 behavior.
+ *
+ * Single batch error semantics, preserved from v3:
+ * - `empty_index` — workspace has no concept pages or skill entries.
+ * - `no_provider` — `getConfiguredProvider("memoryRouter")` returned null.
+ * - `api_error` — any uncaught throw during the provider call (incl. abort).
+ * - `tool_use_missing` — the model returned no `select_pages_to_inject` tool_use.
+ * - `schema_mismatch` — tool input failed Zod validation.
  */
 export async function runRouter(
   params: RunRouterParams,
 ): Promise<RouterResult> {
-  const {
-    workspaceDir,
-    userMessage,
-    assistantMessage,
-    nowText,
-    priorEverInjected,
-    config,
-    signal,
-  } = params;
+  const { workspaceDir, priorEverInjected, config } = params;
 
   const pageIndex = await getPageIndex(workspaceDir);
   if (pageIndex.entries.length === 0) {
@@ -179,31 +169,98 @@ export async function runRouter(
     return emptyResult("no_provider");
   }
 
+  const batchSize = config.memory?.v2?.router?.batch_size ?? null;
+  const batches = partitionPageIndex(pageIndex, batchSize);
+
+  const batchResults = await Promise.all(
+    batches.map((batch) =>
+      runRouterBatch({
+        ...params,
+        batchIndex: batch,
+        priorEverInjected,
+        provider,
+      }),
+    ),
+  );
+
+  const successes = batchResults.filter((r) => r.failureReason === null);
+  if (successes.length === 0) {
+    // For the single-batch (K=null) path this preserves v3's behavior:
+    // one batch, one failure reason surfaces directly.
+    return emptyResult(batchResults[0].failureReason);
+  }
+
+  // Union selected slugs preserving first-seen order across batches; batch
+  // ordering is deterministic (hash bucket index) so the union is stable.
+  const seen = new Set<string>();
+  const selectedSlugs: string[] = [];
+  for (const result of batchResults) {
+    for (const slug of result.selectedSlugs) {
+      if (seen.has(slug)) continue;
+      seen.add(slug);
+      selectedSlugs.push(slug);
+    }
+  }
+  if (successes.length < batchResults.length) {
+    log.warn(
+      {
+        totalBatches: batchResults.length,
+        failedBatches: batchResults.length - successes.length,
+        failureReasons: batchResults
+          .filter((r) => r.failureReason !== null)
+          .map((r) => r.failureReason),
+      },
+      "Some router batches failed; returning union of successful batches",
+    );
+  }
+  return { selectedSlugs, failureReason: null };
+}
+
+interface RunRouterBatchParams extends RunRouterParams {
+  batchIndex: PageIndex;
+  provider: NonNullable<Awaited<ReturnType<typeof getConfiguredProvider>>>;
+}
+
+/**
+ * Route one batch of the page index. Uses batch-local IDs everywhere
+ * (including `<already_injected_ids>`, which is filtered to slugs present
+ * in this batch). Provider is passed in by the orchestrator so we don't
+ * re-resolve it N times for an N-batch turn.
+ */
+async function runRouterBatch(
+  params: RunRouterBatchParams,
+): Promise<RouterResult> {
+  const {
+    workspaceDir,
+    userMessage,
+    assistantMessage,
+    nowText,
+    priorEverInjected,
+    config,
+    signal,
+    batchIndex,
+    provider,
+  } = params;
+
   const systemPrompt = resolveRouterPrompt(
     config.memory?.v2?.router?.router_prompt_path ?? null,
     workspaceDir,
     {
       assistantName: getAssistantName(),
       userName: resolveUserName(workspaceDir),
-      pageIndexBlock: pageIndex.rendered,
+      pageIndexBlock: batchIndex.rendered,
     },
   );
 
-  // Already-injected slugs that map back to a current index ID. Slugs whose
-  // page has been deleted since the prior turn drop out silently — the model
-  // only sees IDs that still resolve.
+  // Filter prior-injected to slugs present in THIS batch and map to
+  // batch-local IDs. The model in batch B can't reference global IDs that
+  // aren't in its prompt, so listing them would just be noise.
   const priorIds: number[] = [];
   for (const entry of priorEverInjected) {
-    const idx = pageIndex.bySlug.get(entry.slug);
-    if (idx) priorIds.push(idx.id);
+    const local = batchIndex.bySlug.get(entry.slug);
+    if (local) priorIds.push(local.id);
   }
 
-  // Cache breakpoint 2 — `<now>` is stable across most turns (NOW.md only
-  // changes when the model rewrites it), so the bulk of the user message
-  // rides the cache. We use a 1h TTL to match the system-prompt breakpoint
-  // and the provider's auto-applied breakpoints. The trailing block has no
-  // `cache_control`; the Anthropic provider auto-applies a 1h breakpoint on
-  // the last text block of a turn-starting user message, which covers it.
   const userMsg: Message = {
     role: "user",
     content: [
@@ -257,8 +314,7 @@ export async function runRouter(
     return emptyResult("schema_mismatch");
   }
 
-  const N = pageIndex.entries.length;
-
+  const N = batchIndex.entries.length;
   const inRangeIds: number[] = [];
   const droppedIds: number[] = [];
   for (const id of parsed.data.page_ids) {
@@ -275,9 +331,8 @@ export async function runRouter(
     );
   }
 
-  // De-duplicate BEFORE applying the cap — otherwise a duplicate-heavy
-  // model output like `[1, 1, 2]` with `max=2` slices to `[1, 1]` and
-  // dedupes to `[1]`, under-filling the cap.
+  // De-duplicate BEFORE applying the cap — `[1, 1, 2]` with max=2 must
+  // yield 2 distinct slugs, not collapse to 1 after slicing duplicates.
   const dedupedIds = Array.from(new Set(inRangeIds));
 
   const truncated = dedupedIds.length > maxPageIds;
@@ -291,7 +346,7 @@ export async function runRouter(
 
   const selectedSlugs: string[] = [];
   for (const id of finalIds) {
-    const entry = pageIndex.byId.get(id);
+    const entry = batchIndex.byId.get(id);
     if (!entry) continue;
     selectedSlugs.push(entry.slug);
   }


### PR DESCRIPTION
## Summary
- New \`config.memory.v2.router.batch_size\` (default \`null\`). When set, splits the page index into \`ceil(N / batch_size)\` parallel router calls and unions the selected slugs.
- Stable bucketing via FNV-1a 32-bit hash on each slug — adding one page only invalidates the KV cache of the batch it lands in, not all batches.
- \`partitionPageIndex(pageIndex, batchSize)\` returns batch-local \`PageIndex\` objects with re-rendered prompt blocks, local 1-based IDs, and edges remapped to local IDs (cross-batch edges drop).
- Single-batch path (\`batch_size: null\`) returns the global index unchanged — request is bit-identical to v3 so the existing system-prompt + \`<now>\` cache breakpoints still hit.
- 13 new tests covering batching, partition stability across adding a page, partial failure, and full failure.

## Original prompt
Step 2 of the memory router v4 spec — build the parallel fan-out infrastructure with K=∞ default so behavior is identical to v3, then expose K via config so we can shake it down by setting it lower in staging without a code change. The KV cache stability requirement was called out mid-implementation: index-modulo splitting cascades cache misses across every batch when one page is added, while hash-bucketing keeps all but one batch unchanged.

## Test plan
- [x] \`bun test src/memory/v2/__tests__/router.test.ts\` — 23 tests pass.
- [x] \`bun test src/memory/v2/__tests__/page-index.test.ts\` — 26 tests pass.
- [x] \`bun test src/memory/v2/__tests__/injection.test.ts\` — 38 tests pass.
- [x] \`bun test src/config/schemas/__tests__/memory-v2.test.ts\` — 25 tests pass.
- [x] \`bunx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->