### PR TITLE
fix: repair lint, test mocks, and OpenAPI spec blocking dev release

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33,6 +33,283 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/acp/{id}/cancel:
+    post:
+      operationId: acp_by_id_cancel_post
+      summary: Cancel ACP session
+      description: Cancel an active ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  cancelled:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - cancelled
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/{id}/close:
+    post:
+      operationId: acp_by_id_close_post
+      summary: Close ACP session
+      description: Close a completed ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  closed:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - closed
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/{id}/steer:
+    post:
+      operationId: acp_by_id_steer_post
+      summary: Steer ACP session
+      description: Send a steering instruction to an active ACP session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  steered:
+                    type: boolean
+                required:
+                  - acpSessionId
+                  - steered
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+              required:
+                - instruction
+              additionalProperties: false
+  /v1/acp/sessions:
+    delete:
+      operationId: acp_sessions_delete
+      summary: Bulk-clear terminal ACP sessions
+      description: Remove every terminal-state row (completed/failed/cancelled) from the persisted acp_session_history table.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - deleted
+                additionalProperties: false
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Must be 'completed'. Shorthand for all terminal statuses (completed/failed/cancelled).
+    get:
+      operationId: acp_sessions_get
+      summary: List ACP sessions
+      description:
+        Return the merged set of in-memory and persisted ACP sessions, newest first. In-memory sessions take
+        precedence on id collision.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        agentId:
+                          type: string
+                        acpSessionId:
+                          type: string
+                        parentConversationId:
+                          type: string
+                        status:
+                          type: string
+                        startedAt:
+                          type: number
+                        completedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        stopReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        eventLog:
+                          type: array
+                          items: {}
+                      required:
+                        - id
+                        - agentId
+                        - acpSessionId
+                        - status
+                        - startedAt
+                      additionalProperties: false
+                    description: Merged in-memory and persisted ACP sessions.
+                required:
+                  - sessions
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Maximum number of sessions to return (default 50, max 500).
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter to sessions whose parentConversationId matches this value.
+  /v1/acp/sessions/{id}:
+    delete:
+      operationId: acp_sessions_by_id_delete
+      summary: Delete ACP session from history
+      description:
+        Remove a persisted ACP session row. Rejects with 409 when the session is still active in memory; idempotent
+        for unknown ids.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                required:
+                  - deleted
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/acp/spawn:
+    post:
+      operationId: acp_spawn_post
+      summary: Spawn ACP session
+      description: Start a new Agent Communication Protocol session.
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acpSessionId:
+                    type: string
+                  protocolSessionId:
+                    type: string
+                  agent:
+                    type: string
+                required:
+                  - acpSessionId
+                  - protocolSessionId
+                  - agent
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent:
+                  type: string
+                  description: Agent name
+                task:
+                  type: string
+                  description: Task description
+                conversationId:
+                  type: string
+                cwd:
+                  type: string
+                  description: Working directory
+              required:
+                - agent
+                - task
+                - conversationId
+              additionalProperties: false
   /v1/admin/rollback-migrations:
     post:
       operationId: admin_rollbackmigrations_post
@@ -2196,6 +2473,114 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/browser/execute:
+    post:
+      operationId: browser_execute_post
+      summary: Execute a browser operation
+      description: Invoke a browser operation (navigate, click, type, screenshot, etc.) via the headless browser subsystem.
+      tags:
+        - browser
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: string
+                  isError:
+                    type: boolean
+                  screenshots:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        mediaType:
+                          type: string
+                        data:
+                          type: string
+                      required:
+                        - mediaType
+                        - data
+                      additionalProperties: false
+                required:
+                  - content
+                  - isError
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                operation:
+                  type: string
+                  enum:
+                    - navigate
+                    - snapshot
+                    - screenshot
+                    - close
+                    - attach
+                    - detach
+                    - click
+                    - type
+                    - press_key
+                    - scroll
+                    - select_option
+                    - hover
+                    - wait_for
+                    - extract
+                    - wait_for_download
+                    - fill_credential
+                    - status
+                input:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                sessionId:
+                  default: default
+                  type: string
+                  minLength: 1
+                conversationId:
+                  type: string
+                  minLength: 1
+              required:
+                - operation
+              additionalProperties: false
+  /v1/btw:
+    post:
+      operationId: btw_post
+      summary: Run ephemeral LLM side-chain
+      description:
+        Stream an ephemeral LLM call reusing the conversation's provider and message history. Response is SSE
+        (btw_text_delta, btw_complete, btw_error).
+      tags:
+        - btw
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Conversation key to scope the call
+                content:
+                  type: string
+                  description: User prompt content
+              required:
+                - conversationKey
+                - content
+              additionalProperties: false
   /v1/cache/delete:
     post:
       operationId: cache_delete_post
@@ -2301,6 +2686,395 @@ paths:
               required:
                 - data
               additionalProperties: false
+  /v1/calls/{callSessionId}:
+    get:
+      operationId: calls_by_callSessionId_get
+      summary: Get call status
+      description: Return the current status and details of a call session.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  conversationId:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  provider:
+                    type: string
+                  providerCallSid:
+                    type: string
+                  task:
+                    type: string
+                  startedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  endedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  lastError:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  pendingQuestion:
+                    anyOf:
+                      - type: object
+                        properties: {}
+                        additionalProperties: {}
+                      - type: "null"
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - callSessionId
+                  - conversationId
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - provider
+                  - providerCallSid
+                  - task
+                  - startedAt
+                  - endedAt
+                  - lastError
+                  - pendingQuestion
+                  - createdAt
+                  - updatedAt
+                additionalProperties: false
+      parameters:
+        - name: callSessionId
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/calls/{callSessionId}/answer:
+    post:
+      operationId: calls_by_callSessionId_answer_post
+      summary: Answer a pending call question
+      description: Provide an answer to a pending question during an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  questionId:
+                    type: string
+                required:
+                  - ok
+                  - questionId
+                additionalProperties: false
+      parameters:
+        - name: callSessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                answer:
+                  type: string
+                  description: Answer text
+                pendingQuestionId:
+                  type: string
+                  description: ID of the pending question
+              required:
+                - answer
+              additionalProperties: false
+  /v1/calls/{callSessionId}/cancel:
+    post:
+      operationId: calls_by_callSessionId_cancel_post
+      summary: Cancel a call
+      description: Cancel an active or pending call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  status:
+                    type: string
+                required:
+                  - callSessionId
+                  - status
+                additionalProperties: false
+      parameters:
+        - name: callSessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Cancellation reason
+              additionalProperties: false
+  /v1/calls/{callSessionId}/instruction:
+    post:
+      operationId: calls_by_callSessionId_instruction_post
+      summary: Relay instruction to active call
+      description: Send a real-time instruction to an active call.
+      tags:
+        - calls
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: callSessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instruction:
+                  type: string
+                  description: Instruction text to relay
+              required:
+                - instruction
+              additionalProperties: false
+  /v1/calls/start:
+    post:
+      operationId: calls_start_post
+      summary: Start a call
+      description: Initiate a new outbound phone call. Supports idempotency keys to prevent duplicate calls.
+      tags:
+        - calls
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  callSessionId:
+                    type: string
+                  callSid:
+                    type: string
+                  status:
+                    type: string
+                  toNumber:
+                    type: string
+                  fromNumber:
+                    type: string
+                  callerIdentityMode:
+                    type: string
+                required:
+                  - callSessionId
+                  - callSid
+                  - status
+                  - toNumber
+                  - fromNumber
+                  - callerIdentityMode
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phoneNumber:
+                  type: string
+                  description: Phone number to call
+                task:
+                  type: string
+                  description: Task description for the call
+                context:
+                  type: string
+                  description: Additional context for the call
+                conversationId:
+                  type: string
+                  description: Conversation to associate with
+                callerIdentityMode:
+                  type: string
+                  description: "Caller identity: 'assistant_number' or 'user_number'"
+                idempotencyKey:
+                  type: string
+                  description: Idempotency key to prevent duplicate calls
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/channel-verification-sessions:
+    delete:
+      operationId: channelverificationsessions_delete
+      summary: Cancel verification sessions
+      description: Cancel all active inbound and outbound verification sessions.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+    post:
+      operationId: channelverificationsessions_post
+      summary: Create verification session
+      description: Create a channel verification session (inbound challenge, outbound, or trusted contact).
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Channel ID
+                destination:
+                  type: string
+                  description: Outbound destination
+                rebind:
+                  type: boolean
+                conversationId:
+                  type: string
+                originConversationId:
+                  type: string
+                purpose:
+                  type: string
+                  description: guardian or trusted_contact
+                contactChannelId:
+                  type: string
+              required:
+                - channel
+                - destination
+                - rebind
+                - conversationId
+                - originConversationId
+                - purpose
+                - contactChannelId
+              additionalProperties: false
+  /v1/channel-verification-sessions/resend:
+    post:
+      operationId: channelverificationsessions_resend_post
+      summary: Resend verification code
+      description: Resend the outbound verification code.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                originConversationId:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/revoke:
+    post:
+      operationId: channelverificationsessions_revoke_post
+      summary: Revoke verification binding
+      description: Cancel all sessions and revoke the guardian binding.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+              required:
+                - channel
+              additionalProperties: false
+  /v1/channel-verification-sessions/status:
+    get:
+      operationId: channelverificationsessions_status_get
+      summary: Get verification status
+      description: Check guardian binding and verification session status.
+      tags:
+        - channel-verification
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
   /v1/channels/available:
     get:
       operationId: channels_available_get
@@ -2366,6 +3140,136 @@ paths:
                 required:
                   - channels
                 additionalProperties: false
+  /v1/channels/conversation:
+    delete:
+      operationId: channels_conversation_delete
+      summary: Delete channel conversation
+      description: Delete a conversation by channel source.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/dead-letters:
+    get:
+      operationId: channels_deadletters_get
+      summary: List dead letters
+      description: Return undeliverable channel messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/delivery-ack:
+    post:
+      operationId: channels_deliveryack_post
+      summary: Acknowledge channel delivery
+      description: Acknowledge delivery of a channel message.
+      tags:
+        - channels
+      responses:
+        "204":
+          description: Successful response
+  /v1/channels/inbound:
+    post:
+      operationId: channels_inbound_post
+      summary: Process inbound channel message
+      description: Receive an inbound message from a channel integration.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+  /v1/channels/readiness:
+    get:
+      operationId: channels_readiness_get
+      summary: Get channel readiness
+      description: Return readiness snapshots for one or all channels.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Channel readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      parameters:
+        - name: channel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional channel ID filter
+        - name: includeRemote
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Include remote checks (default true)
+  /v1/channels/readiness/refresh:
+    post:
+      operationId: channels_readiness_refresh_post
+      summary: Refresh channel readiness
+      description: Invalidate cache and re-evaluate channel readiness.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  snapshots:
+                    type: array
+                    items: {}
+                    description: Refreshed readiness snapshots
+                required:
+                  - success
+                  - snapshots
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channel:
+                  type: string
+                  description: Optional channel ID to refresh
+                includeRemote:
+                  type: boolean
+                  description: Include remote checks (default true)
+              required:
+                - channel
+                - includeRemote
+              additionalProperties: false
+  /v1/channels/replay:
+    post:
+      operationId: channels_replay_post
+      summary: Replay dead letters
+      description: Retry delivery of dead-letter messages.
+      tags:
+        - channels
+      responses:
+        "200":
+          description: Successful response
   /v1/clients:
     get:
       operationId: clients_get
@@ -2431,6 +3335,70 @@ paths:
               required:
                 - clientId
               additionalProperties: false
+  /v1/config:
+    get:
+      operationId: config_get
+      summary: Get full config
+      description: Return the raw settings.json configuration object.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    patch:
+      operationId: config_patch
+      summary: Patch config
+      description: Deep-merge a partial JSON object into the settings.json configuration.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/config/allowlist/validate:
+    get:
+      operationId: config_allowlist_validate_get
+      summary: Validate secret-allowlist.json regex patterns
+      description:
+        "Compile each regex pattern in secret-allowlist.json and return any syntax errors. Returns { exists: false
+        } if no file is present."
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/config/embeddings:
+    get:
+      operationId: config_embeddings_get
+      summary: Get embedding config
+      description: Return the active embedding provider, model, and available options.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+    put:
+      operationId: config_embeddings_put
+      summary: Set embedding config
+      description: Change the embedding provider and optionally model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                model:
+                  type: string
+              required:
+                - provider
+              additionalProperties: false
   /v1/config/llm/call-sites:
     get:
       operationId: config_llm_callsites_get
@@ -2443,6 +3411,22 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/config/llm/profiles/{name}:
+    put:
+      operationId: config_llm_profiles_by_name_put
+      summary: Replace an inference profile
+      description: Replace the settings-UI-managed leaves of a single llm.profiles entry while preserving non-UI leaves.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/config/platform:
     get:
       operationId: config_platform_get
@@ -2486,6 +3470,660 @@ paths:
                   type: string
               required:
                 - baseUrl
+              additionalProperties: false
+  /v1/config/schema:
+    get:
+      operationId: config_schema_get
+      summary: Get config JSON Schema
+      description:
+        Return the JSON Schema for the assistant config, optionally scoped to a dotted-path sub-schema (e.g.
+        ?path=calls).
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: path
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional dotted path to a config sub-key
+  /v1/config/set:
+    post:
+      operationId: config_set_post
+      summary: Set a single config path
+      description:
+        Assign a value at a dotted config path with direct-replacement semantics (preserves explicit null, replaces
+        object subtrees instead of merging). Used by the `assistant config set <key> <value>` CLI command.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/confirm:
+    post:
+      operationId: confirm_post
+      summary: Resolve a pending confirmation
+      description: Approve or deny a pending tool confirmation by requestId.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                decision:
+                  type: string
+                  description: "One of: allow, deny"
+                selectedPattern:
+                  type: string
+                  description: Allowlist pattern for persistent decisions
+                selectedScope:
+                  type: string
+                  description: Scope for persistent decisions
+              required:
+                - requestId
+                - decision
+              additionalProperties: false
+  /v1/consolidation/config:
+    get:
+      operationId: consolidation_config_get
+      summary: Get consolidation config
+      description: Return the current memory v2 consolidation schedule configuration.
+      tags:
+        - consolidation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - available
+                  - enabled
+                  - intervalMs
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+  /v1/consolidation/run-now:
+    post:
+      operationId: consolidation_runnow_post
+      summary: Run consolidation now
+      description:
+        Enqueue an immediate memory v2 consolidation job. Returns once the job is queued; the job itself runs
+        through the memory jobs worker.
+      tags:
+        - consolidation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  ran:
+                    type: boolean
+                    description: Whether a job was enqueued
+                  jobId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - success
+                  - ran
+                  - jobId
+                additionalProperties: false
+  /v1/consolidation/runs:
+    get:
+      operationId: consolidation_runs_get
+      summary: List consolidation runs
+      description:
+        "Return recent memory v2 consolidation conversations as run records. Each consolidation dispatch creates
+        exactly one background conversation tagged with `source = memory_v2_consolidation`; that conversation IS the
+        run. Synthetic fields: `id` mirrors `conversationId` (no separate run row exists), `scheduledFor` and
+        `startedAt` both equal `conversation.createdAt` (no separate schedule timestamp), `finishedAt` is the
+        `createdAt` of the latest assistant message in the conversation (NOT `conversation.lastMessageAt`, which the
+        kickoff user prompt bumps before the agent runs). `status` is `'ok'` when the conversation has at least one
+        assistant message — i.e. positive evidence the agent emitted output — otherwise `'running'`. This is a weaker
+        signal than heartbeat's `'ok'`: without a dedicated runs table we cannot distinguish 'ran cleanly' from 'crashed
+        after emitting at least one assistant message'. `skipReason` and `error` are always null — skipped runs (lock
+        held, disabled, empty buffer) never create a conversation, and run failure detail is not stored on the
+        conversation row. Shape mirrors `heartbeat/runs` so the schedules settings UI can reuse its run-row component."
+      tags:
+        - consolidation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        scheduledFor:
+                          type: number
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        status:
+                          type: string
+                          enum:
+                            - ok
+                            - running
+                        skipReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdAt:
+                          type: number
+                      required:
+                        - id
+                        - scheduledFor
+                        - startedAt
+                        - finishedAt
+                        - durationMs
+                        - status
+                        - skipReason
+                        - error
+                        - conversationId
+                        - createdAt
+                      additionalProperties: false
+                    description: Consolidation run records
+                required:
+                  - runs
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max runs to return (default 20, max 100)
+  /v1/contact-channels/{contactChannelId}:
+    patch:
+      operationId: contactchannels_by_contactChannelId_patch
+      summary: Update a contact channel
+      description: Update status, policy, or reason on a contact's channel.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  contact:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Updated contact (if applicable)
+                required:
+                  - ok
+                  - contact
+                additionalProperties: false
+      parameters:
+        - name: contactChannelId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  description: Channel status
+                policy:
+                  type: string
+                  description: Channel policy
+                reason:
+                  type: string
+                  description: Reason for the change
+              required:
+                - status
+                - policy
+                - reason
+              additionalProperties: false
+  /v1/contacts:
+    get:
+      operationId: contacts_get
+      summary: List contacts
+      description: Return all contacts, optionally filtered by type or channel status.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  contacts:
+                    type: array
+                    items: {}
+                    description: Contact objects with channels and metadata
+                required:
+                  - ok
+                  - contacts
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max contacts to return (default 50)
+        - name: role
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by role (e.g. guardian)
+        - name: contactType
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by contact type (human or assistant)
+        - name: query
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Full-text search query
+        - name: channelAddress
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by channel address
+        - name: channelType
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by channel type
+  /v1/contacts/{id}:
+    get:
+      operationId: contacts_by_id_get
+      summary: Get a contact
+      description: Return a single contact with its channels and assistant metadata.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  contact:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Contact details
+                  assistantMetadata:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Assistant-side metadata
+                required:
+                  - ok
+                  - contact
+                  - assistantMetadata
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites:
+    get:
+      operationId: contacts_invites_get
+      summary: List invites
+      description: Return all invites, optionally filtered by sourceChannel or status.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invites:
+                    type: array
+                    items: {}
+                    description: Invite objects
+                required:
+                  - ok
+                  - invites
+                additionalProperties: false
+      parameters:
+        - name: sourceChannel
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by source channel
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by invite status
+    post:
+      operationId: contacts_invites_post
+      summary: Create an invite
+      description: Create a new invite. Supports voice invites when sourceChannel is "phone".
+      tags:
+        - contacts
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Created invite
+                required:
+                  - ok
+                  - invite
+                additionalProperties: false
+        "400":
+          description: Invalid invite parameters
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contactId:
+                  type: string
+                  description: Contact to invite
+                sourceChannel:
+                  type: string
+                  description: Source channel (e.g. phone)
+                note:
+                  type: string
+                  description: Optional note
+                maxUses:
+                  type: number
+                  description: Max redemptions
+                expiresInMs:
+                  type: number
+                  description: Expiry duration in ms
+                contactName:
+                  type: string
+                  description: Contact display name
+                expectedExternalUserId:
+                  type: string
+                  description: Expected user ID (E.164 for phone)
+                friendName:
+                  type: string
+                  description: Friend name for the invite
+                guardianName:
+                  type: string
+                  description: Guardian name
+              required:
+                - contactId
+              additionalProperties: false
+  /v1/contacts/invites/{id}:
+    delete:
+      operationId: contacts_invites_by_id_delete
+      summary: Revoke an invite
+      description: Revoke an invite by ID.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+        "404":
+          description: Invite not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/{id}/call:
+    post:
+      operationId: contacts_invites_by_id_call_post
+      summary: Trigger invite call
+      description: Trigger an outbound call for a phone invite.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  callSid:
+                    type: string
+                    description: Call SID from the provider
+                required:
+                  - ok
+                  - callSid
+                additionalProperties: false
+        "400":
+          description: Invite not eligible for outbound call
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/contacts/invites/redeem:
+    post:
+      operationId: contacts_invites_redeem_post
+      summary: Redeem an invite
+      description: Redeem an invite by token or voice code.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  invite:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Redeemed invite (token path)
+                  type:
+                    type: string
+                    description: Redemption type (voice path)
+                  memberId:
+                    type: string
+                    description: Member ID (voice path)
+                required:
+                  - ok
+                  - invite
+                  - type
+                  - memberId
+                additionalProperties: false
+        "400":
+          description: Invalid redemption parameters or failed redemption
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  description: Invite token (token-based redemption)
+                code:
+                  type: string
+                  description: Voice code (voice-code redemption)
+                callerExternalUserId:
+                  type: string
+                  description: Caller E.164 phone (voice-code)
+                externalUserId:
+                  type: string
+                  description: External user ID (token-based)
+                externalChatId:
+                  type: string
+                  description: External chat ID (token-based)
+                sourceChannel:
+                  type: string
+                  description: Source channel (token-based)
+                assistantId:
+                  type: string
+                  description: Assistant ID (voice-code)
+              required:
+                - token
+                - code
+                - callerExternalUserId
+                - externalUserId
+                - externalChatId
+                - sourceChannel
+                - assistantId
+              additionalProperties: false
+  /v1/contacts/merge:
+    post:
+      operationId: contacts_merge_post
+      summary: Merge two contacts
+      description: Merge two contacts, keeping one and absorbing the other.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  contact:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Merged contact
+                required:
+                  - ok
+                  - contact
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                keepId:
+                  type: string
+                  description: ID of the contact to keep
+                mergeId:
+                  type: string
+                  description: ID of the contact to merge into the kept one
+              required:
+                - keepId
+                - mergeId
               additionalProperties: false
   /v1/contacts/prompt:
     post:
@@ -2546,6 +4184,40 @@ paths:
                     - guardian
                     - trusted-contact
                     - unknown
+              additionalProperties: false
+  /v1/contacts/search:
+    post:
+      operationId: contacts_search_post
+      summary: Search contacts
+      description: Search contacts by query, channel address, or channel type.
+      tags:
+        - contacts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                channelAddress:
+                  type: string
+                channelType:
+                  type: string
+                limit:
+                  type: number
               additionalProperties: false
   /v1/content-source:
     post:
@@ -2656,6 +4328,15 @@ paths:
           schema:
             type: string
   /v1/conversations:
+    delete:
+      operationId: conversations_delete
+      summary: Clear all conversations
+      description: Permanently delete ALL conversations, messages, and memory.
+      tags:
+        - conversations
+      responses:
+        "204":
+          description: Successful response
     get:
       operationId: conversations_get
       summary: List conversations
@@ -2665,6 +4346,51 @@ paths:
       responses:
         "200":
           description: Successful response
+    post:
+      operationId: conversations_post
+      summary: Create a conversation
+      description: Create or get an existing conversation by key.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  conversationKey:
+                    type: string
+                  conversationType:
+                    type: string
+                  created:
+                    type: boolean
+                required:
+                  - id
+                  - conversationKey
+                  - conversationType
+                  - created
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                  description: Idempotency key for the conversation
+                conversationType:
+                  description: Only standard conversations are created by this endpoint
+                  type: string
+                  const: standard
+              required:
+                - conversationKey
+              additionalProperties: false
   /v1/conversations/{conversationId}/slack-channel/resolve:
     post:
       operationId: conversations_by_conversationId_slackchannel_resolve_post
@@ -2711,6 +4437,21 @@ paths:
           schema:
             type: string
   /v1/conversations/{id}:
+    delete:
+      operationId: conversations_by_id_delete
+      summary: Delete a conversation
+      description: Permanently delete a single conversation and its messages.
+      tags:
+        - conversations
+      responses:
+        "204":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
     get:
       operationId: conversations_by_id_get
       summary: Get conversation detail
@@ -2720,6 +4461,371 @@ paths:
       responses:
         "200":
           description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/analyze:
+    post:
+      operationId: conversations_by_id_analyze_post
+      summary: Analyze a conversation
+      description: Create a new conversation with a structured self-assessment of an existing conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/archive:
+    post:
+      operationId: conversations_by_id_archive_post
+      summary: Archive a conversation
+      description: Move a conversation to the archived state.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/cancel:
+    post:
+      operationId: conversations_by_id_cancel_post
+      summary: Cancel generation
+      description: Abort the in-progress assistant response for a conversation.
+      tags:
+        - conversations
+      responses:
+        "202":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  cancelled:
+                    type: boolean
+                  conversationId:
+                    type: string
+                required:
+                  - ok
+                  - cancelled
+                  - conversationId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/inference-profile:
+    put:
+      operationId: conversations_by_id_inferenceprofile_put
+      summary: Set conversation inference profile
+      description:
+        Override the LLM inference profile for a single conversation. Optionally supply ttlSeconds to create a
+        session-backed (expiring) override.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  profile:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  sessionId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  expiresAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  ttlSeconds:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  replaced:
+                    anyOf:
+                      - type: object
+                        properties:
+                          profile:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          sessionId:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                          expiresAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - profile
+                          - sessionId
+                          - expiresAt
+                        additionalProperties: false
+                      - type: "null"
+                required:
+                  - conversationId
+                  - profile
+                  - sessionId
+                  - expiresAt
+                  - replaced
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                ttlSeconds:
+                  anyOf:
+                    - type: number
+                      exclusiveMinimum: 0
+                    - type: "null"
+                sessionId:
+                  type: string
+                  format: uuid
+                  pattern: ^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$
+              required:
+                - profile
+              additionalProperties: false
+  /v1/conversations/{id}/name:
+    patch:
+      operationId: conversations_by_id_name_patch
+      summary: Rename a conversation
+      description: Update the display name of a conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+              additionalProperties: false
+  /v1/conversations/{id}/playground/compact:
+    post:
+      operationId: conversations_by_id_playground_compact_post
+      summary: Force compaction on a conversation (dev-only playground)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/playground/compaction-state:
+    get:
+      operationId: conversations_by_id_playground_compactionstate_get
+      summary: Read current compaction state for a conversation
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/playground/inject-compaction-failures:
+    post:
+      operationId: conversations_by_id_playground_injectcompactionfailures_post
+      summary: Directly mutate compaction circuit-breaker state (dev-only playground)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consecutiveFailures:
+                  type: integer
+                  minimum: 0
+                  maximum: 10
+                circuitOpenForMs:
+                  type: integer
+                  minimum: 0
+                  maximum: 86400000
+              additionalProperties: false
+  /v1/conversations/{id}/playground/reset-compaction-circuit:
+    post:
+      operationId: conversations_by_id_playground_resetcompactioncircuit_post
+      summary: Clear compaction circuit-breaker state (dev-only playground)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/regenerate:
+    post:
+      operationId: conversations_by_id_regenerate_post
+      summary: Regenerate response
+      description: Re-run the assistant for the last user message in a conversation.
+      tags:
+        - conversations
+      responses:
+        "202":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/unarchive:
+    post:
+      operationId: conversations_by_id_unarchive_post
+      summary: Unarchive a conversation
+      description: Restore an archived conversation back to the default sidebar.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/undo:
+    post:
+      operationId: conversations_by_id_undo_post
+      summary: Undo last message
+      description: Remove the most recent user+assistant message pair from the conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removedCount:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  conversationId:
+                    type: string
+                required:
+                  - removedCount
+                  - conversationId
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/conversations/{id}/wipe:
+    post:
+      operationId: conversations_by_id_wipe_post
+      summary: Wipe a conversation
+      description: Delete all messages in a conversation and revert associated memory changes.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  wiped:
+                    type: boolean
+                  unsupersededItems:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  deletedSummaries:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  cancelledJobs:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - wiped
+                  - unsupersededItems
+                  - deletedSummaries
+                  - cancelledJobs
+                additionalProperties: false
       parameters:
         - name: id
           in: path
@@ -2782,6 +4888,201 @@ paths:
           schema:
             type: number
           description: Cursor for pagination (timestamp)
+  /v1/conversations/cli/clear:
+    post:
+      operationId: conversations_cli_clear_post
+      summary: Clear all conversations (CLI)
+      description:
+        Tear down all active conversations and clear the database. The confirmation prompt is handled client-side
+        by the CLI.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cleared:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                required:
+                  - cleared
+                additionalProperties: false
+  /v1/conversations/cli/create:
+    post:
+      operationId: conversations_cli_create_post
+      summary: Create a conversation (CLI)
+      description: Create a new conversation with an optional title and seeded messages.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  title:
+                    type: string
+                  conversationKey:
+                    type: string
+                  messagesInserted:
+                    type: integer
+                    minimum: 0
+                    maximum: 9007199254740991
+                required:
+                  - id
+                  - title
+                  - conversationKey
+                  - messagesInserted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                messages:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      role:
+                        type: string
+                        enum:
+                          - user
+                          - assistant
+                      content:
+                        type: string
+                    required:
+                      - role
+                      - content
+                    additionalProperties: false
+              additionalProperties: false
+  /v1/conversations/cli/export:
+    post:
+      operationId: conversations_cli_export_post
+      summary: Export a conversation (CLI)
+      description: Export a conversation as markdown or JSON. Returns the formatted output string.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    type: string
+                  conversationId:
+                    type: string
+                required:
+                  - output
+                  - conversationId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                format:
+                  default: md
+                  type: string
+                  enum:
+                    - md
+                    - json
+              additionalProperties: false
+  /v1/conversations/cli/list:
+    post:
+      operationId: conversations_cli_list_post
+      summary: List conversations (CLI)
+      description: Simplified conversation list for CLI output — returns id, title, updatedAt.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        updatedAt:
+                          type: number
+                      required:
+                        - id
+                        - title
+                        - updatedAt
+                      additionalProperties: false
+                required:
+                  - conversations
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                includeArchived:
+                  type: boolean
+              additionalProperties: false
+  /v1/conversations/fork:
+    post:
+      operationId: conversations_fork_post
+      summary: Fork a conversation
+      description: Create a copy of a conversation, optionally truncated at a specific message.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                throughMessageId:
+                  type: string
+                  description: Truncate the fork at this message
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/import:
     post:
       operationId: conversations_import_post
@@ -3107,6 +5408,73 @@ paths:
                 - conversationId
                 - title
               additionalProperties: false
+  /v1/conversations/reorder:
+    post:
+      operationId: conversations_reorder_post
+      summary: Reorder conversations
+      description: Batch-update display order and pin state for conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updates:
+                  type: array
+                  items: {}
+                  description: Array of { conversationId, displayOrder?, isPinned? } objects
+              required:
+                - updates
+              additionalProperties: false
+  /v1/conversations/search:
+    get:
+      operationId: conversations_search_get
+      summary: Search conversations
+      description: Full-text search across conversation titles and message content.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max results
+        - name: maxMessagesPerConversation
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max messages per conversation
   /v1/conversations/seen:
     post:
       operationId: conversations_seen_post
@@ -3117,6 +5485,49 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/conversations/switch:
+    post:
+      operationId: conversations_switch_post
+      summary: Switch active conversation
+      description: Set the active conversation for the current session.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  title:
+                    type: string
+                  conversationType:
+                    type: string
+                  inferenceProfile:
+                    type: string
+                required:
+                  - conversationId
+                  - title
+                  - conversationType
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                conversationKey:
+                  type: string
+                  description: Optional key to register for this conversation
+              required:
+                - conversationId
+              additionalProperties: false
   /v1/conversations/unread:
     post:
       operationId: conversations_unread_post
@@ -3171,6 +5582,48 @@ paths:
               required:
                 - conversationId
                 - hint
+              additionalProperties: false
+  /v1/conversations/wipe:
+    post:
+      operationId: conversations_wipe_post
+      summary: Wipe a conversation
+      description: Permanently delete a conversation and its associated data including memory vectors.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  wiped:
+                    type: boolean
+                  unsupersededItems:
+                    type: number
+                  deletedSummaries:
+                    type: number
+                  cancelledJobs:
+                    type: number
+                required:
+                  - wiped
+                  - unsupersededItems
+                  - deletedSummaries
+                  - cancelledJobs
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  minLength: 1
+              required:
+                - conversationId
               additionalProperties: false
   /v1/credentials/delete:
     post:
@@ -4892,6 +7345,79 @@ paths:
                   description: Upper bound epoch ms
                   type: number
               additionalProperties: false
+  /v1/filing/config:
+    get:
+      operationId: filing_config_get
+      summary: Get filing config
+      description: Return the current filing schedule configuration.
+      tags:
+        - filing
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  activeHoursStart:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  activeHoursEnd:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - available
+                  - enabled
+                  - intervalMs
+                  - activeHoursStart
+                  - activeHoursEnd
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+  /v1/filing/run-now:
+    post:
+      operationId: filing_runnow_post
+      summary: Run filing now
+      description: Trigger an immediate filing run.
+      tags:
+        - filing
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  ran:
+                    type: boolean
+                    description: Whether the filing actually ran
+                required:
+                  - success
+                  - ran
+                additionalProperties: false
   /v1/gateway/logs/tail:
     get:
       operationId: gateway_logs_tail_get
@@ -5042,6 +7568,87 @@ paths:
               required:
                 - updates
               additionalProperties: false
+  /v1/guardian-actions/decision:
+    post:
+      operationId: guardianactions_decision_post
+      summary: Submit guardian decision
+      description: Submit a guardian action decision (approve/reject).
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  applied:
+                    type: boolean
+                  requestId:
+                    type: string
+                  reason:
+                    description: Decline reason (present only when applied is false)
+                    type: string
+                  replyText:
+                    description: Resolver reply text for the guardian (e.g. verification code)
+                    type: string
+                required:
+                  - applied
+                  - requestId
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Guardian request ID
+                action:
+                  type: string
+                  description: Decision action
+                conversationId:
+                  type: string
+                  description: Conversation ID
+              required:
+                - requestId
+                - action
+              additionalProperties: false
+  /v1/guardian-actions/pending:
+    get:
+      operationId: guardianactions_pending_get
+      summary: List pending guardian actions
+      description: Return pending guardian decision prompts for a conversation.
+      tags:
+        - guardian
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  prompts:
+                    type: array
+                    items: {}
+                    description: Guardian decision prompt objects
+                required:
+                  - conversationId
+                  - prompts
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID (required)
   /v1/health:
     get:
       operationId: health_get
@@ -5284,6 +7891,307 @@ paths:
                   - cpu
                   - migrations
                 additionalProperties: false
+  /v1/heartbeat/checklist:
+    get:
+      operationId: heartbeat_checklist_get
+      summary: Get heartbeat checklist
+      description: Return the HEARTBEAT.md checklist content.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: string
+                    description: Checklist markdown content
+                  isDefault:
+                    type: boolean
+                    description: True when no custom checklist exists
+                required:
+                  - content
+                  - isDefault
+                additionalProperties: false
+    put:
+      operationId: heartbeat_checklist_put
+      summary: Write heartbeat checklist
+      description: Overwrite the HEARTBEAT.md checklist content.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                  description: Checklist markdown content
+              required:
+                - content
+              additionalProperties: false
+  /v1/heartbeat/config:
+    get:
+      operationId: heartbeat_config_get
+      summary: Get heartbeat config
+      description: Return the current heartbeat schedule configuration.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  activeHoursStart:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  activeHoursEnd:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  cronExpression:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  timezone:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - enabled
+                  - intervalMs
+                  - activeHoursStart
+                  - activeHoursEnd
+                  - cronExpression
+                  - timezone
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+    put:
+      operationId: heartbeat_config_put
+      summary: Update heartbeat config
+      description: Update the heartbeat schedule configuration.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  activeHoursStart:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  activeHoursEnd:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  cronExpression:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  timezone:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - enabled
+                  - intervalMs
+                  - activeHoursStart
+                  - activeHoursEnd
+                  - cronExpression
+                  - timezone
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  description: Enable or disable heartbeat
+                  type: boolean
+                intervalMs:
+                  description: Heartbeat interval in ms
+                  type: number
+                activeHoursStart:
+                  description: Active hours start (0–23)
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                activeHoursEnd:
+                  description: Active hours end (0–23)
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                cronExpression:
+                  description: Cron expression for heartbeat timing, or null for fixed interval
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                timezone:
+                  description: Timezone for cron evaluation
+                  anyOf:
+                    - type: string
+                    - type: "null"
+              additionalProperties: false
+  /v1/heartbeat/run-now:
+    post:
+      operationId: heartbeat_runnow_post
+      summary: Run heartbeat now
+      description: Trigger an immediate heartbeat run.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  ran:
+                    type: boolean
+                    description: Whether the heartbeat actually ran
+                required:
+                  - success
+                  - ran
+                additionalProperties: false
+  /v1/heartbeat/runs:
+    get:
+      operationId: heartbeat_runs_get
+      summary: List heartbeat runs
+      description: Return recent heartbeat conversation runs.
+      tags:
+        - heartbeat
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        scheduledFor:
+                          type: number
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        status:
+                          type: string
+                        skipReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdAt:
+                          type: number
+                      required:
+                        - id
+                        - scheduledFor
+                        - startedAt
+                        - finishedAt
+                        - durationMs
+                        - status
+                        - skipReason
+                        - error
+                        - conversationId
+                        - createdAt
+                      additionalProperties: false
+                    description: Heartbeat run records
+                required:
+                  - runs
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max runs to return (default 20, max 100)
   /v1/home/feed:
     get:
       operationId: home_feed_get
@@ -5748,6 +8656,79 @@ paths:
                 additionalProperties: false
         "500":
           description: Failed to compute relationship state
+  /v1/host-app-control-result:
+    post:
+      operationId: hostappcontrolresult_post
+      summary: Submit host app-control result
+      description:
+        Resolve a pending host app-control request by requestId. Returns 200 even when no pending interaction
+        matches (late delivery is tolerated).
+      tags:
+        - host
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+        "400":
+          description: x-vellum-client-id header is missing for a targeted host app-control request.
+        "403":
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending app-control request ID
+                state:
+                  type: string
+                  enum:
+                    - running
+                    - missing
+                    - minimized
+                  description: Lifecycle state of the targeted application
+                pngBase64:
+                  type: string
+                  description: Base64 PNG screenshot of the targeted app window
+                windowBounds:
+                  type: object
+                  properties:
+                    x:
+                      type: number
+                    y:
+                      type: number
+                    width:
+                      type: number
+                    height:
+                      type: number
+                  required:
+                    - x
+                    - y
+                    - width
+                    - height
+                  additionalProperties: false
+                executionResult:
+                  type: string
+                executionError:
+                  type: string
+              required:
+                - requestId
+                - state
+              additionalProperties: false
   /v1/host-bash-result:
     post:
       operationId: hostbashresult_post
@@ -5917,6 +8898,74 @@ paths:
                 reason:
                   description: Detach reason
                   type: string
+              additionalProperties: false
+  /v1/host-cu-result:
+    post:
+      operationId: hostcuresult_post
+      summary: Submit host CU result
+      description: Resolve a pending host computer-use request by requestId.
+      tags:
+        - host
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+        "400":
+          description: x-vellum-client-id header is missing for a targeted host CU request.
+        "403":
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
+        "404":
+          description: No pending interaction found for the given requestId, or the conversation/proxy no longer exists.
+        "409":
+          description: Pending interaction exists but is of a different kind (e.g. host_bash, host_file).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending CU request ID
+                axTree:
+                  type: string
+                  description: Accessibility tree
+                axDiff:
+                  type: string
+                  description: Accessibility tree diff
+                screenshot:
+                  type: string
+                  description: Base64 screenshot
+                screenshotWidthPx:
+                  type: number
+                screenshotHeightPx:
+                  type: number
+                screenWidthPt:
+                  type: number
+                screenHeightPt:
+                  type: number
+                executionResult:
+                  type: string
+                executionError:
+                  type: string
+                secondaryWindows:
+                  type: string
+                userGuidance:
+                  type: string
+              required:
+                - requestId
               additionalProperties: false
   /v1/host-file-result:
     post:
@@ -7548,6 +10597,66 @@ paths:
           required: true
           schema:
             type: string
+  /v1/internal/twilio/connect-action:
+    post:
+      operationId: internal_twilio_connectaction_post
+      summary: Internal Twilio connect-action
+      description: Gateway-to-runtime forwarding for ConversationRelay connect-action callback.
+      tags:
+        - internal
+      responses:
+        "200":
+          description: Successful response
+  /v1/internal/twilio/status:
+    post:
+      operationId: internal_twilio_status_post
+      summary: Internal Twilio status callback
+      description: Gateway-to-runtime forwarding for Twilio call status updates. Accepts pre-parsed form params as JSON.
+      tags:
+        - internal
+      responses:
+        "200":
+          description: Successful response
+  /v1/internal/twilio/voice-webhook:
+    post:
+      operationId: internal_twilio_voicewebhook_post
+      summary: Internal Twilio voice webhook
+      description: Gateway-to-runtime forwarding for Twilio voice webhook. Accepts pre-parsed form params as JSON.
+      tags:
+        - internal
+      responses:
+        "200":
+          description: Successful response
+  /v1/llm-request-logs/{id}/payload:
+    get:
+      operationId: llmrequestlogs_by_id_payload_get
+      summary: Get raw payload for a single LLM request log
+      description: Return the full request and response payloads for a specific log entry.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  requestPayload: {}
+                  responsePayload: {}
+                required:
+                  - id
+                  - requestPayload
+                  - responsePayload
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/logs/export:
     post:
       operationId: logs_export_post
@@ -7792,6 +10901,309 @@ paths:
                 importance:
                   type: number
               additionalProperties: false
+  /v1/memory/v2/backfill:
+    post:
+      operationId: memory_v2_backfill_post
+      summary: Enqueue a memory v2 backfill job
+      description:
+        Enqueues one of four operator-triggered backfill jobs (migrate, rebuild-edges, reembed,
+        activation-recompute) against the memory jobs queue.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                op:
+                  type: string
+                  enum:
+                    - migrate
+                    - reembed
+                    - activation-recompute
+                force:
+                  type: boolean
+              required:
+                - op
+              additionalProperties: false
+  /v1/memory/v2/concept-frequency:
+    post:
+      operationId: memory_v2_conceptfrequency_post
+      summary: Aggregate per-concept injection frequency from activation logs
+      description:
+        "Debug-only. Aggregates the existing memory_v2_activation_logs table by (slug, status) and cross-references
+        on-disk concept pages so an operator can see which concepts get injected often, which get scored but rejected,
+        and which on-disk pages never even surface as candidates. Optional filters: conversationId narrows to a single
+        conversation; sinceMs restricts to logs created at-or-after the given epoch ms timestamp."
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  minLength: 1
+                sinceMs:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+              additionalProperties: false
+  /v1/memory/v2/concept-page:
+    post:
+      operationId: memory_v2_conceptpage_post
+      summary: Read a single memory v2 concept page
+      description:
+        Returns the rendered (frontmatter + body) markdown for a slug. 404 when the slug has no on-disk page — the
+        activation log inspector uses this to show what got injected.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slug:
+                  type: string
+                  minLength: 1
+              required:
+                - slug
+              additionalProperties: false
+  /v1/memory/v2/list-concept-pages:
+    post:
+      operationId: memory_v2_listconceptpages_post
+      summary: List all memory v2 concept pages with metadata
+      description:
+        Returns slugs, body sizes, edge counts, and last-modified timestamps for every concept page on disk.
+        Read-only; used by the desktop About → Memories surface to render a browse-able list.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
+  /v1/memory/v2/reembed-skills:
+    post:
+      operationId: memory_v2_reembedskills_post
+      summary: Re-seed v2 skill entries from the current skill catalog
+      description: Synchronously re-runs seedV2SkillEntries against the current skill catalog. Gated on config.memory.v2.enabled.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
+  /v1/memory/v2/validate:
+    post:
+      operationId: memory_v2_validate_post
+      summary: Validate memory v2 workspace state
+      description:
+        Read-only structural validation of the v2 workspace — reports orphan edges, oversized pages, and parse
+        failures. Runnable regardless of memory.v2.enabled so operators can dry-run validation before flipping the flag.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
+  /v1/messages:
+    get:
+      operationId: messages_get
+      summary: List messages
+      description: Return messages for a conversation, including attachments and interface file metadata.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items: {}
+                    description: Array of message objects
+                  hasMore:
+                    description: Whether older messages exist beyond this page
+                    type: boolean
+                  oldestTimestamp:
+                    description:
+                      Timestamp of the oldest message in this page (ms since epoch). Null when page=latest is used on an empty
+                      conversation.
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  oldestMessageId:
+                    description: ID of the oldest message in this page
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - messages
+                additionalProperties: false
+    post:
+      operationId: messages_post
+      summary: Send a message
+      description: Send a user message to a conversation and trigger the assistant response.
+      tags:
+        - messages
+      responses:
+        "202":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationKey:
+                  type: string
+                content:
+                  type: string
+                  description: Message text content
+                attachments:
+                  type: array
+                  items: {}
+                  description: Optional file attachments
+                conversationType:
+                  type: string
+                slashCommand:
+                  type: string
+                clientTimezone:
+                  type: string
+                inferenceProfile:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                riskThreshold:
+                  type: string
+                  enum:
+                    - none
+                    - low
+                    - medium
+                    - high
+              required:
+                - content
+              additionalProperties: false
+  /v1/messages/{id}/content:
+    get:
+      operationId: messages_by_id_content_get
+      summary: Get message content
+      description: Return the full content of a single message by ID.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional conversation ID filter
+  /v1/messages/{id}/llm-context:
+    get:
+      operationId: messages_by_id_llmcontext_get
+      summary: Get LLM context for a message
+      description: Return request/response logs and memory recall data for a specific message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messageId:
+                    type: string
+                  conversationKind:
+                    type: string
+                    enum:
+                      - user
+                      - background
+                      - background_memory_consolidation
+                      - scheduled
+                  conversationTotalEstimatedCostUsd:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  logs:
+                    type: array
+                    items: {}
+                  memoryRecall:
+                    anyOf:
+                      - type: object
+                        properties: {}
+                        additionalProperties: {}
+                      - type: "null"
+                  memoryV2Activation:
+                    anyOf:
+                      - type: object
+                        properties: {}
+                        additionalProperties: {}
+                      - type: "null"
+                required:
+                  - messageId
+                  - conversationKind
+                  - conversationTotalEstimatedCostUsd
+                  - logs
+                  - memoryRecall
+                  - memoryV2Activation
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/messages/{messageId}/tts:
     post:
       operationId: messages_by_messageId_tts_post
@@ -7814,6 +11226,50 @@ paths:
           schema:
             type: string
           description: Conversation that contains the message
+  /v1/messages/queued/{id}:
+    delete:
+      operationId: messages_queued_by_id_delete
+      summary: Delete a queued message
+      description: Remove a pending message from the conversation queue before it is processed.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Conversation ID (required)
+  /v1/messages/queued/{id}/steer:
+    post:
+      operationId: messages_queued_by_id_steer_post
+      summary: Steer to a queued message
+      description: Promote a queued message to the head of the queue and abort the current generation so it is processed next.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Conversation ID (required)
   /v1/migrations/export:
     post:
       operationId: migrations_export_post
@@ -8143,6 +11599,38 @@ paths:
                   - errors
                   - manifest
                 additionalProperties: false
+  /v1/model:
+    get:
+      operationId: model_get
+      summary: Get current model config
+      description: Return the active LLM model ID, provider, and available models.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+  /v1/model/image-gen:
+    put:
+      operationId: model_imagegen_put
+      summary: Set image generation model
+      description: Change the active image generation model.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                modelId:
+                  type: string
+              required:
+                - modelId
+              additionalProperties: false
   /v1/notification-intent-result:
     post:
       operationId: notificationintentresult_post
@@ -8719,6 +12207,68 @@ paths:
           required: true
           schema:
             type: string
+  /v1/pending-interactions:
+    get:
+      operationId: pendinginteractions_get
+      summary: List pending interactions
+      description:
+        Return pending interactions. When conversationKey or conversationId is provided, returns details for that
+        conversation. When neither is provided, returns all pending interactions.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pendingConfirmation:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending confirmation details or null
+                  pendingSecret:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Pending secret request or null
+                  interactions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        requestId:
+                          type: string
+                        conversationId:
+                          type: string
+                        kind:
+                          type: string
+                        toolName:
+                          type: string
+                        riskLevel:
+                          type: string
+                      required:
+                        - requestId
+                        - conversationId
+                        - kind
+                      additionalProperties: false
+                    description: All pending interactions (returned when no filters given)
+                additionalProperties: false
+      parameters:
+        - name: conversationKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation key (optional)
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Conversation ID (optional)
   /v1/platform/callback-routes:
     get:
       operationId: platform_callbackroutes_get
@@ -8769,6 +12319,69 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/playground/seed-conversation:
+    post:
+      operationId: playground_seedconversation_post
+      summary: Create a synthetic seeded conversation for compaction testing
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                turns:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 500
+                avgTokensPerTurn:
+                  default: 500
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 5000
+                title:
+                  type: string
+                  maxLength: 120
+              required:
+                - turns
+              additionalProperties: false
+  /v1/playground/seeded-conversations:
+    delete:
+      operationId: playground_seededconversations_delete
+      summary: Delete every seeded playground conversation (prefix-gated)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+    get:
+      operationId: playground_seededconversations_get
+      summary: List conversations created by the seed-conversation endpoint
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+  /v1/playground/seeded-conversations/{id}:
+    delete:
+      operationId: playground_seededconversations_by_id_delete
+      summary: Delete a single seeded conversation (prefix-gated)
+      tags:
+        - playground
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/profiler/runs:
     get:
       operationId: profiler_runs_get
@@ -9373,6 +12986,347 @@ paths:
                 projectId:
                   type: string
               additionalProperties: false
+  /v1/schedules:
+    get:
+      operationId: schedules_get
+      summary: List schedules
+      description: Return all scheduled jobs.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Schedule objects
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: include_all
+          in: query
+          required: false
+          schema:
+            type: string
+          description: When 'true', include deferred schedules that are normally hidden.
+    post:
+      operationId: schedules_post
+      summary: Create schedule
+      description: Create a new recurring schedule. Currently restricted to mode='execute'.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Display name
+                expression:
+                  type: string
+                  description: Cron or RRULE expression
+                message:
+                  type: string
+                  description: Message body to execute on each fire
+                timezone:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  description: IANA timezone, e.g. America/New_York
+                enabled:
+                  type: boolean
+                  description: Whether the schedule starts active (default true)
+                mode:
+                  type: string
+                  description: Currently must be 'execute'
+              required:
+                - name
+                - expression
+                - message
+              additionalProperties: false
+  /v1/schedules/{id}:
+    delete:
+      operationId: schedules_by_id_delete
+      summary: Delete schedule
+      description: Remove a schedule by ID.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: schedules_by_id_patch
+      summary: Update schedule
+      description: Partially update fields on a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                expression:
+                  type: string
+                timezone:
+                  type: string
+                message:
+                  type: string
+                script:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  description: Shell command for script mode
+                mode:
+                  type: string
+                  description: notify, execute, or script
+                routingIntent:
+                  type: string
+                  description: single_channel, multi_channel, or all_channels
+                quiet:
+                  type: boolean
+                reuseConversation:
+                  type: boolean
+                maxRetries:
+                  type: number
+                  description: Maximum retry attempts
+                retryBackoffMs:
+                  type: number
+                  description: Retry backoff in milliseconds
+              required:
+                - name
+                - expression
+                - timezone
+                - message
+                - script
+                - mode
+                - routingIntent
+                - quiet
+                - reuseConversation
+                - maxRetries
+                - retryBackoffMs
+              additionalProperties: false
+  /v1/schedules/{id}/cancel:
+    post:
+      operationId: schedules_by_id_cancel_post
+      summary: Cancel schedule
+      description: Cancel a pending schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/run:
+    post:
+      operationId: schedules_by_id_run_post
+      summary: Run schedule now
+      description: Trigger an immediate execution of a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/schedules/{id}/runs:
+    get:
+      operationId: schedules_by_id_runs_get
+      summary: List schedule runs
+      description: Return recent invocation history for a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items: {}
+                    description: Schedule run objects
+                required:
+                  - runs
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max runs to return (default 10, max 100)
+  /v1/schedules/{id}/toggle:
+    post:
+      operationId: schedules_by_id_toggle_post
+      summary: Toggle schedule
+      description: Enable or disable a schedule.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedules:
+                    type: array
+                    items: {}
+                    description: Updated schedule list
+                required:
+                  - schedules
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: New enabled state
+              required:
+                - enabled
+              additionalProperties: false
+  /v1/search:
+    get:
+      operationId: search_get
+      summary: Search conversations
+      description: Full-text search across all conversations.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  query:
+                    type: string
+                  results:
+                    type: array
+                    items: {}
+                required:
+                  - query
+                  - results
+                additionalProperties: false
   /v1/search/global:
     get:
       operationId: search_global_get
@@ -9424,6 +13378,45 @@ paths:
           schema:
             type: string
           description: Enable semantic search for memories (true/false)
+  /v1/secret:
+    post:
+      operationId: secret_post
+      summary: Resolve a pending secret request
+      description: Provide a secret value for a pending secret request.
+      tags:
+        - approvals
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending interaction request ID
+                value:
+                  type: string
+                  description: Secret value
+                delivery:
+                  type: string
+                  description: "Delivery mode: store or transient_send"
+              required:
+                - requestId
+              additionalProperties: false
   /v1/secrets:
     delete:
       operationId: secrets_delete
@@ -9825,6 +13818,1142 @@ paths:
               required:
                 - activationKey
               additionalProperties: false
+  /v1/skills:
+    get:
+      operationId: skills_get
+      summary: List all skills
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills. Supports
+        optional filter params: origin, kind, q, category."
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects
+                  categoryCounts:
+                    description: Count of skills per category (before category filter is applied)
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: number
+                  totalCount:
+                    description: Total number of skills matching non-category filters
+                    type: number
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - catalog
+          description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
+        - name: origin
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by skill origin (e.g. 'vellum', 'clawhub', 'skillssh', 'custom').
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Filter by kind: 'installed' (includes bundled), 'available', or pass through as skill.kind."
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Text search across skill name, description, id, and origin label.
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by inferred category (e.g. 'communication', 'productivity').
+    post:
+      operationId: skills_post
+      summary: Create skill
+      description: Create a new skill.
+      tags:
+        - skills
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                skillId:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+                bodyMarkdown:
+                  type: string
+              required:
+                - skillId
+                - name
+                - description
+                - bodyMarkdown
+              additionalProperties: false
+  /v1/skills/{id}:
+    delete:
+      operationId: skills_by_id_delete
+      summary: Uninstall skill
+      description: Remove an installed skill.
+      tags:
+        - skills
+      responses:
+        "204":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: skills_by_id_get
+      summary: Get skill
+      description: Return a single skill by ID with enriched detail fields.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skill:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: vellum
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: clawhub
+                          slug:
+                            type: string
+                          author:
+                            type: string
+                          stars:
+                            type: number
+                          installs:
+                            type: number
+                          reports:
+                            type: number
+                          publishedAt:
+                            type: string
+                          version:
+                            type: string
+                          owner:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  handle:
+                                    type: string
+                                  displayName:
+                                    type: string
+                                  image:
+                                    type: string
+                                required:
+                                  - handle
+                                  - displayName
+                                additionalProperties: false
+                              - type: "null"
+                          stats:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  stars:
+                                    type: number
+                                  installs:
+                                    type: number
+                                  downloads:
+                                    type: number
+                                  versions:
+                                    type: number
+                                required:
+                                  - stars
+                                  - installs
+                                  - downloads
+                                  - versions
+                                additionalProperties: false
+                              - type: "null"
+                          latestVersion:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  version:
+                                    type: string
+                                  changelog:
+                                    type: string
+                                required:
+                                  - version
+                                additionalProperties: false
+                              - type: "null"
+                          createdAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          updatedAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - author
+                          - stars
+                          - installs
+                          - reports
+                          - version
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: skillssh
+                          slug:
+                            type: string
+                          sourceRepo:
+                            type: string
+                          installs:
+                            type: number
+                          audit:
+                            type: object
+                            propertyNames:
+                              type: string
+                            additionalProperties:
+                              type: object
+                              properties:
+                                risk:
+                                  type: string
+                                  enum:
+                                    - safe
+                                    - low
+                                    - medium
+                                    - high
+                                    - critical
+                                    - unknown
+                                alerts:
+                                  type: number
+                                score:
+                                  type: number
+                                analyzedAt:
+                                  type: string
+                              required:
+                                - risk
+                                - analyzedAt
+                              additionalProperties: false
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - sourceRepo
+                          - installs
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                    description: Skill detail object
+                required:
+                  - skill
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/config:
+    patch:
+      operationId: skills_by_id_config_patch
+      summary: Configure skill
+      description: Update skill configuration (env, apiKey, config).
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                env:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Environment variables
+                apiKey:
+                  type: string
+                config:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Arbitrary config
+              required:
+                - env
+                - apiKey
+                - config
+              additionalProperties: false
+  /v1/skills/{id}/disable:
+    post:
+      operationId: skills_by_id_disable_post
+      summary: Disable skill
+      description: Disable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/enable:
+    post:
+      operationId: skills_by_id_enable_post
+      summary: Enable skill
+      description: Enable an installed skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files:
+    get:
+      operationId: skills_by_id_files_get
+      summary: Get skill files
+      description: Return skill metadata and directory contents.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/files/content:
+    get:
+      operationId: skills_by_id_files_content_get
+      summary: Get skill file content
+      description: Return the content of a single file belonging to an installed or catalog skill.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  name:
+                    type: string
+                  size:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                  mimeType:
+                    type: string
+                  isBinary:
+                    type: boolean
+                  content:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - path
+                  - name
+                  - size
+                  - mimeType
+                  - isBinary
+                  - content
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Relative path of the file within the skill directory
+  /v1/skills/{id}/inspect:
+    get:
+      operationId: skills_by_id_inspect_get
+      summary: Inspect skill
+      description: Return detailed skill information.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/local-inspect:
+    get:
+      operationId: skills_by_id_localinspect_get
+      summary: Local skill inspect
+      description:
+        Return full local detail for an installed or bundled skill, including featureFlag, toolManifest,
+        installMeta, configEntry, and directoryPath.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/{id}/update:
+    post:
+      operationId: skills_by_id_update_post
+      summary: Update skill
+      description: Update an installed skill to the latest version.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/skills/check-updates:
+    post:
+      operationId: skills_checkupdates_post
+      summary: Check skill updates
+      description: Check for available updates to installed skills.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Update availability info
+                required:
+                  - data
+                additionalProperties: false
+  /v1/skills/draft:
+    post:
+      operationId: skills_draft_post
+      summary: Draft a skill
+      description: Generate a skill draft from source text.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sourceText:
+                  type: string
+                  description: Source text for drafting
+              required:
+                - sourceText
+              additionalProperties: false
+  /v1/skills/install:
+    post:
+      operationId: skills_install_post
+      summary: Install skill
+      description: Install a skill by slug, URL, or spec.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  skillId:
+                    type: string
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slug:
+                  type: string
+                  description: Skill slug
+                url:
+                  type: string
+                  description: Skill URL
+                spec:
+                  type: string
+                  description: Skill spec
+                version:
+                  type: string
+                origin:
+                  description: Which registry to install from. When omitted, the install flow auto-detects based on slug format.
+                  type: string
+                  enum:
+                    - clawhub
+                    - skillssh
+                overwrite:
+                  description: Replace an existing install. Defaults to true for back-compat with the legacy in-process API.
+                  type: boolean
+                catalogOnly:
+                  description:
+                    When true, restrict to bundled and Vellum catalog skills only — do not fall through to community
+                    registries.
+                  type: boolean
+              required:
+                - slug
+                - url
+                - spec
+                - version
+              additionalProperties: false
+  /v1/skills/search:
+    get:
+      operationId: skills_search_get
+      summary: Search skill catalog
+      description: Search the skill catalog by query string.
+      tags:
+        - skills
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skills:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                            - version
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                            audit:
+                              type: object
+                              propertyNames:
+                                type: string
+                              additionalProperties:
+                                type: object
+                                properties:
+                                  risk:
+                                    type: string
+                                    enum:
+                                      - safe
+                                      - low
+                                      - medium
+                                      - high
+                                      - critical
+                                      - unknown
+                                  alerts:
+                                    type: number
+                                  score:
+                                    type: number
+                                  analyzedAt:
+                                    type: string
+                                required:
+                                  - risk
+                                  - analyzedAt
+                                additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
+                    description: Skill objects matching the search query
+                required:
+                  - skills
+                additionalProperties: false
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query (required)
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Max community results to fetch (default 25)
   /v1/slack/channels:
     get:
       operationId: slack_channels_get
@@ -9974,6 +15103,341 @@ paths:
               required:
                 - filePath
               additionalProperties: false
+  /v1/subagents/{id}:
+    get:
+      operationId: subagents_by_id_get
+      summary: Get subagent detail
+      description: Return subagent objective and event history.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  objective:
+                    type: string
+                  usage:
+                    type: object
+                    properties:
+                      inputTokens:
+                        type: number
+                      outputTokens:
+                        type: number
+                      estimatedCost:
+                        type: number
+                    required:
+                      - inputTokens
+                      - outputTokens
+                      - estimatedCost
+                    additionalProperties: false
+                  events:
+                    type: array
+                    items: {}
+                    description: Subagent event objects
+                required:
+                  - subagentId
+                  - objective
+                  - events
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent conversation ID (required)
+  /v1/subagents/{id}/abort:
+    post:
+      operationId: subagents_by_id_abort_post
+      summary: Abort subagent
+      description: Abort a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  aborted:
+                    type: boolean
+                required:
+                  - subagentId
+                  - aborted
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/subagents/{id}/message:
+    post:
+      operationId: subagents_by_id_message_post
+      summary: Send message to subagent
+      description: Send a text message to a running subagent.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagentId:
+                    type: string
+                  sent:
+                    type: boolean
+                required:
+                  - subagentId
+                  - sent
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                content:
+                  type: string
+              required:
+                - conversationId
+                - content
+              additionalProperties: false
+  /v1/subagents/reconcile:
+    get:
+      operationId: subagents_reconcile_get
+      summary: Reconcile subagent live status
+      description:
+        Returns the live in-memory status of all subagents known to the daemon for a given parent conversation.
+        Subagents not in the response are orphaned.
+      tags:
+        - subagents
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subagents:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                      required:
+                        - status
+                      additionalProperties: false
+                required:
+                  - subagents
+                additionalProperties: false
+      parameters:
+        - name: parentConversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent conversation ID
+  /v1/suggestion:
+    get:
+      operationId: suggestion_get
+      summary: Get reply suggestion
+      description: Return an LLM-generated follow-up suggestion for the most recent assistant message.
+      tags:
+        - messages
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  suggestion:
+                    type: string
+                  messageId:
+                    type: string
+                  source:
+                    type: string
+                required:
+                  - suggestion
+                  - messageId
+                  - source
+                additionalProperties: false
+  /v1/surface-actions:
+    post:
+      operationId: surfaceactions_post
+      summary: Trigger a surface action
+      description: Execute an interactive action on a surface (e.g. button click, form submit).
+      tags:
+        - surfaces
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  conversationId:
+                    type: string
+                    description: Id of a newly launched conversation when the action dispatched one. Omitted otherwise.
+                required:
+                  - ok
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  description: Conversation that owns the surface
+                surfaceId:
+                  type: string
+                  description: Surface to act on
+                actionId:
+                  type: string
+                  description: Action identifier
+                data:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+                  description: Action-specific payload
+              required:
+                - surfaceId
+                - actionId
+              additionalProperties: false
+  /v1/surfaces/{id}/undo:
+    post:
+      operationId: surfaces_by_id_undo_post
+      summary: Undo last surface action
+      description: Revert the most recent action on a surface.
+      tags:
+        - surfaces
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  description: Conversation that owns the surface
+              required:
+                - conversationId
+              additionalProperties: false
+  /v1/surfaces/{surfaceId}:
+    get:
+      operationId: surfaces_by_surfaceId_get
+      summary: Get surface content
+      description: Return the full surface payload from the conversation's in-memory surface state.
+      tags:
+        - surfaces
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  surfaceId:
+                    type: string
+                  surfaceType:
+                    type: string
+                  title:
+                    type: string
+                  data:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                    description: Surface data payload
+                required:
+                  - surfaceId
+                  - surfaceType
+                  - title
+                  - data
+                additionalProperties: false
+      parameters:
+        - name: surfaceId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: conversationId
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Conversation that owns the surface
   /v1/tasks/delete:
     post:
       operationId: tasks_delete_post
@@ -10795,6 +16259,68 @@ paths:
               required:
                 - text
               additionalProperties: false
+  /v1/ui/request:
+    post:
+      operationId: ui_request_post
+      summary: Present an interactive UI surface
+      description: Present an interactive UI surface to the user and await their response.
+      tags:
+        - ui
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  minLength: 1
+                surfaceType:
+                  type: string
+                  enum:
+                    - confirmation
+                    - form
+                title:
+                  type: string
+                data:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                actions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        minLength: 1
+                      label:
+                        type: string
+                        minLength: 1
+                      variant:
+                        type: string
+                        enum:
+                          - primary
+                          - danger
+                          - secondary
+                    required:
+                      - id
+                      - label
+                    additionalProperties: false
+                timeoutMs:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+              required:
+                - conversationId
+                - surfaceType
+                - data
+              additionalProperties: false
   /v1/usage/breakdown:
     get:
       operationId: usage_breakdown_get
@@ -11211,6 +16737,272 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/work-items:
+    get:
+      operationId: workitems_get
+      summary: List work items
+      description: Return work items, optionally filtered by status.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: {}
+                required:
+                  - items
+                additionalProperties: false
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - pending
+              - running
+              - awaiting_review
+              - done
+              - failed
+              - cancelled
+              - archived
+          description: Filter by work item status
+  /v1/work-items/{id}:
+    delete:
+      operationId: workitems_by_id_delete
+      summary: Delete a work item
+      description: Permanently remove a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: workitems_by_id_get
+      summary: Get a work item
+      description: Return a single work item by ID.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: workitems_by_id_patch
+      summary: Update a work item
+      description: Partially update a work item's title, notes, status, or priority.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                notes:
+                  type: string
+                status:
+                  type: string
+                priorityTier:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+                sortIndex:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+              required:
+                - title
+                - notes
+                - status
+                - priorityTier
+                - sortIndex
+              additionalProperties: false
+  /v1/work-items/{id}/approve-permissions:
+    post:
+      operationId: workitems_by_id_approvepermissions_post
+      summary: Approve tool permissions
+      description: Pre-approve a set of tools for a work item before it runs.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approvedTools:
+                  type: array
+                  items: {}
+                  description: Array of tool names to approve
+              required:
+                - approvedTools
+              additionalProperties: false
+  /v1/work-items/{id}/cancel:
+    post:
+      operationId: workitems_by_id_cancel_post
+      summary: Cancel a running work item
+      description: Abort a running work item and set its status to cancelled.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+        "404":
+          description: Work item not found
+        "409":
+          description: Work item is not running
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/complete:
+    post:
+      operationId: workitems_by_id_complete_post
+      summary: Complete a work item
+      description: Transition a work item from awaiting_review to done.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/output:
+    get:
+      operationId: workitems_by_id_output_get
+      summary: Get work item output
+      description: Return the final output of a completed work item run.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  output:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - output
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/preflight:
+    post:
+      operationId: workitems_by_id_preflight_post
+      summary: Preflight check
+      description: Check tool permissions needed before running a work item.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                  permissions:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                required:
+                  - id
+                  - success
+                  - permissions
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/work-items/{id}/run:
+    post:
+      operationId: workitems_by_id_run_post
+      summary: Run a work item
+      description: Execute the task associated with a work item. Returns immediately; execution happens in the background.
+      tags:
+        - work-items
+      responses:
+        "200":
+          description: Successful response
+        "403":
+          description: Required tool permissions not approved
+        "404":
+          description: Work item or associated task not found
+        "409":
+          description: Work item is already running or not runnable
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/workspace-files:
     get:
       operationId: workspacefiles_get

--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -257,7 +257,7 @@ const anthropicStub = { name: "anthropic" };
 mock.module("../providers/registry.js", () => ({
   getProvider: () => anthropicStub,
   listProviders: () => ["anthropic"],
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
   resolveProviderFromConnection: async () => anthropicStub,
 }));
 

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -50,7 +50,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -155,6 +155,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationSlackContextWatermark: mock(() => {}),
   updateConversationTitle: mock(() => {}),
   updateConversationUsage: mock(() => {}),
+  setLastNotifiedInferenceProfile: mock(() => {}),
   wipeConversation: mock(() => ({ memoryIds: [] })),
 }));
 

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -52,7 +52,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -117,7 +117,7 @@ mock.module("../providers/registry.js", () => ({
   getProvider: () => undefined,
   listProviders: () => [],
   getProviderRoutingSource: () => undefined,
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
   // Required by `providers/inference/connections.ts` and
   // `providers/connection-resolution.ts`, both loaded transitively when
   // ConfigWatcher's deps resolve. Without these, the import chain throws

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -19,7 +19,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -169,6 +169,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   getConversationOriginChannel: () => null,
   getMessageById: () => null,
   getLastUserTimestampBefore: () => 0,
+  setLastNotifiedInferenceProfile: () => {},
 }));
 
 mock.module("../memory/conversation-disk-view.js", () => ({

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -195,6 +195,9 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateMessageContent: () => {},
   updateMessageMetadata: () => {},
   clearStrippedInjectionMetadataForConversation: () => {},
+  setLastNotifiedInferenceProfile: () => {},
+  getLastUserTimestampBefore: () => 0,
+  getConversationOverrideProfileFromRow: () => undefined,
 }));
 
 afterAll(() => {

--- a/assistant/src/__tests__/conversation-app-control-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-lifecycle.test.ts
@@ -22,7 +22,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -51,7 +51,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -8,7 +8,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -10,7 +10,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -43,7 +43,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 const mockProviderStub = { name: "mock-provider" };
 mock.module("../providers/registry.js", () => ({
   getProvider: () => mockProviderStub,
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
   listProviders: () => ["anthropic", "openai", "gemini"],
   resolveProviderFromConnection: async () => mockProviderStub,
 }));

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -18,7 +18,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -41,7 +41,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -28,7 +28,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -24,7 +24,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -48,7 +48,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 // Controllable config mock — speed and feature flag behavior are test-specific.

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -18,7 +18,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -27,7 +27,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -141,6 +141,10 @@ mock.module("../memory/conversation-crud.js", () => ({
   deleteLastExchange: () => 0,
   getMessageById: () => null,
   getLastUserTimestampBefore: () => 0,
+  setLastNotifiedInferenceProfile: () => {},
+  getConversationOverrideProfileFromRow: () => undefined,
+  updateMessageMetadata: () => {},
+  clearStrippedInjectionMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -25,7 +25,7 @@ mock.module("../memory/guardian-action-store.js", () => ({
 
 mock.module("../providers/registry.js", () => ({
   getProvider: () => ({ name: "mock-provider" }),
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -138,6 +138,10 @@ mock.module("../memory/conversation-crud.js", () => ({
   deleteLastExchange: () => 0,
   getMessageById: () => null,
   getLastUserTimestampBefore: () => 0,
+  setLastNotifiedInferenceProfile: () => {},
+  getConversationOverrideProfileFromRow: () => undefined,
+  updateMessageMetadata: () => {},
+  clearStrippedInjectionMetadataForConversation: () => {},
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({

--- a/assistant/src/__tests__/thinking-block-replay.test.ts
+++ b/assistant/src/__tests__/thinking-block-replay.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+
 import Anthropic from "@anthropic-ai/sdk";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -311,7 +311,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 }));
 
 mock.module("../providers/registry.js", () => ({
-  initializeProviders: () => {},
+  initializeProviders: async () => {},
 }));
 
 import {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -26,12 +26,12 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   contextWindowConfigFromEffective,
   type EffectiveContextWindow,
   resolveEffectiveContextWindow,
 } from "../config/llm-context-resolution.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   resolveCallSiteConfig,
   resolveDefaultProfileKey,
@@ -66,9 +66,9 @@ import {
   getConversationOriginInterface,
   getConversationOverrideProfileFromRow,
   getLastUserTimestampBefore,
-  setLastNotifiedInferenceProfile,
   getMessageById,
   provenanceFromTrustContext,
+  setLastNotifiedInferenceProfile,
   updateConversationContextWindow,
   updateConversationSlackContextWatermark,
 } from "../memory/conversation-crud.js";
@@ -222,12 +222,12 @@ import {
   SYNC_TAGS,
 } from "./message-types/sync.js";
 import { parseActualTokensFromError } from "./parse-actual-tokens-from-error.js";
-import type { TraceEmitter } from "./trace-emitter.js";
-import type { TrustContext } from "./trust-context.js";
 import {
   classifyQueryComplexity,
   complexityTierToProfileKey,
 } from "./query-complexity-router.js";
+import type { TraceEmitter } from "./trace-emitter.js";
+import type { TrustContext } from "./trust-context.js";
 import { stripHistoricalWebSearchResults } from "./web-search-history.js";
 
 const log = getLogger("conversation-agent-loop");

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -378,7 +378,7 @@ function repairPendingToolUseBlocks(
     const msg = messages[i];
     if (msg.role === "user") {
       for (const block of msg.content) {
-        if (block.type === "tool_result") {
+        if (block.type === "tool_result" || block.type === "web_search_tool_result") {
           resolvedToolUseIds.add(block.tool_use_id);
         }
       }

--- a/assistant/src/daemon/query-complexity-router.ts
+++ b/assistant/src/daemon/query-complexity-router.ts
@@ -1,10 +1,10 @@
-import { getLogger } from "../util/logger.js";
 import {
   createTimeout,
   extractText,
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
+import { getLogger } from "../util/logger.js";
 
 const log = getLogger("query-complexity-router");
 


### PR DESCRIPTION
## Summary
- Auto-fix 3 `simple-import-sort/imports` lint errors on main
- Regenerate stale OpenAPI spec (287 → 422 paths)
- Fix `initializeProviders` mock returning `undefined` instead of `Promise` (19 test files)
- Add missing `setLastNotifiedInferenceProfile` mock to 3 test files
- Fix `web_search_tool_result` guard test violation in `conversation-process.ts`

All of these are pre-existing issues on main that block the Dev Release pipeline, preventing new daemon images from being built and deployed to dev.

## Test plan
- [x] `bun run lint` passes locally
- [x] All 11 previously-failing test files pass locally (in isolation)
- [ ] CI passes
- [ ] Dev Release pipeline unblocks after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)