### PR TITLE
fix(web): wire "New Conversation" buttons to create a draft conversation

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -32,6 +32,7 @@ import { OfflineBanner } from "@/components/offline-banner.js";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu.js";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu.js";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js";
+import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import { ChatLayoutHeader } from "./chat-layout-header.js";
 
 /**
@@ -234,7 +235,11 @@ export function ChatLayout() {
   const canGoForward = historyIndexRef.current < maxHistoryIndexRef.current;
 
   const handleStartNewConversation = useCallback(() => {
-    navigate(routes.assistant);
+    haptic.light();
+    useViewerStore.getState().setMainView("chat");
+    const draftKey = createDraftConversationKey();
+    useConversationStore.getState().setActiveKey(draftKey);
+    void navigate(routes.conversation(draftKey));
   }, [navigate]);
 
   const handleOpenHome = useCallback(() => {

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -148,6 +148,7 @@ export function ChatPage() {
   });
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
   const [assistantIdentity, setAssistantIdentity] = useState<AssistantIdentity | null>(null);
+  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
   const prePinGroupIdsRef = useRef<Map<string, string | undefined>>(new Map());
 
   // -------------------------------------------------------------------------
@@ -984,6 +985,15 @@ export function ChatPage() {
   }, [topBarRightContent, setTopBarRightSlot]);
 
   // -------------------------------------------------------------------------
+  // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    setOverlayTarget(
+      isMobile ? document.getElementById("viewport-overlays") : null,
+    );
+  }, [isMobile]);
+
+  // -------------------------------------------------------------------------
   // Derived UI state
   // -------------------------------------------------------------------------
   const hasUncompletedVisibleSurface = useMemo(() => {
@@ -1243,16 +1253,6 @@ export function ChatPage() {
     didOnboarding,
     onboardingConversationKey,
   };
-
-  // -------------------------------------------------------------------------
-  // Mobile overlay portal — resolve after DOM commit (CONVENTIONS.md §SSR)
-  // -------------------------------------------------------------------------
-  const [overlayTarget, setOverlayTarget] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    setOverlayTarget(
-      isMobile ? document.getElementById("viewport-overlays") : null,
-    );
-  }, [isMobile]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- The sidebar pencil icon (`AssistantSideMenu`) and the top-bar message-plus icon (`ChatLayoutHeader`) both fire `ChatLayout.handleStartNewConversation`, which was just calling `navigate(routes.assistant)`. From `/assistant` that's a no-op — React Router doesn't remount `ChatPage` and the "Hi, I'm Kit!" empty state never appears.
- Mirror the existing in-page `startNewConversation` flow (`use-conversation-loader.ts:503`): mint a draft conversation key, set it active on the conversation store, and navigate to `routes.conversation(draftKey)`. `ChatPage` already handles unknown / draft keys by showing the empty state + conversation starters.

## Test plan
- [ ] Open `/assistant` on an existing conversation, click the pencil icon next to "Conversations" in the sidebar — URL changes to `/assistant/conversations/{newKey}`, empty state renders with starter cards.
- [ ] Click the top-bar message-plus icon — same behavior.
- [ ] Repeat clicks each create a fresh draft (URL key changes).
- [ ] Existing conversation switching from the sidebar list still works.
- [ ] Mobile drawer: clicking the sidebar new-conversation button closes the drawer and navigates correctly.

https://claude.ai/code/session_018e9doM3Mqgmxygu47Gt6UD

---
_Generated by [Claude Code](https://claude.ai/code/session_018e9doM3Mqgmxygu47Gt6UD)_