### PR TITLE
feat(memory-v2): tier provenance for router-selected pages

### DIFF
--- a/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -417,7 +417,7 @@ function ConceptRow({
     });
   }
   if (isCustomSource) {
-    breakdownRows.push({ label: "source", value: concept.source });
+    breakdownRows.push({ label: "source", value: formatSource(concept.source) });
   }
   breakdownRows.push({ label: "status", value: statusText });
 
@@ -449,7 +449,7 @@ function ConceptRow({
         >
           {concept.slug}
         </code>
-        {isCustomSource && <TypeChip label={concept.source} />}
+        {isCustomSource && <TypeChip label={formatSource(concept.source)} />}
         <div
           className="shrink-0 overflow-hidden rounded-full"
           style={{
@@ -650,6 +650,22 @@ function TypeChip({ label }: { label: string }): ReactNode {
       {label}
     </span>
   );
+}
+
+/**
+ * Render a concept-row source string for display. Tier tags (`tier1`,
+ * `tier2`, `tier3:N`) get spaced out for readability; legacy / non-router
+ * sources pass through unchanged.
+ */
+function formatSource(source: string): string {
+  if (source === "tier1") return "tier 1";
+  if (source === "tier2") return "tier 2";
+  if (source.startsWith("tier3:")) {
+    const idx = source.slice("tier3:".length);
+    return `tier 3 · b${idx}`;
+  }
+  if (source === "carry_over") return "carry over";
+  return source;
 }
 
 function CopyButton({ text }: { text: string }): ReactNode {

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -44,19 +44,37 @@ export interface MemoryV2ConceptRowRecord {
    *   - `prior_state` — carried over from prior turn's activation state.
    *   - `ann_top50`   — entered via ANN top-K candidate pool.
    *   - `both`        — present in both prior state and ANN pool.
-   *   - `router`      — selected by the Sonnet router (memory-v2 router
-   *     mode). Router-mode rows zero out all activation values
-   *     (`finalActivation`, `ownActivation`, `priorActivation`, channel
-   *     similarities, rerank boosts, `spreadContribution`) because the
-   *     router does not compute spreading-activation scores.
+   *   - `router`      — legacy tag for memory-v2 router selections written
+   *     before tier-aware provenance landed. New rows never use this; old
+   *     activation log rows still carry it and the inspector renders it
+   *     as-is for backward compat.
+   *   - `tier1`       — router-mode, selected by the tier-1 (recently
+   *     modified) batch.
+   *   - `tier2`       — router-mode, selected by the tier-2 (highest EMA)
+   *     batch.
+   *   - `tier3:<N>`   — router-mode, selected by tier-3 batch N (0-indexed).
+   *     A single-batch (no-tier carve-out) workspace produces `tier3:0`.
+   *     The bucket index lets inspector queries attribute selections to
+   *     specific hash-bucketed parallel calls.
    *   - `carry_over`  — router-mode row representing a slug carried over
    *     from `priorEverInjected` that the router did NOT re-pick on this
    *     turn. The cached attachment from a prior turn is still present
-   *     on a prior user message; emitting `source: "router"` for these
+   *     on a prior user message; emitting one of the tier tags for these
    *     rows would overcount router selections in inspector queries.
-   *     Same zeroed activation values as `router`.
+   *
+   * All router-mode rows (`tier*`, `router`, `carry_over`) zero out the
+   * activation values (`finalActivation`, `ownActivation`, etc.) because
+   * the router does not compute spreading-activation scores.
    */
-  source: "prior_state" | "ann_top50" | "both" | "router" | "carry_over";
+  source:
+    | "prior_state"
+    | "ann_top50"
+    | "both"
+    | "router"
+    | "carry_over"
+    | "tier1"
+    | "tier2"
+    | `tier3:${number}`;
   /**
    * Per-turn outcome for this slug:
    *   - `in_context`  — already injected on a prior turn; cached attachment

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -260,6 +260,8 @@ mock.module("../page-store.js", () => ({
 interface RouterResultStub {
   selectedSlugs: string[];
   failureReason: string | null;
+  /** Tier provenance per slug. Defaults to `tier3:0` for any selected slug. */
+  sourceBySlug?: Map<string, string>;
 }
 
 const routerState = {
@@ -270,12 +272,20 @@ const routerState = {
 mock.module("../router.js", () => ({
   runRouter: async () => {
     routerState.callCount++;
-    return (
-      routerState.nextResult ?? {
-        selectedSlugs: [],
-        failureReason: null,
-      }
-    );
+    const result = routerState.nextResult ?? {
+      selectedSlugs: [],
+      failureReason: null,
+    };
+    // Synthesize a default sourceBySlug for stubs that don't set one — pre-
+    // tier-provenance tests stage `selectedSlugs` only and expect every pick
+    // to flow through as a router selection. Treating them as `tier3:0` is
+    // the closest equivalent under the new model.
+    if (!result.sourceBySlug) {
+      const map = new Map<string, string>();
+      for (const slug of result.selectedSlugs) map.set(slug, "tier3:0");
+      result.sourceBySlug = map;
+    }
+    return result;
   },
 }));
 
@@ -1825,7 +1835,9 @@ describe("injectMemoryV2Block", () => {
       expect(row.mode).toBe("router");
       const aliceRow = row.concepts.find((c) => c.slug === "alice-vscode");
       expect(aliceRow).toBeDefined();
-      expect(aliceRow!.source).toBe("router");
+      // Default-stub provenance is `tier3:0` (single-batch path); see the
+      // runRouter mock for the synthesis rule.
+      expect(aliceRow!.source).toBe("tier3:0");
       expect(aliceRow!.status).toBe("injected");
       expect(aliceRow!.finalActivation).toBe(0);
       expect(aliceRow!.ownActivation).toBe(0);
@@ -2007,7 +2019,7 @@ describe("injectMemoryV2Block", () => {
       );
       expect(phantom).toBeDefined();
       expect(phantom!.status).toBe("page_missing");
-      expect(phantom!.source).toBe("router");
+      expect(phantom!.source).toBe("tier3:0");
     });
 
     test("flag-on: router re-picking a prior-everInjected slug does NOT re-render it; non-overlapping picks render and append to everInjected", async () => {
@@ -2112,7 +2124,7 @@ describe("injectMemoryV2Block", () => {
       expect(bobRow).toBeDefined();
       expect(aliceRow!.source).toBe("carry_over");
       expect(aliceRow!.status).toBe("in_context");
-      expect(bobRow!.source).toBe("router");
+      expect(bobRow!.source).toBe("tier3:0");
       expect(bobRow!.status).toBe("injected");
     });
 

--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -260,6 +260,7 @@ describe("runRouter — early bails", () => {
 
     expect(result).toEqual({
       selectedSlugs: [],
+      sourceBySlug: new Map(),
       failureReason: "empty_index",
     });
     // Provider must NOT be invoked when there is nothing to route.
@@ -315,6 +316,7 @@ describe("runRouter — successful tool_use", () => {
 
     expect(result).toEqual({
       selectedSlugs: [],
+      sourceBySlug: new Map(),
       failureReason: null,
     });
   });
@@ -942,6 +944,36 @@ describe("runRouter — tier 2 (highest EMA)", () => {
     const tier2Prompt = providerCalls[0].systemPrompt ?? "";
     expect(tier2Prompt).toContain("[1] bravo");
     expect(tier2Prompt).not.toMatch(/^\[\d+\] alpha/m);
+  });
+
+  test("sourceBySlug tags each selection with its batch tier", async () => {
+    scoresStub.set("bravo", 5.0);
+    scoresStub.set("delta", 3.0);
+
+    providerStub = makeProvider(toolUseResponse([1]));
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ tier1Size: 1, tier2Size: 1 }),
+      database: stubDb,
+    });
+
+    // Every selected slug should have a tier tag — exactly one of:
+    // "tier1", "tier2", or "tier3:N" (N starts at 0).
+    for (const slug of result.selectedSlugs) {
+      const source = result.sourceBySlug.get(slug);
+      expect(source).toBeDefined();
+      expect(
+        source === "tier1" ||
+          source === "tier2" ||
+          source!.startsWith("tier3:"),
+      ).toBe(true);
+    }
+    // Tier 1 + tier 2 + (some tier 3 batches) ≥ 3 batches → at least one
+    // slug per tier should be present in the source map across the union.
+    const tags = new Set(result.sourceBySlug.values());
+    expect(tags.has("tier1")).toBe(true);
+    expect(tags.has("tier2")).toBe(true);
   });
 
   test("tier2_size set without database logs a warn and skips tier 2", async () => {

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -614,12 +614,12 @@ async function injectViaRouter(args: {
 
   // Build minimal telemetry rows for the union of router-selected slugs and
   // prior `everInjected` slugs. Router-mode rows zero out every activation
-  // value (no spreading activation runs). Slugs the router picked this turn
-  // get `source: "router"`; prior-everInjected slugs the router did NOT
-  // re-pick get `source: "carry_over"`. The `status` placeholder is
-  // overwritten by `finalizeInjection`.
-  const routerPicked = new Set(routerResult.selectedSlugs);
-  const telemetrySlugs = new Set<string>(routerPicked);
+  // value (no spreading activation runs). Slugs the router picked carry
+  // their batch's tier tag from `routerResult.sourceBySlug` (e.g. `tier1`,
+  // `tier3:2`); prior-everInjected slugs the router did NOT re-pick get
+  // `source: "carry_over"`. The `status` placeholder is overwritten by
+  // `finalizeInjection`.
+  const telemetrySlugs = new Set<string>(routerResult.selectedSlugs);
   for (const entry of priorEverInjected) telemetrySlugs.add(entry.slug);
   const telemetryRows: MemoryV2ConceptRowRecord[] = [...telemetrySlugs].map(
     (slug) => ({
@@ -634,7 +634,7 @@ async function injectViaRouter(args: {
       simAssistantRerankBoost: 0,
       inRerankPool: false,
       spreadContribution: 0,
-      source: routerPicked.has(slug) ? "router" : "carry_over",
+      source: routerResult.sourceBySlug.get(slug) ?? "carry_over",
       status: "not_injected",
     }),
   );

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -75,13 +75,27 @@ export type RouterFailureReason =
   | "empty_index";
 
 /**
+ * Tags which batch a router-selected slug came from. Tier 3 carries the
+ * batch index so the inspector can distinguish e.g. `tier3:0` from
+ * `tier3:3` — useful for debugging hash bucketing and batch-quality
+ * regressions per tier 3 bucket.
+ */
+export type RouterSource = "tier1" | "tier2" | `tier3:${number}`;
+
+/**
  * Result of a single router call. `selectedSlugs` preserves the order the
  * model returned and is already capped at `config.memory.v2.router.max_page_ids`
- * with out-of-range IDs dropped.
+ * with out-of-range IDs dropped. `sourceBySlug` attributes each selection
+ * to the batch it came from for inspector display.
  */
 export interface RouterResult {
   /** Selected page slugs in the order the model returned them. */
   selectedSlugs: string[];
+  /**
+   * Per-slug provenance covering every entry in `selectedSlugs`. Empty when
+   * `failureReason !== null` or no batch returned any selections.
+   */
+  sourceBySlug: ReadonlyMap<string, RouterSource>;
   /** `null` on success; one of the failure reasons above otherwise. */
   failureReason: RouterFailureReason | null;
 }
@@ -120,8 +134,24 @@ const RouterResultSchema = z.object({
   page_ids: z.array(z.number().int()),
 });
 
-/** Empty-result helper so call sites don't reconstruct the shape inline. */
+/**
+ * Per-batch internal result. The orchestrator stamps provenance during the
+ * union so individual batches never need to know their own tier tag.
+ */
+interface RouterBatchResult {
+  selectedSlugs: string[];
+  failureReason: RouterFailureReason | null;
+}
+
+/** Empty orchestrator result. */
 function emptyResult(reason: RouterFailureReason | null): RouterResult {
+  return { selectedSlugs: [], sourceBySlug: new Map(), failureReason: reason };
+}
+
+/** Empty batch result — slimmer shape; orchestrator builds provenance. */
+function emptyBatchResult(
+  reason: RouterFailureReason | null,
+): RouterBatchResult {
   return { selectedSlugs: [], failureReason: reason };
 }
 
@@ -209,19 +239,24 @@ export async function runRouter(
   const tier3Batches = partitionPageIndex(afterTier2, batchSize).filter(
     (b) => b.entries.length > 0,
   );
-  const batches: PageIndex[] = [];
-  if (tier1) batches.push(tier1);
-  if (tier2) batches.push(tier2);
-  batches.push(...tier3Batches);
-  if (batches.length === 0) {
+
+  // Tag each batch with its provenance string. Tier 3 batches carry their
+  // bucket index so the inspector can attribute selections per-bucket.
+  const taggedBatches: Array<{ source: RouterSource; index: PageIndex }> = [];
+  if (tier1) taggedBatches.push({ source: "tier1", index: tier1 });
+  if (tier2) taggedBatches.push({ source: "tier2", index: tier2 });
+  tier3Batches.forEach((index, i) => {
+    taggedBatches.push({ source: `tier3:${i}` as const, index });
+  });
+  if (taggedBatches.length === 0) {
     return emptyResult("empty_index");
   }
 
   const batchResults = await Promise.all(
-    batches.map((batch) =>
+    taggedBatches.map(({ index }) =>
       runRouterBatch({
         ...params,
-        batchIndex: batch,
+        batchIndex: index,
         priorEverInjected,
         provider,
       }),
@@ -236,13 +271,17 @@ export async function runRouter(
   }
 
   // Union selected slugs preserving first-seen order across batches; batch
-  // ordering is deterministic (hash bucket index) so the union is stable.
-  const seen = new Set<string>();
+  // ordering is deterministic so the union and provenance map are stable.
+  // First-seen wins if a slug somehow appears in multiple batches (shouldn't
+  // happen — tier 1/2/3 partition is disjoint — but be defensive).
+  const sourceBySlug = new Map<string, RouterSource>();
   const selectedSlugs: string[] = [];
-  for (const result of batchResults) {
+  for (let i = 0; i < batchResults.length; i++) {
+    const result = batchResults[i];
+    const source = taggedBatches[i].source;
     for (const slug of result.selectedSlugs) {
-      if (seen.has(slug)) continue;
-      seen.add(slug);
+      if (sourceBySlug.has(slug)) continue;
+      sourceBySlug.set(slug, source);
       selectedSlugs.push(slug);
     }
   }
@@ -258,7 +297,7 @@ export async function runRouter(
       "Some router batches failed; returning union of successful batches",
     );
   }
-  return { selectedSlugs, failureReason: null };
+  return { selectedSlugs, sourceBySlug, failureReason: null };
 }
 
 interface RunRouterBatchParams extends RunRouterParams {
@@ -274,7 +313,7 @@ interface RunRouterBatchParams extends RunRouterParams {
  */
 async function runRouterBatch(
   params: RunRouterBatchParams,
-): Promise<RouterResult> {
+): Promise<RouterBatchResult> {
   const {
     workspaceDir,
     userMessage,
@@ -338,7 +377,7 @@ async function runRouterBatch(
     );
   } catch (err) {
     log.warn({ err }, "Router provider call threw; treating as api_error");
-    return emptyResult("api_error");
+    return emptyBatchResult("api_error");
   }
 
   const toolBlock = extractToolUse(response);
@@ -347,7 +386,7 @@ async function runRouterBatch(
       { stopReason: response.stopReason },
       "Router model returned no select_pages_to_inject tool_use block",
     );
-    return emptyResult("tool_use_missing");
+    return emptyBatchResult("tool_use_missing");
   }
 
   const parsed = RouterResultSchema.safeParse(toolBlock.input);
@@ -356,7 +395,7 @@ async function runRouterBatch(
       { error: parsed.error.message },
       "Router tool input did not match schema",
     );
-    return emptyResult("schema_mismatch");
+    return emptyBatchResult("schema_mismatch");
   }
 
   const N = batchIndex.entries.length;


### PR DESCRIPTION
## Summary
- \`RouterResult.sourceBySlug: ReadonlyMap<string, RouterSource>\` — orchestrator stamps each selected slug with the batch it came from. \`RouterSource = \"tier1\" | \"tier2\" | tier3:N\`.
- \`MemoryV2ConceptRowRecord.source\` union extended with the tier tags; existing \`\"router\"\` value preserved for backward compat with old activation log rows.
- \`injectViaRouter\` consumes \`routerResult.sourceBySlug.get(slug) ?? \"carry_over\"\` when building telemetry rows.
- Inspector renders \`tier3:N\` as \"tier 3 · bN\" so the bucket index is visible at a glance; \`tier1\`/\`tier2\` render as \"tier 1\"/\"tier 2\".
- New test: \`runRouter\` returns a sourceBySlug covering every selection with tier-prefixed tags.

## Original prompt
Sidd asked for visibility into which tier (and within tier 3, which batch index) each selected page came from before flipping config knobs. Currently the inspector just shows \"router\" next to every router-selected slug, which collapses the tier-1/2/3 distinction the architecture now supports.

## Test plan
- [x] \`bun test src/memory/v2/__tests__/router.test.ts\` — 34 tests pass.
- [x] \`bun test src/memory/v2/__tests__/injection.test.ts\` — 38 tests pass.
- [x] \`bun test src/memory/v2/__tests__/page-index.test.ts\` — 41 tests pass.
- [x] \`bunx tsc --noEmit\` clean in \`assistant/\`. No new errors in \`apps/web/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)