### PR TITLE
feat(web): "Go to Newest" pill + flex-col transcript

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -107,6 +107,10 @@ interface SendMessageResponse {
   queued?: boolean;
   conversationId?: string;
   assistantMessage?: RuntimeMessage;
+  /** Set when `queued` is true — the daemon's request id for the
+   *  queued message, used by the steer/cancel endpoints. Added by
+   *  #7484 (queue steering) but the interface field was missed. */
+  requestId?: string;
 }
 
 interface ListMessagesResponse {

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -73,10 +73,13 @@ export interface ChatBodyProps {
    */
   isKeyboardOpen: boolean;
 
-  /** True when the scroll-to-latest button should be shown above the composer. */
+  /** True when the "Go to Newest" pill should be shown above the composer. */
   showScrollToLatest: boolean;
-  /** Click handler for the scroll-to-latest button. */
+  /** Click handler for the "Go to Newest" pill. */
   onScrollToLatest: () => void;
+  /** True when an assistant response is currently streaming — drives the
+   *  animated dots indicator inside the "Go to Newest" pill. */
+  isStreaming?: boolean;
 
   /** Active refresh-feedback pill, or `null` when no pill is shown. */
   refreshFeedback: RefreshFeedback | null;
@@ -173,6 +176,7 @@ export function ChatBody({
   isKeyboardOpen,
   showScrollToLatest,
   onScrollToLatest,
+  isStreaming = false,
   refreshFeedback,
   onDismissRefreshFeedback,
   onRetryRefresh,
@@ -242,7 +246,10 @@ export function ChatBody({
           <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 flex flex-col items-center">
             {showScrollToLatest && (
               <div className="pointer-events-auto pb-2.5">
-                <ScrollToLatestButton onClick={onScrollToLatest} />
+                <ScrollToLatestButton
+                  onClick={onScrollToLatest}
+                  isStreaming={isStreaming}
+                />
               </div>
             )}
             {bannerSlot}

--- a/apps/web/src/domains/chat/components/chat-pill.tsx
+++ b/apps/web/src/domains/chat/components/chat-pill.tsx
@@ -18,10 +18,20 @@ import { type ReactNode } from "react";
  */
 export type ChatPillTone = "default" | "negative";
 
+/**
+ * "compact" — 12 px label, py-1.5. Original size, used by
+ * `RefreshFeedbackPill`.
+ * "regular" — 14 px body-medium, py-2. Matches the Figma "Go to Newest"
+ * pill spec at node 5010:103945.
+ */
+export type ChatPillSize = "compact" | "regular";
+
 interface ChatPillProps {
   children: ReactNode;
   /** Visual tone. Defaults to "default" (lifted neutral surface). */
   tone?: ChatPillTone;
+  /** Visual size. Defaults to "compact". */
+  size?: ChatPillSize;
   /** When provided, the pill renders as a button with this handler. */
   onClick?: () => void;
   /** Accessible label. Required when `onClick` is set. */
@@ -37,7 +47,12 @@ interface ChatPillProps {
 }
 
 const BASE_CHROME =
-  "pointer-events-auto inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-label-small-default shadow-md";
+  "pointer-events-auto inline-flex items-center gap-1 rounded-full shadow-md";
+
+const SIZE_CLASSES: Record<ChatPillSize, string> = {
+  compact: "px-3 py-1.5 text-label-small-default",
+  regular: "px-3 py-2 text-body-medium-default",
+};
 
 const TONE_CLASSES: Record<ChatPillTone, string> = {
   default: "bg-[var(--surface-lift)] text-[var(--content-secondary)]",
@@ -48,13 +63,19 @@ const TONE_CLASSES: Record<ChatPillTone, string> = {
 export function ChatPill({
   children,
   tone = "default",
+  size = "compact",
   onClick,
   ariaLabel,
   role,
   ariaLive,
   className,
 }: ChatPillProps) {
-  const merged = clsx(BASE_CHROME, TONE_CLASSES[tone], className);
+  const merged = clsx(
+    BASE_CHROME,
+    SIZE_CLASSES[size],
+    TONE_CLASSES[tone],
+    className,
+  );
 
   if (onClick) {
     return (

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -597,6 +597,8 @@ export function ChatRouteContent({
   };
 
   const showThinking = shouldShowThinkingIndicator(turnState, uiContext);
+  const isAssistantStreaming =
+    showThinking || messages.some((m) => m.isStreaming);
   const canStopGenerating =
     isSending(turnState) && turnState.phase !== "awaiting_user_input";
 
@@ -859,8 +861,13 @@ export function ChatRouteContent({
       shouldFocusInputRef.current = true;
     }
     haptic.medium();
+    // Engage the auto-pin window so the new turn lands at the bottom
+    // — even if the user had scrolled up while composing — and so the
+    // initial response render (which expands LatestTurnRow via
+    // useViewportMinHeight) stays anchored at the latest message.
+    scrollCoordinator.scrollToLatest({ behavior: "auto" });
     await sendMessage(trimmed, attachmentsToSend);
-  }, [input, sendDisabled, attachmentUploadedIds.length, attachmentsUploadingCount, activeConversationKey, chatAttachments, resetChatAttachments, sendMessage, setInput, setSuggestion, clearDraft, inputRef]);
+  }, [input, sendDisabled, attachmentUploadedIds.length, attachmentsUploadingCount, activeConversationKey, chatAttachments, resetChatAttachments, sendMessage, setInput, setSuggestion, clearDraft, inputRef, scrollCoordinator]);
 
   const handleSelectStarter = (starter: { prompt: string }) => {
     setInput(starter.prompt);
@@ -1106,9 +1113,7 @@ export function ChatRouteContent({
               customImageUrl={avatarImageUrl}
               size={56}
               interactive
-              isStreaming={
-                showThinking || messages.some((m) => m.isStreaming)
-              }
+              isStreaming={isAssistantStreaming}
             />
           )
         : undefined,
@@ -1285,6 +1290,7 @@ export function ChatRouteContent({
               scrollCoordinator.showScrollToLatest && messages.length > 0
             }
             onScrollToLatest={handleScrollToLatest}
+            isStreaming={isAssistantStreaming}
             refreshFeedback={refreshFeedback}
             onDismissRefreshFeedback={handleDismissRefreshFeedback}
             onRetryRefresh={handleRetryRefreshFromPill}
@@ -1357,6 +1363,7 @@ export function ChatRouteContent({
         scrollCoordinator.showScrollToLatest && messages.length > 0
       }
       onScrollToLatest={handleScrollToLatest}
+      isStreaming={isAssistantStreaming}
       refreshFeedback={refreshFeedback}
       onDismissRefreshFeedback={handleDismissRefreshFeedback}
       onRetryRefresh={handleRetryRefreshFromPill}

--- a/apps/web/src/domains/chat/components/scroll-to-latest-button.tsx
+++ b/apps/web/src/domains/chat/components/scroll-to-latest-button.tsx
@@ -1,18 +1,51 @@
-import { ArrowDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
 import { ChatPill } from "@/domains/chat/components/chat-pill.js";
 
 /**
- * Pill-shaped scroll-to-latest affordance shown when the user has scrolled far
- * enough up that `useTranscriptScroll` reports `showScrollToLatest`. Clicking
- * refetches the latest history page and pins the transcript to the bottom.
- * Rendered as a centered pill above the chat input area by the caller.
+ * Pill-shaped "Go to Newest" affordance shown above the composer when the
+ * user has scrolled far enough up that `useTranscriptScroll` reports
+ * `showScrollToLatest`. Clicking pins the transcript back to the latest
+ * message.
+ *
+ * When `isStreaming` is true, a 3-dot pulse animation renders at the start
+ * of the pill to signal that more content is still arriving out of view —
+ * matches the macOS TypingIndicatorView phase pattern used by the inline
+ * "thinking" row in `TranscriptRow`.
  */
-export function ScrollToLatestButton({ onClick }: { onClick: () => void }) {
+export function ScrollToLatestButton({
+  onClick,
+  isStreaming = false,
+}: {
+  onClick: () => void;
+  isStreaming?: boolean;
+}) {
   return (
-    <ChatPill onClick={onClick} ariaLabel="Scroll to latest message">
-      <ArrowDown className="h-3 w-3" />
-      Scroll to latest
+    <ChatPill
+      onClick={onClick}
+      ariaLabel="Go to newest message"
+      size="regular"
+      className="text-[var(--content-emphasised)]"
+    >
+      {isStreaming && (
+        <span
+          aria-hidden
+          className="inline-flex items-center gap-[3px]"
+        >
+          {([-0.333, 0, -0.667] as const).map((delay, i) => (
+            <span
+              key={i}
+              className="typing-dot block h-2 w-2 rounded-full bg-[var(--content-tertiary)]"
+              style={{
+                animation: "typing-dot-pulse 1s ease-in-out infinite",
+                animationDelay: `${delay}s`,
+              }}
+            />
+          ))}
+        </span>
+      )}
+      Go to Newest
+      <ChevronDown className="h-3 w-3" />
     </ChatPill>
   );
 }

--- a/apps/web/src/domains/chat/transcript/pull-refresh-spinner.tsx
+++ b/apps/web/src/domains/chat/transcript/pull-refresh-spinner.tsx
@@ -8,9 +8,9 @@ import {
 
 interface PullRefreshSpinnerProps {
   /** Visual height of the spinner element in px. Drives the
-   *  flex-item height of this container, which (in the column-reverse
-   *  parent) shows up as growing space at the visual bottom of the
-   *  transcript. */
+   *  flex-item height of this container, which (rendered last inside
+   *  the flex-col parent) shows up as growing space at the visual
+   *  bottom of the transcript. */
   height: number;
   /** Drag progress, 0..1, where 1 is the commit threshold. */
   progress: number;

--- a/apps/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.test.tsx
@@ -5,9 +5,9 @@
  * verify behavior via `renderToStaticMarkup` plus `mock.module` shims that
  * replace leaf rendering dependencies with deterministic stubs.
  *
- * The component uses `flex-col-reverse` to render items: the LatestTurnRow
- * appears first in DOM order (visual bottom) and history items follow in
- * reverse chronological order (column-reverse un-reverses them).
+ * The component uses plain `flex-col` to render items: history items
+ * appear first in DOM order (visual top, oldest first) and the
+ * LatestTurnRow follows at the end of the DOM (visual bottom).
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -92,7 +92,7 @@ describe("Transcript", () => {
     expect(html).not.toContain('data-testid="markdown"');
   });
 
-  test("scroll container has flex-col-reverse class", () => {
+  test("scroll container has flex-col class (chronological order)", () => {
     const html = renderToStaticMarkup(
       <Transcript
         items={[]}
@@ -102,7 +102,8 @@ describe("Transcript", () => {
         onRetryError={noop}
       />,
     );
-    expect(html).toContain("flex-col-reverse");
+    expect(html).toContain("flex-col");
+    expect(html).not.toContain("flex-col-reverse");
   });
 
   test("with trailing user message, renders history rows and a latest-turn row", () => {
@@ -160,7 +161,7 @@ describe("Transcript", () => {
     expect(html).toContain("also assistant");
   });
 
-  test("items render in correct visual order (column-reverse: latest-turn first in DOM, history reversed)", () => {
+  test("items render in correct visual order (flex-col: history first in DOM, latest-turn last)", () => {
     const items: TranscriptItem[] = [
       assistantMessage("a1", "FIRST_MSG"),
       userMessage("u1", "SECOND_MSG"),
@@ -177,14 +178,13 @@ describe("Transcript", () => {
       />,
     );
 
-    // In column-reverse DOM order: LatestTurnRow (u1 + a2) comes BEFORE
-    // history items. History items are reversed in DOM but column-reverse
-    // un-reverses them visually.
+    // In flex-col DOM order: history items come first (visual top),
+    // LatestTurnRow (u1 + a2) is rendered last (visual bottom).
     const latestTurnIdx = html.indexOf('data-latest-turn="true"');
     const firstMsgIdx = html.indexOf("FIRST_MSG");
     expect(latestTurnIdx).toBeGreaterThanOrEqual(0);
     expect(firstMsgIdx).toBeGreaterThanOrEqual(0);
-    // LatestTurnRow appears first in DOM (before history items).
-    expect(latestTurnIdx).toBeLessThan(firstMsgIdx);
+    // History appears first in DOM (before LatestTurnRow).
+    expect(firstMsgIdx).toBeLessThan(latestTurnIdx);
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -119,6 +119,11 @@ export interface TranscriptProps {
 export interface TranscriptHandle {
   scrollToLatest(opts?: { behavior?: "auto" | "smooth" }): void;
   getScrollElement(): HTMLDivElement | null;
+  /** Inner wrapper that surrounds all rendered children. Sized to the
+   *  scroll content; observable via `ResizeObserver` to detect when
+   *  scroll content height changes (e.g. async min-height settling,
+   *  late image loads, streaming growth). */
+  getContentElement(): HTMLDivElement | null;
   getViewportHeight(): number;
 }
 
@@ -126,6 +131,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
   function Transcript(props, ref) {
     const { items, onPullRefresh, pullRefreshEnabled, ...rest } = props;
     const scrollRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
     const viewportMinHeight = useViewportMinHeight(scrollRef);
 
     const pullEnabled = !!pullRefreshEnabled && !!onPullRefresh;
@@ -146,10 +152,6 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
     const [expandedCardIds] = useState(() => new Map<string, boolean>());
 
     const partition = useMemo(() => partitionLatestTurn(items), [items]);
-    const reversedHistory = useMemo(
-      () => [...partition.historyItems].reverse(),
-      [partition.historyItems],
-    );
 
     const subagentsByParent = useMemo(() => {
       if (!rest.subagentEntries?.length) return null;
@@ -184,13 +186,18 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       ref,
       (): TranscriptHandle => ({
         scrollToLatest(opts) {
-          scrollRef.current?.scrollTo({
-            top: 0,
+          const el = scrollRef.current;
+          if (!el) return;
+          el.scrollTo({
+            top: el.scrollHeight - el.clientHeight,
             behavior: opts?.behavior ?? "auto",
           });
         },
         getScrollElement() {
           return scrollRef.current;
+        },
+        getContentElement() {
+          return contentRef.current;
         },
         getViewportHeight() {
           return scrollRef.current?.clientHeight ?? 0;
@@ -227,50 +234,57 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       <div
         ref={scrollRef}
         data-testid="transcript-scroll-container"
-        className="flex h-full w-full flex-col-reverse overflow-y-auto overscroll-none [overflow-anchor:none]"
+        className="flex h-full w-full flex-col overflow-y-auto overscroll-none [overflow-anchor:none]"
       >
-        {/* Spinner first = visual bottom in column-reverse. Only
-         *  rendered when the gesture is feature-flag-enabled so the
-         *  flag-off path has zero DOM impact. */}
-        {pullEnabled && (
-          <PullRefreshSpinner
-            height={pull.pullDistance}
-            progress={pull.pullDistance / PULL_THRESHOLD_PX}
-            phase={pull.phase}
-          />
-        )}
-        {/* LatestTurnRow first = visual bottom with column-reverse */}
-        {partition.anchorMessage && (
-          <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
-            <LatestTurnRow
-              anchorMessage={partition.anchorMessage}
-              responseItems={partition.responseItems}
-              viewportMinHeight={viewportMinHeight}
-              avatarSlot={rest.renderAvatar ? rest.renderAvatar() : undefined}
-              subagentsByParent={subagentsByParent}
-              onSubagentClick={rest.onSubagentClick}
-              onStopSubagent={rest.onStopSubagent}
-              {...rowProps}
-            />
-          </div>
-        )}
-        {/* History items reversed — column-reverse un-reverses for chronological visual order */}
-        {reversedHistory.map((item) => (
-          <Fragment key={item.key}>
+        {/* Inner content wrapper — observed by the scroll coordinator's
+         *  ResizeObserver so we can re-pin to bottom when scroll content
+         *  height changes (async min-height settle, late image loads,
+         *  streaming growth). Wrapping all rows in a single observed
+         *  element is cheaper than observing each row individually. */}
+        <div ref={contentRef} className="flex w-full flex-col">
+          {/* History items in chronological order — oldest at top. */}
+          {partition.historyItems.map((item) => (
+            <Fragment key={item.key}>
+              <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
+                <TranscriptRow item={item} {...rowProps} />
+                {item.kind === "message" &&
+                  subagentsByParent?.get(item.key) &&
+                  rest.onSubagentClick && (
+                    <SubagentProgressCard
+                      entries={subagentsByParent.get(item.key)!}
+                      onSubagentClick={rest.onSubagentClick}
+                      onStopSubagent={rest.onStopSubagent}
+                    />
+                  )}
+              </div>
+            </Fragment>
+          ))}
+          {/* LatestTurnRow last = visual bottom in flex-col. */}
+          {partition.anchorMessage && (
             <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
-              <TranscriptRow item={item} {...rowProps} />
-              {item.kind === "message" &&
-                subagentsByParent?.get(item.key) &&
-                rest.onSubagentClick && (
-                  <SubagentProgressCard
-                    entries={subagentsByParent.get(item.key)!}
-                    onSubagentClick={rest.onSubagentClick}
-                    onStopSubagent={rest.onStopSubagent}
-                  />
-                )}
+              <LatestTurnRow
+                anchorMessage={partition.anchorMessage}
+                responseItems={partition.responseItems}
+                viewportMinHeight={viewportMinHeight}
+                avatarSlot={rest.renderAvatar ? rest.renderAvatar() : undefined}
+                subagentsByParent={subagentsByParent}
+                onSubagentClick={rest.onSubagentClick}
+                onStopSubagent={rest.onStopSubagent}
+                {...rowProps}
+              />
             </div>
-          </Fragment>
-        ))}
+          )}
+          {/* Spinner last = visual bottom in flex-col. Only rendered when
+           *  the gesture is feature-flag-enabled so the flag-off path has
+           *  zero DOM impact. */}
+          {pullEnabled && (
+            <PullRefreshSpinner
+              height={pull.pullDistance}
+              progress={pull.pullDistance / PULL_THRESHOLD_PX}
+              phase={pull.phase}
+            />
+          )}
+        </div>
       </div>
     );
   },

--- a/apps/web/src/domains/chat/transcript/use-pull-to-refresh.test.ts
+++ b/apps/web/src/domains/chat/transcript/use-pull-to-refresh.test.ts
@@ -5,6 +5,11 @@
  * is a thin wiring layer over a few pure helpers — this file targets
  * those helpers directly. Each test maps to one of the acceptance
  * criteria in the PR plan.
+ *
+ * The transcript uses plain `flex-col` (latest at the visual bottom),
+ * so PTR follows the standard iOS pattern: pull DOWN at the bottom to
+ * refresh. `distanceFromBottom = max(0, scrollHeight − clientHeight −
+ * scrollTop)` is the eligibility metric.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -18,22 +23,28 @@ import {
   shouldFireThresholdHaptic,
 } from "@/domains/chat/transcript/use-pull-to-refresh.js";
 
+/** Build a metrics fixture for a transcript where the visual bottom
+ *  (max scrollTop) is at `scrollHeight − clientHeight = 1000`. Then
+ *  `scrollTop = 1000` is at the bottom, `scrollTop = 0` is at the top. */
+function atDistanceFromBottom(distance: number) {
+  return { scrollTop: 1000 - distance, scrollHeight: 1800, clientHeight: 800 };
+}
+
 describe("computePullExtent (gesture direction — single source of truth)", () => {
-  // The reverse PTR on a column-reverse transcript is INVERTED from a
-  // standard PTR: at the visual bottom, the user pulls UP (toward the
-  // top of the screen) to refresh — not down. clientY decreases when
-  // the finger moves up, so positive pull extent = startY - currentY.
+  // In flex-col chat, PTR at the visual bottom is the standard iOS
+  // gesture: the user pulls DOWN to refresh. clientY increases when
+  // the finger moves down, so positive pull extent = currentY - startY.
 
-  test("finger moved up from start → positive pull extent (the actual gesture)", () => {
-    expect(computePullExtent({ startY: 500, currentY: 440 })).toBe(60);
+  test("finger moved down from start → positive pull extent (the actual gesture)", () => {
+    expect(computePullExtent({ startY: 500, currentY: 560 })).toBe(60);
   });
 
-  test("finger moved up far → larger positive extent", () => {
-    expect(computePullExtent({ startY: 500, currentY: 380 })).toBe(120);
+  test("finger moved down far → larger positive extent", () => {
+    expect(computePullExtent({ startY: 500, currentY: 620 })).toBe(120);
   });
 
-  test("finger moved down from start → negative extent (wrong direction)", () => {
-    expect(computePullExtent({ startY: 500, currentY: 540 })).toBe(-40);
+  test("finger moved up from start → negative extent (wrong direction)", () => {
+    expect(computePullExtent({ startY: 500, currentY: 460 })).toBe(-40);
   });
 
   test("finger stationary → zero extent", () => {
@@ -43,7 +54,9 @@ describe("computePullExtent (gesture direction — single source of truth)", () 
 
 describe("classifyPull", () => {
   test("at bottom, partial pull → pulling with fractional progress", () => {
-    expect(classifyPull({ scrollTop: 0, dragDistance: 30 })).toEqual({
+    expect(
+      classifyPull({ ...atDistanceFromBottom(0), dragDistance: 30 }),
+    ).toEqual({
       phase: "pulling",
       progress: 30 / PULL_THRESHOLD_PX,
       atThreshold: false,
@@ -51,7 +64,9 @@ describe("classifyPull", () => {
   });
 
   test("at bottom, past threshold → pulling, progress clamped to 1, atThreshold true", () => {
-    expect(classifyPull({ scrollTop: 0, dragDistance: 80 })).toEqual({
+    expect(
+      classifyPull({ ...atDistanceFromBottom(0), dragDistance: 80 }),
+    ).toEqual({
       phase: "pulling",
       progress: 1,
       atThreshold: true,
@@ -59,19 +74,19 @@ describe("classifyPull", () => {
   });
 
   test("scrolled away from bottom → ineligible regardless of drag", () => {
-    expect(classifyPull({ scrollTop: -120, dragDistance: 80 })).toEqual({
+    expect(
+      classifyPull({ ...atDistanceFromBottom(120), dragDistance: 80 }),
+    ).toEqual({
       phase: "ineligible",
       progress: 0,
       atThreshold: false,
     });
   });
 
-  test("finger moved down (negative pull extent, wrong direction) → ineligible", () => {
-    // dragDistance is the pull extent: positive means the finger moved
-    // upward from start (a real pull on a reverse PTR). A negative
-    // value means the finger moved downward — that's the user starting
-    // to scroll back through history, not a refresh request.
-    expect(classifyPull({ scrollTop: 0, dragDistance: -10 })).toEqual({
+  test("finger moved up (negative pull extent, wrong direction) → ineligible", () => {
+    expect(
+      classifyPull({ ...atDistanceFromBottom(0), dragDistance: -10 }),
+    ).toEqual({
       phase: "ineligible",
       progress: 0,
       atThreshold: false,
@@ -81,7 +96,7 @@ describe("classifyPull", () => {
   test("just inside the eligibility window with positive drag → pulling", () => {
     expect(
       classifyPull({
-        scrollTop: -PULL_ELIGIBLE_BOTTOM_DISTANCE_PX,
+        ...atDistanceFromBottom(PULL_ELIGIBLE_BOTTOM_DISTANCE_PX),
         dragDistance: 20,
       }),
     ).toMatchObject({ phase: "pulling" });
@@ -90,7 +105,7 @@ describe("classifyPull", () => {
   test("one pixel past the eligibility window → ineligible", () => {
     expect(
       classifyPull({
-        scrollTop: -(PULL_ELIGIBLE_BOTTOM_DISTANCE_PX + 1),
+        ...atDistanceFromBottom(PULL_ELIGIBLE_BOTTOM_DISTANCE_PX + 1),
         dragDistance: 20,
       }),
     ).toMatchObject({ phase: "ineligible" });
@@ -98,7 +113,10 @@ describe("classifyPull", () => {
 
   test("exactly at threshold → atThreshold true, progress 1", () => {
     expect(
-      classifyPull({ scrollTop: 0, dragDistance: PULL_THRESHOLD_PX }),
+      classifyPull({
+        ...atDistanceFromBottom(0),
+        dragDistance: PULL_THRESHOLD_PX,
+      }),
     ).toEqual({ phase: "pulling", progress: 1, atThreshold: true });
   });
 });
@@ -134,16 +152,20 @@ describe("shouldFireThresholdHaptic", () => {
 
 describe("canStartPull (refresh-in-flight + at-bottom guards)", () => {
   test("at bottom, not refreshing → can start", () => {
-    expect(canStartPull({ isRefreshing: false, scrollTop: 0 })).toBe(true);
+    expect(
+      canStartPull({ isRefreshing: false, ...atDistanceFromBottom(0) }),
+    ).toBe(true);
   });
 
   test("refresh in flight → cannot start (no flapping)", () => {
-    expect(canStartPull({ isRefreshing: true, scrollTop: 0 })).toBe(false);
+    expect(
+      canStartPull({ isRefreshing: true, ...atDistanceFromBottom(0) }),
+    ).toBe(false);
   });
 
   test("not at bottom → cannot start (gesture is dead while reading history)", () => {
     expect(
-      canStartPull({ isRefreshing: false, scrollTop: -200 }),
+      canStartPull({ isRefreshing: false, ...atDistanceFromBottom(200) }),
     ).toBe(false);
   });
 
@@ -151,7 +173,7 @@ describe("canStartPull (refresh-in-flight + at-bottom guards)", () => {
     expect(
       canStartPull({
         isRefreshing: false,
-        scrollTop: -PULL_ELIGIBLE_BOTTOM_DISTANCE_PX,
+        ...atDistanceFromBottom(PULL_ELIGIBLE_BOTTOM_DISTANCE_PX),
       }),
     ).toBe(true);
   });

--- a/apps/web/src/domains/chat/transcript/use-pull-to-refresh.ts
+++ b/apps/web/src/domains/chat/transcript/use-pull-to-refresh.ts
@@ -1,24 +1,26 @@
-// Pull-to-refresh gesture hook for the column-reverse chat transcript.
+// Pull-to-refresh gesture hook for the chronological-order chat
+// transcript (flex-col, latest at the visual bottom).
 //
 // Eligibility window: the user must be at the visual bottom of the
-// transcript (latest message). In column-reverse, that means
-// |scrollTop| is small. We use a tighter eligibility threshold than the
-// scroll coordinator's `PINNED_THRESHOLD_PX` because the gesture is
-// disruptive and should only fire when the user is unambiguously
-// looking at the latest message.
+// transcript (latest message). In flex-col, that means
+// `scrollHeight − clientHeight − scrollTop` is small. We use a tighter
+// eligibility threshold than the scroll coordinator's
+// `PINNED_THRESHOLD_PX` because the gesture is disruptive and should
+// only fire when the user is unambiguously looking at the latest
+// message.
 //
-// Drag direction (CRITICAL — this is inverted from a standard PTR):
-// At the visual bottom of a column-reverse transcript the iOS-native
-// pull-to-refresh gesture is an UPWARD finger motion. The latest
-// message sits anchored just above the composer; pulling the finger
-// up opens rubber-band space between the latest bubble and the
-// composer where the spinner reveals itself. A downward finger motion
-// at the visual bottom is the user starting to scroll back through
-// history, NOT a refresh request, and is treated as ineligible.
+// Drag direction: at the visual bottom of a flex-col chat the
+// iOS-native pull-to-refresh gesture is a DOWNWARD finger motion —
+// the same direction Mail/Messages use to refresh the latest. The
+// latest message sits anchored just above the composer; pulling the
+// finger down opens rubber-band space below the latest bubble where
+// the spinner reveals itself. An upward finger motion at the visual
+// bottom is the user starting to scroll back through history, NOT a
+// refresh request, and is treated as ineligible.
 //
-// Concretely: clientY DECREASES when the finger moves up the screen,
-// so we compute pull extent as (startY - currentY). Positive extent
-// means the finger has traveled upward — i.e., the user is pulling.
+// Concretely: clientY INCREASES when the finger moves down the screen,
+// so we compute pull extent as (currentY − startY). Positive extent
+// means the finger has traveled downward — i.e., the user is pulling.
 
 import { useEffect, useRef, useState, type RefObject } from "react";
 
@@ -47,29 +49,44 @@ export interface PullClassification {
 }
 
 /** Compute the pull extent (in px) given the touch's starting and
- *  current Y coordinates. At the visual bottom of a column-reverse
- *  transcript, the pull-to-refresh gesture is an UPWARD finger motion
- *  (clientY decreases). We invert so positive extent means "user is
- *  pulling for refresh." Exposed for direct unit testing — this is
- *  the single source of truth for gesture direction. */
+ *  current Y coordinates. At the visual bottom of a flex-col
+ *  transcript, the pull-to-refresh gesture is a DOWNWARD finger motion
+ *  (clientY increases). Positive extent means the user is pulling
+ *  for refresh. Exposed for direct unit testing — this is the single
+ *  source of truth for gesture direction. */
 export function computePullExtent(args: {
   startY: number;
   currentY: number;
 }): number {
-  return args.startY - args.currentY;
+  return args.currentY - args.startY;
+}
+
+/** Distance (in px) from the visual bottom of the transcript. In
+ *  flex-col layout this is `max(0, scrollHeight − clientHeight −
+ *  scrollTop)`. Clamped at 0 so iOS rubber-band (scrollTop briefly
+ *  above max) doesn't report a negative distance. */
+export function distanceFromBottom(args: {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}): number {
+  const max = Math.max(0, args.scrollHeight - args.clientHeight);
+  return Math.max(0, max - args.scrollTop);
 }
 
 /** Pure classification of the current touch state during a drag.
  *  `dragDistance` is the pull extent — positive means the finger
- *  has moved upward from its start (a real pull); non-positive
- *  means the finger is still or has moved downward (no pull).
+ *  has moved downward from its start (a real pull); non-positive
+ *  means the finger is still or has moved upward (no pull).
  *  Exposed for direct unit testing. */
 export function classifyPull(args: {
   scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
   dragDistance: number;
 }): PullClassification {
-  const distanceFromBottom = Math.abs(args.scrollTop);
-  const eligible = distanceFromBottom <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX;
+  const dfb = distanceFromBottom(args);
+  const eligible = dfb <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX;
   if (!eligible || args.dragDistance <= 0) {
     return { phase: "ineligible", progress: 0, atThreshold: false };
   }
@@ -96,9 +113,11 @@ export function shouldFireThresholdHaptic(args: {
 export function canStartPull(args: {
   isRefreshing: boolean;
   scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
 }): boolean {
   if (args.isRefreshing) return false;
-  return Math.abs(args.scrollTop) <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX;
+  return distanceFromBottom(args) <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX;
 }
 
 /** Map raw drag distance to the visual pull height. Past the threshold
@@ -204,6 +223,8 @@ export function usePullToRefresh({
       if (!canStartPull({
         isRefreshing: isRefreshingRef.current,
         scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
       })) {
         return;
       }
@@ -237,18 +258,22 @@ export function usePullToRefresh({
       });
       const cls = classifyPull({
         scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
         dragDistance: pullExtent,
       });
       if (cls.phase === "ineligible") {
         // The user scrolled off the bottom (e.g. momentum carried them
-        // past the eligibility window) or is moving the finger downward
-        // (the wrong direction for our reverse PTR). Only treat as a
-        // real cancel if the visual already showed a pull — otherwise
-        // let touchend decide.
-        if (
-          pullExtent < 0 ||
-          Math.abs(el.scrollTop) > PULL_ELIGIBLE_BOTTOM_DISTANCE_PX
-        ) {
+        // past the eligibility window) or is moving the finger upward
+        // (the wrong direction for PTR-at-bottom). Only treat as a real
+        // cancel if the visual already showed a pull — otherwise let
+        // touchend decide.
+        const dfb = distanceFromBottom({
+          scrollTop: el.scrollTop,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        });
+        if (pullExtent < 0 || dfb > PULL_ELIGIBLE_BOTTOM_DISTANCE_PX) {
           resetVisuals();
         }
         return;
@@ -265,6 +290,15 @@ export function usePullToRefresh({
       }
       setPullDistance(visualPullHeight(pullExtent));
       setIsAtThreshold(cls.atThreshold);
+      // Spinner is the last DOM child of the scroll content (flex-col),
+      // so its growing height extends scrollHeight *below* the current
+      // viewport. Without an explicit follow-scroll the user never sees
+      // the spinner during the pull — in flex-col-reverse this was free
+      // because the visual bottom was anchored to scrollTop=0. Mirror
+      // that anchoring here by pinning to the new bottom on every
+      // touchmove that advances the pull. Cheap (no layout thrash —
+      // scrollTo doesn't force layout when only scrollTop changes).
+      el.scrollTop = el.scrollHeight - el.clientHeight;
     };
 
     const handleTouchEnd = (event: TouchEvent) => {
@@ -283,9 +317,13 @@ export function usePullToRefresh({
           break;
         }
       }
-      const distanceFromBottom = Math.abs(el.scrollTop);
+      const dfb = distanceFromBottom({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      });
       const committed =
-        distanceFromBottom <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX &&
+        dfb <= PULL_ELIGIBLE_BOTTOM_DISTANCE_PX &&
         finalPullExtent >= PULL_THRESHOLD_PX;
 
       if (!committed) {

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -9,10 +9,11 @@
  * those helpers — each test below maps directly to one of the
  * acceptance-criteria behaviors in the PR plan.
  *
- * In column-reverse layout, scrollTop = 0 is the visual bottom (latest
- * messages). Scrolling UP increases scrollTop. So:
- *   - distanceFromBottom = scrollTop
- *   - distanceFromTop = scrollHeight - clientHeight - scrollTop
+ * The transcript uses plain `flex-col` (chronological order):
+ *   - distanceFromTop    = scrollTop
+ *   - distanceFromBottom = scrollHeight − clientHeight − scrollTop
+ * scrollTop = 0 is the visual top (oldest); scrollTop = max is the
+ * visual bottom (latest).
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -49,16 +50,25 @@ function items(ids: readonly string[]): TranscriptItem[] {
   return ids.map(makeMessage);
 }
 
+/** Build ScrollMetrics positioned at a given distance from the bottom,
+ *  for a transcript with `scrollHeight = 1800, clientHeight = 800`
+ *  (max scrollTop = 1000). */
+function metricsAtDistanceFromBottom(distance: number) {
+  return { scrollTop: 1000 - distance, scrollHeight: 1800, clientHeight: 800 };
+}
+
 function makeHandle(): TranscriptHandle & {
   calls: {
     scrollToLatest: Array<[{ behavior?: "auto" | "smooth" }?]>;
     getScrollElement: number;
+    getContentElement: number;
     getViewportHeight: number;
   };
 } {
   const calls = {
     scrollToLatest: [] as Array<[{ behavior?: "auto" | "smooth" }?]>,
     getScrollElement: 0,
+    getContentElement: 0,
     getViewportHeight: 0,
   };
   const scrollToLatest = mock((opts?: { behavior?: "auto" | "smooth" }) => {
@@ -68,6 +78,10 @@ function makeHandle(): TranscriptHandle & {
     calls.getScrollElement += 1;
     return null;
   });
+  const getContentElement = mock((): HTMLDivElement | null => {
+    calls.getContentElement += 1;
+    return null;
+  });
   const getViewportHeight = mock((): number => {
     calls.getViewportHeight += 1;
     return 800;
@@ -75,23 +89,24 @@ function makeHandle(): TranscriptHandle & {
   return {
     scrollToLatest,
     getScrollElement,
+    getContentElement,
     getViewportHeight,
     calls,
   };
 }
 
 // ---------------------------------------------------------------------------
-// classifyScrollPosition — column-reverse thresholds
+// classifyScrollPosition — flex-col thresholds
 //
-// In column-reverse: scrollTop = 0 is the bottom (latest).
-// distanceFromBottom = scrollTop
-// distanceFromTop = scrollHeight - clientHeight - scrollTop
+// In flex-col: scrollTop = max is the bottom (latest).
+// distanceFromBottom = scrollHeight - clientHeight - scrollTop
+// distanceFromTop    = scrollTop
 // ---------------------------------------------------------------------------
 
 describe("classifyScrollPosition — pinned threshold (64 px)", () => {
-  test("at the bottom (scrollTop = 0) is pinned", () => {
+  test("at the bottom (max scrollTop) is pinned", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 0, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(0),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(0);
@@ -100,7 +115,7 @@ describe("classifyScrollPosition — pinned threshold (64 px)", () => {
 
   test("distance exactly 64 is pinned (<=)", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 64, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(64),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(PINNED_THRESHOLD_PX);
@@ -109,18 +124,29 @@ describe("classifyScrollPosition — pinned threshold (64 px)", () => {
 
   test("distance 65 is NOT pinned", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 65, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(65),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(65);
     expect(c.isPinned).toBe(false);
+  });
+
+  test("iOS rubber-band over-bottom (scrollTop > max) clamps distanceFromBottom to 0", () => {
+    // scrollTop briefly larger than max during rubber-band — distance must
+    // not flip negative or the pill would flicker on.
+    const c = classifyScrollPosition(
+      { scrollTop: 1050, scrollHeight: 1800, clientHeight: 800 },
+      { hasMore: false, isLoadingOlder: false, hasConversation: true },
+    );
+    expect(c.distanceFromBottom).toBe(0);
+    expect(c.isPinned).toBe(true);
   });
 });
 
 describe("classifyScrollPosition — show-scroll-button threshold (240 px)", () => {
   test("distance 240 does NOT show the button (>)", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 240, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(240),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(SHOW_SCROLL_BUTTON_THRESHOLD_PX);
@@ -129,7 +155,7 @@ describe("classifyScrollPosition — show-scroll-button threshold (240 px)", () 
 
   test("distance 241 shows the button", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 241, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(241),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(241);
@@ -138,7 +164,7 @@ describe("classifyScrollPosition — show-scroll-button threshold (240 px)", () 
 
   test("dropping back under 240 hides the button", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 239, scrollHeight: 1800, clientHeight: 800 },
+      metricsAtDistanceFromBottom(239),
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.distanceFromBottom).toBe(239);
@@ -148,20 +174,17 @@ describe("classifyScrollPosition — show-scroll-button threshold (240 px)", () 
 
 describe("classifyScrollPosition — load-older threshold (200 px)", () => {
   test("scrolled to the top triggers load-older", () => {
-    // scrollHeight=5000, clientHeight=800, scrollTop=3800 =>
-    // distanceFromTop = 5000 - 800 - 3800 = 400 => NO
-    // We want distanceFromTop <= 200, so scrollTop >= 5000 - 800 - 200 = 4000
+    // distanceFromTop = scrollTop. We want scrollTop <= 200 to trigger.
     const c = classifyScrollPosition(
-      { scrollTop: 4000, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 200, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: true, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.shouldLoadOlder).toBe(true);
   });
 
   test("one pixel below threshold does NOT trigger load-older", () => {
-    // distanceFromTop = 5000 - 800 - 3999 = 201 => NOT triggered
     const c = classifyScrollPosition(
-      { scrollTop: 3999, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 201, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: true, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.shouldLoadOlder).toBe(false);
@@ -169,7 +192,7 @@ describe("classifyScrollPosition — load-older threshold (200 px)", () => {
 
   test("does not trigger when isLoadingOlder is true", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 4200, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 100, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: true, isLoadingOlder: true, hasConversation: true },
     );
     expect(c.shouldLoadOlder).toBe(false);
@@ -177,7 +200,7 @@ describe("classifyScrollPosition — load-older threshold (200 px)", () => {
 
   test("does not trigger when hasMore is false", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 4200, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 100, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: false, isLoadingOlder: false, hasConversation: true },
     );
     expect(c.shouldLoadOlder).toBe(false);
@@ -185,7 +208,7 @@ describe("classifyScrollPosition — load-older threshold (200 px)", () => {
 
   test("does not trigger when hasConversation is false", () => {
     const c = classifyScrollPosition(
-      { scrollTop: 4200, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 100, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: true, isLoadingOlder: false, hasConversation: false },
     );
     expect(c.shouldLoadOlder).toBe(false);
@@ -228,14 +251,17 @@ describe("decideItemsChangeAction — no-conversation returns none", () => {
       previousItems: [],
       conversationKey: null,
       savedAnchor: null,
-      isPinnedToLatest: true,
     });
     expect(action.kind).toBe("none");
   });
 });
 
 describe("decideItemsChangeAction — streaming growth", () => {
-  test("pinned + items changed -> stick-to-latest", () => {
+  // The coordinator deliberately does NOT auto-follow as a response
+  // streams in. The user keeps control of the viewport; the "Go to
+  // Newest" pill surfaces once they drift past the threshold.
+
+  test("items grow during streaming -> none", () => {
     const prev = items(["m1", "m2"]);
     const next = items(["m1", "m2", "m3"]);
     const action = decideItemsChangeAction({
@@ -243,37 +269,11 @@ describe("decideItemsChangeAction — streaming growth", () => {
       previousItems: prev,
       conversationKey: "conv-1",
       savedAnchor: null,
-      isPinnedToLatest: true,
-    });
-    expect(action).toEqual({ kind: "stick-to-latest" });
-  });
-
-  test("NOT pinned + items changed -> none (preserve reader's viewport)", () => {
-    const prev = items(["m1", "m2"]);
-    const next = items(["m1", "m2", "m3"]);
-    const action = decideItemsChangeAction({
-      items: next,
-      previousItems: prev,
-      conversationKey: "conv-1",
-      savedAnchor: null,
-      isPinnedToLatest: false,
     });
     expect(action.kind).toBe("none");
   });
 
-  test("pinned but no change -> none", () => {
-    const list = items(["m1", "m2"]);
-    const action = decideItemsChangeAction({
-      items: list,
-      previousItems: list,
-      conversationKey: "conv-1",
-      savedAnchor: null,
-      isPinnedToLatest: true,
-    });
-    expect(action.kind).toBe("none");
-  });
-
-  test("content swap at same length counts as a change", () => {
+  test("content swap at same length -> none", () => {
     const prev = items(["m1", "m2"]);
     const next = items(["m1", "m2-edited"]);
     const action = decideItemsChangeAction({
@@ -281,53 +281,64 @@ describe("decideItemsChangeAction — streaming growth", () => {
       previousItems: prev,
       conversationKey: "conv-1",
       savedAnchor: null,
-      isPinnedToLatest: true,
     });
-    expect(action.kind).toBe("stick-to-latest");
+    expect(action.kind).toBe("none");
+  });
+
+  test("no change -> none", () => {
+    const list = items(["m1", "m2"]);
+    const action = decideItemsChangeAction({
+      items: list,
+      previousItems: list,
+      conversationKey: "conv-1",
+      savedAnchor: null,
+    });
+    expect(action.kind).toBe("none");
   });
 });
 
 describe("decideItemsChangeAction — anchor-preserving prepend", () => {
-  test("saved anchor present and found -> anchor-correct with new index", () => {
+  test("saved anchor present and found -> anchor-correct with saved metrics", () => {
     const before = items(["m1", "m2", "m3"]);
     const afterPrepend = items(["o1", "o2", "m1", "m2", "m3"]);
     const action = decideItemsChangeAction({
       items: afterPrepend,
       previousItems: before,
       conversationKey: "conv-1",
-      savedAnchor: { key: "m1", scrollTop: 42 },
-      isPinnedToLatest: false,
+      savedAnchor: { key: "m1", scrollTop: 42, scrollHeight: 1800 },
     });
     expect(action).toEqual({
       kind: "anchor-correct",
       newIndex: 2,
-      scrollTop: 42,
+      savedScrollTop: 42,
+      savedScrollHeight: 1800,
     });
   });
 
-  test("anchor correction takes priority over stick-to-latest when both would fire", () => {
+  test("anchor correction wins over the otherwise-noop streaming-growth path", () => {
     const before = items(["m1"]);
     const afterPrepend = items(["o1", "m1", "m2"]);
     const action = decideItemsChangeAction({
       items: afterPrepend,
       previousItems: before,
       conversationKey: "conv-1",
-      savedAnchor: { key: "m1", scrollTop: 123 },
-      // Even if the caller thinks we're pinned, anchor must win.
-      isPinnedToLatest: true,
+      savedAnchor: { key: "m1", scrollTop: 123, scrollHeight: 1800 },
     });
     expect(action.kind).toBe("anchor-correct");
   });
 
-  test("saved anchor but key missing -> falls through to stick-to-latest when pinned", () => {
+  test("saved anchor but key missing -> falls through to none", () => {
     const action = decideItemsChangeAction({
       items: items(["n1", "n2"]),
       previousItems: items(["m1"]),
       conversationKey: "conv-1",
-      savedAnchor: { key: "m1-no-longer-present", scrollTop: 10 },
-      isPinnedToLatest: true,
+      savedAnchor: {
+        key: "m1-no-longer-present",
+        scrollTop: 10,
+        scrollHeight: 1800,
+      },
     });
-    expect(action).toEqual({ kind: "stick-to-latest" });
+    expect(action.kind).toBe("none");
   });
 });
 
@@ -338,13 +349,12 @@ describe("decideItemsChangeAction — anchor-preserving prepend", () => {
 // ---------------------------------------------------------------------------
 
 describe("integration — handleScroll-style dispatch via pure helpers", () => {
-  test("onLoadOlder is called exactly once when near the top (column-reverse)", () => {
+  test("onLoadOlder is called exactly once when near the top", () => {
     const handle = makeHandle();
     const onLoadOlder = mock(() => {});
-    // In column-reverse, near the top means distanceFromTop <= 200
-    // distanceFromTop = 5000 - 800 - 4000 = 200
+    // distanceFromTop = scrollTop. scrollTop = 200 ⇒ load-older fires.
     const c = classifyScrollPosition(
-      { scrollTop: 4000, scrollHeight: 5000, clientHeight: 800 },
+      { scrollTop: 200, scrollHeight: 5000, clientHeight: 800 },
       { hasMore: true, isLoadingOlder: false, hasConversation: true },
     );
     if (c.shouldLoadOlder) onLoadOlder();
@@ -355,7 +365,7 @@ describe("integration — handleScroll-style dispatch via pure helpers", () => {
 
   test("onLoadOlder is NOT called while isLoadingOlder=true", () => {
     const onLoadOlder = mock(() => {});
-    for (const scrollTop of [4000, 4100, 4200]) {
+    for (const scrollTop of [50, 100, 150]) {
       const c = classifyScrollPosition(
         { scrollTop, scrollHeight: 5000, clientHeight: 800 },
         { hasMore: true, isLoadingOlder: true, hasConversation: true },
@@ -366,46 +376,45 @@ describe("integration — handleScroll-style dispatch via pure helpers", () => {
   });
 
   test("pinned flips exactly at the 64 px threshold as the user scrolls up then back down", () => {
-    // In column-reverse: distanceFromBottom = scrollTop
     let isPinned = true;
-    const update = (scrollTop: number) => {
+    const updateByDistanceFromBottom = (distance: number) => {
       const c = classifyScrollPosition(
-        { scrollTop, scrollHeight: 1800, clientHeight: 800 },
+        metricsAtDistanceFromBottom(distance),
         { hasMore: false, isLoadingOlder: false, hasConversation: true },
       );
       isPinned = c.isPinned;
     };
-    update(0); // at bottom, distance 0
+    updateByDistanceFromBottom(0); // at bottom
     expect(isPinned).toBe(true);
-    update(64); // distance 64
+    updateByDistanceFromBottom(64);
     expect(isPinned).toBe(true);
-    update(65); // distance 65 — flip
+    updateByDistanceFromBottom(65); // flip
     expect(isPinned).toBe(false);
-    update(64); // back to 64 — flip back
+    updateByDistanceFromBottom(64); // flip back
     expect(isPinned).toBe(true);
   });
 
   test("showScrollToLatest flips exactly at the 240 px threshold in both directions", () => {
     let show = false;
-    const update = (scrollTop: number) => {
+    const updateByDistanceFromBottom = (distance: number) => {
       const c = classifyScrollPosition(
-        { scrollTop, scrollHeight: 1800, clientHeight: 800 },
+        metricsAtDistanceFromBottom(distance),
         { hasMore: false, isLoadingOlder: false, hasConversation: true },
       );
       show = c.showScrollToLatest;
     };
-    update(240); // distance 240 — still hidden
+    updateByDistanceFromBottom(240); // still hidden
     expect(show).toBe(false);
-    update(241); // distance 241 — flip on
+    updateByDistanceFromBottom(241); // flip on
     expect(show).toBe(true);
-    update(240); // back to 240 — flip off
+    updateByDistanceFromBottom(240); // flip off
     expect(show).toBe(false);
   });
 
   test("anchor-preserving prepend: saved anchor -> anchor-correct on next items change", () => {
     const before = items(["m1", "m2", "m3"]);
     // Saved anchor captured during a load-older scroll event.
-    const saved = { key: "m1", scrollTop: 150 };
+    const saved = { key: "m1", scrollTop: 150, scrollHeight: 1800 };
     // New items arrive with two older messages prepended.
     const after = items(["o1", "o2", "m1", "m2", "m3"]);
     const action = decideItemsChangeAction({
@@ -413,49 +422,28 @@ describe("integration — handleScroll-style dispatch via pure helpers", () => {
       previousItems: before,
       conversationKey: "conv-1",
       savedAnchor: saved,
-      isPinnedToLatest: false,
     });
     expect(action).toEqual({
       kind: "anchor-correct",
       newIndex: 2,
-      scrollTop: 150,
+      savedScrollTop: 150,
+      savedScrollHeight: 1800,
     });
   });
 
-  test("streaming growth: pinned -> scrollToLatest called; not pinned -> NOT called", () => {
+  test("streaming growth never triggers an auto-scroll", () => {
     const handle = makeHandle();
     const prev = items(["m1"]);
     const grown = items(["m1", "m2"]);
-
-    // Case 1: pinned — scrollToLatest fires.
-    {
-      const action = decideItemsChangeAction({
-        items: grown,
-        previousItems: prev,
-        conversationKey: "conv-1",
-        savedAnchor: null,
-        isPinnedToLatest: true,
-      });
-      if (action.kind === "stick-to-latest") {
-        handle.scrollToLatest({ behavior: "auto" });
-      }
-    }
-    expect(handle.calls.scrollToLatest).toEqual([[{ behavior: "auto" }]]);
-
-    // Case 2: not pinned — no scroll command.
-    const handle2 = makeHandle();
-    {
-      const action = decideItemsChangeAction({
-        items: grown,
-        previousItems: prev,
-        conversationKey: "conv-1",
-        savedAnchor: null,
-        isPinnedToLatest: false,
-      });
-      if (action.kind === "stick-to-latest") {
-        handle2.scrollToLatest({ behavior: "auto" });
-      }
-    }
-    expect(handle2.calls.scrollToLatest.length).toBe(0);
+    const action = decideItemsChangeAction({
+      items: grown,
+      previousItems: prev,
+      conversationKey: "conv-1",
+      savedAnchor: null,
+    });
+    // Decision helper no longer emits stick-to-latest under any pinned
+    // state — the viewport stays put while the user reads.
+    expect(action.kind).toBe("none");
+    expect(handle.calls.scrollToLatest.length).toBe(0);
   });
 });

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -1,14 +1,22 @@
-// Scroll coordinator hook for the column-reverse transcript. Owns:
+// Scroll coordinator hook for the chronological-order transcript. Owns:
 //
-//   1. Pinned-to-latest detection + scroll-to-latest affordance visibility.
+//   1. Pinned-to-latest detection + "Go to Newest" affordance visibility.
 //   2. Anchor-preserving older-page prepends.
-//   3. Streaming-growth auto-follow (pinned -> stick to bottom; otherwise
-//      preserve the reader's viewport).
+//   3. Conversation-switch reset: scroll the reused container back to the
+//      latest message so the new conversation does not inherit the
+//      previous conversation's scrollTop.
 //
-// In column-reverse layout, scrollTop = 0 is the visual bottom (latest
-// messages). Scrolling UP to older messages increases the negative
-// scrollTop magnitude (scrollTop becomes more negative in some browsers)
-// but we use the absolute scrollTop value as `distanceFromBottom`.
+// The coordinator deliberately does NOT auto-follow streaming growth.
+// As a response streams in, the viewport stays put and the "Go to Newest"
+// pill surfaces so the user can catch up on their own — see the
+// `LatestTurnRow` min-height spacer for the layout half of this pattern.
+//
+// The transcript uses plain `flex-col` (NOT column-reverse): oldest items
+// first, latest at the bottom. scrollTop = 0 is the visual top (oldest);
+// scrollTop = scrollHeight − clientHeight is the visual bottom (latest).
+// Switching off column-reverse is what makes the "stay put while streaming"
+// behavior possible — column-reverse's intrinsic bottom-anchoring fights
+// every attempt to keep the viewport still.
 //
 // The hook only issues scroll commands through the `TranscriptHandle`
 // interface — it never touches `scrollIntoView` directly.
@@ -34,18 +42,17 @@ export type { TranscriptHandle };
 // ---------------------------------------------------------------------------
 
 /** Distance from bottom (in px) at or below which the transcript is
- *  considered pinned to latest. In column-reverse, this is the absolute
- *  value of scrollTop. */
+ *  considered pinned to latest. In flex-col, this is
+ *  `scrollHeight − clientHeight − scrollTop`. */
 export const PINNED_THRESHOLD_PX = 64;
 
-/** Distance from bottom (in px) above which the scroll-to-latest
+/** Distance from bottom (in px) above which the "Go to Newest"
  *  affordance is shown. */
 export const SHOW_SCROLL_BUTTON_THRESHOLD_PX = 240;
 
 /** Distance from the TOP of scrollable content (in px) at or below which
- *  an older-page load is triggered. In column-reverse, the top of
- *  scrollable content (oldest messages) is at
- *  `scrollHeight - clientHeight - scrollTop`. */
+ *  an older-page load is triggered. In flex-col, the top of scrollable
+ *  content (oldest messages) is at `scrollTop = 0`. */
 export const LOAD_OLDER_THRESHOLD_PX = 200;
 
 // ---------------------------------------------------------------------------
@@ -59,7 +66,6 @@ export interface UseTranscriptScrollArgs {
   hasMore: boolean;
   isLoadingOlder: boolean;
   onLoadOlder: () => void;
-  onStickToLatest?: () => void;
 }
 
 export interface UseTranscriptScrollReturn {
@@ -89,24 +95,26 @@ export interface ScrollClassification {
 /** Pure classification of a scroll position against the load-bearing
  *  thresholds above.
  *
- *  In column-reverse layout, scrollTop = 0 is the visual bottom (latest
- *  messages). As the user scrolls UP toward older messages, scrollTop
- *  increases. So:
- *    - distanceFromBottom = scrollTop
- *    - distanceFromTop = scrollHeight - clientHeight - scrollTop
+ *  In flex-col (chronological) layout:
+ *    - distanceFromTop    = scrollTop
+ *    - distanceFromBottom = scrollHeight − clientHeight − scrollTop
+ *
+ *  iOS rubber-band can briefly push scrollTop outside [0, max], so we
+ *  clamp distanceFromBottom at 0 to avoid spurious pill flicker.
  */
 export function classifyScrollPosition(
   metrics: ScrollMetrics,
   flags: { hasMore: boolean; isLoadingOlder: boolean; hasConversation: boolean },
 ): ScrollClassification {
-  // In column-reverse containers, browsers report negative scrollTop when
-  // scrolled away from the bottom. Use Math.abs to normalize.
-  const distanceFromBottom = Math.abs(metrics.scrollTop);
+  const maxScrollTop = Math.max(
+    0,
+    metrics.scrollHeight - metrics.clientHeight,
+  );
+  const distanceFromBottom = Math.max(0, maxScrollTop - metrics.scrollTop);
+  const distanceFromTop = Math.max(0, metrics.scrollTop);
   const isPinned = distanceFromBottom <= PINNED_THRESHOLD_PX;
   const showScrollToLatest =
     distanceFromBottom > SHOW_SCROLL_BUTTON_THRESHOLD_PX;
-  const distanceFromTop =
-    metrics.scrollHeight - metrics.clientHeight - distanceFromBottom;
   const shouldLoadOlder =
     flags.hasConversation &&
     flags.hasMore &&
@@ -135,19 +143,28 @@ export function findAnchorIndex(
 export interface AnchorSnapshot {
   key: string;
   scrollTop: number;
+  /** scrollHeight captured at the moment the anchor was saved. The
+   *  hook restores `scrollTop + (newScrollHeight − savedScrollHeight)`
+   *  after the older-page prepend lands, so the user's view stays on
+   *  the same row regardless of how many pixels of older content were
+   *  inserted above it. */
+  scrollHeight: number;
 }
 
 export type ItemsChangeAction =
   | { kind: "none" }
-  | { kind: "anchor-correct"; newIndex: number; scrollTop: number }
-  | { kind: "stick-to-latest" };
+  | {
+      kind: "anchor-correct";
+      newIndex: number;
+      savedScrollTop: number;
+      savedScrollHeight: number;
+    };
 
 export interface ItemsChangeContext {
   items: readonly TranscriptItem[];
   previousItems: readonly TranscriptItem[];
   conversationKey: string | null;
   savedAnchor: AnchorSnapshot | null;
-  isPinnedToLatest: boolean;
 }
 
 /** Decide what the scroll coordinator should do in response to an
@@ -155,35 +172,33 @@ export interface ItemsChangeContext {
  *  (calling into the TranscriptHandle) and for updating the
  *  `savedAnchor` bookkeeping state.
  *
- *  Note: "open-to-latest" is not needed in column-reverse because the
- *  browser naturally starts at scrollTop=0 (the visual bottom). */
+ *  Notes:
+ *  - "open-to-latest" on conversation switch is handled by the
+ *    conversation-reset effect, not here.
+ *  - Streaming growth deliberately returns `none` here. The viewport
+ *    stays put so the reader is in control; the "Go to Newest" pill
+ *    appears once distance-from-bottom crosses its threshold. */
 export function decideItemsChangeAction(
   ctx: ItemsChangeContext,
 ): ItemsChangeAction {
   // When there's no active conversation we have nothing to coordinate.
   if (ctx.conversationKey === null) return { kind: "none" };
 
-  // 1. Anchor-preserving prepend correction has highest priority — the
-  //    reader is scrolled up, a page of older messages just landed, and
-  //    we need to keep their viewport anchored on the row they were
-  //    looking at.
+  // Anchor-preserving prepend correction — the reader is scrolled up,
+  // a page of older messages just landed, and we need to keep their
+  // viewport anchored on the row they were looking at. The handler
+  // adds (newScrollHeight − savedScrollHeight) to savedScrollTop, since
+  // the new content was inserted above the anchor in flex-col DOM.
   if (ctx.savedAnchor && ctx.items.length > 0) {
     const newIndex = findAnchorIndex(ctx.items, ctx.savedAnchor.key);
     if (newIndex >= 0) {
       return {
         kind: "anchor-correct",
         newIndex,
-        scrollTop: ctx.savedAnchor.scrollTop,
+        savedScrollTop: ctx.savedAnchor.scrollTop,
+        savedScrollHeight: ctx.savedAnchor.scrollHeight,
       };
     }
-  }
-
-  // 2. Streaming growth — stick to latest only when already pinned.
-  const changed =
-    ctx.items.length !== ctx.previousItems.length ||
-    ctx.items.some((item, i) => item !== ctx.previousItems[i]);
-  if (changed && ctx.isPinnedToLatest) {
-    return { kind: "stick-to-latest" };
   }
 
   return { kind: "none" };
@@ -203,7 +218,6 @@ export function useTranscriptScroll(
     hasMore,
     isLoadingOlder,
     onLoadOlder,
-    onStickToLatest,
   } = args;
 
   const [isPinnedToLatest, setIsPinnedToLatest] = useState(true);
@@ -217,7 +231,6 @@ export function useTranscriptScroll(
     isLoadingOlder,
     conversationKey,
     onLoadOlder,
-    onStickToLatest,
     isPinnedToLatest,
     showScrollToLatest,
   });
@@ -228,7 +241,6 @@ export function useTranscriptScroll(
       isLoadingOlder,
       conversationKey,
       onLoadOlder,
-      onStickToLatest,
       isPinnedToLatest,
       showScrollToLatest,
     };
@@ -238,7 +250,6 @@ export function useTranscriptScroll(
     isLoadingOlder,
     conversationKey,
     onLoadOlder,
-    onStickToLatest,
     isPinnedToLatest,
     showScrollToLatest,
   ]);
@@ -249,9 +260,57 @@ export function useTranscriptScroll(
   // ---------- Previous items ref (for change detection) -----------------
   const previousItemsRef = useRef<TranscriptItem[]>(items);
 
+  // ---------- Auto-pin window --------------------------------------------
+  // While `shouldAutoPinRef` is true, every layout change of the scroll
+  // content re-pins the viewport to the bottom. This is what makes the
+  // initial render of a new conversation land at the latest message
+  // even when content height keeps growing across multiple frames —
+  // `useViewportMinHeight`'s deferred `setHeight`, late image/font
+  // loads, etc. The flag is engaged briefly on intentful events
+  // (conversation switch, "Go to Newest", user submit) and auto-
+  // disengages on a 500 ms timer or on the first user-input scroll —
+  // whichever comes first. The window is intentionally short so a
+  // streaming response (which takes the HTTP round-trip plus first
+  // token to *start*) does not trigger auto-follow.
+  const shouldAutoPinRef = useRef(false);
+  const autoPinTimeoutRef = useRef<number | null>(null);
+
+  const disengageAutoPin = useCallback(() => {
+    shouldAutoPinRef.current = false;
+    if (autoPinTimeoutRef.current !== null) {
+      clearTimeout(autoPinTimeoutRef.current);
+      autoPinTimeoutRef.current = null;
+    }
+  }, []);
+
+  const engageAutoPin = useCallback(() => {
+    shouldAutoPinRef.current = true;
+    if (autoPinTimeoutRef.current !== null) {
+      clearTimeout(autoPinTimeoutRef.current);
+    }
+    autoPinTimeoutRef.current = window.setTimeout(() => {
+      shouldAutoPinRef.current = false;
+      autoPinTimeoutRef.current = null;
+    }, 500);
+  }, []);
+
+  // Always clear the timer on unmount.
+  useEffect(
+    () => () => {
+      if (autoPinTimeoutRef.current !== null) {
+        clearTimeout(autoPinTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
   // -----------------------------------------------------------------------
-  // Conversation switch: reset pinned state.
-  // Wrapped in startTransition so the reset doesn't block urgent updates.
+  // Conversation switch: reset pinned state and engage the auto-pin
+  // window. The items effect + content ResizeObserver will land the
+  // viewport on the latest message once the new content is in the DOM,
+  // and keep re-pinning across the async layout-settling phase
+  // (useViewportMinHeight, late image loads). The window auto-expires
+  // before any streaming response could start.
   // -----------------------------------------------------------------------
   useLayoutEffect(() => {
     startTransition(() => {
@@ -259,11 +318,9 @@ export function useTranscriptScroll(
       setShowScrollToLatest(false);
     });
     savedAnchorRef.current = null;
-    // Reset previousItemsRef so the new conversation's first items aren't
-    // interpreted as a "growth" event.
     previousItemsRef.current = [];
-    // Intentionally only depend on conversationKey.
-  }, [conversationKey]);
+    engageAutoPin();
+  }, [conversationKey, engageAutoPin]);
 
   // -----------------------------------------------------------------------
   // Items change handler — runs in useLayoutEffect so the anchor correction
@@ -278,37 +335,75 @@ export function useTranscriptScroll(
       previousItems: prev,
       conversationKey,
       savedAnchor: savedAnchorRef.current,
-      isPinnedToLatest: latestRef.current.isPinnedToLatest,
     });
 
     switch (action.kind) {
       case "anchor-correct": {
         const scrollElement = transcriptRef.current?.getScrollElement();
         if (scrollElement) {
-          scrollElement.scrollTop = action.scrollTop;
+          const heightDelta =
+            scrollElement.scrollHeight - action.savedScrollHeight;
+          scrollElement.scrollTop = action.savedScrollTop + heightDelta;
         }
         savedAnchorRef.current = null;
-        break;
-      }
-      case "stick-to-latest": {
-        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
-        latestRef.current.onStickToLatest?.();
         break;
       }
       case "none":
       default:
         break;
     }
+
+    // First-pass pin during the auto-pin window. The content
+    // ResizeObserver will catch any subsequent height changes (async
+    // min-height settle, late image loads) and re-pin until the
+    // window expires.
+    if (
+      shouldAutoPinRef.current &&
+      items.length > 0 &&
+      transcriptRef.current
+    ) {
+      transcriptRef.current.scrollToLatest({ behavior: "auto" });
+    }
+
+    // After every items change re-classify the scroll position. The
+    // browser does NOT fire a scroll event when scrollHeight grows under
+    // a stationary scrollTop (the streaming case), so without this the
+    // "Go to Newest" pill would only surface once the user touched the
+    // scroll wheel. Reading via the latestRef avoids putting the
+    // hasMore/isLoadingOlder/conversationKey flags in the dep array.
+    const el = transcriptRef.current?.getScrollElement();
+    if (el) {
+      const classification = classifyScrollPosition(
+        {
+          scrollTop: el.scrollTop,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        },
+        {
+          hasMore: latestRef.current.hasMore,
+          isLoadingOlder: latestRef.current.isLoadingOlder,
+          hasConversation: latestRef.current.conversationKey !== null,
+        },
+      );
+      if (classification.isPinned !== latestRef.current.isPinnedToLatest) {
+        setIsPinnedToLatest(classification.isPinned);
+      }
+      if (
+        classification.showScrollToLatest !==
+        latestRef.current.showScrollToLatest
+      ) {
+        setShowScrollToLatest(classification.showScrollToLatest);
+      }
+    }
   }, [items, conversationKey, transcriptRef]);
 
   // -----------------------------------------------------------------------
   // Container resize re-pin. When the scroll container resizes (e.g. the
-  // document panel opens and squeezes the chat pane), content reflows and
-  // the scroll position may shift. Re-pin to the bottom when the user was
-  // already pinned so the "scroll to latest" button doesn't appear
-  // spuriously. Combined with `overflow-anchor: none` on the scroll
-  // container (Transcript.tsx), this keeps the coordinator — not the
-  // browser — in control of scroll position during layout changes.
+  // document panel opens and squeezes the chat pane), `scrollHeight −
+  // clientHeight` shifts and the max scrollTop changes. Re-pin to the
+  // bottom when the user was already pinned so the "Go to Newest" pill
+  // doesn't appear spuriously after a layout change the user didn't
+  // initiate.
   //
   // The observer lifecycle is managed via refs so that we only
   // disconnect/reconnect when the underlying DOM node actually changes
@@ -348,6 +443,69 @@ export function useTranscriptScroll(
   }, []);
 
   // -----------------------------------------------------------------------
+  // Content resize re-pin. The *content* element (inner wrapper around
+  // all rendered rows) changes size whenever scroll content grows:
+  //   - `useViewportMinHeight` setting min-height after first paint
+  //   - Late image / web-font loads
+  //   - Streaming response items appended
+  //   - User-submitted messages adding a new turn
+  // While `shouldAutoPinRef` is true, every fire snaps scrollTop back
+  // to the visual bottom so the viewport stays at the latest message
+  // through all of those async height changes. The 500 ms window
+  // ensures streaming alone (which starts after first token / HTTP
+  // round-trip) never auto-follows.
+  // -----------------------------------------------------------------------
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
+  const observedContentElRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+
+    const el = transcriptRef.current?.getContentElement?.() ?? null;
+    if (el === observedContentElRef.current) return;
+
+    contentObserverRef.current?.disconnect();
+    observedContentElRef.current = el;
+
+    if (!el) {
+      contentObserverRef.current = null;
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (shouldAutoPinRef.current) {
+        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
+      }
+    });
+    observer.observe(el);
+    contentObserverRef.current = observer;
+  }, [items, transcriptRef]);
+
+  useEffect(() => () => {
+    contentObserverRef.current?.disconnect();
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // User-input scroll cancels the auto-pin window. Any of these gestures
+  // means the user has taken control of the viewport — we stop fighting
+  // them. We listen on the scroll element rather than the scroll event
+  // because the scroll event also fires from our own programmatic pins,
+  // which would otherwise disengage their own window mid-pin.
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    const el = transcriptRef.current?.getScrollElement() ?? null;
+    if (!el) return;
+    el.addEventListener("wheel", disengageAutoPin, { passive: true });
+    el.addEventListener("touchmove", disengageAutoPin, { passive: true });
+    el.addEventListener("keydown", disengageAutoPin, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", disengageAutoPin);
+      el.removeEventListener("touchmove", disengageAutoPin);
+      el.removeEventListener("keydown", disengageAutoPin);
+    };
+  }, [items, transcriptRef, disengageAutoPin]);
+
+  // -----------------------------------------------------------------------
   // Stable scroll handler. Reads latest props via the ref pattern.
   // -----------------------------------------------------------------------
   const handleScroll = useCallback((event: Event) => {
@@ -373,13 +531,16 @@ export function useTranscriptScroll(
     }
 
     if (classification.shouldLoadOlder) {
-      // Capture the top-most visible item so we can restore the reader's
-      // viewport after the prepend lands.
+      // Capture the top-most visible item AND the current scrollHeight so
+      // the items-effect can restore the reader's viewport after the
+      // older-page prepend lands. The restore is
+      // `savedScrollTop + (newScrollHeight − savedScrollHeight)`.
       const firstItem = latest.items[0];
       if (firstItem) {
         savedAnchorRef.current = {
           key: firstItem.key,
           scrollTop: metrics.scrollTop,
+          scrollHeight: metrics.scrollHeight,
         };
       }
       latest.onLoadOlder();
@@ -387,16 +548,19 @@ export function useTranscriptScroll(
   }, []);
 
   // -----------------------------------------------------------------------
-  // Exposed scrollToLatest — thin pass-through.
+  // Exposed scrollToLatest — engages the auto-pin window so any async
+  // layout settling after the scroll (image loads, etc.) stays anchored
+  // at the bottom too.
   // -----------------------------------------------------------------------
   const scrollToLatest = useCallback(
     (opts?: { behavior?: "auto" | "smooth" }) => {
       savedAnchorRef.current = null;
+      engageAutoPin();
       transcriptRef.current?.scrollToLatest({
         behavior: opts?.behavior ?? "smooth",
       });
     },
-    [transcriptRef],
+    [transcriptRef, engageAutoPin],
   );
 
   return {


### PR DESCRIPTION
## Summary

- Renames the chat scroll affordance from "Scroll to latest" to "Go to Newest" (regular 14px size, `ChevronDown` icon on the right, animated 3-dot pulse on the left while streaming, `--content-emphasised` text color — Figma `5010:103945`).
- Flips the transcript from `flex-col-reverse` to `flex-col` so the viewport stays put while a response streams in. Adds a 500ms `shouldAutoPin` window + content `ResizeObserver` that re-pins to bottom on conversation switch, pill click, and user submit; disengages on user-input scroll or timer expiry.
- Adapts pull-to-refresh for the new layout (gesture is DOWN at the bottom now) and carries `scrollHeight` through `AnchorSnapshot` so older-page-load anchor restore shifts `scrollTop` by the prepended-content delta.

## Origin

Faithful port of [vellum-assistant-platform PR #7547](https://github.com/vellum-ai/vellum-assistant-platform/pull/7547). Daemon-side metadata this UI consumes is already merged (#31268, #31196, #31195).

## Original prompt

Port vellum-assistant-platform PR #7547 ("Go to Newest" pill + flex-col transcript) into vellum-assistant `apps/web/`. The platform repo uses Next.js app-router (`web/src/app/(app)/assistant/(chat)/_*`); this repo uses a domains layout (`apps/web/src/domains/chat/`), so files were mapped accordingly. Imports were adapted to the local aliases. The platform-only `provider-connections-client.ts` change was skipped per the task description (unrelated branch noise), and the platform-only `groupPositions` plumbing on `LatestTurnRow`/`TranscriptRow` was skipped because those props don't exist in this repo.

## Deviations from the source PR

- Skipped `web/src/app/(app)/assistant/settings/ai/provider-connections-client.ts` — unrelated branch noise per the port plan.
- Skipped the source PR's `groupPosition`/`computeGroupPositions` additions on `Transcript`/`LatestTurnRow`/`TranscriptRow` — those props don't exist in this repo (separate platform-only feature).
- The platform PR adds a `dismissOnboardingChoice()` call inside `handleSubmit`; in this repo the destructured dismiss function is unused (`_dismissOnboardingChoice`), so the call was omitted. The auto-pin via `scrollCoordinator.scrollToLatest({ behavior: "auto" })` on submit (the load-bearing part) is preserved.

## Build / test

- `bun run typecheck` — clean.
- `bun scripts/run-tests.ts` — 100 / 100 test files pass.
- `bun run build` — clean.

## QA before merge

Per the user's workflow preference, **do not merge** until visual QA in the running app. Walk through the test plan from the source PR:

- [ ] Open a long conversation — viewport lands at the latest message
- [ ] Switch between conversations — each opens at its latest message
- [ ] Send a message — response streams in below without dragging the viewport
- [ ] Scroll up mid-stream — pill appears with animated dots; viewport stays put
- [ ] Click "Go to Newest" while streaming — snaps to bottom, dots disappear on stream end
- [ ] Load older messages — anchor row stays under the same pixel after prepend
- [ ] Pill copy / style matches Figma 5010:103945 (14px medium, chevron-down, `--content-emphasised`)
- [ ] iOS PTR (if flag on) — pull DOWN at the bottom triggers refresh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->