### PR TITLE
refactor(web): extract useContextWindowUsageHydration (LUM-1740 Phase 5a)

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -60,6 +60,7 @@ import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor.js
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure.js";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges.js";
 import { useConversationLoader } from "@/domains/conversations/use-conversation-loader.js";
+import { useContextWindowUsageHydration } from "@/domains/chat/hooks/use-context-window-usage-hydration.js";
 import { useConversationActions } from "@/domains/conversations/use-conversation-actions.js";
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions.js";
 import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-palette-sections.js";
@@ -259,6 +260,13 @@ export function ChatPage() {
   const expandedToolCallIdsRef = useRef<Set<string>>(new Set());
   const contextWindowUsageByConversationRef = useRef<Map<string, ContextWindowUsage>>(new Map());
   const syncRouterRef = useRef<WebSyncRouter | null>(null);
+
+  useContextWindowUsageHydration({
+    assistantId,
+    activeConversationKey,
+    contextWindowUsageByConversationRef,
+    setContextWindowUsage,
+  });
 
   // -------------------------------------------------------------------------
   // Routing

--- a/apps/web/src/domains/chat/hooks/use-context-window-usage-hydration.ts
+++ b/apps/web/src/domains/chat/hooks/use-context-window-usage-hydration.ts
@@ -1,0 +1,64 @@
+/**
+ * Hydrate the page-level context-window-usage map from localStorage when the
+ * assistant comes online, and surface the active conversation's usage to the
+ * caller.
+ *
+ * The map is the source of truth across conversation switches: the switch
+ * effect reads from it to restore the indicator when re-entering a
+ * conversation, and stream events write to it as new usage data arrives.
+ * This hook only handles the initial hydration — the merge is keyed by
+ * `assistantId` so it runs at most once per assistant per page lifetime.
+ */
+
+import {
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+} from "react";
+
+import { loadContextWindowUsageMap } from "@/domains/chat/utils/context-window-storage.js";
+import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator.js";
+
+export interface UseContextWindowUsageHydrationParams {
+  assistantId: string | null;
+  activeConversationKey: string | null;
+  contextWindowUsageByConversationRef: MutableRefObject<Map<string, ContextWindowUsage>>;
+  setContextWindowUsage: Dispatch<SetStateAction<ContextWindowUsage | null>>;
+}
+
+export function useContextWindowUsageHydration({
+  assistantId,
+  activeConversationKey,
+  contextWindowUsageByConversationRef,
+  setContextWindowUsage,
+}: UseContextWindowUsageHydrationParams): void {
+  const hydratedAssistantIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!assistantId) return;
+    if (hydratedAssistantIdRef.current === assistantId) return;
+    hydratedAssistantIdRef.current = assistantId;
+    const stored = loadContextWindowUsageMap(assistantId);
+    if (stored.size === 0) return;
+    const merged = new Map(contextWindowUsageByConversationRef.current);
+    for (const [key, value] of stored) {
+      if (!merged.has(key)) {
+        merged.set(key, value);
+      }
+    }
+    contextWindowUsageByConversationRef.current = merged;
+    if (activeConversationKey) {
+      const cached = merged.get(activeConversationKey);
+      if (cached) {
+        setContextWindowUsage(cached);
+      }
+    }
+  }, [
+    assistantId,
+    activeConversationKey,
+    contextWindowUsageByConversationRef,
+    setContextWindowUsage,
+  ]);
+}

--- a/apps/web/src/domains/conversations/use-conversation-loader.ts
+++ b/apps/web/src/domains/conversations/use-conversation-loader.ts
@@ -18,7 +18,6 @@ import {
   createDraftConversationKey,
   resolveBootstrappedConversationKey,
 } from "@/domains/chat/utils/conversation-selection.js";
-import { loadContextWindowUsageMap } from "@/domains/chat/utils/context-window-storage.js";
 import {
   loadLastViewedConversationKey,
   saveLastViewedConversationKey,
@@ -180,7 +179,6 @@ export function useConversationLoader({
   // Internal refs
   // -------------------------------------------------------------------------
   const refreshConversationsRef = useRef<() => Promise<void>>(async () => {});
-  const hydratedAssistantIdRef = useRef<string | null>(null);
   const queryClient = useQueryClient();
 
   // -------------------------------------------------------------------------
@@ -231,30 +229,6 @@ export function useConversationLoader({
       refreshConversationsRef.current();
     }, CONVERSATION_LIST_INVALIDATED_DEBOUNCE_MS);
   }, [conversationListInvalidatedTimerRef]);
-
-  // -------------------------------------------------------------------------
-  // Context window usage hydration from localStorage
-  // -------------------------------------------------------------------------
-  useEffect(() => {
-    if (!assistantId) return;
-    if (hydratedAssistantIdRef.current === assistantId) return;
-    hydratedAssistantIdRef.current = assistantId;
-    const stored = loadContextWindowUsageMap(assistantId);
-    if (stored.size === 0) return;
-    const merged = new Map(contextWindowUsageByConversationRef.current);
-    for (const [key, value] of stored) {
-      if (!merged.has(key)) {
-        merged.set(key, value);
-      }
-    }
-    contextWindowUsageByConversationRef.current = merged;
-    if (activeConversationKey) {
-      const cached = merged.get(activeConversationKey);
-      if (cached) {
-        setContextWindowUsage(cached);
-      }
-    }
-  }, [assistantId, activeConversationKey, contextWindowUsageByConversationRef, setContextWindowUsage]);
 
   // -------------------------------------------------------------------------
   // Init effect -- fetch conversations when the assistant becomes active


### PR DESCRIPTION
## Summary

Phase 5a of [LUM-1734](https://linear.app/vellum/issue/LUM-1734) — start dismantling `use-conversation-loader.ts` by folding its residuals into focused hooks. This first step extracts the context-window-usage hydration effect.

### What moved

- New `apps/web/src/domains/chat/hooks/use-context-window-usage-hydration.ts` owns the ~20-line effect: read the per-assistant map from `localStorage` on assistant change, merge into the page-level ref, and seed the active conversation's `ContextWindowUsage` state.
- `use-conversation-loader.ts` drops the `hydratedAssistantIdRef` bookkeeping and the `loadContextWindowUsageMap` import. Net 26 lines off the loader.
- `chat-page.tsx` mounts the new hook directly, alongside the existing `useConversationLoader` call.

### Deferred

The page-level `contextWindowUsageByConversationRef` itself still lives in `chat-page.tsx` because `useStreamEventHandler` writes to it on every usage update from the stream — moving it inside the hook would force re-renders the streaming hot path can't afford. That ref will go when the rest of the ref-sync block in `chat-page.tsx` does, later in Phase 5.

Closes LUM-1740 (partial — Phase 5a).

## Test plan

- [x] `bun run test:ci` — 101 / 101 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (1 preexisting unrelated warning)

---
_Generated by [Claude Code](https://claude.ai/code/session_0181LfJ6Lapx1LKyrrnDZ3Vh)_