### PR TITLE
chore(design-library): wire Storybook controls for interactive stories

### DIFF
--- a/packages/design-library/src/components/bottom-sheet.stories.tsx
+++ b/packages/design-library/src/components/bottom-sheet.stories.tsx
@@ -4,28 +4,49 @@ import { Share } from "lucide-react";
 import { Button } from "./button.js";
 import { BottomSheet } from "./bottom-sheet.js";
 
-const meta: Meta = {
+interface BottomSheetStoryArgs {
+  title: string;
+  description: string;
+  showIcon: boolean;
+  triggerLabel: string;
+}
+
+const meta: Meta<BottomSheetStoryArgs> = {
   title: "Components/BottomSheet",
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    title: { control: "text" },
+    description: { control: "text" },
+    showIcon: { control: "boolean" },
+    triggerLabel: { control: "text" },
+  },
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<BottomSheetStoryArgs>;
 
 export const Default: Story = {
-  render: () => (
+  args: {
+    triggerLabel: "Open Bottom Sheet",
+    title: "Select an Option",
+    description: "Choose one of the actions below.",
+    showIcon: false,
+  },
+  render: ({ triggerLabel, title, description, showIcon }) => (
     <BottomSheet.Root>
       <BottomSheet.Trigger asChild>
-        <Button>Open Bottom Sheet</Button>
+        <Button>{triggerLabel}</Button>
       </BottomSheet.Trigger>
       <BottomSheet.Content>
         <BottomSheet.Header>
-          <BottomSheet.Title>Select an Option</BottomSheet.Title>
-          <BottomSheet.Description>
-            Choose one of the actions below.
-          </BottomSheet.Description>
+          <BottomSheet.Title icon={showIcon ? Share : undefined}>
+            {title}
+          </BottomSheet.Title>
+          {description ? (
+            <BottomSheet.Description>{description}</BottomSheet.Description>
+          ) : null}
         </BottomSheet.Header>
         <BottomSheet.Body>
           <div className="flex flex-col gap-2">
@@ -51,14 +72,25 @@ export const Default: Story = {
 };
 
 export const WithIcon: Story = {
-  render: () => (
+  args: {
+    triggerLabel: "Share",
+    title: "Share with",
+    description: "",
+    showIcon: true,
+  },
+  render: ({ triggerLabel, title, description, showIcon }) => (
     <BottomSheet.Root>
       <BottomSheet.Trigger asChild>
-        <Button variant="outlined">Share</Button>
+        <Button variant="outlined">{triggerLabel}</Button>
       </BottomSheet.Trigger>
       <BottomSheet.Content>
         <BottomSheet.Header>
-          <BottomSheet.Title icon={Share}>Share with</BottomSheet.Title>
+          <BottomSheet.Title icon={showIcon ? Share : undefined}>
+            {title}
+          </BottomSheet.Title>
+          {description ? (
+            <BottomSheet.Description>{description}</BottomSheet.Description>
+          ) : null}
         </BottomSheet.Header>
         <BottomSheet.Body>
           <div className="flex flex-col gap-2">

--- a/packages/design-library/src/components/confirm-dialog.stories.tsx
+++ b/packages/design-library/src/components/confirm-dialog.stories.tsx
@@ -2,28 +2,43 @@ import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "./button.js";
-import { ConfirmDialog } from "./confirm-dialog.js";
+import { ConfirmDialog, type ConfirmDialogProps } from "./confirm-dialog.js";
 
-const meta: Meta = {
+const meta: Meta<ConfirmDialogProps> = {
   title: "Components/ConfirmDialog",
+  component: ConfirmDialog,
   parameters: {
     layout: "centered",
+  },
+  argTypes: {
+    title: { control: "text" },
+    message: { control: "text" },
+    confirmLabel: { control: "text" },
+    cancelLabel: { control: "text" },
+    destructive: { control: "boolean" },
+    open: { control: false },
+    onConfirm: { control: false },
+    onCancel: { control: false },
   },
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<ConfirmDialogProps>;
 
 export const Default: Story = {
-  render: function DefaultStory() {
+  args: {
+    title: "Confirm Action",
+    message:
+      "Are you sure you want to proceed? This action cannot be undone.",
+  },
+  render: function DefaultStory(args) {
     const [open, setOpen] = useState(false);
     return (
       <>
         <Button onClick={() => setOpen(true)}>Open Confirm</Button>
         <ConfirmDialog
+          {...args}
           open={open}
-          title="Confirm Action"
-          message="Are you sure you want to proceed? This action cannot be undone."
           onConfirm={() => setOpen(false)}
           onCancel={() => setOpen(false)}
         />
@@ -33,7 +48,15 @@ export const Default: Story = {
 };
 
 export const Destructive: Story = {
-  render: function DestructiveStory() {
+  args: {
+    title: "Delete Item",
+    message:
+      "This will permanently delete this item. This action cannot be undone.",
+    confirmLabel: "Delete",
+    cancelLabel: "Keep",
+    destructive: true,
+  },
+  render: function DestructiveStory(args) {
     const [open, setOpen] = useState(false);
     return (
       <>
@@ -41,12 +64,8 @@ export const Destructive: Story = {
           Delete Item
         </Button>
         <ConfirmDialog
+          {...args}
           open={open}
-          title="Delete Item"
-          message="This will permanently delete this item. This action cannot be undone."
-          confirmLabel="Delete"
-          cancelLabel="Keep"
-          destructive
           onConfirm={() => setOpen(false)}
           onCancel={() => setOpen(false)}
         />
@@ -56,7 +75,13 @@ export const Destructive: Story = {
 };
 
 export const CustomLabels: Story = {
-  render: function CustomLabelsStory() {
+  args: {
+    title: "Publish Draft",
+    message: "Publishing will make this content visible to all users.",
+    confirmLabel: "Publish Now",
+    cancelLabel: "Not Yet",
+  },
+  render: function CustomLabelsStory(args) {
     const [open, setOpen] = useState(false);
     return (
       <>
@@ -64,11 +89,8 @@ export const CustomLabels: Story = {
           Publish Draft
         </Button>
         <ConfirmDialog
+          {...args}
           open={open}
-          title="Publish Draft"
-          message="Publishing will make this content visible to all users."
-          confirmLabel="Publish Now"
-          cancelLabel="Not Yet"
           onConfirm={() => setOpen(false)}
           onCancel={() => setOpen(false)}
         />

--- a/packages/design-library/src/components/dropdown.stories.tsx
+++ b/packages/design-library/src/components/dropdown.stories.tsx
@@ -2,17 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Globe, Lock, Users } from "lucide-react";
 import { useState } from "react";
 
-import { Dropdown, type DropdownOption } from "./dropdown.js";
-
-const meta: Meta = {
-  title: "Components/Dropdown",
-  parameters: {
-    layout: "centered",
-  },
-};
-
-export default meta;
-type Story = StoryObj;
+import { Dropdown, type DropdownOption, type DropdownProps } from "./dropdown.js";
 
 const fruits: DropdownOption<string>[] = [
   { value: "apple", label: "Apple" },
@@ -22,16 +12,41 @@ const fruits: DropdownOption<string>[] = [
   { value: "elderberry", label: "Elderberry" },
 ];
 
+const meta: Meta<DropdownProps<string>> = {
+  title: "Components/Dropdown",
+  component: Dropdown,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    placeholder: { control: "text" },
+    disabled: { control: "boolean" },
+    menuAlign: { control: "select", options: ["start", "center", "end"] },
+    menuMaxHeight: { control: "number" },
+    menuMinWidth: { control: "number" },
+    "aria-label": { control: "text" },
+    options: { control: false },
+    value: { control: false },
+    onChange: { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<DropdownProps<string>>;
+
 export const Default: Story = {
-  render: function DefaultDropdown() {
+  args: {
+    "aria-label": "Fruit",
+  },
+  render: function DefaultDropdown(args) {
     const [value, setValue] = useState("apple");
     return (
       <div className="w-64">
         <Dropdown
+          {...args}
           options={fruits}
           value={value}
           onChange={setValue}
-          aria-label="Fruit"
         />
       </div>
     );
@@ -39,16 +54,19 @@ export const Default: Story = {
 };
 
 export const WithPlaceholder: Story = {
-  render: function PlaceholderDropdown() {
+  args: {
+    placeholder: "Select a fruit…",
+    "aria-label": "Fruit",
+  },
+  render: function PlaceholderDropdown(args) {
     const [value, setValue] = useState("");
     return (
       <div className="w-64">
         <Dropdown
+          {...args}
           options={fruits}
           value={value}
           onChange={setValue}
-          placeholder="Select a fruit…"
-          aria-label="Fruit"
         />
       </div>
     );
@@ -66,15 +84,18 @@ const visibilityOptions: DropdownOption<"public" | "team" | "private">[] = [
 ];
 
 export const WithIcons: Story = {
-  render: function IconDropdown() {
+  args: {
+    "aria-label": "Visibility",
+  },
+  render: function IconDropdown(args) {
     const [value, setValue] = useState<"public" | "team" | "private">("public");
     return (
       <div className="w-64">
         <Dropdown
+          {...(args as DropdownProps<"public" | "team" | "private">)}
           options={visibilityOptions}
           value={value}
           onChange={setValue}
-          aria-label="Visibility"
         />
       </div>
     );
@@ -82,14 +103,17 @@ export const WithIcons: Story = {
 };
 
 export const Disabled: Story = {
-  render: () => (
+  args: {
+    disabled: true,
+    "aria-label": "Fruit",
+  },
+  render: (args) => (
     <div className="w-64">
       <Dropdown
+        {...args}
         options={fruits}
         value="banana"
         onChange={() => {}}
-        disabled
-        aria-label="Fruit"
       />
     </div>
   ),
@@ -104,16 +128,19 @@ const manyOptions: DropdownOption<string>[] = Array.from(
 );
 
 export const LongList: Story = {
-  render: function LongListDropdown() {
+  args: {
+    menuMaxHeight: 200,
+    "aria-label": "Option",
+  },
+  render: function LongListDropdown(args) {
     const [value, setValue] = useState("option-1");
     return (
       <div className="w-64">
         <Dropdown
+          {...args}
           options={manyOptions}
           value={value}
           onChange={setValue}
-          menuMaxHeight={200}
-          aria-label="Option"
         />
       </div>
     );
@@ -121,17 +148,20 @@ export const LongList: Story = {
 };
 
 export const EndAligned: Story = {
-  render: function EndAlignedDropdown() {
+  args: {
+    menuAlign: "end",
+    "aria-label": "Fruit",
+  },
+  render: function EndAlignedDropdown(args) {
     const [value, setValue] = useState("apple");
     return (
       <div className="flex w-96 justify-end">
         <div className="w-48">
           <Dropdown
+            {...args}
             options={fruits}
             value={value}
             onChange={setValue}
-            menuAlign="end"
-            aria-label="Fruit"
           />
         </div>
       </div>

--- a/packages/design-library/src/components/modal.stories.tsx
+++ b/packages/design-library/src/components/modal.stories.tsx
@@ -3,35 +3,60 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Settings } from "lucide-react";
 
 import { Button } from "./button.js";
-import { Modal } from "./modal.js";
+import { Modal, type ModalSize } from "./modal.js";
 
-const meta: Meta = {
+interface ModalStoryArgs {
+  size: ModalSize;
+  hideCloseButton: boolean;
+  title: string;
+  description: string;
+  body: string;
+  showIcon: boolean;
+}
+
+const meta: Meta<ModalStoryArgs> = {
   title: "Components/Modal",
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg", "xl"] },
+    hideCloseButton: { control: "boolean" },
+    title: { control: "text" },
+    description: { control: "text" },
+    body: { control: "text" },
+    showIcon: { control: "boolean" },
+  },
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<ModalStoryArgs>;
 
 export const Default: Story = {
-  render: () => (
+  args: {
+    size: "md",
+    hideCloseButton: false,
+    title: "Modal Title",
+    description: "This is a description of the modal content.",
+    body: "Modal body content goes here.",
+    showIcon: false,
+  },
+  render: ({ size, hideCloseButton, title, description, body, showIcon }) => (
     <Modal.Root>
       <Modal.Trigger asChild>
         <Button>Open Modal</Button>
       </Modal.Trigger>
-      <Modal.Content>
+      <Modal.Content size={size} hideCloseButton={hideCloseButton}>
         <Modal.Header>
-          <Modal.Title>Modal Title</Modal.Title>
-          <Modal.Description>
-            This is a description of the modal content.
-          </Modal.Description>
+          <Modal.Title icon={showIcon ? Settings : undefined}>
+            {title}
+          </Modal.Title>
+          {description ? (
+            <Modal.Description>{description}</Modal.Description>
+          ) : null}
         </Modal.Header>
         <Modal.Body>
-          <p className="text-body-medium-default">
-            Modal body content goes here.
-          </p>
+          <p className="text-body-medium-default">{body}</p>
         </Modal.Body>
         <Modal.Footer>
           <Modal.Close asChild>
@@ -45,46 +70,45 @@ export const Default: Story = {
 };
 
 export const WithIcon: Story = {
-  render: () => (
-    <Modal.Root>
-      <Modal.Trigger asChild>
-        <Button>Settings</Button>
-      </Modal.Trigger>
-      <Modal.Content>
-        <Modal.Header>
-          <Modal.Title icon={Settings}>Preferences</Modal.Title>
-          <Modal.Description>
-            Configure your account preferences.
-          </Modal.Description>
-        </Modal.Header>
-        <Modal.Body>
-          <p className="text-body-medium-default">Settings form content.</p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Modal.Close asChild>
-            <Button variant="outlined">Cancel</Button>
-          </Modal.Close>
-          <Button variant="primary">Save Changes</Button>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal.Root>
-  ),
+  args: {
+    size: "md",
+    hideCloseButton: false,
+    title: "Preferences",
+    description: "Configure your account preferences.",
+    body: "Settings form content.",
+    showIcon: true,
+  },
+  render: Default.render,
 };
 
 export const NoCloseButton: Story = {
-  render: () => (
+  args: {
+    size: "md",
+    hideCloseButton: true,
+    title: "Confirm Action",
+    description:
+      "This modal has no close button — dismiss via the footer buttons.",
+    body: "",
+    showIcon: false,
+  },
+  render: ({ size, hideCloseButton, title, description, body, showIcon }) => (
     <Modal.Root>
       <Modal.Trigger asChild>
         <Button>Open (no close button)</Button>
       </Modal.Trigger>
-      <Modal.Content hideCloseButton>
+      <Modal.Content size={size} hideCloseButton={hideCloseButton}>
         <Modal.Header>
-          <Modal.Title>Confirm Action</Modal.Title>
+          <Modal.Title icon={showIcon ? Settings : undefined}>
+            {title}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Modal.Description>
-            This modal has no close button — dismiss via the footer buttons.
-          </Modal.Description>
+          {description ? (
+            <Modal.Description>{description}</Modal.Description>
+          ) : null}
+          {body ? (
+            <p className="text-body-medium-default">{body}</p>
+          ) : null}
         </Modal.Body>
         <Modal.Footer>
           <Modal.Close asChild>
@@ -98,8 +122,16 @@ export const NoCloseButton: Story = {
 };
 
 export const Sizes: Story = {
-  render: function SizesStory() {
-    const [size, setSize] = useState<"sm" | "md" | "lg" | "xl">("md");
+  args: {
+    size: "md",
+    hideCloseButton: false,
+    title: "Modal",
+    description: "",
+    body: "Click a button to open the modal at that size, or change the size control.",
+    showIcon: false,
+  },
+  render: function SizesStory({ size, hideCloseButton, body, showIcon }) {
+    const [activeSize, setActiveSize] = useState<ModalSize>(size);
     const [open, setOpen] = useState(false);
 
     return (
@@ -110,7 +142,7 @@ export const Sizes: Story = {
             variant="outlined"
             size="compact"
             onClick={() => {
-              setSize(s);
+              setActiveSize(s);
               setOpen(true);
             }}
           >
@@ -118,14 +150,14 @@ export const Sizes: Story = {
           </Button>
         ))}
         <Modal.Root open={open} onOpenChange={setOpen}>
-          <Modal.Content size={size}>
+          <Modal.Content size={activeSize} hideCloseButton={hideCloseButton}>
             <Modal.Header>
-              <Modal.Title>Size: {size}</Modal.Title>
+              <Modal.Title icon={showIcon ? Settings : undefined}>
+                Size: {activeSize}
+              </Modal.Title>
             </Modal.Header>
             <Modal.Body>
-              <p className="text-body-medium-default">
-                This modal is using the &quot;{size}&quot; size preset.
-              </p>
+              <p className="text-body-medium-default">{body}</p>
             </Modal.Body>
             <Modal.Footer>
               <Modal.Close asChild>

--- a/packages/design-library/src/components/popover.stories.tsx
+++ b/packages/design-library/src/components/popover.stories.tsx
@@ -3,23 +3,56 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button } from "./button.js";
 import { Popover } from "./popover.js";
 
-const meta: Meta = {
+interface PopoverStoryArgs {
+  side: "top" | "right" | "bottom" | "left";
+  align: "start" | "center" | "end";
+  sideOffset: number;
+  alignOffset: number;
+  triggerLabel: string;
+}
+
+const meta: Meta<PopoverStoryArgs> = {
   title: "Components/Popover",
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    side: {
+      control: "select",
+      options: ["top", "right", "bottom", "left"],
+    },
+    align: {
+      control: "select",
+      options: ["start", "center", "end"],
+    },
+    sideOffset: { control: "number" },
+    alignOffset: { control: "number" },
+    triggerLabel: { control: "text" },
+  },
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<PopoverStoryArgs>;
 
 export const Default: Story = {
-  render: () => (
+  args: {
+    side: "bottom",
+    align: "center",
+    sideOffset: 6,
+    alignOffset: 0,
+    triggerLabel: "Open Popover",
+  },
+  render: ({ side, align, sideOffset, alignOffset, triggerLabel }) => (
     <Popover.Root>
       <Popover.Trigger asChild>
-        <Button>Open Popover</Button>
+        <Button>{triggerLabel}</Button>
       </Popover.Trigger>
-      <Popover.Content>
+      <Popover.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+      >
         <div className="flex flex-col gap-2 p-2">
           <p className="text-body-medium-default">Popover content</p>
           <p className="text-body-medium-lighter text-[color:var(--content-secondary)]">
@@ -32,12 +65,25 @@ export const Default: Story = {
 };
 
 export const WithCloseButton: Story = {
-  render: () => (
+  args: {
+    side: "bottom",
+    align: "start",
+    sideOffset: 6,
+    alignOffset: 0,
+    triggerLabel: "Settings",
+  },
+  render: ({ side, align, sideOffset, alignOffset, triggerLabel }) => (
     <Popover.Root>
       <Popover.Trigger asChild>
-        <Button variant="outlined">Settings</Button>
+        <Button variant="outlined">{triggerLabel}</Button>
       </Popover.Trigger>
-      <Popover.Content side="bottom" align="start" className="w-64">
+      <Popover.Content
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+        className="w-64"
+      >
         <div className="flex flex-col gap-3 p-2">
           <p className="text-body-medium-default">Settings</p>
           <p className="text-body-medium-lighter text-[color:var(--content-secondary)]">
@@ -45,7 +91,9 @@ export const WithCloseButton: Story = {
           </p>
           <div className="flex justify-end">
             <Popover.Close asChild>
-              <Button variant="ghost" size="compact">Close</Button>
+              <Button variant="ghost" size="compact">
+                Close
+              </Button>
             </Popover.Close>
           </div>
         </div>
@@ -55,17 +103,26 @@ export const WithCloseButton: Story = {
 };
 
 export const Sides: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Renders one popover per side to show all placements at once.",
+      },
+    },
+  },
   render: () => (
     <div className="flex gap-4">
       {(["top", "right", "bottom", "left"] as const).map((side) => (
         <Popover.Root key={side}>
           <Popover.Trigger asChild>
-            <Button variant="outlined" size="compact">{side}</Button>
+            <Button variant="outlined" size="compact">
+              {side}
+            </Button>
           </Popover.Trigger>
           <Popover.Content side={side}>
-            <p className="p-2 text-body-small-default">
-              Popover on {side}
-            </p>
+            <p className="p-2 text-body-small-default">Popover on {side}</p>
           </Popover.Content>
         </Popover.Root>
       ))}

--- a/packages/design-library/src/components/toast.stories.tsx
+++ b/packages/design-library/src/components/toast.stories.tsx
@@ -1,9 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "./button.js";
-import { toast, Toaster } from "./toast.js";
+import { toast, Toaster, type ToastVariant } from "./toast.js";
 
-const meta: Meta = {
+interface ToastStoryArgs {
+  variant: ToastVariant;
+  message: string;
+  description: string;
+  withAction: boolean;
+  actionLabel: string;
+}
+
+const meta: Meta<ToastStoryArgs> = {
   title: "Components/Toast",
   parameters: {
     layout: "centered",
@@ -16,49 +24,74 @@ const meta: Meta = {
       </>
     ),
   ],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "info", "warning", "error", "success"],
+    },
+    message: { control: "text" },
+    description: { control: "text" },
+    withAction: { control: "boolean" },
+    actionLabel: { control: "text" },
+  },
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<ToastStoryArgs>;
+
+function fireToast(args: ToastStoryArgs) {
+  const options = {
+    description: args.description || undefined,
+    action: args.withAction
+      ? {
+          label: args.actionLabel || "Undo",
+          onClick: () => toast.success("Action confirmed"),
+        }
+      : undefined,
+  };
+  const fn = args.variant === "default" ? toast : toast[args.variant];
+  fn(args.message, options);
+}
 
 export const WithDescription: Story = {
-  render: () => (
-    <Button
-      onClick={() =>
-        toast.info("File uploaded", {
-          description: "your-document.pdf was uploaded successfully.",
-        })
-      }
-    >
-      Toast with description
-    </Button>
+  args: {
+    variant: "info",
+    message: "File uploaded",
+    description: "your-document.pdf was uploaded successfully.",
+    withAction: false,
+    actionLabel: "Undo",
+  },
+  render: (args) => (
+    <Button onClick={() => fireToast(args)}>Toast with description</Button>
   ),
 };
 
 export const WithAction: Story = {
-  render: () => (
-    <Button
-      onClick={() =>
-        toast.error("Message deleted", {
-          action: {
-            label: "Undo",
-            onClick: () => toast.success("Message restored"),
-          },
-        })
-      }
-    >
-      Toast with action
-    </Button>
+  args: {
+    variant: "error",
+    message: "Message deleted",
+    description: "",
+    withAction: true,
+    actionLabel: "Undo",
+  },
+  render: (args) => (
+    <Button onClick={() => fireToast(args)}>Toast with action</Button>
   ),
 };
 
 export const AllVariants: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Fires one toast per variant — use the other stories to drive a single toast via controls.",
+      },
+    },
+  },
   render: () => (
     <div className="flex flex-wrap gap-2">
-      <Button
-        variant="outlined"
-        onClick={() => toast("Default notification")}
-      >
+      <Button variant="outlined" onClick={() => toast("Default notification")}>
         Default
       </Button>
       <Button


### PR DESCRIPTION
## Summary

Audit of Storybook controls across the design library. Some stories had a populated Controls tab and others were empty — root cause was that the render-only stories hardcoded all props inside their `render` function, so Storybook had nothing to bind to.

Refactored six story files to accept `args` in their render functions and declared matching `argTypes` in the meta:

- `dropdown.stories.tsx` — placeholder, disabled, menuAlign, menuMaxHeight, menuMinWidth, aria-label
- `confirm-dialog.stories.tsx` — title, message, confirmLabel, cancelLabel, destructive
- `modal.stories.tsx` — size, hideCloseButton, title, description, body, showIcon
- `bottom-sheet.stories.tsx` — title, description, showIcon, triggerLabel
- `popover.stories.tsx` — side, align, sideOffset, alignOffset, triggerLabel (Sides story opts out of controls since it intentionally renders every side)
- `toast.stories.tsx` — variant, message, description, withAction, actionLabel (AllVariants opts out)

**Left alone**: `menu.stories.tsx` and `context-menu.stories.tsx`. Each of those stories demonstrates a structural pattern (submenu, radio items, checkbox items, shortcuts, disabled items) rather than a prop variation — there's no top-level prop that meaningfully drives a control. Forcing args here would be busywork.

## Test plan

- [ ] `bunx tsc --noEmit` in `packages/design-library` passes (verified locally)
- [ ] Run Storybook locally and confirm Controls tab populates for each refactored story
- [ ] Interact with each control and confirm it updates the rendered component
- [ ] Confirm AllVariants (Toast) and Sides (Popover) stories cleanly hide the Controls panel


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqVo3waeTYx7zTnSyQGrKq)_