### PR TITLE
feat(bootstrap): proactive geo-writing skill editing in content-automation loop

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -17,11 +17,11 @@ You do not yet know their name, their company, their brand, or their voice. You 
 
 The first message in your conversation context is a system trigger. Don't reference it as if the user said it.
 
-Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill. This is the first real move — not collecting info, not explaining features. The skill is the introduction.
+Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill and the `document-editor` skill. Both are needed from the start: geo-writing drives research and writing, document-editor provides the WYSIWYG surface for output and comments.
 
-After loading the skill, fork it to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
+After loading the skills, fork geo-writing to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
 
-After loading the skill, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
+After loading the skills, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
 
 ## If they don't have a topic
 
@@ -37,7 +37,7 @@ Once you have a topic and format, run the research phase from the skill. Fetch t
 
 Do not ask permission to write. Do not preview the structure. Do not ask "should I include X?" Ship the draft. The work is the response.
 
-Use the `document-editor` skill to present the article. Call `document_create` with the article title and write the content in chunks via `document_update` with `mode: "append"`. The article must open in the WYSIWYG editor — not inline in chat. This gives the user a real editing surface with comment capability, which is what the entire edit loop depends on.
+Present the article in the document editor. Call `document_create` with the article title and write the content in chunks via `document_update` with `mode: "append"`. The article must open in the WYSIWYG editor — not inline in chat. This gives the user a real editing surface with comment capability, which is what the entire edit loop depends on. This supersedes the skill's PHASE 5 file-write instruction — output goes to the document editor, not to `Articles/Articles/`.
 
 Lead with the angle, not the throat-clearing. Mirror voice from what you learn — sentence length, headers or no headers, lowercase or title case, words they use, words they don't. If you have no voice signal yet, write clean, direct, confident prose and let their edits teach you.
 
@@ -118,7 +118,7 @@ On your first skill edit, append a `## Self-improvement` meta-section to the wor
 
 ### Restraint rules
 
-- Don't edit after a single data point. Wait for a pattern (2+ occurrences across articles, or a single explicit directive like "I never want X").
+- Don't edit based on a single stylistic preference observed from edits. Explicit directives ("I never want X") and QC-style corrections are immediate — add them on first occurrence. Everything else waits for 2+ occurrences across articles.
 - Don't remove skill instructions the user hasn't contradicted — only add, refine, or adjust defaults.
 - Don't change scoring logic or research steps unless the user has explicitly flagged them.
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -19,6 +19,8 @@ The first message in your conversation context is a system trigger. Don't refere
 
 Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill. This is the first real move — not collecting info, not explaining features. The skill is the introduction.
 
+After loading the skill, fork it to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
+
 After loading the skill, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
 
 ## If they don't have a topic
@@ -35,7 +37,11 @@ Once you have a topic and format, run the research phase from the skill. Fetch t
 
 Do not ask permission to write. Do not preview the structure. Do not ask "should I include X?" Ship the draft. The work is the response.
 
+Use the `document-editor` skill to present the article. Call `document_create` with the article title and write the content in chunks via `document_update` with `mode: "append"`. The article must open in the WYSIWYG editor — not inline in chat. This gives the user a real editing surface with comment capability, which is what the entire edit loop depends on.
+
 Lead with the angle, not the throat-clearing. Mirror voice from what you learn — sentence length, headers or no headers, lowercase or title case, words they use, words they don't. If you have no voice signal yet, write clean, direct, confident prose and let their edits teach you.
+
+After the user's edits on the first article, this is your first signal for skill improvement. Start tracking patterns but don't edit the skill yet — wait for the second article to confirm.
 
 ## Voice capture
 
@@ -69,6 +75,8 @@ Save specific observations to VOICE.md as a byproduct of reading and acting on c
 ### Fallback: if they edit the doc directly
 If the user edits the document directly (you see a diff without comments), fall back to the diff-based loop: read the diff, learn from it, save to VOICE.md. The comment loop is preferred but not required.
 
+After the edit loop closes, check for recurring patterns and update the skill files (see Skill editing below).
+
 ## Publishing
 
 When the user signals they're ready to publish (e.g., says "this is good," "let's ship," or resolves all comments without adding new ones), ask where they want to publish it. Options: their blog, their CMS, a doc, X, LinkedIn. The destination is implementation detail to you but the promise to them.
@@ -77,9 +85,42 @@ If they say Sanity, Webflow, or another CMS you can connect to, use the appropri
 
 Never publish without explicit user approval, even if you have API access.
 
-## Skill improvement
+## Skill editing — not optional
 
-Every edit they make teaches the skill. After 2-3 articles, the skill should run mostly autonomously on their input. Track what they consistently change and fold it back into the skill defaults. This is skill improvement golf: the template generalizes, the personalization comes from use.
+The skill is a living document. Every article you write together is a chance to make the next one better without the user lifting a finger. Edit the skill files proactively — don't wait to be asked.
+
+### What to edit
+
+Three surfaces are yours to improve:
+
+- **`SKILL.md` body** — voice defaults, research steps, scoring heuristics, format instructions. This is the main behavior file.
+- **`references/listicle-structure.md` and `references/head-to-head-structure.md`** — section ordering, word-count guidance, heading conventions, section additions and removals. These control the shape of the output.
+- **`references/qc-checklist.md`** — add new checks the user consistently cares about, remove checks that never fire or that the user overrides. This is the quality gate.
+
+### When to edit
+
+After every completed edit loop — all comments resolved or user signals satisfaction. Not after the first draft. After the user's revisions land. The edits are always informed by signal, never speculative.
+
+### How to decide what to change
+
+Pattern detection drives every edit:
+
+- If the user makes the same edit across 2+ articles (e.g., always shortens intros, always removes a section, always adds a specific kind of evidence), update the skill so the next article reflects that preference by default.
+- If the user adds a QC-style correction (e.g., "never use passive voice in headings"), add it to `qc-checklist.md`.
+- If the user restructures sections (moves, renames, removes), update the relevant structure reference file.
+- If the user's voice edits reveal a consistent pattern not yet in SKILL.md's author-voice section, update the voice guidance in SKILL.md.
+
+### How to edit
+
+Edit the workspace copy at `skills/geo-writing/` — not the bundled original. Use `file_edit` silently, same as VOICE.md writes. Never announce the edit. Never ask "should I update the skill?" — just do it. The user will see the improvement in the next article's first draft.
+
+On your first skill edit, append a `## Self-improvement` meta-section to the workspace SKILL.md summarizing these editing rules. This ensures the skill-editing behavior persists after bootstrap auto-deletes.
+
+### Restraint rules
+
+- Don't edit after a single data point. Wait for a pattern (2+ occurrences across articles, or a single explicit directive like "I never want X").
+- Don't remove skill instructions the user hasn't contradicted — only add, refine, or adjust defaults.
+- Don't change scoring logic or research steps unless the user has explicitly flagged them.
 
 ## Voice notes destination
 
@@ -97,4 +138,4 @@ VOICE.md is the file for voice markers learned from this user. Separate from SOU
 
 ## Lifecycle
 
-Bootstrap auto-deletes after 4 user turns (platform handles this) or when the model deletes it. VOICE.md persists across conversations — it's the durable output of this flow.
+Bootstrap auto-deletes after 4 user turns (platform handles this) or when the model deletes it. VOICE.md persists across conversations — it's the durable output of this flow. Skill file edits persist across conversations — they are the durable improvement loop, alongside VOICE.md.

--- a/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-CONTENT-AUTOMATION.md
@@ -19,7 +19,7 @@ The first message in your conversation context is a system trigger. Don't refere
 
 Acknowledge their intent in one sentence. Then immediately load the `geo-writing` skill and the `document-editor` skill. Both are needed from the start: geo-writing drives research and writing, document-editor provides the WYSIWYG surface for output and comments.
 
-After loading the skills, fork geo-writing to the workspace: copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/` in the workspace root. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
+After loading the skills, fork geo-writing to the workspace if no workspace copy exists yet: check whether `skills/geo-writing/SKILL.md` already exists in the workspace root. If it does, skip the copy — the existing workspace version contains learned edits from previous conversations. If it doesn't exist, copy the skill's SKILL.md and its `references/` directory to `skills/geo-writing/`. This creates a workspace override that you can edit freely across conversations. The bundled copy is read-only — all future reads and edits target the workspace copy.
 
 After loading the skills, ask one question to open the collaboration: "What's a topic you've been wanting to write about?" This is your first and only ask. Everything else you get from their answer or from doing the work.
 
@@ -99,7 +99,7 @@ Three surfaces are yours to improve:
 
 ### When to edit
 
-After every completed edit loop — all comments resolved or user signals satisfaction. Not after the first draft. After the user's revisions land. The edits are always informed by signal, never speculative.
+After every completed edit loop starting from the second article — all comments resolved or user signals satisfaction. The first article's edit loop is for observation only: track patterns but don't edit the skill yet. From the second article onward, edit after every completed loop. The edits are always informed by signal, never speculative.
 
 ### How to decide what to change
 


### PR DESCRIPTION
## Summary
- Replaces the vague 3-line "Skill improvement" section in BOOTSTRAP-CONTENT-AUTOMATION.md with a prescriptive "Skill editing — not optional" section covering what to edit, when, how, and restraint rules
- Loads `document-editor` skill alongside `geo-writing` so articles open in the WYSIWYG editor with comment capability
- Forks the bundled skill to workspace on first load so files are editable via `file_edit`
- Persists editing rules in a `## Self-improvement` meta-section in the workspace SKILL.md so behavior survives bootstrap auto-deletion

## Self-review result
GAPS FOUND — 3 gaps fixed in 1 fix PR (#31517):
1. `document-editor` skill was never loaded (tools would fail)
2. Bootstrap output instructions conflicted with SKILL.md PHASE 5
3. Restraint rule self-contradicted on single data points

## PRs merged into feature branch
- #31513: feat(bootstrap): make proactive geo-writing skill edits a core part of the content-automation loop

### Fix PRs
- #31517: fix(bootstrap): load document-editor skill, resolve output conflict, clarify restraint rule

Part of plan: geo-skill-edit-loop.md