### PR TITLE
set `/assistant` basepath for SPA

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
   const sentryUploadEnabled = !!env.SENTRY_AUTH_TOKEN;
 
   return {
-    base: "/",
+    base: "/assistant/",
     plugins: [
       tailwindcss(),
       react(),


### PR DESCRIPTION
Near term we plan to consolidate `/accounts` and `/logout` and serve the SPA completely under the `/assistant` namespace. Let's keep the build assets under that path. Also simplifies deploy/routing rules