### PR TITLE
test(web): surface mock.module pollution with descriptive stubs

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -33,6 +33,22 @@ let fetchCallCount = 0;
 // The messages module has side-effect-heavy imports (HeyAPI client, CSRF, etc.)
 // that can't load in a test environment. We mock the entire module, providing
 // the pure functions that reconcile.ts needs plus our controllable fetch stub.
+//
+// `mock.module()` mutates a process-global module registry, so this mock
+// shadows the real module for every test file that runs in the same Bun
+// process. The CI runner (`bun run test:ci` → `scripts/run-tests.ts`)
+// isolates each file in its own subprocess. A naive `bun test src/...`
+// over a directory will pollute later suites — every export of
+// `messages.ts` is stubbed below so cross-loaded tests fail with a
+// pointer back here rather than an opaque "Export not found".
+const moduleScopeStub = (name: string) => () => {
+  throw new Error(
+    `[use-message-reconciliation.test.tsx] '${name}' was called via the ` +
+      `process-global mock.module shadow. Run this test file in isolation ` +
+      `(\`bun test path/to/file.test.ts\`) or via \`bun run test:ci\`.`,
+  );
+};
+
 mock.module("@/domains/chat/api/messages", () => ({
   fetchConversationMessages: async (_assistantId: string, _conversationKey: string) => {
     fetchCallCount++;
@@ -40,6 +56,14 @@ mock.module("@/domains/chat/api/messages", () => ({
     if (mockFetchError) throw mockFetchError;
     return mockFetchResult;
   },
+  // Stubs for the rest of the real module's surface. Provided so dependent
+  // test files that import these still get *something* under the global
+  // mock shadow; calling any of them surfaces a clear error.
+  pollForResponse: moduleScopeStub("pollForResponse"),
+  getChatHistory: moduleScopeStub("getChatHistory"),
+  uploadChatAttachment: moduleScopeStub("uploadChatAttachment"),
+  postChatMessage: moduleScopeStub("postChatMessage"),
+  deleteQueuedMessage: moduleScopeStub("deleteQueuedMessage"),
   mapRuntimeToolCalls: (
     toolCalls: Array<{ name: string; input?: unknown; result?: unknown; isError?: boolean }>,
     messageId: string,


### PR DESCRIPTION
## Summary

`apps/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx` calls `mock.module()` on the entire `@/domains/chat/api/messages` module so it can stub `fetchConversationMessages`. Bun's `mock.module` mutates a **process-global** module registry — the mock shadows the real module for every other test file that runs in the same Bun process.

The original mock only exported the 4 symbols the hook under test transitively uses. Five other exports (`postChatMessage`, `getChatHistory`, `uploadChatAttachment`, `pollForResponse`, `deleteQueuedMessage`) were unstubbed, so any cross-loaded test that imported one of them failed at import time with an opaque `SyntaxError: Export named 'postChatMessage' not found in module`.

## Resolution

The CI test runner (`bun run test:ci` → `scripts/run-tests.ts`) already isolates each file in its own subprocess, so this only bites the local-dev `bun test <dir>` pattern. Rather than restructure the test (the right long-term fix is to spy on `client.get` like `messages.test.ts` does), this PR provides typed throwing stubs for the missing exports. Cross-loaded suites now fail with a descriptive error pointing back to this test file and recommending the isolated invocation, instead of an opaque "Export not found".

## Test plan

- [x] `bun test src/domains/chat/hooks/use-message-reconciliation.test.tsx` — 26 / 26 pass (test still works).
- [x] `bun test src/domains/chat/hooks` — 166 / 166 pass (intra-dir isolation unchanged).
- [x] `bun test src/domains/chat/hooks src/domains/chat/api` — cross-suite tests now fail with the descriptive stub error instead of "Export not found". This run is still expected to fail without `test:ci`; the goal is a clear pointer, not a fix.
- [x] `bun run test:ci` invocation is unchanged — each file in its own subprocess.

## Follow-up

A larger refactor would migrate this test to use the `client.get` method-spy pattern that `messages.test.ts` already uses (avoids `mock.module` entirely). Out of scope here.


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_