### PR TITLE
fix(web): keep favicon in sync with avatar across all assistant routes

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -6,6 +6,7 @@
     "messaging"
   ],
   "src/domains/chat/chat-layout.tsx": [
+    "avatar",
     "conversations",
     "subagents"
   ],

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -14,6 +14,8 @@ import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { useAssistantLifecycle } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
 import { useAssistantIdentityInit } from "@/hooks/use-assistant-identity-init.js";
+import { useAssistantAvatar } from "@/domains/avatar/use-assistant-avatar.js";
+import { useDynamicFavicon } from "@/domains/avatar/use-dynamic-favicon.js";
 import { useHomeUnreadBadge } from "@/hooks/use-home-unread-badge.js";
 import type { AssistantContextValue } from "@/domains/chat/assistant-context.js";
 
@@ -172,6 +174,18 @@ export function ChatLayout() {
     assistantId: lifecycle.assistantId,
     assistantStateKind: lifecycle.assistantState.kind,
   });
+
+  // Sync the browser favicon to the assistant's avatar across every
+  // chat-layout child route — not just ChatPage. Mounting this in the
+  // layout keeps the favicon live while the user is on identity,
+  // library, workspace, contacts, or home (where ChatPage isn't
+  // mounted). The hook is a no-op when assistantId is null.
+  const layoutAvatar = useAssistantAvatar(lifecycle.assistantId);
+  useDynamicFavicon(
+    layoutAvatar.customImageUrl,
+    layoutAvatar.components,
+    layoutAvatar.traits,
+  );
 
   // Home page unread indicator — drives the red dot on the Home button in
   // the layout header. Gated on the homePage feature flag so the hook

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -55,7 +55,6 @@ import { useChatAttachments } from "@/domains/chat/components/chat-attachments/u
 import { useVoiceInput } from "@/domains/chat/hooks/use-voice-input.js";
 import { useConversationStarters } from "@/domains/chat/hooks/use-conversation-starters.js";
 import { useAssistantAvatar } from "@/domains/avatar/use-assistant-avatar.js";
-import { useDynamicFavicon } from "@/domains/avatar/use-dynamic-favicon.js";
 import { useAssistantReachability } from "@/assistant/use-assistant-reachability.js";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor.js";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure.js";
@@ -335,7 +334,6 @@ export function ChatPage() {
   // Avatar
   // -------------------------------------------------------------------------
   const avatar = useAssistantAvatar(assistantId);
-  useDynamicFavicon(avatar.customImageUrl, avatar.components, avatar.traits);
 
   // -------------------------------------------------------------------------
   // Nudges


### PR DESCRIPTION
## Summary

The browser favicon stopped tracking the assistant's avatar on every route except `/assistant` (chat). Changing the avatar from `/assistant/identity` (or library/workspace/contacts/home) had no visible effect on the favicon until the user navigated back to the chat route.

### Root cause

`useDynamicFavicon` was invoked only from `ChatPage` (`apps/web/src/domains/chat/chat-page.tsx`). The route tree (`routes.tsx`) mounts `IdentityPage`, `LibraryPage`, `WorkspacePage`, `ContactsPage`, and `HomePageRoute` as siblings of `ChatPage` under `ChatLayout` — when those routes are active, `ChatPage` is unmounted and the favicon hook isn't running, so the avatar-invalidation `sync_changed` event has no listener that touches the `<link rel="icon">` element.

In `vellum-assistant-platform`, the equivalent hook lived in `AssistantPageClient.tsx`, which wrapped every assistant sub-route — so the favicon sync was always live.

### Fix

Hoist `useDynamicFavicon` (and the matching `useAssistantAvatar` call) from `ChatPage` into `ChatLayout`. The layout wraps every chat-layout child route, so the favicon stays in sync regardless of which assistant page is open. React Query dedupes the avatar fetch via its query key, so the additional hook call in the layout is a no-op when `ChatPage` is also mounted.

The cross-domain-imports allowlist is regenerated via `bun run audit:cross-domain`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (only one pre-existing unrelated warning)
- [x] `bun test src/domains/avatar/` passes
- [ ] Manual: open `/assistant/identity`, change the avatar, confirm the browser tab favicon updates without leaving the page
- [ ] Manual: same on library, workspace, contacts, home
- [ ] Manual: same on chat (regression check)

Linear: ATL-FAVICON-SYNC (to be filed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZRbrYUcANTbkSCjoCS51M)_