### PR TITLE
fix(web): align document comment popover and sidebar with design system tokens

### DIFF
--- a/apps/web/src/domains/chat/components/document-comment-panel.tsx
+++ b/apps/web/src/domains/chat/components/document-comment-panel.tsx
@@ -170,7 +170,7 @@ export function DocumentCommentPanel({
   );
 
   return (
-    <div className="flex h-full w-80 flex-col border-l border-[var(--border-base)] bg-[var(--surface-overlay)]">
+    <div className="flex h-full w-80 flex-col border-l border-[var(--border-base)] bg-[var(--surface-lift)]">
       <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-base)] px-4 py-3">
         <MessageSquareText
           size={16}

--- a/apps/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/apps/web/src/domains/chat/components/document-viewer-container.tsx
@@ -367,7 +367,7 @@ export function DocumentViewerContainer({
           {/* Floating inline comment popover anchored to selection */}
           {commentsPanelOpen && textSelection ? (
             <div
-              className="absolute z-10 w-72 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] shadow-lg"
+              className="absolute z-10 w-72 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] shadow-[var(--shadow-popover)]"
               style={
                 textSelection.rect && iframeRef.current
                   ? (() => {
@@ -395,14 +395,14 @@ export function DocumentViewerContainer({
                 <Button
                   variant="ghost"
                   size="compact"
-                  iconOnly={<X className="h-3 w-3" />}
+                  iconOnly={<X />}
                   aria-label="Dismiss"
                   onClick={handleDismissInlinePopover}
                 />
               </div>
               <div className="p-3">
                 <textarea
-                  className="w-full resize-none rounded-md border border-[var(--border-base)] bg-[var(--surface-base)] px-2 py-1.5 text-sm text-[var(--content-emphasised)] placeholder:text-[var(--content-tertiary)] focus:border-[var(--border-focus)] focus:outline-none"
+                  className="w-full resize-none rounded-md border border-[var(--field-border)] bg-[var(--field-bg)] px-3 py-2 text-body-medium-lighter text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-[border-color] duration-150 ease-out focus-visible:border-[var(--border-active)]"
                   rows={2}
                   placeholder="Add your feedback…"
                   value={inlineCommentDraft}


### PR DESCRIPTION
## Summary
- Align inline comment popover surface/shadow with Popover.Content pattern (--surface-lift, --shadow-popover)
- Replace hand-rolled textarea styling with fieldVariants tokens (--field-bg, --field-border, --border-active)
- Fix sidebar panel background to --surface-lift matching SubagentDetailPanel pattern

Part of plan: doc-comment-styling.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->