### PR TITLE
feat(memory-v2): tier 2 — top-M-by-EMA pages get their own batch

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -38,6 +38,7 @@ describe("MemoryV2ConfigSchema", () => {
         router_prompt_path: null,
         batch_size: null,
         tier1_size: null,
+        tier2_size: null,
       },
     });
   });

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -300,6 +300,15 @@ export const MemoryV2ConfigSchema = z
           .describe(
             "Pool size for the tier-1 'recently modified' batch. `null` (default) disables tier 1 entirely — all pages flow through tier 3 batching. When set, the top-N concept pages by file mtime become their own dedicated parallel batch with mtime-desc ordering; everything else is partitioned into tier 3 batches by `batch_size`. Synthetic entries (skills, CLI commands) have mtime=0 and naturally rank below real concept pages so they don't crowd tier 1.",
           ),
+        tier2_size: z
+          .number()
+          .int()
+          .min(1)
+          .nullable()
+          .default(null)
+          .describe(
+            "Pool size for the tier-2 'useful' batch. `null` (default) disables tier 2 — pages skip straight from tier 1 to tier 3. When set, the top-M pages by injection-frequency EMA (excluding tier 1) become their own parallel batch ordered by score desc. Pages with score 0 (never selected since EMA tracking began) are ineligible for tier 2 and stay in tier 3 regardless of `tier2_size`. Score is the time-decayed sum `Σ exp(-λ(now - tᵢ))` with 3-day half-life, computed on read from `memory_v2_injection_events`.",
+          ),
       })
       .default({
         enabled: true,
@@ -307,6 +316,7 @@ export const MemoryV2ConfigSchema = z
         router_prompt_path: null,
         batch_size: null,
         tier1_size: null,
+        tier2_size: null,
       })
       .describe(
         "LLM router configuration. When enabled, a single router LLM call replaces spreading activation for per-turn page selection.",

--- a/assistant/src/memory/v2/__tests__/page-index.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-index.test.ts
@@ -497,7 +497,7 @@ describe("partitionPageIndex", () => {
 // splitTier1 — recently modified pool extraction
 // ---------------------------------------------------------------------------
 
-const { splitTier1 } = await import("../page-index.js");
+const { splitTier1, splitTier2 } = await import("../page-index.js");
 const { utimes } = await import("node:fs/promises");
 const { join: joinPath } = await import("node:path");
 
@@ -619,5 +619,106 @@ describe("splitTier1", () => {
 
     const { tier1 } = splitTier1(idx, 2);
     expect(tier1!.entries.map((e) => e.slug)).toEqual(["alpha", "bravo"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitTier2 — top-M-by-EMA pool extraction
+// ---------------------------------------------------------------------------
+
+describe("splitTier2", () => {
+  async function buildIndex(slugs: string[]) {
+    for (const slug of slugs) {
+      await writePage(workspaceDir, makePage(slug, { summary: `${slug} sum` }));
+    }
+    return getPageIndex(workspaceDir);
+  }
+
+  test("tier2Size=null is a no-op — same index reference, no carve-out", async () => {
+    const idx = await buildIndex(["a", "b", "c"]);
+    const { tier2, rest } = splitTier2(idx, null, new Map());
+    expect(tier2).toBeNull();
+    expect(rest).toBe(idx);
+  });
+
+  test("returns no-op when no pages have a positive score", async () => {
+    const idx = await buildIndex(["a", "b", "c"]);
+    // Empty scores map → every page has score 0 → none eligible.
+    const { tier2, rest } = splitTier2(idx, 2, new Map());
+    expect(tier2).toBeNull();
+    expect(rest).toBe(idx);
+  });
+
+  test("top-M by score desc become tier 2; lower-score pages stay in rest", async () => {
+    await buildIndex(["a", "b", "c", "d", "e"]);
+    const idx = await getPageIndex(workspaceDir);
+    const scores = new Map([
+      ["a", 1.0],
+      ["b", 5.0],
+      ["c", 2.0],
+      ["d", 4.0],
+      ["e", 3.0],
+    ]);
+
+    const { tier2, rest } = splitTier2(idx, 2, scores);
+    expect(tier2!.entries.map((e) => e.slug)).toEqual(["b", "d"]);
+    expect(rest.entries.map((e) => e.slug).sort()).toEqual(["a", "c", "e"]);
+  });
+
+  test("score=0 pages are ineligible even when tier2Size is large", async () => {
+    await buildIndex(["a", "b", "c", "d", "e"]);
+    const idx = await getPageIndex(workspaceDir);
+    // Only 2 pages have positive scores; tier2Size=10 should NOT pull in
+    // zero-score pages to fill the pool.
+    const scores = new Map([
+      ["b", 5.0],
+      ["d", 4.0],
+    ]);
+    const { tier2, rest } = splitTier2(idx, 10, scores);
+    expect(tier2!.entries.map((e) => e.slug)).toEqual(["b", "d"]);
+    expect(rest.entries.map((e) => e.slug).sort()).toEqual(["a", "c", "e"]);
+  });
+
+  test("tied scores break by slug ASCII for determinism", async () => {
+    await buildIndex(["alpha", "bravo", "charlie", "delta"]);
+    const idx = await getPageIndex(workspaceDir);
+    const scores = new Map([
+      ["alpha", 2.0],
+      ["bravo", 2.0],
+      ["charlie", 2.0],
+      ["delta", 1.0],
+    ]);
+
+    const { tier2 } = splitTier2(idx, 2, scores);
+    expect(tier2!.entries.map((e) => e.slug)).toEqual(["alpha", "bravo"]);
+  });
+
+  test("tier 2 entries carry batch-local 1-based IDs", async () => {
+    await buildIndex(["a", "b", "c"]);
+    const idx = await getPageIndex(workspaceDir);
+    const { tier2 } = splitTier2(
+      idx,
+      2,
+      new Map([
+        ["a", 1.0],
+        ["b", 2.0],
+      ]),
+    );
+    expect(tier2!.entries.map((e) => e.id)).toEqual([1, 2]);
+    expect(tier2!.rendered).toContain("[1] ");
+    expect(tier2!.rendered).toContain("[2] ");
+  });
+
+  test("tier2Size larger than eligible count fills with available; rest gets remainder", async () => {
+    await buildIndex(["a", "b", "c"]);
+    const idx = await getPageIndex(workspaceDir);
+    const scores = new Map([
+      ["a", 1.0],
+      ["b", 2.0],
+      ["c", 3.0],
+    ]);
+    const { tier2, rest } = splitTier2(idx, 100, scores);
+    expect(tier2!.entries.length).toBe(3);
+    expect(rest.entries.length).toBe(0);
   });
 });

--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -73,6 +73,26 @@ mock.module("../skill-store.js", () => ({
   listSkillEntries: () => skillState.entries,
 }));
 
+// Stub `computeInjectionScores` so tier-2 tests can dictate scores
+// without spinning up a real bun:sqlite db. Real production wiring is
+// covered by the splitTier2 unit tests in page-index.test.ts and the
+// score-formula tests in injection-events.test.ts.
+const scoresStub = new Map<string, number>();
+mock.module("../injection-events.js", () => ({
+  computeInjectionScores: (
+    _db: unknown,
+    slugs: readonly string[],
+    _now: number,
+  ): Map<string, number> => {
+    const out = new Map<string, number>();
+    for (const slug of slugs) {
+      const score = scoresStub.get(slug);
+      if (score !== undefined && score > 0) out.set(slug, score);
+    }
+    return out;
+  },
+}));
+
 // Provider stub. Each test sets `providerStub` to control the response;
 // `null` simulates "no configured provider available".
 let providerStub: Provider | null = null;
@@ -112,6 +132,7 @@ beforeEach(() => {
   providerStub = null;
   providerCalls.length = 0;
   warnLogs.length = 0;
+  scoresStub.clear();
   invalidatePageIndex();
 });
 
@@ -198,6 +219,7 @@ function makeConfig(overrides?: {
   maxPageIds?: number;
   batchSize?: number | null;
   tier1Size?: number | null;
+  tier2Size?: number | null;
 }) {
   return {
     memory: {
@@ -208,6 +230,7 @@ function makeConfig(overrides?: {
           max_page_ids: overrides?.maxPageIds ?? 25,
           batch_size: overrides?.batchSize ?? null,
           tier1_size: overrides?.tier1Size ?? null,
+          tier2_size: overrides?.tier2Size ?? null,
         },
       },
     },
@@ -807,5 +830,133 @@ describe("runRouter — tier 1 (recently modified)", () => {
     });
     // 5 pages, tier1_size=100 → only tier 1 fires; the empty rest is dropped.
     expect(providerCalls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 (highest-EMA) splitting.
+// ---------------------------------------------------------------------------
+
+describe("runRouter — tier 2 (highest EMA)", () => {
+  // Any non-null value passes the `params.database` check in the orchestrator;
+  // the real db is never touched because computeInjectionScores is mocked.
+  const stubDb = {} as Parameters<typeof runRouter>[0]["database"];
+
+  beforeEach(async () => {
+    await writePage(workspaceDir, makePage("alpha", { summary: "A" }));
+    await writePage(workspaceDir, makePage("bravo", { summary: "B" }));
+    await writePage(workspaceDir, makePage("charlie", { summary: "C" }));
+    await writePage(workspaceDir, makePage("delta", { summary: "D" }));
+    await writePage(workspaceDir, makePage("echo", { summary: "E" }));
+  });
+
+  test("tier2_size + tier1_size both null is the v3 single-batch path", async () => {
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig(),
+      database: stubDb,
+    });
+    expect(providerCalls).toHaveLength(1);
+  });
+
+  test("tier2_size=2 produces 2 batches (tier 2 + rest)", async () => {
+    scoresStub.set("alpha", 1.0);
+    scoresStub.set("bravo", 5.0);
+    scoresStub.set("delta", 4.0);
+
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ tier2Size: 2 }),
+      database: stubDb,
+    });
+    expect(providerCalls.length).toBe(2);
+
+    // Tier 2 is the first batch (no tier 1 in this test). Its prompt should
+    // contain exactly the top-2 by score: bravo (5) and delta (4).
+    const tier2Prompt = providerCalls[0].systemPrompt ?? "";
+    const indexedSlugs = new Set(
+      [...tier2Prompt.matchAll(/^\[\d+\] (\S+)/gm)].map((m) => m[1]),
+    );
+    expect(indexedSlugs).toEqual(new Set(["bravo", "delta"]));
+  });
+
+  test("tier 1 then tier 2 then rest — three batches in that order", async () => {
+    // Pin mtimes so tier 1 is deterministic: alpha + bravo are the two
+    // most recent (highest mtime values). Tier 2 runs on the rest
+    // (charlie, delta, echo) using scores we control.
+    const { utimes } = await import("node:fs/promises");
+    const stamp = async (slug: string, s: number) =>
+      utimes(join(workspaceDir, "memory", "concepts", `${slug}.md`), s, s);
+    await stamp("alpha", 9000);
+    await stamp("bravo", 8000);
+    await stamp("charlie", 3000);
+    await stamp("delta", 2000);
+    await stamp("echo", 1000);
+    invalidatePageIndex();
+
+    scoresStub.set("charlie", 2.0);
+    scoresStub.set("delta", 3.0);
+    // echo has no score → ineligible for tier 2.
+
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ tier1Size: 2, tier2Size: 2 }),
+      database: stubDb,
+    });
+    expect(providerCalls.length).toBe(3);
+
+    // Tier 2 batch (index 1) contains charlie + delta. Echo went to rest.
+    const tier2Prompt = providerCalls[1].systemPrompt ?? "";
+    const tier2Slugs = new Set(
+      [...tier2Prompt.matchAll(/^\[\d+\] (\S+)/gm)].map((m) => m[1]),
+    );
+    expect(tier2Slugs).toEqual(new Set(["charlie", "delta"]));
+
+    // Echo (no score) must land in the rest batch, not tier 2.
+    const restPrompt = providerCalls[2].systemPrompt ?? "";
+    const restSlugs = new Set(
+      [...restPrompt.matchAll(/^\[\d+\] (\S+)/gm)].map((m) => m[1]),
+    );
+    expect(restSlugs).toEqual(new Set(["echo"]));
+  });
+
+  test("score=0 pages stay in rest even when tier2_size is large", async () => {
+    // Only one page has a positive score; tier2_size=100 should NOT pull in
+    // zero-score pages.
+    scoresStub.set("bravo", 5.0);
+
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ tier2Size: 100 }),
+      database: stubDb,
+    });
+    expect(providerCalls.length).toBe(2);
+    const tier2Prompt = providerCalls[0].systemPrompt ?? "";
+    expect(tier2Prompt).toContain("[1] bravo");
+    expect(tier2Prompt).not.toMatch(/^\[\d+\] alpha/m);
+  });
+
+  test("tier2_size set without database logs a warn and skips tier 2", async () => {
+    scoresStub.set("bravo", 5.0);
+    providerStub = makeProvider(toolUseResponse([1]));
+    await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ tier2Size: 2 }),
+      // No database → tier 2 silently skipped.
+    });
+    expect(providerCalls).toHaveLength(1);
+    const warned = warnLogs.some((l) =>
+      JSON.stringify(l.args).includes("tier2_size set but no database"),
+    );
+    expect(warned).toBe(true);
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -553,6 +553,7 @@ async function injectViaRouter(args: {
     nowText,
     priorEverInjected,
     config,
+    database,
     ...(signal ? { signal } : {}),
   });
 

--- a/assistant/src/memory/v2/page-index.ts
+++ b/assistant/src/memory/v2/page-index.ts
@@ -392,6 +392,52 @@ export function splitTier1(
   return { tier1, rest: buildLocalPageIndex(restEntries, pageIndex) };
 }
 
+/**
+ * Carve the top-M highest-EMA pages into their own batch (tier 2 in the
+ * v4 router architecture). Caller computes `scores` via
+ * `computeInjectionScores`; this function stays pure so unit tests don't
+ * need a database.
+ *
+ * `tier2Size === null` is a no-op. Pages with `score <= 0` (no events in
+ * the read window) are ineligible regardless of `tier2Size` — a stale
+ * page with zero score belongs in tier 3, not in the "useful" pool.
+ * Ordering is score desc, slug-ASCII tiebreak.
+ *
+ * Expected call shape: orchestrator passes the *post-tier-1* `PageIndex`,
+ * so we never re-promote a tier-1 page to tier 2.
+ */
+export function splitTier2(
+  pageIndex: PageIndex,
+  tier2Size: number | null,
+  scores: ReadonlyMap<string, number>,
+): { tier2: PageIndex | null; rest: PageIndex } {
+  if (tier2Size === null || pageIndex.entries.length === 0) {
+    return { tier2: null, rest: pageIndex };
+  }
+  const eligible = pageIndex.entries
+    .map((entry) => ({ entry, score: scores.get(entry.slug) ?? 0 }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      return a.entry.slug < b.entry.slug
+        ? -1
+        : a.entry.slug > b.entry.slug
+          ? 1
+          : 0;
+    });
+  const tier2Entries = eligible.slice(0, tier2Size).map((x) => x.entry);
+  if (tier2Entries.length === 0) {
+    return { tier2: null, rest: pageIndex };
+  }
+  const tier2Slugs = new Set(tier2Entries.map((e) => e.slug));
+  const restEntries = pageIndex.entries.filter((e) => !tier2Slugs.has(e.slug));
+  const tier2 = buildLocalPageIndex(tier2Entries, pageIndex);
+  if (restEntries.length === 0) {
+    return { tier2, rest: emptyPageIndex() };
+  }
+  return { tier2, rest: buildLocalPageIndex(restEntries, pageIndex) };
+}
+
 function emptyPageIndex(): PageIndex {
   return {
     entries: [],

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -47,8 +47,15 @@ import type {
   ToolDefinition,
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { computeInjectionScores } from "./injection-events.js";
 import type { PageIndex } from "./page-index.js";
-import { getPageIndex, partitionPageIndex, splitTier1 } from "./page-index.js";
+import {
+  getPageIndex,
+  partitionPageIndex,
+  splitTier1,
+  splitTier2,
+} from "./page-index.js";
 import { resolveRouterPrompt } from "./prompts/router.js";
 import type { EverInjectedEntry } from "./types.js";
 
@@ -128,6 +135,13 @@ interface RunRouterParams {
   priorEverInjected: readonly EverInjectedEntry[];
   config: AssistantConfig;
   signal?: AbortSignal;
+  /**
+   * Database handle for reading EMA scores when `tier2_size` is set. When
+   * absent, tier 2 is silently skipped (pages flow tier 1 → tier 3). The
+   * production caller (`injectViaRouter`) always passes it; tests that
+   * only exercise tier 1 / tier 3 paths can omit it.
+   */
+  database?: DrizzleDb;
 }
 
 /**
@@ -171,16 +185,34 @@ export async function runRouter(
 
   const batchSize = config.memory?.v2?.router?.batch_size ?? null;
   const tier1Size = config.memory?.v2?.router?.tier1_size ?? null;
+  const tier2Size = config.memory?.v2?.router?.tier2_size ?? null;
 
-  // Tier 1 is the "recently modified" pool — its own batch with mtime-desc
-  // ordering. The remainder flows through tier-3 hash bucketing. With
-  // tier1_size=null AND batch_size=null we hit the bit-identical single-
-  // batch path that preserves v3's KV cache.
-  const { tier1, rest } = splitTier1(pageIndex, tier1Size);
-  const tier3Batches = partitionPageIndex(rest, batchSize).filter(
+  // Carve in tier order so each later tier sees only what's left. With
+  // every tier disabled (defaults) we hit the bit-identical single-batch
+  // path that preserves v3's KV cache.
+  const { tier1, rest: afterTier1 } = splitTier1(pageIndex, tier1Size);
+
+  let tier2: PageIndex | null = null;
+  let afterTier2: PageIndex = afterTier1;
+  if (tier2Size !== null && params.database && afterTier1.entries.length > 0) {
+    const slugs = afterTier1.entries.map((e) => e.slug);
+    const scores = computeInjectionScores(params.database, slugs, Date.now());
+    const split = splitTier2(afterTier1, tier2Size, scores);
+    tier2 = split.tier2;
+    afterTier2 = split.rest;
+  } else if (tier2Size !== null && !params.database) {
+    log.warn(
+      "tier2_size set but no database passed to runRouter; skipping tier 2",
+    );
+  }
+
+  const tier3Batches = partitionPageIndex(afterTier2, batchSize).filter(
     (b) => b.entries.length > 0,
   );
-  const batches: PageIndex[] = tier1 ? [tier1, ...tier3Batches] : tier3Batches;
+  const batches: PageIndex[] = [];
+  if (tier1) batches.push(tier1);
+  if (tier2) batches.push(tier2);
+  batches.push(...tier3Batches);
   if (batches.length === 0) {
     return emptyResult("empty_index");
   }


### PR DESCRIPTION
## Summary
- New \`config.memory.v2.router.tier2_size\` (default \`null\`). When set, the orchestrator computes EMA scores via the existing \`computeInjectionScores\` and carves the top-M positive-score pages into their own parallel batch ahead of tier 3.
- \`splitTier2(pageIndex, tier2Size, scores)\` is a pure function (no DB) — orchestrator computes scores, then calls it. Score=0 pages are ineligible regardless of M.
- Tier ordering in the batch list: tier 1 → tier 2 → tier 3 batches. Single-batch path still bit-identical to v3 when every tier is null.
- \`RunRouterParams.database\` is now optional; \`injectViaRouter\` threads the existing handle through. Setting \`tier2_size\` without a DB logs a warn and skips tier 2.
- 11 new tests: 7 \`splitTier2\` unit tests + 4 orchestrator tests (mocked scores, full tier 1+2+rest flow, zero-score handling, missing-DB warn).

## Original prompt
Step 4 of the memory router v4 spec — tier 2 (\"useful\") pulls top-M-by-EMA pages from the post-tier-1 set. Gated behind nullable config; \`memory_v2_activation_logs\` backfill at PR #31452 already gave ~54k events so flipping it on doesn't require warmup. Same Opus + generous prompt per the spec's step-4 gate.

## Test plan
- [x] router/page-index/injection/schema tests all green (137 tests total).
- [x] \`bunx tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)