### PR TITLE
fix(web): /assistant/home fails loud + degrades gracefully (LUM-1785)

### DIFF
--- a/apps/web/src/domains/home/home-greeting-header.tsx
+++ b/apps/web/src/domains/home/home-greeting-header.tsx
@@ -8,9 +8,20 @@ interface HomeGreetingHeaderProps {
   avatarComponents: CharacterComponents | null;
   avatarTraits: CharacterTraits | null;
   avatarImageUrl: string | null;
-  /** Optional daemon-supplied dynamic greeting. Falls back to a static string. */
+  /** Optional daemon-supplied dynamic greeting. Falls back to a time-of-day greeting. */
   greeting?: string;
   onStartNewChat: () => void;
+}
+
+// Mirrors `computeGreeting` in assistant/src/runtime/routes/home-feed-routes.ts
+// so the UI degrades to the same string when the daemon response omits a
+// greeting (older daemon build, failed request, etc.).
+function clientComputeGreeting(now: Date): string {
+  const hour = now.getHours();
+  if (hour >= 5 && hour < 12) return "Good morning";
+  if (hour >= 12 && hour < 17) return "Good afternoon";
+  if (hour >= 17 && hour < 22) return "Good evening";
+  return "Welcome back";
 }
 
 export function HomeGreetingHeader({
@@ -30,7 +41,7 @@ export function HomeGreetingHeader({
           size={36}
         />
         <Typography variant="title-large" as="h1" className="truncate">
-          {greeting || "Here’s what’s been going on"}
+          {greeting || clientComputeGreeting(new Date())}
         </Typography>
       </div>
 

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -41,7 +41,7 @@ function HomePageSkeleton() {
 }
 
 export interface HomePageProps {
-  assistantId: string | null;
+  assistantId: string;
   onStartNewChat: () => void;
   onOpenConversation: (conversationId: string) => void;
   onSuggestionSelected: (prompt: string) => void;
@@ -129,6 +129,17 @@ export function HomePage({
         greeting={feedQuery.data?.contextBanner?.greeting}
         onStartNewChat={onStartNewChat}
       />
+      {feedQuery.isError ? (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[var(--app-spacing-lg)] py-[var(--app-spacing-md)] text-[var(--system-negative-strong)]"
+        >
+          Couldn't load home feed
+          {feedQuery.error instanceof Error
+            ? `: ${feedQuery.error.message}`
+            : "."}
+        </div>
+      ) : null}
       <HomeSuggestionPillBar
         suggestions={feedQuery.data?.suggestedPrompts ?? []}
         onSelect={handleSuggestionSelect}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -76,6 +76,11 @@ function ConversationKeyRedirect() {
 function HomePageRoute() {
   const navigate = useNavigate();
   const { assistantId } = useAssistantContext();
+  // Mirror the platform's `mainView === "home" && assistantId` gate
+  // (AssistantPageClient.tsx). Rendering HomePage with a null assistantId
+  // leaves useHomeFeedQuery disabled forever and the page silently
+  // degrades to the empty-fallback state.
+  if (!assistantId) return null;
   return (
     <HomePage
       assistantId={assistantId}


### PR DESCRIPTION
## Summary

`/assistant/home` was silently degrading to a fully-empty fallback state — hard-coded "Here's what's been going on" greeting, generic V avatar, no items, no suggestions, no filter bar — making it impossible to tell whether the daemon errored, returned partial data, or simply hadn't responded yet. On localhost users saw a long skeleton then this empty fallback; on dev the same code rendered the full "Good afternoon" / Connect-* / feed-items UI because the dev daemon had data.

Three targeted changes that surface the underlying state instead of hiding it:

1. **Gate `HomePageRoute` on a resolved `assistantId`** (`apps/web/src/routes.tsx`). Mirrors the platform's `{mainView === "home" && assistantId ? <HomePage .../> : ...}` pattern from `AssistantPageClient.tsx`. Without this, `useHomeFeedQuery(null)` stays `enabled: false` on first mount → `isLoading: false` + `data: undefined` → the empty-fallback state renders silently. `HomePage`'s `assistantId` prop is correspondingly narrowed from `string | null` to `string`.
2. **Client-side `computeGreeting` fallback** (`apps/web/src/domains/home/home-greeting-header.tsx`). Replaces the literal "Here's what's been going on" with a port of the daemon's own `computeGreeting` (`assistant/src/runtime/routes/home-feed-routes.ts:69-75`), so when the daemon response omits a greeting the UI still reads "Good morning/afternoon/evening" — matching the daemon's intent.
3. **Surface `feedQuery.isError`** (`apps/web/src/domains/home/home-page.tsx`). Inline alert when the home-feed query errors, so future failures are self-diagnosing.

## Out of scope — filed separately

There's a larger architectural pattern at play: every route component in `ChatLayout` (Home, Identity, Library, Workspace, Contacts) pulls `assistantId` from `useAssistantContext()` directly and is vulnerable to the same first-render-with-null-assistantId class of bug. The platform avoided this by orchestrating everything in `AssistantPageClient` and only conditionally rendering each view once the lifecycle was ready. The new repo should lift that gate up to `ChatLayout` itself so the `<Outlet />` doesn't mount until `assistantId && assistantState.kind === "active"`. Filed under the Web App Repo Move project for follow-up.

## Test plan

- [x] `bunx eslint src/domains/home src/routes.tsx` — passes
- [x] `bunx tsc --noEmit` — passes
- [ ] Manual: navigate to `/assistant/home` on localhost — expect either the proper rendering once `assistantId` resolves, or a visible error alert if the daemon errors (no more silent "Here's what's been going on")
- [ ] Manual: at 2pm local time, with a daemon that returns no greeting, the page should still say "Good afternoon"
- [ ] Manual: directly load `/assistant/home` via the URL bar (cold) — should not render before `assistantId` is set

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgAoA5fQrzgzYB1s1D3yyt)_