### PR TITLE
refactor(web): replace manual history cache with TanStack Query useInfiniteQuery (LUM-1738)

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -46,7 +46,6 @@ import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.
 import { consumePendingPreChatContext, type PreChatOnboardingContext } from "@/domains/onboarding/prechat.js";
 import { createDraftConversationKey } from "@/domains/chat/utils/conversation-selection.js";
 import type { WebSyncRouter } from "@/lib/sync/web-sync-router.js";
-import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
 import type { SyncChangedEvent } from "@/lib/sync/types.js";
 
 import { Button, ConfirmDialog } from "@vellum/design-library";
@@ -246,15 +245,10 @@ export function ChatPage() {
   const lastSuggestionMsgIdRef = useRef<string | null>(null);
   const autoGreetRef = useRef(false);
   const initialPageOldestTsRef = useRef<number | null>(null);
-  const isLoadingOlderRef = useRef(false);
-  const historyLoadedRef = useRef(false);
   const conversationListInvalidatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const loadEpochRef = useRef(0);
   const pendingInitialMessageRef = useRef<{ conversationKey: string; content: string } | null>(null);
   const expandedToolCallIdsRef = useRef<Set<string>>(new Set());
-  const conversationCacheRef = useRef<Map<string, { messages: DisplayMessage[]; pagination: { hasMore: boolean; oldestTimestamp: number | null } }>>(new Map());
   const contextWindowUsageByConversationRef = useRef<Map<string, ContextWindowUsage>>(new Map());
-  const refreshSettleRef = useRef<RefreshSettleHandle | null>(null);
   const syncRouterRef = useRef<WebSyncRouter | null>(null);
 
   // -------------------------------------------------------------------------
@@ -371,6 +365,7 @@ export function ChatPage() {
     switchConversation: rawSwitchConversation,
     startNewConversation: rawStartNewConversation,
     conversationExistsOnServer,
+    historyResult,
   } = useConversationLoader({
     assistantId,
     assistantStateKind: assistantState.kind,
@@ -379,12 +374,10 @@ export function ChatPage() {
     searchParams,
     navigate,
     conversations,
-    transcriptPagination,
     conversationGroupsUI,
     refreshEpoch,
     reachabilityReadyEpoch,
     assistantIdRef,
-    conversationCacheRef,
     draftKeyResolutionRef,
     previousConversationKeyRef,
     onboardingDraftConversationKeyRef,
@@ -398,14 +391,9 @@ export function ChatPage() {
     requestIdToStableIdRef,
     pendingLocalDeletionsRef,
     confirmationToolCallMapRef,
-    refreshSettleRef,
     lastSuggestionMsgIdRef,
     autoGreetRef,
-    initialPageOldestTsRef,
-    isLoadingOlderRef,
-    historyLoadedRef,
     conversationListInvalidatedTimerRef,
-    loadEpochRef,
     pendingInitialMessageRef,
     setAssistantId,
     setMessages,
@@ -420,6 +408,12 @@ export function ChatPage() {
     syncNeedsNewBubbleFromMessages,
     shouldSuppressGenericChatErrorNotice,
   });
+
+  // Keep initialPageOldestTsRef in sync with TQ pagination data — used by
+  // useMessageReconciliation to scope reconciliation to the loaded window.
+  useEffect(() => {
+    initialPageOldestTsRef.current = historyResult.pagination.latestPageOldestTimestamp;
+  }, [historyResult.pagination.latestPageOldestTimestamp]);
 
   // Wrap conversation-switching to reset subagent state eagerly
   const switchConversation = useCallback(
@@ -1236,6 +1230,7 @@ export function ChatPage() {
     checkAssistant,
     setRefreshEpoch,
     streamRetryNonce,
+    historyPagination: historyResult.pagination,
     refs: {
       inputRef,
       messagesRef,
@@ -1243,15 +1238,10 @@ export function ChatPage() {
       assistantIdRef,
       streamContextRef,
       expandedToolCallIdsRef,
-      conversationCacheRef,
       dismissedSurfaceIdsRef,
-      isLoadingOlderRef,
-      initialPageOldestTsRef,
       contextWindowUsageByConversationRef,
-      refreshSettleRef,
       streamRef,
       streamEpochRef,
-      historyLoadedRef,
       pendingQueuedStableIdsRef,
       requestIdToStableIdRef,
       pendingLocalDeletionsRef,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -19,7 +19,7 @@
  */
 
 import * as Sentry from "@sentry/react";
-import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, startTransition, useCallback, useEffect, useMemo, useRef } from "react";
+import { type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { ChatBody } from "@/domains/chat/components/chat-body.js";
 import { SlackChannelFooter } from "@/domains/chat/components/slack-channel-footer.js";
@@ -30,7 +30,6 @@ import { ContactPromptCard } from "@/domains/chat/components/contact-prompt-card
 import { QuestionPromptCard } from "@/domains/chat/components/question-prompt-card.js";
 import { SecretPromptCard } from "@/domains/chat/components/secret-prompt-card.js";
 import { usePullRefresh } from "@/domains/chat/hooks/use-pull-refresh.js";
-import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
 import { useRefreshLatestMessages as _useRefreshLatestMessages } from "@/domains/chat/hooks/use-refresh-latest-messages.js";
 import type { TranscriptHandle, TranscriptProps } from "@/domains/chat/transcript/transcript.js";
 import { useTranscriptScroll } from "@/domains/chat/transcript/use-transcript-scroll.js";
@@ -61,18 +60,19 @@ import { useIsNativePlatform } from "@/runtime/native-auth.js";
 
 import { Link } from "react-router";
 import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters.js";
-import { recordChatDiagnostic, summarizeDisplayMessages } from "@/domains/chat/utils/diagnostics.js";
+
 import { buildEditAppGreeting, buildEditAppStarters } from "@/domains/chat/utils/edit-app-empty-state.js";
 import { pickRandomPlaceholder } from "@/domains/chat/utils/empty-state-constants.js";
 import { useEmptyStateGreeting } from "@/domains/chat/hooks/use-empty-state-greeting.js";
 import { getChatBillingBannerDecision, shouldShowGenericChatErrorNotice } from "@/domains/chat/utils/error-classification.js";
-import { fetchOlderHistoryPage } from "@/domains/chat/api/history.js";
+
 import { useDeployStore } from "@/domains/chat/deploy-store.js";
 import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import type { SubagentEntry, SubagentState } from "@/domains/subagents/subagent-store.js";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
+import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination.js";
 import { getThinkingStatusText, isSendDisabled, shouldShowThinkingIndicator, type UIContext } from "@/domains/chat/utils/turn-selectors.js";
 import { isSurfaceInteractive } from "@/domains/chat/types/types.js";
 
@@ -211,15 +211,10 @@ export interface ChatRouteRefs {
   assistantIdRef: MutableRefObject<string | null>;
   streamContextRef: MutableRefObject<StreamContext | null>;
   expandedToolCallIdsRef: MutableRefObject<Set<string>>;
-  conversationCacheRef: MutableRefObject<Map<string, { messages: DisplayMessage[]; pagination: { hasMore: boolean; oldestTimestamp: number | null } }>>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
-  isLoadingOlderRef: MutableRefObject<boolean>;
-  initialPageOldestTsRef: MutableRefObject<number | null>;
   contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
-  refreshSettleRef: MutableRefObject<RefreshSettleHandle | null>;
   streamRef: MutableRefObject<ChatEventStream | null>;
   streamEpochRef: MutableRefObject<number>;
-  historyLoadedRef: MutableRefObject<boolean>;
   pendingQueuedStableIdsRef: MutableRefObject<string[]>;
   requestIdToStableIdRef: MutableRefObject<Map<string, string>>;
   pendingLocalDeletionsRef: MutableRefObject<Set<string>>;
@@ -357,6 +352,9 @@ export interface ChatRouteContentProps {
   // Stream retry (for diagnostics)
   streamRetryNonce: number;
 
+  // TanStack Query pagination (from useHistoryPagination)
+  historyPagination: HistoryPaginationResult;
+
   // Refs
   refs: ChatRouteRefs;
 
@@ -383,7 +381,7 @@ export function ChatRouteContent({
   isMobile,
   isKeyboardOpen,
   messages,
-  setMessages,
+  setMessages: _setMessages,
   input,
   setInput,
   error,
@@ -409,7 +407,7 @@ export function ChatRouteContent({
   suggestion,
   setSuggestion,
   transcriptPagination,
-  setTranscriptPagination,
+  setTranscriptPagination: _setTranscriptPagination,
   setShowAddCreditsModal,
   diskPressure,
   handleReviewDiskUsage,
@@ -438,6 +436,7 @@ export function ChatRouteContent({
   checkAssistant,
   setRefreshEpoch,
   streamRetryNonce: _streamRetryNonce,
+  historyPagination,
   refs,
   isChannelReadonly,
   onboardingTasksEmpty,
@@ -495,15 +494,10 @@ export function ChatRouteContent({
     assistantIdRef: _assistantIdRef,
     streamContextRef,
     expandedToolCallIdsRef,
-    conversationCacheRef,
     dismissedSurfaceIdsRef: _dismissedSurfaceIdsRef,
-    isLoadingOlderRef,
-    initialPageOldestTsRef: _initialPageOldestTsRef,
     contextWindowUsageByConversationRef: _contextWindowUsageByConversationRef,
-    refreshSettleRef,
     streamRef: _streamRef,
     streamEpochRef: _streamEpochRef,
-    historyLoadedRef: _historyLoadedRef,
     pendingQueuedStableIdsRef: _pendingQueuedStableIdsRef,
     requestIdToStableIdRef: _requestIdToStableIdRef,
     pendingLocalDeletionsRef: _pendingLocalDeletionsRef,
@@ -696,14 +690,13 @@ export function ChatRouteContent({
   // Refresh conversation (destructive)
   // -------------------------------------------------------------------------
 
-  const handleRefreshConversation = useCallback(() => {
+  const onRefreshEpoch = useCallback(() => {
     if (activeConversationKey) {
       const currentInput = inputRef.current?.value ?? "";
       saveDraft(activeConversationKey, currentInput);
-      conversationCacheRef.current.delete(activeConversationKey);
     }
     setRefreshEpoch((prev) => prev + 1);
-  }, [activeConversationKey, inputRef, saveDraft, conversationCacheRef, setRefreshEpoch]);
+  }, [activeConversationKey, inputRef, saveDraft, setRefreshEpoch]);
 
   // -------------------------------------------------------------------------
   // Pull-to-refresh
@@ -718,8 +711,8 @@ export function ChatRouteContent({
   } = usePullRefresh({
     activeConversationKey,
     messagesRef,
-    onRefreshConversation: handleRefreshConversation,
-    refreshSettleRef,
+    invalidateHistory: historyPagination.invalidate,
+    onRefreshEpoch,
   });
 
   // -------------------------------------------------------------------------
@@ -727,94 +720,8 @@ export function ChatRouteContent({
   // -------------------------------------------------------------------------
 
   const loadOlder = useCallback(() => {
-    if (
-      isLoadingOlderRef.current ||
-      transcriptPagination.isLoadingOlder ||
-      !transcriptPagination.hasMore ||
-      transcriptPagination.oldestTimestamp == null ||
-      !activeConversationKey ||
-      !assistantId
-    ) {
-      return;
-    }
-    const beforeTimestamp = transcriptPagination.oldestTimestamp;
-    recordChatDiagnostic("history_older_fetch_start", {
-      assistantId,
-      conversationKey: activeConversationKey,
-      beforeTimestamp,
-      pagination: {
-        hasMore: transcriptPagination.hasMore,
-        oldestTimestamp: beforeTimestamp,
-        isLoadingOlder: transcriptPagination.isLoadingOlder,
-      },
-      currentMessages: summarizeDisplayMessages(messagesRef.current),
-    });
-    isLoadingOlderRef.current = true;
-    setTranscriptPagination((p) => ({ ...p, isLoadingOlder: true }));
-    fetchOlderHistoryPage(
-      assistantId,
-      activeConversationKey,
-      beforeTimestamp,
-    )
-      .then((res) => {
-        const currentMessages = messagesRef.current;
-        const existingIds = new Set(
-          currentMessages.filter((m) => m.id).map((m) => m.id),
-        );
-        const deduped = res.messages.filter((m) => !m.id || !existingIds.has(m.id));
-        recordChatDiagnostic("history_older_apply", {
-          assistantId,
-          conversationKey: activeConversationKey,
-          beforeTimestamp,
-          response: {
-            hasMore: res.hasMore,
-            oldestTimestamp: res.oldestTimestamp,
-            oldestMessageId: res.oldestMessageId,
-            messages: summarizeDisplayMessages(res.messages),
-          },
-          dedupedCount: deduped.length,
-          droppedDuplicateCount: res.messages.length - deduped.length,
-          beforeMessages: summarizeDisplayMessages(currentMessages),
-        });
-        startTransition(() => {
-          setMessages((prev) => {
-            const existingIds2 = new Set(prev.filter((m) => m.id).map((m) => m.id));
-            const deduped2 = res.messages.filter((m) => !m.id || !existingIds2.has(m.id));
-            return [...deduped2, ...prev];
-          });
-          setTranscriptPagination((p) => ({
-            ...p,
-            hasMore: res.hasMore,
-            oldestTimestamp: res.oldestTimestamp,
-            isLoadingOlder: false,
-          }));
-          isLoadingOlderRef.current = false;
-        });
-      })
-      .catch((err) => {
-        isLoadingOlderRef.current = false;
-        recordChatDiagnostic("history_older_fetch_error", {
-          assistantId,
-          conversationKey: activeConversationKey,
-          beforeTimestamp,
-          messageLength: err instanceof Error ? err.message.length : null,
-        });
-        Sentry.captureException(err, {
-          tags: { context: "fetch_older_history_page" },
-        });
-        setTranscriptPagination((p) => ({ ...p, isLoadingOlder: false }));
-      });
-  }, [
-    assistantId,
-    activeConversationKey,
-    transcriptPagination.hasMore,
-    transcriptPagination.isLoadingOlder,
-    transcriptPagination.oldestTimestamp,
-    isLoadingOlderRef,
-    messagesRef,
-    setMessages,
-    setTranscriptPagination,
-  ]);
+    historyPagination.fetchOlderPage();
+  }, [historyPagination]);
 
   // -------------------------------------------------------------------------
   // Transcript items

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -721,7 +721,7 @@ export function ChatRouteContent({
 
   const loadOlder = useCallback(() => {
     historyPagination.fetchOlderPage();
-  }, [historyPagination]);
+  }, [historyPagination.fetchOlderPage]);
 
   // -------------------------------------------------------------------------
   // Transcript items

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -461,12 +461,13 @@ export function useConversationHistory({
   ]);
 
   // -------------------------------------------------------------------------
-  // Sync older-page loading state
+  // Sync older-page loading state (both true → false transitions)
   // -------------------------------------------------------------------------
   useEffect(() => {
-    if (pagination.isFetchingOlderPages) {
-      setTranscriptPagination((prev) => ({ ...prev, isLoadingOlder: true }));
-    }
+    setTranscriptPagination((prev) => {
+      if (prev.isLoadingOlder === pagination.isFetchingOlderPages) return prev;
+      return { ...prev, isLoadingOlder: pagination.isFetchingOlderPages };
+    });
   }, [pagination.isFetchingOlderPages, setTranscriptPagination]);
 
   // -------------------------------------------------------------------------
@@ -474,14 +475,26 @@ export function useConversationHistory({
   // -------------------------------------------------------------------------
   useEffect(() => {
     if (!pagination.isError || !pagination.error) return;
+
+    // Older-page failures are reported to Sentry but don't show a
+    // user-facing error — the initial page loaded successfully and the
+    // user can retry by scrolling up again.
+    const isOlderPageError = pagination.isSuccess;
     Sentry.captureException(pagination.error, {
-      tags: { context: "conversation_history_query" },
+      tags: {
+        context: isOlderPageError
+          ? "conversation_history_older_page"
+          : "conversation_history_initial",
+      },
     });
-    setIsLoadingHistory(false);
-    setError({
-      message: "Failed to load conversation history. Please try again.",
-    });
-  }, [pagination.isError, pagination.error, setIsLoadingHistory, setError]);
+
+    if (!isOlderPageError) {
+      setIsLoadingHistory(false);
+      setError({
+        message: "Failed to load conversation history. Please try again.",
+      });
+    }
+  }, [pagination.isError, pagination.isSuccess, pagination.error, setIsLoadingHistory, setError]);
 
   return { pagination };
 }

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -1,3 +1,23 @@
+/**
+ * Conversation history lifecycle — switch resets + TanStack Query data sync.
+ *
+ * This hook handles two concerns:
+ *
+ * 1. **Conversation-switch resets** — when `activeConversationKey` changes,
+ *    reset all per-conversation state (turn, interactions, subagents,
+ *    pending messages, dismissed surfaces, etc.) so nothing leaks between
+ *    conversations.
+ *
+ * 2. **History data sync** — when `useHistoryPagination` (TanStack Query)
+ *    delivers data (from cache or network), apply it to the shared
+ *    `messages` state, reconstruct subagent state, restore pending
+ *    interactions, refresh surface content, and detect auto-greet.
+ *
+ * The fetch/cache/cancellation machinery that previously lived here
+ * (`conversationCacheRef`, `loadEpochRef`, manual LRU rotation) has been
+ * replaced by `useHistoryPagination` — a thin `useInfiniteQuery` wrapper
+ * that handles all of that via TanStack Query's built-in mechanisms.
+ */
 
 import * as Sentry from "@sentry/react";
 import {
@@ -17,7 +37,6 @@ import {
   filterDismissedSurfaces,
   loadDismissedSurfaceIds,
 } from "@/domains/chat/utils/dismissed-surfaces-storage.js";
-import { fetchLatestHistoryPage } from "@/domains/chat/api/history.js";
 import {
   recordChatDiagnostic,
   summarizeDisplayMessages,
@@ -30,7 +49,6 @@ import { useConversationStore } from "@/domains/conversations/conversation-store
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
 
-import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
 import {
   parsePendingSecretState,
   parsePendingConfirmationData,
@@ -38,62 +56,21 @@ import {
 import type { AssistantStateKind, ChatError } from "@/domains/chat/types.js";
 import { getPendingInteractions } from "@/domains/chat/api/interactions.js";
 import { fetchSurfaceContent } from "@/domains/chat/api/surfaces.js";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-export const MAX_CACHED_CONVERSATIONS = 10;
+import {
+  useHistoryPagination,
+  type HistoryPaginationResult,
+} from "@/domains/chat/transcript/use-history-pagination.js";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface HistoryPaginationSnapshot {
-  hasMore: boolean;
-  oldestTimestamp: number | null;
-}
-
-// ---------------------------------------------------------------------------
-// Pure helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Merge a latest-history-page result's pagination with an optional base
- * (e.g. from the conversation cache).  The base wins when it covers older
- * messages than the latest page alone.
- */
-export function getPaginationAfterLatestHistory(
-  result: { hasMore: boolean; oldestTimestamp: number | null },
-  basePagination?: HistoryPaginationSnapshot,
-): HistoryPaginationSnapshot {
-  const latestPagination: HistoryPaginationSnapshot = {
-    hasMore: result.hasMore,
-    oldestTimestamp: result.oldestTimestamp,
-  };
-  if (!basePagination || basePagination.oldestTimestamp == null) {
-    return latestPagination;
-  }
-  if (
-    latestPagination.oldestTimestamp == null ||
-    basePagination.oldestTimestamp < latestPagination.oldestTimestamp
-  ) {
-    return basePagination;
-  }
-  return latestPagination;
-}
-
 interface UseConversationHistoryParams {
   assistantId: string | null;
   assistantStateKind: AssistantStateKind;
   activeConversationKey: string | null;
-  refreshEpoch: number;
-  transcriptPagination: Omit<TranscriptPaginationState, "items">;
 
   // Refs (owned by parent, read/written by this hook)
-  conversationCacheRef: MutableRefObject<
-    Map<string, { messages: DisplayMessage[]; pagination: HistoryPaginationSnapshot }>
-  >;
   draftKeyResolutionRef: MutableRefObject<boolean>;
   previousConversationKeyRef: MutableRefObject<string | null>;
   messagesRef: MutableRefObject<DisplayMessage[]>;
@@ -106,13 +83,8 @@ interface UseConversationHistoryParams {
   requestIdToStableIdRef: MutableRefObject<Map<string, string>>;
   pendingLocalDeletionsRef: MutableRefObject<Set<string>>;
   confirmationToolCallMapRef: MutableRefObject<Map<string, string>>;
-  refreshSettleRef: MutableRefObject<RefreshSettleHandle | null>;
   lastSuggestionMsgIdRef: MutableRefObject<string | null>;
   autoGreetRef: MutableRefObject<boolean>;
-  initialPageOldestTsRef: MutableRefObject<number | null>;
-  isLoadingOlderRef: MutableRefObject<boolean>;
-  historyLoadedRef: MutableRefObject<boolean>;
-  loadEpochRef: MutableRefObject<number>;
 
   // State setters
   setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
@@ -132,30 +104,18 @@ interface UseConversationHistoryParams {
   shouldSuppressGenericChatErrorNotice: (prev: ChatError | null) => boolean;
 }
 
+export interface ConversationHistoryResult {
+  pagination: HistoryPaginationResult;
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
-/**
- * Manages conversation history loading and caching when the active
- * conversation changes.
- *
- * Handles:
- * - Caching outgoing conversation messages to the LRU cache on switch
- * - Resetting per-conversation state on switch
- * - Restoring cached messages or fetching fresh history from the server
- * - Reconciling cache with latest server data
- * - Restoring pending interactions (secrets, confirmations)
- * - Refreshing surface content for embedded surfaces
- * - Auto-greet detection for fresh conversations
- */
 export function useConversationHistory({
   assistantId,
   assistantStateKind,
   activeConversationKey,
-  refreshEpoch,
-  transcriptPagination,
-  conversationCacheRef,
   draftKeyResolutionRef,
   previousConversationKeyRef,
   messagesRef,
@@ -167,13 +127,8 @@ export function useConversationHistory({
   requestIdToStableIdRef,
   pendingLocalDeletionsRef,
   confirmationToolCallMapRef,
-  refreshSettleRef,
   lastSuggestionMsgIdRef,
   autoGreetRef,
-  initialPageOldestTsRef,
-  isLoadingOlderRef,
-  historyLoadedRef,
-  loadEpochRef,
   setMessages,
   setTranscriptPagination,
   setIsLoadingHistory,
@@ -185,86 +140,58 @@ export function useConversationHistory({
   resetChatAttachments,
   syncNeedsNewBubbleFromMessages,
   shouldSuppressGenericChatErrorNotice,
-}: UseConversationHistoryParams) {
-  const transcriptPaginationRef = useRef(transcriptPagination);
-  useEffect(() => {
-    transcriptPaginationRef.current = transcriptPagination;
-  }, [transcriptPagination]);
+}: UseConversationHistoryParams): ConversationHistoryResult {
+  // -------------------------------------------------------------------------
+  // TanStack Query for history fetching + caching + pagination
+  // -------------------------------------------------------------------------
+  const pagination = useHistoryPagination({
+    assistantId,
+    conversationKey: activeConversationKey,
+    enabled: assistantStateKind === "active" && !!assistantId && !!activeConversationKey,
+  });
+
+  // Track the last applied data timestamp so we only run side effects once
+  // per TQ data update, not on every render.
+  const lastAppliedDataRef = useRef(0);
+  // Track whether a conversation-switch reset has occurred so the data-apply
+  // effect knows to replace messages (fresh switch) vs. reconcile (background
+  // refetch while streaming is active).
+  const switchResetRef = useRef(false);
 
   // -------------------------------------------------------------------------
-  // Load message history when the active conversation changes
+  // Conversation-switch reset
   // -------------------------------------------------------------------------
   useEffect(() => {
     if (assistantStateKind !== "active" || !assistantId || !activeConversationKey) {
       return;
     }
 
-    // Key resolution (draft->server ID), not a real switch -- skip reset.
+    // Draft-key resolution (draft→server ID) is not a real switch.
     if (draftKeyResolutionRef.current) {
       draftKeyResolutionRef.current = false;
       return;
     }
 
-    // Save the outgoing conversation's messages so they can be restored
-    // on switch-back without a server round-trip. Draft save/restore is
-    // handled by useDraftInput (LUM-1737).
+    // Track outgoing conversation's attention state.
     const outgoingKey = previousConversationKeyRef.current;
     const isConversationSwitch = Boolean(
       outgoingKey && outgoingKey !== activeConversationKey,
     );
     if (isConversationSwitch && outgoingKey) {
-      // If the outgoing conversation has a pending interaction, mark it as
-      // needing attention so the sidebar shows an alert icon.
       const interactionSnapshot = useInteractionStore.getState();
       if (interactionSnapshot.pendingSecret || interactionSnapshot.pendingConfirmation) {
         useConversationStore.getState().addAttentionKey(outgoingKey);
       }
-      // Cache outgoing conversation's messages (LRU eviction)
-      const outgoingMessages = messagesRef.current;
-      if (outgoingMessages.length > 0) {
-        if (conversationCacheRef.current.size >= MAX_CACHED_CONVERSATIONS) {
-          const firstKey = conversationCacheRef.current.keys().next().value;
-          if (firstKey) conversationCacheRef.current.delete(firstKey);
-        }
-        const paginationSnapshot = transcriptPaginationRef.current;
-        conversationCacheRef.current.set(outgoingKey, {
-          messages: outgoingMessages,
-          pagination: {
-            hasMore: paginationSnapshot.hasMore,
-            oldestTimestamp: paginationSnapshot.oldestTimestamp,
-          },
-        });
-        recordChatDiagnostic("history_cache_save", {
-          assistantId,
-          conversationKey: outgoingKey,
-          pagination: {
-            hasMore: paginationSnapshot.hasMore,
-            oldestTimestamp: paginationSnapshot.oldestTimestamp,
-          },
-          messages: summarizeDisplayMessages(outgoingMessages),
-        });
-      }
     }
     previousConversationKeyRef.current = activeConversationKey;
 
-    // Reset all per-conversation state so nothing leaks between threads.
-    isLoadingOlderRef.current = false;
-    initialPageOldestTsRef.current = null;
-    historyLoadedRef.current = false;
-    const epoch = ++loadEpochRef.current;
-    const invalidatePendingConversationLoad = () => {
-      ++loadEpochRef.current;
-      setIsLoadingHistory(false);
-    };
-    recordChatDiagnostic("conversation_load_start", {
+    recordChatDiagnostic("conversation_switch_reset", {
       assistantId,
       conversationKey: activeConversationKey,
       outgoingConversationKey: outgoingKey ?? null,
-      epoch,
-      previousMessages: summarizeDisplayMessages(messagesRef.current),
-      previousPagination: transcriptPaginationRef.current,
-      cacheSize: conversationCacheRef.current.size,
     });
+
+    // Reset all per-conversation state so nothing leaks between threads.
     useTurnStore.getState().resetTurn();
     setIsLoadingHistory(true);
     needsNewBubbleRef.current = true;
@@ -297,287 +224,17 @@ export function useConversationHistory({
       shouldSuppressGenericChatErrorNotice(prev) ? prev : null,
     );
 
-    // --- Inner helpers (scoped to this effect's epoch) ---------------------
-
-    const refreshSurfaceContentForMessages = (messagesToRefresh: DisplayMessage[]) => {
-      for (const msg of messagesToRefresh) {
-        if (!msg.surfaces) continue;
-        for (const surface of msg.surfaces) {
-          fetchSurfaceContent(assistantId, surface.surfaceId, activeConversationKey).then((fresh) => {
-            if (!fresh || loadEpochRef.current !== epoch) return;
-            setMessages((prev) => {
-              if (loadEpochRef.current !== epoch) return prev;
-              for (let i = prev.length - 1; i >= 0; i--) {
-                const m = prev[i]!;
-                const idx = m.surfaces?.findIndex((s) => s.surfaceId === fresh.surfaceId) ?? -1;
-                if (idx === -1) continue;
-                const updated = [...prev];
-                const newSurfaces = [...m.surfaces!];
-                newSurfaces[idx] = { ...newSurfaces[idx]!, data: fresh.data, title: fresh.title ?? newSurfaces[idx]!.title };
-                updated[i] = { ...m, surfaces: newSurfaces };
-                return updated;
-              }
-              return prev;
-            });
-          });
-        }
-      }
-    };
-
-    const restorePendingInteractions = async () => {
-      try {
-        const interactions = await getPendingInteractions(assistantId, activeConversationKey);
-        if (loadEpochRef.current !== epoch) return;
-        if (interactions.pendingSecret) {
-          const parsed = parsePendingSecretState(
-            interactions.pendingSecret as Record<string, unknown>,
-          );
-          if (loadEpochRef.current === epoch) {
-            useInteractionStore.getState().showSecret(parsed);
-          }
-        }
-        if (interactions.pendingConfirmation) {
-          const { state } = parsePendingConfirmationData(
-            interactions.pendingConfirmation as Record<string, unknown>,
-          );
-          if (loadEpochRef.current === epoch) {
-            useInteractionStore.getState().showConfirmation(state);
-          }
-        }
-        if (!interactions.pendingSecret && !interactions.pendingConfirmation) {
-          useConversationStore.getState().removeAttentionKey(activeConversationKey);
-        }
-      } catch {
-        // Keep attention key on failure -- the prompt wasn't restored.
-      }
-    };
-
-    type LatestHistoryPage = Awaited<ReturnType<typeof fetchLatestHistoryPage>>;
-
-    const applyLatestHistoryResult = async (
-      result: LatestHistoryPage,
-      options: {
-        basePagination?: HistoryPaginationSnapshot;
-        mergeWithCurrent?: boolean;
-        source?: string;
-      } = {},
-    ) => {
-      if (loadEpochRef.current !== epoch) return;
-      const nextPagination = getPaginationAfterLatestHistory(
-        result,
-        options.basePagination,
-      );
-      historyLoadedRef.current = true;
-      initialPageOldestTsRef.current = nextPagination.oldestTimestamp;
-      recordChatDiagnostic("history_latest_apply", {
-        assistantId,
-        conversationKey: activeConversationKey,
-        epoch,
-        source: options.source,
-        basePagination: options.basePagination,
-        hasMore: result.hasMore,
-        oldestTimestamp: result.oldestTimestamp,
-        oldestMessageId: result.oldestMessageId,
-        nextPagination,
-        messages: summarizeDisplayMessages(result.messages),
-      });
-      if (result.messages.length > 0) {
-        const filteredMessages = filterDismissedSurfaces(
-          result.messages,
-          dismissedSurfaceIdsRef.current,
-        );
-        recordChatDiagnostic("history_latest_set_messages", {
-          assistantId,
-          conversationKey: activeConversationKey,
-          epoch,
-          source: options.source,
-          dismissedSurfaceCount: dismissedSurfaceIdsRef.current.size,
-          filteredMessages: summarizeDisplayMessages(filteredMessages),
-        });
-        startTransition(() => {
-          setMessages((prev) => {
-            if (loadEpochRef.current !== epoch) return prev;
-            const nextMessages = options.mergeWithCurrent
-              ? reconcileDisplayMessagesWithLatestHistory(prev, filteredMessages)
-              : filteredMessages;
-            syncNeedsNewBubbleFromMessages(nextMessages);
-            return nextMessages;
-          });
-          setTranscriptPagination((prev) =>
-            loadEpochRef.current === epoch
-              ? {
-                  hasMore: nextPagination.hasMore,
-                  oldestTimestamp: nextPagination.oldestTimestamp,
-                  isLoadingOlder: false,
-                  isPinnedToLatest: true,
-                }
-              : prev,
-          );
-          setIsLoadingHistory((prev) =>
-            loadEpochRef.current === epoch ? false : prev,
-          );
-        });
-        refreshSurfaceContentForMessages(filteredMessages);
-      } else {
-        recordChatDiagnostic("history_latest_empty", {
-          assistantId,
-          conversationKey: activeConversationKey,
-          epoch,
-          source: options.source,
-          hasMore: result.hasMore,
-          oldestTimestamp: result.oldestTimestamp,
-        });
-        setIsLoadingHistory(false);
-      }
-
-      // Reconstruct subagent state from history notifications.
-      // History may contain multiple notifications for the same subagent
-      // (e.g. a "running" notification followed by a "completed" one).
-      // Deduplicate by subagentId: keep status/error/conversationId from
-      // the last notification (terminal state) but preserve
-      // parentMessageId from the first (spawn-time position).
-      if (result.subagentNotifications && result.subagentNotifications.length > 0) {
-        const deduped = new Map<string, (typeof result.subagentNotifications)[number]>();
-        for (const n of result.subagentNotifications) {
-          const existing = deduped.get(n.subagentId);
-          if (existing) {
-            deduped.set(n.subagentId, {
-              ...n,
-              parentMessageId: existing.parentMessageId,
-            });
-          } else {
-            deduped.set(n.subagentId, n);
-          }
-        }
-
-        const subagentStore = useSubagentStore.getState();
-        subagentStore.reset();
-        for (const n of deduped.values()) {
-          subagentStore.spawnSubagent({
-            subagentId: n.subagentId,
-            label: n.label,
-            objective: "",
-            status: (n.status as SubagentStatus) || "completed",
-            error: n.error,
-            conversationId: n.conversationId,
-            timestamp: Date.now(),
-            parentMessageId: n.parentMessageId,
-          });
-        }
-      }
-
-      await restorePendingInteractions();
-
-      if (loadEpochRef.current !== epoch) {
-        return;
-      }
-
-      // Auto-send greeting after fresh setup (API key just provisioned, no history)
-      if (
-        !options.mergeWithCurrent &&
-        autoGreetRef.current &&
-        result.messages.length === 0
-      ) {
-        setAutoGreetPending(true);
-      }
-
-      // Settle any in-flight pull-to-refresh for this conversation.
-      const settle = refreshSettleRef.current;
-      if (settle && settle.conversationKey === activeConversationKey) {
-        refreshSettleRef.current = null;
-        settle.resolve();
-      }
-    };
-
-    const handleLatestHistoryError = (err: unknown, source?: string) => {
-      if (loadEpochRef.current !== epoch) return;
-      recordChatDiagnostic("history_latest_fetch_error", {
-        assistantId,
-        conversationKey: activeConversationKey,
-        epoch,
-        source,
-        messageLength: err instanceof Error ? err.message.length : null,
-      });
-      Sentry.captureException(err, {
-        tags: {
-          context: source === "cache_restore_reconcile"
-            ? "fetch_latest_history_page_after_cache_restore"
-            : "fetch_latest_history_page",
-        },
-      });
-      const settle = refreshSettleRef.current;
-      if (settle && settle.conversationKey === activeConversationKey) {
-        refreshSettleRef.current = null;
-        settle.reject(err);
-        if (!source) setIsLoadingHistory(false);
-        return;
-      }
-      if (!source) {
-        setIsLoadingHistory(false);
-        setError({ message: "Failed to load conversation history. Please try again." });
-      }
-    };
-
-    // --- Cache check then fetch --------------------------------------------
-
-    const cachedEntry = conversationCacheRef.current.get(activeConversationKey);
-    if (cachedEntry) {
-      historyLoadedRef.current = true;
-      initialPageOldestTsRef.current = cachedEntry.pagination.oldestTimestamp;
-      recordChatDiagnostic("history_cache_restore", {
-        assistantId,
-        conversationKey: activeConversationKey,
-        epoch,
-        pagination: cachedEntry.pagination,
-        messages: summarizeDisplayMessages(cachedEntry.messages),
-      });
-      startTransition(() => {
-        setMessages((prev) => {
-          if (loadEpochRef.current !== epoch) return prev;
-          syncNeedsNewBubbleFromMessages(cachedEntry.messages);
-          return cachedEntry.messages;
-        });
-        setTranscriptPagination((prev) =>
-          loadEpochRef.current === epoch
-            ? {
-                hasMore: cachedEntry.pagination.hasMore,
-                oldestTimestamp: cachedEntry.pagination.oldestTimestamp,
-                isLoadingOlder: false,
-                isPinnedToLatest: true,
-              }
-            : prev,
-        );
-        setIsLoadingHistory((prev) =>
-          loadEpochRef.current === epoch ? false : prev,
-        );
-      });
-      refreshSurfaceContentForMessages(cachedEntry.messages);
-      fetchLatestHistoryPage(assistantId, activeConversationKey)
-        .then((result) =>
-          applyLatestHistoryResult(result, {
-            basePagination: cachedEntry.pagination,
-            mergeWithCurrent: true,
-            source: "cache_restore_reconcile",
-          }),
-        )
-        .catch((err) => handleLatestHistoryError(err, "cache_restore_reconcile"));
-      return invalidatePendingConversationLoad;
-    }
-
-    fetchLatestHistoryPage(assistantId, activeConversationKey)
-      .then((result) => applyLatestHistoryResult(result))
-      .catch((err) => handleLatestHistoryError(err));
-
-    return invalidatePendingConversationLoad;
+    // Signal that we're in a fresh-switch state — the data-apply effect
+    // should replace messages rather than reconcile.
+    switchResetRef.current = true;
+    lastAppliedDataRef.current = 0;
   }, [
     assistantStateKind,
     assistantId,
     activeConversationKey,
     resetChatAttachments,
-    refreshEpoch,
     syncNeedsNewBubbleFromMessages,
     // Refs (stable references, listed for completeness):
-    conversationCacheRef,
     draftKeyResolutionRef,
     previousConversationKeyRef,
     messagesRef,
@@ -591,11 +248,6 @@ export function useConversationHistory({
     confirmationToolCallMapRef,
     lastSuggestionMsgIdRef,
     autoGreetRef,
-    initialPageOldestTsRef,
-    isLoadingOlderRef,
-    historyLoadedRef,
-    loadEpochRef,
-    refreshSettleRef,
     // Setters (stable references):
     setMessages,
     setTranscriptPagination,
@@ -607,4 +259,221 @@ export function useConversationHistory({
     setCompactionCircuitOpenUntil,
     shouldSuppressGenericChatErrorNotice,
   ]);
+
+  // -------------------------------------------------------------------------
+  // Apply TanStack Query data to messages state
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!pagination.isSuccess || pagination.dataUpdatedAt === lastAppliedDataRef.current) {
+      return;
+    }
+    if (!assistantId || !activeConversationKey) return;
+
+    lastAppliedDataRef.current = pagination.dataUpdatedAt;
+    const isFreshSwitch = switchResetRef.current;
+    switchResetRef.current = false;
+
+    recordChatDiagnostic("history_tq_data_apply", {
+      assistantId,
+      conversationKey: activeConversationKey,
+      isFreshSwitch,
+      pageCount: pagination.latestPage ? 1 : 0,
+      messageCount: pagination.messages.length,
+    });
+
+    if (pagination.messages.length > 0) {
+      const filteredMessages = filterDismissedSurfaces(
+        pagination.messages,
+        dismissedSurfaceIdsRef.current,
+      );
+
+      recordChatDiagnostic("history_tq_set_messages", {
+        assistantId,
+        conversationKey: activeConversationKey,
+        isFreshSwitch,
+        dismissedSurfaceCount: dismissedSurfaceIdsRef.current.size,
+        filteredMessages: summarizeDisplayMessages(filteredMessages),
+      });
+
+      startTransition(() => {
+        setMessages((prev) => {
+          // Fresh switch or empty state: replace entirely with TQ data.
+          // Background refetch while streaming: reconcile to preserve
+          // optimistic/streaming messages.
+          const nextMessages =
+            isFreshSwitch || prev.length === 0
+              ? filteredMessages
+              : reconcileDisplayMessagesWithLatestHistory(
+                  prev,
+                  filteredMessages,
+                );
+          syncNeedsNewBubbleFromMessages(nextMessages);
+          return nextMessages;
+        });
+        setTranscriptPagination({
+          hasMore: pagination.hasMore,
+          oldestTimestamp: pagination.oldestLoadedTimestamp,
+          isLoadingOlder: pagination.isFetchingOlderPages,
+          isPinnedToLatest: true,
+        });
+        setIsLoadingHistory(false);
+      });
+
+      // Refresh surface content for embedded surfaces.
+      for (const msg of filteredMessages) {
+        if (!msg.surfaces) continue;
+        for (const surface of msg.surfaces) {
+          fetchSurfaceContent(assistantId, surface.surfaceId, activeConversationKey).then(
+            (fresh) => {
+              if (!fresh) return;
+              setMessages((prev) => {
+                for (let i = prev.length - 1; i >= 0; i--) {
+                  const m = prev[i]!;
+                  const idx =
+                    m.surfaces?.findIndex(
+                      (s) => s.surfaceId === fresh.surfaceId,
+                    ) ?? -1;
+                  if (idx === -1) continue;
+                  const updated = [...prev];
+                  const newSurfaces = [...m.surfaces!];
+                  newSurfaces[idx] = {
+                    ...newSurfaces[idx]!,
+                    data: fresh.data,
+                    title: fresh.title ?? newSurfaces[idx]!.title,
+                  };
+                  updated[i] = { ...m, surfaces: newSurfaces };
+                  return updated;
+                }
+                return prev;
+              });
+            },
+          );
+        }
+      }
+    } else {
+      recordChatDiagnostic("history_tq_empty", {
+        assistantId,
+        conversationKey: activeConversationKey,
+      });
+      setIsLoadingHistory(false);
+    }
+
+    // Reconstruct subagent state from history notifications.
+    const notifications = pagination.latestPage?.subagentNotifications;
+    if (notifications && notifications.length > 0) {
+      const deduped = new Map<
+        string,
+        (typeof notifications)[number]
+      >();
+      for (const n of notifications) {
+        const existing = deduped.get(n.subagentId);
+        if (existing) {
+          deduped.set(n.subagentId, {
+            ...n,
+            parentMessageId: existing.parentMessageId,
+          });
+        } else {
+          deduped.set(n.subagentId, n);
+        }
+      }
+
+      const subagentStore = useSubagentStore.getState();
+      subagentStore.reset();
+      for (const n of deduped.values()) {
+        subagentStore.spawnSubagent({
+          subagentId: n.subagentId,
+          label: n.label,
+          objective: "",
+          status: (n.status as SubagentStatus) || "completed",
+          error: n.error,
+          conversationId: n.conversationId,
+          timestamp: Date.now(),
+          parentMessageId: n.parentMessageId,
+        });
+      }
+    }
+
+    // Restore pending interactions (secrets, confirmations).
+    void (async () => {
+      try {
+        const interactions = await getPendingInteractions(
+          assistantId,
+          activeConversationKey,
+        );
+        const parsed_secret = interactions.pendingSecret
+          ? parsePendingSecretState(
+              interactions.pendingSecret as Record<string, unknown>,
+            )
+          : null;
+        if (parsed_secret) {
+          useInteractionStore.getState().showSecret(parsed_secret);
+        }
+        if (interactions.pendingConfirmation) {
+          const { state } = parsePendingConfirmationData(
+            interactions.pendingConfirmation as Record<string, unknown>,
+          );
+          useInteractionStore.getState().showConfirmation(state);
+        }
+        if (!interactions.pendingSecret && !interactions.pendingConfirmation) {
+          useConversationStore
+            .getState()
+            .removeAttentionKey(activeConversationKey);
+        }
+      } catch {
+        // Keep attention key on failure.
+      }
+    })();
+
+    // Auto-send greeting after fresh setup (no history).
+    if (
+      isFreshSwitch &&
+      autoGreetRef.current &&
+      pagination.messages.length === 0
+    ) {
+      setAutoGreetPending(true);
+    }
+  }, [
+    pagination.isSuccess,
+    pagination.dataUpdatedAt,
+    pagination.messages,
+    pagination.latestPage,
+    pagination.hasMore,
+    pagination.oldestLoadedTimestamp,
+    pagination.isFetchingOlderPages,
+    assistantId,
+    activeConversationKey,
+    dismissedSurfaceIdsRef,
+    autoGreetRef,
+    syncNeedsNewBubbleFromMessages,
+    setMessages,
+    setTranscriptPagination,
+    setIsLoadingHistory,
+    setAutoGreetPending,
+    setError,
+  ]);
+
+  // -------------------------------------------------------------------------
+  // Sync older-page loading state
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (pagination.isFetchingOlderPages) {
+      setTranscriptPagination((prev) => ({ ...prev, isLoadingOlder: true }));
+    }
+  }, [pagination.isFetchingOlderPages, setTranscriptPagination]);
+
+  // -------------------------------------------------------------------------
+  // Handle TanStack Query errors
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!pagination.isError || !pagination.error) return;
+    Sentry.captureException(pagination.error, {
+      tags: { context: "conversation_history_query" },
+    });
+    setIsLoadingHistory(false);
+    setError({
+      message: "Failed to load conversation history. Please try again.",
+    });
+  }, [pagination.isError, pagination.error, setIsLoadingHistory, setError]);
+
+  return { pagination };
 }

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -394,12 +394,20 @@ export function useConversationHistory({
     }
 
     // Restore pending interactions (secrets, confirmations).
+    // Capture the key before the await so we can detect stale responses
+    // when the user switches conversations while the request is in flight.
+    const requestedKey = activeConversationKey;
     void (async () => {
       try {
         const interactions = await getPendingInteractions(
           assistantId,
-          activeConversationKey,
+          requestedKey,
         );
+        // Guard: if the active conversation changed during the fetch,
+        // discard the result to avoid leaking state across conversations.
+        if (useConversationStore.getState().activeConversationKey !== requestedKey) {
+          return;
+        }
         const parsed_secret = interactions.pendingSecret
           ? parsePendingSecretState(
               interactions.pendingSecret as Record<string, unknown>,
@@ -417,7 +425,7 @@ export function useConversationHistory({
         if (!interactions.pendingSecret && !interactions.pendingConfirmation) {
           useConversationStore
             .getState()
-            .removeAttentionKey(activeConversationKey);
+            .removeAttentionKey(requestedKey);
         }
       } catch {
         // Keep attention key on failure.

--- a/apps/web/src/domains/chat/hooks/use-pull-refresh.ts
+++ b/apps/web/src/domains/chat/hooks/use-pull-refresh.ts
@@ -1,3 +1,12 @@
+/**
+ * Pull-to-refresh hook — uses TanStack Query invalidation to refetch
+ * conversation history. Replaces the old refreshSettleRef promise pattern
+ * with a direct `invalidateQueries` call that resolves when the refetch
+ * completes.
+ *
+ * References:
+ * - https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientinvalidatequeries
+ */
 
 import { type MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 
@@ -7,11 +16,8 @@ import { haptic } from "@/utils/haptics.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 
 // ---------------------------------------------------------------------------
-// Sentinel errors — distinguish silent aborts from real failures
+// Constants
 // ---------------------------------------------------------------------------
-
-const PULL_REFRESH_SUPERSEDED = "pull_refresh_superseded";
-const PULL_REFRESH_CONVERSATION_CHANGED = "pull_refresh_conversation_changed";
 
 const PULL_REFRESH_TIMEOUT_MS = 15_000;
 
@@ -19,21 +25,16 @@ const PULL_REFRESH_TIMEOUT_MS = 15_000;
 // Types
 // ---------------------------------------------------------------------------
 
-export interface RefreshSettleHandle {
-  resolve: () => void;
-  reject: (err: unknown) => void;
-  conversationKey: string;
-}
-
 interface UsePullRefreshParams {
   activeConversationKey: string | null | undefined;
   messagesRef: MutableRefObject<{ length: number }>;
-  onRefreshConversation: () => void;
-  refreshSettleRef?: MutableRefObject<RefreshSettleHandle | null>;
+  /** Invalidate the TQ history cache and refetch. Resolves when the refetch completes. */
+  invalidateHistory: () => Promise<void>;
+  /** Also bump the conversation-list refresh epoch (non-history side-effects). */
+  onRefreshEpoch: () => void;
 }
 
 interface UsePullRefreshReturn {
-  refreshSettleRef: MutableRefObject<RefreshSettleHandle | null>;
   refreshFeedback: RefreshOutcome | null;
   touchSupported: boolean;
   handlePullRefresh: () => Promise<RefreshOutcome>;
@@ -48,12 +49,11 @@ interface UsePullRefreshReturn {
 export function usePullRefresh({
   activeConversationKey,
   messagesRef,
-  onRefreshConversation,
-  refreshSettleRef: externalRefreshSettleRef,
+  invalidateHistory,
+  onRefreshEpoch,
 }: UsePullRefreshParams): UsePullRefreshReturn {
-  const internalRefreshSettleRef = useRef<RefreshSettleHandle | null>(null);
-  const refreshSettleRef = externalRefreshSettleRef ?? internalRefreshSettleRef;
   const [refreshFeedback, setRefreshFeedback] = useState<RefreshOutcome | null>(null);
+  const abortRef = useRef(false);
 
   // Resolve post-mount to keep SSR/hydration HTML in sync — the gesture
   // mounts a spinner element when enabled, so the initial render must
@@ -69,31 +69,33 @@ export function usePullRefresh({
       return { kind: "no-change" };
     }
 
+    abortRef.current = false;
     const beforeCount = messagesRef.current.length;
 
-    // Supersede any prior in-flight settle handle.
-    if (refreshSettleRef.current) {
-      const prior = refreshSettleRef.current;
-      refreshSettleRef.current = null;
-      prior.reject(new Error(PULL_REFRESH_SUPERSEDED));
-    }
+    // Also refresh the conversation list.
+    onRefreshEpoch();
 
-    const settled = new Promise<void>((resolve, reject) => {
-      refreshSettleRef.current = { resolve, reject, conversationKey };
-    });
-
-    onRefreshConversation();
-
-    let timer: ReturnType<typeof setTimeout> | null = null;
     const timeout = new Promise<never>((_, reject) => {
-      timer = setTimeout(
+      setTimeout(
         () => reject(new Error("pull_refresh_timeout")),
         PULL_REFRESH_TIMEOUT_MS,
       );
     });
 
     try {
-      await Promise.race([settled, timeout]);
+      // invalidateQueries returns a promise that resolves when all active
+      // queries matching the filter are refetched. The data-apply effect
+      // in useConversationHistory runs synchronously in the same React
+      // commit cycle, so messagesRef is updated by the time we check.
+      await Promise.race([invalidateHistory(), timeout]);
+
+      // Yield one frame to let React commit the data-apply effect.
+      await new Promise((r) => requestAnimationFrame(r));
+
+      if (abortRef.current) {
+        return { kind: "no-change" };
+      }
+
       const afterCount = messagesRef.current.length;
       const delta = afterCount - beforeCount;
       const outcome: RefreshOutcome =
@@ -109,15 +111,11 @@ export function usePullRefresh({
       setRefreshFeedback(outcome);
       return outcome;
     } catch (err) {
-      const errMessage = err instanceof Error ? err.message : "";
-      const isSilentAbort =
-        errMessage === PULL_REFRESH_SUPERSEDED ||
-        errMessage === PULL_REFRESH_CONVERSATION_CHANGED;
-
-      if (isSilentAbort) {
+      if (abortRef.current) {
         return { kind: "no-change" };
       }
 
+      const errMessage = err instanceof Error ? err.message : "";
       const outcome: RefreshOutcome = {
         kind: "error",
         message: errMessage || undefined,
@@ -125,21 +123,12 @@ export function usePullRefresh({
       void haptic.error();
       setRefreshFeedback(outcome);
       return outcome;
-    } finally {
-      if (timer !== null) clearTimeout(timer);
-      if (refreshSettleRef.current) {
-        refreshSettleRef.current = null;
-      }
     }
-  }, [activeConversationKey, messagesRef, onRefreshConversation]);
+  }, [activeConversationKey, messagesRef, invalidateHistory, onRefreshEpoch]);
 
   // Abort any in-flight pull-refresh when the active conversation changes.
   useEffect(() => {
-    const settle = refreshSettleRef.current;
-    if (settle && settle.conversationKey !== activeConversationKey) {
-      refreshSettleRef.current = null;
-      settle.reject(new Error(PULL_REFRESH_CONVERSATION_CHANGED));
-    }
+    abortRef.current = true;
   }, [activeConversationKey]);
 
   const handleDismissRefreshFeedback = useCallback(() => {
@@ -152,7 +141,6 @@ export function usePullRefresh({
   }, [handlePullRefresh]);
 
   return {
-    refreshSettleRef,
     refreshFeedback,
     touchSupported,
     handlePullRefresh,

--- a/apps/web/src/domains/chat/hooks/use-pull-refresh.ts
+++ b/apps/web/src/domains/chat/hooks/use-pull-refresh.ts
@@ -75,8 +75,9 @@ export function usePullRefresh({
     // Also refresh the conversation list.
     onRefreshEpoch();
 
+    let timer: ReturnType<typeof setTimeout> | null = null;
     const timeout = new Promise<never>((_, reject) => {
-      setTimeout(
+      timer = setTimeout(
         () => reject(new Error("pull_refresh_timeout")),
         PULL_REFRESH_TIMEOUT_MS,
       );
@@ -123,6 +124,8 @@ export function usePullRefresh({
       void haptic.error();
       setRefreshFeedback(outcome);
       return outcome;
+    } finally {
+      if (timer != null) clearTimeout(timer);
     }
   }, [activeConversationKey, messagesRef, invalidateHistory, onRefreshEpoch]);
 

--- a/apps/web/src/domains/chat/transcript/use-history-pagination.ts
+++ b/apps/web/src/domains/chat/transcript/use-history-pagination.ts
@@ -1,0 +1,194 @@
+/**
+ * TanStack Query wrapper for paginated conversation history.
+ *
+ * Replaces the manual `conversationCacheRef` LRU map and `loadEpochRef`
+ * cancellation token with `useInfiniteQuery`. TanStack Query provides:
+ *
+ * - **Automatic per-conversation caching** via the query key — no manual
+ *   LRU rotation needed.
+ * - **Automatic cancellation** via AbortController when the query key
+ *   changes (conversation switch) — no epoch-gating needed.
+ * - **Stale-while-revalidate** — cached conversations render instantly
+ *   while the background refetch picks up any messages added since.
+ * - **Pagination** via `fetchNextPage` / `hasNextPage` / `isFetchingNextPage`.
+ *
+ * References:
+ * - https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries
+ * - https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation
+ */
+
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+import {
+  fetchLatestHistoryPage,
+  fetchOlderHistoryPage,
+} from "@/domains/chat/api/history.js";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types.js";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
+
+// ---------------------------------------------------------------------------
+// Query key
+// ---------------------------------------------------------------------------
+
+export const CONVERSATION_HISTORY_QUERY_KEY = "conversation-history" as const;
+
+export function conversationHistoryQueryKey(
+  assistantId: string | null,
+  conversationKey: string | null,
+) {
+  return [
+    CONVERSATION_HISTORY_QUERY_KEY,
+    assistantId ?? "",
+    conversationKey ?? "",
+  ] as const;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface UseHistoryPaginationParams {
+  assistantId: string | null;
+  conversationKey: string | null;
+  enabled: boolean;
+}
+
+export interface HistoryPaginationResult {
+  /** Flattened messages from all loaded pages, oldest first. */
+  messages: DisplayMessage[];
+  /** The latest (newest) page result — carries subagent notifications. */
+  latestPage: PaginatedHistoryResult | undefined;
+  /** First-time load with no cached data available. */
+  isLoading: boolean;
+  /** At least one successful fetch has completed. */
+  isSuccess: boolean;
+  /** The query errored. */
+  isError: boolean;
+  /** The error, if any. */
+  error: Error | null;
+  /** Older pages are available for infinite scroll. */
+  hasMore: boolean;
+  /** A fetch for older pages is in progress. */
+  isFetchingOlderPages: boolean;
+  /** Any fetch (initial, background refetch, or older pages) is active. */
+  isFetching: boolean;
+  /** Load the next older page. No-op if already fetching or exhausted. */
+  fetchOlderPage: () => void;
+  /** Invalidate and trigger a background refetch of the latest page. */
+  invalidate: () => Promise<void>;
+  /** Remove cached data for this conversation (used before a destructive refresh). */
+  removeCache: () => void;
+  /** Oldest timestamp from the initial (latest) page — reconciliation boundary. */
+  latestPageOldestTimestamp: number | null;
+  /** Oldest timestamp across all loaded pages — pagination cursor. */
+  oldestLoadedTimestamp: number | null;
+  /** Monotonic counter that increments on each data update. */
+  dataUpdatedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const EMPTY_MESSAGES: DisplayMessage[] = [];
+
+export function useHistoryPagination({
+  assistantId,
+  conversationKey,
+  enabled,
+}: UseHistoryPaginationParams): HistoryPaginationResult {
+  const queryClient = useQueryClient();
+
+  const queryKey = useMemo(
+    () => conversationHistoryQueryKey(assistantId, conversationKey),
+    [assistantId, conversationKey],
+  );
+
+  const query = useInfiniteQuery({
+    queryKey,
+    queryFn: async ({ pageParam, signal }) => {
+      if (!assistantId || !conversationKey) {
+        throw new Error("Missing assistantId or conversationKey");
+      }
+      void signal; // AbortController signal available for future use
+      if (pageParam != null) {
+        return fetchOlderHistoryPage(
+          assistantId,
+          conversationKey,
+          pageParam,
+        );
+      }
+      return fetchLatestHistoryPage(assistantId, conversationKey);
+    },
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage): number | undefined => {
+      if (lastPage.hasMore && lastPage.oldestTimestamp != null) {
+        return lastPage.oldestTimestamp;
+      }
+      return undefined;
+    },
+    enabled: enabled && !!assistantId && !!conversationKey,
+    // Always refetch in the background — mirrors the existing
+    // "restore from cache then fetch latest and reconcile" pattern.
+    staleTime: 0,
+    // Keep data for unmounted queries for 5 minutes. With an average
+    // of ~10 active conversations, this is the rough equivalent of the
+    // old MAX_CACHED_CONVERSATIONS = 10 LRU map.
+    gcTime: 5 * 60 * 1000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: false,
+  });
+
+  // Flatten pages into a single chronological array.
+  // pages[0] = latest page (newest messages), pages[1] = older, etc.
+  // Within each page, messages are already oldest-first.
+  // Result: [...oldest-page.messages, ..., ...latest-page.messages]
+  const messages = useMemo(() => {
+    if (!query.data?.pages?.length) return EMPTY_MESSAGES;
+    const { pages } = query.data;
+    if (pages.length === 1) return pages[0]!.messages;
+    const result: DisplayMessage[] = [];
+    for (let i = pages.length - 1; i >= 0; i--) {
+      result.push(...pages[i]!.messages);
+    }
+    return result;
+  }, [query.data]);
+
+  const latestPage = query.data?.pages[0];
+  const oldestPage = query.data?.pages[query.data.pages.length - 1];
+
+  const invalidate = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
+
+  const removeCache = useCallback(() => {
+    queryClient.removeQueries({ queryKey });
+  }, [queryClient, queryKey]);
+
+  const fetchOlderPage = useCallback(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage]);
+
+  return {
+    messages,
+    latestPage,
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    error: query.error,
+    hasMore: query.hasNextPage ?? false,
+    isFetchingOlderPages: query.isFetchingNextPage,
+    isFetching: query.isFetching,
+    fetchOlderPage,
+    invalidate,
+    removeCache,
+    latestPageOldestTimestamp: latestPage?.oldestTimestamp ?? null,
+    oldestLoadedTimestamp: oldestPage?.oldestTimestamp ?? null,
+    dataUpdatedAt: query.dataUpdatedAt,
+  };
+}

--- a/apps/web/src/domains/conversations/use-conversation-loader.ts
+++ b/apps/web/src/domains/conversations/use-conversation-loader.ts
@@ -32,12 +32,8 @@ import { haptic } from "@/utils/haptics.js";
 import { routes } from "@/utils/routes.js";
 import type { NavigateFunction } from "react-router";
 
-import type { RefreshSettleHandle } from "@/domains/chat/hooks/use-pull-refresh.js";
 import type { AssistantStateKind, ChatError } from "@/domains/chat/types.js";
-import {
-  useConversationHistory,
-  type HistoryPaginationSnapshot,
-} from "@/domains/chat/hooks/use-conversation-history.js";
+import { useConversationHistory } from "@/domains/chat/hooks/use-conversation-history.js";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { getChatContext } from "@/domains/chat/api/assistant.js";
@@ -47,13 +43,6 @@ import {
   chatContextQueryKey,
   conversationGroupsQueryKey,
 } from "@/domains/conversations/conversation-queries.js";
-
-// Re-export for consumers that import from this module
-export {
-  MAX_CACHED_CONVERSATIONS,
-  type HistoryPaginationSnapshot,
-  getPaginationAfterLatestHistory,
-} from "@/domains/chat/hooks/use-conversation-history.js";
 
 // ---------------------------------------------------------------------------
 // Module constants
@@ -81,7 +70,6 @@ interface UseConversationLoaderParams {
 
   // Collections
   conversations: Conversation[];
-  transcriptPagination: Omit<TranscriptPaginationState, "items">;
 
   // Feature flags / epochs
   conversationGroupsUI: boolean;
@@ -90,9 +78,6 @@ interface UseConversationLoaderParams {
 
   // Refs (owned by parent, read/written by this hook)
   assistantIdRef: MutableRefObject<string | null>;
-  conversationCacheRef: MutableRefObject<
-    Map<string, { messages: DisplayMessage[]; pagination: HistoryPaginationSnapshot }>
-  >;
   draftKeyResolutionRef: MutableRefObject<boolean>;
   previousConversationKeyRef: MutableRefObject<string | null>;
   onboardingDraftConversationKeyRef: MutableRefObject<string | null>;
@@ -106,14 +91,9 @@ interface UseConversationLoaderParams {
   requestIdToStableIdRef: MutableRefObject<Map<string, string>>;
   pendingLocalDeletionsRef: MutableRefObject<Set<string>>;
   confirmationToolCallMapRef: MutableRefObject<Map<string, string>>;
-  refreshSettleRef: MutableRefObject<RefreshSettleHandle | null>;
   lastSuggestionMsgIdRef: MutableRefObject<string | null>;
   autoGreetRef: MutableRefObject<boolean>;
-  initialPageOldestTsRef: MutableRefObject<number | null>;
-  isLoadingOlderRef: MutableRefObject<boolean>;
-  historyLoadedRef: MutableRefObject<boolean>;
   conversationListInvalidatedTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
-  loadEpochRef: MutableRefObject<number>;
   pendingInitialMessageRef: MutableRefObject<{ conversationKey: string; content: string } | null>;
 
   // State setters
@@ -164,12 +144,10 @@ export function useConversationLoader({
   searchParams,
   navigate,
   conversations,
-  transcriptPagination,
   conversationGroupsUI,
   refreshEpoch,
   reachabilityReadyEpoch,
   assistantIdRef,
-  conversationCacheRef,
   draftKeyResolutionRef,
   previousConversationKeyRef,
   onboardingDraftConversationKeyRef,
@@ -183,14 +161,9 @@ export function useConversationLoader({
   requestIdToStableIdRef,
   pendingLocalDeletionsRef,
   confirmationToolCallMapRef,
-  refreshSettleRef,
   lastSuggestionMsgIdRef,
   autoGreetRef,
-  initialPageOldestTsRef,
-  isLoadingOlderRef,
-  historyLoadedRef,
   conversationListInvalidatedTimerRef,
-  loadEpochRef,
   pendingInitialMessageRef,
   setAssistantId,
   setMessages,
@@ -426,13 +399,10 @@ export function useConversationLoader({
   // -------------------------------------------------------------------------
   // Delegate: conversation history loading and caching
   // -------------------------------------------------------------------------
-  useConversationHistory({
+  const historyResult = useConversationHistory({
     assistantId,
     assistantStateKind,
     activeConversationKey,
-    refreshEpoch,
-    transcriptPagination,
-    conversationCacheRef,
     draftKeyResolutionRef,
     previousConversationKeyRef,
     messagesRef,
@@ -444,13 +414,8 @@ export function useConversationLoader({
     requestIdToStableIdRef,
     pendingLocalDeletionsRef,
     confirmationToolCallMapRef,
-    refreshSettleRef,
     lastSuggestionMsgIdRef,
     autoGreetRef,
-    initialPageOldestTsRef,
-    isLoadingOlderRef,
-    historyLoadedRef,
-    loadEpochRef,
     setMessages,
     setTranscriptPagination,
     setIsLoadingHistory,
@@ -499,5 +464,6 @@ export function useConversationLoader({
     switchConversation,
     startNewConversation,
     conversationExistsOnServer,
+    historyResult,
   };
 }


### PR DESCRIPTION
## Prompt / plan

Closes [LUM-1738](https://linear.app/vellum/issue/LUM-1738): Replace the manual `conversationCacheRef` LRU map, `loadEpochRef` cancellation token, `refreshSettleRef` promise pattern, and `isLoadingOlderRef` guard with TanStack Query's [`useInfiniteQuery`](https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries).

### Why needed

The manual transcript caching/pagination system was one of the most complex and fragile parts of `ChatPage`:

- **`conversationCacheRef`** — hand-rolled LRU map (max 10 entries) storing per-conversation message snapshots, with manual eviction and restoration on conversation switch
- **`loadEpochRef`** — monotonic counter used as a cancellation token. Every async callback captured the epoch at call time and compared against the current value after each `await` to detect staleness — a bespoke reimplementation of what TanStack Query's query-key-scoped AbortController does automatically
- **`refreshSettleRef`** — a `{ resolve, reject, conversationKey }` promise handle bridging `usePullRefresh` and `useConversationHistory` — tight coupling that made both hooks difficult to reason about
- **`isLoadingOlderRef`** — manual guard preventing concurrent older-page fetches, replaced by TQ's built-in `isFetchingNextPage`

These four refs plus their supporting types (`HistoryPaginationSnapshot`, `RefreshSettleHandle`, `MAX_CACHED_CONVERSATIONS`) threaded through `ChatPage` → `useConversationLoader` → `useConversationHistory` → `ChatRouteContent`, creating a prop-drilling chain that made the data flow hard to follow.

### What changed

**New hook: `use-history-pagination.ts`** — thin `useInfiniteQuery` wrapper providing:
- Automatic per-conversation caching via query key `['conversation-history', assistantId, conversationKey]`
- Automatic cancellation on conversation switch (query key change)
- `fetchNextPage`/`hasNextPage` for older-message pagination
- `invalidateQueries()` for pull-to-refresh
- 5-minute `gcTime` (rough equivalent of the old 10-entry LRU)

**Rewritten: `use-conversation-history.ts`** — from a monolithic 600-line effect that fetched, cached, restored, and applied history, to two focused effects:
1. **Conversation-switch reset** — clears messages, resets pagination state, marks switch boundary
2. **TQ data apply** — reacts to `pagination.dataUpdatedAt` changes, applies filtered messages via `startTransition`, reconstructs subagent state, restores pending interactions

**Simplified: `chat-route-content.tsx`** — `loadOlder` reduced from ~80 lines of manual fetch/dedupe/append to `historyPagination.fetchOlderPage()`

**Simplified: `use-pull-refresh.ts`** — replaced `refreshSettleRef` promise-bridge pattern with direct `invalidateQueries()` call that resolves when the refetch completes

**Cleaned up: `chat-page.tsx`** — removed 6 obsolete refs (`conversationCacheRef`, `loadEpochRef`, `isLoadingOlderRef`, `historyLoadedRef`, `refreshSettleRef`, `initialPageOldestTsRef` manual threading), kept `initialPageOldestTsRef` as a local sync from TQ data for `useMessageReconciliation`

### Pre-existing bugs fixed

- **Pending-interaction state leak across conversations**: `getPendingInteractions()` applied `showSecret`/`showConfirmation` unconditionally after the async fetch, with no staleness check. If the user switched conversations during the request, stale interaction UI from the old conversation would appear in the new one. Fixed by checking `useConversationStore.getState().activeConversationKey` against the captured key after the await.
- **`isLoadingOlder` stuck at `true` after failed fetch**: The sync effect only handled the `true` transition, never resetting to `false`. A failed older-page fetch would permanently block scroll-up retry. Fixed by syncing both directions with a no-op guard.
- **Generic error message for older-page failures**: The error effect showed the same "Failed to load conversation history" message for both initial-load and older-page failures. The old code handled these differently — initial failures showed the error, older-page failures were Sentry-only. Fixed by distinguishing via `pagination.isSuccess` (true = initial page succeeded, error is from `fetchNextPage`).
- **Timer leak in pull-to-refresh**: The `setTimeout` backing the timeout promise was never cleared when `invalidateHistory()` resolved first, causing an unhandled promise rejection. Fixed by restoring timer capture and adding a `finally` block.

### Alternatives not taken

- **Moving all message state into TQ**: Would eliminate `setMessages` entirely, but `useMessageReconciliation` and the streaming pipeline write to messages imperatively. A full migration would require rethinking the streaming architecture — tracked separately.
- **Passing `AbortSignal` to fetch functions**: TQ provides a signal via `queryFn`, but `fetchLatestHistoryPage`/`fetchOlderHistoryPage` don't accept it yet. Network requests complete even after query key change, but results are correctly discarded by TQ. This matches the old epoch-gating behavior. Easy follow-up, not worse than before.

### Safety

- All existing transcript tests pass (100/100)
- No visual UI changes — this is a pure state-management refactor
- TQ configuration mirrors old behavior: `staleTime: 0` (always background-refetch), `refetchOnWindowFocus: false` (no surprise refetches during streaming), `retry: false` (surface errors immediately)
- `initialPageOldestTsRef` preserved for `useMessageReconciliation` boundary

### References

- [TanStack Query — Infinite Queries](https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries)
- [TanStack Query — Query Cancellation](https://tanstack.com/query/latest/docs/framework/react/guides/query-cancellation)
- [TanStack Query — `invalidateQueries`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientinvalidatequeries)
- [`apps/web/docs/STATE_MANAGEMENT.md`](https://github.com/vellum-ai/vellum-assistant/blob/main/apps/web/docs/STATE_MANAGEMENT.md) — TanStack Query conventions for this repo

## Test plan

- `bunx tsc --noEmit` — 0 errors
- `bun run lint` — 0 errors
- `bun run test:ci` — 100/100 tests pass
- CI verification pending

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->