### PR TITLE
refactor(web): consolidate raw-fetch Vellum-Organization-Id + CSRF header injection (LUM-1787)

### DIFF
--- a/apps/web/src/components/share-feedback-modal.tsx
+++ b/apps/web/src/components/share-feedback-modal.tsx
@@ -31,9 +31,8 @@ import { Input, Textarea } from "@vellum/design-library/components/input";
 import { Toggle } from "@vellum/design-library/components/toggle";
 import { feedbackCreateMutation } from "@/generated/api/@tanstack/react-query.gen.js";
 import type { ClassificationEnum } from "@/generated/api/types.gen.js";
-import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf.js";
+import { buildVellumMutatingHeaders } from "@/lib/auth/request-headers.js";
 import { buildChatDiagnosticsSnapshot } from "@/domains/chat/utils/diagnostics.js";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 
 type Reason = "bug_report" | "feature_request" | "other";
@@ -142,18 +141,9 @@ async function fetchPlatformLogs(
   },
 ): Promise<Uint8Array | null> {
   try {
-    await ensureCsrfCookie();
-    const headers: Record<string, string> = {
+    const headers = await buildVellumMutatingHeaders({
       "Content-Type": "application/json",
-    };
-    const csrfToken = getCsrfToken();
-    if (csrfToken) {
-      headers["X-CSRFToken"] = csrfToken;
-    }
-    const orgId = getActiveOrganizationIdForRequests();
-    if (orgId) {
-      headers["Vellum-Organization-Id"] = orgId;
-    }
+    });
     const body: Record<string, unknown> = {};
     if (opts.window.startTime != null) {
       body.startTime = opts.window.startTime;

--- a/apps/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -6,7 +6,7 @@ import { createPortal } from "react-dom";
 
 import { Button } from "@vellum/design-library";
 import { Typography } from "@vellum/design-library";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
+import { buildVellumHeaders } from "@/lib/auth/request-headers.js";
 
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview.js";
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview.js";
@@ -99,12 +99,10 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
       try {
         // The attachment-content endpoint streams binary data and isn't
         // exposed via the HeyAPI generated client, so we hit it directly.
-        const headers: HeadersInit = {};
-        const organizationId = getActiveOrganizationIdForRequests();
-        if (organizationId) {
-          headers["Vellum-Organization-Id"] = organizationId;
-        }
-        const response = await fetch(`/v1/assistants/${assistantId}/attachments/${attachment.id}/content`, { headers });
+        const response = await fetch(
+          `/v1/assistants/${assistantId}/attachments/${attachment.id}/content`,
+          { headers: buildVellumHeaders() },
+        );
         if (!response.ok) {
           throw new Error(`Failed to load file: ${response.statusText}`);
         }

--- a/apps/web/src/domains/settings/api/oauth-apps.ts
+++ b/apps/web/src/domains/settings/api/oauth-apps.ts
@@ -1,5 +1,7 @@
-import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf.js";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
+import {
+  buildVellumHeaders,
+  buildVellumMutatingHeaders,
+} from "@/lib/auth/request-headers.js";
 
 /** Custom OAuth app stored on the daemon (encrypted on-disk). */
 export interface OAuthApp {
@@ -42,36 +44,6 @@ interface DaemonErrorBody {
   message?: string;
 }
 
-function buildHeaders(extra?: Record<string, string>): HeadersInit {
-  const headers: Record<string, string> = { ...(extra ?? {}) };
-  const organizationId = getActiveOrganizationIdForRequests();
-  if (organizationId) {
-    headers["Vellum-Organization-Id"] = organizationId;
-  }
-  return headers;
-}
-
-/**
- * Build headers for a mutating request (POST/PUT/PATCH/DELETE) against
- * the Django-proxied daemon routes. Django's SessionAuthentication enforces
- * CSRF on these methods, so we bootstrap the cookie and forward the token in
- * `X-CSRFToken` — same pattern the HeyAPI request interceptor uses for
- * generated clients (see `@/lib/vellum-api/client`).
- */
-async function buildMutatingHeaders(
-  extra?: Record<string, string>,
-): Promise<HeadersInit> {
-  const headers: Record<string, string> = {
-    ...(buildHeaders(extra) as Record<string, string>),
-  };
-  await ensureCsrfCookie();
-  const csrfToken = getCsrfToken();
-  if (csrfToken) {
-    headers["X-CSRFToken"] = csrfToken;
-  }
-  return headers;
-}
-
 async function readError(res: Response, fallback: string): Promise<string> {
   try {
     const body = (await res.json()) as DaemonErrorBody;
@@ -102,7 +74,7 @@ export async function listOAuthApps(
   providerKey: string,
 ): Promise<OAuthApp[]> {
   const url = `/v1/assistants/${assistantId}/oauth/apps/?provider_key=${encodeURIComponent(providerKey)}`;
-  const res = await fetch(url, { headers: buildHeaders() });
+  const res = await fetch(url, { headers: buildVellumHeaders() });
   if (!res.ok) {
     throw new Error(await readError(res, "Failed to load OAuth apps"));
   }
@@ -121,7 +93,7 @@ export async function createOAuthApp(
   const url = `/v1/assistants/${assistantId}/oauth/apps/`;
   const res = await fetch(url, {
     method: "POST",
-    headers: await buildMutatingHeaders({
+    headers: await buildVellumMutatingHeaders({
       "Content-Type": "application/json",
     }),
     body: JSON.stringify(input),
@@ -139,7 +111,7 @@ export async function deleteOAuthApp(
   const url = `/v1/assistants/${assistantId}/oauth/apps/${appId}/`;
   const res = await fetch(url, {
     method: "DELETE",
-    headers: await buildMutatingHeaders(),
+    headers: await buildVellumMutatingHeaders(),
   });
   if (!res.ok) {
     throw new Error(await readError(res, "Failed to delete OAuth app"));
@@ -151,7 +123,7 @@ export async function listOAuthAppConnections(
   appId: string,
 ): Promise<OAuthAppConnection[]> {
   const url = `/v1/assistants/${assistantId}/oauth/apps/${appId}/connections/`;
-  const res = await fetch(url, { headers: buildHeaders() });
+  const res = await fetch(url, { headers: buildVellumHeaders() });
   if (!res.ok) {
     throw new Error(
       await readError(res, "Failed to load OAuth app connections"),
@@ -168,7 +140,7 @@ export async function deleteOAuthAppConnection(
   const url = `/v1/assistants/${assistantId}/oauth/connections/${connectionId}/`;
   const res = await fetch(url, {
     method: "DELETE",
-    headers: await buildMutatingHeaders(),
+    headers: await buildVellumMutatingHeaders(),
   });
   if (!res.ok) {
     throw new Error(await readError(res, "Failed to disconnect OAuth account"));
@@ -183,7 +155,7 @@ export async function startOAuthAppConnect(
   const url = `/v1/assistants/${assistantId}/oauth/apps/${appId}/connect/`;
   const res = await fetch(url, {
     method: "POST",
-    headers: await buildMutatingHeaders({
+    headers: await buildVellumMutatingHeaders({
       "Content-Type": "application/json",
     }),
     body: JSON.stringify({

--- a/apps/web/src/domains/settings/api/oauth-providers.ts
+++ b/apps/web/src/domains/settings/api/oauth-providers.ts
@@ -1,4 +1,4 @@
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
+import { buildVellumHeaders } from "@/lib/auth/request-headers.js";
 
 /** Provider summary returned by the runtime catalog endpoint. */
 export interface OAuthProviderSummary {
@@ -22,15 +22,8 @@ interface OAuthProviderCatalogResponse {
 export async function fetchOAuthProviders(
   assistantId: string,
 ): Promise<OAuthProviderSummary[]> {
-  // The wildcard runtime proxy is excluded from OpenAPI, so the generated HeyAPI client cannot reach this endpoint.
-  const headers: HeadersInit = {};
-  const organizationId = getActiveOrganizationIdForRequests();
-  if (organizationId) {
-    headers["Vellum-Organization-Id"] = organizationId;
-  }
-
   const res = await fetch(`/v1/assistants/${assistantId}/oauth/providers/`, {
-    headers,
+    headers: buildVellumHeaders(),
   });
   if (!res.ok) {
     throw new Error(`Failed to fetch OAuth providers (HTTP ${res.status})`);

--- a/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -28,9 +28,11 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen.js";
 import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen.js";
 import { getAssistant } from "@/assistant/api.js";
-import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf.js";
+import {
+  buildVellumHeaders,
+  buildVellumMutatingHeaders,
+} from "@/lib/auth/request-headers.js";
 import { reportError } from "@/lib/errors/report.js";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
 import { getClientRegistrationHeaders } from "@/lib/telemetry/client-identity.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal.js";
@@ -87,15 +89,9 @@ function nextId(): string {
 }
 
 async function doctorFetch(url: string, init?: RequestInit): Promise<Response> {
-  await ensureCsrfCookie();
-  const csrfToken = getCsrfToken();
-  const orgId = getActiveOrganizationIdForRequests();
-
-  const headers: Record<string, string> = {
+  const headers = await buildVellumMutatingHeaders({
     "Content-Type": "application/json",
-    ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
-    ...(orgId ? { "Vellum-Organization-Id": orgId } : {}),
-  };
+  });
 
   return fetch(url, {
     ...init,
@@ -591,16 +587,10 @@ export function DoctorPanel({
           const response = await fetch(url, {
             signal: controller.signal,
             credentials: "include",
-            headers: {
+            headers: buildVellumHeaders({
               Accept: "text/event-stream",
               ...getClientRegistrationHeaders(),
-              ...(getActiveOrganizationIdForRequests()
-                ? {
-                    "Vellum-Organization-Id":
-                      getActiveOrganizationIdForRequests()!,
-                  }
-                : {}),
-            },
+            }),
           });
 
           if (!isCurrentStream()) return;

--- a/apps/web/src/lib/auth/request-headers.ts
+++ b/apps/web/src/lib/auth/request-headers.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared header builders for raw `fetch()` calls against the
+ * Django-proxied daemon routes (`/v1/assistants/{id}/...`).
+ *
+ * Prefer the generated HeyAPI client (`@/generated/api/client.gen.js`)
+ * when possible — its request interceptor at
+ * `@/lib/api-interceptors.ts` already adds these headers automatically.
+ * These helpers exist only for the cases that genuinely need raw `fetch`
+ * (streaming SSE, blob downloads with manual progress, etc.).
+ *
+ * Anything that handles `Vellum-Organization-Id` or `X-CSRFToken` outside
+ * `lib/auth/` and `lib/api-interceptors.ts` should be routed through here.
+ * Drift between sites is the failure mode that caused
+ * [LUM-1784](https://linear.app/vellum/issue/LUM-1784): a request that
+ * skips the header is silently rejected by Django's
+ * `MissingVellumOrganizationIDHeaderError`, the wrapper returns null,
+ * and the UI degrades to a fallback instead of surfacing the error.
+ */
+import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf.js";
+import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";
+
+/**
+ * Headers for a safe (GET/HEAD) request against an assistant-scoped
+ * daemon route. Adds `Vellum-Organization-Id` when an active
+ * organization is set.
+ */
+export function buildVellumHeaders(
+  extra?: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = { ...(extra ?? {}) };
+  const organizationId = getActiveOrganizationIdForRequests();
+  if (organizationId) {
+    headers["Vellum-Organization-Id"] = organizationId;
+  }
+  return headers;
+}
+
+/**
+ * Headers for a mutating (POST/PUT/PATCH/DELETE) request. Adds the org
+ * header and, after bootstrapping the CSRF cookie, the `X-CSRFToken`
+ * header that Django's `SessionAuthentication` requires.
+ */
+export async function buildVellumMutatingHeaders(
+  extra?: Record<string, string>,
+): Promise<Record<string, string>> {
+  const headers = buildVellumHeaders(extra);
+  await ensureCsrfCookie();
+  const csrfToken = getCsrfToken();
+  if (csrfToken) {
+    headers["X-CSRFToken"] = csrfToken;
+  }
+  return headers;
+}


### PR DESCRIPTION
## Why

Follow-up to [LUM-1784](https://linear.app/vellum/issue/LUM-1784) (PR #31469). While fixing the duplicated HeyAPI client instance, we found that five files under `apps/web/src` were each hand-rolling the `Vellum-Organization-Id` (and `X-CSRFToken` for mutations) header block inline for raw `fetch('/v1/...')` calls. Each instance was correct, but the pattern was drift-prone — the silent failure mode (Django returns 400 from `MissingVellumOrganizationIDHeaderError`, caller's null-fallback kicks in, UI degrades quietly) is exactly the bug class that hid LUM-1784 for so long.

## What

Extracts `buildVellumHeaders()` and `buildVellumMutatingHeaders()` from the local helpers in `oauth-apps.ts` into a shared top-level utility at `apps/web/src/lib/auth/request-headers.ts` (alongside the existing `csrf.ts` it depends on — matches the documented layout in `apps/web/docs/CONVENTIONS.md`).

Replaces inline header construction at every call site:

- `components/share-feedback-modal.tsx`
- `domains/chat/components/chat-attachments/attachment-preview-modal.tsx`
- `domains/settings/api/oauth-apps.ts` (also drops the local helpers)
- `domains/settings/api/oauth-providers.ts`
- `domains/settings/components/panels/doctor-panel.tsx` (two sites: `doctorFetch` and the SSE consumer)

## Option B not applicable here

None of the affected endpoints are in the daemon's OpenAPI schema — they're served through Django's `RuntimeProxyWildcardView`, which is `@extend_schema(exclude=True)` on every method. The generated HeyAPI client can't reach them, so raw fetch + the shared helper is the right shape. New raw-fetch sites should import from `lib/auth/request-headers.js`; anything else should use the generated client (where the interceptor handles this automatically).

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (only pre-existing warning in `lib/errors/report.ts`)
- `bun test src/domains/avatar src/lib` — 12/12 pass
- `grep -rn '"Vellum-Organization-Id"\|"X-CSRFToken"' apps/web/src` outside `generated/`, `api-interceptors.ts`, `lib/auth/`, `lib/vellum-api/`, `.test.` — the only remaining hit is a docstring reference in `domains/voice/stt-api.ts:116` (a comment, not code)

## Test plan

Behavior unchanged — same headers attached to same requests. Sanity-check:

- [ ] OAuth apps tab loads / connect / disconnect still works
- [ ] OAuth providers catalog loads (settings → integrations)
- [ ] Attachment image/PDF preview loads in chat
- [ ] Share Feedback → Send still uploads logs
- [ ] Doctor diagnostics panel still streams + interactive session works

Linear: [LUM-1787](https://linear.app/vellum/issue/LUM-1787)

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCZW79Tf61evfPDvm2HrH)_