### PR TITLE
fix(web): show Home icon on mobile viewports

### DIFF
--- a/apps/web/src/domains/chat/chat-layout-header.tsx
+++ b/apps/web/src/domains/chat/chat-layout-header.tsx
@@ -80,25 +80,25 @@ export function ChatLayoutHeader({
             onClick={toggleSidebar}
           />
         )}
+        {onOpenHome ? (
+          <span className="relative">
+            <Button
+              variant="ghost"
+              iconOnly={<House />}
+              aria-label={hasUnreadHome && !isHomeActive ? "Home (unread notifications)" : "Home"}
+              aria-current={isHomeActive ? "page" : undefined}
+              onClick={onOpenHome}
+            />
+            {hasUnreadHome && !isHomeActive ? (
+              <span
+                className="pointer-events-none absolute right-1 top-1 h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
+                aria-hidden="true"
+              />
+            ) : null}
+          </span>
+        ) : null}
         {!isMobile ? (
           <>
-            {onOpenHome ? (
-              <span className="relative">
-                <Button
-                  variant="ghost"
-                  iconOnly={<House />}
-                  aria-label={hasUnreadHome && !isHomeActive ? "Home (unread notifications)" : "Home"}
-                  aria-current={isHomeActive ? "page" : undefined}
-                  onClick={onOpenHome}
-                />
-                {hasUnreadHome && !isHomeActive ? (
-                  <span
-                    className="pointer-events-none absolute right-1 top-1 h-2 w-2 rounded-full bg-[var(--system-negative-strong)]"
-                    aria-hidden="true"
-                  />
-                ) : null}
-              </span>
-            ) : null}
             {onSearchClick ? (
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Summary
- The Home button (with its unread notification badge) was previously hidden on iPhone/mobile viewports because it was inside the `!isMobile` conditional block alongside the search and back/forward navigation buttons
- Moved the Home button out of the desktop-only `!isMobile` block so it renders on all viewport sizes
- Search and back/forward buttons remain desktop-only

## Test plan
- [ ] Open the web app on a mobile viewport (iPhone or Chrome DevTools responsive mode)
- [ ] Verify the Home icon appears in the header bar
- [ ] Verify the unread badge dot appears on the Home icon when there are unread home notifications
- [ ] Verify search and back/forward buttons are still hidden on mobile
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)