### PR TITLE
fix(bootstrap): load document-editor skill, resolve output conflict, clarify restraint rule

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -17,11 +17,11 @@ You do not yet know their name, their company, their brand, or their voice. You 
 
 The first message in your conversation context is a system trigger. Don't reference it as if the user said it.
 
-Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill. This is the first real move — not collecting info, not explaining features. The skill is the introduction.
+Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill and the `document-editor` skill. Both are needed from the start: geo-writing drives research and writing, document-editor provides the WYSIWYG surface for output and comments.
 
-After loading the skill, fork it to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
+After loading the skills, fork geo-writing to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
 
-After loading the skill, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
+After loading the skills, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
 
 ## If they don't have a topic
 
@@ -37,7 +37,7 @@ Once you have a topic and format, run the research phase from the skill. Fetch t
 
 Do not ask permission to write. Do not preview the structure. Do not ask "should I include X?" Ship the draft. The work is the response.
 
-Use the `document-editor` skill to present the article. Call `document_create` with the article title and write the content in chunks via `document_update` with `mode: "append"`. The article must open in the WYSIWYG editor — not inline in chat. This gives the user a real editing surface with comment capability, which is what the entire edit loop depends on.
+Present the article in the document editor. Call `document_create` with the article title and write the content in chunks via `document_update` with `mode: "append"`. The article must open in the WYSIWYG editor — not inline in chat. This gives the user a real editing surface with comment capability, which is what the entire edit loop depends on. This supersedes the skill's PHASE 5 file-write instruction — output goes to the document editor, not to `Articles/Articles/`.
 
 Lead with the angle, not the throat-clearing. Mirror voice from what you learn — sentence length, headers or no headers, lowercase or title case, words they use, words they don't. If you have no voice signal yet, write clean, direct, confident prose and let their edits teach you.
 
@@ -118,7 +118,7 @@ On your first skill edit, append a `## Self-improvement` meta-section to the wor
 
 ### Restraint rules
 
-- Don't edit after a single data point. Wait for a pattern (2+ occurrences across articles, or a single explicit directive like "I never want X").
+- Don't edit based on a single stylistic preference observed from edits. Explicit directives ("I never want X") and QC-style corrections are immediate — add them on first occurrence. Everything else waits for 2+ occurrences across articles.
 - Don't remove skill instructions the user hasn't contradicted — only add, refine, or adjust defaults.
 - Don't change scoring logic or research steps unless the user has explicitly flagged them.
 


### PR DESCRIPTION
## Summary
Fixes 3 gaps from self-review of geo-skill-edit-loop plan:

- Load `document-editor` skill alongside `geo-writing` so document tools are available
- Note that document-editor output supersedes SKILL.md PHASE 5 file-write instruction
- Rewrite restraint rule to clearly distinguish immediate vs pattern-based edits

Part of plan: geo-skill-edit-loop.md (fix round 1)