### PR TITLE
fix(web): subscribe to assistant-global sync events at layout scope (LUM-1791)

### DIFF
--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -58,14 +58,6 @@
   "src/domains/chat/hooks/use-assistant-lifecycle.ts": [
     "onboarding"
   ],
-  "src/domains/chat/hooks/use-assistant-sync-stream.test.tsx": [
-    "avatar",
-    "conversations"
-  ],
-  "src/domains/chat/hooks/use-assistant-sync-stream.ts": [
-    "avatar",
-    "conversations"
-  ],
   "src/domains/chat/hooks/use-conversation-history.ts": [
     "conversations",
     "interactions",

--- a/apps/web/.cross-domain-allowlist.json
+++ b/apps/web/.cross-domain-allowlist.json
@@ -58,6 +58,14 @@
   "src/domains/chat/hooks/use-assistant-lifecycle.ts": [
     "onboarding"
   ],
+  "src/domains/chat/hooks/use-assistant-sync-stream.test.tsx": [
+    "avatar",
+    "conversations"
+  ],
+  "src/domains/chat/hooks/use-assistant-sync-stream.ts": [
+    "avatar",
+    "conversations"
+  ],
   "src/domains/chat/hooks/use-conversation-history.ts": [
     "conversations",
     "interactions",

--- a/apps/web/src/domains/avatar/use-assistant-avatar.ts
+++ b/apps/web/src/domains/avatar/use-assistant-avatar.ts
@@ -7,17 +7,12 @@ import {
   fetchAvatarImageUrl,
 } from "./api.js";
 import type { CharacterComponents, CharacterTraits } from "./types.js";
+import { avatarQueryKey } from "@/lib/sync/query-tags.js";
 
 interface AvatarData {
   components: CharacterComponents | null;
   traits: CharacterTraits | null;
   customImageUrl: string | null;
-}
-
-export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
-
-export function avatarQueryKey(assistantId: string) {
-  return [AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
 }
 
 const activeBlobUrls = new Map<string, string>();

--- a/apps/web/src/domains/avatar/use-assistant-avatar.ts
+++ b/apps/web/src/domains/avatar/use-assistant-avatar.ts
@@ -14,9 +14,9 @@ interface AvatarData {
   customImageUrl: string | null;
 }
 
-const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
+export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
 
-function avatarQueryKey(assistantId: string) {
+export function avatarQueryKey(assistantId: string) {
   return [AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
 }
 

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -13,6 +13,7 @@ import { routes } from "@/utils/routes.js";
 import { MOBILE_MEDIA_QUERY, useIsMobile } from "@/hooks/use-is-mobile.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { useAssistantLifecycle } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+import { useAssistantSyncStream } from "@/domains/chat/hooks/use-assistant-sync-stream.js";
 import { useAssistantIdentityInit } from "@/hooks/use-assistant-identity-init.js";
 import { useAssistantAvatar } from "@/domains/avatar/use-assistant-avatar.js";
 import { useDynamicFavicon } from "@/domains/avatar/use-dynamic-favicon.js";
@@ -186,6 +187,14 @@ export function ChatLayout() {
     layoutAvatar.components,
     layoutAvatar.traits,
   );
+
+  // Layout-scoped SSE subscriber for assistant-global sync events.
+  // ChatPage owns the conversation-scoped stream; this one keeps the
+  // avatar / identity / config / sounds / schedules / conversation list
+  // caches reactive on every assistant route — not just inside a
+  // conversation. See use-assistant-sync-stream.ts for the event
+  // routing contract.
+  useAssistantSyncStream(lifecycle.assistantId, isAssistantActive);
 
   // Home page unread indicator — drives the red dot on the Home button in
   // the layout header. Gated on the homePage feature flag so the hook

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
@@ -1,0 +1,212 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
+import { avatarQueryKey } from "@/domains/avatar/use-assistant-avatar.js";
+import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init.js";
+import { chatContextQueryKey } from "@/domains/conversations/conversation-queries.js";
+import {
+  assistantDaemonConfigQueryKey,
+  assistantSoundsConfigQueryKey,
+  assistantSchedulesQueryKey,
+} from "@/lib/sync/query-tags.js";
+import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types.js";
+
+type EventHandler = (event: AssistantEvent) => void;
+
+let activeHandler: EventHandler | null = null;
+let lastSubscribeArgs: {
+  assistantId: string;
+  conversationKey: string | null | undefined;
+} | null = null;
+const cancelMock = mock(() => {});
+const subscribeChatEventsMock = mock(
+  (
+    assistantId: string,
+    conversationKey: string | null | undefined,
+    onEvent: EventHandler,
+    _onError: (err: Error) => void,
+  ) => {
+    lastSubscribeArgs = { assistantId, conversationKey };
+    activeHandler = onEvent;
+    return { cancel: cancelMock };
+  },
+);
+
+mock.module("@/domains/chat/api/stream.js", () => ({
+  subscribeChatEvents: subscribeChatEventsMock,
+}));
+
+const { useAssistantSyncStream } = await import(
+  "@/domains/chat/hooks/use-assistant-sync-stream.js"
+);
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function freshQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function syncEvent(tags: string[]): SyncChangedEvent {
+  return { type: "sync_changed", tags };
+}
+
+beforeEach(() => {
+  activeHandler = null;
+  lastSubscribeArgs = null;
+  cancelMock.mockClear();
+  subscribeChatEventsMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useAssistantSyncStream", () => {
+  test("does not subscribe when assistant is not active", () => {
+    const queryClient = freshQueryClient();
+    renderHook(() => useAssistantSyncStream("asst-1", false), {
+      wrapper: createWrapper(queryClient),
+    });
+    expect(subscribeChatEventsMock).not.toHaveBeenCalled();
+  });
+
+  test("does not subscribe when assistantId is null", () => {
+    const queryClient = freshQueryClient();
+    renderHook(() => useAssistantSyncStream(null, true), {
+      wrapper: createWrapper(queryClient),
+    });
+    expect(subscribeChatEventsMock).not.toHaveBeenCalled();
+  });
+
+  test("opens an unfiltered (null conversation key) stream when active", () => {
+    const queryClient = freshQueryClient();
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    expect(subscribeChatEventsMock).toHaveBeenCalledTimes(1);
+    expect(lastSubscribeArgs).toEqual({
+      assistantId: "asst-1",
+      conversationKey: null,
+    });
+  });
+
+  test("cancels the stream on unmount", () => {
+    const queryClient = freshQueryClient();
+    const { unmount } = renderHook(
+      () => useAssistantSyncStream("asst-1", true),
+      { wrapper: createWrapper(queryClient) },
+    );
+    expect(cancelMock).not.toHaveBeenCalled();
+    unmount();
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalidates avatar query on assistant:self:avatar sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!(syncEvent([SYNC_TAGS.assistantAvatar]));
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        queryKey: avatarQueryKey("asst-1"),
+      });
+    });
+  });
+
+  test("invalidates identity query on assistant:self:identity sync tag", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!(syncEvent([SYNC_TAGS.assistantIdentity]));
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        queryKey: assistantIdentityQueryKey("asst-1"),
+      });
+    });
+  });
+
+  test("invalidates config / sounds / schedules queries on their sync tags", async () => {
+    const queryClient = freshQueryClient();
+    const calls: unknown[][] = [];
+    queryClient.invalidateQueries = ((arg: unknown) => {
+      calls.push([arg]);
+      return Promise.resolve();
+    }) as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!(
+      syncEvent([
+        SYNC_TAGS.assistantConfig,
+        SYNC_TAGS.assistantSounds,
+        SYNC_TAGS.assistantSchedules,
+      ]),
+    );
+    await waitFor(() => {
+      const queryKeys = calls.map(
+        ([arg]) => (arg as { queryKey: readonly unknown[] }).queryKey,
+      );
+      expect(queryKeys).toEqual(
+        expect.arrayContaining([
+          assistantDaemonConfigQueryKey("asst-1"),
+          assistantSoundsConfigQueryKey("asst-1"),
+          assistantSchedulesQueryKey("asst-1"),
+        ]) as never,
+      );
+    });
+  });
+
+  test("debounces conversations:list invalidation", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!(syncEvent([SYNC_TAGS.conversationsList]));
+    activeHandler!(syncEvent([SYNC_TAGS.conversationsList]));
+    activeHandler!(syncEvent([SYNC_TAGS.conversationsList]));
+    // Debounced — wait past the 250ms window.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const listCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
+      (call) => {
+        const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
+        return arg?.queryKey?.[0] === chatContextQueryKey("asst-1")[0];
+      },
+    );
+    expect(listCalls.length).toBe(1);
+  });
+
+  test("ignores conversation-scoped events (text deltas, tool calls, etc.)", () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    // Fabricate a non-sync event — handler should not touch the cache.
+    activeHandler!({
+      type: "assistant_text_delta",
+      conversationId: "convo-1",
+      delta: "hi",
+    } as unknown as AssistantEvent);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
@@ -4,13 +4,13 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
-import { avatarQueryKey } from "@/domains/avatar/use-assistant-avatar.js";
 import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init.js";
-import { chatContextQueryKey } from "@/domains/conversations/conversation-queries.js";
 import {
   assistantDaemonConfigQueryKey,
-  assistantSoundsConfigQueryKey,
   assistantSchedulesQueryKey,
+  assistantSoundsConfigQueryKey,
+  avatarQueryKey,
+  chatContextQueryKey,
 } from "@/lib/sync/query-tags.js";
 import { SYNC_TAGS, type SyncChangedEvent } from "@/lib/sync/types.js";
 
@@ -208,5 +208,44 @@ describe("useAssistantSyncStream", () => {
       delta: "hi",
     } as unknown as AssistantEvent);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("per-conversation metadata/messages tags schedule a debounced list refresh", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!(syncEvent(["conversation:abc:metadata"]));
+    activeHandler!(syncEvent(["conversation:abc:messages"]));
+    // Both tags fall into the default branch and trigger the
+    // debounced sidebar refresh — coalesced into a single invalidate.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const listCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
+      (call) => {
+        const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
+        return arg?.queryKey?.[0] === chatContextQueryKey("asst-1")[0];
+      },
+    );
+    expect(listCalls.length).toBe(1);
+  });
+
+  test("cancels the stream when isAssistantActive flips true -> false", () => {
+    const queryClient = freshQueryClient();
+    const { rerender } = renderHook(
+      ({ active }: { active: boolean }) =>
+        useAssistantSyncStream("asst-1", active),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { active: true },
+      },
+    );
+    expect(subscribeChatEventsMock).toHaveBeenCalledTimes(1);
+    expect(cancelMock).not.toHaveBeenCalled();
+    rerender({ active: false });
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+    // Stays cancelled — no new subscribe while inactive.
+    expect(subscribeChatEventsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.test.tsx
@@ -231,6 +231,33 @@ describe("useAssistantSyncStream", () => {
     expect(listCalls.length).toBe(1);
   });
 
+  test("invalidates home-feed queries on home_feed_updated and relationship_state_updated", async () => {
+    const queryClient = freshQueryClient();
+    const spy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = spy as never;
+    renderHook(() => useAssistantSyncStream("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    activeHandler!({
+      type: "home_feed_updated",
+      updatedAt: "2026-05-21T00:00:00Z",
+      newItemCount: 1,
+    } as unknown as AssistantEvent);
+    activeHandler!({
+      type: "relationship_state_updated",
+      updatedAt: "2026-05-21T00:00:00Z",
+    } as unknown as AssistantEvent);
+    await waitFor(() => {
+      const homeCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
+        (call) => {
+          const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
+          return arg?.queryKey?.[0] === "home-feed";
+        },
+      );
+      expect(homeCalls.length).toBe(2);
+    });
+  });
+
   test("cancels the stream when isAssistantActive flips true -> false", () => {
     const queryClient = freshQueryClient();
     const { rerender } = renderHook(

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
@@ -1,0 +1,158 @@
+/**
+ * Layout-scoped subscriber for assistant-global SSE events.
+ *
+ * Opens an unfiltered `/v1/events` connection (no conversation key) and
+ * routes `sync_changed` invalidations into the React Query caches that
+ * back avatar, identity, config, sounds, schedules, and the conversation
+ * list. Per-conversation events (text deltas, tool calls, interactions,
+ * per-conversation message tags) are ignored here — those are owned by
+ * the conversation-scoped `useEventStream` mounted in ChatPage.
+ *
+ * Mount in ChatLayout so global state stays live on every assistant
+ * sibling route (home, identity, library, workspace, contacts, inspect),
+ * not just `/assistant/conversations/:key`. Concurrent with ChatPage's
+ * stream when the user is in a conversation — the daemon supports
+ * multiple subscribers per assistant and the React Query invalidations
+ * are idempotent.
+ */
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import * as Sentry from "@sentry/browser";
+
+import { subscribeChatEvents } from "@/domains/chat/api/stream.js";
+import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
+import { avatarQueryKey } from "@/domains/avatar/use-assistant-avatar.js";
+import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init.js";
+import {
+  chatContextQueryKey,
+  conversationGroupsQueryKey,
+} from "@/domains/conversations/conversation-queries.js";
+import {
+  assistantDaemonConfigQueryKey,
+  assistantScheduleRunsQueryKey,
+  assistantSchedulesQueryKey,
+  assistantSoundsAvailableQueryKey,
+  assistantSoundsConfigQueryKey,
+} from "@/lib/sync/query-tags.js";
+import {
+  isConversationMessagesSyncTag,
+  isConversationMetadataSyncTag,
+  SYNC_TAGS,
+  type SyncChangedEvent,
+} from "@/lib/sync/types.js";
+
+const CONVERSATION_LIST_DEBOUNCE_MS = 250;
+
+/**
+ * Subscribes to assistant-global sync events at layout scope.
+ *
+ * Idempotent across remounts and safe to call when the assistant is not
+ * active (returns without opening a connection).
+ */
+export function useAssistantSyncStream(
+  assistantId: string | null,
+  isAssistantActive: boolean,
+): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!assistantId || !isAssistantActive) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleConversationListRefetch = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        void queryClient.invalidateQueries({
+          queryKey: chatContextQueryKey(assistantId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: conversationGroupsQueryKey(assistantId),
+        });
+      }, CONVERSATION_LIST_DEBOUNCE_MS);
+    };
+
+    const handleSyncChanged = (event: SyncChangedEvent) => {
+      for (const tag of event.tags) {
+        switch (tag) {
+          case SYNC_TAGS.assistantAvatar:
+            void queryClient.invalidateQueries({
+              queryKey: avatarQueryKey(assistantId),
+            });
+            break;
+          case SYNC_TAGS.assistantIdentity:
+            void queryClient.invalidateQueries({
+              queryKey: assistantIdentityQueryKey(assistantId),
+            });
+            break;
+          case SYNC_TAGS.assistantConfig:
+            void queryClient.invalidateQueries({
+              queryKey: assistantDaemonConfigQueryKey(assistantId),
+            });
+            break;
+          case SYNC_TAGS.assistantSounds:
+            void queryClient.invalidateQueries({
+              queryKey: assistantSoundsConfigQueryKey(assistantId),
+            });
+            void queryClient.invalidateQueries({
+              queryKey: assistantSoundsAvailableQueryKey(assistantId),
+            });
+            break;
+          case SYNC_TAGS.assistantSchedules:
+            void queryClient.invalidateQueries({
+              queryKey: assistantSchedulesQueryKey(assistantId),
+            });
+            void queryClient.invalidateQueries({
+              queryKey: assistantScheduleRunsQueryKey(assistantId),
+            });
+            break;
+          case SYNC_TAGS.conversationsList:
+            scheduleConversationListRefetch();
+            break;
+          default:
+            // Per-conversation message/metadata tags also bump the
+            // sidebar list. The per-conversation message fetch itself
+            // is owned by ChatPage's stream — we only debounce a list
+            // refresh here so the sidebar stays current on every
+            // route.
+            if (
+              isConversationMetadataSyncTag(tag) ||
+              isConversationMessagesSyncTag(tag)
+            ) {
+              scheduleConversationListRefetch();
+            }
+            break;
+        }
+      }
+    };
+
+    const handleEvent = (event: AssistantEvent) => {
+      if (event.type === "sync_changed") {
+        handleSyncChanged(event);
+      }
+      // All other event types (assistant_text_delta, tool_*, message_*,
+      // confirmation_request, etc.) are conversation-scoped and handled
+      // by ChatPage's useEventStream. Ignoring them here is intentional.
+    };
+
+    const handleError = (err: Error) => {
+      Sentry.captureException(err, {
+        level: "warning",
+        tags: { context: "assistant_sync_stream" },
+      });
+    };
+
+    const stream = subscribeChatEvents(
+      assistantId,
+      null,
+      handleEvent,
+      handleError,
+    );
+
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      stream.cancel();
+    };
+  }, [assistantId, isAssistantActive, queryClient]);
+}

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
@@ -22,18 +22,16 @@ import * as Sentry from "@sentry/browser";
 
 import { subscribeChatEvents } from "@/domains/chat/api/stream.js";
 import type { AssistantEvent } from "@/domains/chat/api/event-types.js";
-import { avatarQueryKey } from "@/domains/avatar/use-assistant-avatar.js";
 import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init.js";
-import {
-  chatContextQueryKey,
-  conversationGroupsQueryKey,
-} from "@/domains/conversations/conversation-queries.js";
 import {
   assistantDaemonConfigQueryKey,
   assistantScheduleRunsQueryKey,
   assistantSchedulesQueryKey,
   assistantSoundsAvailableQueryKey,
   assistantSoundsConfigQueryKey,
+  avatarQueryKey,
+  chatContextQueryKey,
+  conversationGroupsQueryKey,
 } from "@/lib/sync/query-tags.js";
 import {
   isConversationMessagesSyncTag,

--- a/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
+++ b/apps/web/src/domains/chat/hooks/use-assistant-sync-stream.ts
@@ -126,12 +126,25 @@ export function useAssistantSyncStream(
     };
 
     const handleEvent = (event: AssistantEvent) => {
-      if (event.type === "sync_changed") {
-        handleSyncChanged(event);
+      switch (event.type) {
+        case "sync_changed":
+          handleSyncChanged(event);
+          return;
+        case "home_feed_updated":
+        case "relationship_state_updated":
+          // Broadcast events that mutate home-feed-derived state
+          // (home page list + sidebar unread-home indicator). Invalidate
+          // by prefix so every home-feed query key for the assistant is
+          // refreshed, matching the existing per-conversation handler.
+          void queryClient.invalidateQueries({ queryKey: ["home-feed"] });
+          return;
+        default:
+          // All other event types (assistant_text_delta, tool_*,
+          // message_*, confirmation_request, etc.) are
+          // conversation-scoped and handled by ChatPage's
+          // useEventStream. Ignoring them here is intentional.
+          return;
       }
-      // All other event types (assistant_text_delta, tool_*, message_*,
-      // confirmation_request, etc.) are conversation-scoped and handled
-      // by ChatPage's useEventStream. Ignoring them here is intentional.
     };
 
     const handleError = (err: Error) => {

--- a/apps/web/src/domains/conversations/conversation-queries.ts
+++ b/apps/web/src/domains/conversations/conversation-queries.ts
@@ -44,16 +44,19 @@ import {
 // Query keys
 // ---------------------------------------------------------------------------
 
-export const CHAT_CONTEXT_QUERY_KEY = "chat-context" as const;
-export const CONVERSATION_GROUPS_QUERY_KEY = "conversation-groups" as const;
+import {
+  CHAT_CONTEXT_QUERY_KEY,
+  CONVERSATION_GROUPS_QUERY_KEY,
+  chatContextQueryKey,
+  conversationGroupsQueryKey,
+} from "@/lib/sync/query-tags.js";
 
-export function chatContextQueryKey(assistantId: string | null) {
-  return [CHAT_CONTEXT_QUERY_KEY, assistantId ?? ""] as const;
-}
-
-export function conversationGroupsQueryKey(assistantId: string | null) {
-  return [CONVERSATION_GROUPS_QUERY_KEY, assistantId ?? ""] as const;
-}
+export {
+  CHAT_CONTEXT_QUERY_KEY,
+  CONVERSATION_GROUPS_QUERY_KEY,
+  chatContextQueryKey,
+  conversationGroupsQueryKey,
+};
 
 // ---------------------------------------------------------------------------
 // Queries

--- a/apps/web/src/lib/sync/query-tags.ts
+++ b/apps/web/src/lib/sync/query-tags.ts
@@ -1,5 +1,22 @@
 import type { QueryClient } from "@tanstack/react-query";
 
+export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
+
+export function avatarQueryKey(assistantId: string) {
+  return [AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
+}
+
+export const CHAT_CONTEXT_QUERY_KEY = "chat-context" as const;
+export const CONVERSATION_GROUPS_QUERY_KEY = "conversation-groups" as const;
+
+export function chatContextQueryKey(assistantId: string | null) {
+  return [CHAT_CONTEXT_QUERY_KEY, assistantId ?? ""] as const;
+}
+
+export function conversationGroupsQueryKey(assistantId: string | null) {
+  return [CONVERSATION_GROUPS_QUERY_KEY, assistantId ?? ""] as const;
+}
+
 export function assistantDaemonConfigQueryKey(
   assistantId: string | null | undefined,
 ) {


### PR DESCRIPTION
PR 1 of the staged rollout described in [LUM-1791](https://linear.app/vellum/issue/LUM-1791). Follow-up to [LUM-1790](https://linear.app/vellum/issue/LUM-1790) (favicon hoist), which patched the most visible symptom of the same underlying gap.

## Problem

`useEventStream` (`apps/web/src/domains/chat/chat-page.tsx`) is conversation-scoped. It only opens when `assistantStateKind === "active" && activeConversationKey && conversationExistsOnServer`. On every sibling route under `ChatLayout` — `/assistant/home`, `/identity`, `/library`, `/workspace`, `/contacts`, `/inspect` — no SSE subscriber is mounted, so every `sync_changed` invalidation the daemon emits for assistant-global state goes to `/dev/null`.

Affected:

| Daemon source (`assistant/src/runtime/sync/resource-sync-events.ts`) | Tag | Symptom on non-chat routes |
| --- | --- | --- |
| `publishAvatarChanged` | `assistant:self:avatar` | Stale avatar/favicon (mitigated for local edits by LUM-1790) |
| `publishIdentityChanged` | `assistant:self:identity` | Stale assistant name/role/personality |
| `publishConfigChanged` | `assistant:self:config` | Stale daemon config |
| `publishSoundsConfigUpdated` | `assistant:self:sounds` | Stale sounds settings |
| `publishSchedulesChanged` | `assistant:self:schedules` | Stale schedules list |
| `publishConversationListChanged` | `conversations:list` | Stale sidebar conversation list |

This **is a regression**: in `vellum-assistant-platform` every non-chat sub-route's `page.tsx` rendered `<AssistantPageClient />` (see `identity/page.tsx`, `home/page.tsx`, etc. — five identical one-liners), and `AssistantPageClient` owned `useEventStream`. The OSS port split that monolith into separate route components but kept the stream inside `ChatPage` only.

## Fix

Add a layout-scoped `useAssistantSyncStream` that:

- Opens `subscribeChatEvents(assistantId, null, ...)` — the daemon broadcasts global events to any subscriber regardless of conversation key (per `assistant/src/runtime/assistant-event-hub.ts`).
- Routes only `sync_changed` events through React Query invalidation for avatar / identity / config / sounds / schedules / conversation list query keys.
- Ignores all conversation-scoped events (text deltas, tool calls, interactions, per-conversation messages). Those remain `ChatPage`'s responsibility — its existing stream is untouched.
- Debounces sidebar list refresh (250 ms trailing edge) to match the existing `scheduleConversationListRefetch` debounce in `useConversationLoader`.

When the user is in a conversation, two concurrent SSE subscribers run (layout + page). The daemon supports it (each subscriber has its own `ReadableStream`, per-subscriber backpressure shedding), and React Query invalidations are idempotent.

The hook is self-contained — no React Context, no `useReducer` for cross-component state. State sharing happens via `queryClient` (server data) and the existing Zustand identity store (which `useAssistantIdentityInit` already drives off the React Query result). Matches the codebase's documented conventions, not the platform's `AssistantPageClient` monolith pattern.

## Scope

Routes under `ChatLayout`: `/assistant`, `/assistant/conversations/:key`, `/assistant/documents/:id`, `/assistant/home`, `/assistant/identity`, `/assistant/library`, `/assistant/workspace`, `/assistant/contacts`, `/assistant/inspect`.

Out of scope (file a follow-up if needed): `/assistant/settings/*` and `/assistant/logs/*`. Those live under their own layouts in OSS. Platform handled them via a separate `settings-sync-bridge.tsx`; OSS will need an equivalent if those routes need live sync.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (no new errors; one pre-existing unrelated warning)
- [x] `bun test src/domains/chat/hooks/use-assistant-sync-stream.test.tsx` — 9 tests covering: no subscribe when inactive / no assistant; unfiltered subscribe with `conversationKey === null`; cancel on unmount; correct query invalidation for each tag; debounced list refresh; ignore conversation-scoped events
- [ ] Manual: open `/assistant/identity`, change avatar from a second tab/device, confirm favicon + identity-tab avatar update without leaving the page
- [ ] Manual: confirm in DevTools Network that two SSE connections open on `/assistant/conversations/:key` (one with `?conversationKey=...`, one without), and one open on `/assistant/identity`
- [ ] Manual: leave `/assistant/identity` for >1 minute, confirm the watchdog reconnect logs still fire

## Follow-ups (not in this PR)

- PR 2: kill the 10 s `setInterval` in `useAttentionTracking` (`apps/web/src/domains/conversations/use-attention-tracking.ts:198`) and react to the layout-level SSE instead.
- PR 3: wire `home_feed_updated` / `relationship_state_updated` into `useHomeUnreadBadge` for real-time updates instead of focus-refetch.
- PR 4 (optional): consolidate down to a single layout-owned stream by hoisting `useEventStream` + its refs out of `ChatPage`. Defer until the dual-subscriber model has bake time.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZRbrYUcANTbkSCjoCS51M)_