### PR TITLE
docs(web): document the event bus convention

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -8,6 +8,7 @@ Read these before making changes:
 
 - **[`docs/CONVENTIONS.md`](./docs/CONVENTIONS.md)** — Architecture, code organization, component patterns, framework strategy, data fetching, testing.
 - **[`docs/STATE_MANAGEMENT.md`](./docs/STATE_MANAGEMENT.md)** — Zustand stores, atomic selectors, TanStack Query, the no-`useReducer` rule.
+- **[`docs/EVENT_BUS.md`](./docs/EVENT_BUS.md)** — Cross-domain push signals (SSE, app lifecycle, network). Single connection, typed events, no per-component `visibilitychange` handlers.
 - **[`docs/STYLE_GUIDE.md`](./docs/STYLE_GUIDE.md)** — Naming, imports, TypeScript, component authoring, formatting.
 - **[`docs/CAPACITOR.md`](./docs/CAPACITOR.md)** — Capacitor / iOS patterns: lazy plugin imports, native auth, deep links, autogrowing textareas, streaming watchdogs, OS permission UI, capability detection, keyboard-only affordances. Mandatory reading if any code path you're touching might run inside the iOS WKWebView shell.
 

--- a/apps/web/docs/CONVENTIONS.md
+++ b/apps/web/docs/CONVENTIONS.md
@@ -311,6 +311,19 @@ Quick summary:
 - **`useReducer` is not used** for client state, even within a single hook. See [STATE_MANAGEMENT.md — useReducer is not used](./STATE_MANAGEMENT.md#usereducer-is-not-used-for-client-state).
 - **`useShallow`** is not introduced in new code — atomic selectors avoid the need.
 
+## Event bus
+
+Cross-domain push signals (SSE, app lifecycle, network reachability)
+flow through a single event bus. See
+[`EVENT_BUS.md`](./EVENT_BUS.md).
+
+Quick summary:
+
+- **One SSE connection per tab.** Only `useEventBusInit` calls `subscribeChatEvents`; every other consumer subscribes to `bus.sse.event`.
+- **No per-component `visibilitychange` listeners** for data-refresh. Subscribe to `bus.app.resume` / `bus.app.hidden` instead.
+- **No `window.online` / `window.offline` listeners** in components or stores. Subscribe to `bus.app.online` / `bus.app.offline`.
+- **No polling** for state the daemon could push. Emit a typed event over `/v1/events` and subscribe via the bus.
+
 
 ## Component patterns
 

--- a/apps/web/docs/EVENT_BUS.md
+++ b/apps/web/docs/EVENT_BUS.md
@@ -1,0 +1,146 @@
+# Web App — Event Bus
+
+How cross-domain push signals (SSE, app lifecycle, network reachability)
+flow through `apps/web/`. One bus instance per tab, one SSE connection
+per tab, typed events, synchronous delivery.
+
+See also [`apps/web/AGENTS.md`](../AGENTS.md), the umbrella
+[`CONVENTIONS.md`](./CONVENTIONS.md), and
+[`STATE_MANAGEMENT.md`](./STATE_MANAGEMENT.md).
+
+---
+
+## Why a bus
+
+The daemon serves SSE on `GET /v1/events` and identifies clients via a
+stable per-browser `clientId` header. Each `clientId` may have at most
+one active subscription — a second subscribe from the same id replaces
+the first. A single bus owner is therefore the only correct way to
+have multiple parts of the UI observe daemon events from the same tab.
+
+Centralizing through a bus also gives us:
+
+- **Typed delivery.** Subscribers narrow on event name and get a
+  payload type from `BusEventMap` — no per-call casting, no string
+  matching on event shapes.
+- **One place for lifecycle policy.** Tab visibility, network
+  reachability, and Capacitor app-state all interact with the SSE
+  connection (tear down on hidden, reopen on resume, bounce on
+  retry). Putting that policy in the bus owner keeps it consistent
+  across every consumer.
+- **No polling.** Components that need to react to server-side state
+  changes subscribe to a typed event instead of running their own
+  interval timer. If the daemon already knows when something
+  resolves, it pushes the event; the client reacts.
+
+## Where it lives
+
+| Module | Role |
+|---|---|
+| `apps/web/src/stores/event-bus-store.ts` | The bus itself. Zustand store with `subscribe(event, handler)` / `publish(event, payload)` actions and a module-private handler registry. |
+| `apps/web/src/hooks/use-event-bus-init.ts` | Wires the bus to its sources: opens the single assistant-scoped `/v1/events` SSE, registers `document.visibilitychange` + `window.online`/`offline` + Capacitor `App.appStateChange`. Mounted exactly once by `ChatLayout`. |
+
+The bus is a Zustand store per the [state-management
+convention](./STATE_MANAGEMENT.md) — all shared client-state primitives
+live in Zustand. The store's state is private; consumers only ever call
+the action surface (`subscribe` / `publish`). Pub/sub semantics do not
+flow through Zustand reactivity: handlers fire synchronously from
+`publish()` so a burst of events isn't collapsed into a single React
+commit cycle.
+
+## Event protocol
+
+Every event name in `BusEventMap` has a typed payload. The producer is
+`useEventBusInit` for everything except `reachability.retry-requested`,
+which is produced by the burst-limited reachability retry in
+`use-event-stream.ts`.
+
+| Event | Payload | Produced when |
+|---|---|---|
+| `sse.event` | `AssistantEvent` | Every event the bus-owned SSE connection sees. Consumers narrow on `payload.type` and filter on `payload.conversationKey` themselves. |
+| `sse.opened` | `{ assistantId; cause: "fresh" \| "error" \| "watchdog" \| "resume" }` | After each successful (re)open. `cause` lets consumers distinguish a fresh connection from a watchdog-driven recovery. |
+| `sse.closed` | `{ reason }` | Transport error on the SSE connection. Not published for intentional teardowns (hidden tab, reachability bounce). |
+| `app.resume` | `{ signal: "visibility" \| "app_state" \| "online" }` | Page visible, app foregrounded, or network came back online. |
+| `app.hidden` | `{ signal: "visibility" \| "app_state" }` | Page hidden or app backgrounded. |
+| `app.online` | `{}` | `window.online` fired. Always accompanies a paired `app.resume{signal:"online"}`. |
+| `app.offline` | `{}` | `window.offline` fired. |
+| `reachability.retry-requested` | `{}` | Burst-limited reachability retry succeeded; the bus bounces its SSE. |
+
+## Subscribing
+
+```ts
+// In a hook
+useEffect(() => {
+  const unsubscribe = useEventBusStore
+    .getState()
+    .subscribe("app.resume", ({ signal }) => {
+      // Refetch stale-while-revalidate data here.
+    });
+  return unsubscribe;
+}, []);
+```
+
+```ts
+// In a Zustand store bootstrap (no React context)
+const unsubscribeResume = useEventBusStore
+  .getState()
+  .subscribe("app.resume", () => {
+    refetchIfStale();
+  });
+// Add unsubscribeResume() to the existing teardown closure.
+```
+
+`subscribe()` always returns an unsubscribe function. Call it in the
+effect cleanup (React) or the bootstrap teardown (stores).
+
+## Publishing
+
+Publishing is reserved for the bus owner (`useEventBusInit`) and the
+narrow surfaces that need to ask the bus to do something — today only
+`reachability.retry-requested`. Don't add new producers without a
+documented reason.
+
+```ts
+useEventBusStore.getState().publish("reachability.retry-requested", {});
+```
+
+## Adding a new event
+
+1. Add the name + payload type to `BusEventMap` in
+   `event-bus-store.ts`. Keep the JSDoc on the field — it's how
+   consumers learn when the event fires.
+2. Add the producer. SSE-derived events go in `use-event-bus-init.ts`'s
+   SSE effect. DOM-derived events go in its lifecycle effect.
+3. Add subscribers where needed. Each subscriber's `useEffect` (or
+   bootstrap closure) gets one `subscribe(name, handler)` call and
+   returns the unsubscribe.
+4. Test the producer (publish round-trip in `use-event-bus-init.test.tsx`
+   or `event-bus-store.test.ts`) and at least one consumer.
+
+## Don't do this
+
+- **Don't call `subscribeChatEvents` directly outside `use-event-bus-init.ts`.** Every other consumer subscribes to `bus.sse.event`. A second SSE handle from the same `clientId` will evict the first on the daemon.
+- **Don't register `document.addEventListener("visibilitychange", ...)`** in a component or store for data-refresh purposes. Subscribe to `bus.app.resume` instead. The only legitimate `visibilitychange` registration in the app is the one inside `use-event-bus-init.ts`.
+- **Don't register `window.online` / `window.offline` listeners** in a component or store. Subscribe to `bus.app.online` / `bus.app.offline`.
+- **Don't add polling intervals to discover state the daemon could push.** If the daemon already knows when something resolves, emit a typed event over `/v1/events` and subscribe to it via the bus.
+- **Don't read `useEventBusStore.use.*` in a component render body.** The store's reactive surface is empty by design — there's no state worth subscribing to. Always use `.getState().subscribe(...)` inside an effect or bootstrap closure.
+
+## Testing
+
+`event-bus-store.test.ts` covers the pub/sub surface (subscribe,
+unsubscribe, publish, isolation between event names, throwing-handler
+robustness). `use-event-bus-init.test.tsx` covers the source-wiring:
+SSE open gating, event re-broadcast, `sse.opened` cause tagging,
+teardown on `app.hidden`, reopen on `app.resume`, and the dedup window.
+
+`__resetEventBusForTesting()` is exported from
+`event-bus-store.ts` for use in `beforeEach`/`afterEach`. Don't import
+it from production code.
+
+## References
+
+- [Zustand — Reading/writing state outside components](https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components)
+- [`STATE_MANAGEMENT.md`](./STATE_MANAGEMENT.md) — why the bus is a
+  Zustand store even though it doesn't expose reactive state.
+- [`CAPACITOR.md`](./CAPACITOR.md) — Capacitor `App.appStateChange`
+  feeds the bus's `app.resume` / `app.hidden` channels on iOS.


### PR DESCRIPTION
## Summary

Adds `apps/web/docs/EVENT_BUS.md` as a top-level convention doc covering the event bus introduced for the SSE-to-bus migration. Mirrors the structure of `STATE_MANAGEMENT.md` so future contributors know:

- **Why** the bus exists (one SSE per tab, no per-component `visibilitychange` handlers).
- **Where it lives** (`stores/event-bus-store.ts`, `hooks/use-event-bus-init.ts`).
- **The typed event protocol** — table of every `BusEventMap` entry with producer + meaning.
- **How to subscribe** (`useEventBusStore.getState().subscribe(...)` from effects or store bootstraps).
- **How to add a new event** (four-step recipe).
- **"Don't do this" list** — direct `subscribeChatEvents` calls, per-component `visibilitychange`, per-component `online`/`offline`, polling for daemon-knowable state.

Also adds:
- A pointer from `apps/web/AGENTS.md`'s required-reading list.
- A `## Event bus` summary section in `apps/web/docs/CONVENTIONS.md` linking back to the full doc.

## Test plan

- [x] Docs-only change. No code touched.
- [x] Verified the cross-doc links resolve (`AGENTS.md` → `EVENT_BUS.md`, `CONVENTIONS.md` → `EVENT_BUS.md`, `EVENT_BUS.md` → `STATE_MANAGEMENT.md` / `CAPACITOR.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_