### PR TITLE
feat(web): wire WebsiteCarousel into WebSearchProgressCard header

### DIFF
--- a/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/tool-call-progress-card/tool-call-progress-card.tsx
@@ -340,6 +340,7 @@ export function ToolCallProgressCard(props: ToolCallProgressCardProps) {
         stepCount={webSearchData.stepCount}
         steps={webSearchData.steps}
         state={webSearchData.state}
+        carouselItems={webSearchData.carouselItems}
       />
     );
   }

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.test.tsx
@@ -127,6 +127,61 @@ describe("WebSearchProgressCard — collapsed state", () => {
     expect(getByText("Tigers — Wikipedia")).toBeTruthy();
     expect(getByText("Searching the web")).toBeTruthy();
   });
+
+  test("renders WebsiteCarousel in the info slot when carouselItems are provided in loading state", () => {
+    // Carousel mode supersedes the text info slot — `currentStepInfo` is not
+    // rendered, the carousel's current item title is.
+    const items: WebSearchResultItem[] = [
+      makeResult(1, { title: "Sotheby's — Auctions" }),
+    ];
+    const { getByText, queryByText } = render(
+      <WebSearchProgressCard
+        currentStepTitle="Searching the web"
+        currentStepInfo="should be hidden"
+        stepCount="2 steps"
+        steps={TWO_THINKING_STEPS}
+        state="loading"
+        carouselItems={items}
+      />,
+    );
+    expect(getByText("Searching the web")).toBeTruthy();
+    expect(getByText("Sotheby's — Auctions")).toBeTruthy();
+    expect(queryByText("should be hidden")).toBeNull();
+  });
+
+  test("falls back to text mode when carouselItems is empty", () => {
+    const { getByText } = render(
+      <WebSearchProgressCard
+        currentStepTitle="Searching the web"
+        currentStepInfo="Tigers — Wikipedia"
+        stepCount="2 steps"
+        steps={TWO_THINKING_STEPS}
+        state="loading"
+        carouselItems={[]}
+      />,
+    );
+    expect(getByText("Tigers — Wikipedia")).toBeTruthy();
+  });
+
+  test("does not render the carousel in complete state even with items", () => {
+    // Complete state is the resting visual — the user-facing label should be
+    // the final result title, not a still-rotating carousel.
+    const items: WebSearchResultItem[] = [
+      makeResult(1, { title: "Sotheby's — Auctions" }),
+    ];
+    const { getByText, queryByText } = render(
+      <WebSearchProgressCard
+        currentStepTitle="Searched the web"
+        currentStepInfo="Final result title"
+        stepCount="2 steps"
+        steps={TWO_THINKING_STEPS}
+        state="complete"
+        carouselItems={items}
+      />,
+    );
+    expect(getByText("Final result title")).toBeTruthy();
+    expect(queryByText("Sotheby's — Auctions")).toBeNull();
+  });
 });
 
 describe("WebSearchProgressCard — expanded state", () => {

--- a/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
+++ b/apps/web/src/domains/chat/components/web-search/web-search-progress-card.tsx
@@ -10,6 +10,7 @@ import { FaviconChip } from "@/domains/chat/components/web-search/favicon-chip.j
 import { StepRow } from "@/domains/chat/components/web-search/step-row.js";
 import { ThinkingChip } from "@/domains/chat/components/web-search/thinking-chip.js";
 import { ThreeDotIndicator } from "@/domains/chat/components/web-search/three-dot-indicator.js";
+import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel.js";
 
 /**
  * Live progress card rendered while an assistant turn is actively searching the
@@ -40,6 +41,9 @@ import { ThreeDotIndicator } from "@/domains/chat/components/web-search/three-do
  * - `"web_search_error"` → renders a red AlertCircle + the provider's
  *   `errorMessage` inside a negatively-toned chip. Used when the search
  *   itself failed and there are no results to surface.
+ *
+ * The plan reserves richer `web_fetch` rendering for a follow-up; the PR-8
+ * selector currently maps fetches to a `thinking` step ("Reading <title>").
  */
 export type StepDescriptor =
   | { kind: "thinking"; durationLabel: string; text: string }
@@ -86,6 +90,17 @@ export interface WebSearchProgressCardProps {
    *   card is rendering a finished search result set.
    */
   state?: "loading" | "complete";
+  /**
+   * Optional websites to feed the collapsed-header rotating carousel.
+   * When non-empty AND `state === "loading"`, the info slot in the header
+   * swaps from text (`currentStepInfo`) to a `WebsiteCarousel` rotating
+   * through these favicon + title chips. Empty → text mode stays.
+   *
+   * Populated by `useWebSearchCardData` from the most recently completed
+   * `web_search`'s results — see `WebSearchCardData.carouselItems` for the
+   * derivation contract.
+   */
+  carouselItems?: WebSearchResultItem[];
 }
 
 /**
@@ -141,6 +156,13 @@ function ErrorChip({ message }: { message: string }) {
  * once the previous has been on-screen long enough to register.
  */
 const HEADER_STEP_MIN_DWELL_MS = 400;
+
+/**
+ * Stable empty-array reference used as the `carouselItems` default. Avoids
+ * a fresh `[]` per render that would needlessly tick the
+ * `useCarousel` boolean back and forth (and remount `WebsiteCarousel`).
+ */
+const EMPTY_CAROUSEL_ITEMS: WebSearchResultItem[] = [];
 
 /**
  * Latch a value to its previous render until at least `minDwellMs` has
@@ -278,6 +300,45 @@ function HeaderStepCarousel({
   );
 }
 
+/**
+ * Header layout used when the carousel feed is non-empty during an active
+ * search. Mirrors `HeaderStepCarousel`'s flex shell so the title hugs the
+ * left, the dimmed pipe separator follows, and the carousel fills the
+ * remaining width.
+ *
+ * The title text isn't tuple-throttled here because — in carousel mode —
+ * the only meaningful title transition is `Searching → Searched` (which
+ * only occurs once the carousel hands off back to text mode on
+ * `state === "complete"`). The carousel itself owns the rotation animation.
+ */
+function HeaderTitleWithCarousel({
+  currentStepTitle,
+  carouselItems,
+}: {
+  currentStepTitle: string;
+  carouselItems: WebSearchResultItem[];
+}) {
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-1">
+      <Typography
+        variant="body-medium-default"
+        className="ml-1 shrink-0 whitespace-nowrap text-[var(--content-emphasised)]"
+      >
+        {currentStepTitle}
+      </Typography>
+      <span
+        aria-hidden="true"
+        className="shrink-0 text-[var(--content-tertiary)] opacity-10"
+      >
+        |
+      </span>
+      <span className="block min-w-0 flex-1">
+        <WebsiteCarousel items={carouselItems} />
+      </span>
+    </span>
+  );
+}
+
 export function WebSearchProgressCard({
   currentStepTitle,
   currentStepInfo,
@@ -285,7 +346,12 @@ export function WebSearchProgressCard({
   steps,
   defaultExpanded = false,
   state = "loading",
+  carouselItems = EMPTY_CAROUSEL_ITEMS,
 }: WebSearchProgressCardProps) {
+  // Carousel mode supersedes text mode in the collapsed-header info slot,
+  // but only during the active search — `complete` state stays text-only so
+  // the final-result title reads as the resting visual.
+  const useCarousel = state === "loading" && carouselItems.length > 0;
   const [expanded, setExpanded] = useState(defaultExpanded);
   const reduce = useReducedMotion();
 
@@ -297,7 +363,12 @@ export function WebSearchProgressCard({
     // Hover ownership lives on the inner Button. Padding ownership lives on
     // the inner Button (header) and the steps section (when expanded) — the
     // outer wrapper provides only the card chrome (border, radius, base bg)
-    // and no padding of its own.
+    // and no padding of its own. The Button's `rounded-*` is conditional so
+    // its hover bg paints into the correct corners without clipping its
+    // focus ring (overflow:hidden on the wrapper would clip the ring):
+    //   - Collapsed: the Button IS the whole card content → fully rounded.
+    //   - Expanded: the Button is just the header → rounded only on top so
+    //     the divider + steps section flow flush below.
     <div
       data-testid="web-search-progress-card"
       className="flex w-full flex-col rounded-[var(--radius-lg)] border-b border-[var(--border-base)] bg-[var(--surface-overlay)]"
@@ -331,14 +402,25 @@ export function WebSearchProgressCard({
               className="shrink-0"
             />
           )}
-          {/* Animated step carousel: the title + info tuple slides in/out as
-              new steps stream in. Always rendered (both collapsed and
-              expanded) so the header reads as a coherent per-step row in
-              both modes. */}
-          <HeaderStepCarousel
-            currentStepTitle={currentStepTitle}
-            currentStepInfo={currentStepInfo}
-          />
+          {/* Header info slot.
+              - Carousel mode (loading + at least one completed search):
+                static title + a `WebsiteCarousel` rotating through the most
+                recent search's favicon-title chips. The carousel handles its
+                own rotation animation independently of the per-step text
+                carousel below.
+              - Text mode (default): the existing throttled tuple animation
+                slides through `(title, info)` as new steps stream in. */}
+          {useCarousel ? (
+            <HeaderTitleWithCarousel
+              currentStepTitle={currentStepTitle}
+              carouselItems={carouselItems}
+            />
+          ) : (
+            <HeaderStepCarousel
+              currentStepTitle={currentStepTitle}
+              currentStepInfo={currentStepInfo}
+            />
+          )}
         </span>
         <span className="flex shrink-0 items-center rounded-[var(--radius-pill)] bg-[var(--surface-base)] px-[6px] py-[4px]">
           <Typography

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.test.ts
@@ -977,6 +977,109 @@ describe("computeWebSearchCardData — state", () => {
 });
 
 // ---------------------------------------------------------------------------
+// carouselItems
+// ---------------------------------------------------------------------------
+
+describe("computeWebSearchCardData — carouselItems", () => {
+  test("is empty when no web_search has completed", () => {
+    const tc = makeToolCall({
+      id: "tc1",
+      toolName: "web_search",
+      status: "running",
+      input: { query: "foo" },
+    });
+    const result = computeWebSearchCardData([tc], {});
+    expect(result?.carouselItems).toEqual([]);
+  });
+
+  test("feeds from the most recent completed web_search's results", () => {
+    const olderResults = [makeResult(1, { title: "Old A" })];
+    const newerResults = [
+      makeResult(1, { title: "New A" }),
+      makeResult(2, { title: "New B" }),
+    ];
+    const tc1 = makeToolCall({ id: "tc1", toolName: "web_search" });
+    const tc2 = makeToolCall({ id: "tc2", toolName: "web_search" });
+    const live: Record<string, ToolActivityMetadata> = {
+      tc1: { webSearch: { query: "old", provider: "anthropic-native", resultCount: 1, durationMs: 100, results: olderResults } },
+      tc2: { webSearch: { query: "new", provider: "anthropic-native", resultCount: 2, durationMs: 100, results: newerResults } },
+    };
+    const result = computeWebSearchCardData([tc1, tc2], live);
+    // Most recent (`tc2`) wins; earlier search is not concatenated.
+    expect(result?.carouselItems).toEqual(newerResults);
+  });
+
+  test("skips an in-flight latest call to use the previous completed search's results", () => {
+    const completedResults = [makeResult(1, { title: "Old A" })];
+    const tc1 = makeToolCall({ id: "tc1", toolName: "web_search" });
+    const tc2 = makeToolCall({
+      id: "tc2",
+      toolName: "web_search",
+      status: "running",
+      input: { query: "next" },
+    });
+    const live: Record<string, ToolActivityMetadata> = {
+      tc1: { webSearch: { query: "old", provider: "anthropic-native", resultCount: 1, durationMs: 100, results: completedResults } },
+    };
+    const result = computeWebSearchCardData([tc1, tc2], live);
+    expect(result?.carouselItems).toEqual(completedResults);
+  });
+
+  test("skips error-state searches (errorMessage + empty results)", () => {
+    const tc = makeToolCall({ id: "tc1", toolName: "web_search", status: "error" });
+    const live: Record<string, ToolActivityMetadata> = {
+      tc1: {
+        webSearch: {
+          query: "bad",
+          provider: "anthropic-native",
+          resultCount: 0,
+          durationMs: 100,
+          results: [],
+          errorMessage: "rate limited",
+        },
+      },
+    };
+    const result = computeWebSearchCardData([tc], live);
+    expect(result?.carouselItems).toEqual([]);
+  });
+
+  test("does not include web_fetch results in the carousel", () => {
+    const tc = makeToolCall({ id: "tc1", toolName: "web_fetch" });
+    const live: Record<string, ToolActivityMetadata> = {
+      tc1: {
+        webFetch: {
+          url: "https://x.test",
+          finalUrl: "https://x.test",
+          status: 200,
+          byteCount: 1,
+          charCount: 1,
+          truncated: false,
+          domain: "x.test",
+          redirectCount: 0,
+          durationMs: 100,
+          title: "X",
+        },
+      },
+    };
+    const result = computeWebSearchCardData([tc], live);
+    expect(result?.carouselItems).toEqual([]);
+  });
+
+  test("reads persisted tc.activityMetadata when liveWebActivity is empty", () => {
+    const results = [makeResult(1, { title: "Persisted A" })];
+    const tc = makeToolCall({
+      id: "tc1",
+      toolName: "web_search",
+      activityMetadata: {
+        webSearch: { query: "x", provider: "anthropic-native", resultCount: 1, durationMs: 100, results },
+      },
+    });
+    const result = computeWebSearchCardData([tc], {});
+    expect(result?.carouselItems).toEqual(results);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // formatMs
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
+++ b/apps/web/src/domains/chat/hooks/use-web-search-card-data.ts
@@ -75,6 +75,21 @@ export interface WebSearchCardData {
    * per-step row tense in the expanded body.
    */
   state: "loading" | "complete";
+  /**
+   * Results from the most recently completed `web_search` in the turn,
+   * suitable for feeding the collapsed-header `WebsiteCarousel`.
+   *
+   * The daemon emits `web_search` results atomically on `tool_result` — there
+   * is no mid-stream progress event. So this stays empty until at least one
+   * search returns, and re-feeds each time a subsequent search completes
+   * (the carousel always reflects the most recent search batch).
+   *
+   * Sourced from `liveWebActivity[tc.id]` first, falling back to the
+   * persisted `tc.activityMetadata` for historical reopens. Skips
+   * error-state results (an `errorMessage` with empty `results` would yield
+   * nothing to show anyway).
+   */
+  carouselItems: WebSearchResultItem[];
 }
 
 /**
@@ -267,6 +282,35 @@ function deriveCurrentStepTitle(
 }
 
 /**
+ * Results to feed the collapsed-header `WebsiteCarousel` (favicon + title
+ * chips rotating). Returns the result list from the most recently completed
+ * `web_search` tool call, or an empty array when nothing has landed yet.
+ *
+ * Why the *latest* search only (not a flatMap across all searches):
+ * - Keeps the carousel "current" — what the model just looked at rotates,
+ *   re-feeding as each subsequent search completes.
+ * - Bounds the rotation cycle to a single search's `resultCount` (~5 items
+ *   @2.5s = ~12.5s full loop), so the carousel doesn't drag through a
+ *   20-item backlog by the end of a long turn.
+ *
+ * Skips searches with no results — both empty-results-with-error rows and
+ * pristine in-flight calls — so the carousel only ever feeds on real data.
+ */
+function deriveCarouselItems(
+  toolCalls: ChatMessageToolCall[],
+  liveWebActivity: Record<string, ToolActivityMetadata>,
+): WebSearchResultItem[] {
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    const tc = toolCalls[i]!;
+    if (tc.toolName !== "web_search") continue;
+    const metadata = resolveMetadata(tc, liveWebActivity);
+    const results = metadata?.webSearch?.results;
+    if (results && results.length > 0) return results;
+  }
+  return [];
+}
+
+/**
  * Per-step gray subtext shown in the collapsed header. The card carousels
  * through this value alongside `currentStepTitle` so each transition reads
  * as a discrete step. Driven by the *most recent* web tool call.
@@ -435,6 +479,7 @@ export function computeWebSearchCardData(
   const state: "loading" | "complete" = anyInFlight ? "loading" : "complete";
   const currentStepTitle = deriveCurrentStepTitle(toolCalls, liveWebActivity);
   const currentStepInfo = deriveCurrentStepInfo(toolCalls, liveWebActivity);
+  const carouselItems = deriveCarouselItems(toolCalls, liveWebActivity);
   const stepCount = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
 
   return {
@@ -443,5 +488,6 @@ export function computeWebSearchCardData(
     stepCount,
     steps,
     state,
+    carouselItems,
   };
 }


### PR DESCRIPTION
## Summary

- Wires the rotating `WebsiteCarousel` into the collapsed header of `WebSearchProgressCard` so the "Searching the web" loading state shows live favicon + title chips from the most recently completed `web_search` (carousel mode supersedes the text info slot during `state === "loading"`).
- Closes the remaining gap from vellum-assistant-platform PR #7430 (~5870-line stack). The prior domain-drift port (#31450) brought over the building blocks — `WebsiteCarousel`, `useWebSearchCardData`, `turn-store.liveWebActivity`, `event-parser` `activityMetadata` plumbing — but didn't connect the carousel to the progress card.
- Extends the `useWebSearchCardData` projection with a `deriveCarouselItems` helper that picks the latest completed `web_search`'s results (skipping in-flight, error-state, and `web_fetch` entries). New unit tests cover the derivation contract end-to-end.

## Original prompt

Port `vellum-ai/vellum-assistant-platform` PR #7430 (`feat(chat): Searching the Web — loading-state UI`) into this repo at `apps/web/`. After investigation, ~95% of that PR (33 files, ~5870 LOC) had already landed via the prior chat-domain-drift port #31450 (LUM-1757). The remaining gap was the carousel wiring inside `WebSearchProgressCard` itself — the new `carouselItems` prop, the `HeaderTitleWithCarousel` layout that swaps in for `HeaderStepCarousel` when there are items to rotate, the matching `WebSearchCardData.carouselItems` projection in the hook, and the call-site update in `tool-call-progress-card.tsx`. The user requested the build-before-merge workflow: build, push, open the PR, **do NOT merge** — they want to QA the live carousel against a real `web_search` turn before merging.

## Build-before-merge

**Do not merge yet.** Please QA the live carousel against a real `web_search` turn (the rotating favicon + title chips in the collapsed header) before merging. The user has a strong preference for visual verification on UI changes — see CLAUDE.md memory `feedback_build_before_merge.md`.

## Deviations from the source PR

- **Path map**: source `web/src/...` lives at `apps/web/src/domains/chat/...` in this repo. The prior drift port (#31450) had already moved everything; this PR follows the same locations.
- **`ChatProvider` / `useChatStateOptional`**: source threads `liveWebActivity` through React context. This repo uses a Zustand `useTurnStore` (per the prior port), so the hook reads `liveWebActivity` directly from the store — no `useChatStateOptional` needed.
- **`ToolCallProgressCard.test.tsx` skipped**: source adds a new integration test file. This repo's test infrastructure for that level isn't wired in the same way (no `ChatProvider`); existing coverage on `useWebSearchCardData` already exercises the same projection paths. Could add a thinner integration test wrapped around `useTurnStore.setState` if the user wants it.
- **`web-search-progress-card.gallery.tsx` skipped**: no `/ui-gallery` route in this repo.

## Build / test status

- `bun test src/domains/chat/components/web-search/ src/domains/chat/hooks/use-web-search-card-data.test.ts src/domains/chat/utils/web-search-result-text.test.ts src/domains/chat/hooks/stream-message-updaters.test.ts src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts` — **148 pass, 0 fail**
- `bunx tsc --noEmit` — clean for our changes (pre-existing `@/generated/api/*` errors are present regardless of this PR)
- `bun run build` — succeeds (after `bun run openapi-ts` to seed the generated client)
- `bunx eslint src/domains/chat/components/web-search/ src/domains/chat/hooks/use-web-search-card-data.ts src/domains/chat/components/tool-call-progress-card/` — clean

## Test plan

- [ ] Visual QA: trigger a real `web_search` from the assistant and verify the collapsed header rotates through favicon + title chips during `state === "loading"`.
- [ ] Visual QA: confirm the carousel disappears and the static "Searched the web" + final-title text takes over once the turn completes (`state === "complete"`).
- [ ] Visual QA: confirm an in-flight `web_search` with no prior completed search shows the original text "Searching ..." info row (no carousel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->