### PR TITLE
feat(settings): require approval for Doctor exec commands (LUM-1681)

### DIFF
--- a/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -53,6 +53,14 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+const APPROVAL_RESPONSES = new Set([
+  "approve",
+  "approve all exec",
+  "approve all future exec commands",
+  "approve_all_exec",
+  "deny",
+]);
+
 type DoctorEvent =
   | { type: "message"; content: string }
   | { type: "message_delta"; content: string }
@@ -296,6 +304,7 @@ function ApprovalBlock({
   const [showDetails, setShowDetails] = useState(false);
 
   const hasDetails = !!toolName || !!description || !!input;
+  const canApproveFutureExecCommands = toolName === "exec_command";
 
   return (
     <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] p-4">
@@ -316,6 +325,16 @@ function ApprovalBlock({
           >
             Allow once
           </button>
+          {canApproveFutureExecCommands && (
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onRespond("approve all exec")}
+              className="flex items-center gap-1.5 rounded-md border border-[var(--system-positive-strong)] bg-[var(--surface-lift)] px-3 py-1.5 text-body-small-default text-[var(--system-positive-strong)] transition-colors hover:bg-[var(--system-positive-weak)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Always Allow
+            </button>
+          )}
           <button
             type="button"
             disabled={disabled}
@@ -919,7 +938,7 @@ export function DoctorPanel({
       appendEntry({ kind: "user", content: text });
       setInputValue("");
 
-      if (text.toLowerCase() === "approve" || text.toLowerCase() === "deny") {
+      if (APPROVAL_RESPONSES.has(text.toLowerCase())) {
         setPendingApproval(false);
       }
 


### PR DESCRIPTION
## Summary

Port of [vellum-assistant-platform#7242](https://github.com/vellum-ai/vellum-assistant-platform/pull/7242). The Doctor panel's `exec_command` tool was previously runnable without user confirmation; this drift adds an approval gate plus an "Always Allow" affordance so the user can opt in to subsequent commands in the same session.

Three semantic changes, all in `apps/web/src/domains/settings/components/panels/doctor-panel.tsx`:

1. **`APPROVAL_RESPONSES` set** captures every variant the daemon emits (`approve`, `deny`, `approve all exec`, `approve all future exec commands`, `approve_all_exec`). Clearing `pendingApproval` on any of them keeps the panel from getting stuck when the user picks the new "Always Allow" path.
2. **`ApprovalBlock`** now renders an additional **Always Allow** button when `toolName === "exec_command"`. The button dispatches `"approve all exec"`.
3. **Pending-approval clear** uses `APPROVAL_RESPONSES.has(text.toLowerCase())` instead of the hardcoded `approve` / `deny` strings.

Platform's diff was ~283 lines because the file was reformatted (whitespace, line-wrap, eslint-disable comment style); only the three semantic deltas above are ported. No formatting noise.

Closes LUM-1681.

## Test plan

- [x] `bun run test:ci` — 100 / 100 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (1 preexisting unrelated warning)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181LfJ6Lapx1LKyrrnDZ3Vh)_