### PR TITLE
feat(JARVIS-913): inject species-migration bootstrap hint when prior assistants present

### DIFF
--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -20,6 +20,20 @@ export const TOOL_DISPLAY_NAMES: Record<string, string> = {
 };
 
 /**
+ * Map of known prior-assistant IDs (from the client onboarding UI) to display names.
+ * Unknown IDs pass through with first-letter capitalization via `normalizePriorAssistants`.
+ */
+export const PRIOR_ASSISTANT_DISPLAY_NAMES: Record<string, string> = {
+  chatgpt: "ChatGPT",
+  claude: "Claude",
+  openclaw: "OpenClaw",
+  hermes: "Hermes",
+  manus: "Manus",
+  gemini: "Gemini",
+  copilot: "Copilot",
+};
+
+/**
  * Map of known task IDs to plain-language labels describing what the assistant
  * does for each task category.
  */
@@ -56,12 +70,23 @@ export function normalizeTasks(tasks: string[]): string[] {
   return tasks.map((id) => TASK_DISPLAY_LABELS[id] ?? id);
 }
 
+/**
+ * Maps each prior-assistant ID through `PRIOR_ASSISTANT_DISPLAY_NAMES`,
+ * falling back to first-letter capitalization for unknown IDs.
+ */
+export function normalizePriorAssistants(assistants: string[]): string[] {
+  return assistants.map(
+    (id) => PRIOR_ASSISTANT_DISPLAY_NAMES[id] ?? capitalizeFirst(id),
+  );
+}
+
 export interface NormalizedOnboarding {
   preferredName?: string;
   commonWork: string[];
   dailyTools: string[];
   tone?: string;
   assistantName?: string;
+  priorAssistants?: string[];
   googleConnected?: boolean;
   googleServices?: string[];
   cohort?: string;
@@ -105,6 +130,9 @@ export function normalizeOnboardingContext(
     googleConnected: ctx.googleConnected,
     googleServices: ctx.googleConnected
       ? deriveGoogleServices(ctx.googleScopes)
+      : undefined,
+    priorAssistants: ctx.priorAssistants?.length
+      ? normalizePriorAssistants(ctx.priorAssistants)
       : undefined,
     cohort: ctx.cohort,
     websiteUrl:

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -415,11 +415,30 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
           `- Google connected: yes (${n.googleServices.join(", ")} access granted)`,
         );
       }
+      if (n.priorAssistants?.length)
+        lines.push(
+          `- Prior AI assistants used: ${n.priorAssistants.join(", ")}`,
+        );
       lines.push(
         "",
         "Apply this context quietly. Do not recap it as a list unless the user asks.",
       );
       systemParts.push(lines.join("\n"));
+
+      if (n.priorAssistants?.length) {
+        systemParts.push(
+          "## Species Migration\n\n" +
+            "This user has prior experience with other AI assistants. " +
+            "During the first conversation, after the initial greeting and rapport, " +
+            "gently mention that you can help them bring over anything they've built " +
+            "with their previous assistant — memory, skills, workflows, integrations — " +
+            "using the species-migration skill. Frame it as an offer, not a push: " +
+            "\"I noticed you've used [X] before — if you've built anything there you'd like to bring over, " +
+            "I can help with that whenever you're ready.\" " +
+            "Only proceed with migration if the user expresses interest. " +
+            "Do not load or activate the species-migration skill preemptively.",
+        );
+      }
     }
   }
   // Configuration section removed — workspace files are self-describing,


### PR DESCRIPTION
## Summary
- Add `priorAssistants` to `NormalizedOnboarding` with display name mapping
- Add 'Prior AI assistants used' line to First-Run User Context section
- Inject conditional 'Species Migration' section into bootstrap prompt when prior assistants present
- Migration hint is framed as a soft offer, not forced activation

Part of plan: prior-ai-assistant-onboarding.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->