### PR TITLE
fix(web-fetch): surface mayRequireJavaScript signal for JS-rendered SPAs

### DIFF
--- a/apps/web/src/assistant/web-activity-types.ts
+++ b/apps/web/src/assistant/web-activity-types.ts
@@ -40,6 +40,7 @@ export interface WebFetchMetadata {
   redirectCount: number;
   durationMs: number;
   errorMessage?: string;
+  mayRequireJavaScript?: boolean;
 }
 
 export interface ToolActivityMetadata {

--- a/assistant/src/daemon/message-types/web-activity.ts
+++ b/assistant/src/daemon/message-types/web-activity.ts
@@ -46,6 +46,8 @@ export interface WebFetchMetadata {
   redirectCount: number;
   durationMs: number;
   errorMessage?: string;
+  /** Set when extracted text is dramatically smaller than raw HTML — likely a JS-rendered SPA whose meaningful content the static fetcher missed. */
+  mayRequireJavaScript?: boolean;
 }
 
 /** Discriminated container so future tools can add their own metadata. */

--- a/assistant/src/tools/network/__tests__/web-fetch-metadata.test.ts
+++ b/assistant/src/tools/network/__tests__/web-fetch-metadata.test.ts
@@ -89,13 +89,10 @@ describe("web_fetch activityMetadata", () => {
           headers: { location: "https://example.com/final" },
         });
       }
-      return new Response(
-        "<!doctype html><title>Final</title><p>done</p>",
-        {
-          status: 200,
-          headers: { "content-type": "text/html; charset=utf-8" },
-        },
-      );
+      return new Response("<!doctype html><title>Final</title><p>done</p>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
     }) as unknown as typeof globalThis.fetch;
 
     const result = await executeWithMockFetch({
@@ -154,6 +151,65 @@ describe("web_fetch activityMetadata", () => {
     expect(meta?.url).toBe("https://example.com/missing");
     expect(meta?.finalUrl).toBe("https://example.com/missing");
     expect(meta?.domain).toBe("example.com");
+  });
+
+  test("flags mayRequireJavaScript when HTML compresses to <5% text and exceeds 10KB", async () => {
+    const scriptPayload = `var x = ${JSON.stringify("a".repeat(40_000))};`;
+    const body =
+      "<!doctype html><html><head><title>App</title></head>" +
+      `<body><div id="root"></div><script>${scriptPayload}</script></body></html>`;
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({ url: "https://example.com/" });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta?.mayRequireJavaScript).toBe(true);
+    expect(result.status).toContain("Content may be JavaScript-rendered");
+    expect(result.status).toContain(`${meta?.byteCount} bytes`);
+  });
+
+  test("flags mayRequireJavaScript when extracted text is under 200 chars", async () => {
+    const body =
+      '<!doctype html><html><head><title>Tiny</title></head><body><div id="app"></div></body></html>';
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({ url: "https://example.com/" });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta?.mayRequireJavaScript).toBe(true);
+    expect(result.status).toContain("Content may be JavaScript-rendered");
+  });
+
+  test("does not flag mayRequireJavaScript for content-heavy HTML", async () => {
+    const paragraph =
+      "<p>" +
+      "The quick brown fox jumps over the lazy dog. ".repeat(20) +
+      "</p>";
+    const body =
+      "<!doctype html><html><head><title>Article</title></head>" +
+      `<body>${paragraph.repeat(40)}</body></html>`;
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await executeWithMockFetch({ url: "https://example.com/" });
+    expect(result.isError).toBe(false);
+
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta?.mayRequireJavaScript).toBeUndefined();
+    expect(result.status ?? "").not.toContain("JavaScript-rendered");
   });
 
   test("populates metadata for blocked private-network targets", async () => {

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -886,9 +886,20 @@ export async function executeWebFetch(
         `start_index (${startIndex}) exceeded available content length (${processed.length}).`,
       );
     }
-    if (html && !rawMode && processed.length < 200) {
+    // Detect likely JS-rendered SPAs: text is absolutely tiny, or a non-trivial
+    // HTML payload compresses to almost nothing (a shell page whose meaningful
+    // content is painted after fetch + document.body rewrite).
+    const lowAbsolute = processed.length < 200;
+    const lowRatio =
+      body.bytesRead >= 10_000 && processed.length / body.bytesRead < 0.05;
+    const mayRequireJavaScript = html && !rawMode && (lowAbsolute || lowRatio);
+    if (mayRequireJavaScript) {
+      const pct =
+        body.bytesRead > 0
+          ? ((processed.length / body.bytesRead) * 100).toFixed(1)
+          : "0";
       notices.push(
-        `Extracted text content is very short (${processed.length} characters). The page may require JavaScript rendering for full content.`,
+        `Extracted only ${processed.length} chars of text from ${body.bytesRead} bytes of HTML (${pct}%). Content may be JavaScript-rendered — the static fetch likely missed dynamically injected content.`,
       );
     }
 
@@ -927,6 +938,7 @@ export async function executeWebFetch(
       faviconUrl: faviconUrlForDomain(finalDomain),
       redirectCount,
       durationMs: Date.now() - startedAt,
+      mayRequireJavaScript: mayRequireJavaScript || undefined,
     };
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- Compression-ratio heuristic in `web_fetch`: when HTML >= 10 KB compresses to <5% extracted text (or text < 200 chars), the result now emits a notice that names the byte/char numbers and explains the static fetch likely missed dynamically injected content.
- Adds a structured `mayRequireJavaScript?: boolean` field to `WebFetchMetadata` (and the `apps/web/` mirror) so clients and the model both get a machine-readable signal, not just a notice string.
- Tests cover the SPA-like fixture (large HTML, low ratio), the existing tiny-shell case, and a content-heavy article negative case.

## Original prompt

A user reported that the assistant set the wrong reminder time after fetching `https://regnyctix.com/`. The page is an SPA that injects "Registration begins at 10:00 AM Monday May 25th" via JS, and `web_fetch` silently returned just the static shell — ~2.6k chars of pre-rendered form labels from ~81k bytes of HTML. The existing `< 200 chars` heuristic never fired because the shell cleared that floor.

The agent's own self-diagnosis named the right platform fix: detect dramatic compression (text-to-bytes ratio) and surface a structured signal so future agents know the static fetch was likely incomplete. Adding actual JS rendering via the existing Playwright integration under `assistant/src/tools/browser/` is a separate, larger change (per-fetch browser cost, approval semantics) and is out of scope for this PR.