### PR TITLE
feat(JARVIS-913): add prior assistant catalog for onboarding screen

### DIFF
--- a/apps/web/src/domains/onboarding/prechat-prior-assistants.ts
+++ b/apps/web/src/domains/onboarding/prechat-prior-assistants.ts
@@ -1,0 +1,32 @@
+/**
+ * Prior AI assistant catalog for the PreChat onboarding screen.
+ *
+ * Follows the same shape as `prechat-tools.ts`. The order here is
+ * significant -- the screen renders assistants in this order.
+ *
+ * `logoSrc` is `null` for all entries initially -- the tile component
+ * falls back to initials. Logo assets can be added as a follow-up.
+ *
+ * `logoSrcDark` is an optional alternate asset shown in dark mode.
+ *
+ * For the `stripOtherPrefix` helper (stripping `"other:"` from custom
+ * entries, deduping, and sorting), reuse the identical implementation
+ * exported from `prechat-tools.ts`.
+ */
+
+export interface PreChatPriorAssistantItem {
+  id: string;
+  label: string;
+  logoSrc: string | null;
+  logoSrcDark?: string;
+}
+
+export const PRECHAT_PRIOR_ASSISTANTS: PreChatPriorAssistantItem[] = [
+  { id: "chatgpt", label: "ChatGPT", logoSrc: null },
+  { id: "claude", label: "Claude", logoSrc: null },
+  { id: "openclaw", label: "OpenClaw", logoSrc: null },
+  { id: "hermes", label: "Hermes", logoSrc: null },
+  { id: "manus", label: "Manus", logoSrc: null },
+  { id: "gemini", label: "Gemini", logoSrc: null },
+  { id: "copilot", label: "Copilot", logoSrc: null },
+];


### PR DESCRIPTION
## Summary
- Create `prechat-prior-assistants.ts` with `PreChatPriorAssistantItem` interface and `PRECHAT_PRIOR_ASSISTANTS` catalog
- Includes ChatGPT, Claude, OpenClaw, Hermes, Manus, Gemini, Copilot
- All items use `logoSrc: null` (initials fallback) — logo assets to follow

Part of plan: prior-ai-assistant-onboarding.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->