### PR TITLE
fix(web): disable layout-scoped sync stream to unblock chat send

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -188,13 +188,18 @@ export function ChatLayout() {
     layoutAvatar.traits,
   );
 
-  // Layout-scoped SSE subscriber for assistant-global sync events.
-  // ChatPage owns the conversation-scoped stream; this one keeps the
-  // avatar / identity / config / sounds / schedules / conversation list
-  // caches reactive on every assistant route — not just inside a
-  // conversation. See use-assistant-sync-stream.ts for the event
-  // routing contract.
-  useAssistantSyncStream(lifecycle.assistantId, isAssistantActive);
+  // Layout-scoped SSE subscriber is disabled. The daemon dedups client
+  // subscribers by `clientId` (assistant-event-hub.ts), so this layout
+  // stream and ChatPage's conversation-scoped stream evict each other
+  // every (re-)subscribe — leaving the conversation stream silent and
+  // the chat composer permanently in "thinking" state after a send.
+  // Restoring the platform behavior of a single conversation-scoped
+  // stream until the dual-subscription support lands. Sibling routes
+  // (home, identity, library, workspace, contacts, inspect) drop back
+  // to the pre-LUM-1791 staleness for now.
+  //
+  // useAssistantSyncStream(lifecycle.assistantId, isAssistantActive);
+  void useAssistantSyncStream;
 
   // Home page unread indicator — drives the red dot on the Home button in
   // the layout header. Gated on the homePage feature flag so the hook


### PR DESCRIPTION
## Summary

**Hot fix for: web chat composer permanently stuck in "thinking" state after a send.**

### Symptom

User sends a message. Optimistic user bubble appears, the composer flips to "Stop" mode, the thinking dots show — and no assistant response ever arrives. Eventually the SSE idle watchdog (45s) times out. macOS unaffected.

### Root cause

`AssistantEventHub.subscribe()` (`assistant/src/runtime/assistant-event-hub.ts:152–179`) dedups client subscribers by `clientId` alone:

```ts
if (existing.type === "client" && existing.clientId === subscriber.clientId) {
  stale.push(existing);  // evicts the prior subscription
}
```

The web has **one** `clientId` in `localStorage`. LUM-1791 added a layout-scoped `useAssistantSyncStream` for assistant-global sync events; it opens an SSE connection in parallel with `ChatPage`'s conversation-scoped `useEventStream`. **Both reuse the same `clientId`.** Each (re-)subscribe disposes the other — whichever registered last receives events; the other sits open at the HTTP layer but silent. The daemon shows it in the network tab as `events?conversationKey=…` with an empty EventStream payload.

macOS clients have their own `clientId`, so they're unaffected. Hence "only the new web" — exactly what the user reported.

### Fix

Stop calling `useAssistantSyncStream` from `ChatLayout`. Sibling routes (home, identity, library, workspace, contacts, inspect) revert to the pre-LUM-1791 staleness on assistant-global sync events while the architecture-level fix (broader rework of subscription scoping) is in flight. The hook itself stays in the tree (the import is kept alive with a `void` so the unused-vars rule doesn't fire) so re-enabling is a one-line change.

### Architecturally-correct fix (deferred)

The daemon dedup should compare both `clientId` AND `filter.conversationId` — two parallel subscriptions from the same client with different scope should coexist. That's a daemon-side change and the user's noted an architecture rework is coming, so this PR is the surgical stopgap.

## Test plan

- [x] `bun run test:ci` — 102 / 102 pass
- [x] `bun run lint` — clean (1 preexisting unrelated warning)
- [ ] Manual: load assistant, send a message, confirm streaming response renders

---
_Generated by [Claude Code](https://claude.ai/code/session_0181LfJ6Lapx1LKyrrnDZ3Vh)_