### PR TITLE
feat(web): VITE_AUTH_MODE=local skips sign-in for local-daemon dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ yarn-error.log*
 
 # env files
 .env*
-!.env.example
+!.env*.example
 
 # vercel
 .vercel

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,24 @@
+# Local SPA development against a local daemon.
+#
+# Copy to .env.local (Vite reads .env.local automatically) and start
+# the gateway + daemon however you normally do, then `bun run dev`.
+#
+# The combination of these three settings means:
+#   1. The Vite dev server proxies /v1/*, /_allauth/*, /accounts/*
+#      to the local gateway on its default port.
+#   2. The SPA boots in "local" mode — no sign-in screen, no allauth
+#      probe — and behaves as if the user is the (single) owner of
+#      the local daemon.
+#   3. The daemon and gateway should be running with HTTP auth
+#      disabled (e.g. `DISABLE_HTTP_AUTH=true`), which is the
+#      expected configuration for a single-owner local install.
+#      Security perimeter in this mode is the loopback bind and the
+#      browser's private-network-access policy, not a token.
+#
+# DO NOT use these settings for a cloud / hosted build.
+
+# Point at the local gateway (loopback). Default gateway port is 7830.
+API_PROXY_TARGET=http://localhost:7830
+
+# Tell the SPA to skip the sign-in flow.
+VITE_AUTH_MODE=local

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -36,24 +36,45 @@ bun run dev         # Vite dev server on localhost:3000
 The Vite dev server includes a built-in
 [reverse proxy](https://vite.dev/config/server-options#server-proxy)
 that forwards API paths (`/v1/*`, `/_allauth/*`, `/accounts/*`) to the
-Django backend. This keeps all requests same-origin so session cookies
-work automatically — no CORS configuration or HTTPS setup needed.
+backend. This keeps all requests same-origin so session cookies work
+automatically — no CORS configuration or HTTPS setup needed.
 
-By default the proxy targets `http://localhost:8000`. To change it,
-set `API_PROXY_TARGET` in a `.env` file (see
-[`.env.example`](./.env.example)):
+There are two supported local-development backends.
+
+#### Option A — local daemon + gateway (recommended for OSS / self-host work)
+
+Run the assistant daemon and gateway you'd normally use (`vellum hatch`
+/ `vellum wake` — see the [root CONTRIBUTING.md](../../CONTRIBUTING.md)),
+configured with HTTP auth disabled, then point the SPA's proxy at the
+local gateway. Copy [`.env.local.example`](./.env.local.example) to
+`.env.local`:
+
+```bash
+cp .env.local.example .env.local
+```
+
+That file sets `API_PROXY_TARGET=http://localhost:7830` (gateway) and
+`VITE_AUTH_MODE=local`. The SPA boots straight into the app — no
+sign-in screen — and the gateway+daemon serve `/v1/*` directly. This
+is the configuration that does not require any hosted infrastructure.
+
+#### Option B — hosted backend (cloud-replicating development)
+
+To develop against the hosted backend stack (Django + allauth +
+WorkOS sign-in), leave `VITE_AUTH_MODE` unset (it defaults to
+`"cloud"`) and point `API_PROXY_TARGET` at your Django instance:
 
 ```bash
 # .env (not committed)
 API_PROXY_TARGET=http://localhost:8000
 ```
 
-Browse to **http://localhost:3000** and log in normally.
+Then browse to **http://localhost:3000** and sign in normally.
 
 > **Note:** Some API endpoints (avatar, feed, assistant state) return
-> 404 unless the assistant daemon is running. This is expected in
-> frontend-only mode — the core UI and auth flow work without the
-> daemon.
+> 404 unless the assistant daemon is running. In Option B this is
+> expected in frontend-only mode — the core UI and auth flow work
+> without the daemon.
 
 ### How the proxy works
 

--- a/apps/web/src/domains/account/pages/login-page.tsx
+++ b/apps/web/src/domains/account/pages/login-page.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link, Navigate, useSearchParams } from "react-router";
 import { Mail } from "lucide-react";
 
 import { Button } from "@vellum/design-library";
@@ -8,6 +8,7 @@ import { GoogleLogo } from "@/components/icons/google-logo.js";
 import { NativeSplash } from "@/components/native-splash.js";
 import { LoginBackground } from "@/domains/account/components/login-background.js";
 import { PROVIDER_ID, buildProviderCallbackUrl } from "@/domains/account/login-flow.js";
+import { isLocalMode } from "@/lib/auth/mode.js";
 import {
   startAuthFlow,
   startNativeLogin,
@@ -207,6 +208,12 @@ export function LoginPage() {
   const [searchParams] = useSearchParams();
   const isNative = useIsNativePlatform();
   const returnTo = searchParams.get("returnTo");
+
+  // Local mode has no sign-in flow. If a deep link or stale redirect
+  // lands a user here, bounce them back into the app.
+  if (isLocalMode()) {
+    return <Navigate to={returnTo || "/"} replace />;
+  }
 
   if (isNative) return <NativeLoginForm returnTo={returnTo} />;
   return <WebLoginForm returnTo={returnTo} />;

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -18,6 +18,13 @@ interface ImportMetaEnv {
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */
   readonly VITE_APP_VERSION?: string;
+  /**
+   * Auth mode for this build. `"local"` skips the sign-in flow entirely
+   * — the SPA assumes it's pointed at a local-only daemon (e.g. the
+   * gateway running with `DISABLE_HTTP_AUTH=true`). `"cloud"` (default,
+   * also used when unset) runs the normal sign-in flow against allauth.
+   */
+  readonly VITE_AUTH_MODE?: "local" | "cloud";
 }
 
 interface ImportMeta {

--- a/apps/web/src/lib/auth/mode.ts
+++ b/apps/web/src/lib/auth/mode.ts
@@ -1,0 +1,38 @@
+/**
+ * SPA auth mode — a single build-time switch that determines whether
+ * the app expects a sign-in flow.
+ *
+ * - `"cloud"` (default): the normal allauth-backed sign-in flow. Used
+ *   for hosted deployments where a user identity is required.
+ * - `"local"`: no sign-in. The SPA assumes it's pointed at a
+ *   single-owner local daemon (typically the gateway running with
+ *   `DISABLE_HTTP_AUTH=true`). The user owns the machine; that's the
+ *   auth perimeter. The login screen is never rendered, and the auth
+ *   store boots into an "always signed in as the local owner" state.
+ *
+ * Set at build time via `VITE_AUTH_MODE=local|cloud`. Unset → `"cloud"`.
+ *
+ * Why a build-time switch instead of runtime detection:
+ *   1. Servers — not the SPA — enforce auth. The mode here only
+ *      controls UI presence. Anyone can edit their build to claim
+ *      `"local"`, but the daemon and gateway still gate on their own
+ *      auth config. So the switch can't bypass real security.
+ *   2. A self-hosted build, a cloud build, and a local-dev build are
+ *      different deployable artifacts. The deployer knows which one
+ *      they're producing; encoding that at build time avoids runtime
+ *      mode-detection footguns.
+ */
+
+export type AuthMode = "local" | "cloud";
+
+const RAW_MODE = (import.meta.env.VITE_AUTH_MODE ?? "").toLowerCase();
+
+const AUTH_MODE: AuthMode = RAW_MODE === "local" ? "local" : "cloud";
+
+export function getAuthMode(): AuthMode {
+  return AUTH_MODE;
+}
+
+export function isLocalMode(): boolean {
+  return AUTH_MODE === "local";
+}

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface SessionResult {
+  ok: boolean;
+  data: {
+    user: {
+      id?: string;
+      username?: string;
+      email?: string | null;
+      is_staff?: boolean;
+    } | null;
+  };
+}
+
+const getSession = mock(
+  async (): Promise<SessionResult> => ({ ok: false, data: { user: null } }),
+);
+const allauthLogout = mock(async () => undefined);
+const isLocalMode = mock(() => false);
+
+mock.module("@/lib/auth/allauth-client", () => ({
+  getSession,
+  logout: allauthLogout,
+}));
+
+mock.module("@/lib/auth/mode", () => ({
+  isLocalMode,
+  getAuthMode: () => (isLocalMode() ? "local" : "cloud"),
+}));
+
+// Import after mocks so the store sees them.
+const { useAuthStore } = await import("./auth-store.js");
+
+function resetStore() {
+  useAuthStore.setState({ isLoggedIn: false, isLoading: true, user: null });
+}
+
+beforeEach(() => {
+  getSession.mockClear();
+  allauthLogout.mockClear();
+  isLocalMode.mockReset();
+  isLocalMode.mockImplementation(() => false);
+  resetStore();
+});
+
+afterEach(() => {
+  resetStore();
+});
+
+describe("auth-store — local mode", () => {
+  test("initSession skips the allauth probe and boots logged-in", async () => {
+    isLocalMode.mockImplementation(() => true);
+
+    await useAuthStore.getState().initSession();
+
+    expect(getSession).not.toHaveBeenCalled();
+    const state = useAuthStore.getState();
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.isLoading).toBe(false);
+    expect(state.user).not.toBeNull();
+    expect(state.user?.id).toBe("local");
+  });
+
+  test("refreshSession is a no-op that reports success", async () => {
+    isLocalMode.mockImplementation(() => true);
+    await useAuthStore.getState().initSession();
+    getSession.mockClear();
+
+    const ok = await useAuthStore.getState().refreshSession();
+
+    expect(ok).toBe(true);
+    expect(getSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isLoggedIn).toBe(true);
+  });
+
+  test("logout does not call allauth and leaves state intact", async () => {
+    isLocalMode.mockImplementation(() => true);
+    await useAuthStore.getState().initSession();
+
+    await useAuthStore.getState().logout();
+
+    expect(allauthLogout).not.toHaveBeenCalled();
+    // Local mode keeps the synthetic user; logout is a no-op.
+    expect(useAuthStore.getState().isLoggedIn).toBe(true);
+  });
+});
+
+describe("auth-store — cloud mode (default)", () => {
+  test("initSession probes allauth and sets isLoggedIn on success", async () => {
+    getSession.mockImplementation(async () => ({
+      ok: true,
+      data: {
+        user: {
+          id: "cloud-user-1",
+          username: "cloud",
+          email: "cloud@example.com",
+          is_staff: false,
+        },
+      },
+    }));
+
+    await useAuthStore.getState().initSession();
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+    const state = useAuthStore.getState();
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.user?.id).toBe("cloud-user-1");
+  });
+
+  test("initSession leaves the user logged-out when allauth has no session", async () => {
+    getSession.mockImplementation(async () => ({
+      ok: false,
+      data: { user: null },
+    }));
+
+    await useAuthStore.getState().initSession();
+
+    const state = useAuthStore.getState();
+    expect(state.isLoggedIn).toBe(false);
+    expect(state.user).toBeNull();
+  });
+
+  test("logout calls allauth", async () => {
+    getSession.mockImplementation(async () => ({
+      ok: true,
+      data: {
+        user: {
+          id: "cloud-user-2",
+          username: "cloud2",
+          email: null,
+        },
+      },
+    }));
+    await useAuthStore.getState().initSession();
+
+    await useAuthStore.getState().logout();
+
+    expect(allauthLogout).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().isLoggedIn).toBe(false);
+  });
+});

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,7 +19,25 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
+import { isLocalMode } from "@/lib/auth/mode.js";
 import { clearOrganization } from "@/stores/organization-store.js";
+
+/**
+ * Synthetic user for local mode. The SPA never queries identity in
+ * local mode (no IdP, no allauth), but the rest of the app reads
+ * `useAuthStore().user` to decide what to render — so we provide a
+ * stable placeholder identity. Anything that needs a real user id
+ * (telemetry, multi-tenant features) should branch on `isLocalMode()`
+ * rather than reading the synthetic id.
+ */
+const LOCAL_MODE_USER: AuthUser = {
+  id: "local",
+  username: "local",
+  email: null,
+  isStaff: false,
+  firstName: "",
+  lastName: "",
+};
 
 export interface AuthUser {
   id: string | null;
@@ -89,6 +107,13 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   user: null,
 
   initSession: async () => {
+    if (isLocalMode()) {
+      // No allauth backend in local mode. Boot straight into an
+      // "always signed in as local owner" state and skip the probe.
+      syncOrganizationState(LOCAL_MODE_USER.id);
+      set({ isLoggedIn: true, isLoading: false, user: LOCAL_MODE_USER });
+      return;
+    }
     try {
       const result = await getSession();
       if (result.ok && result.data.user) {
@@ -105,6 +130,10 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   },
 
   refreshSession: async () => {
+    if (isLocalMode()) {
+      // Local mode has no remote session to refresh against.
+      return true;
+    }
     try {
       const result = await getSession();
       if (result.ok && result.data.user) {
@@ -122,6 +151,12 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
   },
 
   logout: async () => {
+    if (isLocalMode()) {
+      // No remote session to terminate; ignore. (Surfaces in UI as a
+      // no-op; the logout button is hidden in local mode at the view
+      // layer.)
+      return;
+    }
     try {
       await allauthLogout();
     } finally {


### PR DESCRIPTION
Closing this. Cloud sign-in already works correctly on `main` (preserved through the LUM-1784 chain and the LUM-1787 / LUM-1792 cleanup), so there is no minimum-viable change needed in the SPA right now to "just make sign-in work."

The local-mode bypass this PR introduced (`VITE_AUTH_MODE`) is a tactical patch I shouldn't be shipping while the broader auth architecture is still being designed. Merging it would calcify a shape we might not want — specifically: a build-time mode flag baked into the SPA, an "always logged in as local" synthetic user, and a self-host story that depends on `DISABLE_HTTP_AUTH=true` on the daemon. Those choices belong inside a thought-out design doc, not in a one-off PR.

The redesign work — including the local-mode story for self-host, the Capacitor iOS path, and the future Electron path — is being captured in a single Linear issue with a written design doc, threat model, and per-client flow before any more code lands in this area.

In the meantime the merged guardrails ([#31481](https://github.com/vellum-ai/vellum-assistant/pull/31481) lint rules, [#31475](https://github.com/vellum-ai/vellum-assistant/pull/31475) header consolidation, [#31469](https://github.com/vellum-ai/vellum-assistant/pull/31469) shared HeyAPI client) prevent the codebase from drifting further while we figure out the right architecture.

Closing without merge.