### PR TITLE
fix(web): point avatar API at unscoped daemon routes (LUM-1784)

### DIFF
--- a/apps/web/src/components/avatar/avatar-customization-panel.tsx
+++ b/apps/web/src/components/avatar/avatar-customization-panel.tsx
@@ -41,7 +41,7 @@ export function AvatarCustomizationPanel({
     }
     let cancelled = false;
 
-    fetchCharacterComponents(assistantId).then((data) => {
+    fetchCharacterComponents().then((data) => {
       if (cancelled) {
         return;
       }
@@ -91,12 +91,12 @@ export function AvatarCustomizationPanel({
 
     setIsSaving(true);
     try {
-      await saveCharacterTraits(assistantId, traits);
+      await saveCharacterTraits(traits);
       onSave?.(traits);
     } finally {
       setIsSaving(false);
     }
-  }, [components, bodyIndex, eyeIndex, colorIndex, assistantId, onSave]);
+  }, [components, bodyIndex, eyeIndex, colorIndex, onSave]);
 
   if (isLoading) {
     return (

--- a/apps/web/src/components/avatar/avatar-management-modal.tsx
+++ b/apps/web/src/components/avatar/avatar-management-modal.tsx
@@ -105,7 +105,7 @@ export function AvatarManagementModal({
       }
 
       setIsUploading(true);
-      const ok = await uploadAvatarImage(assistantId, file);
+      const ok = await uploadAvatarImage(file);
       setIsUploading(false);
 
       if (ok) {
@@ -117,7 +117,7 @@ export function AvatarManagementModal({
         fileInputRef.current.value = "";
       }
     },
-    [assistantId, onUploadImage, handleClose],
+    [onUploadImage, handleClose],
   );
 
   const handleUploadClick = useCallback(() => {

--- a/apps/web/src/domains/avatar/api.ts
+++ b/apps/web/src/domains/avatar/api.ts
@@ -2,19 +2,19 @@
  * Avatar API functions for fetching character components and traits.
  *
  * These call daemon endpoints via the configured HeyAPI client singleton.
+ * The daemon serves a single assistant per process, so its avatar and
+ * workspace routes are unscoped — they live at `/v1/avatar/...` and
+ * `/v1/workspace/...`, not under `/v1/assistants/{assistant_id}/...`.
  */
 import { client } from "@/lib/api-client.js";
 import { assertHasResponse } from "@/lib/api-errors.js";
 import type { CharacterComponents, CharacterTraits } from "./types.js";
 import { isCharacterTraits } from "./types.js";
 
-export async function fetchCharacterComponents(
-  assistantId: string,
-): Promise<CharacterComponents | null> {
+export async function fetchCharacterComponents(): Promise<CharacterComponents | null> {
   try {
     const { data, error, response } = await client.get({
-      url: "/v1/assistants/{assistant_id}/avatar/character-components",
-      path: { assistant_id: assistantId },
+      url: "/v1/avatar/character-components",
     });
     assertHasResponse(response, error, "Failed to fetch character components");
     if (!response.ok || !data || typeof data !== "object") return null;
@@ -24,50 +24,58 @@ export async function fetchCharacterComponents(
   }
 }
 
-export async function fetchCharacterTraits(
-  assistantId: string,
-): Promise<CharacterTraits | null> {
-  const { data, error, response } = await client.get({
-    url: "/v1/assistants/{assistant_id}/avatar/character-traits",
-    path: { assistant_id: assistantId },
-  });
-  assertHasResponse(response, error, "Failed to fetch character traits");
-  if (!response.ok || !data) return null;
-  if (!isCharacterTraits(data)) return null;
-  return data;
+interface WorkspaceFileResponse {
+  content: string | null;
 }
 
-export async function saveCharacterTraits(
-  assistantId: string,
-  traits: CharacterTraits,
-): Promise<void> {
+export async function fetchCharacterTraits(): Promise<CharacterTraits | null> {
   try {
-    await client.put({
-      url: "/v1/assistants/{assistant_id}/avatar/character-traits",
-      path: { assistant_id: assistantId },
-      body: traits,
+    const { data, error, response } = await client.get({
+      url: "/v1/workspace/file",
+      query: { path: "data/avatar/character-traits.json" },
     });
+    assertHasResponse(response, error, "Failed to fetch character traits");
+    if (!response.ok || !data || typeof data !== "object") return null;
+
+    const content = (data as WorkspaceFileResponse).content;
+    if (typeof content !== "string") return null;
+
+    const parsed: unknown = JSON.parse(content);
+    if (!isCharacterTraits(parsed)) return null;
+    return parsed;
   } catch {
-    // Best-effort — avatar traits are non-critical. The assistant still
-    // functions without persisted traits; the next session fetch will
-    // regenerate random traits and the user can customise later.
+    return null;
   }
 }
 
-
-export async function uploadAvatarImage(
-  assistantId: string,
-  file: File,
+export async function saveCharacterTraits(
+  traits: CharacterTraits,
 ): Promise<boolean> {
+  try {
+    const { error, response } = await client.post({
+      url: "/v1/avatar/render-from-traits",
+      body: traits,
+      headers: { "Content-Type": "application/json" },
+    });
+    assertHasResponse(response, error, "Failed to save character traits");
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function uploadAvatarImage(file: File): Promise<boolean> {
   try {
     const arrayBuffer = await file.arrayBuffer();
     const base64 = btoa(
-      new Uint8Array(arrayBuffer).reduce((data, byte) => data + String.fromCharCode(byte), ""),
+      new Uint8Array(arrayBuffer).reduce(
+        (acc, byte) => acc + String.fromCharCode(byte),
+        "",
+      ),
     );
 
     const { error: writeError, response: writeResponse } = await client.post({
-      url: "/v1/assistants/{assistant_id}/workspace/write/",
-      path: { assistant_id: assistantId },
+      url: "/v1/workspace/write",
       body: { path: "data/avatar/avatar-image.png", content: base64, encoding: "base64" },
       headers: { "Content-Type": "application/json" },
     });
@@ -75,8 +83,7 @@ export async function uploadAvatarImage(
     if (!writeResponse.ok) return false;
 
     await client.post({
-      url: "/v1/assistants/{assistant_id}/workspace/delete/",
-      path: { assistant_id: assistantId },
+      url: "/v1/workspace/delete",
       body: { path: "data/avatar/character-traits.json" },
       headers: { "Content-Type": "application/json" },
     });
@@ -87,13 +94,10 @@ export async function uploadAvatarImage(
   }
 }
 
-export async function fetchAvatarImageUrl(
-  assistantId: string,
-): Promise<string | null> {
+export async function fetchAvatarImageUrl(): Promise<string | null> {
   try {
     const { data, error, response } = await client.get({
-      url: "/v1/assistants/{assistant_id}/workspace/file/content/",
-      path: { assistant_id: assistantId },
+      url: "/v1/workspace/file/content",
       query: { path: "data/avatar/avatar-image.png" },
       parseAs: "blob",
     });

--- a/apps/web/src/domains/avatar/use-assistant-avatar.ts
+++ b/apps/web/src/domains/avatar/use-assistant-avatar.ts
@@ -36,15 +36,15 @@ export function useAssistantAvatar(assistantId: string | null) {
     queryFn: async () => {
       const id = assistantId!;
       const [components, imageUrl] = await Promise.all([
-        fetchCharacterComponents(id),
-        fetchAvatarImageUrl(id),
+        fetchCharacterComponents(),
+        fetchAvatarImageUrl(),
       ]);
       // Skip the traits fetch when a custom image exists — the traits
       // file is intentionally deleted on the daemon side in that case,
       // so requesting it just generates 404s on every SSE-driven
       // reconnect invalidation. `AvatarRenderer` only reads `traits`
       // when there is no `customImageUrl`.
-      const traits = imageUrl ? null : await fetchCharacterTraits(id);
+      const traits = imageUrl ? null : await fetchCharacterTraits();
 
       const prev = activeBlobUrls.get(id);
       if (prev && prev !== imageUrl) {

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -233,10 +233,9 @@ export function HatchingScreen() {
           markPrivacyConsent(userId);
 
           if (result.ok) {
-            const assistantId = result.data.id;
-            fetchCharacterTraits(assistantId).then((existing) => {
+            fetchCharacterTraits().then((existing) => {
               if (existing) return;
-              return saveCharacterTraits(assistantId, hatchTraits);
+              return saveCharacterTraits(hatchTraits);
             }).catch((err) => {
               Sentry.captureException(err, {
                 tags: { context: "onboarding_avatar_sync" },


### PR DESCRIPTION
## Summary

The "Build a Character" modal in `apps/web` fails with **"Unable to load avatar components. Make sure your assistant is running."** even when the daemon is up. All five functions in `apps/web/src/domains/avatar/api.ts` were ported from `vellum-assistant-platform/web/src/lib/avatar/api.ts` with platform-shaped URLs (`/v1/assistants/{assistant_id}/avatar/...`). That prefix only exists in the platform's Django proxy — the daemon registers its routes unscoped at `/v1/avatar/...` and `/v1/workspace/...` because it serves a single assistant per process. The Vite proxy forwards `/v1/*` straight to the daemon on `:8000`, so the prefixed requests 404.

Linear: [LUM-1784](https://linear.app/vellum/issue/LUM-1784/build-a-character-modal-fails-to-load-avatar-components-in-vellum)

## Changes

`apps/web/src/domains/avatar/api.ts` rewritten to call the daemon's actual routes:

| Function | Was | Now |
|---|---|---|
| `fetchCharacterComponents` | `GET /v1/assistants/{id}/avatar/character-components` | `GET /v1/avatar/character-components` |
| `fetchCharacterTraits` | `GET /v1/assistants/{id}/avatar/character-traits` *(404 — never existed on daemon)* | `GET /v1/workspace/file?path=data/avatar/character-traits.json` then JSON-parse `data.content`, matching the platform helper |
| `saveCharacterTraits` | `PUT /v1/assistants/{id}/avatar/character-traits` *(404)* | `POST /v1/avatar/render-from-traits` — persists traits **and** regenerates the PNG in one call. Returns `boolean`. |
| `uploadAvatarImage` | `POST /v1/assistants/{id}/workspace/write/` + `…/delete/` | `POST /v1/workspace/write` + `/v1/workspace/delete` |
| `fetchAvatarImageUrl` | `GET /v1/assistants/{id}/workspace/file/content/` | `GET /v1/workspace/file/content?path=data/avatar/avatar-image.png` |

The `assistantId` argument is dropped from every helper — the daemon already knows which assistant it serves. Callers updated:

- `apps/web/src/components/avatar/avatar-customization-panel.tsx`
- `apps/web/src/components/avatar/avatar-management-modal.tsx`
- `apps/web/src/domains/avatar/use-assistant-avatar.ts`
- `apps/web/src/domains/onboarding/pages/hatching-screen.tsx`

The component-level `assistantId` props are kept because they still scope the React Query cache key and the `fetchedRef` mount-tracking in `AvatarCustomizationPanel`.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (pre-existing unrelated warning in `lib/errors/report.ts`)
- `bun test src/domains/avatar` — 2/2 pass (`use-assistant-avatar.test.tsx`)

## Test plan

- [ ] Identity → **Update Avatar** → **Build a Character** loads body/eye/color selectors with daemon running
- [ ] Randomize cycles values
- [ ] Save closes the modal and the new avatar appears in the Identity card and sidebar
- [ ] Custom image upload still works (Update Avatar → Upload Image)
- [ ] Onboarding hatching screen still persists the randomized character on first hatch (no traits file yet) and skips the save when traits already exist


---
_Generated by [Claude Code](https://claude.ai/code/session_016bCZW79Tf61evfPDvm2HrH)_