### PR TITLE
refactor(web): migrate remaining visibilitychange handlers to event bus

### DIFF
--- a/apps/web/src/assistant/use-disk-pressure-monitor.ts
+++ b/apps/web/src/assistant/use-disk-pressure-monitor.ts
@@ -12,6 +12,7 @@ import {
   getDiskPressureMonitorMode,
   type DiskPressureMonitorMode,
 } from "@/assistant/disk-pressure.js";
+import { useEventBusStore } from "@/stores/event-bus-store.js";
 
 export interface UseDiskPressureMonitorOptions {
   assistantId: string | null;
@@ -167,23 +168,18 @@ export function useDiskPressureMonitor({
       void refresh();
     }, cadenceMs);
 
-    const refreshOnFocus = () => {
-      void refresh();
-    };
-
-    const refreshOnVisibility = () => {
-      if (document.visibilityState === "visible") {
+    // The bus's `"app.resume"` channel fans in browser visibility,
+    // Capacitor foreground, and `window.online`, so a single
+    // subscription drives the focus-style refetch.
+    const unsubResume = useEventBusStore
+      .getState()
+      .subscribe("app.resume", () => {
         void refresh();
-      }
-    };
-
-    window.addEventListener("focus", refreshOnFocus);
-    document.addEventListener("visibilitychange", refreshOnVisibility);
+      });
 
     return () => {
       window.clearInterval(intervalId);
-      window.removeEventListener("focus", refreshOnFocus);
-      document.removeEventListener("visibilitychange", refreshOnVisibility);
+      unsubResume();
     };
   }, [assistantId, cadenceMs, enabled, refresh, refreshKey]);
 

--- a/apps/web/src/domains/home/hooks/use-home-feed-query.ts
+++ b/apps/web/src/domains/home/hooks/use-home-feed-query.ts
@@ -11,6 +11,7 @@ import type {
   FeedItemStatus,
   HomeFeedResponse,
 } from "../types.js";
+import { useEventBusStore } from "@/stores/event-bus-store.js";
 
 const QUERY_KEY_PREFIX = "home-feed" as const;
 
@@ -21,8 +22,12 @@ function homeFeedQueryKey(assistantId: string) {
 /**
  * React Query hook for the home feed.
  *
- * Tracks time-away via `document.visibilitychange` so the daemon can
- * personalise the greeting and decide which items to surface.
+ * Tracks time-away via the layout-scoped event bus (`"app.hidden"` +
+ * `"app.resume"`) so the daemon can personalise the greeting and decide
+ * which items to surface. The `"online"` resume signal is ignored for
+ * elapsed-time tracking — only visibility / app-state transitions
+ * record a `hiddenAt` mark, so a network blip while the tab is in the
+ * foreground does not synthesise fake time-away.
  */
 export function useHomeFeedQuery(assistantId: string | null) {
   const queryClient = useQueryClient();
@@ -31,27 +36,29 @@ export function useHomeFeedQuery(assistantId: string | null) {
   const timeAwaySecondsRef = useRef(0);
 
   useEffect(() => {
-    function handleVisibilityChange() {
-      if (document.hidden) {
-        hiddenAtRef.current = Date.now();
-      } else if (hiddenAtRef.current !== null) {
-        const elapsed = Math.round(
-          (Date.now() - hiddenAtRef.current) / 1000,
-        );
-        timeAwaySecondsRef.current = elapsed;
-        hiddenAtRef.current = null;
+    const bus = useEventBusStore.getState();
 
-        if (assistantId) {
-          void queryClient.invalidateQueries({
-            queryKey: homeFeedQueryKey(assistantId),
-          });
-        }
+    const unsubHidden = bus.subscribe("app.hidden", () => {
+      hiddenAtRef.current = Date.now();
+    });
+
+    const unsubResume = bus.subscribe("app.resume", ({ signal }) => {
+      if (signal === "online") return;
+      if (hiddenAtRef.current === null) return;
+      const elapsed = Math.round((Date.now() - hiddenAtRef.current) / 1000);
+      timeAwaySecondsRef.current = elapsed;
+      hiddenAtRef.current = null;
+
+      if (assistantId) {
+        void queryClient.invalidateQueries({
+          queryKey: homeFeedQueryKey(assistantId),
+        });
       }
-    }
+    });
 
-    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      unsubHidden();
+      unsubResume();
     };
   }, [assistantId, queryClient]);
 

--- a/apps/web/src/domains/settings/hooks/use-settings-sync.ts
+++ b/apps/web/src/domains/settings/hooks/use-settings-sync.ts
@@ -1,9 +1,7 @@
-import type { PluginListenerHandle } from "@capacitor/core";
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen.js";
-import { isNativePlatform } from "@/runtime/native-auth.js";
 import { createSyncTagRegistry } from "@/lib/sync/tag-registry.js";
 import {
   invalidateAssistantConfigQueries,
@@ -12,13 +10,16 @@ import {
 } from "@/lib/sync/query-tags.js";
 import { SYNC_TAGS } from "@/lib/sync/types.js";
 import { subscribeChatEvents, type ChatEventStream } from "@/domains/chat/api/stream.js";
+import { useEventBusStore } from "@/stores/event-bus-store.js";
 
 const SETTINGS_STREAM_RETRY_DELAY_MS = 30_000;
 
 /**
  * Subscribes to the assistant event stream while on the settings pages
  * and invalidates TanStack Query caches when relevant sync tags arrive.
- * On native platforms also re-syncs when the app resumes from background.
+ * Also re-syncs whenever the layout-scoped event bus publishes
+ * `"app.resume"` — covering web visibility, Capacitor foreground, and
+ * `window.online` behind a single channel.
  */
 export function useSettingsSync(
   streamRetryDelayMs = SETTINGS_STREAM_RETRY_DELAY_MS,
@@ -107,43 +108,22 @@ export function useSettingsSync(
     }
 
     openStream();
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        refreshOnResume();
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
 
-    let appStateHandle: PluginListenerHandle | null = null;
-    let appStateCancelled = false;
-    if (isNativePlatform()) {
-      import("@capacitor/app")
-        .then(({ App }) =>
-          App.addListener("appStateChange", ({ isActive }) => {
-            if (isActive) {
-              refreshOnResume();
-            }
-          }),
-        )
-        .then((registered) => {
-          if (appStateCancelled) {
-            void registered.remove();
-            return;
-          }
-          appStateHandle = registered;
-        })
-        .catch(() => {
-          // Browser visibility still covers non-native and plugin failure paths.
-        });
-    }
+    // The bus's `"app.resume"` channel fans in browser visibility,
+    // Capacitor `appStateChange` (active), and `window.online`.
+    // `refreshOnResume` keeps its own 1s dedup window for the case
+    // where the bus delivers visibility + online in close succession.
+    const unsubResume = useEventBusStore
+      .getState()
+      .subscribe("app.resume", () => {
+        refreshOnResume();
+      });
 
     return () => {
       cancelled = true;
       clearRetryTimer();
       stream?.cancel();
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      appStateCancelled = true;
-      void appStateHandle?.remove();
+      unsubResume();
       for (const registration of registrations) {
         registration.dispose();
       }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -2,10 +2,10 @@
  * Zustand auth store.
  *
  * Session lifecycle: probes the allauth session on `initSession()`,
- * re-validates on window focus / visibility change, and synchronizes
- * logout across tabs via BroadcastChannel. Middleware, loaders, and
- * API interceptors read state synchronously via
- * `useAuthStore.getState()`.
+ * re-validates when the app resumes (foreground / visibility / online,
+ * delivered via the layout-scoped event bus), and synchronizes logout
+ * across tabs via BroadcastChannel. Middleware, loaders, and API
+ * interceptors read state synchronously via `useAuthStore.getState()`.
  *
  * References:
  * - https://zustand.docs.pmnd.rs/guides/reading-and-writing-state-outside-components
@@ -20,6 +20,7 @@ import {
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client.js";
 import { clearOrganization } from "@/stores/organization-store.js";
+import { useEventBusStore } from "@/stores/event-bus-store.js";
 
 export interface AuthUser {
   id: string | null;
@@ -135,8 +136,12 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 export const useAuthStore = createSelectors(useAuthStoreBase);
 
 /**
- * Subscribe to window focus / visibility changes and cross-tab
- * BroadcastChannel messages. Call once at app startup.
+ * Subscribe to app-resume signals on the layout-scoped event bus and to
+ * cross-tab BroadcastChannel messages. Call once at app startup.
+ *
+ * The bus's `"app.resume"` payload fans in page visibility flipping to
+ * "visible", a Capacitor `appStateChange` going active on native, and
+ * `window.online`, so a single subscription drives the session refresh.
  */
 export function setupAuthListeners(): () => void {
   const { refreshSession } = useAuthStore.getState();
@@ -147,17 +152,12 @@ export function setupAuthListeners(): () => void {
       console.warn("auth.refreshSession failed", err),
     );
 
-  const onFocus = () => safeRefresh();
-  const onVisibilityChange = () => {
-    if (document.visibilityState === "visible") safeRefresh();
-  };
-
-  window.addEventListener("focus", onFocus);
-  document.addEventListener("visibilitychange", onVisibilityChange);
-  cleanups.push(() => {
-    window.removeEventListener("focus", onFocus);
-    document.removeEventListener("visibilitychange", onVisibilityChange);
-  });
+  const unsubResume = useEventBusStore
+    .getState()
+    .subscribe("app.resume", () => {
+      void safeRefresh();
+    });
+  cleanups.push(unsubResume);
 
   if (typeof BroadcastChannel !== "undefined") {
     broadcastChannel = new BroadcastChannel("auth");

--- a/apps/web/src/stores/organization-store.ts
+++ b/apps/web/src/stores/organization-store.ts
@@ -21,6 +21,7 @@ import { createSelectors } from "@/utils/create-selectors.js";
 import { organizationsList } from "@/generated/api/sdk.gen.js";
 import type { OrganizationRead } from "@/generated/api/types.gen.js";
 import { useAuthStore } from "@/stores/auth-store.js";
+import { useEventBusStore } from "@/stores/event-bus-store.js";
 
 const ACTIVE_ORGANIZATION_STORAGE_KEY = "vellum_active_organization_id";
 
@@ -173,15 +174,18 @@ export function clearOrganization(): void {
  *
  * 1. Auth subscription — fetches orgs when the user logs in or switches
  *    accounts (including cross-tab via BroadcastChannel).
- * 2. Window focus / visibility — refetches the org list when the tab
- *    regains focus, but only if data is older than STALE_TIME_MS so
- *    rapid focus events on fresh data don't trigger redundant fetches.
+ * 2. App resume — refetches the org list when the user returns to the
+ *    tab (visibility / native foreground / online), but only if data is
+ *    older than STALE_TIME_MS so rapid resume signals on fresh data
+ *    don't trigger redundant fetches. Delivered via the layout-scoped
+ *    event bus, which covers the visibility + focus + online surface
+ *    behind a single channel.
  */
 export function setupOrganizationStore(): () => void {
   const STALE_TIME_MS = 10_000;
   let lastFetchedAt = 0;
 
-  // Track when fetches complete so we can enforce staleTime on focus refetch.
+  // Track when fetches complete so we can enforce staleTime on resume refetch.
   const unsubStale = useOrganizationStore.subscribe((state) => {
     if (state.status === "ready" || state.status === "error") {
       lastFetchedAt = Date.now();
@@ -198,7 +202,7 @@ export function setupOrganizationStore(): () => void {
     }
   });
 
-  // 2. Window focus / visibility — refetch if stale.
+  // 2. App resume — refetch if stale.
   const refetchIfStale = () => {
     const { status } = useOrganizationStore.getState();
     if (
@@ -209,18 +213,15 @@ export function setupOrganizationStore(): () => void {
     }
   };
 
-  const onFocus = () => refetchIfStale();
-  const onVisibilityChange = () => {
-    if (document.visibilityState === "visible") refetchIfStale();
-  };
-
-  window.addEventListener("focus", onFocus);
-  document.addEventListener("visibilitychange", onVisibilityChange);
+  const unsubResume = useEventBusStore
+    .getState()
+    .subscribe("app.resume", () => {
+      refetchIfStale();
+    });
 
   return () => {
     unsubStale();
     unsubAuth();
-    window.removeEventListener("focus", onFocus);
-    document.removeEventListener("visibilitychange", onVisibilityChange);
+    unsubResume();
   };
 }


### PR DESCRIPTION
## Summary

PR3 of the LUM-1812 follow-up sequence. Migrates the five remaining per-component `visibilitychange` (and adjacent `window.focus` / Capacitor `appStateChange`) handlers onto the layout-scoped event bus introduced in PR1/PR2.

Files migrated:

- `stores/auth-store.ts` — `setupAuthListeners` now subscribes to `app.resume` for session refresh instead of `window.focus` + `document.visibilitychange`.
- `stores/organization-store.ts` — `setupOrganizationStore` subscribes to `app.resume` for the stale-refetch on focus instead of `window.focus` + `document.visibilitychange`.
- `domains/settings/hooks/use-settings-sync.ts` — single `app.resume` subscription replaces the inline `document.visibilitychange` + Capacitor `appStateChange` plugin handlers.
- `domains/home/hooks/use-home-feed-query.ts` — time-away tracking now subscribes to `app.hidden` + `app.resume` (with the `online` resume signal filtered out so a network blip while the tab is in foreground does not synthesise fake time-away).
- `assistant/use-disk-pressure-monitor.ts` — `app.resume` subscription replaces the `window.focus` + `document.visibilitychange` pair driving the focus-refresh.

After this change, `grep -rn visibilitychange apps/web/src` only matches inside `hooks/use-event-bus-init.ts` (the bus's own DOM owner), the `stores/event-bus-store.ts` doc, doc comments in `chat-layout` / `use-event-stream`, and a test file. The LUM-1812 acceptance criterion "no component holds its own `visibilitychange` listener for data-refresh purposes" is delivered.

## Test plan

- [x] `bun run typecheck` (apps/web) — clean
- [x] `bun run lint` (apps/web) — clean (one pre-existing unrelated warning)
- [x] `bun test src/stores src/hooks src/assistant` — 64 pass
- [ ] Manual: sign in, background the tab for >10s, foreground it, verify auth + organization refetch fire once
- [ ] Manual: open settings page, background and resume, verify a sync reconcile pass runs
- [ ] Manual: open home, background for 30s, resume, verify home feed invalidates with `time_away` populated on the request
- [ ] Manual: when disk pressure is being polled, background + resume the tab and verify the next status poll fires immediately on resume

https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg

---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_