### PR TITLE
refactor(web): extract useConversationSwitch hook (LUM-1739 Phase 4a)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -61,8 +61,12 @@
   "src/domains/chat/hooks/use-conversation-history.ts": [
     "conversations",
     "interactions",
-    "messaging",
     "subagents"
+  ],
+  "src/domains/chat/hooks/use-conversation-switch.ts": [
+    "conversations",
+    "interactions",
+    "messaging"
   ],
   "src/domains/chat/hooks/use-event-stream.ts": [
     "conversations",

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -380,7 +380,6 @@ export function ChatPage() {
     previousConversationKeyRef,
     onboardingDraftConversationKeyRef,
     activeConversationKeyRef,
-    messagesRef,
     contextWindowUsageByConversationRef,
     dismissedSurfaceIdsRef,
     needsNewBubbleRef,

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -145,9 +145,9 @@ export function useConversationHistory({
   });
 
   // -------------------------------------------------------------------------
-  // Conversation-switch reset — extracted into its own hook (LUM-1739/4a).
-  // Owns the two refs (`switchResetRef`, `lastAppliedDataRef`) the data-apply
-  // effect below reads to decide between a fresh-switch replace and a
+  // Conversation-switch reset — delegated to a focused hook. Owns the two
+  // refs (`switchResetRef`, `lastAppliedDataRef`) the data-apply effect
+  // below reads to decide between a fresh-switch replace and a
   // background-refetch reconcile.
   // -------------------------------------------------------------------------
   const { switchResetRef, lastAppliedDataRef } = useConversationSwitch({

--- a/apps/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -26,26 +26,21 @@ import {
   type SetStateAction,
   startTransition,
   useEffect,
-  useRef,
 } from "react";
 
 import {
   type DisplayMessage,
   reconcileDisplayMessagesWithLatestHistory,
 } from "@/domains/chat/utils/reconcile.js";
-import {
-  filterDismissedSurfaces,
-  loadDismissedSurfaceIds,
-} from "@/domains/chat/utils/dismissed-surfaces-storage.js";
+import { filterDismissedSurfaces } from "@/domains/chat/utils/dismissed-surfaces-storage.js";
 import {
   recordChatDiagnostic,
   summarizeDisplayMessages,
 } from "@/domains/chat/utils/diagnostics.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
-import { useTurnStore } from "@/domains/messaging/turn-store.js";
-import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
 import type { SubagentStatus } from "@/domains/chat/api/event-types.js";
 
@@ -53,6 +48,7 @@ import {
   parsePendingSecretState,
   parsePendingConfirmationData,
 } from "@/domains/chat/hooks/use-send-message.js";
+import { useConversationSwitch } from "@/domains/chat/hooks/use-conversation-switch.js";
 import type { AssistantStateKind, ChatError } from "@/domains/chat/types.js";
 import { getPendingInteractions } from "@/domains/chat/api/interactions.js";
 import { fetchSurfaceContent } from "@/domains/chat/api/surfaces.js";
@@ -73,7 +69,6 @@ interface UseConversationHistoryParams {
   // Refs (owned by parent, read/written by this hook)
   draftKeyResolutionRef: MutableRefObject<boolean>;
   previousConversationKeyRef: MutableRefObject<string | null>;
-  messagesRef: MutableRefObject<DisplayMessage[]>;
 
   contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
@@ -118,7 +113,6 @@ export function useConversationHistory({
   activeConversationKey,
   draftKeyResolutionRef,
   previousConversationKeyRef,
-  messagesRef,
   contextWindowUsageByConversationRef,
   dismissedSurfaceIdsRef,
   needsNewBubbleRef,
@@ -150,96 +144,18 @@ export function useConversationHistory({
     enabled: assistantStateKind === "active" && !!assistantId && !!activeConversationKey,
   });
 
-  // Track the last applied data timestamp so we only run side effects once
-  // per TQ data update, not on every render.
-  const lastAppliedDataRef = useRef(0);
-  // Track whether a conversation-switch reset has occurred so the data-apply
-  // effect knows to replace messages (fresh switch) vs. reconcile (background
-  // refetch while streaming is active).
-  const switchResetRef = useRef(false);
-
   // -------------------------------------------------------------------------
-  // Conversation-switch reset
+  // Conversation-switch reset — extracted into its own hook (LUM-1739/4a).
+  // Owns the two refs (`switchResetRef`, `lastAppliedDataRef`) the data-apply
+  // effect below reads to decide between a fresh-switch replace and a
+  // background-refetch reconcile.
   // -------------------------------------------------------------------------
-  useEffect(() => {
-    if (assistantStateKind !== "active" || !assistantId || !activeConversationKey) {
-      return;
-    }
-
-    // Draft-key resolution (draft→server ID) is not a real switch.
-    if (draftKeyResolutionRef.current) {
-      draftKeyResolutionRef.current = false;
-      return;
-    }
-
-    // Track outgoing conversation's attention state.
-    const outgoingKey = previousConversationKeyRef.current;
-    const isConversationSwitch = Boolean(
-      outgoingKey && outgoingKey !== activeConversationKey,
-    );
-    if (isConversationSwitch && outgoingKey) {
-      const interactionSnapshot = useInteractionStore.getState();
-      if (interactionSnapshot.pendingSecret || interactionSnapshot.pendingConfirmation) {
-        useConversationStore.getState().addAttentionKey(outgoingKey);
-      }
-    }
-    previousConversationKeyRef.current = activeConversationKey;
-
-    recordChatDiagnostic("conversation_switch_reset", {
-      assistantId,
-      conversationKey: activeConversationKey,
-      outgoingConversationKey: outgoingKey ?? null,
-    });
-
-    // Reset all per-conversation state so nothing leaks between threads.
-    useTurnStore.getState().resetTurn();
-    setIsLoadingHistory(true);
-    needsNewBubbleRef.current = true;
-    setMessages([]);
-    streamingMessageIdsRef.current.clear();
-    pendingQueuedStableIdsRef.current = [];
-    requestIdToStableIdRef.current.clear();
-    pendingLocalDeletionsRef.current.clear();
-    setTranscriptPagination({
-      hasMore: false,
-      oldestTimestamp: null,
-      isLoadingOlder: false,
-      isPinnedToLatest: true,
-    });
-    useInteractionStore.getState().resetAll();
-    confirmationToolCallMapRef.current.clear();
-    setAutoGreetPending(false);
-    resetChatAttachments();
-    setSuggestion(null);
-    setCompactionCircuitOpenUntil(null);
-    lastSuggestionMsgIdRef.current = null;
-    setContextWindowUsage(
-      contextWindowUsageByConversationRef.current.get(activeConversationKey) ?? null,
-    );
-    dismissedSurfaceIdsRef.current = loadDismissedSurfaceIds(
-      assistantId,
-      activeConversationKey,
-    );
-    setError((prev) =>
-      shouldSuppressGenericChatErrorNotice(prev) ? prev : null,
-    );
-
-    // Signal that we're in a fresh-switch state — the data-apply effect
-    // should replace messages rather than reconcile.
-    switchResetRef.current = true;
-    lastAppliedDataRef.current = 0;
-  }, [
-    assistantStateKind,
+  const { switchResetRef, lastAppliedDataRef } = useConversationSwitch({
     assistantId,
+    assistantStateKind,
     activeConversationKey,
-    resetChatAttachments,
-    syncNeedsNewBubbleFromMessages,
-    // Refs (stable references, listed for completeness):
     draftKeyResolutionRef,
     previousConversationKeyRef,
-    messagesRef,
-    contextWindowUsageByConversationRef,
-    dismissedSurfaceIdsRef,
     needsNewBubbleRef,
     streamingMessageIdsRef,
     pendingQueuedStableIdsRef,
@@ -247,8 +163,8 @@ export function useConversationHistory({
     pendingLocalDeletionsRef,
     confirmationToolCallMapRef,
     lastSuggestionMsgIdRef,
-    autoGreetRef,
-    // Setters (stable references):
+    contextWindowUsageByConversationRef,
+    dismissedSurfaceIdsRef,
     setMessages,
     setTranscriptPagination,
     setIsLoadingHistory,
@@ -257,8 +173,9 @@ export function useConversationHistory({
     setContextWindowUsage,
     setSuggestion,
     setCompactionCircuitOpenUntil,
+    resetChatAttachments,
     shouldSuppressGenericChatErrorNotice,
-  ]);
+  });
 
   // -------------------------------------------------------------------------
   // Apply TanStack Query data to messages state

--- a/apps/web/src/domains/chat/hooks/use-conversation-switch.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-switch.ts
@@ -8,10 +8,6 @@
  * replace messages rather than reconcile, and resets
  * `lastAppliedDataRef` so the next TQ update is treated as the first one
  * for the new conversation.
- *
- * Extracted from `use-conversation-history.ts` as Phase 4a of LUM-1734.
- * Phase 5 (LUM-1740) will fold the rest of `use-conversation-loader.ts`
- * into focused hooks; this is the seam that makes that split clean.
  */
 
 import {

--- a/apps/web/src/domains/chat/hooks/use-conversation-switch.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-switch.ts
@@ -1,0 +1,214 @@
+/**
+ * Conversation-switch lifecycle — reset all per-conversation state when the
+ * user navigates to a different conversation.
+ *
+ * Owns the two refs (`switchResetRef`, `lastAppliedDataRef`) that mediate
+ * between a switch happening and the downstream TanStack Query data-apply
+ * step: the switch flips `switchResetRef` so the apply effect knows to
+ * replace messages rather than reconcile, and resets
+ * `lastAppliedDataRef` so the next TQ update is treated as the first one
+ * for the new conversation.
+ *
+ * Extracted from `use-conversation-history.ts` as Phase 4a of LUM-1734.
+ * Phase 5 (LUM-1740) will fold the rest of `use-conversation-loader.ts`
+ * into focused hooks; this is the seam that makes that split clean.
+ */
+
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+} from "react";
+
+import { useTurnStore } from "@/domains/messaging/turn-store.js";
+import { useInteractionStore } from "@/domains/interactions/interaction-store.js";
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import { recordChatDiagnostic } from "@/domains/chat/utils/diagnostics.js";
+import { loadDismissedSurfaceIds } from "@/domains/chat/utils/dismissed-surfaces-storage.js";
+import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
+import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
+import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
+import type { AssistantStateKind, ChatError } from "@/domains/chat/types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseConversationSwitchParams {
+  assistantId: string | null;
+  assistantStateKind: AssistantStateKind;
+  activeConversationKey: string | null;
+
+  // Refs owned by the parent that the reset clears or refreshes.
+  draftKeyResolutionRef: MutableRefObject<boolean>;
+  previousConversationKeyRef: MutableRefObject<string | null>;
+  needsNewBubbleRef: MutableRefObject<boolean>;
+  streamingMessageIdsRef: MutableRefObject<Set<string>>;
+  pendingQueuedStableIdsRef: MutableRefObject<string[]>;
+  requestIdToStableIdRef: MutableRefObject<Map<string, string>>;
+  pendingLocalDeletionsRef: MutableRefObject<Set<string>>;
+  confirmationToolCallMapRef: MutableRefObject<Map<string, string>>;
+  lastSuggestionMsgIdRef: MutableRefObject<string | null>;
+  contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
+  dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
+
+  // Setters wired into the surrounding chat-page state.
+  setMessages: Dispatch<SetStateAction<DisplayMessage[]>>;
+  setTranscriptPagination: Dispatch<SetStateAction<Omit<TranscriptPaginationState, "items">>>;
+  setIsLoadingHistory: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<ChatError | null>>;
+  setAutoGreetPending: Dispatch<SetStateAction<boolean>>;
+  setContextWindowUsage: Dispatch<SetStateAction<ContextWindowUsage | null>>;
+  setSuggestion: Dispatch<SetStateAction<string | null>>;
+  setCompactionCircuitOpenUntil: Dispatch<SetStateAction<Date | null>>;
+
+  resetChatAttachments: () => void;
+  shouldSuppressGenericChatErrorNotice: (prev: ChatError | null) => boolean;
+}
+
+export interface ConversationSwitchHandles {
+  /** True when the most recent switch-reset has fired and the data-apply
+   *  effect hasn't yet consumed it. Consumers should set this to `false`
+   *  after using it so subsequent background refetches reconcile instead
+   *  of replace. */
+  switchResetRef: MutableRefObject<boolean>;
+  /** Timestamp (matching TanStack Query's `dataUpdatedAt`) of the last
+   *  history payload the consumer applied. Reset to `0` on every switch
+   *  so the next payload always triggers an apply for the new
+   *  conversation. */
+  lastAppliedDataRef: MutableRefObject<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useConversationSwitch({
+  assistantId,
+  assistantStateKind,
+  activeConversationKey,
+  draftKeyResolutionRef,
+  previousConversationKeyRef,
+  needsNewBubbleRef,
+  streamingMessageIdsRef,
+  pendingQueuedStableIdsRef,
+  requestIdToStableIdRef,
+  pendingLocalDeletionsRef,
+  confirmationToolCallMapRef,
+  lastSuggestionMsgIdRef,
+  contextWindowUsageByConversationRef,
+  dismissedSurfaceIdsRef,
+  setMessages,
+  setTranscriptPagination,
+  setIsLoadingHistory,
+  setError,
+  setAutoGreetPending,
+  setContextWindowUsage,
+  setSuggestion,
+  setCompactionCircuitOpenUntil,
+  resetChatAttachments,
+  shouldSuppressGenericChatErrorNotice,
+}: UseConversationSwitchParams): ConversationSwitchHandles {
+  const switchResetRef = useRef(false);
+  const lastAppliedDataRef = useRef(0);
+
+  useEffect(() => {
+    if (assistantStateKind !== "active" || !assistantId || !activeConversationKey) {
+      return;
+    }
+
+    // Draft-key resolution (draft→server ID) is not a real switch.
+    if (draftKeyResolutionRef.current) {
+      draftKeyResolutionRef.current = false;
+      return;
+    }
+
+    // Track outgoing conversation's attention state.
+    const outgoingKey = previousConversationKeyRef.current;
+    const isConversationSwitch = Boolean(
+      outgoingKey && outgoingKey !== activeConversationKey,
+    );
+    if (isConversationSwitch && outgoingKey) {
+      const interactionSnapshot = useInteractionStore.getState();
+      if (interactionSnapshot.pendingSecret || interactionSnapshot.pendingConfirmation) {
+        useConversationStore.getState().addAttentionKey(outgoingKey);
+      }
+    }
+    previousConversationKeyRef.current = activeConversationKey;
+
+    recordChatDiagnostic("conversation_switch_reset", {
+      assistantId,
+      conversationKey: activeConversationKey,
+      outgoingConversationKey: outgoingKey ?? null,
+    });
+
+    // Reset all per-conversation state so nothing leaks between threads.
+    useTurnStore.getState().resetTurn();
+    setIsLoadingHistory(true);
+    needsNewBubbleRef.current = true;
+    setMessages([]);
+    streamingMessageIdsRef.current.clear();
+    pendingQueuedStableIdsRef.current = [];
+    requestIdToStableIdRef.current.clear();
+    pendingLocalDeletionsRef.current.clear();
+    setTranscriptPagination({
+      hasMore: false,
+      oldestTimestamp: null,
+      isLoadingOlder: false,
+      isPinnedToLatest: true,
+    });
+    useInteractionStore.getState().resetAll();
+    confirmationToolCallMapRef.current.clear();
+    setAutoGreetPending(false);
+    resetChatAttachments();
+    setSuggestion(null);
+    setCompactionCircuitOpenUntil(null);
+    lastSuggestionMsgIdRef.current = null;
+    setContextWindowUsage(
+      contextWindowUsageByConversationRef.current.get(activeConversationKey) ?? null,
+    );
+    dismissedSurfaceIdsRef.current = loadDismissedSurfaceIds(
+      assistantId,
+      activeConversationKey,
+    );
+    setError((prev) =>
+      shouldSuppressGenericChatErrorNotice(prev) ? prev : null,
+    );
+
+    // Signal that we're in a fresh-switch state — the data-apply effect
+    // should replace messages rather than reconcile.
+    switchResetRef.current = true;
+    lastAppliedDataRef.current = 0;
+  }, [
+    assistantStateKind,
+    assistantId,
+    activeConversationKey,
+    resetChatAttachments,
+    // Refs (stable references, listed for completeness):
+    draftKeyResolutionRef,
+    previousConversationKeyRef,
+    contextWindowUsageByConversationRef,
+    dismissedSurfaceIdsRef,
+    needsNewBubbleRef,
+    streamingMessageIdsRef,
+    pendingQueuedStableIdsRef,
+    requestIdToStableIdRef,
+    pendingLocalDeletionsRef,
+    confirmationToolCallMapRef,
+    lastSuggestionMsgIdRef,
+    // Setters (stable references):
+    setMessages,
+    setTranscriptPagination,
+    setIsLoadingHistory,
+    setError,
+    setAutoGreetPending,
+    setContextWindowUsage,
+    setSuggestion,
+    setCompactionCircuitOpenUntil,
+    shouldSuppressGenericChatErrorNotice,
+  ]);
+
+  return { switchResetRef, lastAppliedDataRef };
+}

--- a/apps/web/src/domains/conversations/use-conversation-loader.ts
+++ b/apps/web/src/domains/conversations/use-conversation-loader.ts
@@ -82,7 +82,6 @@ interface UseConversationLoaderParams {
   previousConversationKeyRef: MutableRefObject<string | null>;
   onboardingDraftConversationKeyRef: MutableRefObject<string | null>;
   activeConversationKeyRef: MutableRefObject<string | null>;
-  messagesRef: MutableRefObject<DisplayMessage[]>;
   contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
   dismissedSurfaceIdsRef: MutableRefObject<Set<string>>;
   needsNewBubbleRef: MutableRefObject<boolean>;
@@ -152,7 +151,6 @@ export function useConversationLoader({
   previousConversationKeyRef,
   onboardingDraftConversationKeyRef,
   activeConversationKeyRef,
-  messagesRef,
   contextWindowUsageByConversationRef,
   dismissedSurfaceIdsRef,
   needsNewBubbleRef,
@@ -405,7 +403,6 @@ export function useConversationLoader({
     activeConversationKey,
     draftKeyResolutionRef,
     previousConversationKeyRef,
-    messagesRef,
     contextWindowUsageByConversationRef,
     dismissedSurfaceIdsRef,
     needsNewBubbleRef,


### PR DESCRIPTION
## Summary

Phase 4a of [LUM-1734](https://linear.app/vellum/issue/LUM-1734) — extract the conversation-switch lifecycle into its own focused hook. **No behavior change.** This is the structural seam that the rest of Phase 4 (per-conversation dismissed-surface storage) and Phase 5 (delete `use-conversation-loader.ts`) can land against as smaller follow-ups.

### What moved

- New `apps/web/src/domains/chat/hooks/use-conversation-switch.ts` owns:
  - The conversation-switch reset effect (formerly `use-conversation-history.ts:164–261`).
  - The two refs (`switchResetRef`, `lastAppliedDataRef`) that mediate between a switch and the downstream TanStack Query data-apply step. The hook returns them so the data-apply effect can read them.

- `use-conversation-history.ts` now calls `useConversationSwitch` and contains only the TQ data-apply, older-page sync, and error effects. ~85 lines of switch logic + 25 lines of redundant-deps cleanup gone.

- `messagesRef` was threaded through three layers (`chat-page` → `useConversationLoader` → `useConversationHistory`) but never read inside the hook (a leftover from earlier shape). Dropped from the chain.

### Allowlist

Regenerated by `scripts/audit-cross-domain-imports.mjs` — `messaging` moved from `use-conversation-history` to `use-conversation-switch` (where `useTurnStore` now lives); rest of the cross-domain imports follow.

### Out of scope (deferred)

- Replacing the page-level `dismissedSurfaceIdsRef` with a per-conversation `useLocalStorage` hook (next sub-PR; the storage layer already exists via `dismissed-surfaces-storage.ts`).
- Deleting `use-conversation-loader.ts` (Phase 5 / LUM-1740).
- New tests for cross-conversation stream isolation and graduation — both die-by-construction once Phase 4 lands fully, but those test additions belong with the remaining work.

Closes LUM-1739 (partial — Phase 4a).

## Test plan

- [x] `bun run test:ci` — 100 / 100 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (1 preexisting unrelated warning)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181LfJ6Lapx1LKyrrnDZ3Vh)_