### PR TITLE
fix(JARVIS-913): thread priorAssistants through wire format to daemon

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -454,6 +454,7 @@ export async function postChatMessage(
     if (normalizedOnboarding.assistantName !== undefined) onboardingDict.assistantName = normalizedOnboarding.assistantName;
     if (normalizedOnboarding.googleConnected !== undefined) onboardingDict.googleConnected = normalizedOnboarding.googleConnected;
     if (normalizedOnboarding.googleScopes !== undefined) onboardingDict.googleScopes = normalizedOnboarding.googleScopes;
+    if (normalizedOnboarding.priorAssistants !== undefined) onboardingDict.priorAssistants = normalizedOnboarding.priorAssistants;
     body.onboarding = onboardingDict;
   }
   if (normalizedOnboarding) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1087,6 +1087,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tone: string;
   userName?: string;
   assistantName?: string;
+  priorAssistants?: string[];
   cohort?: string;
   websiteUrl?: string;
   contentSourceUrl?: string;
@@ -1167,6 +1168,7 @@ export async function handleSendMessage(
       assistantName?: string;
       googleConnected?: boolean;
       googleScopes?: string[];
+      priorAssistants?: string[];
       cohort?: string;
       websiteUrl?: string;
       contentSourceUrl?: string;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for prior-ai-assistant-onboarding.md.

**Gap:** priorAssistants field collected by onboarding UI but never sent to daemon
**What was expected:** priorAssistants should flow from web client to daemon for system prompt injection
**What was found:** Three integration seams (postChatMessage serializer, handleSendMessage body type, persistOnboardingArtifacts type) were missing the field

- Add priorAssistants to onboardingDict in postChatMessage
- Add priorAssistants to inline onboarding type in handleSendMessage
- Add priorAssistants to persistOnboardingArtifacts parameter type
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->