### PR TITLE
fix(apps-web): render detail panel overflow menu items on a single line

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -90,16 +90,20 @@ export function HomeDetailPanel({
               onSelect={() =>
                 onUpdateStatus(item.id, isUnread ? "seen" : "new")
               }
+              leftIcon={
+                isUnread ? (
+                  <MailOpen className="size-4" />
+                ) : (
+                  <Mail className="size-4" />
+                )
+              }
             >
-              {isUnread ? (
-                <MailOpen className="size-4" />
-              ) : (
-                <Mail className="size-4" />
-              )}
               {isUnread ? "Mark as read" : "Mark as unread"}
             </Menu.Item>
-            <Menu.Item onSelect={() => onDismiss(item.id)}>
-              <CircleX className="size-4" />
+            <Menu.Item
+              onSelect={() => onDismiss(item.id)}
+              leftIcon={<CircleX className="size-4" />}
+            >
               Dismiss
             </Menu.Item>
           </Menu.Content>


### PR DESCRIPTION
## Summary

Mirror of [vellum-assistant-platform#7548](https://github.com/vellum-ai/vellum-assistant-platform/pull/7548) into `apps/web`.

Same bug, same fix. `Menu.Item` from `@vellum/design-library` already exposes a dedicated `leftIcon` slot (`packages/design-library/src/components/menu.tsx:101`) that puts the icon in a fixed 16×16 inline wrapper next to a `flex-1 truncate` text slot. The home detail panel was passing both the icon and the label as children of the same span, which caused them to render on separate lines.

Move the lucide icons into `leftIcon` for both menu items.

## Test plan

- [x] Lint clean
- [ ] Verify visually on the home detail panel overflow menu — both items single-line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->