### PR TITLE
fix: filter null catalog entries and route Skills tab (JARVIS-923)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -193,6 +193,9 @@
   "src/domains/intelligence/identity-page.tsx": [
     "chat"
   ],
+  "src/domains/intelligence/skills-page.tsx": [
+    "chat"
+  ],
   "src/domains/interactions/interaction-store.ts": [
     "chat"
   ],

--- a/apps/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/apps/web/src/domains/intelligence/intelligence-layout.tsx
@@ -7,7 +7,7 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store.js"
 
 const INTELLIGENCE_TABS = [
   { label: "Identity", to: routes.identity },
-  { label: "Skills", to: routes.library.root },
+  { label: "Skills", to: routes.skills },
   { label: "Workspace", to: routes.workspace },
   { label: "Contacts", to: routes.contacts.root },
 ] as const;

--- a/apps/web/src/domains/intelligence/skills-page.tsx
+++ b/apps/web/src/domains/intelligence/skills-page.tsx
@@ -1,14 +1,12 @@
 import { useSearchParams } from "react-router";
 
-import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { useActiveAssistantContext } from "@/domains/chat/active-assistant-gate.js";
 import { SkillsTab } from "@/domains/intelligence/components/skills/skills-tab.js";
 
 export function SkillsPage() {
-  const { assistantId } = useAssistantContext();
+  const { assistantId } = useActiveAssistantContext();
   const [searchParams] = useSearchParams();
   const initialSkillId = searchParams.get("skill") ?? undefined;
-
-  if (!assistantId) return null;
 
   return <SkillsTab assistantId={assistantId} initialSkillId={initialSkillId} />;
 }

--- a/apps/web/src/domains/intelligence/skills-page.tsx
+++ b/apps/web/src/domains/intelligence/skills-page.tsx
@@ -1,0 +1,14 @@
+import { useSearchParams } from "react-router";
+
+import { useAssistantContext } from "@/domains/chat/assistant-context.js";
+import { SkillsTab } from "@/domains/intelligence/components/skills/skills-tab.js";
+
+export function SkillsPage() {
+  const { assistantId } = useAssistantContext();
+  const [searchParams] = useSearchParams();
+  const initialSkillId = searchParams.get("skill") ?? undefined;
+
+  if (!assistantId) return null;
+
+  return <SkillsTab assistantId={assistantId} initialSkillId={initialSkillId} />;
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { LibraryPage } from "@/domains/library/library-page.js";
 import { LibraryDetailPage } from "@/domains/library/library-detail-page.js";
 import { IdentityPage } from "@/domains/intelligence/identity-page.js";
 import { IntelligenceLayout } from "@/domains/intelligence/intelligence-layout.js";
+import { SkillsPage } from "@/domains/intelligence/skills-page.js";
 import { ConnectPage } from "@/domains/contacts/connect-page.js";
 import { ContactsPage } from "@/domains/contacts/contacts-page.js";
 import { WorkspacePage } from "@/domains/workspace/workspace-page.js";
@@ -196,6 +197,7 @@ export const router = createBrowserRouter([
                 element: <IntelligenceLayout />,
                 children: [
                   { path: "identity", element: <IdentityPage /> },
+                  { path: "skills", element: <SkillsPage /> },
                   { path: "library", element: <LibraryPage /> },
                   { path: "workspace", element: <WorkspacePage /> },
                   { path: "contacts", element: <ContactsPage /> },

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -50,6 +50,7 @@ export const routes = {
 
   home: r("/assistant/home"),
   identity: r("/assistant/identity"),
+  skills: r("/assistant/skills"),
   workspace: r("/assistant/workspace"),
   library: {
     root: r("/assistant/library"),

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { Anthropic } from "@anthropic-ai/sdk";
+
 import type { Message, ToolDefinition } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -2582,16 +2584,16 @@ describe("AnthropicProvider — thinking block send-time filtering", () => {
     expect(assistantTurns.length).toBeGreaterThanOrEqual(2);
 
     // Historical turn: thinking stripped
-    const historicalBlocks =
-      assistantTurns[0].content as Anthropic.ContentBlockParam[];
+    const historicalBlocks = assistantTurns[0]
+      .content as Anthropic.ContentBlockParam[];
     const historicalThinking = historicalBlocks.filter(
       (b) => typeof b !== "string" && b.type === "thinking",
     );
     expect(historicalThinking).toHaveLength(0);
 
     // Active turn: thinking preserved
-    const activeBlocks =
-      assistantTurns[1].content as Anthropic.ContentBlockParam[];
+    const activeBlocks = assistantTurns[1]
+      .content as Anthropic.ContentBlockParam[];
     const activeThinking = activeBlocks.filter(
       (b) => typeof b !== "string" && b.type === "thinking",
     );
@@ -2622,9 +2624,7 @@ describe("AnthropicProvider — thinking block send-time filtering", () => {
     expect(blocks).toHaveLength(1);
     expect((blocks[0] as { type: string; text: string }).type).toBe("text");
     expect(
-      isPlaceholderSentinelText(
-        (blocks[0] as { text: string }).text,
-      ),
+      isPlaceholderSentinelText((blocks[0] as { text: string }).text),
     ).toBe(true);
   });
 

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -111,7 +111,9 @@ export async function fetchCatalog(): Promise<CatalogSkill[]> {
   if (!Array.isArray(manifest.skills)) {
     throw new Error("Platform catalog has invalid skills array");
   }
-  return manifest.skills;
+  return manifest.skills.filter(
+    (s): s is CatalogSkill => !!s && typeof s.id === "string",
+  );
 }
 
 export function readLocalCatalog(repoSkillsDir: string): CatalogSkill[] {
@@ -119,7 +121,9 @@ export function readLocalCatalog(repoSkillsDir: string): CatalogSkill[] {
     const raw = readFileSync(join(repoSkillsDir, "catalog.json"), "utf-8");
     const manifest = JSON.parse(raw) as CatalogManifest;
     if (!Array.isArray(manifest.skills)) return [];
-    return manifest.skills;
+    return manifest.skills.filter(
+      (s): s is CatalogSkill => !!s && typeof s.id === "string",
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Filter null/undefined entries from platform catalog API response in `fetchCatalog()` and `readLocalCatalog()`, preventing the `undefined is not an object (evaluating 's.id')` crash in the skills handler
- Give Skills its own route (`/assistant/skills`) instead of pointing the "Skills" tab at the Library page (`/assistant/library`)

## Test plan
- [ ] Verify skills catalog loads without 500 errors when platform API returns null entries
- [ ] Verify clicking "Skills" tab navigates to `/assistant/skills` and renders the skills browser
- [ ] Verify Library tab still works at `/assistant/library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->