### PR TITLE
feat(macos): inline file attachments in assistant bubbles

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -84,6 +84,82 @@ describe("renderHistoryContent", () => {
     );
   });
 
+  test("emits attachment:N entries in contentOrder for interleaved file blocks", () => {
+    const output = renderHistoryContent([
+      { type: "text", text: "first paragraph" },
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/markdown",
+          filename: "dream-015.md",
+          data: Buffer.from("a").toString("base64"),
+        },
+        _attachmentId: "att-015",
+      },
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/markdown",
+          filename: "dream-016.md",
+          data: Buffer.from("b").toString("base64"),
+        },
+        _attachmentId: "att-016",
+      },
+      { type: "text", text: "trailing paragraph" },
+    ]);
+
+    expect(output.contentOrder).toEqual([
+      "text:0",
+      "attachment:0",
+      "attachment:1",
+      "text:1",
+    ]);
+    expect(output.attachments).toEqual([
+      {
+        attachmentId: "att-015",
+        filename: "dream-015.md",
+        mimeType: "text/markdown",
+        sizeBytes: 1,
+      },
+      {
+        attachmentId: "att-016",
+        filename: "dream-016.md",
+        mimeType: "text/markdown",
+        sizeBytes: 1,
+      },
+    ]);
+    // Trailing-segment summary is preserved for legacy channel-reply
+    // delivery (Slack/Telegram outbound text) and iOS rehydrate.
+    expect(output.textSegments[1]).toContain("[File attachment] dream-015.md");
+  });
+
+  test("omits attachmentId when file block has no _attachmentId", () => {
+    const output = renderHistoryContent([
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          filename: "legacy.pdf",
+          data: Buffer.from("x").toString("base64"),
+        },
+      },
+    ]);
+
+    // attachment:0 marks the file's inline position; text:0 follows because
+    // the legacy summary append (for Slack/iOS) opens a trailing segment.
+    expect(output.contentOrder).toEqual(["attachment:0", "text:0"]);
+    expect(output.attachments).toEqual([
+      {
+        filename: "legacy.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1,
+      },
+    ]);
+  });
+
   test("falls back to string conversion for non-array content", () => {
     expect(renderHistoryContent("raw string").text).toBe("raw string");
     expect(renderHistoryContent(null).text).toBe("");

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -38,6 +38,7 @@ export function attachmentsToContentBlocks(
         filename: attachment.filename,
       },
       extracted_text: attachment.extractedText,
+      ...(attachment.id ? { _attachmentId: attachment.id } : {}),
     } as ContentBlock;
   });
 }

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -92,6 +92,19 @@ export interface HistorySurface {
   completionSummary?: string;
 }
 
+/**
+ * Positional reference to a file attachment captured while walking the
+ * content array. The index of an entry in `RenderedHistoryContent.attachments`
+ * is what `contentOrder` references as `attachment:N`.
+ */
+export interface HistoryAttachmentRef {
+  /** Stable DB attachment id when persisted on the file block (`_attachmentId`). */
+  attachmentId?: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
 export interface RenderedHistoryContent {
   text: string;
   toolCalls: HistoryToolCall[];
@@ -99,12 +112,18 @@ export interface RenderedHistoryContent {
   toolCallsBeforeText: boolean;
   /** Text segments split by tool-call boundaries. */
   textSegments: string[];
-  /** Content block ordering using "text:N", "tool:N", "surface:N" encoding. */
+  /** Content block ordering using "text:N", "tool:N", "surface:N", "attachment:N" encoding. */
   contentOrder: string[];
   /** UI surfaces (widgets) embedded in the message. */
   surfaces: HistorySurface[];
   /** Thinking segments extracted from thinking blocks. */
   thinkingSegments: string[];
+  /**
+   * File attachments captured in content order. Index `N` matches an
+   * `attachment:N` entry in `contentOrder`. Callers align their DB-sourced
+   * attachment metadata to this ordering for inline placement.
+   */
+  attachments: HistoryAttachmentRef[];
 }
 
 /**
@@ -194,22 +213,42 @@ function clampAttachmentText(text: string): string {
   return `${text.slice(0, HISTORY_ATTACHMENT_TEXT_LIMIT)}<truncated />`;
 }
 
-function renderFileBlockForHistory(block: Record<string, unknown>): string {
+interface FileBlockMetadata {
+  mediaType: string;
+  filename: string;
+  sizeBytes: number;
+}
+
+function extractFileBlockMetadata(
+  block: Record<string, unknown>,
+): FileBlockMetadata {
   const source = isRecord(block.source) ? block.source : null;
-  const mediaType =
-    source && typeof source.media_type === "string"
-      ? source.media_type
-      : "application/octet-stream";
-  const filename =
-    source && typeof source.filename === "string"
-      ? source.filename
-      : "attachment";
-  const sizeBytes =
-    source && typeof source.data === "string"
-      ? estimateBase64Bytes(source.data)
-      : 0;
-  const summaryParts = [`[File attachment] ${filename}`, `type=${mediaType}`];
-  if (sizeBytes > 0) summaryParts.push(`size=${formatBytes(sizeBytes)}`);
+  return {
+    mediaType:
+      source && typeof source.media_type === "string"
+        ? source.media_type
+        : "application/octet-stream",
+    filename:
+      source && typeof source.filename === "string"
+        ? source.filename
+        : "attachment",
+    sizeBytes:
+      source && typeof source.data === "string"
+        ? estimateBase64Bytes(source.data)
+        : 0,
+  };
+}
+
+function renderFileBlockForHistory(
+  block: Record<string, unknown>,
+  meta: FileBlockMetadata,
+): string {
+  const summaryParts = [
+    `[File attachment] ${meta.filename}`,
+    `type=${meta.mediaType}`,
+  ];
+  if (meta.sizeBytes > 0)
+    summaryParts.push(`size=${formatBytes(meta.sizeBytes)}`);
 
   const extractedText =
     typeof block.extracted_text === "string" ? block.extracted_text.trim() : "";
@@ -239,11 +278,13 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       contentOrder: text ? ["text:0"] : [],
       surfaces: [],
       thinkingSegments: [],
+      attachments: [],
     };
   }
 
   const textParts: string[] = [];
   const attachmentParts: string[] = [];
+  const attachments: HistoryAttachmentRef[] = [];
   const toolCalls: HistoryToolCall[] = [];
   const surfaces: HistorySurface[] = [];
   const thinkingSegments: string[] = [];
@@ -353,7 +394,19 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       continue;
     }
     if (block.type === "file") {
-      attachmentParts.push(renderFileBlockForHistory(block));
+      const meta = extractFileBlockMetadata(block);
+      attachmentParts.push(renderFileBlockForHistory(block, meta));
+      finalizeSegment();
+      const ref: HistoryAttachmentRef = {
+        filename: meta.filename,
+        mimeType: meta.mediaType,
+        sizeBytes: meta.sizeBytes,
+      };
+      if (typeof block._attachmentId === "string" && block._attachmentId) {
+        ref.attachmentId = block._attachmentId;
+      }
+      attachments.push(ref);
+      contentOrder.push(`attachment:${attachments.length - 1}`);
       continue;
     }
     if (block.type === "image") {
@@ -540,6 +593,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     contentOrder,
     surfaces,
     thinkingSegments,
+    attachments,
   };
 }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -127,6 +127,7 @@ const log = getLogger("conversation-routes");
 
 /** Matches the `<no_response/>` sentinel used by channel delivery suppression. */
 const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/g;
+const ATTACHMENT_ENTRY_RE = /^attachment:(\d+)$/;
 
 const SUGGESTION_CACHE_MAX = 100;
 const VALID_RISK_THRESHOLDS = ["none", "low", "medium", "high"] as const;
@@ -619,6 +620,7 @@ export function handleListMessages({
         textSegments: filteredSegments,
         contentOrder: filteredContentOrder,
         surfaces: rendered.surfaces,
+        attachmentRefs: rendered.attachments,
         slackMessage,
         ...(rendered.thinkingSegments.length > 0
           ? { thinkingSegments: rendered.thinkingSegments }
@@ -638,6 +640,7 @@ export function handleListMessages({
       textSegments: rendered.textSegments,
       contentOrder: rendered.contentOrder,
       surfaces: rendered.surfaces,
+      attachmentRefs: rendered.attachments,
       slackMessage,
       ...(rendered.thinkingSegments.length > 0
         ? { thinkingSegments: rendered.thinkingSegments }
@@ -693,6 +696,78 @@ export function handleListMessages({
       }
     }
 
+    // Align msgAttachments order with the file-block order captured by
+    // renderHistoryContent. When a file block was persisted with
+    // `_attachmentId`, we can join on that id to position the chip inline
+    // (the `attachment:N` entries in contentOrder index into msgAttachments).
+    // DB rows without a matching ref go to the tail as orphan chips;
+    // unmatched refs drop their contentOrder entry and trigger a remap.
+    let alignedContentOrder = m.contentOrder;
+    if (
+      m.attachmentRefs.length > 0 &&
+      msgAttachments.length > 0 &&
+      m.contentOrder.length > 0
+    ) {
+      const byId = new Map<string, number>();
+      msgAttachments.forEach((att, idx) => {
+        if (att.id) byId.set(att.id, idx);
+      });
+      const consumed = new Set<number>();
+      const orderedRowIdx: Array<number | null> = m.attachmentRefs.map(
+        (ref) => {
+          if (!ref.attachmentId) return null;
+          const idx = byId.get(ref.attachmentId);
+          if (idx === undefined || consumed.has(idx)) return null;
+          consumed.add(idx);
+          return idx;
+        },
+      );
+      const matchedRows = orderedRowIdx.filter(
+        (idx): idx is number => idx !== null,
+      );
+      if (matchedRows.length > 0) {
+        const orphanRows: number[] = [];
+        for (let i = 0; i < msgAttachments.length; i++) {
+          if (!consumed.has(i)) orphanRows.push(i);
+        }
+        msgAttachments = [
+          ...matchedRows.map((i) => msgAttachments[i]),
+          ...orphanRows.map((i) => msgAttachments[i]),
+        ];
+        const refToNewIdx = new Map<number, number>();
+        let nextIdx = 0;
+        orderedRowIdx.forEach((rowIdx, refIdx) => {
+          if (rowIdx !== null) {
+            refToNewIdx.set(refIdx, nextIdx);
+            nextIdx++;
+          }
+        });
+        alignedContentOrder = m.contentOrder
+          .map((entry) => {
+            const match = entry.match(ATTACHMENT_ENTRY_RE);
+            if (!match) return entry;
+            const remapped = refToNewIdx.get(Number(match[1]));
+            return remapped !== undefined
+              ? `attachment:${remapped}`
+              : undefined;
+          })
+          .filter((e): e is string => e !== undefined);
+      } else {
+        // No refs carried an attachmentId we could match — strip any
+        // attachment:N entries so the client doesn't try to position
+        // attachments inline against a misaligned array.
+        alignedContentOrder = m.contentOrder.filter(
+          (entry) => !ATTACHMENT_ENTRY_RE.test(entry),
+        );
+      }
+    } else if (m.attachmentRefs.length > 0 && msgAttachments.length === 0) {
+      // Refs were captured but no DB rows came back — drop the
+      // contentOrder entries to avoid out-of-bounds renders.
+      alignedContentOrder = m.contentOrder.filter(
+        (entry) => !ATTACHMENT_ENTRY_RE.test(entry),
+      );
+    }
+
     // Use sentAt (actual event time) for the display timestamp when
     // available, falling back to createdAt (persistence time).
     // Note: clients use this display timestamp as their pagination cursor
@@ -718,7 +793,9 @@ export function handleListMessages({
       ...(m.thinkingSegments?.length
         ? { thinkingSegments: m.thinkingSegments }
         : {}),
-      ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
+      ...(alignedContentOrder.length > 0
+        ? { contentOrder: alignedContentOrder }
+        : {}),
       ...(m.subagentNotification
         ? { subagentNotification: m.subagentNotification }
         : {}),

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -10,6 +10,34 @@ extension Notification.Name {
     static let internalImageDragStarted = Notification.Name("com.vellum.internalImageDragStarted")
 }
 
+/// Partition attachments into image, video, audio, and file buckets by MIME prefix.
+/// Free function so renderers can partition arbitrary subsets (e.g. a single
+/// inline attachment referenced by contentOrder) without going through the
+/// message-level computed-var path.
+func partitionAttachments(_ attachments: [ChatAttachment]) -> (
+    images: [ChatAttachment],
+    videos: [ChatAttachment],
+    audios: [ChatAttachment],
+    files: [ChatAttachment]
+) {
+    var images: [ChatAttachment] = []
+    var videos: [ChatAttachment] = []
+    var audios: [ChatAttachment] = []
+    var files: [ChatAttachment] = []
+    for attachment in attachments {
+        if attachment.mimeType.hasPrefix("image/") {
+            images.append(attachment)
+        } else if attachment.mimeType.hasPrefix("video/") {
+            videos.append(attachment)
+        } else if attachment.mimeType.hasPrefix("audio/") {
+            audios.append(attachment)
+        } else {
+            files.append(attachment)
+        }
+    }
+    return (images, videos, audios, files)
+}
+
 // MARK: - Display-Resolution Image Downsampling
 
 /// Downsample raw image data to the target display size using ImageIO's streaming
@@ -433,22 +461,7 @@ extension ChatBubble {
     /// performing any image decoding — decoding happens asynchronously in
     /// AttachmentImageGrid to keep NSImage(data:) off the layout path.
     var partitionedAttachments: (images: [ChatAttachment], videos: [ChatAttachment], audios: [ChatAttachment], files: [ChatAttachment]) {
-        var images: [ChatAttachment] = []
-        var videos: [ChatAttachment] = []
-        var audios: [ChatAttachment] = []
-        var files: [ChatAttachment] = []
-        for attachment in message.attachments {
-            if attachment.mimeType.hasPrefix("image/") {
-                images.append(attachment)
-            } else if attachment.mimeType.hasPrefix("video/") {
-                videos.append(attachment)
-            } else if attachment.mimeType.hasPrefix("audio/") {
-                audios.append(attachment)
-            } else {
-                files.append(attachment)
-            }
-        }
-        return (images, videos, audios, files)
+        partitionAttachments(message.attachments)
     }
 
     func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -24,6 +24,7 @@ extension ChatBubble {
         case toolCalls([Int])
         case surface(Int)
         case thinking([Int])
+        case attachment(Int)
 
         /// Stable identity based on the first index in the group.
         /// Using \.self as ForEach identity causes SwiftUI to destroy and recreate
@@ -35,6 +36,7 @@ extension ChatBubble {
             case .toolCalls(let indices): return "tc\(indices.first ?? 0)"
             case .surface(let i): return "s\(i)"
             case .thinking(let indices): return "th\(indices.first ?? 0)"
+            case .attachment(let i): return "a\(i)"
             }
         }
     }
@@ -158,7 +160,7 @@ extension ChatBubble {
                 }
                 pendingThinkingIndices.append(contentsOf: indices)
                 pendingGroupStableIds.append(group.stableId)
-            case .texts, .surface:
+            case .texts, .surface, .attachment:
                 flushBurst()
             }
         }
@@ -298,7 +300,7 @@ extension ChatBubble {
         for ref in contentOrder {
             switch ref {
             case .text: hasTextBlock = true
-            case .toolCall, .surface, .thinking: hasNonText = true
+            case .toolCall, .surface, .thinking, .attachment: hasNonText = true
             }
             if hasTextBlock && hasNonText { return true }
         }
@@ -334,6 +336,8 @@ extension ChatBubble {
                 } else {
                     groups.append(.thinking([i]))
                 }
+            case .attachment(let i):
+                groups.append(.attachment(i))
             }
         }
 
@@ -349,7 +353,7 @@ extension ChatBubble {
         // Post-process: coalesce text groups that are only separated by tool call
         // groups so that the user can drag-select across text that spans a tool
         // invocation (tool calls render as EmptyView and produce no visual gap).
-        // Only .surface entries break a text run because they render visible content.
+        // Only visible groups (.surface, .thinking, .attachment) break a text run.
         var coalesced: [ContentGroup] = []
         var pendingTexts: [Int]?
         var pendingToolCalls: [ContentGroup] = []
@@ -370,8 +374,8 @@ extension ChatBubble {
                 } else {
                     coalesced.append(group)
                 }
-            case .surface, .thinking:
-                // A surface or thinking block breaks the text run — flush pending state.
+            case .surface, .thinking, .attachment:
+                // A surface, thinking, or attachment block breaks the text run.
                 if let texts = pendingTexts {
                     coalesced.append(.texts(texts))
                     coalesced.append(contentsOf: pendingToolCalls)
@@ -614,6 +618,22 @@ extension ChatBubble {
             return false
         })?.stableId
 
+        // Attachments referenced by contentOrder render inline at their position;
+        // the rest (orphans — e.g. messages with attachments but no `attachment:N`
+        // entries) render after the last text group as before.
+        let inlineAttachmentIndices: Set<Int> = {
+            var set = Set<Int>()
+            for group in groups {
+                if case .attachment(let i) = group { set.insert(i) }
+            }
+            return set
+        }()
+        let orphanAttachments: [ChatAttachment] = message.attachments
+            .enumerated()
+            .compactMap { (idx, att) in
+                inlineAttachmentIndices.contains(idx) ? nil : att
+            }
+
         // Render all content groups in order: text, burst cards, and surfaces.
         ForEach(groups, id: \.stableId) { group in
             switch group {
@@ -639,9 +659,11 @@ extension ChatBubble {
                     }
                     inlineToolCallImages(from: deferredCalls)
                 }
-                // Render attachments right after the last text group
+                // Render orphan attachments right after the last text group.
+                // Attachments referenced by `attachment:N` entries render inline
+                // at their own position in the .attachment case below.
                 if group.stableId == lastTextGroupId {
-                    inlineAttachments
+                    inlineAttachments(for: orphanAttachments)
                 }
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
@@ -680,6 +702,10 @@ extension ChatBubble {
                 if i < message.inlineSurfaces.count,
                    message.inlineSurfaces[i].id != activeSurfaceId {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
+                }
+            case .attachment(let i):
+                if i < message.attachments.count {
+                    inlineAttachments(for: [message.attachments[i]])
                 }
             case .thinking:
                 if burstForGroup[group.stableId] != nil {
@@ -728,18 +754,22 @@ extension ChatBubble {
             }
         }
 
-        // Fallback: if there are no text groups, render attachments after all content groups.
+        // Fallback: if there are no text groups, render orphan attachments
+        // after all content groups (inline attachments already rendered above).
         if lastTextGroupId == nil {
-            inlineAttachments
+            inlineAttachments(for: orphanAttachments)
         }
         attachmentWarningBanners(message.attachmentWarnings)
     }
 
-    /// Renders all non-tool-block attachments (images, videos, audios, files)
-    /// inline at the current position in the content flow.
+    /// Renders the given subset of attachments (images, videos, audios, files)
+    /// inline at the current position in the content flow. The subset is what
+    /// lets a `.attachment(N)` group render a single chip in the middle of a
+    /// message while the trailing slot renders only attachments not referenced
+    /// by any inline contentOrder entry.
     @ViewBuilder
-    private var inlineAttachments: some View {
-        let partitioned = partitionedAttachments
+    private func inlineAttachments(for attachments: [ChatAttachment]) -> some View {
+        let partitioned = partitionAttachments(attachments)
         let visibleImages = visibleAttachmentImages(partitioned.images)
         if !visibleImages.isEmpty {
             attachmentImageGrid(visibleImages)

--- a/clients/macos/vellum-assistantTests/HistoryReconstructionParseContentOrderTests.swift
+++ b/clients/macos/vellum-assistantTests/HistoryReconstructionParseContentOrderTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@Suite("HistoryReconstructionService.parseContentOrder")
+struct HistoryReconstructionParseContentOrderTests {
+
+    @Test("Parses known prefixes including attachment")
+    func parsesAllKnownPrefixes() {
+        let refs = HistoryReconstructionService.parseContentOrder([
+            "text:0",
+            "attachment:0",
+            "attachment:1",
+            "text:1",
+            "tool:0",
+            "surface:2",
+            "thinking:0",
+        ])
+        #expect(refs == [
+            .text(0),
+            .attachment(0),
+            .attachment(1),
+            .text(1),
+            .toolCall(0),
+            .surface(2),
+            .thinking(0),
+        ])
+    }
+
+    @Test("Drops unknown prefixes silently")
+    func dropsUnknownPrefixes() {
+        let refs = HistoryReconstructionService.parseContentOrder([
+            "text:0",
+            "futureType:5",
+            "attachment:0",
+        ])
+        #expect(refs == [.text(0), .attachment(0)])
+    }
+
+    @Test("Drops malformed entries")
+    func dropsMalformed() {
+        let refs = HistoryReconstructionService.parseContentOrder([
+            "attachment:",
+            "attachment:notanumber",
+            "noColon",
+            "attachment:7",
+        ])
+        #expect(refs == [.attachment(7)])
+    }
+}
+
+@Suite("ChatBubble.computeContentGroupsStatic with attachments")
+struct ChatBubbleComputeContentGroupsAttachmentTests {
+
+    private typealias ContentGroup = ChatBubble.ContentGroup
+
+    @Test("Attachment entries become their own group between text runs")
+    func attachmentInterleavedWithText() {
+        let groups = ChatBubble.computeContentGroupsStatic(
+            contentOrder: [
+                .text(0),
+                .attachment(0),
+                .attachment(1),
+                .text(1),
+            ],
+            hasInterleavedContent: true
+        )
+        #expect(groups == [
+            .texts([0]),
+            .attachment(0),
+            .attachment(1),
+            .texts([1]),
+        ])
+    }
+
+    @Test("Attachment breaks text-run coalescing")
+    func attachmentBreaksCoalescing() {
+        // With no tool calls, the post-process coalescing kicks in. Attachments
+        // must act like surfaces and prevent the two text groups from merging.
+        let groups = ChatBubble.computeContentGroupsStatic(
+            contentOrder: [
+                .text(0),
+                .attachment(0),
+                .text(1),
+            ],
+            hasInterleavedContent: false
+        )
+        #expect(groups == [
+            .texts([0]),
+            .attachment(0),
+            .texts([1]),
+        ])
+    }
+}

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1630,6 +1630,7 @@ public enum ContentBlockRef: Hashable {
     case toolCall(Int)
     case surface(Int)
     case thinking(Int)
+    case attachment(Int)
 }
 
 public struct ChatMessage: Identifiable, Equatable {

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -190,8 +190,8 @@ public enum HistoryReconstructionService {
 
     // MARK: - Content order parsing
 
-    /// Parse string-encoded content order entries ("text:0", "tool:1", "surface:0")
-    /// into ContentBlockRef values.
+    /// Parse string-encoded content order entries ("text:0", "tool:1",
+    /// "surface:0", "thinking:0", "attachment:0") into ContentBlockRef values.
     nonisolated static func parseContentOrder(_ strings: [String]) -> [ContentBlockRef] {
         strings.compactMap { str in
             let parts = str.split(separator: ":", maxSplits: 1)
@@ -201,6 +201,7 @@ public enum HistoryReconstructionService {
             case "tool": return .toolCall(idx)
             case "surface": return .surface(idx)
             case "thinking": return .thinking(idx)
+            case "attachment": return .attachment(idx)
             default: return nil
             }
         }

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -218,6 +218,10 @@ public struct MessageBubbleView: View {
                 }
             case .surface(let i):
                 groups.append(.surface(i))
+            case .attachment:
+                // This view doesn't render inline attachments — the bubble's
+                // attachment slot handles them at the trailing position.
+                continue
             }
         }
         return groups


### PR DESCRIPTION
## Summary

- Daemon emits `attachment:N` entries in `contentOrder` and a structured `attachments[]` array so clients can position file chips between text blocks.
- `attachmentsToContentBlocks` persists `_attachmentId` on file content blocks; the history route uses it to align DB-sourced attachment metadata with the in-content order.
- macOS Swift client adds `.attachment(Int)` to `ContentBlockRef`, parses `attachment:N`, and renders a single chip inline for each entry in `ChatBubbleInterleavedContent`. The trailing slot now renders only orphan attachments not referenced inline.

## Original prompt

Velissa sent an assistant message in the macOS app with two markdown files (dream-015 and dream-016) attached, and a visible gap between text paragraphs where they were meant to render inline. The chips ended up batched at the bottom of the bubble instead. Scope was explicitly macOS-only — web continues to render attachments at the bottom (graceful drop of unknown contentOrder entries). Slack-ingested messages and live-streamed assistant turns keep their current trailing behavior, since neither carries positional `file` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)