### PR TITLE
feat(apps-web): add task_preferences daemon-driven surface

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -14,6 +14,7 @@ import { FormSurface } from "@/domains/chat/components/surfaces/form-surface.js"
 import { ListSurface } from "@/domains/chat/components/surfaces/list-surface.js";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container.js";
 import { TableSurface } from "@/domains/chat/components/surfaces/table-surface.js";
+import { TaskPreferencesSurface } from "@/domains/chat/components/surfaces/task-preferences-surface.js";
 
 export interface SurfaceRouterProps {
   surface: Surface;
@@ -32,7 +33,7 @@ export function SurfaceRouter({
   onOpenDocument,
   isToolCallComplete = true,
 }: SurfaceRouterProps) {
-  const CHIP_COLLAPSE_TYPES = ["form", "confirmation", "file_upload"];
+  const CHIP_COLLAPSE_TYPES = ["form", "confirmation", "file_upload", "task_preferences"];
   if (surface.completed && CHIP_COLLAPSE_TYPES.includes(surface.surfaceType)) {
     const isCancelled = surface.completionSummary === "Cancelled";
     if (isCancelled) {
@@ -86,6 +87,9 @@ export function SurfaceRouter({
 
     case "browser_view":
       return <BrowserViewSurface surface={surface} onAction={onAction} />;
+
+    case "task_preferences":
+      return <TaskPreferencesSurface surface={surface} onAction={onAction} />;
 
     case "document_preview":
       return (

--- a/apps/web/src/domains/chat/components/surfaces/task-preferences-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/task-preferences-surface.tsx
@@ -1,0 +1,210 @@
+import { Check, MessageSquare } from "lucide-react";
+import { useRef, useState, type CSSProperties } from "react";
+
+import { Button } from "@vellum/design-library";
+
+import { TASK_ICONS } from "@/components/prechat-task-icons.js";
+import type { Surface } from "@/domains/chat/types/types.js";
+import { PRECHAT_TASKS } from "@/types/prechat-tasks.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TaskPreferencesSurfaceProps {
+  surface: Surface;
+  onAction: (
+    surfaceId: string,
+    actionId: string,
+    data?: Record<string, unknown>,
+  ) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-select task-category grid surface. Renders the same task tiles as
+ * `OnboardingChoiceCard`'s task-selection phase, but presented inline in the
+ * chat transcript as a daemon-driven surface that the LLM can spawn from a
+ * tool call. Submits selections back through `onAction("submit", { tasks,
+ * customText })`.
+ */
+export function TaskPreferencesSurface({
+  surface,
+  onAction,
+}: TaskPreferencesSurfaceProps) {
+  const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set());
+  const [otherSelected, setOtherSelected] = useState(false);
+  const [otherText, setOtherText] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  if (surface.completed) {
+    return null;
+  }
+
+  const toggleTask = (taskId: string) => {
+    setSelectedTasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  };
+
+  const toggleOther = () => {
+    setOtherSelected((prev) => {
+      const next = !prev;
+      if (next) {
+        // Focus textarea after React re-renders with it visible.
+        requestAnimationFrame(() => {
+          textareaRef.current?.focus();
+        });
+      } else {
+        setOtherText("");
+      }
+      return next;
+    });
+  };
+
+  const canSubmit =
+    selectedTasks.size > 0 || (otherSelected && otherText.trim().length > 0);
+
+  const handleSubmit = () => {
+    if (!canSubmit || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      onAction(surface.surfaceId, "submit", {
+        tasks: Array.from(selectedTasks),
+        customText: otherText.trim() || undefined,
+      });
+    } catch {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-[var(--border-element)] bg-[var(--surface-overlay)] p-4">
+      <div className="flex flex-col gap-1">
+        <div className="text-body-medium-default text-[var(--content-default)]">
+          {surface.title ?? "What can I help with?"}
+        </div>
+        <div className="text-label-small-default text-[color:var(--content-tertiary)]">
+          Select all that apply
+        </div>
+      </div>
+
+      <div className="grid auto-rows-fr grid-cols-2 gap-2">
+        {PRECHAT_TASKS.map((task) => {
+          const Icon = TASK_ICONS[task.iconKey];
+          const isSelected = selectedTasks.has(task.id);
+          return (
+            <button
+              key={task.id}
+              type="button"
+              onClick={() => toggleTask(task.id)}
+              aria-pressed={isSelected}
+              className={[
+                "flex cursor-pointer flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors",
+                isSelected
+                  ? "border-[var(--primary-base)] bg-[var(--primary-base)]/10"
+                  : "border-[var(--border-element)] bg-[var(--surface-lift)] hover:bg-[var(--surface-base)]",
+              ].join(" ")}
+            >
+              <div className="flex w-full items-center justify-between">
+                <div className="flex h-5 w-5 items-center justify-center text-[var(--content-secondary)]">
+                  {Icon ? <Icon className="h-4 w-4" /> : null}
+                </div>
+                {isSelected && (
+                  <div
+                    aria-hidden="true"
+                    className="flex h-4 w-4 items-center justify-center rounded-sm bg-[var(--primary-base)]"
+                  >
+                    <Check className="h-3 w-3 text-[var(--content-inset)]" />
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="text-body-small-default text-[var(--content-default)]">
+                  {task.label}
+                </div>
+                <div className="text-label-small-default text-[var(--content-tertiary)]">
+                  {task.sublabel}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+
+        {/* "Other" tile — `div` with `role="button"` rather than a native
+           `<button>` because the inner textarea swallows Enter/Space, and a
+           parent button would re-fire its own click on Space-keyup while the
+           user is typing. */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={toggleOther}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              toggleOther();
+            }
+          }}
+          aria-pressed={otherSelected}
+          className={[
+            "col-span-2 flex cursor-pointer items-start gap-2.5 rounded-lg border p-3 text-left transition-colors",
+            otherSelected
+              ? "border-[var(--primary-base)] bg-[var(--primary-base)]/10"
+              : "border-[var(--border-element)] bg-[var(--surface-lift)] hover:bg-[var(--surface-base)]",
+          ].join(" ")}
+        >
+          <div className="flex flex-1 items-start gap-2.5">
+            <MessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-secondary)]" />
+            {otherSelected ? (
+              <textarea
+                ref={textareaRef}
+                value={otherText}
+                onChange={(e) => setOtherText(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+                placeholder="Describe what you need help with..."
+                className="w-full resize-none overflow-hidden bg-transparent text-body-medium-default text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] focus:outline-none"
+                style={{ fieldSizing: "content" } as CSSProperties}
+                rows={1}
+              />
+            ) : (
+              <div className="flex flex-col">
+                <div className="text-body-medium-default text-[var(--content-default)]">
+                  Other
+                </div>
+                <div className="text-label-small-default text-[var(--content-tertiary)]">
+                  something else entirely
+                </div>
+              </div>
+            )}
+          </div>
+          {otherSelected && (
+            <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-[var(--primary-base)]">
+              <Check className="h-3 w-3 text-[var(--content-inset)]" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Button
+        variant="primary"
+        size="regular"
+        fullWidth
+        disabled={!canSubmit || isSubmitting}
+        onClick={handleSubmit}
+      >
+        Continue
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/components/surfaces/task-preferences-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/task-preferences-surface.tsx
@@ -75,11 +75,11 @@ export function TaskPreferencesSurface({
   const canSubmit =
     selectedTasks.size > 0 || (otherSelected && otherText.trim().length > 0);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!canSubmit || isSubmitting) return;
     setIsSubmitting(true);
     try {
-      onAction(surface.surfaceId, "submit", {
+      await onAction(surface.surfaceId, "submit", {
         tasks: Array.from(selectedTasks),
         customText: otherText.trim() || undefined,
       });

--- a/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-interaction-actions.ts
@@ -659,7 +659,7 @@ export function useInteractionActions({
 
       useTurnStore.getState().requestSend();
 
-      const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload", "card", "list", "table", "browser_view"];
+      const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload", "card", "list", "table", "browser_view", "task_preferences"];
       setMessages((prev: DisplayMessage[]) => {
         for (let i = prev.length - 1; i >= 0; i--) {
           const surface = prev[i]!.surfaces?.find((s) => s.surfaceId === surfaceId);

--- a/apps/web/src/domains/chat/types/types.ts
+++ b/apps/web/src/domains/chat/types/types.ts
@@ -136,6 +136,7 @@ const INHERENTLY_INTERACTIVE_SURFACE_TYPES = [
   "form",
   "confirmation",
   "file_upload",
+  "task_preferences",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Mirror of [vellum-assistant-platform#7406](https://github.com/vellum-ai/vellum-assistant-platform/pull/7406) (and its subset [#7405](https://github.com/vellum-ai/vellum-assistant-platform/pull/7405)) into `apps/web`. Adds the daemon-driven `task_preferences` surface — a multi-select task-category grid the LLM can spawn inline in chat via a tool call.

The companion onboarding-choice changes from those platform PRs are already present in `apps/web` from prior mirror work, so the diff here is just the new surface + the three registry entries that gate it.

## Changes

- **New** `apps/web/src/domains/chat/components/surfaces/task-preferences-surface.tsx` — multi-select grid of `PRECHAT_TASKS` + an "Other" tile with inline textarea. Selections submit via `onAction("submit", { tasks, customText })`.
- `apps/web/src/domains/chat/components/surfaces/surface-router.tsx` — import + `case "task_preferences"` + `CHIP_COLLAPSE_TYPES` entry.
- `apps/web/src/domains/chat/hooks/use-interaction-actions.ts` — `ONE_SHOT_SURFACE_TYPES` entry.
- `apps/web/src/domains/chat/types/types.ts` — `INHERENTLY_INTERACTIVE_SURFACE_TYPES` entry (so the composer is gated while awaiting input).

## Adaptations from the platform port

Followed `apps/web/AGENTS.md` + `docs/CONVENTIONS.md` — patterns diverge from `vellum-assistant-platform`:

| Platform pattern | apps/web equivalent applied here |
|---|---|
| `import { Button, Typography } from "@/components/app/core/..."` | `import { Button } from "@vellum/design-library"` |
| `import { PRECHAT_TASKS } from "@/lib/onboarding/..."` | `import { PRECHAT_TASKS } from "@/types/prechat-tasks.js"` (top-level shared, keeps the chat surface cross-domain-import-clean) |
| `<Typography variant="body-medium-default" ...>` | Plain `<div className="text-body-medium-default ...">` — matches the idiom in `onboarding-choice-card.tsx` and other domain components |
| `"use client"` directive | Removed (Vite SPA, not Next.js) |
| `.tsx` imports without extension | `.js` extension on internal imports (apps/web convention) |
| `useReducer` for selection state (n/a here) | Would have been rewritten to `useState`/Zustand — the platform code happened to already use `useState`, so no rewrite needed |

## Test plan

- [x] `bunx eslint …` — clean (no cross-domain violations)
- [x] Targeted `bunx tsc --noEmit` — no errors in any touched file (pre-existing `Cannot find type definition file for 'bun'` is unrelated config noise)
- [ ] After deploy: trigger a `task_preferences` surface from the daemon, verify the grid renders, multi-select works, the "Other" textarea behaves (Space/Enter inside it doesn't toggle the parent tile), Continue submits the right payload, and the surface collapses to a chip on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->