### PR TITLE
fix(notifications): thread originating convo into sourceContextId so home feed gets a "Go to Convo" button

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -249,8 +249,6 @@ Examples:
                 }
               }
 
-              const sourceContextId = opts.sessionId ?? `cli-${Date.now()}`;
-
               // Validate --conversation-id if provided
               const conversationId = opts.conversationId?.trim();
               if (opts.conversationId != null && !conversationId) {
@@ -266,6 +264,21 @@ Examples:
               // so deferred-emit can buffer notifications when called from a
               // background job that hasn't confirmed success yet.
               const originatingConversationId = tryResolveConversationId();
+
+              // The signal's `sourceContextId` doubles as the home-feed's
+              // navigation target — `resolveHomeFeedMirror` looks it up via
+              // `getConversation()` and only renders a "Go to Convo" button
+              // when it resolves to a real row. Prefer the conversation the
+              // CLI was invoked from (env-derived) so notifications emitted
+              // by background jobs and skills link back to their producing
+              // convo; an explicit --session-id still wins to preserve
+              // caller intent, and --conversation-id is the last resort
+              // before the unresolvable `cli-<ts>` sentinel.
+              const sourceContextId =
+                opts.sessionId ??
+                originatingConversationId ??
+                conversationId ??
+                `cli-${Date.now()}`;
 
               const result = await cliIpcCall<{
                 signalId: string;


### PR DESCRIPTION
## Summary

Phase 1 of a two-part fix for missing "Go to Convo" buttons on Home feed notifications.

The `notifications send` CLI command set `sourceContextId = opts.sessionId ?? "cli-<ts>"` — a sentinel string that `getConversation()` never resolves. The home-feed side-effect (`notifications/home-feed-side-effect.ts:175-185`) uses that lookup to populate `FeedItem.conversationId`, and both clients gate the "Go to Convo" button on its presence. Net effect: every notification emitted via `notifications send` from a background job or skill landed on the Home page without a navigation link, even though the producing conversation was right there in the sidebar.

The command already resolves `originatingConversationId` from `__CONVERSATION_ID` / `__SKILL_CONTEXT_JSON` env vars and reads `--conversation-id` from `opts.conversationId` — both real conversation ids, both passed to the emit only as `conversationAffinityHint` and never as `sourceContextId`.

Reorder the resolution so `sourceContextId` can use either. New priority chain:

| # | Source | Why |
|---|---|---|
| 1 | `--session-id` | Explicit caller intent wins |
| 2 | Originating convo (env) | CLI invoked from a background job / skill |
| 3 | `--conversation-id` | Explicit delivery target |
| 4 | `cli-<ts>` sentinel | No real convo in scope |

## DB confirmation (local home-feed.json)

Before this fix, 5 of 15 feed items were missing `conversationId`. From the `notification_events` table, 100% of:
- `assistant.share`
- `market.premarket_brief`
- `assistant.github_digest.*`
- `user.send_notification`

…use `sourceContextId = "cli-<ts>"`. After this fix, all of these resolve to either the env-derived originating convo or the explicit delivery convo — and the button renders.

## What this does NOT fix

The remaining missing-button cases emit notifications before any convo exists:
- `heartbeat-service.ts:188` (startup-missed alert — literal `"heartbeat"`)
- `heartbeat-service.ts:614` (credential health — uses connectionId)
- `daemon/lifecycle.ts:999` (watcher — uses random uuid)
- `memory/v2/sweep-job.ts:213` (sweep job id)
- `schedule/scheduler.ts:691` (retries-exhausted)

These need a structural fix (Phase 2): write the convo id back into the FeedItem via the broadcaster's `onConversationCreated` callback after pairing completes. Separate PR.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint src/cli/commands/notifications.ts` — clean
- [x] `bun test src/notifications/__tests__/home-feed-side-effect.test.ts` — 25/25 pass
- [ ] After deploy: trigger a pre-market brief or GitHub digest, verify the Home feed item shows a "Go to Convo" button that opens the producing convo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->