### PR TITLE
feat(web): add useBusSubscription + subscribeBus helpers

### DIFF
--- a/apps/web/docs/EVENT_BUS.md
+++ b/apps/web/docs/EVENT_BUS.md
@@ -68,30 +68,37 @@ which is produced by the burst-limited reachability retry in
 
 ## Subscribing
 
-```ts
-// In a hook
-useEffect(() => {
-  const unsubscribe = useEventBusStore
-    .getState()
-    .subscribe("app.resume", ({ signal }) => {
-      // Refetch stale-while-revalidate data here.
-    });
-  return unsubscribe;
-}, []);
-```
+In a React hook or component, use `useBusSubscription` from
+`@/hooks/use-bus-subscription.js`. It wraps `useEffect` + `subscribe`
++ cleanup and stabilises the handler ref so inline arrows don't
+re-register on every render.
 
 ```ts
-// In a Zustand store bootstrap (no React context)
-const unsubscribeResume = useEventBusStore
-  .getState()
-  .subscribe("app.resume", () => {
-    refetchIfStale();
-  });
+import { useBusSubscription } from "@/hooks/use-bus-subscription.js";
+
+useBusSubscription("app.resume", ({ signal }) => {
+  // Refetch stale-while-revalidate data here.
+});
+```
+
+In code outside the React tree (Zustand store bootstraps, route
+loaders, middleware), use `subscribeBus` from the same module and
+store the returned unsubscribe handle alongside the bootstrap's other
+teardown:
+
+```ts
+import { subscribeBus } from "@/hooks/use-bus-subscription.js";
+
+const unsubscribeResume = subscribeBus("app.resume", () => {
+  refetchIfStale();
+});
 // Add unsubscribeResume() to the existing teardown closure.
 ```
 
-`subscribe()` always returns an unsubscribe function. Call it in the
-effect cleanup (React) or the bootstrap teardown (stores).
+Both helpers wrap `useEventBusStore.getState().subscribe(...)`. New
+code should not call `useEventBusStore.getState()` directly for
+subscriptions — use the helpers so the unsubscribe lifecycle is
+consistent everywhere.
 
 ## Publishing
 
@@ -111,11 +118,87 @@ useEventBusStore.getState().publish("reachability.retry-requested", {});
    consumers learn when the event fires.
 2. Add the producer. SSE-derived events go in `use-event-bus-init.ts`'s
    SSE effect. DOM-derived events go in its lifecycle effect.
-3. Add subscribers where needed. Each subscriber's `useEffect` (or
-   bootstrap closure) gets one `subscribe(name, handler)` call and
-   returns the unsubscribe.
+3. Add subscribers where needed via `useBusSubscription` (React) or
+   `subscribeBus` (stores / non-React).
 4. Test the producer (publish round-trip in `use-event-bus-init.test.tsx`
    or `event-bus-store.test.ts`) and at least one consumer.
+
+## Conventions
+
+- **Use the helpers, not the raw store.** `useBusSubscription` and
+  `subscribeBus` from `@/hooks/use-bus-subscription.js` are the only
+  blessed subscriber surfaces. Don't reach into
+  `useEventBusStore.getState().subscribe(...)` from new code — the
+  helpers exist to keep the unsubscribe lifecycle consistent.
+- **Inline handlers are fine.** `useBusSubscription` stabilises the
+  handler ref internally, so passing an arrow function does not
+  re-register the subscription on every render. No `useCallback`
+  ceremony required.
+- **Subscribe at the right scope.** Bus subscribers belong in the
+  layer that owns the resulting side-effect: the hook that mutates a
+  query cache, the store whose state needs to refresh, the component
+  whose visual state depends on it. Don't subscribe inside deeply
+  nested presentational components.
+- **Filter inside the handler.** `bus.sse.event` is unfiltered;
+  consumers narrow on `payload.type` and (for conversation-scoped
+  consumers) on `payload.conversationKey`. The bus delivers every
+  event the SSE connection sees.
+- **Skip resume signals you don't care about.** `app.resume` fires for
+  visibility, app foregrounding, AND network online. A handler that
+  only cares about real foregrounding can early-return when
+  `signal === "online"` (see `use-home-feed-query.ts`).
+
+## Common patterns
+
+### Invalidate a query cache on resume
+
+```ts
+const queryClient = useQueryClient();
+useBusSubscription("app.resume", () => {
+  void queryClient.invalidateQueries({ queryKey: ["my-data"] });
+});
+```
+
+### Track time-away between hidden and resume
+
+```ts
+const hiddenAtRef = useRef<number | null>(null);
+useBusSubscription("app.hidden", () => {
+  hiddenAtRef.current = Date.now();
+});
+useBusSubscription("app.resume", ({ signal }) => {
+  if (signal === "online") return; // network blip, not real time-away
+  const hiddenAt = hiddenAtRef.current;
+  hiddenAtRef.current = null;
+  if (hiddenAt == null) return;
+  const elapsedMs = Date.now() - hiddenAt;
+  // Use elapsedMs.
+});
+```
+
+### React to a typed SSE event
+
+```ts
+useBusSubscription("sse.event", (event) => {
+  if (event.type !== "interaction_resolved") return;
+  // event is narrowed to the InteractionResolvedEvent shape.
+  queryClient.setQueryData(["interactions", event.requestId], { state: event.state });
+});
+```
+
+### Imperative subscriber inside a store bootstrap
+
+```ts
+export function setupMyStore(): () => void {
+  const unsubResume = subscribeBus("app.resume", () => {
+    refetchIfStale();
+  });
+  return () => {
+    unsubResume();
+    // ...other teardown.
+  };
+}
+```
 
 ## Don't do this
 

--- a/apps/web/src/hooks/use-bus-subscription.test.tsx
+++ b/apps/web/src/hooks/use-bus-subscription.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { __resetEventBusForTesting, useEventBusStore } from "@/stores/event-bus-store.js";
+import { subscribeBus, useBusSubscription } from "@/hooks/use-bus-subscription.js";
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+});
+
+describe("useBusSubscription", () => {
+  test("invokes the handler when the named event is published", () => {
+    const handler = mock(() => {});
+    renderHook(() => useBusSubscription("app.online", handler));
+    useEventBusStore.getState().publish("app.online", {});
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribes when the hook unmounts", () => {
+    const handler = mock(() => {});
+    const { unmount } = renderHook(() =>
+      useBusSubscription("app.online", handler),
+    );
+    unmount();
+    useEventBusStore.getState().publish("app.online", {});
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("does not tear down and re-register on every render", () => {
+    const handler = mock(() => {});
+    const { rerender } = renderHook(
+      ({ h }: { h: () => void }) => useBusSubscription("app.online", h),
+      { initialProps: { h: handler } },
+    );
+    useEventBusStore.getState().publish("app.online", {});
+    expect(handler).toHaveBeenCalledTimes(1);
+    rerender({ h: handler });
+    rerender({ h: handler });
+    useEventBusStore.getState().publish("app.online", {});
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  test("always reads the latest handler reference (no stale closure)", () => {
+    const first = mock(() => {});
+    const second = mock(() => {});
+    const { rerender } = renderHook(
+      ({ h }: { h: () => void }) => useBusSubscription("app.online", h),
+      { initialProps: { h: first } },
+    );
+    rerender({ h: second });
+    useEventBusStore.getState().publish("app.online", {});
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes the typed payload to the handler", () => {
+    const handler = mock((_: { signal: "visibility" | "app_state" | "online" }) => {});
+    renderHook(() => useBusSubscription("app.resume", handler));
+    useEventBusStore.getState().publish("app.resume", { signal: "online" });
+    expect(handler).toHaveBeenCalledWith({ signal: "online" });
+  });
+});
+
+describe("subscribeBus", () => {
+  test("returns an unsubscribe function that stops delivery", () => {
+    const handler = mock(() => {});
+    const unsubscribe = subscribeBus("app.offline", handler);
+    useEventBusStore.getState().publish("app.offline", {});
+    expect(handler).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    useEventBusStore.getState().publish("app.offline", {});
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("multiple subscribers receive independent unsubscribe handles", () => {
+    const a = mock(() => {});
+    const b = mock(() => {});
+    const unsubA = subscribeBus("app.offline", a);
+    subscribeBus("app.offline", b);
+    unsubA();
+    useEventBusStore.getState().publish("app.offline", {});
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/use-bus-subscription.ts
+++ b/apps/web/src/hooks/use-bus-subscription.ts
@@ -1,0 +1,58 @@
+/**
+ * Subscribe a React hook to a typed event-bus channel.
+ *
+ * Wraps the standard pattern:
+ *
+ * ```ts
+ * useEffect(() => {
+ *   const unsubscribe = useEventBusStore
+ *     .getState()
+ *     .subscribe(event, handler);
+ *   return unsubscribe;
+ * }, [...]);
+ * ```
+ *
+ * The handler is wrapped in a ref so consumers don't need to memoize
+ * it: passing an inline arrow function is fine — the subscription is
+ * not torn down and re-registered on every render. The subscription's
+ * effect-lifecycle deps are exactly `[event]`; pass nothing else here.
+ *
+ * For imperative call sites that live outside the React tree (Zustand
+ * store bootstraps, middleware), use {@link subscribeBus} instead.
+ */
+import { useEffect, useRef } from "react";
+
+import {
+  type BusEventName,
+  type BusHandler,
+  useEventBusStore,
+} from "@/stores/event-bus-store.js";
+
+export function useBusSubscription<K extends BusEventName>(
+  event: K,
+  handler: BusHandler<K>,
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    return useEventBusStore.getState().subscribe(event, (payload) => {
+      handlerRef.current(payload);
+    });
+  }, [event]);
+}
+
+/**
+ * Imperative bus subscription for code outside the React tree
+ * (Zustand store bootstraps, route loaders, middleware). Returns the
+ * unsubscribe function — store it alongside the bootstrap's other
+ * teardown handles.
+ *
+ * Inside a React component or hook, prefer {@link useBusSubscription}.
+ */
+export function subscribeBus<K extends BusEventName>(
+  event: K,
+  handler: BusHandler<K>,
+): () => void {
+  return useEventBusStore.getState().subscribe(event, handler);
+}


### PR DESCRIPTION
## Summary

Adds two small helpers in `apps/web/src/hooks/use-bus-subscription.ts` that wrap the standard subscribe pattern, and updates `apps/web/docs/EVENT_BUS.md` with a Conventions section + Common patterns section so the helpers become the canonical subscriber surface.

### `useBusSubscription(event, handler)`

Wraps the boilerplate every subscriber writes today:

```ts
// Before
useEffect(() => {
  const unsub = useEventBusStore.getState().subscribe("app.resume", () => {...});
  return unsub;
}, []);

// After
useBusSubscription("app.resume", () => {...});
```

The handler is stabilised in a ref, so inline arrows don't re-register the subscription on every render — no `useCallback` ceremony required.

### `subscribeBus(event, handler)`

Imperative version for code outside the React tree (Zustand store bootstraps, middleware). Returns the unsubscribe handle for the bootstrap's existing teardown closure.

### Doc updates

- New **Conventions** section: use the helpers (not raw `getState().subscribe`), inline handlers are fine, subscribe at the right scope, filter inside the handler, skip resume signals you don't care about.
- New **Common patterns** section with four worked examples (query invalidation on resume, time-away tracking between `app.hidden` and `app.resume`, typed `sse.event` narrowing, store-bootstrap subscriber).

## Test plan

- [x] `bun test src/hooks/use-bus-subscription.test.tsx` — 7 / 7 pass.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean (only the pre-existing warning in `lib/errors/report.ts`).

## Follow-up

A follow-up PR will sweep existing subscribers (`use-event-stream.ts`, `use-assistant-sync-stream.ts`, the 5 stores/hooks migrated in #31547) to use the helpers. Out of scope here so the helper itself is reviewable in isolation.


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_