### PR TITLE
fix(notifications): fall back to paired delivery convo for home feed when sourceContextId is a sentinel

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -229,6 +229,70 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(conversationLookups).toEqual(["scheduler-job-42"]);
   });
 
+  test("falls back to the paired delivery conversation when sourceContextId does not resolve", async () => {
+    // Regression: producers whose `sourceContextId` is a sentinel string
+    // (heartbeat startup `"heartbeat"`, credential health `connectionId`,
+    // watcher `watcher-<ts>`, scheduler retries-exhausted `jobId`, sweep
+    // job id) never resolve via `getConversation`. The notification
+    // broadcaster pairs each vellum delivery with a real conversation
+    // before the home-feed write runs, so the caller threads that paired
+    // id through as the fallback — the "Go to Convo" button now points at
+    // the conversation the notification was actually delivered into.
+    conversationRow = null;
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "assistant.share",
+      sourceContextId: "watcher-1700000000",
+      contextPayload: { title: "Watcher alert" },
+      attentionHints: {
+        requiresAction: false,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Watcher alert", body: "Watcher body" },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(
+      signal,
+      decision,
+      "paired-delivery-conv-id",
+    );
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.conversationId).toBe("paired-delivery-conv-id");
+  });
+
+  test("source conversation id wins over the paired delivery fallback when both are available", async () => {
+    // When the producer's `sourceContextId` already points at a real
+    // conversation (the canonical "where the work happened"), prefer it
+    // over the paired delivery — the fallback is only meant to fill the
+    // gap for sentinel-id producers.
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      contextPayload: { title: "Background job done" },
+    });
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: { title: "Background job done", body: "Summary." },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(
+      signal,
+      decision,
+      "paired-delivery-conv-id",
+    );
+
+    expect(item).not.toBeNull();
+    expect(appendCalls[0]!.conversationId).toBe("conv-source-1");
+  });
+
   test("returns null and does not write when no rendered copy or payload title/body is present", async () => {
     conversationRow = { conversationType: "scheduled" };
     const signal = makeSignal({

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -388,7 +388,19 @@ export async function emitNotificationSignal<TEventName extends string>(
     // Step 5: Mirror background-origin signals into the home activity feed.
     // The helper itself decides whether to write (background filter); we
     // catch and log so a feed-write failure cannot poison the dispatch result.
-    await writeHomeFeedItemForSignal(signal, decision).catch((err) => {
+    // Pass the paired vellum delivery conversation as a fallback so producers
+    // whose `sourceContextId` is a sentinel string (e.g. heartbeat startup,
+    // credential health, watcher emits, scheduler retries-exhausted) still
+    // get a "Go to Convo" button — pointing at the conversation the
+    // broadcaster paired the notification with.
+    const pairedVellumConversationId = dispatchResult.deliveryResults.find(
+      (r) => r.channel === "vellum",
+    )?.conversationId;
+    await writeHomeFeedItemForSignal(
+      signal,
+      decision,
+      pairedVellumConversationId,
+    ).catch((err) => {
       log.warn({ err, signalId }, "writeHomeFeedItemForSignal threw");
     });
 

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -37,6 +37,16 @@ const FEED_ITEM_URGENCIES: ReadonlySet<string> = new Set<FeedItemUrgency>([
  * Append a `FeedItem` for the given notification signal when the
  * filter criteria pass.
  *
+ * `fallbackConversationId` is used as the feed item's "Go to Convo"
+ * navigation target when `signal.sourceContextId` doesn't resolve to a
+ * real conversation row. The notification broadcaster pairs the vellum
+ * delivery with a conversation (newly created or reused) before this
+ * function runs, so callers can thread that paired id through here for
+ * producers whose `sourceContextId` is a sentinel (heartbeat startup,
+ * credential health, watcher emits, scheduler retries-exhausted) — the
+ * feed item will then carry the paired delivery conversation and the
+ * "Go to Convo" button can render.
+ *
  * Returns the persisted `FeedItem`, or `null` if the signal does not
  * qualify for home-feed mirroring (non-background origin AND no
  * `isAsyncBackground` hint) or if schema validation fails.
@@ -44,8 +54,12 @@ const FEED_ITEM_URGENCIES: ReadonlySet<string> = new Set<FeedItemUrgency>([
 export async function writeHomeFeedItemForSignal(
   signal: NotificationSignal,
   decision: NotificationDecision,
+  fallbackConversationId?: string,
 ): Promise<FeedItem | null> {
-  const { mirror, sourceConversationId } = resolveHomeFeedMirror(signal);
+  const { mirror, sourceConversationId } = resolveHomeFeedMirror(
+    signal,
+    fallbackConversationId,
+  );
   if (!mirror) return null;
 
   const renderedCopy =
@@ -170,7 +184,10 @@ function deriveDetailPanelKind(
  * does not require a background-typed conversation or the
  * `isAsyncBackground` hint.
  */
-function resolveHomeFeedMirror(signal: NotificationSignal): {
+function resolveHomeFeedMirror(
+  signal: NotificationSignal,
+  fallbackConversationId?: string,
+): {
   mirror: boolean;
   sourceConversationId?: string;
 } {
@@ -182,7 +199,14 @@ function resolveHomeFeedMirror(signal: NotificationSignal): {
       sourceRow = null;
     }
   }
-  const sourceConversationId = sourceRow ? signal.sourceContextId : undefined;
+  // Prefer the producer's source context (e.g. the heartbeat / background
+  // job conversation that emitted the signal) for the "Go to Convo" target,
+  // since that's where the work actually happened. Fall back to the paired
+  // delivery conversation only when the source context didn't resolve —
+  // covers producers whose `sourceContextId` is a sentinel string.
+  const sourceConversationId = sourceRow
+    ? signal.sourceContextId
+    : fallbackConversationId;
 
   if (signal.sourceChannel === "assistant_tool") {
     return { mirror: true, sourceConversationId };


### PR DESCRIPTION
## Summary

Phase 2 of the missing "Go to Convo" button fix.

Phase 1 ([#31470](https://github.com/vellum-ai/vellum-assistant/pull/31470)) covered the `notifications send` CLI path where a real conversation id was already in scope but never threaded into `sourceContextId`.

This PR closes the gap for the other producers — ones whose `sourceContextId` is a sentinel string the home-feed lookup can never resolve:

| Producer | `sourceContextId` |
|---|---|
| `heartbeat-service.ts:188` (startup-missed) | literal `"heartbeat"` |
| `heartbeat-service.ts:614` (credential health) | `connectionId` (e.g. `managed:linear`) |
| `daemon/lifecycle.ts:999` (watcher) | `"watcher-<ts>"` |
| `schedule/scheduler.ts:691` (retries-exhausted) | `jobId` |
| `memory/v2/sweep-job.ts:213` | sweep job id |

For each of these the source conversation doesn't exist at emit time — the notification broadcaster creates or reuses a vellum conversation **during dispatch**. Since `writeHomeFeedItemForSignal` runs *after* `dispatchDecision` in `emit-signal.ts`, the paired conversation is already known by the time the feed item is written. Just thread it through.

## Changes

- `writeHomeFeedItemForSignal` and `resolveHomeFeedMirror` accept an optional `fallbackConversationId`.
- Producer-source still wins when it resolves; the fallback fills the gap only when the source lookup misses, so existing background-convo producers (`runBackgroundJob`, scheduler success path) are unaffected.
- `emit-signal.ts` extracts the vellum delivery's `conversationId` from `dispatchResult.deliveryResults` and passes it forward.

## Why no async backfill / no `onConversationCreated` hook

An earlier sketch involved patching the feed item after the broadcaster's `notification_conversation_created` event fires. That's unnecessary: in `emit-signal.ts`, **Step 4** (`dispatchDecision`) runs **before** **Step 5** (`writeHomeFeedItemForSignal`). The paired conversation is available synchronously when we write — no need for a callback or an `updateFeedItem` helper.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint …` — clean
- [x] `bun test src/notifications/__tests__/home-feed-side-effect.test.ts` — 27/27 (added 2 new cases: fallback-used and source-wins)
- [ ] After deploy: trigger a heartbeat startup-missed alert or credential-health alert. Home feed item should show a "Go to Convo" button that opens the conversation the alert was delivered into.
- [ ] Regression: existing `runBackgroundJob` paths (which set a real `sourceContextId`) still navigate to the producing convo, not the delivery convo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->