### PR TITLE
[codex] Port message-level LLM inspector entrypoint

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -63,6 +63,7 @@ import { useConversationLoader } from "@/domains/conversations/use-conversation-
 import { useContextWindowUsageHydration } from "@/domains/chat/hooks/use-context-window-usage-hydration.js";
 import { useConversationActions } from "@/domains/conversations/use-conversation-actions.js";
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions.js";
+import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
 import { useCommandPaletteSections } from "@/domains/chat/hooks/use-command-palette-sections.js";
 import { useMessageReconciliation } from "@/domains/chat/hooks/use-message-reconciliation.js";
 import { useStreamEventHandler } from "@/domains/chat/hooks/use-stream-event-handler.js";
@@ -112,6 +113,8 @@ import {
 export function ChatPage() {
   const authLoading = useAuthStore.use.isLoading();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
+  const authUser = useAuthStore.use.user();
+  const showLlmInspector = canUseLlmInspector(authUser);
   const isMobile = useIsMobile();
   const isNative = useIsNativePlatform();
   const navigate = useNavigate();
@@ -779,6 +782,7 @@ export function ChatPage() {
     handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,
+    handleInspectMessage,
     handleCopyConversation,
   } = useConversationSecondaryActions({
     assistantId,
@@ -882,7 +886,7 @@ export function ChatPage() {
             : undefined
         }
         onInspect={
-          activeConversation.conversationKey
+          showLlmInspector && activeConversation.conversationKey
             ? () => handleInspectConversation(activeConversation)
             : undefined
         }
@@ -943,6 +947,7 @@ export function ChatPage() {
     handleForkConversationFromMenu,
     handleOpenInNewWindow,
     handleInspectConversation,
+    showLlmInspector,
     handleCopyConversation,
     handleMoveToGroup,
     handleRemoveFromGroup,
@@ -1297,6 +1302,7 @@ export function ChatPage() {
       if (app && assistantId) void useDeployStore.getState().deployApp(assistantId, app.appId, app.name, app.html);
     } : undefined,
     handleForkConversation,
+    handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
     subagentEntries,
     subagentState,
     activeSubagentId: viewerState.activeSubagentId,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -332,6 +332,7 @@ export interface ChatRouteContentProps {
 
   // Conversation secondary actions
   handleForkConversation: (throughMessageId: string) => Promise<void>;
+  handleInspectMessage?: (messageId: string) => void;
 
   // Subagent
   subagentEntries: SubagentEntry[];
@@ -425,6 +426,7 @@ export function ChatRouteContent({
   handleShareApp,
   handleDeployApp,
   handleForkConversation,
+  handleInspectMessage,
   subagentEntries,
   subagentState,
   activeSubagentId,
@@ -1069,6 +1071,7 @@ export function ChatRouteContent({
     onForkConversation: (messageId) => {
       void handleForkConversation(messageId);
     },
+    onInspectMessage: handleInspectMessage,
     renderPendingSecret: () =>
       pendingSecret ? (
         <SecretPromptCard

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -29,4 +29,17 @@ describe("MessageHoverActions", () => {
 
     expect(html).toBe("");
   });
+
+  test("renders inspect action for user messages when provided", () => {
+    const html = renderToStaticMarkup(
+      <MessageHoverActions
+        content="hello"
+        timestamp={Date.UTC(2026, 0, 2, 12, 34)}
+        role="user"
+        onInspect={() => {}}
+      />,
+    );
+
+    expect(html).toContain('title="Inspect"');
+  });
 });

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -67,7 +67,6 @@ export function MessageHoverActions({
   const displayTimestamp = timestamp ?? fallbackTimestamp;
 
   const hasCopyableText = content.trim().length > 0;
-  const isAssistant = role === "assistant";
 
   useEffect(() => {
     return () => {
@@ -135,7 +134,7 @@ export function MessageHoverActions({
         </button>
       )}
 
-      {onInspect && isAssistant && (
+      {onInspect && (
         <button
           type="button"
           onClick={onInspect}

--- a/apps/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -54,6 +54,7 @@ export interface UseConversationSecondaryActionsReturn {
   handleAnalyzeConversation: (conversation: Conversation) => Promise<void>;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
+  handleInspectMessage: (messageId: string) => void;
   handleCopyConversation: () => void;
   feedbackOpen: boolean;
   setFeedbackOpen: Dispatch<SetStateAction<boolean>>;
@@ -169,6 +170,17 @@ export function useConversationSecondaryActions({
     [navigate, activeConversation?.conversationKey],
   );
 
+  const handleInspectMessage = useCallback(
+    (messageId: string) => {
+      if (!activeConversationKey) return;
+      const params = new URLSearchParams();
+      params.set("conversationKey", activeConversationKey);
+      params.set("messageId", messageId);
+      void navigate(`${routes.inspect}?${params.toString()}`);
+    },
+    [activeConversationKey, navigate],
+  );
+
   const handleShareFeedback = useCallback(() => {
     setFeedbackOpen(true);
   }, []);
@@ -195,6 +207,7 @@ export function useConversationSecondaryActions({
     handleAnalyzeConversation,
     handleOpenInNewWindow,
     handleInspectConversation,
+    handleInspectMessage,
     handleCopyConversation,
     feedbackOpen,
     setFeedbackOpen,

--- a/apps/web/src/domains/chat/inspector/access.test.ts
+++ b/apps/web/src/domains/chat/inspector/access.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
+import type { AuthUser } from "@/stores/auth-store.js";
+
+function user(overrides: Partial<AuthUser>): AuthUser {
+  return {
+    id: "user-123",
+    username: null,
+    email: "user@example.com",
+    isStaff: false,
+    firstName: "",
+    lastName: "",
+    ...overrides,
+  };
+}
+
+describe("canUseLlmInspector", () => {
+  test("allows staff users", () => {
+    expect(canUseLlmInspector(user({ isStaff: true }))).toBe(true);
+  });
+
+  test("allows Vellum email users case-insensitively", () => {
+    expect(canUseLlmInspector(user({ email: "alice@" + "VELLUM.AI" }))).toBe(true);
+  });
+
+  test("rejects regular users", () => {
+    expect(canUseLlmInspector(user({ email: "user@example.com" }))).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/inspector/access.ts
+++ b/apps/web/src/domains/chat/inspector/access.ts
@@ -1,0 +1,8 @@
+import type { AuthUser } from "@/stores/auth-store.js";
+
+export function canUseLlmInspector(user: AuthUser | null): boolean {
+  return (
+    user?.isStaff === true ||
+    user?.email?.toLowerCase().endsWith("@vellum.ai") === true
+  );
+}

--- a/apps/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.tsx
@@ -4,7 +4,9 @@ import { type ReactNode } from "react";
 
 import { useActiveAssistantContext } from "@/components/layout/active-assistant-gate.js";
 import { fetchConversationMessages } from "@/domains/chat/api/messages.js";
+import { canUseLlmInspector } from "@/domains/chat/inspector/access.js";
 import { MessageInspectorView } from "@/domains/chat/inspector/components/message-inspector-view.js";
+import { useAuthStore } from "@/stores/auth-store.js";
 
 /**
  * `/assistant/inspect` page. Reads `?conversationKey=...&messageId=...`
@@ -13,9 +15,22 @@ import { MessageInspectorView } from "@/domains/chat/inspector/components/messag
  * conversation.
  */
 export function InspectPage(): ReactNode {
+  const user = useAuthStore.use.user();
+  const authLoading = useAuthStore.use.isLoading();
   const [searchParams] = useSearchParams();
   const conversationKey = searchParams.get("conversationKey");
   const messageId = searchParams.get("messageId");
+
+  if (authLoading) {
+    return <CenteredMessage tone="muted">Loading...</CenteredMessage>;
+  }
+  if (!canUseLlmInspector(user)) {
+    return (
+      <CenteredMessage tone="muted">
+        Inspector is available to Vellum developers only.
+      </CenteredMessage>
+    );
+  }
 
   if (!conversationKey) {
     return <MissingConversationKeyState />;
@@ -69,7 +84,7 @@ function ResolveLatestMessage({
   });
 
   if (isLoading) {
-    return <CenteredMessage tone="muted">Loading…</CenteredMessage>;
+    return <CenteredMessage tone="muted">Loading...</CenteredMessage>;
   }
   if (isError) {
     return (

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -38,6 +38,7 @@ export interface LatestTurnRowProps {
   onConfirmationDecision: (requestId: string, decision: string) => void;
   onRetryError: () => void;
   onForkConversation?: (messageId: string) => void;
+  onInspectMessage?: (messageId: string) => void;
   renderPendingSecret?: (requestId: string) => ReactNode;
   renderPendingConfirmation?: (requestId: string) => ReactNode;
   renderPendingContactRequest?: (requestId: string) => ReactNode;
@@ -89,6 +90,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   onConfirmationDecision,
   onRetryError,
   onForkConversation,
+  onInspectMessage,
   renderPendingSecret,
   renderPendingConfirmation,
   renderPendingContactRequest,
@@ -123,6 +125,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         onConfirmationDecision={onConfirmationDecision}
         onRetryError={onRetryError}
         onForkConversation={onForkConversation}
+        onInspectMessage={onInspectMessage}
         renderPendingSecret={renderPendingSecret}
         renderPendingConfirmation={renderPendingConfirmation}
         renderPendingContactRequest={renderPendingContactRequest}
@@ -149,6 +152,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             onConfirmationDecision={onConfirmationDecision}
             onRetryError={onRetryError}
             onForkConversation={onForkConversation}
+            onInspectMessage={onInspectMessage}
             renderPendingSecret={renderPendingSecret}
             renderPendingConfirmation={renderPendingConfirmation}
             renderPendingContactRequest={renderPendingContactRequest}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 mock.module("@/domains/chat/components/chat-attachments/message-attachments.js", () => ({
   MessageAttachments: () => <div data-testid="attachments" />,
@@ -18,15 +19,6 @@ mock.module("@/domains/chat/components/surfaces/surface-router.js", () => ({
 }));
 
 mock.module(
-  "@/domains/chat/components/message-hover-actions/message-hover-actions.js",
-  () => ({
-    MessageHoverActions: ({ timestamp }: { timestamp?: number }) => (
-      <div data-testid="hover-actions" data-timestamp={timestamp ?? ""} />
-    ),
-  }),
-);
-
-mock.module(
   "@/domains/chat/components/tool-call-progress-card/tool-call-progress-card.js",
   () => ({
     ToolCallProgressCard: () => <div data-testid="tool-progress-card" />,
@@ -39,13 +31,24 @@ import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-mess
 
 const noop = () => {};
 
-function renderMessage(message: DisplayMessage): string {
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+function renderMessage(
+  message: DisplayMessage,
+  props: { onInspectMessage?: (messageId: string) => void } = {},
+): string {
   return renderToStaticMarkup(
     <TranscriptMessageBody
       message={message}
       expandedToolCallIds={new Set()}
       expandedCardIds={new Map()}
       onSurfaceAction={noop}
+      onInspectMessage={props.onInspectMessage}
     />,
   );
 }
@@ -70,8 +73,8 @@ describe("TranscriptMessageBody", () => {
       ],
     });
 
-    expect(html).toContain('data-testid="hover-actions"');
-    expect(html).toContain('data-timestamp="2000"');
+    expect(html).toContain("title=");
+    expect(html).toContain(":02");
   });
 
   test("falls back to the tool start time for active tool-only messages", () => {
@@ -92,6 +95,50 @@ describe("TranscriptMessageBody", () => {
       ],
     });
 
-    expect(html).toContain('data-timestamp="1500"');
+    expect(html).toContain("title=");
+    expect(html).toContain(":01");
+  });
+
+  test("passes daemon message id to inspect handler", () => {
+    const inspectedIds: string[] = [];
+    const { getByTitle } = render(
+      <TranscriptMessageBody
+        message={{
+          stableId: "stable-1",
+          id: "local-1",
+          daemonMessageId: "daemon-1",
+          role: "assistant",
+          content: "hello",
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+        onInspectMessage={(messageId) => inspectedIds.push(messageId)}
+      />,
+    );
+
+    fireEvent.click(getByTitle("Inspect"));
+    expect(inspectedIds).toEqual(["daemon-1"]);
+  });
+
+  test("falls back to message id for inspect handler", () => {
+    const inspectedIds: string[] = [];
+    const { getByTitle } = render(
+      <TranscriptMessageBody
+        message={{
+          stableId: "stable-1",
+          id: "message-1",
+          role: "user",
+          content: "hello",
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+        onInspectMessage={(messageId) => inspectedIds.push(messageId)}
+      />,
+    );
+
+    fireEvent.click(getByTitle("Inspect"));
+    expect(inspectedIds).toEqual(["message-1"]);
   });
 });

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -58,6 +58,7 @@ export interface TranscriptMessageBodyProps {
     data?: Record<string, unknown>,
   ) => void;
   onForkConversation?: (messageId: string) => void;
+  onInspectMessage?: (messageId: string) => void;
   onOpenRuleEditor?: (context: OpenRuleEditorContext) => void;
   /** Tool-call ids whose chip should display the "command not recognized"
    *  nudge. Optional — when undefined no nudge ever shows. */
@@ -180,6 +181,7 @@ export function TranscriptMessageBody({
   expandedCardIds,
   onSurfaceAction,
   onForkConversation,
+  onInspectMessage,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
@@ -211,6 +213,10 @@ export function TranscriptMessageBody({
   const forkMessageId = message.daemonMessageId ?? message.id;
   const forkHandler = forkMessageId && onForkConversation
     ? () => onForkConversation(forkMessageId)
+    : undefined;
+  const inspectMessageId = message.daemonMessageId ?? message.id;
+  const inspectHandler = inspectMessageId && onInspectMessage
+    ? () => onInspectMessage(inspectMessageId)
     : undefined;
   const isToolCallComplete = isSurfaceToolCallComplete(message);
 
@@ -414,6 +420,7 @@ export function TranscriptMessageBody({
               role={message.role}
               isStreaming={message.isStreaming}
               onFork={forkHandler}
+              onInspect={inspectHandler}
             />
           </div>
         </div>
@@ -545,6 +552,7 @@ export function TranscriptMessageBody({
             role={message.role}
             isStreaming={message.isStreaming}
             onFork={forkHandler}
+            onInspect={inspectHandler}
           />
         </div>
       </div>

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -34,6 +34,7 @@ export interface TranscriptRowProps {
   onConfirmationDecision: (requestId: string, decision: string) => void;
   onRetryError: () => void;
   onForkConversation?: (messageId: string) => void;
+  onInspectMessage?: (messageId: string) => void;
   /** Render-prop override for `kind: "pendingSecret"`. */
   renderPendingSecret?: (requestId: string) => ReactNode;
   /** Render-prop override for `kind: "pendingConfirmation"`. */
@@ -76,6 +77,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   onConfirmationDecision,
   onRetryError,
   onForkConversation,
+  onInspectMessage,
   renderPendingSecret,
   renderPendingConfirmation,
   renderPendingContactRequest,
@@ -100,6 +102,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           expandedCardIds={expandedCardIds}
           onSurfaceAction={onSurfaceAction}
           onForkConversation={onForkConversation}
+          onInspectMessage={onInspectMessage}
           onOpenRuleEditor={onOpenRuleEditor}
           unknownNudgeToolCallIds={unknownNudgeToolCallIds}
           onDismissUnknownNudge={onDismissUnknownNudge}

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -45,6 +45,8 @@ export interface TranscriptProps {
   onRetryError: () => void;
   /** Callback for "Fork from here" from a message's hover actions. */
   onForkConversation?: (messageId: string) => void;
+  /** Callback for "Inspect" from a message's hover actions. */
+  onInspectMessage?: (messageId: string) => void;
   /** Persistent expanded tool-call ids. Optional — the Transcript owns its
    *  own set if not provided. Callers that need cross-render persistence
    *  should pass a stable ref. */
@@ -214,6 +216,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       onConfirmationDecision: rest.onConfirmationDecision,
       onRetryError: rest.onRetryError,
       onForkConversation: rest.onForkConversation,
+      onInspectMessage: rest.onInspectMessage,
       renderPendingSecret: rest.renderPendingSecret,
       renderPendingConfirmation: rest.renderPendingConfirmation,
       renderPendingContactRequest: rest.renderPendingContactRequest,


### PR DESCRIPTION
## Summary
- Gate the web LLM inspector route and menu entrypoints to Vellum developer/staff users.
- Add the per-message inspect action path from transcript hover controls through `ChatRouteContent` to `/assistant/inspect?conversationKey=...&messageId=...`.
- Cover the access helper, hover action rendering, and message-id forwarding with focused tests.

## Original prompt
The user asked to deterministically recreate recent platform web PRs in `vellum-assistant` as part of migrating the web app from `vellum-assistant-platform/web` into `apps/web`. This PR ports the missing message-level LLM inspector entrypoint behavior from platform PR #7521.

## Validation
- `cd apps/web && bun test src/domains/chat/inspector/access.test.ts src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx src/domains/chat/transcript/transcript-message-body.test.tsx`
- `cd apps/web && bunx tsc --noEmit --pretty false`
- `git diff --check`
