### PR TITLE
ci(ios): migrate iOS release to same-repo reusable workflow (+ASC_KEY_P8 fix)

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1653,35 +1653,15 @@ jobs:
 
           echo "Uploaded Sparkle artifacts to gs://${BUCKET}/dev/ (version=${VERSION})"
 
-  # ── Dispatch iOS release to platform repo ────────────────────────────
+  # ── iOS release (same-repo reusable workflow) ────────────────────────
 
-  dispatch-ios-release:
+  release-ios:
     needs: [compute-version, register-release, upload-sparkle, build-chrome-extension]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment: dev
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
-          owner: vellum-ai
-          repositories: vellum-assistant-platform
-
-      - name: Dispatch iOS release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ needs.compute-version.outputs.version }}"
-          curl -fsSL \
-            -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/dispatches" \
-            -d "{\"event_type\":\"ios-release\",\"client_payload\":{\"environment\":\"dev\",\"version\":\"$VERSION\"}}"
-          echo "Dispatched ios-release to vellum-assistant-platform (environment=dev, version=$VERSION)"
+    uses: ./.github/workflows/release-ios.yaml
+    with:
+      environment: dev
+      version: ${{ needs.compute-version.outputs.version }}
+    secrets: inherit
 
   # ── Slack notification (first failure only) ──────────────────────────
 

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -237,7 +237,7 @@ jobs:
           BUILD_VERSION: ${{ steps.version.outputs.build_version }}
         run: |
           mkdir -p ~/.private_keys
-          echo "$ASC_KEY_P8" | base64 -D > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+          echo "$ASC_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
 
           APPLE_APP_ID_KEY="${{ steps.config.outputs.apple_app_id_key }}"
           APPLE_APP_ID="${!APPLE_APP_ID_KEY}"

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -1,0 +1,304 @@
+name: Release iOS
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment: dev, staging, or production"
+        required: true
+        type: string
+      version:
+        description: "Release version string (e.g. 0.6.0, 0.6.1-staging.1)"
+        required: true
+        type: string
+
+concurrency:
+  group: ios-release-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      KEYCHAIN_NAME: ios-build.keychain
+      KEYCHAIN_PASSWORD: temporary-ci-password
+    steps:
+      - name: Validate inputs
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "$ENVIRONMENT" ] || [ -z "$VERSION" ]; then
+            echo "::error::Missing required inputs: environment=$ENVIRONMENT, version=$VERSION"
+            exit 1
+          fi
+          if [[ "$ENVIRONMENT" != "dev" && "$ENVIRONMENT" != "staging" && "$ENVIRONMENT" != "production" ]]; then
+            echo "::error::Invalid environment: $ENVIRONMENT (expected dev, staging, or production)"
+            exit 1
+          fi
+          echo "Building iOS $ENVIRONMENT release, version $VERSION"
+
+      - name: Resolve environment config
+        id: config
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          case "$ENVIRONMENT" in
+            production)
+              echo "scheme=App" >> "$GITHUB_OUTPUT"
+              echo "bundle_id=ai.vocify-inc.vellum-assistant-ios" >> "$GITHUB_OUTPUT"
+              echo "profile_key=IOS_PROVISIONING_PROFILE" >> "$GITHUB_OUTPUT"
+              echo "profile_name=Vellum Assistant iOS Distribution" >> "$GITHUB_OUTPUT"
+              echo "apple_app_id_key=APPLE_APP_ID_PROD" >> "$GITHUB_OUTPUT"
+              echo "vellum_env=production" >> "$GITHUB_OUTPUT"
+              echo "testflight_internal=false" >> "$GITHUB_OUTPUT"
+              ;;
+            staging)
+              echo "scheme=App Staging" >> "$GITHUB_OUTPUT"
+              echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.staging" >> "$GITHUB_OUTPUT"
+              echo "profile_key=IOS_PROVISIONING_PROFILE_STAGING" >> "$GITHUB_OUTPUT"
+              echo "profile_name=Vellum Assistant iOS Staging Distribution" >> "$GITHUB_OUTPUT"
+              echo "apple_app_id_key=APPLE_APP_ID_STAGING" >> "$GITHUB_OUTPUT"
+              echo "vellum_env=staging" >> "$GITHUB_OUTPUT"
+              echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
+              ;;
+            dev)
+              echo "scheme=App Dev" >> "$GITHUB_OUTPUT"
+              echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.dev" >> "$GITHUB_OUTPUT"
+              echo "profile_key=IOS_PROVISIONING_PROFILE_DEV" >> "$GITHUB_OUTPUT"
+              echo "profile_name=Vellum Assistant iOS Dev Distribution" >> "$GITHUB_OUTPUT"
+              echo "apple_app_id_key=APPLE_APP_ID_DEV" >> "$GITHUB_OUTPUT"
+              echo "vellum_env=dev" >> "$GITHUB_OUTPUT"
+              echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Cache Bun packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('apps/web/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: apps/web
+        run: bun install --frozen-lockfile
+
+      - name: Capacitor sync
+        working-directory: apps/web
+        env:
+          VELLUM_ENVIRONMENT: ${{ steps.config.outputs.vellum_env }}
+        run: bunx cap sync ios
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: apps/ios/App
+        run: xcodegen generate --spec project.yml
+
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Import code-signing certificate
+        env:
+          CERT_P12: ${{ secrets.DIST_CERTIFICATE_P12 }}
+          CERT_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$CERT_P12" | base64 -D > /tmp/ios-certificate.p12
+          security import /tmp/ios-certificate.p12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm /tmp/ios-certificate.p12
+
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Verify signing identity
+        run: |
+          security find-identity -v -p codesigning | grep -q "Apple Distribution" \
+            || { echo "::error::Apple Distribution identity not found in keychain."; exit 1; }
+
+      - name: Install provisioning profile
+        env:
+          IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
+          IOS_PROVISIONING_PROFILE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_STAGING }}
+          IOS_PROVISIONING_PROFILE_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_DEV }}
+        run: |
+          PROFILE_KEY="${{ steps.config.outputs.profile_key }}"
+          PROFILE_B64="${!PROFILE_KEY}"
+          if [ -z "$PROFILE_B64" ]; then
+            echo "::error::Provisioning profile secret $PROFILE_KEY is empty"
+            exit 1
+          fi
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          echo "$PROFILE_B64" | base64 -D > "$PROFILE_DIR/ios_distribution.mobileprovision"
+          echo "Provisioning profile installed from $PROFILE_KEY"
+
+      - name: Set version
+        id: version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Apple requires CFBundleShortVersionString to be exactly X.Y.Z
+          # (numeric only, no prerelease suffixes). Strip any suffix for all
+          # environments. The full version is logged for traceability.
+          # https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring
+          DISPLAY_VERSION=$(echo "$VERSION" | sed 's/-.*//')
+          BUILD_VERSION=$(date -u +%Y%m%d%H%M)
+          echo "display_version=$DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Display version: $DISPLAY_VERSION (from $VERSION) / Build version: $BUILD_VERSION"
+
+      - name: Generate ExportOptions.plist
+        env:
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          BUNDLE_ID: ${{ steps.config.outputs.bundle_id }}
+          PROFILE_NAME: ${{ steps.config.outputs.profile_name }}
+          TESTFLIGHT_INTERNAL: ${{ steps.config.outputs.testflight_internal }}
+        run: |
+          INTERNAL_ENTRY=""
+          if [ "$TESTFLIGHT_INTERNAL" = "true" ]; then
+            INTERNAL_ENTRY="    <key>testFlightInternalTestingOnly</key>
+              <true/>"
+          fi
+          cat > /tmp/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>$TEAM_ID</string>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>$BUNDLE_ID</key>
+                  <string>$PROFILE_NAME</string>
+              </dict>
+              $INTERNAL_ENTRY
+          </dict>
+          </plist>
+          EOF
+
+      - name: Archive
+        working-directory: apps/ios/App
+        run: |
+          xcodebuild archive \
+            -project App.xcodeproj \
+            -scheme "${{ steps.config.outputs.scheme }}" \
+            -archivePath /tmp/App.xcarchive \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="${{ steps.config.outputs.profile_name }}" \
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            MARKETING_VERSION="${{ steps.version.outputs.display_version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build_version }}"
+
+      - name: Export .ipa
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath /tmp/App.xcarchive \
+            -exportPath /tmp/export \
+            -exportOptionsPlist /tmp/ExportOptions.plist
+
+      - name: Validate and upload to TestFlight
+        env:
+          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APPLE_APP_ID_DEV: ${{ secrets.APPLE_APP_ID_DEV }}
+          APPLE_APP_ID_STAGING: ${{ secrets.APPLE_APP_ID_STAGING }}
+          APPLE_APP_ID_PROD: ${{ secrets.APPLE_APP_ID_PROD }}
+          BUNDLE_ID: ${{ steps.config.outputs.bundle_id }}
+          DISPLAY_VERSION: ${{ steps.version.outputs.display_version }}
+          BUILD_VERSION: ${{ steps.version.outputs.build_version }}
+        run: |
+          mkdir -p ~/.private_keys
+          echo "$ASC_KEY_P8" | base64 -D > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+
+          APPLE_APP_ID_KEY="${{ steps.config.outputs.apple_app_id_key }}"
+          APPLE_APP_ID="${!APPLE_APP_ID_KEY}"
+          if [ -z "$APPLE_APP_ID" ]; then
+            echo "::error::Apple App ID secret $APPLE_APP_ID_KEY is empty"
+            exit 1
+          fi
+
+          IPA_FILE=$(find /tmp/export -name "*.ipa" -maxdepth 1 | head -1)
+          if [ -z "$IPA_FILE" ]; then
+            echo "::error::No .ipa file found in /tmp/export"
+            exit 1
+          fi
+
+          echo "Validating $IPA_FILE..."
+          xcrun altool --validate-app \
+            -f "$IPA_FILE" \
+            --type ios \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID"
+
+          echo "Uploading $IPA_FILE to TestFlight..."
+          xcrun altool --upload-package "$IPA_FILE" \
+            --type ios \
+            --apple-id "$APPLE_APP_ID" \
+            --bundle-id "$BUNDLE_ID" \
+            --bundle-version "$BUILD_VERSION" \
+            --bundle-short-version-string "$DISPLAY_VERSION" \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID"
+
+      - name: Upload .ipa artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ios-ipa-${{ inputs.environment }}
+          path: /tmp/export/*.ipa
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Cleanup keychain and keys
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf ~/.private_keys 2>/dev/null || true
+
+  notify-slack:
+    needs: [build-and-upload]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/send-build-alert
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/send-build-alert
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ needs.build-and-upload.result }}
+          slack-user-id: ${{ github.actor }}
+          should-tag: 'false'

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -11,6 +11,11 @@ on:
         description: "Release version string (e.g. 0.6.0, 0.6.1-staging.1)"
         required: true
         type: string
+      notify_slack:
+        description: "Whether the reusable workflow sends its own Slack alert. Set false when the caller already summarizes iOS status."
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ios-release-${{ inputs.environment }}
@@ -19,6 +24,7 @@ concurrency:
 jobs:
   build-and-upload:
     runs-on: macos-15
+    environment: ${{ inputs.environment }}
     timeout-minutes: 45
     env:
       KEYCHAIN_NAME: ios-build.keychain
@@ -286,7 +292,7 @@ jobs:
 
   notify-slack:
     needs: [build-and-upload]
-    if: always()
+    if: always() && inputs.notify_slack
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2657,6 +2657,7 @@ jobs:
     with:
       environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
       version: ${{ needs.extract-version.outputs.version }}
+      notify_slack: false
     secrets: inherit
 
   # ci-assistant runs lint/typecheck/test for the assistant service. It also

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2635,9 +2635,9 @@ jobs:
           sleep 10
           gh pr merge "$PR_URL" --auto --squash
 
-  # ── Dispatch iOS release to platform repo ────────────────────────────
+  # ── iOS release (same-repo reusable workflow) ────────────────────────
 
-  dispatch-ios-release:
+  release-ios:
     needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
     if: >-
       ${{
@@ -2653,36 +2653,11 @@ jobs:
         && (needs.publish-meta.result == 'success' || needs.publish-meta.result == 'skipped')
         && (needs.push-dockerhub-image.result == 'success' || needs.push-dockerhub-image.result == 'skipped')
       }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
-          owner: vellum-ai
-          repositories: vellum-assistant-platform
-
-      - name: Dispatch iOS release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ needs.extract-version.outputs.version }}"
-          IS_STAGING="${{ needs.extract-version.outputs.is_staging }}"
-          if [ "$IS_STAGING" = "true" ]; then
-            ENVIRONMENT="staging"
-          else
-            ENVIRONMENT="production"
-          fi
-          curl -fsSL \
-            -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/dispatches" \
-            -d "{\"event_type\":\"ios-release\",\"client_payload\":{\"environment\":\"$ENVIRONMENT\",\"version\":\"$VERSION\"}}"
-          echo "Dispatched ios-release to vellum-assistant-platform (environment=$ENVIRONMENT, version=$VERSION)"
+    uses: ./.github/workflows/release-ios.yaml
+    with:
+      environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
+      version: ${{ needs.extract-version.outputs.version }}
+    secrets: inherit
 
   # ci-assistant runs lint/typecheck/test for the assistant service. It also
   # transitively gates the release pipeline because push-assistant-image and
@@ -3044,7 +3019,7 @@ jobs:
   notify-release:
     name: Slack Notification (Release)
     if: ${{ always() && !cancelled() }}
-    needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, dispatch-ios-release, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, ci-playwright, build-chrome-extension, publish-chrome-extension]
+    needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, ci-playwright, build-chrome-extension, publish-chrome-extension]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -3125,7 +3100,7 @@ jobs:
           RR=$(ci_icon "${{ needs.register-release.result }}")
           PC=$(ci_icon "${{ needs.pack-cli.result }}")
           TQ=$(ci_icon "${{ needs.trigger-platform-qa.result }}")
-          DI=$(ci_icon "${{ needs.dispatch-ios-release.result }}")
+          DI=$(ci_icon "${{ needs.release-ios.result }}")
           CX=$(ci_icon "${{ needs.build-chrome-extension.result }}")
           CXP=$(ci_icon "${{ needs.publish-chrome-extension.result }}")
           MERGE_OUTCOME="${{ needs.merge-release-branch.outputs.outcome || needs.merge-release-branch.result }}"
@@ -3142,7 +3117,7 @@ jobs:
             fi
           fi
 
-          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s credential-executor\n• %s gateway\n• %s playwright%s\n• %s desktop (arm64)\n• %s desktop (x64)\n• %s dispatch-ios-release\n• %s chrome-extension\n• %s cws-publish\n• %s assistant-docker\n• %s gateway-docker\n• %s credential-executor-docker\n• %s dockerhub\n• %s register-release\n• %s pack-cli\n• %s trigger-platform-qa\n• %s merge-release-branch' "$A" "$C" "$CE" "$G" "$P" "$PLAYWRIGHT_LINE" "$D" "$DX" "$DI" "$CX" "$CXP" "$AI" "$GI" "$CEI" "$DH" "$RR" "$PC" "$TQ" "$MB")
+          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s credential-executor\n• %s gateway\n• %s playwright%s\n• %s desktop (arm64)\n• %s desktop (x64)\n• %s release-ios\n• %s chrome-extension\n• %s cws-publish\n• %s assistant-docker\n• %s gateway-docker\n• %s credential-executor-docker\n• %s dockerhub\n• %s register-release\n• %s pack-cli\n• %s trigger-platform-qa\n• %s merge-release-branch' "$A" "$C" "$CE" "$G" "$P" "$PLAYWRIGHT_LINE" "$D" "$DX" "$DI" "$CX" "$CXP" "$AI" "$GI" "$CEI" "$DH" "$RR" "$PC" "$TQ" "$MB")
 
           if [ -n "$SLACK_USER_ID" ]; then
             TRIGGERED_BY="<@${SLACK_USER_ID}>"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,11 @@ We do **not** pin: `apt-get` packages (Debian rotates), `brew install` formulae 
 
 `dev-release.yaml` and `release.yml` share inline logic (e.g. "Compute migration ceilings"). When changing logic that lives in both, update both in the same PR.
 
-### iOS release dispatch
+### iOS release
 
 The Capacitor iOS source-of-truth lives in [`apps/ios/`](./apps/ios/) and is built locally from `apps/web/` via `bun run ios:open`. See [`apps/ios/README.md`](./apps/ios/README.md) for the local build flow and full release pipeline mapping.
 
-Until the deployment cutover, TestFlight builds still come from `vellum-assistant-platform/web/ios/`: `dev-release.yaml` / `release.yml` fire a `repository_dispatch` to [`vellum-assistant-platform`](https://github.com/vellum-ai/vellum-assistant-platform)'s `release-ios.yaml` with `{ environment, version }`. When the pipeline is migrated, the dispatch becomes a same-repo `needs:` and the platform copy is decommissioned.
+TestFlight builds are produced by the `release-ios.yaml` reusable workflow in this repo. Both `dev-release.yaml` and `release.yml` call it as a same-repo `uses:` job with `{ environment, version }` inputs. The workflow runs on `macos-15`, installs web dependencies, runs `cap sync ios`, generates the Xcode project via XcodeGen, archives, signs, and uploads to TestFlight.
 
 ## Testing
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -22,9 +22,7 @@ all `.xcscheme` files, `contents.xcworkspacedata`, the SPM workspace
 state) is regenerated from `App/project.yml` by
 [XcodeGen](https://github.com/yonaskolb/XcodeGen) every time you build —
 locally via `bun run ios:setup`, in CI via the `xcodegen generate` step
-in `release-ios.yaml`. **Until the deployment cutover, the release
-pipeline still runs from `vellum-assistant-platform/web/ios/`** — the
-workflow migration is a separate follow-up.
+in `.github/workflows/release-ios.yaml`.
 
 What _is_ committed and what generates from where:
 
@@ -276,63 +274,48 @@ On first build after pulling:
 
 ## CI / Release pipeline
 
-> **Migration note**: this directory is the new home for the Capacitor
-> iOS shell. Until the deployment cutover, the actual release pipeline
-> still runs from `vellum-assistant-platform/web/ios/` — that's the
-> copy that gets built and shipped to TestFlight. The description below
-> documents the existing pipeline as it lives in the platform repo;
-> pointing it at this directory is a follow-up task.
-
-iOS builds are triggered **cross-repo** from
-[`vellum-assistant`](https://github.com/vellum-ai/vellum-assistant) via
-GitHub Actions
-[`repository_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch)
-events. This keeps iOS releases in sync with the macOS release pipeline
-without duplicating version/environment logic.
+iOS builds are produced by `.github/workflows/release-ios.yaml`, a
+reusable workflow called from both `dev-release.yaml` and `release.yml`
+in the same repo. This keeps iOS releases in sync with the macOS
+release pipeline without cross-repo dispatch complexity.
 
 ### How it works
 
-There are three release tracks, each originating in `vellum-assistant`:
+There are three release tracks:
 
 **Dev release** — `dev-release.yaml` runs hourly (cron) or via manual
-`workflow_dispatch`. It builds from `main`, and the `dispatch-ios-release`
-job fires an `ios-release` event with `environment=dev`.
+`workflow_dispatch`. It builds from `main`, and the `release-ios` job
+calls `release-ios.yaml` with `environment=dev`.
 
 **Staging release** — `/release` (slash command) runs `create-release-branch.yml`,
 which creates a `release/v*` branch. Pushing to that branch triggers
-`release.yml` with `is_staging=true`, and the `dispatch-ios-release` job
-fires an `ios-release` event with `environment=staging`. A manual
+`release.yml` with `is_staging=true`, and the `release-ios` job
+calls `release-ios.yaml` with `environment=staging`. A manual
 `workflow_dispatch` of `release.yml` from `main` also produces a staging release.
 
 **Production release** — A manual `workflow_dispatch` of `release.yml` on
 the `release/v*` branch (not `main`) sets `is_staging=false`, and the
-`dispatch-ios-release` job fires an `ios-release` event with
-`environment=production`.
+`release-ios` job calls `release-ios.yaml` with `environment=production`.
 
 ```
-vellum-assistant                           vellum-assistant-platform
-────────────────                           ────────────────────────
-dev-release.yaml (hourly / manual)         release-ios.yaml
-  └─ dispatch-ios-release ──────────────►    repository_dispatch: ios-release
-     environment=dev                           └─ builds App Dev → TestFlight
+dev-release.yaml (hourly / manual)
+  └─ release-ios (uses: release-ios.yaml)
+     environment=dev → builds App Dev → TestFlight
 
-release.yml (push to release/v* or         release-ios.yaml
-             manual dispatch from main)
-  └─ dispatch-ios-release ──────────────►    repository_dispatch: ios-release
-     environment=staging                       └─ builds App Staging → TestFlight
+release.yml (push to release/v* or manual dispatch from main)
+  └─ release-ios (uses: release-ios.yaml)
+     environment=staging → builds App Staging → TestFlight
 
-release.yml (manual dispatch on            release-ios.yaml
-             release/v* branch)
-  └─ dispatch-ios-release ──────────────►    repository_dispatch: ios-release
-     environment=production                    └─ builds App → TestFlight
-
+release.yml (manual dispatch on release/v* branch)
+  └─ release-ios (uses: release-ios.yaml)
+     environment=production → builds App → TestFlight
 ```
 
-### Workflows (currently in `vellum-assistant-platform`)
+### Workflow
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `release-ios.yaml` | `repository_dispatch` from vellum-assistant | Automated release builds (dev/staging/production) |
+| `release-ios.yaml` | `workflow_call` from release workflows | Automated release builds (dev/staging/production) |
 
 ### Environment → scheme mapping
 
@@ -353,11 +336,8 @@ the boolean differs.
 
 ### Notifications
 
-The workflow calls the repo's reusable
-[`slack-build-alert.yml`](.github/workflows/slack-build-alert.yml)
-workflow on completion (`if: always()`), matching the pattern used by
-`main-ci-cd.yaml`, `cd-vembda-assistant-server.yml`, and the Terraform
-apply workflows. Failures surface in `#build-alerts` via
+The workflow uses the `.github/actions/send-build-alert` composite action
+on completion (`if: always()`). Failures surface in `#build-alerts` via
 `SLACK_WEBHOOK_URL`.
 
 ### Why no `bun run build` before `cap sync`
@@ -385,11 +365,10 @@ confirmed on the `macos-15` GitHub Actions runner image
 ### Workflow file conventions
 
 Files are named `.yaml` (not `.yml`) to match the majority convention
-in this repo. The iOS release is a single combined workflow (not
-separate CI/CD files) because it's an atomic operation triggered by
-`repository_dispatch` — there's no separate CI gate. Signing steps are
-not extracted into a reusable workflow because it's the only iOS
-workflow.
+in this repo. The iOS release is a reusable `workflow_call` workflow
+called from the release pipelines — there's no separate CI gate.
+Signing steps are not extracted into their own reusable workflow
+because it's the only iOS workflow.
 
 ### Secrets (GitHub Actions)
 
@@ -402,13 +381,6 @@ All iOS signing secrets are stored as GitHub Actions secrets:
 - `IOS_PROVISIONING_PROFILE_STAGING` / `_DEV` — Per-environment profiles
 - `APPLE_APP_ID_PROD` / `_STAGING` / `_DEV` — Numeric App Store Connect app IDs (e.g. `123456789`), passed as `--apple-id` to [`xcrun altool --upload-package`](https://keith.github.io/xcode-man-pages/altool.7.html). Each environment has its own ASC app record with its own ID.
 - `SLACK_WEBHOOK_URL` — Slack incoming webhook for `#build-alerts` notifications
-
-### Cross-repo auth
-
-The dispatch uses a GitHub App token generated from `VELLUM_AUTOMATION_GITHUB_APP_ID`
-/ `VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY` (stored in `vellum-assistant`), scoped to
-`vellum-assistant-platform` via
-[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token).
 
 ## Structure
 


### PR DESCRIPTION
Takeover of #31523. Same content + one fix on top.

## Delta from #31523

- **`release-ios.yaml`**: write `ASC_KEY_P8` as raw P8 content instead of `base64 -D` (matches the existing macOS notarization pattern in this repo at `dev-release.yaml:1458` and `release.yml:1613`). With `secrets: inherit`, both consumers must agree on encoding — the existing macOS step treats it as raw, so the new iOS step must too.

## Everything else

Unchanged from #31523. See that PR for the full migration rationale, caller diffs, and prerequisite secret list.

## Recommended follow-ups (deferred, see #31523 comment)

- Decide whether `release.yml`'s notify-release summary makes the reusable workflow's own `notify-slack` redundant.
- Consider restoring `environment: ${{ inputs.environment }}` on the reusable build job for deployment history.

Closes #31523 if merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLR12Mp7qigNjfHu4X7A3E)_