### PR TITLE
fix(web): hoist ChatPage overlay hooks above early-return guards

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -148,6 +148,7 @@ export function ChatPage() {
   });
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
   const [assistantIdentity, setAssistantIdentity] = useState<AssistantIdentity | null>(null);
+  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
   const prePinGroupIdsRef = useRef<Map<string, string | undefined>>(new Map());
 
   // -------------------------------------------------------------------------
@@ -984,6 +985,15 @@ export function ChatPage() {
   }, [topBarRightContent, setTopBarRightSlot]);
 
   // -------------------------------------------------------------------------
+  // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    setOverlayTarget(
+      isMobile ? document.getElementById("viewport-overlays") : null,
+    );
+  }, [isMobile]);
+
+  // -------------------------------------------------------------------------
   // Derived UI state
   // -------------------------------------------------------------------------
   const hasUncompletedVisibleSurface = useMemo(() => {
@@ -1243,16 +1253,6 @@ export function ChatPage() {
     didOnboarding,
     onboardingConversationKey,
   };
-
-  // -------------------------------------------------------------------------
-  // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
-  // -------------------------------------------------------------------------
-  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    setOverlayTarget(
-      isMobile ? document.getElementById("viewport-overlays") : null,
-    );
-  }, [isMobile]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Fixes `Rendered more hooks than during the previous render.` on `/assistant` (ChatPage).
- The chat-domain drift port added loading/error early-returns near the middle of `chat-page.tsx`, while leaving the mobile overlay-portal `useState` + `useEffect` at the bottom of the component. On the initial render the guards short-circuited (so React recorded N hooks); once the assistant resolved, the function ran past the guards and React saw N+2 hooks — boom.
- Hoists the `overlayTarget` `useState` next to the other state hooks at the top of the component and moves its `useEffect` above the early-return guards.

## Test plan
- [ ] `bun --filter @vellum/web dev` and open `/assistant` — no hook-order error, normal load.
- [ ] Resize to mobile width — overlay portal still resolves (`viewport-overlays` mount).
- [ ] No regressions in chat send/receive flow.

https://claude.ai/code/session_018e9doM3Mqgmxygu47Gt6UD

---
_Generated by [Claude Code](https://claude.ai/code/session_018e9doM3Mqgmxygu47Gt6UD)_