### PR TITLE
fix(web): port dynamic avatar favicon hook from platform

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="/favicon.svg" />
+  <link rel="apple-touch-icon" href="/favicon.svg" />
   <title>Vellum Assistant</title>
 </head>
 <body>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,28 @@
+<svg width="177" height="177" viewBox="0 0 177 177" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_85_161)">
+<rect x="2" y="1" width="173" height="173" rx="24" fill="url(#paint0_radial_85_161)"/>
+<path d="M65.2927 45L87.5854 93.3893L109.79 45H132.171L87.4084 137.09L43 45H65.2927Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_di_85_161" x="0" y="0" width="177" height="177" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_85_161"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_85_161" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_85_161"/>
+</filter>
+<radialGradient id="paint0_radial_85_161" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(88.5 -123.344) rotate(90) scale(362.219 174.427)">
+<stop stop-color="#7A8B6F"/>
+<stop offset="1" stop-color="#23793D"/>
+</radialGradient>
+</defs>
+</svg>

--- a/apps/web/src/domains/avatar/use-dynamic-favicon.ts
+++ b/apps/web/src/domains/avatar/use-dynamic-favicon.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+
+import { composeSvg } from "@/domains/avatar/svg-compositor.js";
+import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
+
+const FAVICON_SIZE = 32;
+const DEFAULT_FAVICON = "/favicon.svg";
+
+/**
+ * Dynamically replaces the document favicon with the assistant's avatar.
+ *
+ * Priority matches ChatAvatar:
+ *   1. Character SVG (when components + explicit traits are available)
+ *   2. Custom uploaded image (blob URL or remote URL)
+ *   3. Default Vellum favicon
+ */
+export function useDynamicFavicon(
+  customImageUrl: string | null,
+  components: CharacterComponents | null,
+  traits: CharacterTraits | null,
+): void {
+  useEffect(() => {
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!link) return;
+
+    let href: string | null = null;
+
+    if (components && traits) {
+      try {
+        const svg = composeSvg(
+          components,
+          traits.bodyShape,
+          traits.eyeStyle,
+          traits.color,
+          FAVICON_SIZE,
+        );
+        href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+      } catch {
+        // composeSvg throws on unknown IDs — fall through to image or default
+      }
+    }
+
+    if (!href && customImageUrl) {
+      href = customImageUrl;
+    }
+
+    link.href = href ?? DEFAULT_FAVICON;
+
+    return () => {
+      link.href = DEFAULT_FAVICON;
+    };
+  }, [customImageUrl, components, traits]);
+}

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -56,6 +56,7 @@ import { useChatAttachments } from "@/domains/chat/components/chat-attachments/u
 import { useVoiceInput } from "@/domains/chat/hooks/use-voice-input.js";
 import { useConversationStarters } from "@/domains/chat/hooks/use-conversation-starters.js";
 import { useAssistantAvatar } from "@/domains/avatar/use-assistant-avatar.js";
+import { useDynamicFavicon } from "@/domains/avatar/use-dynamic-favicon.js";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability.js";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor.js";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure.js";
@@ -329,6 +330,7 @@ export function ChatPage() {
   // Avatar
   // -------------------------------------------------------------------------
   const avatar = useAssistantAvatar(assistantId);
+  useDynamicFavicon(avatar.customImageUrl, avatar.components, avatar.traits);
 
   // -------------------------------------------------------------------------
   // Nudges


### PR DESCRIPTION
## Summary

The platform repo dynamically swaps the browser favicon to the assistant's avatar (composed SVG, or uploaded image as a fallback). That hook was missed during the chat-domain port to `vellum-assistant` — `useAssistantAvatar` already runs in `chat-page.tsx`, but its `components` / `traits` / `customImageUrl` are never wired to the favicon, so local tabs show the default browser tab icon while platform tabs show the avatar.

## Changes

- Add `apps/web/src/domains/avatar/use-dynamic-favicon.ts` — port of platform's `useDynamicFavicon` (kebab-case, no `"use client"` since we're Vite, not Next).
- Call it next to `useAssistantAvatar(assistantId)` in `apps/web/src/domains/chat/chat-page.tsx` so the favicon stays in sync as the avatar resolves / changes.
- Add `apps/web/public/favicon.svg` (Vellum mark, copied from platform) and a matching `<link rel="icon" href="/favicon.svg" />` (+ `apple-touch-icon`) in `apps/web/index.html`. Without the link element, `document.querySelector('link[rel="icon"]')` returns `null` and the hook would silently no-op — the platform happened to have this link in its Next.js `layout.tsx`, but the Vite SPA's `index.html` had no favicon link at all.

## Test plan

- [ ] `bunx tsc --noEmit` clean (verified locally)
- [ ] `bunx eslint` clean on touched files (verified locally)
- [ ] In the browser: open a chat with a character avatar → tab favicon shows the composed character SVG
- [ ] Switch to an assistant with an uploaded custom image → favicon updates to that image
- [ ] Navigate away from a chat → favicon resets to the default Vellum mark


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJVU3PtsNNzRaZnCabR5dQ)_