### PR TITLE
feat(web): add TiptapDocumentEditor component with bubble menu (LUM-1804)

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -37,6 +37,7 @@
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",
+        "@tiptap/pm": "3.23.5",
         "@tiptap/react": "3.23.5",
         "@tiptap/starter-kit": "3.23.5",
         "@vellum/design-library": "file:../../packages/design-library",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",
+    "@tiptap/pm": "3.23.5",
     "@tiptap/react": "3.23.5",
     "@tiptap/starter-kit": "3.23.5",
     "@vellum/design-library": "file:../../packages/design-library",

--- a/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
+++ b/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
@@ -73,13 +73,13 @@ const CommentAnchorHighlightExtension = Extension.create<{
   },
 
   addProseMirrorPlugins() {
-    const extension = this;
+    const { anchors } = this.options;
     return [
       new Plugin({
         key: commentAnchorPluginKey,
         state: {
           init(_, { doc }) {
-            return buildCommentDecorations(doc, extension.options.anchors);
+            return buildCommentDecorations(doc, anchors);
           },
           apply(tr, oldDecorations) {
             const meta = tr.getMeta(commentAnchorPluginKey);
@@ -137,13 +137,13 @@ const ActiveHighlightExtension = Extension.create<{
   },
 
   addProseMirrorPlugins() {
-    const extension = this;
+    const { range } = this.options;
     return [
       new Plugin({
         key: activeHighlightPluginKey,
         state: {
           init(_, { doc }) {
-            return buildActiveHighlightDecorations(doc, extension.options.range);
+            return buildActiveHighlightDecorations(doc, range);
           },
           apply(tr, oldDecorations) {
             const meta = tr.getMeta(activeHighlightPluginKey);
@@ -309,7 +309,8 @@ export function TiptapDocumentEditor({
     ],
     content,
     onUpdate({ editor: ed }) {
-      const md = (ed.storage.markdown as { getMarkdown: () => string }).getMarkdown();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const md = (ed.storage as any).markdown.getMarkdown() as string;
       onContentChangeRef.current?.(md);
     },
     onSelectionUpdate({ editor: ed }) {
@@ -348,7 +349,8 @@ export function TiptapDocumentEditor({
     if (content === prevContentRef.current) return;
     prevContentRef.current = content;
 
-    const currentMd = (editor.storage.markdown as { getMarkdown: () => string }).getMarkdown();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const currentMd = (editor.storage as any).markdown.getMarkdown() as string;
     if (currentMd === content) return; // avoid cursor-reset loops
 
     editor.commands.setContent(content);
@@ -411,7 +413,7 @@ export function TiptapDocumentEditor({
       <style>{editorStyles}</style>
       <EditorContent editor={editor} className="flex-1 overflow-y-auto" />
       {editor ? (
-        <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
+        <BubbleMenu editor={editor} updateDelay={100}>
           <BubbleToolbar editor={editor} />
         </BubbleMenu>
       ) : null}

--- a/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
+++ b/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
@@ -1,0 +1,530 @@
+/**
+ * Tiptap/ProseMirror-based WYSIWYG document editor.
+ *
+ * Replaces the sandboxed iframe approach (`editor-bridge.ts`) with a native
+ * React component that supports:
+ * - Rich-text editing of markdown content
+ * - Floating bubble menu toolbar (bold, italic, strike, code, link)
+ * - Comment anchor highlight decorations (yellow)
+ * - Active/temporary highlight range decorations (blue)
+ * - Text selection tracking with character offset conversion
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { Extension } from "@tiptap/core";
+import { BubbleMenu } from "@tiptap/react/menus";
+import { EditorContent, useEditor } from "@tiptap/react";
+import Link from "@tiptap/extension-link";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "tiptap-markdown";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import {
+  Bold,
+  Code,
+  Italic,
+  Link as LinkIcon,
+  Strikethrough,
+} from "lucide-react";
+import { cn } from "@vellum/design-library";
+
+import type { CommentAnchor } from "@/domains/chat/utils/tiptap-position-map.js";
+import {
+  charOffsetToPmPos,
+  pmPosToCharOffset,
+} from "@/domains/chat/utils/tiptap-position-map.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TiptapDocumentEditorProps {
+  content: string;
+  onContentChange?: (markdown: string) => void;
+  onTextSelect?: (selection: {
+    start: number;
+    end: number;
+    text: string;
+    rect: DOMRect;
+  }) => void;
+  commentAnchors?: CommentAnchor[];
+  highlightRange?: { start: number; end: number } | null;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Decoration plugin keys
+// ---------------------------------------------------------------------------
+
+const commentAnchorPluginKey = new PluginKey("commentAnchorHighlights");
+const activeHighlightPluginKey = new PluginKey("activeHighlight");
+
+// ---------------------------------------------------------------------------
+// Comment anchor decoration extension
+// ---------------------------------------------------------------------------
+
+const CommentAnchorHighlightExtension = Extension.create<{
+  anchors: CommentAnchor[];
+}>({
+  name: "commentAnchorHighlight",
+
+  addOptions() {
+    return { anchors: [] };
+  },
+
+  addProseMirrorPlugins() {
+    const extension = this;
+    return [
+      new Plugin({
+        key: commentAnchorPluginKey,
+        state: {
+          init(_, { doc }) {
+            return buildCommentDecorations(doc, extension.options.anchors);
+          },
+          apply(tr, oldDecorations) {
+            const meta = tr.getMeta(commentAnchorPluginKey);
+            if (meta) {
+              return buildCommentDecorations(tr.doc, meta.anchors);
+            }
+            if (tr.docChanged) {
+              return oldDecorations.map(tr.mapping, tr.doc);
+            }
+            return oldDecorations;
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+function buildCommentDecorations(
+  doc: import("@tiptap/pm/model").Node,
+  anchors: CommentAnchor[],
+): DecorationSet {
+  const decorations: Decoration[] = [];
+
+  for (const anchor of anchors) {
+    const from = charOffsetToPmPos(doc, anchor.anchorStart);
+    const to = charOffsetToPmPos(doc, anchor.anchorEnd);
+    if (from < to) {
+      decorations.push(
+        Decoration.inline(from, to, {
+          class: "comment-anchor-highlight",
+        }),
+      );
+    }
+  }
+
+  return DecorationSet.create(doc, decorations);
+}
+
+// ---------------------------------------------------------------------------
+// Active highlight decoration extension
+// ---------------------------------------------------------------------------
+
+const ActiveHighlightExtension = Extension.create<{
+  range: { start: number; end: number } | null;
+}>({
+  name: "activeHighlight",
+
+  addOptions() {
+    return { range: null };
+  },
+
+  addProseMirrorPlugins() {
+    const extension = this;
+    return [
+      new Plugin({
+        key: activeHighlightPluginKey,
+        state: {
+          init(_, { doc }) {
+            return buildActiveHighlightDecorations(doc, extension.options.range);
+          },
+          apply(tr, oldDecorations) {
+            const meta = tr.getMeta(activeHighlightPluginKey);
+            if (meta) {
+              return buildActiveHighlightDecorations(tr.doc, meta.range);
+            }
+            if (tr.docChanged) {
+              return oldDecorations.map(tr.mapping, tr.doc);
+            }
+            return oldDecorations;
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+function buildActiveHighlightDecorations(
+  doc: import("@tiptap/pm/model").Node,
+  range: { start: number; end: number } | null,
+): DecorationSet {
+  if (!range) return DecorationSet.empty;
+
+  const from = charOffsetToPmPos(doc, range.start);
+  const to = charOffsetToPmPos(doc, range.end);
+  if (from >= to) return DecorationSet.empty;
+
+  return DecorationSet.create(doc, [
+    Decoration.inline(from, to, {
+      class: "active-highlight",
+    }),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Bubble toolbar sub-component
+// ---------------------------------------------------------------------------
+
+interface BubbleToolbarProps {
+  editor: ReturnType<typeof useEditor> & object;
+}
+
+function BubbleToolbar({ editor }: BubbleToolbarProps) {
+  if (!editor) return null;
+
+  const btnBase = cn(
+    "h-7 w-7 rounded-md flex items-center justify-center",
+    "text-[var(--content-secondary)]",
+    "hover:bg-[var(--surface-hover)] hover:text-[var(--content-emphasised)]",
+    "transition-colors",
+  );
+  const btnActive = cn(
+    "bg-[var(--surface-active)] text-[var(--content-emphasised)]",
+  );
+
+  type MarkName = "bold" | "italic" | "strike" | "code" | "link";
+
+  const buttons: {
+    name: MarkName;
+    icon: React.ReactNode;
+    action: () => void;
+    separator?: boolean;
+  }[] = [
+    {
+      name: "bold",
+      icon: <Bold size={14} />,
+      action: () => editor.chain().focus().toggleBold().run(),
+    },
+    {
+      name: "italic",
+      icon: <Italic size={14} />,
+      action: () => editor.chain().focus().toggleItalic().run(),
+    },
+    {
+      name: "strike",
+      icon: <Strikethrough size={14} />,
+      action: () => editor.chain().focus().toggleStrike().run(),
+      separator: true,
+    },
+    {
+      name: "code",
+      icon: <Code size={14} />,
+      action: () => editor.chain().focus().toggleCode().run(),
+      separator: true,
+    },
+    {
+      name: "link",
+      icon: <LinkIcon size={14} />,
+      action: () => {
+        if (editor.isActive("link")) {
+          editor.chain().focus().unsetLink().run();
+        } else {
+          const url = window.prompt("Enter URL:");
+          if (url) {
+            editor.chain().focus().setLink({ href: url }).run();
+          }
+        }
+      },
+    },
+  ];
+
+  return (
+    <div
+      className={cn(
+        "bg-[var(--surface-lift)] rounded-lg",
+        "shadow-[var(--shadow-popover)]",
+        "border border-[var(--border-base)]",
+        "p-1 flex items-center gap-0.5",
+      )}
+    >
+      {buttons.map((btn, i) => (
+        <span key={btn.name} className="contents">
+          {i > 0 && buttons[i - 1]?.separator && (
+            <span className="mx-0.5 h-4 w-px bg-[var(--border-base)]" />
+          )}
+          <button
+            type="button"
+            className={cn(btnBase, editor.isActive(btn.name) && btnActive)}
+            onClick={btn.action}
+            aria-label={btn.name}
+            aria-pressed={editor.isActive(btn.name)}
+          >
+            {btn.icon}
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function TiptapDocumentEditor({
+  content,
+  onContentChange,
+  onTextSelect,
+  commentAnchors = [],
+  highlightRange = null,
+  className,
+}: TiptapDocumentEditorProps) {
+  const onContentChangeRef = useRef(onContentChange);
+  onContentChangeRef.current = onContentChange;
+
+  const onTextSelectRef = useRef(onTextSelect);
+  onTextSelectRef.current = onTextSelect;
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        // History is included in StarterKit
+      }),
+      Link.configure({ openOnClick: false }),
+      Markdown,
+      CommentAnchorHighlightExtension.configure({ anchors: commentAnchors }),
+      ActiveHighlightExtension.configure({ range: highlightRange }),
+    ],
+    content,
+    onUpdate({ editor: ed }) {
+      const md = (ed.storage.markdown as { getMarkdown: () => string }).getMarkdown();
+      onContentChangeRef.current?.(md);
+    },
+    onSelectionUpdate({ editor: ed }) {
+      const { from, to } = ed.state.selection;
+      if (from === to) return; // collapsed selection, nothing to report
+
+      const text = ed.state.doc.textBetween(from, to);
+      if (!text.trim()) return;
+
+      const start = pmPosToCharOffset(ed.state.doc, from);
+      const end = pmPosToCharOffset(ed.state.doc, to);
+
+      // Build bounding rect from ProseMirror coords
+      const coordsFrom = ed.view.coordsAtPos(from);
+      const coordsTo = ed.view.coordsAtPos(to);
+      const rect = new DOMRect(
+        Math.min(coordsFrom.left, coordsTo.left),
+        Math.min(coordsFrom.top, coordsTo.top),
+        Math.abs(coordsTo.right - coordsFrom.left),
+        Math.max(coordsTo.bottom, coordsFrom.bottom) -
+          Math.min(coordsFrom.top, coordsTo.top),
+      );
+
+      onTextSelectRef.current?.({ start, end, text, rect });
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Sync content prop → editor (only when externally changed)
+  // -------------------------------------------------------------------------
+
+  const prevContentRef = useRef(content);
+
+  useEffect(() => {
+    if (!editor) return;
+    if (content === prevContentRef.current) return;
+    prevContentRef.current = content;
+
+    const currentMd = (editor.storage.markdown as { getMarkdown: () => string }).getMarkdown();
+    if (currentMd === content) return; // avoid cursor-reset loops
+
+    editor.commands.setContent(content);
+  }, [content, editor]);
+
+  // -------------------------------------------------------------------------
+  // Sync commentAnchors prop → decoration plugin
+  // -------------------------------------------------------------------------
+
+  const syncAnchors = useCallback(
+    (anchors: CommentAnchor[]) => {
+      if (!editor) return;
+      const tr = editor.state.tr.setMeta(commentAnchorPluginKey, { anchors });
+      editor.view.dispatch(tr);
+    },
+    [editor],
+  );
+
+  useEffect(() => {
+    syncAnchors(commentAnchors);
+  }, [commentAnchors, syncAnchors]);
+
+  // -------------------------------------------------------------------------
+  // Sync highlightRange prop → decoration plugin + auto-scroll
+  // -------------------------------------------------------------------------
+
+  const syncHighlight = useCallback(
+    (range: { start: number; end: number } | null) => {
+      if (!editor) return;
+      const tr = editor.state.tr.setMeta(activeHighlightPluginKey, { range });
+      editor.view.dispatch(tr);
+
+      // Auto-scroll the highlight into view
+      if (range) {
+        const pos = charOffsetToPmPos(editor.state.doc, range.start);
+        const dom = editor.view.domAtPos(pos);
+        if (dom.node instanceof HTMLElement) {
+          dom.node.scrollIntoView({ behavior: "smooth", block: "center" });
+        } else if (dom.node.parentElement) {
+          dom.node.parentElement.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          });
+        }
+      }
+    },
+    [editor],
+  );
+
+  useEffect(() => {
+    syncHighlight(highlightRange);
+  }, [highlightRange, syncHighlight]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      <style>{editorStyles}</style>
+      <EditorContent editor={editor} className="flex-1 overflow-y-auto" />
+      {editor ? (
+        <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
+          <BubbleToolbar editor={editor} />
+        </BubbleMenu>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Editor styles — mirrors editor-bridge.ts CSS using design system tokens
+// ---------------------------------------------------------------------------
+
+const editorStyles = /* css */ `
+  .tiptap {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.65;
+    color: var(--content-default, #1a1a1a);
+    padding: 24px 32px;
+    outline: none;
+  }
+  .tiptap:focus {
+    outline: none;
+  }
+
+  /* Headings */
+  .tiptap h1 { font-size: 1.6em; font-weight: 700; margin: 0.8em 0 0.4em; }
+  .tiptap h2 { font-size: 1.3em; font-weight: 600; margin: 0.7em 0 0.35em; }
+  .tiptap h3 { font-size: 1.1em; font-weight: 600; margin: 0.6em 0 0.3em; }
+
+  /* Block elements */
+  .tiptap p { margin: 0.5em 0; }
+  .tiptap ul, .tiptap ol { margin: 0.5em 0 0.5em 1.5em; }
+  .tiptap li { margin: 0.2em 0; }
+  .tiptap blockquote {
+    margin: 0.5em 0;
+    padding: 0.5em 1em;
+    border-left: 3px solid var(--border-base, #d0d0d0);
+    color: var(--content-secondary, #555);
+  }
+  .tiptap hr {
+    border: none;
+    border-top: 1px solid var(--border-base, #d0d0d0);
+    margin: 1em 0;
+  }
+
+  /* Inline code */
+  .tiptap code {
+    font-family: "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.9em;
+    background: var(--surface-base, #f0f0f0);
+    padding: 0.15em 0.35em;
+    border-radius: 3px;
+  }
+
+  /* Code blocks */
+  .tiptap pre {
+    margin: 0.5em 0;
+    padding: 12px 16px;
+    background: var(--surface-base, #f5f5f5);
+    border-radius: 6px;
+    overflow-x: auto;
+  }
+  .tiptap pre code {
+    background: none;
+    padding: 0;
+  }
+
+  /* Links */
+  .tiptap a {
+    color: #2563eb;
+    text-decoration: none;
+  }
+  .tiptap a:hover {
+    text-decoration: underline;
+  }
+
+  /* Tables */
+  .tiptap table {
+    border-collapse: collapse;
+    margin: 0.5em 0;
+    width: 100%;
+  }
+  .tiptap th, .tiptap td {
+    border: 1px solid var(--border-base, #ddd);
+    padding: 6px 10px;
+    text-align: left;
+  }
+  .tiptap th {
+    background: var(--surface-base, #f9f9f9);
+    font-weight: 600;
+  }
+
+  /* Comment anchor highlights */
+  .comment-anchor-highlight {
+    background-color: rgba(255, 213, 79, 0.35);
+    border-bottom: 2px solid rgba(255, 167, 38, 0.6);
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+  .comment-anchor-highlight:hover {
+    background-color: rgba(255, 213, 79, 0.55);
+  }
+
+  /* Active/temporary highlight */
+  .active-highlight {
+    background-color: rgba(66, 165, 245, 0.35);
+    border-bottom: 2px solid rgba(33, 150, 243, 0.7);
+    border-radius: 2px;
+  }
+
+  /* Selection color */
+  .tiptap ::selection {
+    background-color: rgba(66, 165, 245, 0.3);
+  }
+`;

--- a/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
+++ b/apps/web/src/domains/chat/components/tiptap-document-editor.tsx
@@ -1,8 +1,5 @@
 /**
- * Tiptap/ProseMirror-based WYSIWYG document editor.
- *
- * Replaces the sandboxed iframe approach (`editor-bridge.ts`) with a native
- * React component that supports:
+ * Tiptap/ProseMirror-based WYSIWYG document editor React component that supports:
  * - Rich-text editing of markdown content
  * - Floating bubble menu toolbar (bold, italic, strike, code, link)
  * - Comment anchor highlight decorations (yellow)
@@ -323,16 +320,9 @@ export function TiptapDocumentEditor({
       const start = pmPosToCharOffset(ed.state.doc, from);
       const end = pmPosToCharOffset(ed.state.doc, to);
 
-      // Build bounding rect from ProseMirror coords
-      const coordsFrom = ed.view.coordsAtPos(from);
-      const coordsTo = ed.view.coordsAtPos(to);
-      const rect = new DOMRect(
-        Math.min(coordsFrom.left, coordsTo.left),
-        Math.min(coordsFrom.top, coordsTo.top),
-        Math.abs(coordsTo.right - coordsFrom.left),
-        Math.max(coordsTo.bottom, coordsFrom.bottom) -
-          Math.min(coordsFrom.top, coordsTo.top),
-      );
+      const domSelection = ed.view.dom.ownerDocument.getSelection();
+      if (!domSelection || domSelection.rangeCount === 0) return;
+      const rect = domSelection.getRangeAt(0).getBoundingClientRect();
 
       onTextSelectRef.current?.({ start, end, text, rect });
     },

--- a/apps/web/src/domains/chat/utils/tiptap-position-map.ts
+++ b/apps/web/src/domains/chat/utils/tiptap-position-map.ts
@@ -1,0 +1,108 @@
+/**
+ * Position mapping between plain-text character offsets (used by stored comment
+ * anchors) and ProseMirror document positions.
+ *
+ * Comment anchors persist start/end as character offsets into the document's
+ * plain text. ProseMirror uses its own position scheme that accounts for node
+ * boundaries, so we need conversion helpers when applying or reading anchors.
+ */
+
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CommentAnchor {
+  commentId: string;
+  anchorStart: number;
+  anchorEnd: number;
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a plain-text character offset to a ProseMirror document position.
+ *
+ * Walks every text node in document order, tracking a cumulative character
+ * count. Returns the PM position corresponding to `charOffset` characters
+ * into the document's concatenated text content.
+ *
+ * Edge cases:
+ * - Offset beyond document end: clamped to the last valid text position.
+ * - Offset 0: returns the position of the first character in the document.
+ */
+export function charOffsetToPmPos(
+  doc: ProseMirrorNode,
+  charOffset: number,
+): number {
+  let cumulative = 0;
+  let result = -1;
+
+  doc.descendants((node, pos) => {
+    // Already found — skip remaining nodes
+    if (result >= 0) return false;
+
+    if (node.isText) {
+      const text = node.text ?? "";
+      const nodeEnd = cumulative + text.length;
+
+      if (charOffset <= nodeEnd) {
+        // The target offset lands within (or at the boundary of) this node
+        result = pos + (charOffset - cumulative);
+        return false;
+      }
+
+      cumulative = nodeEnd;
+    }
+
+    return true; // continue traversal
+  });
+
+  // If we exhausted the document without finding the offset, clamp to doc end
+  if (result < 0) {
+    result = doc.content.size;
+  }
+
+  return result;
+}
+
+/**
+ * Convert a ProseMirror document position to a plain-text character offset.
+ *
+ * Inverse of `charOffsetToPmPos`. Walks text nodes and accumulates character
+ * counts until the cumulative PM position passes `pmPos`.
+ *
+ * Edge cases:
+ * - Position inside a non-text node: snaps to the nearest text boundary
+ *   (the end of the previous text node or the start of the next one).
+ * - Position beyond document end: returns total text length.
+ */
+export function pmPosToCharOffset(
+  doc: ProseMirrorNode,
+  pmPos: number,
+): number {
+  let charOffset = 0;
+
+  doc.descendants((node, pos) => {
+    if (node.isText) {
+      const text = node.text ?? "";
+      const nodeEndPos = pos + text.length;
+
+      if (pmPos <= nodeEndPos) {
+        // Target is within or before this text node
+        const offsetInNode = Math.max(0, pmPos - pos);
+        charOffset += offsetInNode;
+        return false; // stop traversal
+      }
+
+      charOffset += text.length;
+    }
+
+    return true;
+  });
+
+  return charOffset;
+}


### PR DESCRIPTION
## Summary
- Create TiptapDocumentEditor React component with Tiptap/ProseMirror WYSIWYG editing
- Add floating bubble menu toolbar with bold, italic, strike, code, link buttons styled with design system tokens
- Implement position mapping utilities for character offset ↔ ProseMirror position conversion
- Support comment anchor decorations and active highlight range via ProseMirror plugins

Part of plan: tiptap-doc-editor.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->