### PR TITLE
ci(ios): add workflow_dispatch trigger to release-ios.yaml

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -16,6 +16,26 @@ on:
         required: false
         type: boolean
         default: true
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+        default: dev
+      version:
+        description: "Release version string (e.g. 0.6.0)"
+        required: true
+        type: string
+      notify_slack:
+        description: "Send Slack alert from this workflow"
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ios-release-${{ inputs.environment }}


### PR DESCRIPTION
Follow-up to #31530.

## Why

`release-ios.yaml` is currently `workflow_call`-only, which means the only way to test it is to dispatch the full `dev-release.yaml` pipeline (macOS arm64 + x64 + sparkle + chrome ext, ~30 min of gates before iOS even starts). Adding `workflow_dispatch` lets us invoke iOS directly when iterating on the build itself or validating a stale Apple secret.

## What

Add a `workflow_dispatch` trigger with the same three inputs as `workflow_call`. `environment` is a `choice` for the dropdown in the Actions UI.

## Usage

```sh
gh workflow run release-ios.yaml --ref main \
  -f environment=dev -f version=0.8.3
```

Or via the Actions UI: **Release iOS → Run workflow**.

## Test plan

- Manually dispatch with `environment=dev`, watch the run end-to-end on a smoke-test version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLR12Mp7qigNjfHu4X7A3E)_