### PR TITLE
[codex] Port Slack spectator mode

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -1340,6 +1340,7 @@ export function ChatPage() {
       reconcileAfterNextStreamOpenRef,
     },
     isChannelReadonly,
+    ...(authUser?.email ? { currentUserEmail: authUser.email } : {}),
     onboardingTasksEmpty,
     didOnboarding,
     onboardingConversationKey,

--- a/apps/web/src/domains/chat/components/chat-body.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.test.tsx
@@ -58,6 +58,31 @@ mock.module(
   }),
 );
 
+mock.module("@/domains/chat/components/spectator-bar.js", () => ({
+  SpectatorBar: ({
+    assistantName,
+    canStopGenerating,
+    onStopGenerating,
+  }: {
+    assistantName?: string;
+    canStopGenerating?: boolean;
+    onStopGenerating: () => void;
+  }) => (
+    <div data-testid="spectator-bar">
+      Watching {assistantName}
+      {canStopGenerating && (
+        <button
+          aria-label="Stop generating"
+          title="Stop generation"
+          onClick={onStopGenerating}
+        >
+          STOP
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 mock.module("@vellum/design-library", () => ({
   Button: ({
     children,
@@ -219,18 +244,22 @@ describe("ChatBody — startersSlot rendering", () => {
   });
 });
 
-describe("ChatBody — read-only cancellation", () => {
-  test("renders the read-only banner without a stop control while idle", () => {
+describe("ChatBody — read-only spectator bar", () => {
+  test("renders the spectator bar without a stop control while idle", () => {
     const html = renderToStaticMarkup(
       <ChatBody
         {...baseProps({
           isChannelReadonly: true,
+          spectatorBarProps: {
+            assistantName: "TestBot",
+            conversation: null,
+          },
           composerProps: { onStopGenerating: noop } as never,
         })}
       />,
     );
 
-    expect(html).toContain("Read-only conversation");
+    expect(html).toContain("Watching TestBot");
     expect(html).not.toContain('aria-label="Stop generating"');
     expect(html).not.toContain("COMPOSER");
   });
@@ -240,13 +269,17 @@ describe("ChatBody — read-only cancellation", () => {
       <ChatBody
         {...baseProps({
           isChannelReadonly: true,
-          canStopGenerating: true,
+          spectatorBarProps: {
+            assistantName: "TestBot",
+            conversation: null,
+            canStopGenerating: true,
+          },
           composerProps: { onStopGenerating: noop } as never,
         })}
       />,
     );
 
-    expect(html).toContain("Read-only conversation");
+    expect(html).toContain("Watching TestBot");
     expect(html).toContain('aria-label="Stop generating"');
     expect(html).toContain('title="Stop generation"');
     expect(html).not.toContain("COMPOSER");

--- a/apps/web/src/domains/chat/components/chat-body.tsx
+++ b/apps/web/src/domains/chat/components/chat-body.tsx
@@ -1,6 +1,6 @@
 import { type DragEventHandler, type ReactNode } from "react";
 
-import { Eye, Paperclip, Square } from "lucide-react";
+import { Paperclip } from "lucide-react";
 
 import { ChatScrollArea, type ChatScrollAreaProps } from "@/domains/chat/components/chat-scroll-area.js";
 import {
@@ -9,7 +9,8 @@ import {
 } from "@/domains/chat/refresh-feedback-pill.js";
 import { ScrollToLatestButton } from "@/domains/chat/components/scroll-to-latest-button.js";
 import { ChatComposer, type ChatComposerProps } from "@/domains/chat/components/chat-composer/chat-composer.js";
-import { Button, Notice } from "@vellum/design-library";
+import { SpectatorBar, type SpectatorBarProps } from "@/domains/chat/components/spectator-bar.js";
+import { Notice } from "@vellum/design-library";
 
 /**
  * Single composition of a chat panel: a scrollable messages/empty-state
@@ -91,13 +92,13 @@ export interface ChatBodyProps {
   /** Generic chat error rendered above the composer, or `null` when none. */
   genericChatError: { message: string; actions?: ReactNode } | null;
 
-  /** When true, a read-only banner replaces the composer entirely. */
+  /** When true, a spectator bar replaces the composer entirely. */
   isChannelReadonly: boolean;
   /**
-   * True when the read-only banner should expose the active turn
-   * cancellation control.
+   * Props for the spectator bar shown when `isChannelReadonly` is true.
+   * Includes assistant name, channel info, and stop-generating controls.
    */
-  canStopGenerating?: boolean;
+  spectatorBarProps?: Omit<SpectatorBarProps, "onStopGenerating">;
 
   /**
    * Optional pre-rendered banner stack (mobile-app nudge / GitHub / Discord)
@@ -122,7 +123,7 @@ export interface ChatBodyProps {
 
   /**
    * Optional pre-rendered footer rendered inside the max-width wrapper
-   * immediately above the composer or read-only banner.
+   * immediately above the composer.
    */
   channelFooterSlot?: ReactNode;
 
@@ -134,37 +135,6 @@ export interface ChatBodyProps {
    * starter data model.
    */
   startersSlot?: ReactNode;
-}
-
-/**
- * Read-only composer replacement shown when the active conversation is
- * bound to an external channel (Slack, Telegram, voice/phone, etc.).
- * Mirrors the macOS read-only banner in `ChatView.swift`.
- */
-function ChatReadonlyBanner({
-  canStopGenerating = false,
-  onStopGenerating,
-}: {
-  canStopGenerating?: boolean;
-  onStopGenerating: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-center gap-3 py-4 text-body-small-default text-[var(--content-tertiary)]">
-      <div className="flex items-center gap-2">
-        <Eye size={14} />
-        <span>Read-only conversation</span>
-      </div>
-      {canStopGenerating && (
-        <Button
-          variant="primary"
-          iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
-          onClick={onStopGenerating}
-          aria-label="Stop generating"
-          title="Stop generation"
-        />
-      )}
-    </div>
-  );
 }
 
 export function ChatBody({
@@ -182,7 +152,7 @@ export function ChatBody({
   onRetryRefresh,
   genericChatError,
   isChannelReadonly,
-  canStopGenerating,
+  spectatorBarProps,
   bannerSlot,
   queuedDrawerSlot,
   questionPromptSlot,
@@ -263,16 +233,16 @@ export function ChatBody({
           )}
           {queuedDrawerSlot}
           {questionPromptSlot}
-          {channelFooterSlot}
-          {isChannelReadonly ? (
-            <ChatReadonlyBanner
-              canStopGenerating={canStopGenerating}
+          {!isChannelReadonly && channelFooterSlot}
+          {isChannelReadonly && spectatorBarProps ? (
+            <SpectatorBar
+              {...spectatorBarProps}
               onStopGenerating={composerProps.onStopGenerating}
             />
-          ) : (
+          ) : !isChannelReadonly ? (
             <ChatComposer {...composerProps} />
-          )}
-          {startersSlot}
+          ) : null}
+          {!isKeyboardOpen && startersSlot}
         </div>
       </div>
       {isAttachmentDragOver && (

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -82,7 +82,6 @@ import { modelSupportsVision } from "@/assistant/model-capabilities.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 import { routes } from "@/utils/routes.js";
 import { haptic } from "@/utils/haptics.js";
-import { isChannelConversation as _isChannelConversation } from "@/domains/chat/utils/conversation-channel.js";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure.js";
 import type { DiskPressureStatusEventPayload } from "@/assistant/use-disk-pressure-monitor.js";
 import { isSending, type TurnState, useTurnStore } from "@/domains/messaging/turn-store.js";
@@ -361,6 +360,7 @@ export interface ChatRouteContentProps {
 
   // Is channel readonly (computed in parent, used in topbar + here)
   isChannelReadonly: boolean;
+  currentUserEmail?: string;
 
   // Onboarding (iOS post-hatch flow)
   onboardingTasksEmpty: boolean;
@@ -375,7 +375,7 @@ export interface ChatRouteContentProps {
 export function ChatRouteContent({
   assistantId,
   assistantState,
-  assistantIdentity: _assistantIdentity,
+  assistantIdentity,
   chatPullToRefresh,
   deployToVercel,
   doctor: doctorEnabled,
@@ -441,6 +441,7 @@ export function ChatRouteContent({
   historyPagination,
   refs,
   isChannelReadonly,
+  currentUserEmail,
   onboardingTasksEmpty,
   didOnboarding,
   onboardingConversationKey,
@@ -1043,6 +1044,8 @@ export function ChatRouteContent({
     onOpenApp: handleOpenApp,
     onOpenDocument: handleOpenDocument,
     assistantId,
+    isChannelConversation: isChannelReadonly,
+    currentUserEmail,
     unknownNudgeToolCallIds,
     onDismissUnknownNudge: (toolCallId) =>
       setUnknownNudgeToolCallIds((ids) => {
@@ -1259,13 +1262,25 @@ export function ChatRouteContent({
     </div>
   ) : null;
 
-  const channelFooterSlot = (
+  const channelFooterSlot = isChannelReadonly ? undefined : (
     <SlackChannelFooter
       assistantId={assistantId ?? undefined}
       conversation={activeConversation}
       messages={messages}
     />
   );
+
+  const spectatorBarProps = isChannelReadonly
+    ? {
+        ...(assistantIdentity?.name
+          ? { assistantName: assistantIdentity.name }
+          : {}),
+        ...(assistantId ? { assistantId } : {}),
+        conversation: activeConversation,
+        messages,
+        canStopGenerating,
+      }
+    : undefined;
 
   // -------------------------------------------------------------------------
   // Render
@@ -1299,7 +1314,7 @@ export function ChatRouteContent({
             onRetryRefresh={handleRetryRefreshFromPill}
             genericChatError={genericChatError}
             isChannelReadonly={isChannelReadonly}
-            canStopGenerating={canStopGenerating}
+            spectatorBarProps={spectatorBarProps}
             questionPromptSlot={questionPromptSlot}
             channelFooterSlot={channelFooterSlot}
             startersSlot={startersSlot}
@@ -1372,7 +1387,7 @@ export function ChatRouteContent({
       onRetryRefresh={handleRetryRefreshFromPill}
       genericChatError={genericChatError}
       isChannelReadonly={isChannelReadonly}
-      canStopGenerating={canStopGenerating}
+      spectatorBarProps={spectatorBarProps}
       bannerSlot={mainBannerSlot}
       queuedDrawerSlot={mainQueuedDrawerSlot}
       questionPromptSlot={questionPromptSlot}

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -1,136 +1,15 @@
-import { useEffect, useState } from "react";
-
 import { ExternalLink, Hash } from "lucide-react";
 
-import { resolveSlackChannelName } from "@/domains/chat/api/slack-channel-name.js";
-import type {
-  Conversation,
-  ConversationChannelBinding,
-} from "@/domains/chat/api/conversations.js";
 import {
-  getSlackLinkUrl,
-  type DisplayMessage,
-  type SlackMessageLink,
-} from "@/domains/chat/types/types.js";
-
-type SlackFooterConversation = Pick<
-  Conversation,
-  "channelBinding" | "originChannel"
-> &
-  Partial<Pick<Conversation, "conversationKey">>;
+  type SlackConversationLike,
+  useSlackChannelResolution,
+} from "@/domains/chat/utils/slack-channel-helpers.js";
+import type { DisplayMessage } from "@/domains/chat/types/types.js";
 
 export interface SlackChannelFooterProps {
   assistantId?: string;
-  conversation: SlackFooterConversation | null | undefined;
+  conversation: SlackConversationLike | null | undefined;
   messages?: DisplayMessage[];
-}
-
-const slackChannelNameRequests = new Map<string, Promise<string | null>>();
-
-function getSlackChannelLink(
-  slackChannel: ConversationChannelBinding["slackChannel"],
-  messageLink?: SlackMessageLink,
-  channelId?: string,
-): string | undefined {
-  if (slackChannel?.link) {
-    if (typeof slackChannel.link === "string") return slackChannel.link;
-    return getSlackLinkUrl(slackChannel.link);
-  }
-  return getSlackChannelLinkFromMessageLink(messageLink, channelId);
-}
-
-function getSlackChannelLinkFromMessageLink(
-  messageLink: SlackMessageLink | undefined,
-  channelId: string | undefined,
-): string | undefined {
-  if (!messageLink || !channelId) return undefined;
-
-  if (messageLink.webUrl) {
-    try {
-      const url = new URL(messageLink.webUrl);
-      const channelPath = `/archives/${channelId}`;
-      if (url.pathname.startsWith(`${channelPath}/`)) {
-        url.pathname = channelPath;
-        url.search = "";
-        url.hash = "";
-        return url.toString();
-      }
-    } catch {
-      // Fall through to app URL parsing.
-    }
-  }
-
-  if (!messageLink.appUrl) return undefined;
-  try {
-    const url = new URL(messageLink.appUrl);
-    if (url.protocol !== "slack:" || url.hostname !== "channel") {
-      return undefined;
-    }
-    const team = url.searchParams.get("team");
-    if (!team || url.searchParams.get("id") !== channelId) {
-      return undefined;
-    }
-    return `slack://channel?${new URLSearchParams({
-      team,
-      id: channelId,
-    }).toString()}`;
-  } catch {
-    return undefined;
-  }
-}
-
-function getSlackMessageChannel(
-  messages: DisplayMessage[] | undefined,
-  channelId: string | undefined,
-) {
-  if (!messages || messages.length === 0) return undefined;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const slackMessage = messages[i]?.slackMessage;
-    if (!slackMessage) continue;
-    if (channelId && slackMessage.channelId !== channelId) continue;
-    return slackMessage;
-  }
-  return undefined;
-}
-
-function isChannelIdFallback(
-  value: string | undefined,
-  channelBinding: ConversationChannelBinding,
-): boolean {
-  return (
-    value === undefined ||
-    value === channelBinding.externalChatId ||
-    value === channelBinding.slackChannel?.channelId ||
-    value === channelBinding.slackChannel?.id
-  );
-}
-
-function getSlackChannelDisplayText(
-  channelBinding: ConversationChannelBinding,
-  fallbackChannelName?: string,
-): string | undefined {
-  const slackChannel = channelBinding.slackChannel;
-  const primaryName = slackChannel?.name ?? channelBinding.externalChatName;
-
-  if (!isChannelIdFallback(primaryName, channelBinding)) {
-    return primaryName;
-  }
-  if (
-    fallbackChannelName &&
-    !isChannelIdFallback(fallbackChannelName, channelBinding)
-  ) {
-    return fallbackChannelName;
-  }
-
-  return (
-    slackChannel?.channelId ??
-    slackChannel?.id ??
-    channelBinding.externalChatId
-  );
-}
-
-function isSlackDmChannelId(channelId: string | undefined): boolean {
-  return channelId?.startsWith("D") === true;
 }
 
 export function SlackChannelFooter({
@@ -138,105 +17,16 @@ export function SlackChannelFooter({
   conversation,
   messages,
 }: SlackChannelFooterProps) {
-  const [resolvedChannelName, setResolvedChannelName] = useState<{
-    key: string;
-    channelName: string;
-  } | null>(null);
-
-  const channelBinding =
-    conversation?.originChannel === "slack"
-      ? conversation.channelBinding
-      : undefined;
-  const slackChannel = channelBinding?.slackChannel;
-  const channelId =
-    slackChannel?.channelId ??
-    slackChannel?.id ??
-    channelBinding?.externalChatId;
-  const messageChannel = getSlackMessageChannel(messages, channelId);
-  const fallbackDisplayText = channelBinding
-    ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
-    : undefined;
-  const conversationId = conversation?.conversationKey;
-  const resolutionKey =
-    assistantId && conversationId && channelId
-      ? `${assistantId}:${conversationId}:${channelId}`
-      : undefined;
-  const shouldResolveChannelName =
-    Boolean(assistantId && conversationId && channelId && channelBinding) &&
-    !isSlackDmChannelId(channelId) &&
-    channelBinding !== undefined &&
-    isChannelIdFallback(fallbackDisplayText, channelBinding);
-
-  useEffect(() => {
-    if (
-      !shouldResolveChannelName ||
-      !assistantId ||
-      !conversationId ||
-      !channelId ||
-      !resolutionKey
-    ) {
-      return;
-    }
-
-    let cancelled = false;
-    let request = slackChannelNameRequests.get(resolutionKey);
-
-    if (!request) {
-      request = resolveSlackChannelName(assistantId, conversationId).then(
-        (result) => {
-          if (
-            !result?.resolved ||
-            result.channelId !== channelId ||
-            !result.channelName
-          ) {
-            return null;
-          }
-          return result.channelName;
-        },
-      );
-      slackChannelNameRequests.set(resolutionKey, request);
-      request.finally(() => {
-        if (slackChannelNameRequests.get(resolutionKey) === request) {
-          slackChannelNameRequests.delete(resolutionKey);
-        }
-      });
-    }
-
-    request.then((channelName) => {
-      if (!cancelled && channelName) {
-        setResolvedChannelName({ key: resolutionKey, channelName });
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
+  const { channelBinding, displayText, href } = useSlackChannelResolution(
     assistantId,
-    channelId,
-    conversationId,
-    resolutionKey,
-    shouldResolveChannelName,
-  ]);
+    conversation,
+    messages,
+  );
 
-  if (!channelBinding) {
+  if (!channelBinding || !displayText) {
     return null;
   }
 
-  const resolvedDisplayText =
-    resolutionKey && resolvedChannelName?.key === resolutionKey
-      ? resolvedChannelName.channelName
-      : undefined;
-  const displayText = !isChannelIdFallback(fallbackDisplayText, channelBinding)
-    ? fallbackDisplayText
-    : (resolvedDisplayText ?? fallbackDisplayText);
-  if (!displayText) return null;
-
-  const href = getSlackChannelLink(
-    slackChannel,
-    messageChannel?.messageLink,
-    channelId,
-  );
   const content = (
     <>
       <Hash className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />

--- a/apps/web/src/domains/chat/components/spectator-bar.tsx
+++ b/apps/web/src/domains/chat/components/spectator-bar.tsx
@@ -1,0 +1,90 @@
+import { Eye, ExternalLink, Hash, Square } from "lucide-react";
+
+import { Button } from "@vellum/design-library";
+import type { DisplayMessage } from "@/domains/chat/types/types.js";
+import {
+  useSlackChannelResolution,
+  type SlackConversationLike,
+} from "@/domains/chat/utils/slack-channel-helpers.js";
+
+export interface SpectatorBarProps {
+  assistantName?: string;
+  assistantId?: string;
+  conversation: SlackConversationLike | null | undefined;
+  messages?: DisplayMessage[];
+  canStopGenerating?: boolean;
+  onStopGenerating: () => void;
+}
+
+export function SpectatorBar({
+  assistantName,
+  assistantId,
+  conversation,
+  messages,
+  canStopGenerating = false,
+  onStopGenerating,
+}: SpectatorBarProps) {
+  const { displayText: channelDisplayText, href } = useSlackChannelResolution(
+    assistantId,
+    conversation,
+    messages,
+  );
+
+  return (
+    <div className="flex items-center justify-center gap-3 border-t border-[var(--border-base)] bg-[var(--surface-overlay)] px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2 text-body-small-default text-[var(--content-tertiary)]">
+        <Eye size={14} className="shrink-0" />
+        <span className="truncate">
+          Watching
+          {assistantName && (
+            <>
+              {" "}
+              <span className="text-[var(--content-secondary)]">
+                {assistantName}
+              </span>
+            </>
+          )}
+          {channelDisplayText && (
+            <>
+              {" in "}
+              {href ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-[var(--content-secondary)] underline-offset-2 hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Hash className="inline h-3 w-3 shrink-0" aria-hidden />
+                  <span className="overflow-hidden text-ellipsis">
+                    {channelDisplayText}
+                  </span>
+                  <ExternalLink
+                    className="inline h-3 w-3 shrink-0"
+                    aria-hidden
+                  />
+                </a>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-[var(--content-secondary)]">
+                  <Hash className="inline h-3 w-3 shrink-0" aria-hidden />
+                  <span className="overflow-hidden text-ellipsis">
+                    {channelDisplayText}
+                  </span>
+                </span>
+              )}
+            </>
+          )}
+        </span>
+      </div>
+      {canStopGenerating && (
+        <Button
+          variant="primary"
+          iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
+          onClick={onStopGenerating}
+          aria-label="Stop generating"
+          title="Stop generation"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -7,6 +7,7 @@ import type { MessageItem, TranscriptItem } from "@/domains/chat/transcript/type
 
 import { TranscriptRow } from "@/domains/chat/transcript/transcript-row.js";
 import type { ConfirmationDecision } from "@/domains/chat/api/event-types.js";
+import type { GroupPosition } from "@/domains/chat/transcript/transcript.js";
 
 /**
  * Renders the newest user message (the "anchor") plus any response items that
@@ -24,6 +25,8 @@ import type { ConfirmationDecision } from "@/domains/chat/api/event-types.js";
 export interface LatestTurnRowProps {
   anchorMessage: MessageItem;
   responseItems: TranscriptItem[];
+  /** Pre-computed group positions for the anchor + response items. */
+  groupPositions?: Map<string, GroupPosition>;
   /** Current scroll container height — drives `minHeight`. Provided by the
    *  parent `Transcript` via `useViewportMinHeight`. */
   viewportMinHeight: number;
@@ -77,11 +80,16 @@ export interface LatestTurnRowProps {
    *  the chat avatar at the bottom of the latest assistant message
    *  rather than at the bottom of the entire chat. */
   avatarSlot?: ReactNode;
+  /** When true, this is a channel conversation with spectator layout. */
+  isChannelConversation?: boolean;
+  /** Logged-in user email for guardian detection in channel conversations. */
+  currentUserEmail?: string;
 }
 
 export const LatestTurnRow = memo(function LatestTurnRow({
   anchorMessage,
   responseItems,
+  groupPositions,
   viewportMinHeight,
   expandedToolCallIds,
   expandedCardIds,
@@ -109,6 +117,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   onSubagentClick,
   onStopSubagent,
   avatarSlot,
+  isChannelConversation,
+  currentUserEmail,
 }: LatestTurnRowProps) {
   return (
     <div
@@ -118,6 +128,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
     >
       <TranscriptRow
         item={anchorMessage}
+        groupPosition={groupPositions?.get(anchorMessage.key)}
         expandedToolCallIds={expandedToolCallIds}
         expandedCardIds={expandedCardIds}
         onSurfaceAction={onSurfaceAction}
@@ -140,11 +151,14 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         onOpenApp={onOpenApp}
         onOpenDocument={onOpenDocument}
         assistantId={assistantId}
+        isChannelConversation={isChannelConversation}
+        currentUserEmail={currentUserEmail}
       />
       {responseItems.map((response) => (
         <Fragment key={response.key}>
           <TranscriptRow
             item={response}
+            groupPosition={groupPositions?.get(response.key)}
             expandedToolCallIds={expandedToolCallIds}
             expandedCardIds={expandedCardIds}
             onSurfaceAction={onSurfaceAction}
@@ -167,6 +181,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             onOpenApp={onOpenApp}
             onOpenDocument={onOpenDocument}
             assistantId={assistantId}
+            isChannelConversation={isChannelConversation}
+            currentUserEmail={currentUserEmail}
           />
           {response.kind === "message" &&
             subagentsByParent?.get(response.key) &&

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -141,4 +141,86 @@ describe("TranscriptMessageBody", () => {
     fireEvent.click(getByTitle("Inspect"));
     expect(inspectedIds).toEqual(["message-1"]);
   });
+
+  test("marks the logged-in Slack sender as You in channel conversations", () => {
+    const html = renderToStaticMarkup(
+      <TranscriptMessageBody
+        message={{
+          stableId: "stable-1",
+          id: "message-1",
+          role: "user",
+          content: "Can @assistant take this?",
+          slackMessage: {
+            channelId: "C123",
+            channelTs: "123.456",
+            sender: {
+              username: "alice",
+              displayName: "Alice",
+            },
+          },
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+        isChannelConversation
+        currentUserEmail="alice@example.com"
+      />,
+    );
+
+    expect(html).toContain("You");
+    expect(html).toContain("**@assistant**");
+    expect(html).toContain("bg-[var(--system-positive-weak)]");
+  });
+
+  test("does not highlight mentions inside markdown code or links", () => {
+    const html = renderToStaticMarkup(
+      <TranscriptMessageBody
+        message={{
+          stableId: "stable-1",
+          id: "message-1",
+          role: "user",
+          content: "`@code` [@link](https://example.com/@link) @plain",
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+        isChannelConversation
+      />,
+    );
+
+    expect(html).toContain("`@code`");
+    expect(html).toContain("[@link](https://example.com/@link)");
+    expect(html).toContain("**@plain**");
+    expect(html).not.toContain("**@code**");
+    expect(html).not.toContain("**@link**");
+  });
+
+  test("hides Slack attribution on channel continuation messages", () => {
+    const html = renderToStaticMarkup(
+      <TranscriptMessageBody
+        message={{
+          stableId: "stable-1",
+          id: "message-1",
+          role: "user",
+          content: "Second grouped message",
+          slackMessage: {
+            channelId: "C123",
+            channelTs: "123.456",
+            sender: {
+              username: "bob",
+              displayName: "Bob",
+            },
+          },
+        }}
+        expandedToolCallIds={new Set()}
+        expandedCardIds={new Map()}
+        onSurfaceAction={noop}
+        isChannelConversation
+        groupPosition="last"
+      />,
+    );
+
+    expect(html).not.toContain("Bob");
+    expect(html).toContain("h-2");
+  });
 });

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -18,6 +18,7 @@ import type { DisplayMessage } from "@/domains/chat/utils/reconcile.js";
 import { getSlackLinkUrl, type Surface } from "@/domains/chat/types/types.js";
 import { isPointerCoarse } from "@/utils/pointer.js";
 import type { AllowlistOption, ChatMessageToolCall, ConfirmationDecision, DirectoryScopeOption, ScopeOption } from "@/domains/chat/api/event-types.js";
+import type { GroupPosition } from "@/domains/chat/transcript/transcript.js";
 
 export interface OpenRuleEditorContext {
   toolName: string;
@@ -77,6 +78,12 @@ export interface TranscriptMessageBodyProps {
   onOpenDocument?: (documentSurfaceId: string) => void;
   /** Forwarded to inline app surfaces so they can render live preview iframes. */
   assistantId?: string | null;
+  /** When true, channel spectator layout is used. */
+  isChannelConversation?: boolean;
+  /** Logged-in user email, used to identify guardian messages. */
+  currentUserEmail?: string;
+  /** Position within a consecutive same-sender message group. */
+  groupPosition?: GroupPosition;
 }
 
 function isSurfaceToolCallComplete(message: DisplayMessage): boolean {
@@ -133,22 +140,78 @@ function getSlackSenderLabel(message: DisplayMessage): string | null {
   ) ?? fallbackRoleLabel(message.role);
 }
 
+function isGuardianMessage(
+  message: DisplayMessage,
+  currentUserEmail?: string,
+): boolean {
+  if (!currentUserEmail || !message.slackMessage?.sender) return false;
+  const emailPrefix = currentUserEmail.split("@")[0]?.toLowerCase();
+  if (!emailPrefix) return false;
+  const senderName = (
+    message.slackMessage.sender.username ??
+    message.slackMessage.sender.name ??
+    ""
+  ).toLowerCase();
+  return senderName === emailPrefix;
+}
+
+const MENTION_RE = /(^|[\s(])(@\w[\w.-]*)/g;
+
+function highlightMentions(content: string): string {
+  const parts: string[] = [];
+  let lastEnd = 0;
+  const codeBlockOrSpanOrLink =
+    /```[\s\S]*?```|`[^`]+`|\[[^\]]*\]\([^)]*\)/g;
+  let match: RegExpExecArray | null;
+  const protectedRanges: Array<[number, number]> = [];
+  while ((match = codeBlockOrSpanOrLink.exec(content)) !== null) {
+    protectedRanges.push([match.index, match.index + match[0].length]);
+  }
+  const isProtected = (pos: number) =>
+    protectedRanges.some(([start, end]) => pos >= start && pos < end);
+
+  content.replace(MENTION_RE, (matched, prefix, mention, offset) => {
+    if (isProtected(offset)) return matched;
+    parts.push(content.slice(lastEnd, offset));
+    parts.push(`${prefix}**${mention}**`);
+    lastEnd = offset + matched.length;
+    return matched;
+  });
+  parts.push(content.slice(lastEnd));
+  return parts.join("");
+}
+
 function isInteractiveClickTarget(target: Element | null): boolean {
   return Boolean(
     target?.closest('a, button, [role="button"], input, textarea, select'),
   );
 }
 
-function SlackMessageAttribution({ message }: { message: DisplayMessage }) {
+function SlackMessageAttribution({
+  message,
+  isChannelConversation,
+  isGuardian,
+}: {
+  message: DisplayMessage;
+  isChannelConversation?: boolean;
+  isGuardian?: boolean;
+}) {
   const label = getSlackSenderLabel(message);
   if (!label) return null;
 
   const url = getSlackLinkUrl(message.slackMessage?.messageLink);
   const className =
     "inline-flex items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)]";
+  const guardianBadge =
+    isChannelConversation && isGuardian ? (
+      <span className="rounded-full bg-[var(--system-positive-weak)] px-1.5 py-0.5 text-body-small-default text-[var(--content-default)]">
+        You
+      </span>
+    ) : null;
   const content = (
     <>
       <span>{label}</span>
+      {guardianBadge}
       {url && <ExternalLink aria-hidden className="h-3 w-3 shrink-0" />}
     </>
   );
@@ -192,15 +255,47 @@ export function TranscriptMessageBody({
   onOpenApp,
   onOpenDocument,
   assistantId,
+  isChannelConversation,
+  currentUserEmail,
+  groupPosition,
 }: TranscriptMessageBodyProps) {
   const hasInterleavedToolCalls = message.contentOrder?.some(
     (e) => e.type === "toolCall" || e.type === "tool",
   );
 
-  const textBubbleClass =
-    message.role === "user"
-      ? "max-w-[80%] rounded-lg px-4 py-3 bg-[var(--surface-lift)] text-[var(--content-default)]"
-      : "w-full text-[var(--content-default)]";
+  const isGuardian = isChannelConversation
+    ? isGuardianMessage(message, currentUserEmail)
+    : false;
+  const isContinuation =
+    isChannelConversation &&
+    (groupPosition === "middle" || groupPosition === "last");
+  const isRightAligned = isChannelConversation
+    ? message.role === "assistant"
+    : message.role === "user";
+
+  const bubbleBase =
+    "max-w-[80%] rounded-lg px-4 py-3 text-[var(--content-default)]";
+  let textBubbleClass: string;
+  if (isChannelConversation) {
+    if (message.role === "assistant") {
+      textBubbleClass = `${bubbleBase} bg-[var(--system-info-weak)]`;
+    } else if (isGuardian) {
+      textBubbleClass = `${bubbleBase} bg-[var(--system-positive-weak)]`;
+    } else {
+      textBubbleClass = `${bubbleBase} bg-[var(--surface-lift)]`;
+    }
+  } else {
+    textBubbleClass =
+      message.role === "user"
+        ? `${bubbleBase} bg-[var(--surface-lift)]`
+        : "w-full text-[var(--content-default)]";
+  }
+
+  const processContent = (text: string) =>
+    isChannelConversation ? highlightMentions(text) : text;
+  const mentionWrapperClass = isChannelConversation
+    ? " channel-mentions"
+    : "";
 
   const handleExpandChange = (toolCallId: string, isExpanded: boolean) => {
     if (isExpanded) {
@@ -324,10 +419,10 @@ export function TranscriptMessageBody({
         data-revealed={revealed}
         data-slack-message-link={slackMessageUrl ? "true" : undefined}
         title={slackMessageUrl ? "Open in Slack" : undefined}
-        className={`group/msg flex ${slackMessageUrl ? "cursor-pointer" : ""} ${message.role === "user" ? "justify-end" : "justify-start"}`}
+        className={`group/msg flex ${isContinuation ? "mt-0.5" : ""} ${slackMessageUrl ? "cursor-pointer" : ""} ${isRightAligned ? "justify-end" : "justify-start"}`}
       >
         <div
-          className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
+          className={`flex w-full flex-col gap-2 ${isRightAligned ? "items-end" : "items-start"}`}
         >
           {groups.map((group, gi) => {
             if (group.type === "toolCalls") {
@@ -370,9 +465,9 @@ export function TranscriptMessageBody({
               return (
                 <div
                   key={`text-${gi}`}
-                  className={`text-[15px] break-words ${textBubbleClass}`}
+                  className={`text-[15px] break-words ${textBubbleClass} ${mentionWrapperClass}`}
                 >
-                  <ChatMarkdownMessage content={text} hardLineBreaks={message.role === "user"} />
+                  <ChatMarkdownMessage content={processContent(text)} hardLineBreaks={message.role === "user"} />
                 </div>
               );
             }
@@ -401,9 +496,9 @@ export function TranscriptMessageBody({
               content. */}
           {!groups.some((g) => g.type === "text") && message.content && (
             <div
-              className={`text-[15px] break-words ${textBubbleClass}`}
+              className={`text-[15px] break-words ${textBubbleClass} ${mentionWrapperClass}`}
             >
-              <ChatMarkdownMessage content={message.content} hardLineBreaks={message.role === "user"} />
+              <ChatMarkdownMessage content={processContent(message.content)} hardLineBreaks={message.role === "user"} />
             </div>
           )}
           {message.attachments && message.attachments.length > 0 && (
@@ -412,8 +507,14 @@ export function TranscriptMessageBody({
               assistantId={assistantId}
             />
           )}
-          <SlackMessageAttribution message={message} />
-          <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
+          {!isContinuation && (
+            <SlackMessageAttribution
+              message={message}
+              isChannelConversation={isChannelConversation}
+              isGuardian={isGuardian}
+            />
+          )}
+          <div className={`${isContinuation ? "h-2" : "h-6"} opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100`}>
             <MessageHoverActions
               content={message.content}
               timestamp={messageTimestamp}
@@ -443,7 +544,7 @@ export function TranscriptMessageBody({
             );
         const segText = seg?.content ?? entry.id;
         contentElements.push(
-          <ChatMarkdownMessage key={`text-${entry.id}`} content={segText} hardLineBreaks={message.role === "user"} />,
+          <ChatMarkdownMessage key={`text-${entry.id}`} content={processContent(segText)} hardLineBreaks={message.role === "user"} />,
         );
       } else if (entry.type === "surface") {
         const surface = resolveSurface(entry.id);
@@ -465,13 +566,13 @@ export function TranscriptMessageBody({
     }
     if (contentElements.length === 0 && message.content) {
       contentElements.push(
-        <ChatMarkdownMessage key="fallback" content={message.content} hardLineBreaks={message.role === "user"} />,
+        <ChatMarkdownMessage key="fallback" content={processContent(message.content)} hardLineBreaks={message.role === "user"} />,
       );
     }
   } else {
     contentElements.push(
       message.content ? (
-        <ChatMarkdownMessage key="content" content={message.content} hardLineBreaks={message.role === "user"} />
+        <ChatMarkdownMessage key="content" content={processContent(message.content)} hardLineBreaks={message.role === "user"} />
       ) : null,
     );
   }
@@ -483,10 +584,10 @@ export function TranscriptMessageBody({
       data-revealed={revealed}
       data-slack-message-link={slackMessageUrl ? "true" : undefined}
       title={slackMessageUrl ? "Open in Slack" : undefined}
-      className={`group/msg flex ${slackMessageUrl ? "cursor-pointer" : ""} ${message.role === "user" ? "justify-end" : "justify-start"}`}
+      className={`group/msg flex ${isContinuation ? "mt-0.5" : ""} ${slackMessageUrl ? "cursor-pointer" : ""} ${isRightAligned ? "justify-end" : "justify-start"}`}
     >
       <div
-        className={`flex w-full flex-col gap-2 ${message.role === "user" ? "items-end" : "items-start"}`}
+        className={`flex w-full flex-col gap-2 ${isRightAligned ? "items-end" : "items-start"}`}
       >
         {message.toolCalls && message.toolCalls.filter((tc) => !isSuppressedUiTool(tc)).length > 0 && (
           <ToolCallProgressCard
@@ -508,7 +609,7 @@ export function TranscriptMessageBody({
           (!message.toolCalls?.length &&
             !(message.attachments && message.attachments.length > 0))) && (
           <div
-            className={`text-[15px] break-words ${textBubbleClass}`}
+            className={`text-[15px] break-words ${textBubbleClass} ${mentionWrapperClass}`}
           >
             {contentElements}
           </div>
@@ -544,8 +645,14 @@ export function TranscriptMessageBody({
             </div>
           ));
         })()}
-        <SlackMessageAttribution message={message} />
-        <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
+        {!isContinuation && (
+          <SlackMessageAttribution
+            message={message}
+            isChannelConversation={isChannelConversation}
+            isGuardian={isGuardian}
+          />
+        )}
+        <div className={`${isContinuation ? "h-2" : "h-6"} opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100`}>
           <MessageHoverActions
             content={message.content}
             timestamp={messageTimestamp}

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -8,6 +8,7 @@ import type { TranscriptItem } from "@/domains/chat/transcript/types.js";
 
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body.js";
 import type { ConfirmationDecision } from "@/domains/chat/api/event-types.js";
+import type { GroupPosition } from "@/domains/chat/transcript/transcript.js";
 
 /**
  * Thin dispatcher: render one `TranscriptItem` using the matching existing
@@ -66,6 +67,12 @@ export interface TranscriptRowProps {
   onOpenDocument?: (documentSurfaceId: string) => void;
   /** Forwarded to inline app surfaces so they can render live preview iframes. */
   assistantId?: string | null;
+  /** When true, this is a channel conversation with spectator layout. */
+  isChannelConversation?: boolean;
+  /** Logged-in user email for guardian detection in channel conversations. */
+  currentUserEmail?: string;
+  /** Position within a consecutive same-sender message group. */
+  groupPosition?: GroupPosition;
 }
 
 export const TranscriptRow = memo(function TranscriptRow({
@@ -92,6 +99,9 @@ export const TranscriptRow = memo(function TranscriptRow({
   onOpenApp,
   onOpenDocument,
   assistantId,
+  isChannelConversation,
+  currentUserEmail,
+  groupPosition,
 }: TranscriptRowProps) {
   switch (item.kind) {
     case "message":
@@ -113,6 +123,9 @@ export const TranscriptRow = memo(function TranscriptRow({
           onOpenApp={onOpenApp}
           onOpenDocument={onOpenDocument}
           assistantId={assistantId}
+          isChannelConversation={isChannelConversation}
+          currentUserEmail={currentUserEmail}
+          groupPosition={groupPosition}
         />
       );
 

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -13,7 +13,11 @@ import {
 import { SubagentProgressCard } from "@/domains/chat/components/subagent-progress-card.js";
 import type { SubagentEntry } from "@/domains/subagents/subagent-store.js";
 import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn.js";
-import type { TranscriptItem } from "@/domains/chat/transcript/types.js";
+import type {
+  MessageItem,
+  TranscriptItem,
+} from "@/domains/chat/transcript/types.js";
+import type { DisplayMessage } from "@/domains/chat/types/types.js";
 
 import { LatestTurnRow } from "@/domains/chat/transcript/latest-turn-row.js";
 import { PullRefreshSpinner } from "@/domains/chat/transcript/pull-refresh-spinner.js";
@@ -116,6 +120,85 @@ export interface TranscriptProps {
    *  gated). When `false`, no spinner element renders and no touch
    *  listeners attach. */
   pullRefreshEnabled?: boolean;
+  /** When true, this is a channel conversation with spectator layout. */
+  isChannelConversation?: boolean;
+  /** Logged-in user email for guardian detection in channel conversations. */
+  currentUserEmail?: string;
+}
+
+export type GroupPosition = "first" | "middle" | "last" | "solo";
+
+const MAX_GROUP_GAP_MS = 5 * 60 * 1000;
+
+function isSameSender(a: DisplayMessage, b: DisplayMessage): boolean {
+  const aSender = a.slackMessage?.sender;
+  const bSender = b.slackMessage?.sender;
+  if (aSender && bSender) {
+    if (aSender.externalUserId && bSender.externalUserId) {
+      return aSender.externalUserId === bSender.externalUserId;
+    }
+    if (aSender.username && bSender.username) {
+      return aSender.username === bSender.username;
+    }
+  }
+  return a.role === b.role;
+}
+
+function isWithinGroupWindow(a: DisplayMessage, b: DisplayMessage): boolean {
+  if (a.timestamp == null || b.timestamp == null) return false;
+  return Math.abs(b.timestamp - a.timestamp) <= MAX_GROUP_GAP_MS;
+}
+
+function computeGroupPositions(
+  items: TranscriptItem[],
+): Map<string, GroupPosition> {
+  const positions = new Map<string, GroupPosition>();
+
+  const messageEntries: Array<{ index: number; item: MessageItem }> = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item?.kind === "message") {
+      messageEntries.push({ index: i, item });
+    }
+  }
+
+  for (let mi = 0; mi < messageEntries.length; mi++) {
+    const entry = messageEntries[mi];
+    if (!entry) continue;
+    const { index, item } = entry;
+    const msg = item.message;
+
+    const prev = mi > 0 ? messageEntries[mi - 1] : undefined;
+    const next =
+      mi < messageEntries.length - 1 ? messageEntries[mi + 1] : undefined;
+
+    const groupedWithPrev =
+      prev != null &&
+      prev.index === index - 1 &&
+      isSameSender(prev.item.message, msg) &&
+      isWithinGroupWindow(prev.item.message, msg);
+
+    const groupedWithNext =
+      next != null &&
+      next.index === index + 1 &&
+      isSameSender(msg, next.item.message) &&
+      isWithinGroupWindow(msg, next.item.message);
+
+    let position: GroupPosition;
+    if (groupedWithPrev && groupedWithNext) {
+      position = "middle";
+    } else if (groupedWithPrev) {
+      position = "last";
+    } else if (groupedWithNext) {
+      position = "first";
+    } else {
+      position = "solo";
+    }
+
+    positions.set(item.key, position);
+  }
+
+  return positions;
 }
 
 export interface TranscriptHandle {
@@ -154,6 +237,10 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
     const [expandedCardIds] = useState(() => new Map<string, boolean>());
 
     const partition = useMemo(() => partitionLatestTurn(items), [items]);
+    const groupPositions = useMemo(
+      () => computeGroupPositions(items),
+      [items],
+    );
 
     const subagentsByParent = useMemo(() => {
       if (!rest.subagentEntries?.length) return null;
@@ -231,13 +318,19 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       onOpenApp: rest.onOpenApp,
       onOpenDocument: rest.onOpenDocument,
       assistantId: rest.assistantId,
+      isChannelConversation: rest.isChannelConversation,
+      currentUserEmail: rest.currentUserEmail,
     };
+
+    const spectatorBg = rest.isChannelConversation
+      ? " border-l-2 border-[var(--system-info-weak)]"
+      : "";
 
     return (
       <div
         ref={scrollRef}
         data-testid="transcript-scroll-container"
-        className="flex h-full w-full flex-col overflow-y-auto overscroll-none [overflow-anchor:none]"
+        className={`flex h-full w-full flex-col overflow-y-auto overscroll-none [overflow-anchor:none]${spectatorBg}`}
       >
         {/* Inner content wrapper — observed by the scroll coordinator's
          *  ResizeObserver so we can re-pin to bottom when scroll content
@@ -249,7 +342,11 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
           {partition.historyItems.map((item) => (
             <Fragment key={item.key}>
               <div className="mx-auto w-full max-w-[var(--chat-max-width)] contain-content px-4 sm:px-6">
-                <TranscriptRow item={item} {...rowProps} />
+                <TranscriptRow
+                  item={item}
+                  groupPosition={groupPositions.get(item.key)}
+                  {...rowProps}
+                />
                 {item.kind === "message" &&
                   subagentsByParent?.get(item.key) &&
                   rest.onSubagentClick && (
@@ -268,6 +365,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
               <LatestTurnRow
                 anchorMessage={partition.anchorMessage}
                 responseItems={partition.responseItems}
+                groupPositions={groupPositions}
                 viewportMinHeight={viewportMinHeight}
                 avatarSlot={rest.renderAvatar ? rest.renderAvatar() : undefined}
                 subagentsByParent={subagentsByParent}

--- a/apps/web/src/domains/chat/utils/slack-channel-helpers.ts
+++ b/apps/web/src/domains/chat/utils/slack-channel-helpers.ts
@@ -1,0 +1,241 @@
+/**
+ * Shared helpers for resolving Slack channel display names and links.
+ * Used by both SlackChannelFooter and SpectatorBar.
+ */
+
+import { useEffect, useState } from "react";
+
+import type {
+  Conversation,
+  ConversationChannelBinding,
+} from "@/domains/chat/api/conversations.js";
+import { resolveSlackChannelName } from "@/domains/chat/api/slack-channel-name.js";
+import {
+  getSlackLinkUrl,
+  type DisplayMessage,
+  type SlackMessageLink,
+} from "@/domains/chat/types/types.js";
+
+export type SlackConversationLike = Pick<
+  Conversation,
+  "channelBinding" | "originChannel"
+> &
+  Partial<Pick<Conversation, "conversationKey">>;
+
+export function getSlackChannelLink(
+  slackChannel: ConversationChannelBinding["slackChannel"],
+  messageLink?: SlackMessageLink,
+  channelId?: string,
+): string | undefined {
+  if (slackChannel?.link) {
+    if (typeof slackChannel.link === "string") return slackChannel.link;
+    return getSlackLinkUrl(slackChannel.link);
+  }
+  return getSlackChannelLinkFromMessageLink(messageLink, channelId);
+}
+
+function getSlackChannelLinkFromMessageLink(
+  messageLink: SlackMessageLink | undefined,
+  channelId: string | undefined,
+): string | undefined {
+  if (!messageLink || !channelId) return undefined;
+
+  if (messageLink.webUrl) {
+    try {
+      const url = new URL(messageLink.webUrl);
+      const channelPath = `/archives/${channelId}`;
+      if (url.pathname.startsWith(`${channelPath}/`)) {
+        url.pathname = channelPath;
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+      }
+    } catch {
+      // Fall through to app URL parsing.
+    }
+  }
+
+  if (!messageLink.appUrl) return undefined;
+  try {
+    const url = new URL(messageLink.appUrl);
+    if (url.protocol !== "slack:" || url.hostname !== "channel") {
+      return undefined;
+    }
+    const team = url.searchParams.get("team");
+    if (!team || url.searchParams.get("id") !== channelId) {
+      return undefined;
+    }
+    return `slack://channel?${new URLSearchParams({
+      team,
+      id: channelId,
+    }).toString()}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getSlackMessageChannel(
+  messages: DisplayMessage[] | undefined,
+  channelId: string | undefined,
+) {
+  if (!messages || messages.length === 0) return undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const slackMessage = messages[i]?.slackMessage;
+    if (!slackMessage) continue;
+    if (channelId && slackMessage.channelId !== channelId) continue;
+    return slackMessage;
+  }
+  return undefined;
+}
+
+export function isChannelIdFallback(
+  value: string | undefined,
+  channelBinding: ConversationChannelBinding,
+): boolean {
+  return (
+    value === undefined ||
+    value === channelBinding.externalChatId ||
+    value === channelBinding.slackChannel?.channelId ||
+    value === channelBinding.slackChannel?.id
+  );
+}
+
+export function getSlackChannelDisplayText(
+  channelBinding: ConversationChannelBinding,
+  fallbackChannelName?: string,
+): string | undefined {
+  const slackChannel = channelBinding.slackChannel;
+  const primaryName = slackChannel?.name ?? channelBinding.externalChatName;
+
+  if (!isChannelIdFallback(primaryName, channelBinding)) {
+    return primaryName;
+  }
+  if (
+    fallbackChannelName &&
+    !isChannelIdFallback(fallbackChannelName, channelBinding)
+  ) {
+    return fallbackChannelName;
+  }
+
+  return (
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding.externalChatId
+  );
+}
+
+function isSlackDmChannelId(channelId: string | undefined): boolean {
+  return channelId?.startsWith("D") === true;
+}
+
+const slackChannelNameRequests = new Map<string, Promise<string | null>>();
+
+export interface SlackChannelResolution {
+  channelBinding: ConversationChannelBinding | undefined;
+  channelId: string | undefined;
+  displayText: string | undefined;
+  href: string | undefined;
+}
+
+export function useSlackChannelResolution(
+  assistantId: string | undefined,
+  conversation: SlackConversationLike | null | undefined,
+  messages: DisplayMessage[] | undefined,
+): SlackChannelResolution {
+  const [resolvedChannelName, setResolvedChannelName] = useState<{
+    key: string;
+    channelName: string;
+  } | null>(null);
+
+  const channelBinding =
+    conversation?.originChannel === "slack"
+      ? conversation.channelBinding
+      : undefined;
+  const slackChannel = channelBinding?.slackChannel;
+  const channelId =
+    slackChannel?.channelId ??
+    slackChannel?.id ??
+    channelBinding?.externalChatId;
+  const messageChannel = getSlackMessageChannel(messages, channelId);
+  const fallbackDisplayText = channelBinding
+    ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
+    : undefined;
+  const conversationId = conversation?.conversationKey;
+  const resolutionKey =
+    assistantId && conversationId && channelId
+      ? `${assistantId}:${conversationId}:${channelId}`
+      : undefined;
+  const shouldResolveChannelName =
+    Boolean(assistantId && conversationId && channelId && channelBinding) &&
+    !isSlackDmChannelId(channelId) &&
+    channelBinding !== undefined &&
+    isChannelIdFallback(fallbackDisplayText, channelBinding);
+
+  useEffect(() => {
+    if (
+      !shouldResolveChannelName ||
+      !assistantId ||
+      !conversationId ||
+      !channelId ||
+      !resolutionKey
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let request = slackChannelNameRequests.get(resolutionKey);
+
+    if (!request) {
+      request = resolveSlackChannelName(assistantId, conversationId).then(
+        (result) => {
+          if (
+            !result?.resolved ||
+            result.channelId !== channelId ||
+            !result.channelName
+          ) {
+            return null;
+          }
+          return result.channelName;
+        },
+      );
+      slackChannelNameRequests.set(resolutionKey, request);
+      request.finally(() => {
+        if (slackChannelNameRequests.get(resolutionKey) === request) {
+          slackChannelNameRequests.delete(resolutionKey);
+        }
+      });
+    }
+
+    request.then((channelName) => {
+      if (!cancelled && channelName) {
+        setResolvedChannelName({ key: resolutionKey, channelName });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assistantId,
+    channelId,
+    conversationId,
+    resolutionKey,
+    shouldResolveChannelName,
+  ]);
+
+  const resolvedDisplayText =
+    resolutionKey && resolvedChannelName?.key === resolutionKey
+      ? resolvedChannelName.channelName
+      : undefined;
+  const displayText =
+    channelBinding && !isChannelIdFallback(fallbackDisplayText, channelBinding)
+      ? fallbackDisplayText
+      : (resolvedDisplayText ?? fallbackDisplayText);
+  const href = getSlackChannelLink(
+    slackChannel,
+    messageChannel?.messageLink,
+    channelId,
+  );
+
+  return { channelBinding, channelId, displayText, href };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -192,3 +192,12 @@
     opacity: 0.7 !important;
   }
 }
+
+/* Channel @mention highlighting. Mentions are pre-processed into markdown
+ * bold (**@mention**) which renders as <strong>. The wrapper div gets
+ * `channel-mentions` so we can style only mention-generated bold, not all
+ * bold text. */
+.channel-mentions strong {
+  color: var(--system-info-strong);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Ports Slack spectator mode from `vellum-assistant-platform` PRs #7540 and #7546 into `apps/web`.
- Extracts shared Slack channel resolution for the existing footer and the new spectator bar.
- Replaces the read-only channel banner with a spectator bar that shows assistant/channel context and preserves stop-generation.
- Adds channel transcript styling: assistant messages on the right, external senders on the left, guardian `You` badge, same-sender grouping, and Slack mention highlighting.

Stacked on #31505 so this PR stays focused on the spectator-mode migration.

## Validation
- `cd apps/web && bun test src/domains/chat/components/chat-body.test.tsx src/domains/chat/components/slack-channel-footer.test.tsx src/domains/chat/transcript/transcript-message-body.test.tsx src/domains/chat/transcript/transcript.test.tsx src/domains/chat/transcript/latest-turn-row.test.tsx`
- `cd apps/web && bunx tsc --noEmit --pretty false`
