### PR TITLE
ci(web): publish SPA to GCS on main (extend CI Main Web into CI/CD)

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -227,16 +227,19 @@ jobs:
             exit 1
           fi
 
-          # 1. Upload the whole build, additive (no deletion). Leaving old hashed
-          #    chunks in place means clients that loaded the previous index.html can
-          #    still fetch their lazy-loaded chunks during the rollout. Fingerprinted
-          #    assets are immutable, so they get a long-lived cache.
-          gcloud storage cp -r \
+          # 1. Upload everything EXCEPT index.html with a long immutable cache,
+          #    additive (no deletion) so clients that loaded the previous shell can
+          #    still fetch their lazy-loaded hashed chunks during the rollout.
+          #    index.html is excluded here so that a run cancelled before step 2
+          #    (e.g. superseded by concurrency.cancel-in-progress) can never leave
+          #    the entrypoint pinned with a year-long immutable cache.
+          gcloud storage rsync -r \
+            --exclude="^index\.html$" \
             --cache-control="public, max-age=31536000, immutable" \
-            dist/* "gs://${BUCKET}/"
+            dist "gs://${BUCKET}"
 
-          # 2. Re-upload the HTML entrypoint last with no-cache so the new release is
-          #    served immediately instead of from a stale edge/browser cache.
+          # 2. Upload the HTML entrypoint last, with no-cache, so the new release
+          #    only goes live once its assets exist and is always revalidated.
           gcloud storage cp \
             --cache-control="no-cache, max-age=0, must-revalidate" \
             dist/index.html "gs://${BUCKET}/index.html"

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -118,17 +118,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 
-      # Hand the built SPA off to the deploy jobs so we publish exactly what CI
-      # built (and verified) rather than rebuilding. Source maps are stripped by
-      # the Sentry plugin during the build, so dist contains no .map files.
-      - name: Upload SPA build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: web-spa-dist
-          path: apps/web/dist
-          if-no-files-found: error
-          retention-days: 7
-
   checks:
     name: Lint, Type Check & Build
     needs: [lint, typecheck, test, build]
@@ -155,13 +144,18 @@ jobs:
 
   # ── CD: build + publish the SPA to each environment's GCS bucket ──────────
   # Runs only after every CI check passes (a `needs` dependency on a failed job
-  # skips this job automatically). One matrix leg per GitHub environment so the
-  # GCP_* secrets — including the project id that names the bucket — resolve to
-  # that environment. `production` will gate here if it has required reviewers.
+  # skips this job automatically). One matrix leg per GitHub environment, all in
+  # parallel (fail-fast: false). Each leg builds under its own `environment:` so
+  # the env-scoped secrets — the public VITE_* config baked into the bundle, the
+  # workload-identity creds, and the project id that names the bucket — resolve
+  # to that environment. `production` gates here if it has required reviewers.
   deploy:
     name: Deploy SPA (${{ matrix.environment }})
     needs: [checks]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
     strategy:
       fail-fast: false
       matrix:
@@ -171,11 +165,34 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Download SPA build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          name: web-spa-dist
-          path: dist
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate API clients
+        run: bun run openapi-ts
+
+      # Build per environment so the bundle bakes in this environment's public
+      # config — the Sentry environment tag and Stripe publishable key differ per
+      # env (e.g. pk_test_ vs pk_live_). The values live in the GitHub environment
+      # without the VITE_ prefix and are mapped onto VITE_* here. The API base URL
+      # is not baked in: in the browser the client uses same-origin paths, so each
+      # bucket's origin reaches its own backend.
+      - name: Build
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: ${{ matrix.environment }}
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          VITE_APP_VERSION: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: bun run build
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
@@ -192,7 +209,7 @@ jobs:
           BUCKET="${PROJECT_ID}-assistant-spa"
 
           if [ ! -f dist/index.html ]; then
-            echo "::error::dist/index.html not found — the build artifact is missing or empty."
+            echo "::error::dist/index.html not found — the build produced no output."
             exit 1
           fi
 

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -1,7 +1,6 @@
 name: CI/CD Main Web
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -180,15 +180,23 @@ jobs:
         run: bun run openapi-ts
 
       # Build per environment so the bundle bakes in this environment's public
-      # config — the Sentry environment tag and Stripe publishable key differ per
-      # env (e.g. pk_test_ vs pk_live_). The values live in the GitHub environment
-      # without the VITE_ prefix and are mapped onto VITE_* here. The API base URL
-      # is not baked in: in the browser the client uses same-origin paths, so each
-      # bucket's origin reaches its own backend.
+      # config — the Stripe publishable key differs per env (pk_test_ vs pk_live_)
+      # and the Sentry environment tag must match. Sources, per the GitHub config:
+      #   - VITE_SENTRY_DSN          repo-level variable (same for every env)
+      #   - VITE_SENTRY_ENVIRONMENT  per-environment variable (resolves via the
+      #                              job's `environment:`)
+      #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
+      #                              are public, so embedding them is expected
+      #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
+      #                              inlines it — it only authenticates the
+      #                              build-time source-map upload and is not
+      #                              emitted into dist/.
+      # The API base URL is not baked in: in the browser the client uses
+      # same-origin paths, so each bucket's origin reaches its own backend.
       - name: Build
         env:
-          VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          VITE_SENTRY_ENVIRONMENT: ${{ matrix.environment }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_APP_VERSION: ${{ github.sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -9,6 +9,13 @@ on:
       - 'packages/design-library/**'
       - '.github/workflows/ci-main-web.yaml'
 
+# Serialize runs per branch and cancel any superseded in-flight run, so an
+# older commit's deploy can never finish after — and overwrite the bucket's
+# index.html behind — a newer one. Only the newest main run publishes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Independent jobs run in parallel — same structure as PR workflow.
 jobs:
   lint:

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -1,4 +1,4 @@
-name: CI Main Web Checks
+name: CI/CD Main Web
 
 on:
   workflow_dispatch:
@@ -118,6 +118,17 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
 
+      # Hand the built SPA off to the deploy jobs so we publish exactly what CI
+      # built (and verified) rather than rebuilding. Source maps are stripped by
+      # the Sentry plugin during the build, so dist contains no .map files.
+      - name: Upload SPA build artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: web-spa-dist
+          path: apps/web/dist
+          if-no-files-found: error
+          retention-days: 7
+
   checks:
     name: Lint, Type Check & Build
     needs: [lint, typecheck, test, build]
@@ -142,9 +153,68 @@ jobs:
             fi
           done
 
+  # ── CD: build + publish the SPA to each environment's GCS bucket ──────────
+  # Runs only after every CI check passes (a `needs` dependency on a failed job
+  # skips this job automatically). One matrix leg per GitHub environment so the
+  # GCP_* secrets — including the project id that names the bucket — resolve to
+  # that environment. `production` will gate here if it has required reviewers.
+  deploy:
+    name: Deploy SPA (${{ matrix.environment }})
+    needs: [checks]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, staging, production]
+    environment: ${{ matrix.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SPA build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: web-spa-dist
+          path: dist
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Publish SPA to GCS
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          TARGET_ENV: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          BUCKET="${PROJECT_ID}-assistant-spa"
+
+          if [ ! -f dist/index.html ]; then
+            echo "::error::dist/index.html not found — the build artifact is missing or empty."
+            exit 1
+          fi
+
+          # 1. Upload the whole build, additive (no deletion). Leaving old hashed
+          #    chunks in place means clients that loaded the previous index.html can
+          #    still fetch their lazy-loaded chunks during the rollout. Fingerprinted
+          #    assets are immutable, so they get a long-lived cache.
+          gcloud storage cp -r \
+            --cache-control="public, max-age=31536000, immutable" \
+            dist/* "gs://${BUCKET}/"
+
+          # 2. Re-upload the HTML entrypoint last with no-cache so the new release is
+          #    served immediately instead of from a stale edge/browser cache.
+          gcloud storage cp \
+            --cache-control="no-cache, max-age=0, must-revalidate" \
+            dist/index.html "gs://${BUCKET}/index.html"
+
+          echo "Published SPA to gs://${BUCKET}/ (environment=${TARGET_ENV})"
+
   notify-web:
     name: Slack Notification (Web)
-    needs: [checks]
+    needs: [checks, deploy]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -157,9 +227,9 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+          if [[ "${{ needs.checks.result }}" == "failure" || "${{ needs.deploy.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.checks.result }}" == "cancelled" || "${{ needs.deploy.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
           elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
             STATUS="skipped"


### PR DESCRIPTION
## What

Extends the main web workflow (`ci-main-web.yaml`, renamed **CI Main Web Checks** → **CI/CD Main Web**) with a CD half that builds and publishes the SPA to each environment's `{project_id}-assistant-spa` GCS bucket on every push to `main`.

## How

- **`build` job** now uploads the built SPA (`apps/web/dist`) as a `web-spa-dist` artifact, so deploy publishes exactly what CI built rather than rebuilding. (Vite's Sentry plugin strips `.map` files during the build, so no source maps ship.)
- **New `deploy` job** — `needs: [checks]`, so it's skipped automatically if any lint/typecheck/test/build leg fails. `fail-fast: false` matrix over `[dev, staging, production]` with `environment: ${{ matrix.environment }}`, so each leg resolves that environment's `GCP_PROJECT_ID` + workload-identity secrets. Reuses the existing `google-github-actions/auth` pattern (`permissions: { contents: read, id-token: write }`), then publishes to `gs://${GCP_PROJECT_ID}-assistant-spa/`:
  - Additive upload of the full `dist` (no deletion) with `Cache-Control: immutable, max-age=1yr` — old hashed chunks stay so mid-rollout clients don't 404 on lazy-loaded chunks.
  - `index.html` re-uploaded last with `no-cache` so releases go live immediately.
- **`notify-web`** now also depends on `deploy`; a failed deploy triggers the failure Slack alert.

## Notes / things to confirm

- **Production deploys on every main merge.** If the `production` environment has required reviewers, that matrix leg (and the Slack notify, which `needs` deploy) waits for manual approval while dev/staging auto-deploy. Drop `production` from the matrix if prod should go through the tagged-release flow instead.
- **Single build for all 3 envs** — artifact is built once with repo-scoped `VITE_*` vars, so the baked-in `VITE_SENTRY_ENVIRONMENT` is identical across targets. Fine for a runtime-configured SPA; needs per-env builds otherwise.
- **No stale-asset cleanup** — deploy never deletes, so old hashed assets accumulate; best handled by a GCS lifecycle policy.
- **Assumes** each env's `GCP_SERVICE_ACCOUNT` has object-admin on its `*-assistant-spa` bucket and the buckets already exist (this workflow doesn't create them). Reuses the same secret names as the image publishers: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/31516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->