### PR TITLE
fix(web): remove admin route constant and preferences menu item

### DIFF
--- a/apps/web/src/domains/chat/components/preferences-menu.tsx
+++ b/apps/web/src/domains/chat/components/preferences-menu.tsx
@@ -7,7 +7,6 @@ import {
   LogOut,
   MessageSquareText,
   Settings as SettingsIcon,
-  Shield,
   SlidersHorizontal,
 } from "lucide-react";
 import { useState } from "react";
@@ -39,7 +38,7 @@ import { ThemeToggle } from "@/components/theme-toggle.js";
  * pinned to the bottom of the rail).
  *
  * Content mirrors `UserMenu`'s dropdown — Theme, Credits, Earn credits,
- * Settings, Usage, Share Feedback, Admin, Log Out — but rendered
+ * Settings, Usage, Share Feedback, Log Out — but rendered
  * with `PanelItem` for every row except the two custom ones (Theme
  * toggle group + Credits / Add credits row). Those two have bespoke
  * layout that doesn't map onto a generic icon + label + badge row.
@@ -149,10 +148,7 @@ function PreferencesMenuContent({
   onEarnCredits,
 }: PreferencesMenuContentProps) {
   const navigate = useNavigate();
-  const user = useAuthStore.use.user();
   const logout = useAuthStore.use.logout();
-  const isAdmin = user?.isStaff ?? false;
-
   const { data: billingSummary } = useQuery({
     ...organizationsBillingSummaryRetrieveOptions(),
   });
@@ -224,17 +220,6 @@ function PreferencesMenuContent({
           onShareFeedback();
         }}
       />
-
-      {isAdmin ? (
-        <PanelItem
-          icon={Shield}
-          label="Admin"
-          onSelect={() => {
-            onClose();
-            navigate(routes.admin.root);
-          }}
-        />
-      ) : null}
 
       <PanelItem
         icon={LogOut}

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -83,10 +83,6 @@ export const routes = {
     upgradeSuccess: r("/assistant/settings/billing/upgrade/success"),
   },
 
-  admin: {
-    root: r("/admin"),
-  },
-
   docs: {
     legal: {
       privacyPolicy: r("/docs/privacy-policy"),


### PR DESCRIPTION
## Prompt / plan

Admin pages stay in the platform per AGENTS.md ("Marketing pages and admin/internal surfaces are out of scope"). The web app only serves `/assistant/*` and `/account/*` routes.

The `routes.admin.root` constant existed with no matching route handler in `routes.tsx`, so clicking "Admin" in the preferences menu (staff-only) would do a client-side `navigate("/admin")` that hit a 404 within the SPA.

**Removes:**
- `routes.admin` constant from `routes.ts`
- Admin `PanelItem` from `PreferencesMenuContent` (was gated behind `isAdmin` / `user.isStaff`)
- Unused `user` state and `Shield` icon import (only consumers were the admin menu item)

**Alternatives not taken:**
- Keeping the menu item with `window.location.href = "/admin"` (full-page nav to platform) — rejected because admin is explicitly out of scope for this app. Staff who need admin access can navigate directly or use the platform app.

## Root cause

The admin route constant and menu item were carried over during the initial port from the platform repo. In the platform, `/admin` is a real Next.js route served by the same app. In the new Vite SPA, there's no `/admin` route — admin pages are not in scope — so the constant and menu item were dead/broken code from day one.

**Prevention:** The web app's AGENTS.md already states admin is out of scope. Future ports should cross-reference the scope section before carrying over route constants and navigation items.

## Test plan

- `bunx tsc --noEmit` — 0 errors
- `bun run lint` — 0 errors
- Grep confirms no remaining references to `routes.admin` in `apps/web/src/`

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->