### PR TITLE
feat(macos): Auto option in profile picker for query complexity routing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -54,12 +54,17 @@ struct ChatProfilePicker: View {
     /// conversation falls back to `activeProfile`.
     let onSelect: (String?) -> Void
 
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     /// Pill label: the override profile's display name when set, otherwise
-    /// "Default (`<activeProfile>`)". Internal so tests can assert on it
-    /// without spinning up a SwiftUI host.
-    static func label(current: String?, profiles: [InferenceProfile], activeProfile: String) -> String {
+    /// "Auto" when auto-routing is enabled or "Default (`<activeProfile>`)"
+    /// when it is not.
+    static func label(current: String?, profiles: [InferenceProfile], activeProfile: String, autoRouting: Bool = false) -> String {
         if let current {
             return profiles.first(where: { $0.name == current })?.displayName ?? current
+        }
+        if autoRouting {
+            return "Auto"
         }
         let activeDisplay = profiles.first(where: { $0.name == activeProfile })?.displayName ?? activeProfile
         return "Default (\(activeDisplay))"
@@ -67,7 +72,9 @@ struct ChatProfilePicker: View {
 
     var body: some View {
         let activeProfiles = profiles.filter { !$0.isDisabled }
-        let pillLabel = Self.label(current: current, profiles: activeProfiles, activeProfile: activeProfile)
+        let autoRoutingEnabled = assistantFeatureFlagStore.isEnabled("query-complexity-routing")
+        let isAutoActive = autoRoutingEnabled && current == nil
+        let pillLabel = Self.label(current: current, profiles: activeProfiles, activeProfile: activeProfile, autoRouting: autoRoutingEnabled)
         #if os(macOS)
         ComposerPillMenu(
             isEnabled: isEnabled,
@@ -82,35 +89,56 @@ struct ChatProfilePicker: View {
                 .foregroundStyle(VColor.contentSecondary)
                 .lineLimit(1)
         } menu: {
-            ForEach(activeProfiles) { profile in
+            if autoRoutingEnabled {
                 VMenuItem(
-                    icon: VIcon.sparkles.rawValue,
-                    label: profile.displayName,
-                    isActive: current == profile.name,
+                    icon: VIcon.wand.rawValue,
+                    label: "Auto",
+                    isActive: isAutoActive,
                     size: .regular
                 ) {
-                    onSelect(profile.name)
+                    onSelect(nil)
                 } trailing: {
                     VStack(alignment: .trailing, spacing: 2) {
-                        if current == profile.name {
+                        if isAutoActive {
                             VIconView(.check, size: 12)
                                 .foregroundStyle(VColor.primaryBase)
                         }
                     }
                 }
             }
-            VMenuItem(
-                icon: VIcon.rotateCcw.rawValue,
-                label: "Reset to default (\(activeProfiles.first { $0.name == activeProfile }?.displayName ?? activeProfile))",
-                isActive: current == nil,
-                size: .regular
-            ) {
-                onSelect(nil)
-            } trailing: {
-                VStack(alignment: .trailing, spacing: 2) {
-                    if current == nil {
-                        VIconView(.check, size: 12)
-                            .foregroundStyle(VColor.primaryBase)
+
+            ForEach(activeProfiles) { profile in
+                VMenuItem(
+                    icon: VIcon.sparkles.rawValue,
+                    label: profile.displayName,
+                    isActive: !isAutoActive && current == profile.name,
+                    size: .regular
+                ) {
+                    onSelect(profile.name)
+                } trailing: {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        if !isAutoActive && current == profile.name {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
+                    }
+                }
+            }
+
+            if !autoRoutingEnabled {
+                VMenuItem(
+                    icon: VIcon.rotateCcw.rawValue,
+                    label: "Reset to default (\(activeProfiles.first { $0.name == activeProfile }?.displayName ?? activeProfile))",
+                    isActive: current == nil,
+                    size: .regular
+                ) {
+                    onSelect(nil)
+                } trailing: {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        if current == nil {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -22,6 +22,8 @@ struct ComposerSettingsMenu: View {
 
     let inferenceProfilePicker: ChatProfilePickerConfiguration?
 
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+
     // MARK: - Threshold state (mirrors ComposerThresholdPicker)
 
     @State private var currentPreset: ThresholdPreset = .relaxed
@@ -150,20 +152,39 @@ struct ComposerSettingsMenu: View {
                 }
 
                 if let config, !config.profiles.isEmpty {
+                    let autoRoutingEnabled = assistantFeatureFlagStore.isEnabled("query-complexity-routing")
+                    let hasOverride = config.current != nil
+                    let isAutoActive = autoRoutingEnabled && !hasOverride
                     let effectiveProfile = config.current ?? config.activeProfile
 
                     sectionHeader("Model Profile")
+
+                    if autoRoutingEnabled {
+                        VMenuItem(
+                            icon: VIcon.wand.rawValue,
+                            label: "Auto",
+                            isActive: isAutoActive,
+                            size: .regular
+                        ) {
+                            config.onSelect(nil)
+                        } trailing: {
+                            if isAutoActive {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                    }
 
                     ForEach(config.profiles) { profile in
                         VMenuItem(
                             icon: VIcon.sparkles.rawValue,
                             label: profile.displayName,
-                            isActive: effectiveProfile == profile.name,
+                            isActive: !isAutoActive && effectiveProfile == profile.name,
                             size: .regular
                         ) {
                             config.onSelect(profile.name)
                         } trailing: {
-                            if effectiveProfile == profile.name {
+                            if !isAutoActive && effectiveProfile == profile.name {
                                 VIconView(.check, size: 12)
                                     .foregroundStyle(VColor.primaryBase)
                             }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -729,6 +729,12 @@ public struct ConversationInferenceProfileUpdatedMessage: Decodable, Sendable {
     }
 }
 
+public struct TurnProfileAutoRoutedMessage: Decodable, Sendable {
+    public let conversationId: String
+    public let profile: String
+    public let profileLabel: String
+}
+
 /// Server push — tells clients their sidebar conversation list is stale.
 public struct ConversationListInvalidatedMessage: Decodable, Sendable {
     public let reason: String
@@ -2901,6 +2907,7 @@ public enum ServerMessage: Decodable, Sendable {
     case messageComplete(MessageCompleteMessage)
     case conversationInfo(ConversationInfoMessage)
     case conversationInferenceProfileUpdated(ConversationInferenceProfileUpdatedMessage)
+    case turnProfileAutoRouted(TurnProfileAutoRoutedMessage)
     case conversationTitleUpdated(ConversationTitleUpdatedMessage)
     case conversationListResponse(ConversationListResponseMessage)
     case conversationListInvalidated(ConversationListInvalidatedMessage)
@@ -3121,6 +3128,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "conversation_inference_profile_updated":
             let message = try ConversationInferenceProfileUpdatedMessage(from: decoder)
             self = .conversationInferenceProfileUpdated(message)
+        case "turn_profile_auto_routed":
+            let message = try TurnProfileAutoRoutedMessage(from: decoder)
+            self = .turnProfileAutoRouted(message)
         case "conversation_title_updated":
             let message = try ConversationTitleUpdatedMessage(from: decoder)
             self = .conversationTitleUpdated(message)


### PR DESCRIPTION
## Summary

- Adds "Auto" option to the Model Profile section of both `ComposerSettingsMenu` and `ChatProfilePicker` on macOS
- When the `query-complexity-routing` feature flag is on, "Auto" appears at the top of the profile list
- Selecting Auto clears the per-conversation inference profile override, enabling the daemon's complexity router to pick the optimal profile per-turn
- Selecting any specific profile disables auto-routing for that conversation
- Adds `TurnProfileAutoRoutedMessage` to the `ServerMessage` enum so the macOS client can decode the daemon's routing notification event

**Depends on:** PR #31365 (daemon-side query complexity routing)

## Test plan

- [ ] Verify "Auto" appears as the first profile option when the `query-complexity-routing` flag is enabled
- [ ] Verify selecting Auto clears the conversation override (sends `nil`)
- [ ] Verify selecting a specific profile pins it and un-checks Auto
- [ ] Verify the picker looks unchanged when the feature flag is disabled
- [ ] Verify `ChatProfilePicker` pill label shows "Auto" when no override is set and flag is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->