### PR TITLE
refactor(web): extract environment config from feature flag store

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/domains/conversations/conversation-queries.js";
 import { useAttentionTracking } from "@/domains/conversations/use-attention-tracking.js";
 import { useConversationGroupActions } from "@/domains/conversations/use-conversation-group-actions.js";
+import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
 import { useViewerStore } from "@/stores/viewer-store.js";
 import { useSubagentStore } from "@/domains/subagents/subagent-store.js";
@@ -121,12 +122,13 @@ export function ChatLayout() {
   const location = useLocation();
   const isLoggedIn = useAuthStore.use.isLoggedIn();
   const authLoading = useAuthStore.use.isLoading();
+  const isNonProduction = useEnvironmentStore.use.isNonProduction();
 
   const lifecycle = useAssistantLifecycle({
     isLoggedIn,
     isLoading: authLoading,
     isRetired: false,
-    isNonProduction: false,
+    isNonProduction,
     onRedirect: navigate,
   });
 

--- a/apps/web/src/domains/settings/ai/ai-page.tsx
+++ b/apps/web/src/domains/settings/ai/ai-page.tsx
@@ -43,7 +43,7 @@ import {
   organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen.js";
 import { reportError } from "@/lib/errors/report.js";
-import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
+import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 import {
   type LlmCatalogModel,
   PROVIDER_DISPLAY_NAMES,
@@ -856,7 +856,7 @@ interface EmailServiceCardProps {
 function EmailServiceCard({ assistantId }: EmailServiceCardProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const emailRootDomain = useFeatureFlagStore.use.emailRootDomain();
+  const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const [mode, setMode] = useState<ServiceMode>(
     () => getLocalSetting(LS_EMAIL_MODE, "managed") as ServiceMode,
   );

--- a/apps/web/src/domains/settings/billing/onboarding-page.tsx
+++ b/apps/web/src/domains/settings/billing/onboarding-page.tsx
@@ -27,7 +27,7 @@ import {
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen.js";
 import { SIZE_LABEL, TIER_TO_SIZES } from "@/lib/billing/machine-sizes.js";
-import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
+import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 import { routes } from "@/utils/routes.js";
 
 export const DOMAIN_EXIT_DELAY_MS = 800;
@@ -456,7 +456,7 @@ function MachineSizeStep({
 }
 
 function DomainStep({ onExit }: { onExit: () => void }) {
-  const emailRootDomain = useFeatureFlagStore.use.emailRootDomain();
+  const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
   const [subdomain, setSubdomain] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);

--- a/apps/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/apps/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/assistant/api.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { reportError } from "@/lib/errors/report.js";
-import { useFeatureFlagStore } from "@/lib/feature-flags/feature-flag-store.js";
+import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
 
 const CURRENT_ASSISTANT_QUERY_KEY = ["currentAssistant"] as const;
 
@@ -99,7 +99,7 @@ export function AssistantStatusPanel({
   healthz,
   healthzLoading,
 }: AssistantStatusPanelProps) {
-  const isNonProduction = useFeatureFlagStore.use.isNonProduction();
+  const isNonProduction = useEnvironmentStore.use.isNonProduction();
   const user = useAuthStore.use.user();
   const email = user?.email;
 

--- a/apps/web/src/domains/settings/components/panels/environment-config-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/environment-config-panel.tsx
@@ -1,0 +1,52 @@
+import { Tag } from "@vellum/design-library/components/tag";
+import { Toggle } from "@vellum/design-library/components/toggle";
+import { SettingsCard } from "@/domains/settings/components/settings-card.js";
+import { useEnvironmentStore } from "@/lib/environment/environment-store.js";
+
+export function EnvironmentConfigPanel() {
+  const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
+  const isNonProduction = useEnvironmentStore.use.isNonProduction();
+  const setEnvironment = useEnvironmentStore.use.setEnvironment();
+
+  return (
+    <SettingsCard
+      title="Environment"
+      subtitle="Environment configuration overrides for this session."
+    >
+      <div className="space-y-2">
+        <div className="flex items-start gap-3 py-3">
+          <div className="shrink-0 pt-0.5">
+            <Toggle
+              checked={isNonProduction}
+              onChange={(next) =>
+                setEnvironment({ isNonProduction: next })
+              }
+              aria-label={`Non-Production is ${isNonProduction ? "on" : "off"}`}
+            />
+          </div>
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <span className="text-body-medium-default text-[var(--content-default)]">
+              Non-Production
+            </span>
+            <span className="block text-body-small-default text-[var(--content-tertiary)]">
+              Indicates a non-production environment. Enables dev-only UI surfaces and diagnostics.
+            </span>
+          </div>
+        </div>
+        <div className="flex items-start gap-3 py-3">
+          <div className="shrink-0 pt-0.5">
+            <Tag tone="neutral">{emailRootDomain}</Tag>
+          </div>
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <span className="text-body-medium-default text-[var(--content-default)]">
+              Email Root Domain
+            </span>
+            <span className="block text-body-small-default text-[var(--content-tertiary)]">
+              Root domain used for assistant email addresses (e.g. vellum.me).
+            </span>
+          </div>
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -137,13 +137,6 @@ const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
     description: "Enable the Home page as the default landing view.",
     defaultValue: false,
   },
-  isNonProduction: {
-    ldKey: "is-non-production",
-    label: "Non-Production",
-    description:
-      "Indicates a non-production environment. Enables dev-only UI surfaces and diagnostics.",
-    defaultValue: false,
-  },
   openAICompatibleEndpoints: {
     ldKey: "openai-compatible-endpoints",
     label: "OpenAI-Compatible Endpoints",
@@ -156,13 +149,6 @@ const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
     label: "Velvet",
     description: "Enable the Velvet design theme.",
     defaultValue: false,
-  },
-  emailRootDomain: {
-    ldKey: "email-root-domain",
-    label: "Email Root Domain",
-    description:
-      "Root domain used for assistant email addresses (e.g. vellum.me).",
-    defaultValue: "vellum.me",
   },
 };
 

--- a/apps/web/src/domains/settings/pages/developer-page.tsx
+++ b/apps/web/src/domains/settings/pages/developer-page.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 
 import { AssistantLifecyclePanel } from "@/domains/settings/components/panels/assistant-lifecycle-panel.js";
+import { EnvironmentConfigPanel } from "@/domains/settings/components/panels/environment-config-panel.js";
 import { FeatureFlagsPanel } from "@/domains/settings/components/panels/feature-flags-panel.js";
 import { SentryTestingPanel } from "@/domains/settings/components/panels/sentry-testing-panel.js";
 import { cn } from "@/utils/misc.js";
@@ -71,8 +72,9 @@ export function DeveloperPage() {
         className="flex min-h-0 flex-1 flex-col pt-6"
       >
         {activeTab === "feature-flags" && (
-          <div className="max-w-[940px]">
+          <div className="max-w-[940px] space-y-6">
             <FeatureFlagsPanel />
+            <EnvironmentConfigPanel />
           </div>
         )}
         {activeTab === "lifecycle" && (

--- a/apps/web/src/lib/environment/environment-store.ts
+++ b/apps/web/src/lib/environment/environment-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors.js";
+
+export interface EnvironmentConfig {
+  emailRootDomain: string;
+  isNonProduction: boolean;
+}
+
+interface EnvironmentActions {
+  setEnvironment: (config: Partial<EnvironmentConfig>) => void;
+}
+
+type EnvironmentStore = EnvironmentConfig & EnvironmentActions;
+
+const DEFAULT_ENVIRONMENT: EnvironmentConfig = {
+  emailRootDomain: "vellum.me",
+  isNonProduction: false,
+};
+
+const useEnvironmentStoreBase = create<EnvironmentStore>()((set) => ({
+  ...DEFAULT_ENVIRONMENT,
+  setEnvironment: (config) => set(config),
+}));
+
+export const useEnvironmentStore = createSelectors(useEnvironmentStoreBase);

--- a/apps/web/src/lib/feature-flags/feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-store.ts
@@ -35,9 +35,7 @@ export interface AppFeatureFlags {
   deployToVercel: boolean;
   developerSettings: boolean;
   doctor: boolean;
-  emailRootDomain: string;
   homePage: boolean;
-  isNonProduction: boolean;
   multiPlatformAssistant: boolean;
   openAICompatibleEndpoints: boolean;
   platformNotifications: boolean;
@@ -63,9 +61,7 @@ export const DEFAULT_FLAGS: AppFeatureFlags = {
   deployToVercel: false,
   developerSettings: false,
   doctor: false,
-  emailRootDomain: "vellum.me",
   homePage: false,
-  isNonProduction: false,
   multiPlatformAssistant: false,
   openAICompatibleEndpoints: false,
   platformNotifications: false,


### PR DESCRIPTION
## Summary
- Created a new `useEnvironmentStore` Zustand store for `emailRootDomain` and `isNonProduction`, separating environment config from LaunchDarkly feature flags
- Updated all consumers (ai-page, onboarding-page, assistant-status-panel, chat-layout) to read from the new store
- Added an `EnvironmentConfigPanel` to the developer settings page for toggling/viewing environment values
- Wired `chat-layout.tsx` to read `isNonProduction` from the store instead of hardcoding `false`

## Original prompt
The Zustand feature flag store contained two fields (`emailRootDomain` and `isNonProduction`) that are not LaunchDarkly feature flags — they're server-derived environment configuration values that got lumped in during the platform repo migration. The goal was to extract them into a separate environment store for structural separation, keeping the same defaults until a server hydration endpoint is wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)