### PR TITLE
fix(web): prefix public asset URLs with Vite base path

### DIFF
--- a/apps/web/src/components/native-splash.tsx
+++ b/apps/web/src/components/native-splash.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { publicAsset } from "@/lib/public-asset.js";
+
 /**
  * Full-screen branded splash shown on native iOS during:
  * - Initial login (behind the ASWebAuthenticationSession Safari sheet)
@@ -13,14 +15,14 @@ export function NativeSplash({ children }: { children?: ReactNode }) {
   return (
     <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-[var(--surface-base)] text-[var(--content-default)]">
       <img
-        src="/vellum-logo.svg"
+        src={publicAsset("/vellum-logo.svg")}
         alt="Vellum"
         width={220}
         height={66}
         className="block dark:hidden"
       />
       <img
-        src="/vellum-logo-white.svg"
+        src={publicAsset("/vellum-logo-white.svg")}
         alt="Vellum"
         width={220}
         height={66}
@@ -33,7 +35,7 @@ export function NativeSplash({ children }: { children?: ReactNode }) {
         style={{ bottom: 0 }}
       >
         <img
-          src="/login-background-characters.svg"
+          src={publicAsset("/login-background-characters.svg")}
           alt=""
           width={880}
           height={182}

--- a/apps/web/src/domains/account/components/login-background.tsx
+++ b/apps/web/src/domains/account/components/login-background.tsx
@@ -1,3 +1,5 @@
+import { publicAsset } from "@/lib/public-asset.js";
+
 /**
  * Decorative background for the branded `/account/login` screen.
  *
@@ -10,7 +12,7 @@ export function LoginBackground() {
     <>
       <div className="pointer-events-none absolute top-[120px] left-1/2 z-0 -translate-x-1/2">
         <img
-          src="/vellum-logo-white.svg"
+          src={publicAsset("/vellum-logo-white.svg")}
           alt="Vellum"
           width={92}
           height={28}
@@ -21,7 +23,7 @@ export function LoginBackground() {
         className="pointer-events-none absolute right-0 bottom-0 left-1/2 z-0 w-full max-w-[1100px] -translate-x-1/2"
       >
         <img
-          src="/login-background-characters.svg"
+          src={publicAsset("/login-background-characters.svg")}
           alt=""
           width={880}
           height={182}

--- a/apps/web/src/domains/onboarding/components/creature-footer.tsx
+++ b/apps/web/src/domains/onboarding/components/creature-footer.tsx
@@ -1,3 +1,5 @@
+import { publicAsset } from "@/lib/public-asset.js";
+
 /**
  * Decorative SVG footer pinned to the bottom of every onboarding screen.
  * Uses a plain `<img>` (Vite serves static assets from the public directory
@@ -10,7 +12,7 @@ export function CreatureFooter({ className = "" }: { className?: string }) {
       className={`pointer-events-none absolute bottom-0 left-0 right-0 flex justify-center overflow-hidden ${className}`}
     >
       <img
-        src="/login-background-characters.svg"
+        src={publicAsset("/login-background-characters.svg")}
         alt=""
         width={1200}
         height={180}

--- a/apps/web/src/domains/onboarding/prechat-prior-assistants.ts
+++ b/apps/web/src/domains/onboarding/prechat-prior-assistants.ts
@@ -13,6 +13,8 @@
  * exported from `prechat-tools.ts`.
  */
 
+import { publicAsset } from "@/lib/public-asset.js";
+
 export interface PreChatPriorAssistantItem {
   id: string;
   label: string;
@@ -21,11 +23,11 @@ export interface PreChatPriorAssistantItem {
 }
 
 export const PRECHAT_PRIOR_ASSISTANTS: PreChatPriorAssistantItem[] = [
-  { id: "chatgpt", label: "ChatGPT", logoSrc: "/images/prior-assistants/chatgpt.svg" },
-  { id: "claude", label: "Claude", logoSrc: "/images/prior-assistants/claude.svg" },
-  { id: "openclaw", label: "OpenClaw", logoSrc: "/images/prior-assistants/openclaw.png" },
-  { id: "hermes", label: "Hermes", logoSrc: "/images/prior-assistants/hermes.png" },
-  { id: "manus", label: "Manus", logoSrc: "/images/prior-assistants/manus.svg" },
-  { id: "gemini", label: "Gemini", logoSrc: "/images/prior-assistants/gemini.svg" },
-  { id: "copilot", label: "Copilot", logoSrc: "/images/prior-assistants/copilot.svg" },
+  { id: "chatgpt", label: "ChatGPT", logoSrc: publicAsset("/images/prior-assistants/chatgpt.svg") },
+  { id: "claude", label: "Claude", logoSrc: publicAsset("/images/prior-assistants/claude.svg") },
+  { id: "openclaw", label: "OpenClaw", logoSrc: publicAsset("/images/prior-assistants/openclaw.png") },
+  { id: "hermes", label: "Hermes", logoSrc: publicAsset("/images/prior-assistants/hermes.png") },
+  { id: "manus", label: "Manus", logoSrc: publicAsset("/images/prior-assistants/manus.svg") },
+  { id: "gemini", label: "Gemini", logoSrc: publicAsset("/images/prior-assistants/gemini.svg") },
+  { id: "copilot", label: "Copilot", logoSrc: publicAsset("/images/prior-assistants/copilot.svg") },
 ];

--- a/apps/web/src/domains/onboarding/prechat-tools.ts
+++ b/apps/web/src/domains/onboarding/prechat-tools.ts
@@ -14,6 +14,8 @@
  * dark-on-light by default).
  */
 
+import { publicAsset } from "@/lib/public-asset.js";
+
 export interface PreChatToolItem {
   id: string;
   label: string;
@@ -24,46 +26,46 @@ export interface PreChatToolItem {
 export const GOOGLE_TOOL_IDS = new Set(["gmail", "google-calendar", "google-drive"]);
 
 export const PRECHAT_TOOLS: PreChatToolItem[] = [
-  { id: "gmail", label: "Gmail", logoSrc: "/images/integrations/gmail.svg" },
+  { id: "gmail", label: "Gmail", logoSrc: publicAsset("/images/integrations/gmail.svg") },
   {
     id: "outlook",
     label: "Outlook",
-    logoSrc: "/images/integrations/outlook.png",
+    logoSrc: publicAsset("/images/integrations/outlook.png"),
   },
   {
     id: "google-calendar",
     label: "Google Calendar",
-    logoSrc: "/images/integrations/google-calendar.svg",
+    logoSrc: publicAsset("/images/integrations/google-calendar.svg"),
   },
-  { id: "slack", label: "Slack", logoSrc: "/images/integrations/slack.svg" },
-  { id: "notion", label: "Notion", logoSrc: "/images/integrations/notion.svg" },
+  { id: "slack", label: "Slack", logoSrc: publicAsset("/images/integrations/slack.svg") },
+  { id: "notion", label: "Notion", logoSrc: publicAsset("/images/integrations/notion.svg") },
   {
     id: "linear",
     label: "Linear",
-    logoSrc: "/images/integrations/linear-light-logo.svg",
+    logoSrc: publicAsset("/images/integrations/linear-light-logo.svg"),
   },
   {
     id: "jira",
     label: "Jira",
-    logoSrc: "/images/integrations/jira.svg",
+    logoSrc: publicAsset("/images/integrations/jira.svg"),
   },
   {
     id: "github",
     label: "GitHub",
-    logoSrc: "/images/integrations/github.svg",
-    logoSrcDark: "/images/integrations/github-dark.svg",
+    logoSrc: publicAsset("/images/integrations/github.svg"),
+    logoSrcDark: publicAsset("/images/integrations/github-dark.svg"),
   },
-  { id: "figma", label: "Figma", logoSrc: "/images/integrations/figma.svg" },
+  { id: "figma", label: "Figma", logoSrc: publicAsset("/images/integrations/figma.svg") },
   {
     id: "google-drive",
     label: "Google Drive",
-    logoSrc: "/images/integrations/google-drive.svg",
+    logoSrc: publicAsset("/images/integrations/google-drive.svg"),
   },
-  { id: "excel", label: "Excel", logoSrc: "/images/integrations/excel.svg" },
+  { id: "excel", label: "Excel", logoSrc: publicAsset("/images/integrations/excel.svg") },
   {
     id: "apple-notes",
     label: "Apple Notes",
-    logoSrc: "/images/integrations/apple-notes.svg",
+    logoSrc: publicAsset("/images/integrations/apple-notes.svg"),
   },
 ];
 

--- a/apps/web/src/lib/public-asset.ts
+++ b/apps/web/src/lib/public-asset.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve a path under `public/` to a URL that respects Vite's `base`
+ * configuration. Required because Vite does NOT rewrite absolute `src`/`href`
+ * strings in JSX/data at runtime — only HTML entry points and CSS `url()`s.
+ *
+ * Pass either `/foo.svg` or `foo.svg` — both forms produce `{BASE_URL}foo.svg`.
+ */
+export function publicAsset(path: string): string {
+  const base = import.meta.env.BASE_URL;
+  const trimmed = path.startsWith("/") ? path.slice(1) : path;
+  return `${base}${trimmed}`;
+}


### PR DESCRIPTION
## Summary

After #31525 switched the Vite `base` from `/` to `/assistant/`, public assets are served at `/assistant/foo.svg`. But several JSX ``&lt;img src="/foo.svg"&gt;`` tags and data-file `logoSrc` strings still used root-absolute paths. Vite only rewrites entry-HTML and CSS `url()` references — it does **not** rewrite runtime JS strings — so the browser kept requesting `/foo.svg` and getting a 404. Result: the creature footer, login background, native splash, integration logos, and prior-assistant logos all rendered as broken images throughout the onboarding flow.

Fix:
- Add `apps/web/src/lib/public-asset.ts` exporting `publicAsset(path)` that prepends `import.meta.env.BASE_URL`.
- Apply it to `creature-footer.tsx`, `native-splash.tsx`, `login-background.tsx`, and the `logoSrc` entries in `prechat-tools.ts` / `prechat-prior-assistants.ts`.

## Test plan
- [ ] Load the hatching screen and confirm the bottom creature footer renders (no broken image)
- [ ] Visit `/account/login` and confirm the Vellum wordmark + creature footer render
- [ ] Walk through the prechat onboarding tool-selection and prior-assistant screens and confirm every integration/assistant logo renders
- [ ] Native splash screens (iOS) render the wordmark + creatures correctly

https://claude.ai/code/session_01QiwKueighgB3aMpAFzgL7z

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiwKueighgB3aMpAFzgL7z)_