### PR TITLE
ci(dev-release): post #dev-releases notification via webhook with collapsible commit list

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1086,10 +1086,11 @@ jobs:
   # blocks, which Slack renders as a collapsible "Show more" element, so the
   # channel stays tidy even when a release spans many commits.
   #
-  # Reuses the existing SLACK_WEBHOOK_URL secret (also used by notify-releases
-  # below) with a per-message channel override, so no extra setup is required.
-  # Optionally override the target channel with a repo Actions variable
-  # DEV_RELEASES_SLACK_CHANNEL (defaults to #dev-releases).
+  # Posts via a #dev-releases incoming webhook stored in the repo secret
+  # SLACK_DEV_RELEASES_WEBHOOK_URL. The channel is baked into the webhook URL
+  # (incoming webhooks ignore a payload `channel` field), so each channel needs
+  # its own webhook — mirroring SLACK_WEBHOOK_URL (#build-alerts) and
+  # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
     needs: [compute-version, register-release, register-preview-release]
@@ -1107,8 +1108,7 @@ jobs:
         id: build
         env:
           GH_TOKEN: ${{ github.token }}
-          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: ${{ vars.DEV_RELEASES_SLACK_CHANNEL || '#dev-releases' }}
+          WEBHOOK: ${{ secrets.SLACK_DEV_RELEASES_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
           VERSION: ${{ needs.compute-version.outputs.version }}
           HEAD_SHA: ${{ github.sha }}
@@ -1118,7 +1118,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${WEBHOOK:-}" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL is not set — skipping #dev-releases notification."
+            echo "::warning::SLACK_DEV_RELEASES_WEBHOOK_URL is not set — skipping #dev-releases notification."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -1231,19 +1231,19 @@ jobs:
             fi
           fi
 
+          # No `channel` field: incoming webhooks ignore it and post to the
+          # channel baked into SLACK_DEV_RELEASES_WEBHOOK_URL (#dev-releases).
           jq -n \
-            --arg channel "$SLACK_CHANNEL" \
             --arg version "$VERSION" \
             --argjson blocks "$BLOCKS" \
             '{
-              channel: $channel,
               unfurl_links: false,
               unfurl_media: false,
               text: ("Dev Release " + $version),
               blocks: $blocks
             }' > "${RUNNER_TEMP}/dev-release-slack-payload.json"
 
-          echo "Built Slack payload for ${SLACK_CHANNEL} (${COUNT} commits listed)."
+          echo "Built Slack payload (${COUNT} commits listed)."
 
       - name: Notify Slack
         id: slack
@@ -1251,7 +1251,7 @@ jobs:
         continue-on-error: true
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_DEV_RELEASES_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload-file-path: ${{ runner.temp }}/dev-release-slack-payload.json
           errors: true

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1081,20 +1081,15 @@ jobs:
           done
 
   # ── Notify #dev-releases with the commit changelog ─────────────────────
-  # Posts a summary to Slack once the release is registered, then drops the
-  # full ordered commit list (author + message) into a thread reply so the
+  # Posts a single summary message to Slack once the release is registered.
+  # The full ordered commit list (message + author) goes inside fenced code
+  # blocks, which Slack renders as a collapsible "Show more" element, so the
   # channel stays tidy even when a release spans many commits.
   #
-  # MANUAL SETUP (one-time): this job no-ops until SLACK_BOT_TOKEN exists, so
-  # merging it will not break the hourly release before setup is done.
-  #   1. Create (or reuse) a Slack app with the `chat:write` bot scope and
-  #      install it to the workspace.
-  #   2. Invite the bot to the channel: `/invite @<your-app>` in #dev-releases.
-  #   3. Add the bot token as a repo Actions secret named SLACK_BOT_TOKEN
-  #      (Settings → Secrets and variables → Actions → New repository secret).
-  #   4. (Optional) Override the target channel with a repo Actions variable
-  #      DEV_RELEASES_SLACK_CHANNEL (defaults to #dev-releases). A channel ID
-  #      (e.g. C0123ABCD) is more robust than a #name.
+  # Reuses the existing SLACK_WEBHOOK_URL secret (also used by notify-releases
+  # below) with a per-message channel override, so no extra setup is required.
+  # Optionally override the target channel with a repo Actions variable
+  # DEV_RELEASES_SLACK_CHANNEL (defaults to #dev-releases).
 
   notify-dev-release:
     needs: [compute-version, register-release, register-preview-release]
@@ -1108,10 +1103,11 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Post dev release notification to Slack
+      - name: Build Slack payload
+        id: build
         env:
           GH_TOKEN: ${{ github.token }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_CHANNEL: ${{ vars.DEV_RELEASES_SLACK_CHANNEL || '#dev-releases' }}
           REPO: ${{ github.repository }}
           VERSION: ${{ needs.compute-version.outputs.version }}
@@ -1121,10 +1117,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
-            echo "::warning::SLACK_BOT_TOKEN is not set — skipping #dev-releases notification. See the MANUAL SETUP note in dev-release.yaml."
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL is not set — skipping #dev-releases notification."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
           # Find the SHA of the last actually-released dev build to diff against.
           # We key off the register-release JOB conclusion, not the overall run
@@ -1183,69 +1181,40 @@ jobs:
             HEADER_TEXT="*${TOTAL} ${COMMIT_WORD}* since the last dev release"
           fi
 
-          # ── Main channel message ──────────────────────────────────────────
-          MAIN_PAYLOAD=$(jq -n \
-            --arg channel "$SLACK_CHANNEL" \
+          # ── Build the message blocks ──────────────────────────────────────
+          # Header, summary line, and the action buttons. The commit list is
+          # appended below as fenced code blocks, which Slack collapses behind
+          # a "Show more" expander when long.
+          BLOCKS=$(jq -n \
             --arg version "$VERSION" \
             --arg header "$HEADER_TEXT" \
             --arg run_url "$RUN_URL" \
             --arg compare_url "$COMPARE_URL" \
-            '{
-              channel: $channel,
-              unfurl_links: false,
-              unfurl_media: false,
-              text: ("Dev Release " + $version),
-              blocks: [
-                { type: "header", text: { type: "plain_text", text: ("🚀 Dev Release " + $version), emoji: true } },
-                { type: "section", text: { type: "mrkdwn", text: $header } },
-                { type: "actions", elements: [
-                  { type: "button", text: { type: "plain_text", text: "View workflow run" }, url: $run_url },
-                  { type: "button", text: { type: "plain_text", text: "View commit diff" }, url: $compare_url }
-                ] }
-              ]
-            }')
+            '[
+              { type: "header", text: { type: "plain_text", text: ("🚀 Dev Release " + $version), emoji: true } },
+              { type: "section", text: { type: "mrkdwn", text: $header } },
+              { type: "actions", elements: [
+                { type: "button", text: { type: "plain_text", text: "View workflow run" }, url: $run_url },
+                { type: "button", text: { type: "plain_text", text: "View commit diff" }, url: $compare_url }
+              ] }
+            ]')
 
-          RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-            -H "Content-Type: application/json; charset=utf-8" \
-            --data "$MAIN_PAYLOAD")
-          if [ "$(echo "$RESP" | jq -r '.ok')" != "true" ]; then
-            echo "::error::Slack chat.postMessage failed: $(echo "$RESP" | jq -r '.error // "unknown"')"
-            echo "$RESP"
-            exit 1
-          fi
-          TS=$(echo "$RESP" | jq -r '.ts')
-          echo "Posted main message (ts=${TS})"
-
-          # ── Threaded commit list ──────────────────────────────────────────
-          post_thread_reply() {
-            local body="$1"
-            local payload
-            payload=$(jq -n --arg channel "$SLACK_CHANNEL" --arg ts "$TS" --arg text "$body" \
-              '{ channel: $channel, thread_ts: $ts, unfurl_links: false, unfurl_media: false,
-                 text: $text, blocks: [ { type: "section", text: { type: "mrkdwn", text: $text } } ] }')
-            local r
-            r=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
-              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-              -H "Content-Type: application/json; charset=utf-8" \
-              --data "$payload")
-            if [ "$(echo "$r" | jq -r '.ok')" != "true" ]; then
-              echo "::error::Slack thread reply failed: $(echo "$r" | jq -r '.error // "unknown"')"
-              echo "$r"
-              exit 1
-            fi
-            sleep 1  # stay under chat.postMessage rate limits when chunking
+          # Append one collapsible code-block section per chunk of commits.
+          append_code_section() {
+            BLOCKS=$(echo "$BLOCKS" | jq --arg t "$1" \
+              '. + [{ type: "section", text: { type: "mrkdwn", text: ("```\n" + $t + "\n```") } }]')
           }
 
           if [ "$COUNT" -gt 0 ]; then
-            # Chunk the numbered list to stay under Slack's 3000-char section limit.
+            # Chunk the numbered list to stay under Slack's 3000-char section
+            # limit (the ``` fences add a few chars, so cap the body at 2800).
             CHUNK=""
             IDX=0
             for line in "${LINES[@]}"; do
               IDX=$((IDX + 1))
-              ENTRY="*${IDX}.* ${line}"
+              ENTRY="${IDX}. ${line}"
               if [ -n "$CHUNK" ] && [ $(( ${#CHUNK} + ${#ENTRY} + 1 )) -gt 2800 ]; then
-                post_thread_reply "$CHUNK"
+                append_code_section "$CHUNK"
                 CHUNK="$ENTRY"
               elif [ -z "$CHUNK" ]; then
                 CHUNK="$ENTRY"
@@ -1253,14 +1222,47 @@ jobs:
                 CHUNK="${CHUNK}"$'\n'"${ENTRY}"
               fi
             done
-            [ -n "$CHUNK" ] && post_thread_reply "$CHUNK"
+            [ -n "$CHUNK" ] && append_code_section "$CHUNK"
 
             if [ "$TOTAL" -gt "$COUNT" ]; then
-              post_thread_reply "_…and $((TOTAL - COUNT)) more commits not shown (GitHub compares are capped at 250 commits). See *View commit diff* above for the full list._"
+              BLOCKS=$(echo "$BLOCKS" | jq \
+                --arg t "_…and $((TOTAL - COUNT)) more commits not shown (GitHub compares are capped at 250 commits). See *View commit diff* above for the full list._" \
+                '. + [{ type: "context", elements: [{ type: "mrkdwn", text: $t }] }]')
             fi
           fi
 
-          echo "Dev release notification posted to ${SLACK_CHANNEL}."
+          jq -n \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg version "$VERSION" \
+            --argjson blocks "$BLOCKS" \
+            '{
+              channel: $channel,
+              unfurl_links: false,
+              unfurl_media: false,
+              text: ("Dev Release " + $version),
+              blocks: $blocks
+            }' > "${RUNNER_TEMP}/dev-release-slack-payload.json"
+
+          echo "Built Slack payload for ${SLACK_CHANNEL} (${COUNT} commits listed)."
+
+      - name: Notify Slack
+        id: slack
+        if: steps.build.outputs.skip != 'true'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: ${{ runner.temp }}/dev-release-slack-payload.json
+          errors: true
+
+      - name: Log Slack notification result
+        if: always() && steps.build.outputs.skip != 'true'
+        run: |
+          echo "Slack step outcome: ${{ steps.slack.outcome }}"
+          if [ "${{ steps.slack.outcome }}" != "success" ]; then
+            echo "::warning::#dev-releases notification failed to send."
+          fi
 
   # ── Chrome Extension ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

The `notify-dev-release` job posted to `#dev-releases` via the Slack Web API (`chat.postMessage` + a `SLACK_BOT_TOKEN` + threaded replies). That bot token doesn't exist in the repo and requires one-time Slack app setup, so the job no-op'd on every run. Every other workflow posts fine because they use a pre-provisioned **incoming webhook**.

## What

- **Post via an incoming webhook.** Uses the same `slackapi/slack-github-action` pattern as `notify-releases` / `release.yml`. The channel is baked into the webhook URL (Slack-app incoming webhooks ignore a payload `channel` field), so this targets a **dedicated `SLACK_DEV_RELEASES_WEBHOOK_URL` secret bound to `#dev-releases`** — mirroring how `SLACK_WEBHOOK_URL` → `#build-alerts` and `SLACK_RELEASES_WEBHOOK_URL` → releases. The job no-ops with a warning until the secret is set.
- **Commit list is a collapsible element.** A webhook posts a single message (no threads), so the commit changelog now lives in fenced code blocks within the message, which Slack renders behind a native "Show more" expander.

Message structure: header → `*N commits* since the last dev release` → View run / View diff buttons → numbered commit list in collapsible code fence(s) → "…and N more" context note when GitHub's 250-commit compare cap is hit.

Existing 2800-char chunking (Slack's 3000-char section limit), previous-release SHA discovery, and `continue-on-error` safety are preserved.

## One-time setup

Add an incoming webhook to `#dev-releases` (same Slack app that owns the other two webhooks) and store its URL as the repo secret **`SLACK_DEV_RELEASES_WEBHOOK_URL`**. Until then the job logs a warning and skips — it never fails the release.

## Testing

- YAML validated (`yaml.safe_load`).
- No leftover `SLACK_BOT_TOKEN` / `chat.postMessage` / `SLACK_WEBHOOK_URL` / `channel` references in the job.
- Unit-tested the block-building shell/jq logic in bash: valid JSON, commit list correctly nested in a fenced code block, no `channel` key, mrkdwn escaping intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)