### PR TITLE
fix(web): read __Secure-csrftoken in prod builds

### DIFF
--- a/apps/web/src/lib/auth/csrf.ts
+++ b/apps/web/src/lib/auth/csrf.ts
@@ -10,7 +10,9 @@
  */
 import { getAllauthByClientV1AuthSession } from "@/generated/auth/sdk.gen.js";
 
-const CSRF_COOKIE_NAME = "csrftoken";
+const CSRF_COOKIE_NAME = import.meta.env.PROD
+  ? "__Secure-csrftoken"
+  : "csrftoken";
 
 /**
  * Read the CSRF token from the browser cookie jar.


### PR DESCRIPTION
## Summary
- Django configures `CSRF_COOKIE_NAME = \"__Secure-csrftoken\"` in prod (`django/config/settings/production.py:81` in `vellum-assistant-platform`), but `apps/web/src/lib/auth/csrf.ts` was hardcoded to read `csrftoken`. In prod that means `getCsrfToken()` returns `undefined` and mutating requests omit `X-CSRFToken`.
- Switch to a build-time constant via `import.meta.env.PROD` so Vite dead-code-eliminates the wrong branch: prod bundles only contain `\"__Secure-csrftoken\"`, dev bundles only contain `\"csrftoken\"`.
- No runtime fallback / dual-name lookup — if backend and frontend names ever drift, CSRF fails loudly instead of silently checking the other name.

## Test plan
- [x] `bun test src/domains/chat/api/post-chat-message.test.ts src/domains/chat/api/stream.test.ts` — 28/28 pass. Under Bun, `import.meta.env.PROD` is falsy, so tests resolve to `\"csrftoken\"`, matching existing `document.cookie = \"csrftoken=test\"` fixtures.
- [x] `bunx tsc --noEmit` — no new errors in `csrf.ts`; pre-existing errors elsewhere are unrelated.
- [ ] Manual: in a prod build, confirm `getCsrfToken()` returns the value of `document.cookie["__Secure-csrftoken"]` and that POST/PATCH/DELETE requests include `X-CSRFToken`.

## Notes
- `apps/web/src/runtime/native-auth.ts:134` has a related anti-pattern (manually writes both `sessionid` and `__Secure-sessionid` in prod, where only the prefixed one is read). Out of scope for this PR; flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->