### PR TITLE
fix(design-library): use Slottable for Button asChild + icons (LUM-1680)

### DIFF
--- a/packages/design-library/src/components/button.test.tsx
+++ b/packages/design-library/src/components/button.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Tests for the core Button primitive.
+ *
+ * No DOM environment — we verify behavior through two angles:
+ *   1. `renderToStaticMarkup` — asserts the HTML the component emits.
+ *   2. Direct invocation of the onClick prop — asserts wiring is preserved.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { createRef } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Button } from "./button.js";
+
+describe("Button rendering", () => {
+  test("renders a <button> by default with type=button and children", () => {
+    const html = renderToStaticMarkup(<Button>Hello</Button>);
+    expect(html).toContain("<button");
+    expect(html).toContain('type="button"');
+    expect(html).toContain(">Hello</button>");
+  });
+
+  test("asChild renders the slotted element instead of <button>", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild>
+        <a href="/somewhere">Link</a>
+      </Button>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/somewhere"');
+    expect(html).not.toContain("<button");
+  });
+
+  test("asChild still renders the slotted anchor when disabled is set", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild disabled>
+        <a href="/x">Link</a>
+      </Button>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/x"');
+    expect(html).not.toContain("<button");
+  });
+
+  test("asChild + leftIcon clones the slotted element with the icon as a sibling of its children", () => {
+    // Regression: previously the icon branch rendered children as a Fragment,
+    // which made Radix Slot try to forward `type` onto React.Fragment and
+    // hard-error on React 19. The fix wraps `children` in `<Slottable>` so
+    // Slot clones the caller's element and re-parents the icon as a sibling
+    // of the element's original children.
+    const html = renderToStaticMarkup(
+      <Button asChild leftIcon={<svg data-testid="left-icon" aria-hidden />}>
+        <a href="/back">Back</a>
+      </Button>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/back"');
+    expect(html).not.toContain("<button");
+    expect(html).toContain('data-testid="left-icon"');
+    expect(html).toContain("Back");
+  });
+
+  test("asChild + rightIcon also clones and re-parents the icon", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild rightIcon={<svg data-testid="right-icon" aria-hidden />}>
+        <a href="/next">Next</a>
+      </Button>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/next"');
+    expect(html).not.toContain("<button");
+    expect(html).toContain('data-testid="right-icon"');
+    expect(html).toContain("Next");
+  });
+
+  test("iconOnly ignores children and leftIcon/rightIcon", () => {
+    const html = renderToStaticMarkup(
+      <Button
+        iconOnly={<svg data-testid="only-icon" />}
+        leftIcon={<span>L</span>}
+        rightIcon={<span>R</span>}
+        aria-label="action"
+      >
+        should-not-render
+      </Button>,
+    );
+    expect(html).not.toContain("should-not-render");
+    expect(html).not.toContain(">L</span>");
+    expect(html).not.toContain(">R</span>");
+    expect(html).toContain('data-testid="only-icon"');
+  });
+
+  test("iconOnly applies square dimensions for regular size (h-8 w-8)", () => {
+    const html = renderToStaticMarkup(
+      <Button iconOnly={<svg />} aria-label="a" />,
+    );
+    expect(html).toContain("h-8");
+    expect(html).toContain("w-8");
+    expect(html).toContain("p-0");
+  });
+
+  test("tintColor sets the --vbtn-fg custom property inline", () => {
+    const html = renderToStaticMarkup(
+      <Button tintColor="rebeccapurple">Tinted</Button>,
+    );
+    expect(html).toContain("--vbtn-fg:rebeccapurple");
+  });
+
+  test("tintColor is skipped when disabled so variant disabled fg wins", () => {
+    const html = renderToStaticMarkup(
+      <Button tintColor="rebeccapurple" disabled>
+        Tinted
+      </Button>,
+    );
+    expect(html).not.toContain("--vbtn-fg:rebeccapurple");
+  });
+
+  test("disabled plain <button> sets the disabled attribute", () => {
+    const html = renderToStaticMarkup(<Button disabled>Off</Button>);
+    expect(html).toContain("disabled");
+  });
+
+  test("ref passed as a prop is accepted without throwing (React 19 ref-as-prop)", () => {
+    const ref = createRef<HTMLButtonElement>();
+    expect(() =>
+      renderToStaticMarkup(<Button ref={ref}>Ref</Button>),
+    ).not.toThrow();
+  });
+});
+
+describe("Button click behavior", () => {
+  test("onClick fires when invoked directly (wiring sanity)", () => {
+    const onClick = mock(() => {});
+    renderToStaticMarkup(<Button onClick={onClick}>Click</Button>);
+    onClick();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("disabled attribute is rendered so the browser suppresses native clicks", () => {
+    const html = renderToStaticMarkup(
+      <Button disabled onClick={() => {}}>
+        Nope
+      </Button>,
+    );
+    expect(html).toMatch(/<button[^>]*\sdisabled(?:=""|\s|>)/);
+  });
+
+  test("asChild + disabled does not render a native <button> with disabled attribute", () => {
+    const onClick = mock(() => {});
+    const html = renderToStaticMarkup(
+      <Button asChild disabled onClick={onClick}>
+        <a href="/x">Blocked</a>
+      </Button>,
+    );
+    expect(html).not.toMatch(/<button[^>]*disabled/);
+    expect(html).toContain("<a");
+  });
+});
+
+describe("Button class output", () => {
+  test("primary variant uses token-backed background and text", () => {
+    const html = renderToStaticMarkup(<Button variant="primary">P</Button>);
+    expect(html).toContain("bg-[var(--primary-base)]");
+    expect(html).toContain("[--vbtn-fg:var(--content-inset)]");
+  });
+
+  test("outlined variant emits --primary-base text and --border-element border", () => {
+    const html = renderToStaticMarkup(<Button variant="outlined">O</Button>);
+    expect(html).toContain("[--vbtn-fg:var(--primary-base)]");
+    expect(html).toContain("border-[var(--border-element)]");
+  });
+
+  test("outlined disabled border uses --primary-disabled (Figma spec)", () => {
+    const html = renderToStaticMarkup(
+      <Button variant="outlined" disabled>
+        O
+      </Button>,
+    );
+    expect(html).toContain("disabled:border-[var(--primary-disabled)]");
+  });
+
+  test("danger variant uses --system-negative-strong background", () => {
+    const html = renderToStaticMarkup(<Button variant="danger">D</Button>);
+    expect(html).toContain("bg-[var(--system-negative-strong)]");
+  });
+
+  test("regular size applies text-body-medium-default typography class", () => {
+    const html = renderToStaticMarkup(<Button size="regular">R</Button>);
+    expect(html).toContain("text-body-medium-default");
+  });
+
+  test("compact size applies text-label-medium-default typography class", () => {
+    const html = renderToStaticMarkup(<Button size="compact">C</Button>);
+    expect(html).toContain("text-label-medium-default");
+  });
+
+  test("no raw hex colors appear in rendered output", () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <Button variant="primary">P</Button>
+        <Button variant="outlined">O</Button>
+        <Button variant="danger">D</Button>
+        <Button variant="dangerOutline">DO</Button>
+        <Button variant="ghost">G</Button>
+      </div>,
+    );
+    expect(html).not.toMatch(/#[0-9A-Fa-f]{6}\b/);
+  });
+});

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "@radix-ui/react-slot";
+import { Slot, Slottable } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import {
   type ButtonHTMLAttributes,
@@ -287,13 +287,21 @@ export function Button({
       ) : leftIcon == null && rightIcon == null ? (
         children
       ) : (
+        // When `asChild` is set, `Comp` is Radix's `Slot`, which forwards its
+        // props (e.g. `type`, `disabled`) onto its single React-element child.
+        // A bare Fragment can't accept those props — React 19 hard-errors with
+        // "Invalid prop `type` supplied to React.Fragment". `Slottable` marks
+        // `children` as the prop target so Slot clones the caller's element
+        // and re-parents the icons as its children. In the non-asChild path
+        // (`Comp === "button"`) Slottable is a transparent Fragment, so this
+        // is safe for both branches.
         <>
           {leftIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
               {leftIcon}
             </span>
           ) : null}
-          {children}
+          <Slottable>{children}</Slottable>
           {rightIcon != null ? (
             <span aria-hidden="true" style={iconStyle}>
               {rightIcon}


### PR DESCRIPTION
## Summary

Port the React 19 `Button asChild + icons` crash fix from [vellum-assistant-platform#7377](https://github.com/vellum-ai/vellum-assistant-platform/pull/7377) to the design-library.

When `Button` renders `leftIcon` / `rightIcon` + `children`, the icon branch wraps them in a Fragment. With `asChild=true`, Radix's `Slot` tries to forward button props (`type`, `disabled`, etc.) onto that Fragment, which only accepts `key` / `ref` / `children`. React 19 hard-errors: `Invalid prop "type" supplied to React.Fragment`.

The fix wraps `children` in `<Slottable>` so `Slot` clones the caller's element and re-parents the icons as its children. `Slottable` is a transparent Fragment in the non-`asChild` path (`Comp === "button"`), so the change is safe for both branches.

Also adds `packages/design-library/src/components/button.test.tsx` — there was no test file for the Button primitive in the new repo yet. The suite ports the existing platform tests (rendering, click behavior, class output) plus the two new regression tests for `asChild + leftIcon` and `asChild + rightIcon`.

Closes LUM-1680.

## Test plan

- [x] `bun test packages/design-library/src/components/button.test.tsx` — 21 / 21 pass
- [x] `apps/web` full suite: `bun run test:ci` — 91 / 91 pass
- [x] `apps/web` `bun run lint` clean (only a preexisting unrelated warning)
- [x] `packages/design-library` `bunx tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_0181LfJ6Lapx1LKyrrnDZ3Vh)_