### PR TITLE
fix(web): restore platform-parity avatar API URLs (LUM-1784)

### DIFF
--- a/apps/web/src/components/avatar/avatar-customization-panel.tsx
+++ b/apps/web/src/components/avatar/avatar-customization-panel.tsx
@@ -41,7 +41,7 @@ export function AvatarCustomizationPanel({
     }
     let cancelled = false;
 
-    fetchCharacterComponents().then((data) => {
+    fetchCharacterComponents(assistantId).then((data) => {
       if (cancelled) {
         return;
       }
@@ -91,12 +91,12 @@ export function AvatarCustomizationPanel({
 
     setIsSaving(true);
     try {
-      await saveCharacterTraits(traits);
+      await saveCharacterTraits(assistantId, traits);
       onSave?.(traits);
     } finally {
       setIsSaving(false);
     }
-  }, [components, bodyIndex, eyeIndex, colorIndex, onSave]);
+  }, [components, bodyIndex, eyeIndex, colorIndex, assistantId, onSave]);
 
   if (isLoading) {
     return (

--- a/apps/web/src/components/avatar/avatar-management-modal.tsx
+++ b/apps/web/src/components/avatar/avatar-management-modal.tsx
@@ -105,7 +105,7 @@ export function AvatarManagementModal({
       }
 
       setIsUploading(true);
-      const ok = await uploadAvatarImage(file);
+      const ok = await uploadAvatarImage(assistantId, file);
       setIsUploading(false);
 
       if (ok) {
@@ -117,7 +117,7 @@ export function AvatarManagementModal({
         fileInputRef.current.value = "";
       }
     },
-    [onUploadImage, handleClose],
+    [assistantId, onUploadImage, handleClose],
   );
 
   const handleUploadClick = useCallback(() => {

--- a/apps/web/src/domains/avatar/api.ts
+++ b/apps/web/src/domains/avatar/api.ts
@@ -1,20 +1,24 @@
 /**
  * Avatar API functions for fetching character components and traits.
  *
- * These call daemon endpoints via the configured HeyAPI client singleton.
- * The daemon serves a single assistant per process, so its avatar and
- * workspace routes are unscoped — they live at `/v1/avatar/...` and
- * `/v1/workspace/...`, not under `/v1/assistants/{assistant_id}/...`.
+ * Targets the gateway-proxied `/v1/assistants/{assistant_id}/...` namespace,
+ * matching the platform implementation. The gateway runtime-proxy rewrites
+ * `/v1/assistants/<id>/X` to `/v1/X` before forwarding to the daemon, which
+ * registers avatar and workspace routes flat (`/v1/avatar/...`,
+ * `/v1/workspace/...`).
  */
 import { client } from "@/lib/api-client.js";
 import { assertHasResponse } from "@/lib/api-errors.js";
 import type { CharacterComponents, CharacterTraits } from "./types.js";
 import { isCharacterTraits } from "./types.js";
 
-export async function fetchCharacterComponents(): Promise<CharacterComponents | null> {
+export async function fetchCharacterComponents(
+  assistantId: string,
+): Promise<CharacterComponents | null> {
   try {
     const { data, error, response } = await client.get({
-      url: "/v1/avatar/character-components",
+      url: "/v1/assistants/{assistant_id}/avatar/character-components",
+      path: { assistant_id: assistantId },
     });
     assertHasResponse(response, error, "Failed to fetch character components");
     if (!response.ok || !data || typeof data !== "object") return null;
@@ -28,10 +32,13 @@ interface WorkspaceFileResponse {
   content: string | null;
 }
 
-export async function fetchCharacterTraits(): Promise<CharacterTraits | null> {
+export async function fetchCharacterTraits(
+  assistantId: string,
+): Promise<CharacterTraits | null> {
   try {
     const { data, error, response } = await client.get({
-      url: "/v1/workspace/file",
+      url: "/v1/assistants/{assistant_id}/workspace/file/",
+      path: { assistant_id: assistantId },
       query: { path: "data/avatar/character-traits.json" },
     });
     assertHasResponse(response, error, "Failed to fetch character traits");
@@ -49,11 +56,13 @@ export async function fetchCharacterTraits(): Promise<CharacterTraits | null> {
 }
 
 export async function saveCharacterTraits(
+  assistantId: string,
   traits: CharacterTraits,
 ): Promise<boolean> {
   try {
     const { error, response } = await client.post({
-      url: "/v1/avatar/render-from-traits",
+      url: "/v1/assistants/{assistant_id}/avatar/render-from-traits",
+      path: { assistant_id: assistantId },
       body: traits,
       headers: { "Content-Type": "application/json" },
     });
@@ -64,7 +73,10 @@ export async function saveCharacterTraits(
   }
 }
 
-export async function uploadAvatarImage(file: File): Promise<boolean> {
+export async function uploadAvatarImage(
+  assistantId: string,
+  file: File,
+): Promise<boolean> {
   try {
     const arrayBuffer = await file.arrayBuffer();
     const base64 = btoa(
@@ -75,7 +87,8 @@ export async function uploadAvatarImage(file: File): Promise<boolean> {
     );
 
     const { error: writeError, response: writeResponse } = await client.post({
-      url: "/v1/workspace/write",
+      url: "/v1/assistants/{assistant_id}/workspace/write/",
+      path: { assistant_id: assistantId },
       body: { path: "data/avatar/avatar-image.png", content: base64, encoding: "base64" },
       headers: { "Content-Type": "application/json" },
     });
@@ -83,7 +96,8 @@ export async function uploadAvatarImage(file: File): Promise<boolean> {
     if (!writeResponse.ok) return false;
 
     await client.post({
-      url: "/v1/workspace/delete",
+      url: "/v1/assistants/{assistant_id}/workspace/delete/",
+      path: { assistant_id: assistantId },
       body: { path: "data/avatar/character-traits.json" },
       headers: { "Content-Type": "application/json" },
     });
@@ -94,10 +108,13 @@ export async function uploadAvatarImage(file: File): Promise<boolean> {
   }
 }
 
-export async function fetchAvatarImageUrl(): Promise<string | null> {
+export async function fetchAvatarImageUrl(
+  assistantId: string,
+): Promise<string | null> {
   try {
     const { data, error, response } = await client.get({
-      url: "/v1/workspace/file/content",
+      url: "/v1/assistants/{assistant_id}/workspace/file/content/",
+      path: { assistant_id: assistantId },
       query: { path: "data/avatar/avatar-image.png" },
       parseAs: "blob",
     });

--- a/apps/web/src/domains/avatar/use-assistant-avatar.ts
+++ b/apps/web/src/domains/avatar/use-assistant-avatar.ts
@@ -36,15 +36,15 @@ export function useAssistantAvatar(assistantId: string | null) {
     queryFn: async () => {
       const id = assistantId!;
       const [components, imageUrl] = await Promise.all([
-        fetchCharacterComponents(),
-        fetchAvatarImageUrl(),
+        fetchCharacterComponents(id),
+        fetchAvatarImageUrl(id),
       ]);
       // Skip the traits fetch when a custom image exists — the traits
       // file is intentionally deleted on the daemon side in that case,
       // so requesting it just generates 404s on every SSE-driven
       // reconnect invalidation. `AvatarRenderer` only reads `traits`
       // when there is no `customImageUrl`.
-      const traits = imageUrl ? null : await fetchCharacterTraits();
+      const traits = imageUrl ? null : await fetchCharacterTraits(id);
 
       const prev = activeBlobUrls.get(id);
       if (prev && prev !== imageUrl) {

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -233,9 +233,10 @@ export function HatchingScreen() {
           markPrivacyConsent(userId);
 
           if (result.ok) {
-            fetchCharacterTraits().then((existing) => {
+            const assistantId = result.data.id;
+            fetchCharacterTraits(assistantId).then((existing) => {
               if (existing) return;
-              return saveCharacterTraits(hatchTraits);
+              return saveCharacterTraits(assistantId, hatchTraits);
             }).catch((err) => {
               Sentry.captureException(err, {
                 tags: { context: "onboarding_avatar_sync" },


### PR DESCRIPTION
## Why

#31462 (the original LUM-1784 fix) dropped the `/v1/assistants/{assistant_id}/...` prefix from the avatar API calls on the assumption that the SPA was talking directly to the daemon. That assumption was wrong — the gateway runtime-proxy at `gateway/src/http/routes/runtime-proxy.ts:88-96` rewrites `/v1/assistants/<id>/X` to `/v1/X` before forwarding to the daemon, so the assistant-scoped prefix is the correct shape end-to-end and matches what the platform web client has always sent.

The "Build a Character" modal is still failing after #31462. Restoring the prefix is necessary but not sufficient — investigation into the actual cause continues in a follow-up.

## What

- Restores `fetchCharacterComponents`, `uploadAvatarImage`, `fetchAvatarImageUrl` to the `/v1/assistants/{assistant_id}/...` URL shape and the original `assistantId` argument.
- Updates callers: `avatar-customization-panel.tsx`, `avatar-management-modal.tsx`, `use-assistant-avatar.ts`, `hatching-screen.tsx`.

## What's kept from #31462

The two endpoints that were genuinely wrong in the original port:

- `fetchCharacterTraits` → `GET /v1/assistants/{id}/workspace/file/?path=data/avatar/character-traits.json` then JSON-parse `data.content`. The daemon has no `avatar/character-traits` route; the platform reads traits from the workspace file the same way.
- `saveCharacterTraits` → `POST /v1/assistants/{id}/avatar/render-from-traits` with `{bodyShape, eyeStyle, color}` body. The daemon's `render-from-traits` handler both persists traits and regenerates the PNG.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (only the pre-existing unrelated warning in `lib/errors/report.ts`)
- `bun test src/domains/avatar` — 2/2 pass

## Test plan

- [ ] "Build a Character" no worse than current state (URL parity with platform now confirmed)
- [ ] Custom image upload still works
- [ ] Onboarding hatching-screen still persists the randomized character

Linear: [LUM-1784](https://linear.app/vellum/issue/LUM-1784/build-a-character-modal-fails-to-load-avatar-components-in-vellum)

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCZW79Tf61evfPDvm2HrH)_