### PR TITLE
fix(web): stop conflating daemon conversationId with web conversationKey

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.test.ts
+++ b/apps/web/src/domains/chat/api/event-parser.test.ts
@@ -16,7 +16,7 @@ describe("parseAssistantEvent", () => {
     });
   });
 
-  test("maps assistant_text_delta conversationId to conversationKey", () => {
+  test("does not conflate conversationId with conversationKey", () => {
     const event = parseAssistantEvent("assistant_text_delta", {
       text: "Hello",
       messageId: "msg-1",
@@ -26,7 +26,6 @@ describe("parseAssistantEvent", () => {
       type: "assistant_text_delta",
       text: "Hello",
       messageId: "msg-1",
-      conversationKey: "conversation-1",
     });
   });
 
@@ -234,7 +233,7 @@ describe("parseAssistantEvent", () => {
 
   test("parses assistant_activity_state idle", () => {
     const event = parseAssistantEvent("assistant_activity_state", {
-      conversationId: "conv-1",
+      conversationKey: "conv-1",
       activityVersion: 7,
       phase: "idle",
       anchor: "global",
@@ -254,7 +253,7 @@ describe("parseAssistantEvent", () => {
 
   test("parses assistant_activity_state thinking with statusText", () => {
     const event = parseAssistantEvent("assistant_activity_state", {
-      conversationId: "conv-1",
+      conversationKey: "conv-1",
       activityVersion: 3,
       phase: "thinking",
       anchor: "assistant_turn",
@@ -277,7 +276,7 @@ describe("parseAssistantEvent", () => {
     // follow-up message_complete. The web handler must treat this as
     // terminal so the loading indicator clears.
     const event = parseAssistantEvent("assistant_activity_state", {
-      conversationId: "conv-1",
+      conversationKey: "conv-1",
       activityVersion: 1,
       phase: "idle",
       anchor: "global",
@@ -295,7 +294,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown for assistant_activity_state with invalid phase", () => {
     const data = {
-      conversationId: "conv-1",
+      conversationKey: "conv-1",
       activityVersion: 1,
       phase: "definitely_not_a_phase",
       anchor: "global",
@@ -312,7 +311,7 @@ describe("parseAssistantEvent", () => {
 
   test("returns unknown for assistant_activity_state with invalid reason", () => {
     const data = {
-      conversationId: "conv-1",
+      conversationKey: "conv-1",
       activityVersion: 1,
       phase: "idle",
       anchor: "global",

--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -36,11 +36,12 @@ export function readEventConversationKey(
   if (typeof data.conversationKey === "string" && data.conversationKey) {
     return data.conversationKey;
   }
-  // Daemon emits `conversationId` for many events. In the web client this maps
-  // 1:1 to the conversation key used by the sidebar/history APIs.
-  if (typeof data.conversationId === "string" && data.conversationId) {
-    return data.conversationId;
-  }
+  // Intentionally do NOT fall back to `data.conversationId`. The daemon's
+  // `conversationId` is its internal id from the conversation-keys mapping
+  // table and is not guaranteed to equal the web-facing conversationKey.
+  // When this returns undefined, stream.ts substitutes the subscription
+  // URL's `requestedConversationKey`, which is the authoritative routing
+  // key for the per-conversation SSE stream.
   return undefined;
 }
 
@@ -451,10 +452,6 @@ export function parseAssistantEvent(
     }
 
     case "conversation_title_updated": {
-      // Daemon emits `conversationId` (the internal ID), which for web maps
-      // 1:1 to the `conversationKey` the sidebar indexes by — the client
-      // never sees a separate conversationId because our only create path
-      // is POST /v1/messages with a client-chosen key.
       const conversationId =
         typeof data.conversationId === "string" ? data.conversationId : "";
       const title = typeof data.title === "string" ? data.title : "";


### PR DESCRIPTION
## Summary

- `readEventConversationKey` silently fell back to `data.conversationId`, which is the daemon's internal id from the `conversation_keys` mapping table — not guaranteed to equal the web-facing `conversationKey`.
- When the two diverge, per-turn SSE events (`assistant_text_delta`, `message_complete`, `conversation_error`, etc.) get tagged with the wrong `conversationKey` and the conversation-scoped handler silently drops them. Chat composer hangs and `pollForResponse()` eventually surfaces a misleading "Assistant did not respond in time" timeout (`use-send-message.ts:325`).
- The conversation-scoped SSE stream is already filtered server-side by the daemon, so `stream.ts`'s existing fallback to `requestedConversationKey` (the subscription URL) is the authoritative source for routing per-event.
- Also drops the parallel "1:1" comment on the `conversation_title_updated` parser case so future readers don't repeat the same migration assumption.

## Test plan

- [x] `bun test src/domains/chat/api/event-parser.test.ts` — 64 pass
- [x] Updated 5 tests that asserted the old conflation (`conversationId` input → `conversationKey` output) to pass `conversationKey` directly, preserving propagation coverage
- [ ] Manual: confirm chat composer no longer hangs on provider-error turns; banner shows the actual `conversation_error` userMessage

https://claude.ai/code/session_01GxmYJSib1ivVpMVrJwwXNi

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxmYJSib1ivVpMVrJwwXNi)_