### PR TITLE
refactor(web): redesign AssistantSideMenu — extract state + split components (LUM-1744)

### DIFF
--- a/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -23,6 +23,7 @@ import {
   ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT,
   AssistantSideMenu,
 } from "@/domains/chat/components/assistant-side-menu.js";
+import { SIDEBAR_CONVERSATION_LIMIT } from "@/domains/chat/use-sidebar-state.js";
 
 function makeConversation(overrides: Partial<Conversation>): Conversation {
   return {
@@ -161,18 +162,19 @@ describe("AssistantSideMenu · Show more affordance", () => {
 
   test("wires the same 'Show more' affordance for Slack conversations", () => {
     const src = readFileSync(
-      new URL("./assistant-side-menu.tsx", import.meta.url).pathname,
+      new URL("../use-sidebar-state.ts", import.meta.url).pathname,
       "utf8",
     );
 
     expect(src).toContain(
-      "slack.slice(0, ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT)",
+      "slack.slice(0, SIDEBAR_CONVERSATION_LIMIT)",
     );
     expect(src).toContain(
-      "slack.length > ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT",
+      "slack.length > SIDEBAR_CONVERSATION_LIMIT",
     );
-    expect(src).toContain("showMoreSlackVisible");
-    expect(src).toContain("onSelect={() => setShowAllSlack(true)}");
+    expect(src).toContain("showAllSlack");
+    expect(src).toContain("setShowAllSlack");
+    expect(SIDEBAR_CONVERSATION_LIMIT).toBe(ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT);
   });
 });
 

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -389,8 +389,8 @@ export function AssistantSideMenu({
               pinned={sidebar.pinned}
               scheduled={sidebar.scheduled}
               background={sidebar.background}
-              slack={sidebar.slack.items}
-              recents={sidebar.recents.items}
+              slack={sidebar.slack.all}
+              recents={sidebar.recents.all}
               customGroups={sidebar.conversationGroupsEnabled ? sidebar.customGroups : undefined}
               activeConversationKey={activeConversationKey}
               onSelectConversation={selectAndClose}

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,73 +1,49 @@
 import {
   Brain,
   Calendar,
-  CircleAlert,
   Clock,
   FolderPlus,
   Globe,
   Hash,
-  LayoutGrid,
   Layers,
-  MoreHorizontal,
-  Pencil,
+  LayoutGrid,
   Pin,
-  PinOff,
   Search,
   SquarePen,
-  Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState, startTransition, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 
-import {
-  groupBackgroundConversationsBySource,
-} from "@/domains/chat/utils/background-sub-groups.js";
-import {
-  groupScheduledConversationsByJobId,
-} from "@/domains/chat/utils/scheduled-sub-groups.js";
-import {
-  loadOpenCategories,
-  loadOpenCustomGroups,
-  saveOpenCategories,
-  saveOpenCustomGroups,
-} from "@/domains/chat/utils/sidebar-group-collapse-storage.js";
-import type { SubGroup } from "@/domains/chat/utils/sub-group-utils.js";
-import { CollapsedConversationsButton } from "@/domains/chat/components/collapsed-conversations-button.js";
 import {
   ConversationActionsMenu,
   renderConversationMenuItems,
   type ConversationMenuItemsProps,
 } from "@/domains/chat/components/conversation-actions-menu.js";
+import { CollapsedConversationsButton } from "@/domains/chat/components/collapsed-conversations-button.js";
+import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle.js";
+import { GroupActionsMenu } from "@/domains/chat/components/group-actions-menu.js";
+import { BackgroundSubGroups, ScheduledSubGroups } from "@/domains/chat/components/sub-group-accordion.js";
+import { countBadge } from "@/domains/chat/components/sidebar-count-badge.js";
+import { useSidebarState, SIDEBAR_CONVERSATION_LIMIT, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state.js";
 import {
-  BottomSheet,
   Button,
-  cn,
   ContextMenu,
   PanelItem,
-  Popover,
   SideMenu,
 } from "@vellum/design-library";
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section.js";
-import { useIsMobile } from "@/hooks/use-is-mobile.js";
 import { usePinnedAppsStore } from "@/domains/chat/pinned-apps-store.js";
-import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
-
-import { buildMoveToGroupTargets, groupConversations, isConversationPinned } from "@/domains/chat/utils/group-conversations.js";
+import { buildMoveToGroupTargets, isConversationPinned } from "@/domains/chat/utils/group-conversations.js";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel.js";
-import { canMarkRead, canMarkUnread, type Conversation, type ConversationGroup } from "@/domains/chat/api/conversations.js";
+import { canMarkRead, canMarkUnread, type Conversation } from "@/domains/chat/api/conversations.js";
 
-/**
- * Maximum number of conversation entries rendered under expanded Slack and
- * Recents rows before a "Show more" affordance appears.
- */
-export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT = 5;
+/** @deprecated Use {@link SIDEBAR_CONVERSATION_LIMIT} from `use-sidebar-state.ts` */
+export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT = SIDEBAR_CONVERSATION_LIMIT;
 
-export interface AssistantSideMenuProps {
-  assistantId: string;
+export interface AssistantSideMenuProps extends UseSidebarStateParams {
   assistantName?: string | null;
   collapsed: boolean;
   variant: "rail" | "overlay";
-  conversations: Conversation[];
   activeConversationKey?: string;
   onSelectConversation: (key: string) => void;
   isIntelligenceActive?: boolean;
@@ -87,31 +63,17 @@ export interface AssistantSideMenuProps {
   onUnarchiveConversation?: (conversation: Conversation) => void;
   onMarkConversationUnread?: (conversation: Conversation) => void;
   onMarkConversationRead?: (conversation: Conversation) => void;
-  conversationGroups?: ConversationGroup[];
   onCreateGroup?: () => void;
   onMoveToGroup?: (conversation: Conversation, groupId: string) => void;
   onRemoveFromGroup?: (conversation: Conversation) => void;
   onRenameGroup?: (groupId: string) => void;
   onDeleteGroup?: (groupId: string) => void;
   processingConversationKeys?: Set<string>;
-  attentionConversationKeys?: Set<string>;
   activeConversationProcessing?: boolean;
   onAnalyze?: (conversation: Conversation) => void;
   onOpenInNewWindow?: (conversation: Conversation) => void;
   onShareFeedback?: () => void;
   onInspect?: (conversation: Conversation) => void;
-}
-
-// ---------------------------------------------------------------------------
-// countBadge — shared count-badge renderer (used by multiple sub-components)
-// ---------------------------------------------------------------------------
-
-function countBadge(n: number): ReactNode {
-  return n > 0 ? (
-    <span className="text-label-small-default inline-flex items-center justify-center rounded-[4px] bg-[var(--surface-base)] px-[4px] py-[2px] text-[var(--content-tertiary)]">
-      {n}
-    </span>
-  ) : null;
 }
 
 /**
@@ -134,12 +96,6 @@ function countBadge(n: number): ReactNode {
  *   Footer
  *     • ───────────────
  *     • caller-provided action (PreferencesMenu)
- *
- * Every rendered thread row carries:
- *   - A Pin icon when `isPinned === true`.
- *   - A hover-revealed `ConversationActionsMenu` (Pin / Rename / Archive /
- *     Mark as unread). Action handlers are passed in as props — each one
- *     is optional, and when omitted its menu item is skipped entirely.
  */
 export function AssistantSideMenu({
   assistantId,
@@ -180,103 +136,16 @@ export function AssistantSideMenu({
   onShareFeedback,
   onInspect,
 }: AssistantSideMenuProps) {
-  const conversationGroupsUI = useFeatureFlagStore.use.conversationGroupsUI();
-
-  const { pinned, scheduled, background, slack, recents, customGroups } =
-    groupConversations(conversations, {
-      groups: conversationGroups,
-      customGroupsEnabled: conversationGroupsUI,
-    });
+  const sidebar = useSidebarState({
+    assistantId,
+    conversations,
+    conversationGroups,
+    attentionConversationKeys,
+  });
 
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
 
-  const [showAllRecents, setShowAllRecents] = useState(false);
-  const hasAttentionBeyondLimit = !showAllRecents
-    && recents.length > ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT
-    && attentionConversationKeys
-    && recents.slice(ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT).some(c => attentionConversationKeys.has(c.conversationKey));
-  const effectiveShowAll = showAllRecents || !!hasAttentionBeyondLimit;
-  const recentsToShow = effectiveShowAll
-    ? recents
-    : recents.slice(0, ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT);
-  const showMoreVisible =
-    !effectiveShowAll && recents.length > ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT;
-  const [showAllSlack, setShowAllSlack] = useState(false);
-  const hasSlackAttentionBeyondLimit = !showAllSlack
-    && slack.length > ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT
-    && attentionConversationKeys
-    && slack.slice(ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT).some(c => attentionConversationKeys.has(c.conversationKey));
-  const effectiveShowAllSlack = showAllSlack || !!hasSlackAttentionBeyondLimit;
-  const slackToShow = effectiveShowAllSlack
-    ? slack
-    : slack.slice(0, ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT);
-  const showMoreSlackVisible =
-    !effectiveShowAllSlack && slack.length > ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT;
-
-  // Category accordion state lives here (lifted out of the
-  // CollapsibleNavSection.Root uncontrolled default) so it survives
-  // the rail's collapsed → expanded transition.
-  const [openCategories, setOpenCategories] = useState<string[]>(["recents"]);
-
-  // Custom groups use a SEPARATE state (and separate localStorage key) so
-  // their CollapsibleNavSection.Root's onValueChange doesn't clobber the
-  // built-in sections' state.
-  const [openCustomGroups, setOpenCustomGroups] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (assistantId) {
-      startTransition(() => {
-        setOpenCategories(loadOpenCategories(assistantId));
-        setOpenCustomGroups(loadOpenCustomGroups(assistantId));
-      });
-    }
-  }, [assistantId]);
-
-  const handleOpenCategoriesChange = useCallback(
-    (next: string[]) => {
-      setOpenCategories(next);
-      saveOpenCategories(assistantId, next);
-    },
-    [assistantId],
-  );
-
-  const handleOpenCustomGroupsChange = useCallback(
-    (next: string[]) => {
-      setOpenCustomGroups(next);
-      saveOpenCustomGroups(assistantId, next);
-    },
-    [assistantId],
-  );
-
-  const hasAttentionIn = useCallback(
-    (convs: Conversation[]) =>
-      attentionConversationKeys ? convs.some(c => attentionConversationKeys.has(c.conversationKey)) : false,
-    [attentionConversationKeys],
-  );
-
-  const effectiveOpenCategories = useMemo(() => {
-    if (!attentionConversationKeys || attentionConversationKeys.size === 0) return openCategories;
-    const extra: string[] = [];
-    if (pinned.length > 0 && hasAttentionIn(pinned)) extra.push("pinned");
-    if (scheduled.length > 0 && hasAttentionIn(scheduled)) extra.push("scheduled");
-    if (background.length > 0 && hasAttentionIn(background)) extra.push("background");
-    if (slack.length > 0 && hasAttentionIn(slack)) extra.push("slack");
-    if (recents.length > 0 && hasAttentionIn(recents)) extra.push("recents");
-    if (extra.length === 0) return openCategories;
-    if (extra.every(c => openCategories.includes(c))) return openCategories;
-    return [...new Set([...openCategories, ...extra])];
-  }, [openCategories, attentionConversationKeys, pinned, scheduled, background, slack, recents, hasAttentionIn]);
-
-  const effectiveOpenCustomGroups = useMemo(() => {
-    if (!attentionConversationKeys || attentionConversationKeys.size === 0 || !customGroups) return openCustomGroups;
-    const extra: string[] = [];
-    for (const group of customGroups) {
-      if (hasAttentionIn(group.conversations)) extra.push(group.id);
-    }
-    if (extra.length === 0) return openCustomGroups;
-    if (extra.every(id => openCustomGroups.includes(id))) return openCustomGroups;
-    return [...new Set([...openCustomGroups, ...extra])];
-  }, [openCustomGroups, attentionConversationKeys, customGroups, hasAttentionIn]);
+  // --- Render helpers (action wiring, context menu, pin toggle) ---
 
   const renderThreadPinToggle = (conversation: Conversation): ReactNode => {
     const isProcessing =
@@ -328,15 +197,15 @@ export function AssistantSideMenu({
           : undefined,
       isMarkUnreadDisabled: !canMarkUnread(conversation),
       moveToGroups:
-        conversationGroupsUI && onMoveToGroup
+        sidebar.conversationGroupsEnabled && onMoveToGroup
           ? buildMoveToGroupTargets(conversation, conversationGroups)
           : undefined,
       onMoveToGroup:
-        conversationGroupsUI && onMoveToGroup
+        sidebar.conversationGroupsEnabled && onMoveToGroup
           ? (groupId) => onMoveToGroup(conversation, groupId)
           : undefined,
       onRemoveFromGroup:
-        conversationGroupsUI && onRemoveFromGroup && inCustomGroup
+        sidebar.conversationGroupsEnabled && onRemoveFromGroup && inCustomGroup
           ? () => onRemoveFromGroup(conversation)
           : undefined,
       onAnalyze:
@@ -376,9 +245,30 @@ export function AssistantSideMenu({
     );
   };
 
+  // --- Shared sub-component props ---
+
+  const subGroupProps = {
+    activeConversationKey,
+    attentionConversationKeys,
+    onSelectConversation: useCallback(
+      (key: string) => { onSelectConversation(key); onClose?.(); },
+      [onSelectConversation, onClose],
+    ),
+    renderActions: renderThreadActions,
+    renderPinToggle: renderThreadPinToggle,
+    renderRow: renderThreadRow,
+  };
+
+  const selectAndClose = useCallback(
+    (key: string) => { onSelectConversation(key); onClose?.(); },
+    [onSelectConversation, onClose],
+  );
+
+  // --- Header actions ---
+
   const headerActions = (
     <>
-      {conversationGroupsUI ? (
+      {sidebar.conversationGroupsEnabled ? (
         <Button
           variant="ghost"
           size="compact"
@@ -396,6 +286,41 @@ export function AssistantSideMenu({
       />
     </>
   );
+
+  // --- Flat conversation list renderer ---
+
+  const renderFlatList = (
+    items: Conversation[],
+    showMore: boolean,
+    onShowMore: () => void,
+  ): ReactNode => (
+    <SideMenu.SubList>
+      {items.map((c) =>
+        renderThreadRow(
+          c,
+          <PanelItem
+            leadingSlot={renderThreadPinToggle(c)}
+            label={c.title ?? "Untitled"}
+            marqueeOnHover
+            active={c.conversationKey === activeConversationKey}
+            onSelect={() => selectAndClose(c.conversationKey)}
+            trailingAction={renderThreadActions(c)}
+          />,
+        ),
+      )}
+      {showMore ? (
+        <SideMenu.Item
+          label="Show more"
+          size="compact"
+          indent
+          emphasized
+          onSelect={onShowMore}
+        />
+      ) : null}
+    </SideMenu.SubList>
+  );
+
+  // --- JSX ---
 
   return (
     <SideMenu
@@ -461,14 +386,14 @@ export function AssistantSideMenu({
           <div className="flex flex-col items-center gap-1">
             {headerActions}
             <CollapsedConversationsButton
-              pinned={pinned}
-              scheduled={scheduled}
-              background={background}
-              slack={slack}
-              recents={recents}
-              customGroups={conversationGroupsUI ? customGroups : undefined}
+              pinned={sidebar.pinned}
+              scheduled={sidebar.scheduled}
+              background={sidebar.background}
+              slack={sidebar.slack.items}
+              recents={sidebar.recents.items}
+              customGroups={sidebar.conversationGroupsEnabled ? sidebar.customGroups : undefined}
               activeConversationKey={activeConversationKey}
-              onSelectConversation={(key) => { onSelectConversation(key); onClose?.(); }}
+              onSelectConversation={selectAndClose}
               renderActions={renderThreadActions}
               attentionConversationKeys={attentionConversationKeys}
             />
@@ -480,46 +405,27 @@ export function AssistantSideMenu({
           >
             <CollapsibleNavSection.Root
               type="multiple"
-              value={effectiveOpenCategories}
-              onValueChange={handleOpenCategoriesChange}
+              value={sidebar.effectiveOpenCategories}
+              onValueChange={sidebar.onOpenCategoriesChange}
             >
               <CollapsibleNavSection.Section
                 value="pinned"
                 icon={Pin}
                 label="Pinned"
-                trailing={countBadge(pinned.length)}
+                trailing={countBadge(sidebar.pinned.length)}
               >
-                <SideMenu.SubList>
-                  {pinned.map((c) =>
-                    renderThreadRow(
-                      c,
-                      <PanelItem
-                        leadingSlot={renderThreadPinToggle(c)}
-                        label={c.title ?? "Untitled"}
-                        marqueeOnHover
-                        active={c.conversationKey === activeConversationKey}
-                        onSelect={() => { onSelectConversation(c.conversationKey); onClose?.(); }}
-                        trailingAction={renderThreadActions(c)}
-                      />,
-                    ),
-                  )}
-                </SideMenu.SubList>
+                {renderFlatList(sidebar.pinned, false, () => {})}
               </CollapsibleNavSection.Section>
 
               <CollapsibleNavSection.Section
                 value="scheduled"
                 icon={Calendar}
                 label="Scheduled"
-                trailing={countBadge(scheduled.length)}
+                trailing={countBadge(sidebar.scheduled.length)}
               >
                 <ScheduledSubGroups
-                  conversations={scheduled}
-                  activeConversationKey={activeConversationKey}
-                  attentionConversationKeys={attentionConversationKeys}
-                  onSelectConversation={(key) => { onSelectConversation(key); onClose?.(); }}
-                  renderActions={renderThreadActions}
-                  renderPinToggle={renderThreadPinToggle}
-                  renderRow={renderThreadRow}
+                  subGroups={sidebar.scheduledSubGroups}
+                  {...subGroupProps}
                 />
               </CollapsibleNavSection.Section>
 
@@ -527,50 +433,22 @@ export function AssistantSideMenu({
                 value="background"
                 icon={Layers}
                 label="Background"
-                trailing={countBadge(background.length)}
+                trailing={countBadge(sidebar.background.length)}
               >
                 <BackgroundSubGroups
-                  conversations={background}
-                  activeConversationKey={activeConversationKey}
-                  attentionConversationKeys={attentionConversationKeys}
-                  onSelectConversation={(key) => { onSelectConversation(key); onClose?.(); }}
-                  renderActions={renderThreadActions}
-                  renderPinToggle={renderThreadPinToggle}
-                  renderRow={renderThreadRow}
+                  subGroups={sidebar.backgroundSubGroups}
+                  {...subGroupProps}
                 />
               </CollapsibleNavSection.Section>
 
-              {slack.length > 0 ? (
+              {sidebar.slack.totalCount > 0 ? (
                 <CollapsibleNavSection.Section
                   value="slack"
                   icon={Hash}
                   label="Slack"
-                  trailing={countBadge(slack.length)}
+                  trailing={countBadge(sidebar.slack.totalCount)}
                 >
-                  <SideMenu.SubList>
-                    {slackToShow.map((c) =>
-                      renderThreadRow(
-                        c,
-                        <PanelItem
-                          leadingSlot={renderThreadPinToggle(c)}
-                          label={c.title ?? "Untitled"}
-                          marqueeOnHover
-                          active={c.conversationKey === activeConversationKey}
-                          onSelect={() => { onSelectConversation(c.conversationKey); onClose?.(); }}
-                          trailingAction={renderThreadActions(c)}
-                        />,
-                      ),
-                    )}
-                    {showMoreSlackVisible ? (
-                      <SideMenu.Item
-                        label="Show more"
-                        size="compact"
-                        indent
-                        emphasized
-                        onSelect={() => setShowAllSlack(true)}
-                      />
-                    ) : null}
-                  </SideMenu.SubList>
+                  {renderFlatList(sidebar.slack.items, sidebar.slack.showMore, sidebar.slack.onShowMore)}
                 </CollapsibleNavSection.Section>
               ) : null}
 
@@ -578,45 +456,22 @@ export function AssistantSideMenu({
                 value="recents"
                 icon={Clock}
                 label="Recents"
-                trailing={countBadge(recents.length)}
+                trailing={countBadge(sidebar.recents.totalCount)}
               >
-                <SideMenu.SubList>
-                  {recentsToShow.map((c) =>
-                    renderThreadRow(
-                      c,
-                      <PanelItem
-                        leadingSlot={renderThreadPinToggle(c)}
-                        label={c.title ?? "Untitled"}
-                        marqueeOnHover
-                        active={c.conversationKey === activeConversationKey}
-                        onSelect={() => { onSelectConversation(c.conversationKey); onClose?.(); }}
-                        trailingAction={renderThreadActions(c)}
-                      />,
-                    ),
-                  )}
-                  {showMoreVisible ? (
-                    <SideMenu.Item
-                      label="Show more"
-                      size="compact"
-                      indent
-                      emphasized
-                      onSelect={() => setShowAllRecents(true)}
-                    />
-                  ) : null}
-                </SideMenu.SubList>
+                {renderFlatList(sidebar.recents.items, sidebar.recents.showMore, sidebar.recents.onShowMore)}
               </CollapsibleNavSection.Section>
             </CollapsibleNavSection.Root>
 
-            {conversationGroupsUI && customGroups.length > 0 ? (
+            {sidebar.conversationGroupsEnabled && sidebar.customGroups.length > 0 ? (
               <>
                 <SideMenu.Separator />
                 <SideMenu.Section title="Your Groups">
                   <CollapsibleNavSection.Root
                     type="multiple"
-                    value={effectiveOpenCustomGroups}
-                    onValueChange={handleOpenCustomGroupsChange}
+                    value={sidebar.effectiveOpenCustomGroups}
+                    onValueChange={sidebar.onOpenCustomGroupsChange}
                   >
-                    {customGroups.map((group) => (
+                    {sidebar.customGroups.map((group) => (
                       <CollapsibleNavSection.Section
                         key={group.id}
                         value={group.id}
@@ -642,10 +497,8 @@ export function AssistantSideMenu({
                                 leadingSlot={renderThreadPinToggle(c)}
                                 label={c.title ?? "Untitled"}
                                 marqueeOnHover
-                                active={
-                                  c.conversationKey === activeConversationKey
-                                }
-                                onSelect={() => { onSelectConversation(c.conversationKey); onClose?.(); }}
+                                active={c.conversationKey === activeConversationKey}
+                                onSelect={() => selectAndClose(c.conversationKey)}
                                 trailingAction={renderThreadActions(c)}
                               />,
                             ),
@@ -669,379 +522,5 @@ export function AssistantSideMenu({
         </SideMenu.Footer>
       ) : null}
     </SideMenu>
-  );
-}
-
-
-// ---------------------------------------------------------------------------
-// SubGroupAccordion — shared sub-accordion for Background + Scheduled
-// ---------------------------------------------------------------------------
-
-interface SubGroupAccordionProps {
-  subGroups: SubGroup[];
-  isSingleRow: (group: SubGroup) => boolean;
-  activeConversationKey?: string;
-  attentionConversationKeys?: Set<string>;
-  onSelectConversation: (key: string) => void;
-  renderActions: (conversation: Conversation) => ReactNode;
-  renderPinToggle: (conversation: Conversation) => ReactNode;
-  renderRow: (conversation: Conversation, panelItem: ReactNode) => ReactNode;
-}
-
-function SubGroupAccordion({
-  subGroups,
-  isSingleRow,
-  activeConversationKey,
-  attentionConversationKeys,
-  onSelectConversation,
-  renderActions,
-  renderPinToggle,
-  renderRow,
-}: SubGroupAccordionProps) {
-  return (
-    <div className="flex flex-col gap-2">
-      {subGroups.map((group) => {
-        if (isSingleRow(group)) {
-          const c = group.conversations[0];
-          if (!c) return null;
-          return renderRow(
-            c,
-            <PanelItem
-              leadingSlot={renderPinToggle(c)}
-              label={c.title ?? "Untitled"}
-              marqueeOnHover
-              active={c.conversationKey === activeConversationKey}
-              onSelect={() => onSelectConversation(c.conversationKey)}
-              trailingAction={renderActions(c)}
-            />,
-          );
-        }
-        const groupHasAttention = attentionConversationKeys
-          ? group.conversations.some(c => attentionConversationKeys.has(c.conversationKey))
-          : false;
-        return (
-          <CollapsibleNavSection.Root
-            key={group.key}
-            type="multiple"
-            className="gap-0"
-            {...(groupHasAttention ? { value: [group.key] } : {})}
-          >
-            <CollapsibleNavSection.Section
-              value={group.key}
-              label={group.label}
-              trailing={countBadge(group.conversations.length)}
-            >
-              <SideMenu.SubList>
-                {group.conversations.map((c) =>
-                  renderRow(
-                    c,
-                    <PanelItem
-                      leadingSlot={renderPinToggle(c)}
-                      label={c.title ?? "Untitled"}
-                      marqueeOnHover
-                      active={c.conversationKey === activeConversationKey}
-                      onSelect={() => onSelectConversation(c.conversationKey)}
-                      trailingAction={renderActions(c)}
-                    />,
-                  ),
-                )}
-              </SideMenu.SubList>
-            </CollapsibleNavSection.Section>
-          </CollapsibleNavSection.Root>
-        );
-      })}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// BackgroundSubGroups / ScheduledSubGroups — thin wrappers over SubGroupAccordion
-// ---------------------------------------------------------------------------
-
-interface CategorySubGroupsProps {
-  conversations: Conversation[];
-  activeConversationKey?: string;
-  attentionConversationKeys?: Set<string>;
-  onSelectConversation: (key: string) => void;
-  renderActions: (conversation: Conversation) => ReactNode;
-  renderPinToggle: (conversation: Conversation) => ReactNode;
-  renderRow: (conversation: Conversation, panelItem: ReactNode) => ReactNode;
-}
-
-function BackgroundSubGroups(props: CategorySubGroupsProps) {
-  return (
-    <SubGroupAccordion
-      subGroups={groupBackgroundConversationsBySource(props.conversations)}
-      isSingleRow={(g) => g.key.startsWith("__single__:")}
-      activeConversationKey={props.activeConversationKey}
-      attentionConversationKeys={props.attentionConversationKeys}
-      onSelectConversation={props.onSelectConversation}
-      renderActions={props.renderActions}
-      renderPinToggle={props.renderPinToggle}
-      renderRow={props.renderRow}
-    />
-  );
-}
-
-function ScheduledSubGroups(props: CategorySubGroupsProps) {
-  return (
-    <SubGroupAccordion
-      subGroups={groupScheduledConversationsByJobId(props.conversations)}
-      isSingleRow={(g) => g.conversations.length === 1}
-      activeConversationKey={props.activeConversationKey}
-      attentionConversationKeys={props.attentionConversationKeys}
-      onSelectConversation={props.onSelectConversation}
-      renderActions={props.renderActions}
-      renderPinToggle={props.renderPinToggle}
-      renderRow={props.renderRow}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ThreadPinToggle — leading pin icon for thread rows
-// ---------------------------------------------------------------------------
-
-interface ThreadPinToggleProps {
-  conversation: Conversation;
-  onPinToggle?: () => void;
-  isProcessing?: boolean;
-  needsAttention?: boolean;
-}
-
-const SLOT_BASE = cn(
-  "relative inline-flex size-[14px] shrink-0 items-center justify-center",
-  "text-[var(--content-tertiary)]",
-);
-
-const HOVER_REVEAL =
-  "absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100";
-
-const IDLE_FADE = cn(
-  "transition-opacity group-hover:opacity-0 group-focus-within:opacity-0",
-);
-
-/**
- * Idle-state indicator that fades out on hover, paired with a pin/unpin
- * glyph that fades in. The two occupy the same slot via absolute positioning
- * so the swap is layout-shift-free.
- */
-function IdleAndHoverGlyphs({
-  idle,
-  isPinned,
-}: {
-  idle: ReactNode;
-  isPinned: boolean;
-}) {
-  const HoverIcon = isPinned ? PinOff : Pin;
-  return (
-    <>
-      {idle}
-      <HoverIcon size={14} aria-hidden className={HOVER_REVEAL} />
-    </>
-  );
-}
-
-/**
- * Leading-slot button for a thread row. State machine (priority order):
- *
- *   Needs attention   → Exclamation circle (warning color, no pulse).
- *   Processing + idle → Pulsing dot (animate-pulse, primary-base).
- *   Unread + idle     → Static dot (system-mid-strong).
- *   Pinned + idle     → Hidden (no glyph; PinOff appears on hover).
- *   Unpinned + idle   → Pin glyph at 0 opacity (hidden; label aligns).
- *   Any + hover       → Pin/PinOff toggle (overrides dot).
- *
- * Clicking fires `onPinToggle` with event propagation stopped so the
- * row's own `onSelect` doesn't also fire.
- */
-function ThreadPinToggle({ conversation, onPinToggle, isProcessing, needsAttention }: ThreadPinToggleProps) {
-  const isPinned = isConversationPinned(conversation);
-  const showUnreadDot = conversation.hasUnseenLatestAssistantMessage === true;
-
-  // --- Determine which idle indicator to show ---
-
-  let glyphs: ReactNode;
-
-  if (needsAttention) {
-    glyphs = (
-      <IdleAndHoverGlyphs
-        isPinned={isPinned}
-        idle={
-          <CircleAlert
-            size={14}
-            aria-hidden
-            className={cn("absolute inset-0 m-auto text-[var(--system-mid-strong)]", IDLE_FADE)}
-          />
-        }
-      />
-    );
-  } else if (isProcessing) {
-    glyphs = (
-      <IdleAndHoverGlyphs
-        isPinned={isPinned}
-        idle={
-          <span
-            aria-hidden
-            className={cn(
-              "absolute inset-0 m-auto h-2 w-2 rounded-full bg-[var(--primary-base)] animate-pulse",
-              IDLE_FADE,
-            )}
-          />
-        }
-      />
-    );
-  } else if (showUnreadDot) {
-    glyphs = (
-      <IdleAndHoverGlyphs
-        isPinned={isPinned}
-        idle={
-          <span
-            aria-hidden
-            className={cn(
-              "absolute inset-0 m-auto h-2 w-2 rounded-full bg-[var(--system-mid-strong)]",
-              IDLE_FADE,
-            )}
-          />
-        }
-      />
-    );
-  } else if (isPinned) {
-    glyphs = <PinOff size={14} aria-hidden className={HOVER_REVEAL} />;
-  } else {
-    glyphs = (
-      <Pin
-        size={14}
-        aria-hidden
-        className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-      />
-    );
-  }
-
-  // --- Wrap in interactive or non-interactive container ---
-
-  if (!onPinToggle) {
-    return (
-      <span aria-hidden className={SLOT_BASE}>
-        {glyphs}
-      </span>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
-      onClick={(event) => {
-        event.stopPropagation();
-        onPinToggle();
-      }}
-      className={cn(
-        SLOT_BASE,
-        "cursor-pointer hover:text-[var(--content-secondary)]",
-        "rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
-      )}
-    >
-      {glyphs}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// GroupActionsMenu — rename/delete context menu for custom group headers
-// ---------------------------------------------------------------------------
-
-interface GroupActionsMenuProps {
-  groupId: string;
-  onRename?: (groupId: string) => void;
-  onDelete?: (groupId: string) => void;
-}
-
-export function GroupActionsMenu({ groupId, onRename, onDelete }: GroupActionsMenuProps) {
-  const [open, setOpen] = useState(false);
-  const isMobile = useIsMobile();
-  const closeMenu = () => setOpen(false);
-
-  const trigger = (
-    <button
-      type="button"
-      aria-label="Group actions"
-      aria-haspopup="menu"
-      onClick={(event) => event.stopPropagation()}
-      className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
-    >
-      <MoreHorizontal size={14} aria-hidden />
-    </button>
-  );
-
-  if (isMobile) {
-    return (
-      <BottomSheet.Root open={open} onOpenChange={setOpen}>
-        <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
-        <BottomSheet.Content>
-          <BottomSheet.Header className="sr-only">
-            <BottomSheet.Title>Group actions</BottomSheet.Title>
-          </BottomSheet.Header>
-          <BottomSheet.Body className="pt-0">
-            {onRename ? (
-              <PanelItem
-                icon={Pencil}
-                label="Rename"
-                onSelect={() => {
-                  closeMenu();
-                  onRename(groupId);
-                }}
-              />
-            ) : null}
-            {onDelete ? (
-              <PanelItem
-                icon={Trash2}
-                label="Delete"
-                onSelect={() => {
-                  closeMenu();
-                  onDelete(groupId);
-                }}
-              />
-            ) : null}
-          </BottomSheet.Body>
-        </BottomSheet.Content>
-      </BottomSheet.Root>
-    );
-  }
-
-  return (
-    <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
-      <Popover.Content
-        side="right"
-        align="start"
-        sideOffset={4}
-        className="w-40 rounded-lg py-2 px-0"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <div className="px-2">
-          {onRename ? (
-            <PanelItem
-              icon={Pencil}
-              label="Rename"
-              onSelect={() => {
-                closeMenu();
-                onRename(groupId);
-              }}
-            />
-          ) : null}
-          {onDelete ? (
-            <PanelItem
-              icon={Trash2}
-              label="Delete"
-              onSelect={() => {
-                closeMenu();
-                onDelete(groupId);
-              }}
-            />
-          ) : null}
-        </div>
-      </Popover.Content>
-    </Popover.Root>
   );
 }

--- a/apps/web/src/domains/chat/components/group-actions-menu.tsx
+++ b/apps/web/src/domains/chat/components/group-actions-menu.tsx
@@ -1,0 +1,112 @@
+import {
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  BottomSheet,
+  PanelItem,
+  Popover,
+} from "@vellum/design-library";
+import { useIsMobile } from "@/hooks/use-is-mobile.js";
+
+// ---------------------------------------------------------------------------
+// GroupActionsMenu — rename/delete context menu for custom group headers
+// ---------------------------------------------------------------------------
+
+interface GroupActionsMenuProps {
+  groupId: string;
+  onRename?: (groupId: string) => void;
+  onDelete?: (groupId: string) => void;
+}
+
+export function GroupActionsMenu({ groupId, onRename, onDelete }: GroupActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const closeMenu = () => setOpen(false);
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label="Group actions"
+      aria-haspopup="menu"
+      onClick={(event) => event.stopPropagation()}
+      className="flex h-5 w-5 items-center justify-center rounded-[4px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-secondary)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-emphasised)]"
+    >
+      <MoreHorizontal size={14} aria-hidden />
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <BottomSheet.Root open={open} onOpenChange={setOpen}>
+        <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
+        <BottomSheet.Content>
+          <BottomSheet.Header className="sr-only">
+            <BottomSheet.Title>Group actions</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body className="pt-0">
+            {onRename ? (
+              <PanelItem
+                icon={Pencil}
+                label="Rename"
+                onSelect={() => {
+                  closeMenu();
+                  onRename(groupId);
+                }}
+              />
+            ) : null}
+            {onDelete ? (
+              <PanelItem
+                icon={Trash2}
+                label="Delete"
+                onSelect={() => {
+                  closeMenu();
+                  onDelete(groupId);
+                }}
+              />
+            ) : null}
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet.Root>
+    );
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+      <Popover.Content
+        side="right"
+        align="start"
+        sideOffset={4}
+        className="w-40 rounded-lg py-2 px-0"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="px-2">
+          {onRename ? (
+            <PanelItem
+              icon={Pencil}
+              label="Rename"
+              onSelect={() => {
+                closeMenu();
+                onRename(groupId);
+              }}
+            />
+          ) : null}
+          {onDelete ? (
+            <PanelItem
+              icon={Trash2}
+              label="Delete"
+              onSelect={() => {
+                closeMenu();
+                onDelete(groupId);
+              }}
+            />
+          ) : null}
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/apps/web/src/domains/chat/components/sidebar-count-badge.tsx
+++ b/apps/web/src/domains/chat/components/sidebar-count-badge.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function countBadge(n: number): ReactNode {
+  return n > 0 ? (
+    <span className="text-label-small-default inline-flex items-center justify-center rounded-[4px] bg-[var(--surface-base)] px-[4px] py-[2px] text-[var(--content-tertiary)]">
+      {n}
+    </span>
+  ) : null;
+}

--- a/apps/web/src/domains/chat/components/sub-group-accordion.tsx
+++ b/apps/web/src/domains/chat/components/sub-group-accordion.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from "react";
+
+import { CollapsibleNavSection } from "@/components/collapsible-nav-section.js";
+import { PanelItem, SideMenu } from "@vellum/design-library";
+import type { Conversation } from "@/domains/chat/api/conversations.js";
+import type { SubGroup } from "@/domains/chat/utils/sub-group-utils.js";
+import { countBadge } from "@/domains/chat/components/sidebar-count-badge.js";
+
+// ---------------------------------------------------------------------------
+// SubGroupAccordion — shared sub-accordion for Background + Scheduled
+// ---------------------------------------------------------------------------
+
+interface SubGroupAccordionProps {
+  subGroups: SubGroup[];
+  isSingleRow: (group: SubGroup) => boolean;
+  activeConversationKey?: string;
+  attentionConversationKeys?: Set<string>;
+  onSelectConversation: (key: string) => void;
+  renderActions: (conversation: Conversation) => ReactNode;
+  renderPinToggle: (conversation: Conversation) => ReactNode;
+  renderRow: (conversation: Conversation, panelItem: ReactNode) => ReactNode;
+}
+
+export function SubGroupAccordion({
+  subGroups,
+  isSingleRow,
+  activeConversationKey,
+  attentionConversationKeys,
+  onSelectConversation,
+  renderActions,
+  renderPinToggle,
+  renderRow,
+}: SubGroupAccordionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {subGroups.map((group) => {
+        if (isSingleRow(group)) {
+          const c = group.conversations[0];
+          if (!c) return null;
+          return renderRow(
+            c,
+            <PanelItem
+              leadingSlot={renderPinToggle(c)}
+              label={c.title ?? "Untitled"}
+              marqueeOnHover
+              active={c.conversationKey === activeConversationKey}
+              onSelect={() => onSelectConversation(c.conversationKey)}
+              trailingAction={renderActions(c)}
+            />,
+          );
+        }
+        const groupHasAttention = attentionConversationKeys
+          ? group.conversations.some(c => attentionConversationKeys.has(c.conversationKey))
+          : false;
+        return (
+          <CollapsibleNavSection.Root
+            key={group.key}
+            type="multiple"
+            className="gap-0"
+            {...(groupHasAttention ? { value: [group.key] } : {})}
+          >
+            <CollapsibleNavSection.Section
+              value={group.key}
+              label={group.label}
+              trailing={countBadge(group.conversations.length)}
+            >
+              <SideMenu.SubList>
+                {group.conversations.map((c) =>
+                  renderRow(
+                    c,
+                    <PanelItem
+                      leadingSlot={renderPinToggle(c)}
+                      label={c.title ?? "Untitled"}
+                      marqueeOnHover
+                      active={c.conversationKey === activeConversationKey}
+                      onSelect={() => onSelectConversation(c.conversationKey)}
+                      trailingAction={renderActions(c)}
+                    />,
+                  ),
+                )}
+              </SideMenu.SubList>
+            </CollapsibleNavSection.Section>
+          </CollapsibleNavSection.Root>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BackgroundSubGroups / ScheduledSubGroups
+// ---------------------------------------------------------------------------
+
+interface CategorySubGroupsProps {
+  subGroups: SubGroup[];
+  activeConversationKey?: string;
+  attentionConversationKeys?: Set<string>;
+  onSelectConversation: (key: string) => void;
+  renderActions: (conversation: Conversation) => ReactNode;
+  renderPinToggle: (conversation: Conversation) => ReactNode;
+  renderRow: (conversation: Conversation, panelItem: ReactNode) => ReactNode;
+}
+
+export function BackgroundSubGroups(props: CategorySubGroupsProps) {
+  return (
+    <SubGroupAccordion
+      subGroups={props.subGroups}
+      isSingleRow={(g) => g.key.startsWith("__single__:")}
+      activeConversationKey={props.activeConversationKey}
+      attentionConversationKeys={props.attentionConversationKeys}
+      onSelectConversation={props.onSelectConversation}
+      renderActions={props.renderActions}
+      renderPinToggle={props.renderPinToggle}
+      renderRow={props.renderRow}
+    />
+  );
+}
+
+export function ScheduledSubGroups(props: CategorySubGroupsProps) {
+  return (
+    <SubGroupAccordion
+      subGroups={props.subGroups}
+      isSingleRow={(g) => g.conversations.length === 1}
+      activeConversationKey={props.activeConversationKey}
+      attentionConversationKeys={props.attentionConversationKeys}
+      onSelectConversation={props.onSelectConversation}
+      renderActions={props.renderActions}
+      renderPinToggle={props.renderPinToggle}
+      renderRow={props.renderRow}
+    />
+  );
+}

--- a/apps/web/src/domains/chat/components/thread-pin-toggle.tsx
+++ b/apps/web/src/domains/chat/components/thread-pin-toggle.tsx
@@ -1,0 +1,155 @@
+import {
+  CircleAlert,
+  Pin,
+  PinOff,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@vellum/design-library";
+import { isConversationPinned } from "@/domains/chat/utils/group-conversations.js";
+import type { Conversation } from "@/domains/chat/api/conversations.js";
+
+// ---------------------------------------------------------------------------
+// ThreadPinToggle — leading pin icon for thread rows
+// ---------------------------------------------------------------------------
+
+export interface ThreadPinToggleProps {
+  conversation: Conversation;
+  onPinToggle?: () => void;
+  isProcessing?: boolean;
+  needsAttention?: boolean;
+}
+
+const SLOT_BASE = cn(
+  "relative inline-flex size-[14px] shrink-0 items-center justify-center",
+  "text-[var(--content-tertiary)]",
+);
+
+const HOVER_REVEAL =
+  "absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100";
+
+const IDLE_FADE = cn(
+  "transition-opacity group-hover:opacity-0 group-focus-within:opacity-0",
+);
+
+/**
+ * Idle-state indicator that fades out on hover, paired with a pin/unpin
+ * glyph that fades in. The two occupy the same slot via absolute positioning
+ * so the swap is layout-shift-free.
+ */
+function IdleAndHoverGlyphs({
+  idle,
+  isPinned,
+}: {
+  idle: ReactNode;
+  isPinned: boolean;
+}) {
+  const HoverIcon = isPinned ? PinOff : Pin;
+  return (
+    <>
+      {idle}
+      <HoverIcon size={14} aria-hidden className={HOVER_REVEAL} />
+    </>
+  );
+}
+
+/**
+ * Leading-slot button for a thread row. State machine (priority order):
+ *
+ *   Needs attention   → Exclamation circle (warning color, no pulse).
+ *   Processing + idle → Pulsing dot (animate-pulse, primary-base).
+ *   Unread + idle     → Static dot (system-mid-strong).
+ *   Pinned + idle     → Hidden (no glyph; PinOff appears on hover).
+ *   Unpinned + idle   → Pin glyph at 0 opacity (hidden; label aligns).
+ *   Any + hover       → Pin/PinOff toggle (overrides dot).
+ *
+ * Clicking fires `onPinToggle` with event propagation stopped so the
+ * row's own `onSelect` doesn't also fire.
+ */
+export function ThreadPinToggle({ conversation, onPinToggle, isProcessing, needsAttention }: ThreadPinToggleProps) {
+  const isPinned = isConversationPinned(conversation);
+  const showUnreadDot = conversation.hasUnseenLatestAssistantMessage === true;
+
+  let glyphs: ReactNode;
+
+  if (needsAttention) {
+    glyphs = (
+      <IdleAndHoverGlyphs
+        isPinned={isPinned}
+        idle={
+          <CircleAlert
+            size={14}
+            aria-hidden
+            className={cn("absolute inset-0 m-auto text-[var(--system-mid-strong)]", IDLE_FADE)}
+          />
+        }
+      />
+    );
+  } else if (isProcessing) {
+    glyphs = (
+      <IdleAndHoverGlyphs
+        isPinned={isPinned}
+        idle={
+          <span
+            aria-hidden
+            className={cn(
+              "absolute inset-0 m-auto h-2 w-2 rounded-full bg-[var(--primary-base)] animate-pulse",
+              IDLE_FADE,
+            )}
+          />
+        }
+      />
+    );
+  } else if (showUnreadDot) {
+    glyphs = (
+      <IdleAndHoverGlyphs
+        isPinned={isPinned}
+        idle={
+          <span
+            aria-hidden
+            className={cn(
+              "absolute inset-0 m-auto h-2 w-2 rounded-full bg-[var(--system-mid-strong)]",
+              IDLE_FADE,
+            )}
+          />
+        }
+      />
+    );
+  } else if (isPinned) {
+    glyphs = <PinOff size={14} aria-hidden className={HOVER_REVEAL} />;
+  } else {
+    glyphs = (
+      <Pin
+        size={14}
+        aria-hidden
+        className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      />
+    );
+  }
+
+  if (!onPinToggle) {
+    return (
+      <span aria-hidden className={SLOT_BASE}>
+        {glyphs}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
+      onClick={(event) => {
+        event.stopPropagation();
+        onPinToggle();
+      }}
+      className={cn(
+        SLOT_BASE,
+        "cursor-pointer hover:text-[var(--content-secondary)]",
+        "rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+      )}
+    >
+      {glyphs}
+    </button>
+  );
+}

--- a/apps/web/src/domains/chat/sidebar-collapse-store.test.ts
+++ b/apps/web/src/domains/chat/sidebar-collapse-store.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { useSidebarCollapseStore } from "@/domains/chat/sidebar-collapse-store.js";
+
+function resetStore() {
+  useSidebarCollapseStore.setState({
+    assistantId: null,
+    openCategories: ["recents"],
+    openCustomGroups: [],
+  });
+}
+
+afterEach(() => {
+  resetStore();
+  localStorage.clear();
+});
+
+describe("SidebarCollapseStore", () => {
+  test("defaults to recents open and no custom groups", () => {
+    const state = useSidebarCollapseStore.getState();
+    expect(state.openCategories).toEqual(["recents"]);
+    expect(state.openCustomGroups).toEqual([]);
+    expect(state.assistantId).toBeNull();
+  });
+
+  test("setAssistantId hydrates from localStorage", () => {
+    localStorage.setItem(
+      "vellum:sidebar-open-categories:asst-1",
+      JSON.stringify(["pinned", "background"]),
+    );
+    localStorage.setItem(
+      "vellum:sidebar-open-custom-groups:asst-1",
+      JSON.stringify(["grp-abc"]),
+    );
+
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+
+    const state = useSidebarCollapseStore.getState();
+    expect(state.assistantId).toBe("asst-1");
+    expect(state.openCategories).toEqual(["pinned", "background"]);
+    expect(state.openCustomGroups).toEqual(["grp-abc"]);
+  });
+
+  test("setAssistantId no-ops when assistantId is unchanged", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    useSidebarCollapseStore.getState().setOpenCategories(["scheduled"]);
+
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "scheduled",
+    ]);
+  });
+
+  test("setOpenCategories persists to localStorage", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    useSidebarCollapseStore.getState().setOpenCategories(["pinned", "recents"]);
+
+    const raw = localStorage.getItem(
+      "vellum:sidebar-open-categories:asst-1",
+    );
+    expect(JSON.parse(raw!)).toEqual(["pinned", "recents"]);
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "pinned",
+      "recents",
+    ]);
+  });
+
+  test("setOpenCustomGroups persists to localStorage", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    useSidebarCollapseStore
+      .getState()
+      .setOpenCustomGroups(["grp-1", "grp-2"]);
+
+    const raw = localStorage.getItem(
+      "vellum:sidebar-open-custom-groups:asst-1",
+    );
+    expect(JSON.parse(raw!)).toEqual(["grp-1", "grp-2"]);
+  });
+
+  test("switching assistant re-hydrates from new assistant's storage", () => {
+    localStorage.setItem(
+      "vellum:sidebar-open-categories:asst-1",
+      JSON.stringify(["pinned"]),
+    );
+    localStorage.setItem(
+      "vellum:sidebar-open-categories:asst-2",
+      JSON.stringify(["background", "slack"]),
+    );
+
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "pinned",
+    ]);
+
+    useSidebarCollapseStore.getState().setAssistantId("asst-2");
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "background",
+      "slack",
+    ]);
+  });
+
+  test("falls back to defaults when localStorage has invalid data", () => {
+    localStorage.setItem(
+      "vellum:sidebar-open-categories:asst-1",
+      "not-json",
+    );
+
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "recents",
+    ]);
+  });
+
+  test("setOpenCategories does not persist when no assistantId is set", () => {
+    useSidebarCollapseStore.getState().setOpenCategories(["pinned"]);
+
+    expect(useSidebarCollapseStore.getState().openCategories).toEqual([
+      "pinned",
+    ]);
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/apps/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/apps/web/src/domains/chat/sidebar-collapse-store.ts
@@ -1,0 +1,93 @@
+/**
+ * Zustand store for sidebar section collapse/expand state.
+ *
+ * Replaces the two `useState` + `useEffect` + manual `localStorage`
+ * read/write pairs that previously lived inside `AssistantSideMenu`.
+ *
+ * **Storage model:**
+ *
+ * - Built-in categories (pinned, scheduled, background, slack, recents)
+ *   and custom groups are stored as two separate `string[]` values,
+ *   keyed per assistant. This mirrors the Radix Accordion `value` prop
+ *   for `type="multiple"`.
+ * - Reads happen synchronously from localStorage on `setAssistantId`;
+ *   writes happen on every toggle via `persist` helpers.
+ * - Defaults to `["recents"]` for categories and `[]` for custom groups
+ *   when no stored state exists.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors.js";
+import {
+  loadOpenCategories,
+  loadOpenCustomGroups,
+  saveOpenCategories,
+  saveOpenCustomGroups,
+} from "@/domains/chat/utils/sidebar-group-collapse-storage.js";
+
+// ---------------------------------------------------------------------------
+// State + Actions
+// ---------------------------------------------------------------------------
+
+export interface SidebarCollapseState {
+  assistantId: string | null;
+  openCategories: string[];
+  openCustomGroups: string[];
+}
+
+export interface SidebarCollapseActions {
+  setAssistantId: (assistantId: string) => void;
+  setOpenCategories: (next: string[]) => void;
+  setOpenCustomGroups: (next: string[]) => void;
+}
+
+export type SidebarCollapseStore = SidebarCollapseState &
+  SidebarCollapseActions;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: SidebarCollapseState = {
+  assistantId: null,
+  openCategories: ["recents"],
+  openCustomGroups: [],
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
+  (set, get) => ({
+    ...INITIAL_STATE,
+
+    setAssistantId: (assistantId: string) => {
+      if (get().assistantId === assistantId) return;
+      set({
+        assistantId,
+        openCategories: loadOpenCategories(assistantId),
+        openCustomGroups: loadOpenCustomGroups(assistantId),
+      });
+    },
+
+    setOpenCategories: (next: string[]) => {
+      set({ openCategories: next });
+      const { assistantId } = get();
+      if (assistantId) saveOpenCategories(assistantId, next);
+    },
+
+    setOpenCustomGroups: (next: string[]) => {
+      set({ openCustomGroups: next });
+      const { assistantId } = get();
+      if (assistantId) saveOpenCustomGroups(assistantId, next);
+    },
+  }),
+);
+
+export const useSidebarCollapseStore = createSelectors(
+  useSidebarCollapseStoreBase,
+);

--- a/apps/web/src/domains/chat/use-sidebar-state.ts
+++ b/apps/web/src/domains/chat/use-sidebar-state.ts
@@ -34,6 +34,7 @@ export const SIDEBAR_CONVERSATION_LIMIT = 5;
 // ---------------------------------------------------------------------------
 
 export interface PaginatedSection {
+  all: Conversation[];
   items: Conversation[];
   totalCount: number;
   showMore: boolean;
@@ -132,6 +133,7 @@ export function useSidebarState({
         .some((c) => attentionConversationKeys.has(c.conversationKey));
     const effectiveShowAll = showAllRecents || !!hasAttentionBeyondLimit;
     return {
+      all: grouped.recents,
       items: effectiveShowAll
         ? grouped.recents
         : grouped.recents.slice(0, SIDEBAR_CONVERSATION_LIMIT),
@@ -153,6 +155,7 @@ export function useSidebarState({
         .some((c) => attentionConversationKeys.has(c.conversationKey));
     const effectiveShowAll = showAllSlack || !!hasAttentionBeyondLimit;
     return {
+      all: grouped.slack,
       items: effectiveShowAll
         ? grouped.slack
         : grouped.slack.slice(0, SIDEBAR_CONVERSATION_LIMIT),

--- a/apps/web/src/domains/chat/use-sidebar-state.ts
+++ b/apps/web/src/domains/chat/use-sidebar-state.ts
@@ -1,0 +1,241 @@
+/**
+ * Data-shaping hook for the assistant sidebar.
+ *
+ * Owns conversation grouping, pagination ("show more"), collapse/expand
+ * state, and attention-forced expansion. Returns a typed object the
+ * presentational `AssistantSideMenu` renders without any inline
+ * computation, `useEffect`, or derived state.
+ *
+ * Memoizes grouping per `conversations` reference so parent re-renders
+ * that don't change the conversation list skip the grouping work.
+ *
+ * @see {@link https://zustand.docs.pmnd.rs/}
+ * @see {@link https://react.dev/reference/react/useMemo}
+ */
+
+import { useCallback, useEffect, useMemo, useState, startTransition } from "react";
+
+import type { Conversation, ConversationGroup } from "@/domains/chat/api/conversations.js";
+import { groupConversations, type CustomGroup } from "@/domains/chat/utils/group-conversations.js";
+import { groupBackgroundConversationsBySource } from "@/domains/chat/utils/background-sub-groups.js";
+import { groupScheduledConversationsByJobId } from "@/domains/chat/utils/scheduled-sub-groups.js";
+import type { SubGroup } from "@/domains/chat/utils/sub-group-utils.js";
+import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
+import { useSidebarCollapseStore } from "@/domains/chat/sidebar-collapse-store.js";
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+export const SIDEBAR_CONVERSATION_LIMIT = 5;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PaginatedSection {
+  items: Conversation[];
+  totalCount: number;
+  showMore: boolean;
+  onShowMore: () => void;
+}
+
+export interface SidebarState {
+  pinned: Conversation[];
+
+  scheduled: Conversation[];
+  scheduledSubGroups: SubGroup[];
+
+  background: Conversation[];
+  backgroundSubGroups: SubGroup[];
+
+  slack: PaginatedSection;
+  recents: PaginatedSection;
+
+  customGroups: CustomGroup[];
+
+  effectiveOpenCategories: string[];
+  effectiveOpenCustomGroups: string[];
+  onOpenCategoriesChange: (next: string[]) => void;
+  onOpenCustomGroupsChange: (next: string[]) => void;
+
+  conversationGroupsEnabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseSidebarStateParams {
+  assistantId: string;
+  conversations: Conversation[];
+  conversationGroups?: ConversationGroup[];
+  attentionConversationKeys?: Set<string>;
+}
+
+export function useSidebarState({
+  assistantId,
+  conversations,
+  conversationGroups,
+  attentionConversationKeys,
+}: UseSidebarStateParams): SidebarState {
+  const conversationGroupsUI = useFeatureFlagStore.use.conversationGroupsUI();
+
+  // --- Collapse store hydration ---
+
+  useEffect(() => {
+    if (assistantId) {
+      startTransition(() => {
+        useSidebarCollapseStore.getState().setAssistantId(assistantId);
+      });
+    }
+  }, [assistantId]);
+
+  const openCategories = useSidebarCollapseStore.use.openCategories();
+  const openCustomGroups = useSidebarCollapseStore.use.openCustomGroups();
+  const setOpenCategories = useSidebarCollapseStore.use.setOpenCategories();
+  const setOpenCustomGroups = useSidebarCollapseStore.use.setOpenCustomGroups();
+
+  // --- Grouping (memoized per conversations reference) ---
+
+  const grouped = useMemo(
+    () =>
+      groupConversations(conversations, {
+        groups: conversationGroups,
+        customGroupsEnabled: conversationGroupsUI,
+      }),
+    [conversations, conversationGroups, conversationGroupsUI],
+  );
+
+  const scheduledSubGroups = useMemo(
+    () => groupScheduledConversationsByJobId(grouped.scheduled),
+    [grouped.scheduled],
+  );
+
+  const backgroundSubGroups = useMemo(
+    () => groupBackgroundConversationsBySource(grouped.background),
+    [grouped.background],
+  );
+
+  // --- Pagination ("show more") ---
+
+  const [showAllRecents, setShowAllRecents] = useState(false);
+  const [showAllSlack, setShowAllSlack] = useState(false);
+
+  const recentsSection = useMemo((): PaginatedSection => {
+    const hasAttentionBeyondLimit =
+      !showAllRecents &&
+      grouped.recents.length > SIDEBAR_CONVERSATION_LIMIT &&
+      attentionConversationKeys != null &&
+      grouped.recents
+        .slice(SIDEBAR_CONVERSATION_LIMIT)
+        .some((c) => attentionConversationKeys.has(c.conversationKey));
+    const effectiveShowAll = showAllRecents || !!hasAttentionBeyondLimit;
+    return {
+      items: effectiveShowAll
+        ? grouped.recents
+        : grouped.recents.slice(0, SIDEBAR_CONVERSATION_LIMIT),
+      totalCount: grouped.recents.length,
+      showMore:
+        !effectiveShowAll &&
+        grouped.recents.length > SIDEBAR_CONVERSATION_LIMIT,
+      onShowMore: () => setShowAllRecents(true),
+    };
+  }, [grouped.recents, showAllRecents, attentionConversationKeys]);
+
+  const slackSection = useMemo((): PaginatedSection => {
+    const hasAttentionBeyondLimit =
+      !showAllSlack &&
+      grouped.slack.length > SIDEBAR_CONVERSATION_LIMIT &&
+      attentionConversationKeys != null &&
+      grouped.slack
+        .slice(SIDEBAR_CONVERSATION_LIMIT)
+        .some((c) => attentionConversationKeys.has(c.conversationKey));
+    const effectiveShowAll = showAllSlack || !!hasAttentionBeyondLimit;
+    return {
+      items: effectiveShowAll
+        ? grouped.slack
+        : grouped.slack.slice(0, SIDEBAR_CONVERSATION_LIMIT),
+      totalCount: grouped.slack.length,
+      showMore:
+        !effectiveShowAll &&
+        grouped.slack.length > SIDEBAR_CONVERSATION_LIMIT,
+      onShowMore: () => setShowAllSlack(true),
+    };
+  }, [grouped.slack, showAllSlack, attentionConversationKeys]);
+
+  // --- Attention-forced expansion ---
+
+  const hasAttentionIn = useCallback(
+    (convs: Conversation[]) =>
+      attentionConversationKeys
+        ? convs.some((c) =>
+            attentionConversationKeys.has(c.conversationKey),
+          )
+        : false,
+    [attentionConversationKeys],
+  );
+
+  const effectiveOpenCategories = useMemo(() => {
+    if (!attentionConversationKeys || attentionConversationKeys.size === 0)
+      return openCategories;
+    const extra: string[] = [];
+    if (grouped.pinned.length > 0 && hasAttentionIn(grouped.pinned))
+      extra.push("pinned");
+    if (grouped.scheduled.length > 0 && hasAttentionIn(grouped.scheduled))
+      extra.push("scheduled");
+    if (grouped.background.length > 0 && hasAttentionIn(grouped.background))
+      extra.push("background");
+    if (grouped.slack.length > 0 && hasAttentionIn(grouped.slack))
+      extra.push("slack");
+    if (grouped.recents.length > 0 && hasAttentionIn(grouped.recents))
+      extra.push("recents");
+    if (extra.length === 0) return openCategories;
+    if (extra.every((c) => openCategories.includes(c))) return openCategories;
+    return [...new Set([...openCategories, ...extra])];
+  }, [
+    openCategories,
+    attentionConversationKeys,
+    grouped.pinned,
+    grouped.scheduled,
+    grouped.background,
+    grouped.slack,
+    grouped.recents,
+    hasAttentionIn,
+  ]);
+
+  const effectiveOpenCustomGroups = useMemo(() => {
+    if (!attentionConversationKeys || attentionConversationKeys.size === 0)
+      return openCustomGroups;
+    const extra: string[] = [];
+    for (const group of grouped.customGroups) {
+      if (
+        group.conversations.some((c) =>
+          attentionConversationKeys.has(c.conversationKey),
+        )
+      ) {
+        extra.push(group.id);
+      }
+    }
+    if (extra.length === 0) return openCustomGroups;
+    if (extra.every((g) => openCustomGroups.includes(g)))
+      return openCustomGroups;
+    return [...new Set([...openCustomGroups, ...extra])];
+  }, [openCustomGroups, attentionConversationKeys, grouped.customGroups]);
+
+  return {
+    pinned: grouped.pinned,
+    scheduled: grouped.scheduled,
+    scheduledSubGroups,
+    background: grouped.background,
+    backgroundSubGroups,
+    slack: slackSection,
+    recents: recentsSection,
+    customGroups: grouped.customGroups,
+    effectiveOpenCategories,
+    effectiveOpenCustomGroups,
+    onOpenCategoriesChange: setOpenCategories,
+    onOpenCustomGroupsChange: setOpenCustomGroups,
+    conversationGroupsEnabled: conversationGroupsUI,
+  };
+}


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1744 — "Redesign: AssistantSideMenu (1047 lines mixing presentation + grouping logic + collapse state)".

Decomposes the monolithic 1047-line `AssistantSideMenu` into focused, single-responsibility pieces following the repo's [state management conventions](apps/web/docs/STATE_MANAGEMENT.md) and [style guide](apps/web/docs/STYLE_GUIDE.md).

### Why this is needed

`AssistantSideMenu` was a god-component mixing:
- Per-assistant collapse/expand persistence (manual `useState` + `useEffect` + raw `localStorage`)
- Conversation grouping and pagination derivation
- Attention-forced expansion logic
- Sub-group accordion rendering
- Thread pin toggle state machine
- Custom group context menu
- Count badge rendering

This made the component hard to test in isolation, impossible to compose into different layouts, and a frequent merge conflict target.

### What changed

| New file | Responsibility | Lines |
|---|---|---|
| `sidebar-collapse-store.ts` | Zustand store for per-assistant collapse/expand state, replacing manual `useState` + `useEffect` + `localStorage` read/write pairs. Uses `createSelectors` per repo convention. | 93 |
| `use-sidebar-state.ts` | Data-shaping hook: conversation grouping (memoized per `conversations` ref), pagination ("show more"), collapse hydration, attention-forced expansion. Returns typed `SidebarState`. | 243 |
| `thread-pin-toggle.tsx` | Leading-slot pin/unpin button with attention/processing/unread state machine. | 155 |
| `group-actions-menu.tsx` | Context menu for custom group headers (rename/delete) with mobile bottom sheet. | 112 |
| `sub-group-accordion.tsx` | Shared sub-accordion for background and scheduled conversation sub-groups + thin `BackgroundSubGroups`/`ScheduledSubGroups` wrappers. | 132 |
| `sidebar-count-badge.tsx` | Tiny count badge helper. | 9 |

The parent `AssistantSideMenu` is now ~525 lines of pure JSX wiring — zero inline computation, `useEffect`, or derived state.

### Why this is safe

- All existing behavior is preserved — grouping, pagination, collapse persistence, attention expansion, context menus, mobile bottom sheets, pin toggle state machine.
- The Zustand store delegates to the same `sidebar-group-collapse-storage.ts` read/write functions, so localStorage keys and serialization format are unchanged.
- 102/102 test files pass (including 11 existing sidebar tests + 8 new store tests).
- tsc 0 errors, lint 0 errors, production build succeeds.

### Bug fix included

`CollapsedConversationsButton` (the rail-mode popover) was wired to the paginated `slack.items` / `recents.items` slices instead of full arrays. This would have truncated the badge count and hidden conversations beyond the "show more" limit when the sidebar was collapsed. Fixed by adding `PaginatedSection.all` and wiring it to the popover.

### Alternatives not taken

- **Zustand `persist` middleware for collapse store**: Considered using Zustand's built-in persist, but the existing per-assistant keying (`vellum:sidebar-open-categories:{assistantId}`) doesn't map cleanly to persist's single-key model. Delegating to the existing storage helpers preserves the key format and avoids a storage migration.
- **Keeping grouping in the component**: Could have left `groupConversations` inline, but it's a pure function with memoizable inputs — extracting it into the hook makes the memoization explicit and testable.

### References

- [Zustand docs — `createSelectors`](https://zustand.docs.pmnd.rs/guides/auto-generating-selectors)
- [React docs — `useMemo`](https://react.dev/reference/react/useMemo)
- [apps/web/docs/STATE_MANAGEMENT.md](apps/web/docs/STATE_MANAGEMENT.md) — Zustand store conventions

## Test plan

- 8 new unit tests for `SidebarCollapseStore`: default state, localStorage hydration, assistant switching, persistence, no-op on same ID, invalid data fallback, no-persist without assistantId.
- 11 existing `assistant-side-menu.test.tsx` tests pass (updated the Slack "show more" source-reading test to point at `use-sidebar-state.ts` where the pagination logic now lives).
- Full test suite: 102/102 files pass.
- `bunx tsc --noEmit`: 0 errors.
- `bun run lint`: 0 errors.
- `bun run build`: succeeds.

Link to Devin session: https://app.devin.ai/sessions/c4696ace57fe43649f2475d7661ac273
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->