### PR TITLE
fix(web): route sidebar assistant-name item to /identity (LUM-1783)

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -246,6 +246,10 @@ export function ChatLayout() {
     navigate(routes.home);
   }, [navigate]);
 
+  const handleOpenIdentity = useCallback(() => {
+    navigate(routes.identity);
+  }, [navigate]);
+
   const handleGoBack = useCallback(() => {
     navigate(-1);
   }, [navigate]);
@@ -255,6 +259,7 @@ export function ChatLayout() {
   }, [navigate]);
 
   const isHomeActive = location.pathname === routes.home;
+  const isIdentityActive = location.pathname === routes.identity;
 
   // --- Sidebar collapsed / drawer state ---
   const [collapsed, setCollapsed] = useState<boolean>(readPersistedCollapsed);
@@ -417,8 +422,8 @@ export function ChatLayout() {
         attentionConversationKeys={attentionKeys}
         onSelectConversation={handleSelectConversation}
         onStartNewConversation={handleStartNewConversation}
-        isIntelligenceActive={isHomeActive}
-        onOpenIntelligence={handleOpenHome}
+        isIntelligenceActive={isIdentityActive}
+        onOpenIntelligence={handleOpenIdentity}
         isLibraryActive={isLibraryActive}
         onOpenLibrary={handleOpenLibrary}
         onCreateGroup={handleCreateGroup}
@@ -449,8 +454,8 @@ export function ChatLayout() {
       handleCreateGroup,
       handleRenameGroup,
       handleDeleteGroup,
-      isHomeActive,
-      handleOpenHome,
+      isIdentityActive,
+      handleOpenIdentity,
       isLibraryActive,
       handleOpenLibrary,
     ],


### PR DESCRIPTION
## Summary

Fixes part 1 of [LUM-1783](https://linear.app/vellum/issue/LUM-1783): clicking the assistant's name (Brain-icon item) in the left sidebar was navigating to `/assistant/home` instead of `/assistant/identity`.

The prop names threading through `AssistantSideMenu` (`onOpenIntelligence` / `isIntelligenceActive`) indicate the intended destination is the Intelligence/Identity view, but the handler in `chat-layout.tsx` was pointing at `routes.home`. The `IntelligenceLayout` + `/assistant/identity` route was added recently ("About Assistant tab bar") and the sidebar wasn't repointed.

## Changes

- `chat-layout.tsx`: add `handleOpenIdentity` → `navigate(routes.identity)` and `isIdentityActive` checking `routes.identity`.
- Wire `AssistantSideMenu`'s `onOpenIntelligence` / `isIntelligenceActive` to those.
- The header's Home button (House icon) keeps `handleOpenHome` / `isHomeActive` — it remains the only entry point to `/assistant/home`.

## Still open in LUM-1783

This PR does not address the secondary report that `/assistant/home` "loads something but not the right thing" on localhost — the page renders with the fallback greeting "Here's what's been going on", no suggested-prompts pill bar, no filter bar, and "No items to show", while prod renders the full "Good afternoon" / Connect-* prompts / filter / feed items UI. That looks like an empty/missing-data response from the daemon's `/v1/assistants/{id}/home/feed` endpoint on localhost, not a UI bug, but needs verification. Will follow up separately.

## Test plan

- [x] `bunx eslint src/domains/chat/chat-layout.tsx` — passes
- [x] `bunx tsc --noEmit` — passes
- [x] `bun test src/domains/chat/components/assistant-side-menu.test.tsx` — 11/11 passing
- [ ] Manual: click assistant-name item in sidebar → lands on `/assistant/identity`, "About <Name>" view, sidebar item highlighted
- [ ] Manual: click Home (house) icon in top bar → still lands on `/assistant/home`, home icon highlighted, sidebar assistant-name item NOT highlighted

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAoA5fQrzgzYB1s1D3yyt)_