### PR TITLE
chore(web): add auth lint guardrails

### DIFF
--- a/apps/web/docs/CONVENTIONS.md
+++ b/apps/web/docs/CONVENTIONS.md
@@ -603,6 +603,81 @@ If bypassing, add a comment explaining why.
 
 ---
 
+## Authentication
+
+The SPA is converging on a single auth design: gateway-issued
+HttpOnly session cookies, applied uniformly across browser, Capacitor
+iOS, and Electron. Until that lands, follow these conventions to keep
+the codebase convergent rather than divergent.
+
+### One HeyAPI client instance
+
+There is exactly one HeyAPI client per app, exported by
+`@/generated/api/client.gen.js`. Hand-written wrappers and call sites
+must import that singleton — they must **not** call `createClient(...)`
+themselves.
+
+This is enforced by an ESLint rule
+(`no-restricted-syntax`/`CallExpression[callee.name='createClient']`).
+A second `createClient(...)` instance does not inherit the request
+interceptors that attach the auth headers, so every request through it
+silently ships unauthenticated. Upstream rejects the request; the
+wrapper returns `null`; the UI degrades to a fallback. The class of bug
+is hard to notice in code review because the second-instance code looks
+correct in isolation. Don't add a second instance.
+
+### Auth-related headers stay inside the auth boundary
+
+The headers `Vellum-Organization-Id`, `X-CSRFToken`, and `X-Session-Token`
+only appear inside `src/lib/auth/` and `src/lib/api-interceptors.ts`.
+Everywhere else, an ESLint rule (`no-restricted-syntax` literal
+selectors) flags string-literal uses of those header names.
+
+If you find yourself wanting to set one of those headers in app code,
+the answer is to use the central interceptor (already installed on the
+singleton client). If you're writing raw `fetch()` for a streaming
+endpoint, use the helpers in `src/lib/auth/request-headers.ts` — but
+do not extend those helpers; the file is transitional and slated for
+deletion.
+
+### No JS-readable storage for tokens or credentials
+
+Do not write anything token-, credential-, secret-, JWT-, bearer-,
+password-, or api-key-shaped to `localStorage` or `sessionStorage`.
+JS-readable storage is XSS-exposed; an injected script can exfiltrate
+the entire store. An ESLint rule blocks `setItem` calls whose key
+literal matches that pattern.
+
+The right storage:
+
+- **Web / Capacitor iOS:** the HttpOnly session cookie issued by the
+  gateway, set automatically by the browser. The SPA never touches it.
+- **Electron:** the same HttpOnly cookie via Electron's session
+  partition. For anything that genuinely needs client-managed storage,
+  `Electron.safeStorage` (Keychain on macOS, libsecret on Linux,
+  DPAPI on Windows).
+- **Capacitor iOS biometric persistence:** Keychain via the existing
+  `native-biometric` plugin (only for opt-in "remember me" persistence;
+  not the primary token store).
+
+### No new `X-Session-Token` users
+
+`X-Session-Token` is a legacy native-bridge artifact from the iOS
+plugin (it forwards a server-side session ID across the JS↔Swift
+boundary). It is being retired once the gateway issues cookies that
+the WKWebView populates directly. New code that mentions this header
+is a lint error.
+
+### Native-platform branching belongs in `lib/auth/`
+
+If you need to write `if (isNativePlatform)` in auth-touching code,
+leave a `TODO` next to it pointing at the planned consolidation. The
+end state has a single native bridge interface (Capacitor today,
+Electron next) so app code shouldn't be branching on which shell is
+wrapping the SPA.
+
+---
+
 ## Testing
 
 - **Test framework:** [Bun's test runner](https://bun.sh/docs/test)

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -3,6 +3,140 @@ import tseslint from "typescript-eslint";
 
 import { noCrossDomainImports } from "./eslint-rules/no-cross-domain-imports.mjs";
 
+// ---------------------------------------------------------------------------
+// no-restricted-syntax rule sets
+//
+// `no-restricted-syntax` is an array, and ESLint flat config REPLACES the
+// array when redeclared. So path-scoped overrides have to restate every rule
+// they want to keep. We split the rules into named groups to make the
+// overrides readable.
+// ---------------------------------------------------------------------------
+
+/**
+ * `dark:`-paired color-scale utilities — protects the velvet theme.
+ *
+ * The `dark:` custom variant only matches `[data-theme=dark]`, not
+ * `[data-theme=velvet]`, so any paired utility silently breaks velvet
+ * contrast. Use semantic tokens (`--surface-*`, `--content-*`,
+ * `--border-*`) instead. See `apps/web/docs/STYLE_GUIDE.md`.
+ */
+const darkPairedColorScaleRules = [
+  {
+    selector:
+      "Literal[value=/\\bdark:(\\w+:)*(bg|text|border|divide|ring|fill|stroke|outline|decoration|placeholder|accent|caret)-[a-z]+-\\d+/]",
+    message:
+      "Use a semantic token (e.g. bg-[var(--surface-lift)], text-[var(--content-default)]) instead of dark: paired with a color-scale utility. Semantic tokens are defined in packages/design-library/src/tokens.css and switch per data-theme automatically, including velvet. See apps/web/docs/STYLE_GUIDE.md.",
+  },
+  {
+    selector:
+      "TemplateElement[value.raw=/\\bdark:(\\w+:)*(bg|text|border|divide|ring|fill|stroke|outline|decoration|placeholder|accent|caret)-[a-z]+-\\d+/]",
+    message:
+      "Use a semantic token (e.g. bg-[var(--surface-lift)], text-[var(--content-default)]) instead of dark: paired with a color-scale utility. Semantic tokens are defined in packages/design-library/src/tokens.css and switch per data-theme automatically, including velvet. See apps/web/docs/STYLE_GUIDE.md.",
+  },
+];
+
+/**
+ * Universal auth-boundary rules — apply EVERYWHERE, including inside
+ * `lib/auth/` and `lib/api-interceptors.ts`. These guardrails have no
+ * legitimate exception:
+ *
+ * - A duplicate HeyAPI client instance inside `lib/auth/` would silently
+ *   bypass the interceptors just as badly as one outside it.
+ * - Tokens, credentials, and secrets do not belong in JS-readable
+ *   storage anywhere, regardless of which module is doing the writing.
+ *
+ * See `apps/web/docs/CONVENTIONS.md` → "Authentication".
+ */
+const universalAuthRules = [
+  // No new `createClient(...)` outside generated/. There must be exactly
+  // one HeyAPI client instance per app — the generated singleton. Hand-
+  // written wrappers import `client` from `@/generated/api/client.gen.js`.
+  // Note: `src/generated/**` is globally ignored, so this effectively
+  // means "no createClient anywhere we lint".
+  {
+    selector: "CallExpression[callee.name='createClient']",
+    message:
+      'Do not call createClient(...) outside src/generated/. Import the singleton: `import { client } from "@/generated/api/client.gen.js"`. A second instance does not inherit the auth-header interceptors and silently sends unauthenticated requests.',
+  },
+
+  // No `localStorage.setItem(key, …)` / `sessionStorage.setItem(key, …)`
+  // where the literal key looks like a token / credential / session /
+  // secret / JWT / bearer / password / api-key. Browser-readable storage
+  // is XSS-exposed and the wrong place for any of those — even inside
+  // auth code, which should use HttpOnly cookies or platform-secure
+  // storage instead.
+  {
+    selector:
+      "CallExpression[callee.object.name='localStorage'][callee.property.name='setItem'][arguments.0.value=/(?:token|credential|secret|jwt|bearer|password|api[_-]?key|session[_-]?token)/i]",
+    message:
+      "Do not write tokens, credentials, or session-like values to localStorage — JS-readable storage is XSS-exposed. Use HttpOnly cookies (issued by the server, stored by the browser) or platform-secure storage (Keychain, Electron safeStorage) instead.",
+  },
+  {
+    selector:
+      "CallExpression[callee.object.name='sessionStorage'][callee.property.name='setItem'][arguments.0.value=/(?:token|credential|secret|jwt|bearer|password|api[_-]?key|session[_-]?token)/i]",
+    message:
+      "Do not write tokens, credentials, or session-like values to sessionStorage — JS-readable storage is XSS-exposed. Use HttpOnly cookies (issued by the server, stored by the browser) or platform-secure storage (Keychain, Electron safeStorage) instead.",
+  },
+  // Same patterns via `window.localStorage` / `window.sessionStorage`.
+  {
+    selector:
+      "CallExpression[callee.object.object.name='window'][callee.object.property.name='localStorage'][callee.property.name='setItem'][arguments.0.value=/(?:token|credential|secret|jwt|bearer|password|api[_-]?key|session[_-]?token)/i]",
+    message:
+      "Do not write tokens, credentials, or session-like values to localStorage — JS-readable storage is XSS-exposed.",
+  },
+  {
+    selector:
+      "CallExpression[callee.object.object.name='window'][callee.object.property.name='sessionStorage'][callee.property.name='setItem'][arguments.0.value=/(?:token|credential|secret|jwt|bearer|password|api[_-]?key|session[_-]?token)/i]",
+    message:
+      "Do not write tokens, credentials, or session-like values to sessionStorage — JS-readable storage is XSS-exposed.",
+  },
+];
+
+/**
+ * Header-literal rules — apply OUTSIDE the auth boundary only.
+ *
+ * The `lib/auth/` directory and `lib/api-interceptors.ts` are the only
+ * places that legitimately set these headers. Restricting them to that
+ * boundary keeps auth-header drift from spreading back across the
+ * codebase.
+ *
+ * Path-scoped via the override block below.
+ */
+const headerLiteralRules = [
+  // No new literal `X-Session-Token` strings. This header is a legacy
+  // native-bridge artifact and is being retired.
+  {
+    selector: "Literal[value='X-Session-Token']",
+    message:
+      "Do not introduce new uses of the X-Session-Token header. It is a legacy native-bridge artifact that is being retired in favor of cookie-based session auth issued by the gateway.",
+  },
+
+  // No new literal `X-CSRFToken` strings outside the auth/interceptor
+  // surface. CSRF protection is being centralized.
+  {
+    selector: "Literal[value='X-CSRFToken']",
+    message:
+      "Do not introduce new uses of the X-CSRFToken header outside src/lib/auth/ or src/lib/api-interceptors.ts. CSRF is centralized in the auth interceptor.",
+  },
+
+  // No new literal `Vellum-Organization-Id` strings outside the
+  // auth/interceptor surface. The active-org context belongs in one
+  // place, not handcrafted across call sites.
+  {
+    selector: "Literal[value='Vellum-Organization-Id']",
+    message:
+      "Do not introduce new uses of the Vellum-Organization-Id header outside src/lib/auth/. Only the central interceptor should be reading or setting this header.",
+  },
+];
+
+// Paths that legitimately produce/consume the auth headers.
+// Exempt from `headerLiteralRules` but still subject to
+// `universalAuthRules` and `darkPairedColorScaleRules`.
+const authBoundaryAllowedPaths = [
+  "src/lib/auth/**",
+  "src/lib/api-interceptors.ts",
+];
+
 const eslintConfig = defineConfig([
   ...tseslint.configs.recommended,
   globalIgnores(["dist/**", "src/generated/**"]),
@@ -16,37 +150,26 @@ const eslintConfig = defineConfig([
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
       "local/no-cross-domain-imports": "error",
-      // Flag `dark:` paired with any color-scale utility — including
-      // compound variants like `dark:hover:bg-moss-700` and Tailwind's
-      // default palettes (`dark:text-red-400`, `dark:bg-sky-950`). The
-      // `dark:` custom-variant in packages/design-library/src/tokens.css
-      // only matches [data-theme=dark] — NOT [data-theme=velvet] — so
-      // paired utilities silently break velvet contrast regardless of
-      // which color scale they use. Use semantic tokens (--surface-*,
-      // --content-*, --border-*) instead.
-      //
-      // Regex breakdown:
-      //   \bdark:           — `dark:` variant prefix
-      //   (\w+:)*           — optional intermediate variants
-      //                       (hover:, focus:, motion-safe:, etc.)
-      //   <prop>-           — utility prefix (bg, text, border, …)
-      //   [a-z]+-\d+        — any color name + numeric shade
-      //                       (matches in-repo scales like moss-700
-      //                       and Tailwind defaults like red-400 / sky-950)
       "no-restricted-syntax": [
         "error",
-        {
-          selector:
-            "Literal[value=/\\bdark:(\\w+:)*(bg|text|border|divide|ring|fill|stroke|outline|decoration|placeholder|accent|caret)-[a-z]+-\\d+/]",
-          message:
-            "Use a semantic token (e.g. bg-[var(--surface-lift)], text-[var(--content-default)]) instead of dark: paired with a color-scale utility. Semantic tokens are defined in packages/design-library/src/tokens.css and switch per data-theme automatically, including velvet. See apps/web/docs/STYLE_GUIDE.md.",
-        },
-        {
-          selector:
-            "TemplateElement[value.raw=/\\bdark:(\\w+:)*(bg|text|border|divide|ring|fill|stroke|outline|decoration|placeholder|accent|caret)-[a-z]+-\\d+/]",
-          message:
-            "Use a semantic token (e.g. bg-[var(--surface-lift)], text-[var(--content-default)]) instead of dark: paired with a color-scale utility. Semantic tokens are defined in packages/design-library/src/tokens.css and switch per data-theme automatically, including velvet. See apps/web/docs/STYLE_GUIDE.md.",
-        },
+        ...darkPairedColorScaleRules,
+        ...universalAuthRules,
+        ...headerLiteralRules,
+      ],
+    },
+  },
+  // Override: files inside the auth boundary may use the auth-header
+  // literals. The `createClient` ban and the storage-of-credentials
+  // bans still apply — they have no legitimate exception anywhere.
+  // Restate `no-restricted-syntax` with everything EXCEPT the header
+  // literal rules, since flat-config replaces the array on override.
+  {
+    files: authBoundaryAllowedPaths,
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...darkPairedColorScaleRules,
+        ...universalAuthRules,
       ],
     },
   },

--- a/apps/web/src/lib/auth/request-headers.ts
+++ b/apps/web/src/lib/auth/request-headers.ts
@@ -1,6 +1,8 @@
 /**
- * Shared header builders for raw `fetch()` calls against the
- * Django-proxied daemon routes (`/v1/assistants/{id}/...`).
+ * **Transitional — do not extend. Slated for deletion.**
+ *
+ * Shared header builders for raw `fetch()` calls against assistant-scoped
+ * routes (`/v1/assistants/{id}/...`).
  *
  * Prefer the generated HeyAPI client (`@/generated/api/client.gen.js`)
  * when possible — its request interceptor at
@@ -10,11 +12,14 @@
  *
  * Anything that handles `Vellum-Organization-Id` or `X-CSRFToken` outside
  * `lib/auth/` and `lib/api-interceptors.ts` should be routed through here.
- * Drift between sites is the failure mode that caused
- * [LUM-1784](https://linear.app/vellum/issue/LUM-1784): a request that
- * skips the header is silently rejected by Django's
- * `MissingVellumOrganizationIDHeaderError`, the wrapper returns null,
- * and the UI degrades to a fallback instead of surfacing the error.
+ * Drift between sites is the failure mode where a request that skips the
+ * header is silently rejected upstream, the wrapper returns null, and the
+ * UI degrades to a fallback instead of surfacing the error.
+ *
+ * **DO NOT add new helpers here.** Auth is moving to a single
+ * gateway-issued session-cookie model where the SPA no longer
+ * hand-attaches these headers — the central interceptor handles both
+ * modes. This whole file is deleted once that lands.
  */
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf.js";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store.js";


### PR DESCRIPTION
## Why

Lint guardrails to prevent the SPA's auth-header plumbing from regressing while the broader auth design converges. Pure guardrail PR — zero code-path changes.

## What

ESLint rules added (all path-scoped to allow legitimate uses in `src/lib/auth/` and `src/lib/api-interceptors.ts`):

1. **No `createClient(...)` outside `src/generated/`.** A second HeyAPI client instance does not inherit the request interceptors that attach auth headers, so any wrapper using it silently ships unauthenticated requests. The class of bug is hard to notice in code review because the second-instance code looks correct in isolation.
2. **No literal `X-Session-Token` strings.** Legacy native-bridge artifact; being retired in favor of cookie-based session auth.
3. **No literal `X-CSRFToken` strings** outside the auth boundary. CSRF is centralized in the auth interceptor.
4. **No literal `Vellum-Organization-Id` strings** outside the auth boundary. Active-org context belongs in one place.
5. **No `localStorage.setItem` / `sessionStorage.setItem` (or via `window.*`) of token-/credential-/secret-/JWT-/bearer-/password-/api-key-shaped keys.** JS-readable storage is XSS-exposed.

Also:

- **"Do not extend" deprecation banner on `src/lib/auth/request-headers.ts`** — the file is transitional and slated for deletion once auth-header injection moves to the central interceptor for both modes.
- **New "Authentication" section in `apps/web/docs/CONVENTIONS.md`** documenting the conventions and the rationale.

## Verification

- `bun run lint` — clean on existing code (the only pre-existing warning in `lib/errors/report.ts` is unchanged).
- `bun run typecheck` — clean.
- **Smoke test:** dropped in a deliberately-bad fixture with `createClient(...)`, all three forbidden header literals, and `localStorage.setItem("user_session_token", …)` / `window.sessionStorage.setItem("api_key", …)`. All 6 rules fired with the intended error messages. Deleted the fixture before committing.

## How the path-scoping works

ESLint flat-config's `no-restricted-syntax` array is *replaced* (not merged) when redeclared in a later config object. `apps/web/eslint.config.mjs` defines the auth-boundary rules globally and then restates `no-restricted-syntax` for `src/lib/auth/**` + `src/lib/api-interceptors.ts` with **only** the `dark:` rules — dropping the auth restrictions exclusively in those paths.

## Out of scope

- No code-path changes. Existing imports / call sites unchanged.
- No deletion of the `request-headers.ts` helpers — they still serve raw-fetch sites today. Banner-only.
- No new auth code.