### PR TITLE
feat: push-based interaction resolution (LUM-1813)

### DIFF
--- a/apps/web/src/domains/chat/api/event-parser.test.ts
+++ b/apps/web/src/domains/chat/api/event-parser.test.ts
@@ -183,6 +183,55 @@ describe("parseAssistantEvent", () => {
     });
   });
 
+  test("parses interaction_resolved with explicit conversationKey", () => {
+    const event = parseAssistantEvent("interaction_resolved", {
+      requestId: "req-1",
+      conversationKey: "conv-1",
+      state: "approved",
+      kind: "confirmation",
+    });
+    expect(event).toEqual({
+      type: "interaction_resolved",
+      requestId: "req-1",
+      conversationKey: "conv-1",
+      state: "approved",
+      kind: "confirmation",
+    });
+  });
+
+  test("interaction_resolved falls back to conversationId when conversationKey is absent", () => {
+    const event = parseAssistantEvent("interaction_resolved", {
+      requestId: "req-2",
+      conversationId: "conv-internal",
+      state: "answered",
+      kind: "secret",
+    });
+    expect(event).toMatchObject({
+      type: "interaction_resolved",
+      requestId: "req-2",
+      conversationKey: "conv-internal",
+      state: "answered",
+    });
+  });
+
+  test("interaction_resolved with an invalid state degrades to unknown", () => {
+    const event = parseAssistantEvent("interaction_resolved", {
+      requestId: "req-3",
+      conversationKey: "conv-3",
+      state: "exploded",
+      kind: "confirmation",
+    });
+    expect(event.type).toBe("unknown");
+  });
+
+  test("interaction_resolved without a requestId degrades to unknown", () => {
+    const event = parseAssistantEvent("interaction_resolved", {
+      conversationKey: "conv-4",
+      state: "cancelled",
+    });
+    expect(event.type).toBe("unknown");
+  });
+
   test("returns unknown event for unrecognized type", () => {
     const data = { foo: "bar" };
     const event = parseAssistantEvent("some_future_event", data);

--- a/apps/web/src/domains/chat/api/event-parser.ts
+++ b/apps/web/src/domains/chat/api/event-parser.ts
@@ -688,6 +688,41 @@ export function parseAssistantEvent(
       return { type: rawType as "document_comment_reopened" | "document_comment_deleted", ...base };
     }
 
+    case "interaction_resolved": {
+      const requestId =
+        typeof data.requestId === "string" ? data.requestId : "";
+      const stateRaw = typeof data.state === "string" ? data.state : "";
+      const validStates = new Set([
+        "approved",
+        "rejected",
+        "answered",
+        "cancelled",
+        "superseded",
+      ]);
+      if (!requestId || !validStates.has(stateRaw)) {
+        return { type: "unknown", rawType, data };
+      }
+      const conversationKey =
+        typeof data.conversationKey === "string"
+          ? data.conversationKey
+          : typeof data.conversationId === "string"
+            ? data.conversationId
+            : "";
+      const kind = typeof data.kind === "string" ? data.kind : "";
+      return {
+        type: "interaction_resolved",
+        requestId,
+        conversationKey,
+        state: stateRaw as
+          | "approved"
+          | "rejected"
+          | "answered"
+          | "cancelled"
+          | "superseded",
+        kind,
+      };
+    }
+
     case "document_editor_update": {
       const surfaceId =
         typeof data.surfaceId === "string" ? data.surfaceId : "";

--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -690,6 +690,32 @@ export interface AssistantSyncChangedEvent extends SyncChangedEvent {
   conversationKey?: string;
 }
 
+/**
+ * Lifecycle outcome reported alongside `interaction_resolved`. Mirrors the
+ * daemon-side `InteractionResolutionState` union.
+ */
+export type InteractionResolutionState =
+  | "approved"
+  | "rejected"
+  | "answered"
+  | "cancelled"
+  | "superseded";
+
+/**
+ * Emitted when a daemon-side pending interaction (confirmation, secret,
+ * question, host-proxy request) transitions to a resolved state. Drives
+ * push-based attention reconciliation in the sidebar.
+ */
+export interface InteractionResolvedEvent {
+  type: "interaction_resolved";
+  requestId: string;
+  /** Conversation key the resolved interaction was registered against. */
+  conversationKey: string;
+  state: InteractionResolutionState;
+  /** Kind of the resolved interaction (e.g. `"confirmation"`, `"secret"`). */
+  kind: string;
+}
+
 export type AssistantEvent =
   | AssistantTextDeltaEvent
   | MessageCompleteEvent
@@ -735,4 +761,5 @@ export type AssistantEvent =
   | DocumentCommentReopenedSseEvent
   | DocumentCommentDeletedSseEvent
   | DocumentEditorUpdateEvent
+  | InteractionResolvedEvent
   | UnknownEvent;

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -447,6 +447,11 @@ export function useStreamEventHandler(
         case "document_comment_resolved":
         case "document_comment_reopened":
         case "document_comment_deleted":
+        case "interaction_resolved":
+          // Attention reconciliation lives in `useAttentionTracking`, which
+          // subscribes to the event bus directly. The chat-stream handler
+          // is intentionally a no-op here.
+          break;
         case "unknown":
           break;
         default: {

--- a/apps/web/src/domains/conversations/use-attention-tracking-graduation.test.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking-graduation.test.ts
@@ -5,17 +5,11 @@ import { decideGraduationDispatches } from "@/domains/conversations/use-attentio
 // ---------------------------------------------------------------------------
 // Tests for the graduation-decision helper used by `useAttentionTracking`.
 //
-// The bug this protects against (Codex P1 on PR #6686): when the bulk
-// pending-interactions fetch fails, the previous shape still removed every
-// graduating key from `processingKeys` without adding any to `attentionKeys`.
-// Conversations with real pending approvals lost both indicators, and once
-// both sets were empty the 10s poller's gate short-circuited so nothing
-// recovered them until the user manually reopened the conversation.
-//
-// The helper now signals "do nothing" by returning [] when `pendingKeys` is
+// The helper signals "do nothing" by returning [] when `pendingKeys` is
 // null (the hook passes null on bulk-fetch failure). Keys stay in
-// `processingKeys` with their snapshots intact; the 10s poller or the next
-// render retries.
+// `processingKeys` with their snapshots intact; the next render retries.
+// Conversations with real pending approvals keep their processing indicator
+// even when the bulk fetch fails.
 // ---------------------------------------------------------------------------
 
 describe("decideGraduationDispatches", () => {
@@ -74,8 +68,8 @@ describe("decideGraduationDispatches", () => {
   test("ignores pending keys that are not in the graduating list", () => {
     // Pending interactions can exist on conversations whose snapshots haven't
     // advanced yet (they're still streaming). Those don't graduate here —
-    // they'll be picked up by the 10s poller's "graduate processing keys
-    // that are now pending" path.
+    // the graduation effect only acts on keys that have actually finished a
+    // turn.
     const actions = decideGraduationDispatches(
       ["conv-1"],
       new Set(["conv-1", "conv-99", "conv-100"]),
@@ -88,9 +82,9 @@ describe("decideGraduationDispatches", () => {
 
   test("empty pendingKeys Set is not the same as null", () => {
     // An empty Set means "fetch succeeded, nothing pending" — graduate
-    // freely. Null means "fetch failed, don't graduate." This is the
-    // distinction the original Codex finding was about: the previous code
-    // collapsed the two cases.
+    // freely. Null means "fetch failed, don't graduate." The two cases
+    // must stay distinct so a fetch failure does not silently drop
+    // processing indicators.
     const successActions = decideGraduationDispatches(["conv-1"], new Set());
     const failureActions = decideGraduationDispatches(["conv-1"], null);
     expect(successActions).toEqual([

--- a/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
+++ b/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
@@ -192,6 +192,42 @@ describe("useAttentionTracking — interaction_resolved subscriber", () => {
     ).toBe(false);
   });
 
+  test("ignores host-proxy resolutions so in-progress tool steps don't clear the processing indicator", () => {
+    useConversationStore.getState().addProcessingKey("conv-host");
+    expect(
+      useConversationStore.getState().processingKeys.has("conv-host"),
+    ).toBe(true);
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    for (const kind of [
+      "host_bash",
+      "host_file",
+      "host_cu",
+      "host_browser",
+      "host_app_control",
+      "host_transfer",
+    ]) {
+      publishInteractionResolved({
+        requestId: `req-${kind}`,
+        conversationKey: "conv-host",
+        state: "answered",
+        kind,
+      });
+    }
+
+    expect(
+      useConversationStore.getState().processingKeys.has("conv-host"),
+    ).toBe(true);
+  });
+
   test("unsubscribes when assistantId becomes null", () => {
     useConversationStore.getState().addAttentionKey("conv-detach");
 

--- a/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
+++ b/apps/web/src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Push-based attention reconciliation: an `interaction_resolved` SSE event
+ * removes the resolved conversation from both `attentionKeys` and
+ * `processingKeys` without any HTTP polling.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+
+import { useConversationStore } from "@/domains/conversations/conversation-store.js";
+import {
+  __resetEventBusForTesting,
+  useEventBusStore,
+} from "@/stores/event-bus-store.js";
+
+// The hook fetches the conversation list and runs an initial sweep; stub
+// both so renderHook does not try to hit a real backend.
+mock.module("@/domains/conversations/conversation-queries.js", () => ({
+  useConversationListQuery: () => ({ conversations: [] }),
+  getConversations: () => [],
+  findConversation: () => undefined,
+  markConversationSeenLocal: () => {},
+}));
+
+mock.module("@/domains/chat/api/conversations.js", () => ({
+  markConversationSeen: async () => {},
+}));
+
+mock.module("@/domains/chat/api/interactions.js", () => ({
+  listConversationKeysWithPendingInteractions: async () => new Set<string>(),
+}));
+
+const { useAttentionTracking } = await import(
+  "@/domains/conversations/use-attention-tracking.js"
+);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function publishInteractionResolved(payload: {
+  requestId: string;
+  conversationKey: string;
+  state: "approved" | "rejected" | "answered" | "cancelled" | "superseded";
+  kind?: string;
+}) {
+  act(() => {
+    useEventBusStore.getState().publish("sse.event", {
+      type: "interaction_resolved",
+      requestId: payload.requestId,
+      conversationKey: payload.conversationKey,
+      state: payload.state,
+      kind: payload.kind ?? "confirmation",
+    });
+  });
+}
+
+beforeEach(() => {
+  __resetEventBusForTesting();
+  useConversationStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetEventBusForTesting();
+  useConversationStore.getState().reset();
+});
+
+describe("useAttentionTracking — interaction_resolved subscriber", () => {
+  test("removes the conversation from attentionKeys", () => {
+    useConversationStore.getState().addAttentionKey("conv-1");
+    expect(useConversationStore.getState().attentionKeys.has("conv-1")).toBe(true);
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    publishInteractionResolved({
+      requestId: "req-1",
+      conversationKey: "conv-1",
+      state: "approved",
+    });
+
+    expect(useConversationStore.getState().attentionKeys.has("conv-1")).toBe(false);
+  });
+
+  test("removes the conversation from processingKeys", () => {
+    useConversationStore.getState().addProcessingKey("conv-2");
+    expect(useConversationStore.getState().processingKeys.has("conv-2")).toBe(true);
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    publishInteractionResolved({
+      requestId: "req-2",
+      conversationKey: "conv-2",
+      state: "answered",
+      kind: "secret",
+    });
+
+    expect(useConversationStore.getState().processingKeys.has("conv-2")).toBe(
+      false,
+    );
+  });
+
+  test("does not touch the active conversation", () => {
+    useConversationStore.getState().setActiveKey("conv-active");
+    useConversationStore.getState().addAttentionKey("conv-active");
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    publishInteractionResolved({
+      requestId: "req-3",
+      conversationKey: "conv-active",
+      state: "approved",
+    });
+
+    // Active conversation keeps its attention badge — the open chat view
+    // owns the bubble lifecycle directly.
+    expect(
+      useConversationStore.getState().attentionKeys.has("conv-active"),
+    ).toBe(true);
+  });
+
+  test("ignores events with an empty conversationKey", () => {
+    useConversationStore.getState().addAttentionKey("conv-7");
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    publishInteractionResolved({
+      requestId: "req-7",
+      conversationKey: "",
+      state: "cancelled",
+    });
+
+    expect(useConversationStore.getState().attentionKeys.has("conv-7")).toBe(
+      true,
+    );
+  });
+
+  test("superseded state also clears attention", () => {
+    useConversationStore.getState().addAttentionKey("conv-super");
+
+    renderHook(
+      () =>
+        useAttentionTracking({
+          assistantId: "asst-1",
+          assistantStateKind: "active",
+        }),
+      { wrapper },
+    );
+
+    publishInteractionResolved({
+      requestId: "req-super",
+      conversationKey: "conv-super",
+      state: "superseded",
+    });
+
+    expect(
+      useConversationStore.getState().attentionKeys.has("conv-super"),
+    ).toBe(false);
+  });
+
+  test("unsubscribes when assistantId becomes null", () => {
+    useConversationStore.getState().addAttentionKey("conv-detach");
+
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) =>
+        useAttentionTracking({
+          assistantId: id,
+          assistantStateKind: "active",
+        }),
+      { wrapper, initialProps: { id: "asst-1" } as { id: string | null } },
+    );
+
+    rerender({ id: null });
+
+    // After unsubscribe, the event-resolved subscriber must not fire.
+    publishInteractionResolved({
+      requestId: "req-detach",
+      conversationKey: "conv-detach",
+      state: "approved",
+    });
+
+    expect(
+      useConversationStore.getState().attentionKeys.has("conv-detach"),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/domains/conversations/use-attention-tracking.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking.ts
@@ -201,6 +201,51 @@ export function useAttentionTracking({
   });
 
   // -------------------------------------------------------------------------
+  // Post-reconnect reconciliation.
+  //
+  // The bus-owned SSE connection is live-only — it tears down on
+  // `app.hidden` and reopens on `app.resume` or a reachability bounce.
+  // Any `interaction_resolved` event published while the stream is down
+  // is permanently missed, which would leave a stale attention dot on
+  // the sidebar until the user opens the conversation or refreshes.
+  // Re-running the bulk pending-interactions fetch closes that gap:
+  // anything no longer pending is removed from `attentionKeys` /
+  // `processingKeys`, and anything newly pending is promoted to
+  // `attentionKeys`. Skips the very first `sse.opened` (cause ===
+  // "fresh") because the initial-sweep effect below handles that.
+  // -------------------------------------------------------------------------
+  useBusSubscription("sse.opened", ({ cause }) => {
+    if (!assistantId || cause === "fresh") return;
+    void (async () => {
+      let pendingKeys: Set<string>;
+      try {
+        pendingKeys = await listConversationKeysWithPendingInteractions(assistantId);
+      } catch {
+        return; // Best-effort — sse.event will catch subsequent transitions.
+      }
+      const state = useConversationStore.getState();
+      const activeKey = state.activeConversationKey;
+      for (const key of state.attentionKeys) {
+        if (key === activeKey) continue;
+        if (!pendingKeys.has(key)) state.removeAttentionKey(key);
+      }
+      for (const key of state.processingKeys) {
+        if (key === activeKey) continue;
+        if (pendingKeys.has(key)) {
+          state.addAttentionKey(key);
+          state.removeProcessingKey(key);
+        }
+      }
+      for (const key of pendingKeys) {
+        if (key === activeKey) continue;
+        if (!state.attentionKeys.has(key) && !state.processingKeys.has(key)) {
+          state.addAttentionKey(key);
+        }
+      }
+    })();
+  });
+
+  // -------------------------------------------------------------------------
   // One-time sweep on mount: seed attention keys for every non-active
   // conversation with a pending interaction. Single bulk request, intersected
   // with the loaded conversations list so we only flag conversations the

--- a/apps/web/src/domains/conversations/use-attention-tracking.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking.ts
@@ -184,10 +184,18 @@ export function useAttentionTracking({
   // event fires for a non-active conversation, drop it from both
   // `attentionKeys` and `processingKeys` — the user has either responded
   // elsewhere or the daemon discarded the prompt.
+  //
+  // Host-proxy kinds (`host_bash`, `host_file`, `host_cu`,
+  // `host_browser`, `host_app_control`, `host_transfer`) resolve as
+  // intermediate tool steps during a turn that is still running, so
+  // they must not clear the processing indicator. Only the
+  // user-facing kinds (confirmation, secret, question,
+  // acp_confirmation) signal that the turn has handed control back.
   // -------------------------------------------------------------------------
   useBusSubscription("sse.event", (event) => {
     if (!assistantId) return;
     if (event.type !== "interaction_resolved") return;
+    if (event.kind.startsWith("host_")) return;
     const key = event.conversationKey;
     if (!key) return;
     const state = useConversationStore.getState();

--- a/apps/web/src/domains/conversations/use-attention-tracking.ts
+++ b/apps/web/src/domains/conversations/use-attention-tracking.ts
@@ -4,7 +4,6 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { useConversationStore } from "@/domains/conversations/conversation-store.js";
 import {
-  findConversation,
   getConversations,
   markConversationSeenLocal,
   useConversationListQuery,
@@ -12,6 +11,7 @@ import {
 import { markConversationSeen } from "@/domains/chat/api/conversations.js";
 import { listConversationKeysWithPendingInteractions } from "@/domains/chat/api/interactions.js";
 import type { AssistantState } from "@/domains/chat/hooks/use-assistant-lifecycle.js";
+import { useBusSubscription } from "@/hooks/use-bus-subscription.js";
 
 interface UseAttentionTrackingParams {
   /** From `useAssistantLifecycle` in `ChatLayout`. */
@@ -29,7 +29,7 @@ interface UseAttentionTrackingParams {
  * and manages processing-key lifecycle for background conversations.
  *
  * Reads `conversations` from the TanStack Query chat-context cache via
- * `useConversationListQuery`; reads `processingKeys`, `attentionKeys`, and
+ * `useConversationListQuery`; reads `processingKeys` and
  * `processingSnapshots` directly from `useConversationStore`. Mounted
  * in `ChatLayout` so the sidebar's processing/attention indicators stay
  * live on every chat-layout route (home, library, contacts, identity,
@@ -38,8 +38,8 @@ interface UseAttentionTrackingParams {
  * Handles:
  * - Marking conversations as seen when opened
  * - Graduating processing keys when the assistant finishes responding
- * - Polling background processing conversations for pending interactions
- * - Clearing attention keys when interactions are resolved
+ * - Clearing attention/processing keys when an `interaction_resolved`
+ *   SSE event arrives on the event bus
  * - One-time initial sweep of all conversations for pending interactions
  */
 
@@ -53,11 +53,9 @@ type GraduationAction =
  *
  * Pass `pendingKeys = null` to signal "we don't know" (bulk fetch failed). In
  * that case this returns no actions so the keys stay in `processingKeys` with
- * their snapshots intact; the 10s poller or the next render will retry.
- * Graduating without pending-state knowledge would risk silently dropping the
- * processing indicator on a conversation that actually has a pending approval,
- * and once both processingKeys and attentionKeys are empty the poller's gate
- * (`processingKeys.size === 0 && attentionKeys.size === 0`) short-circuits.
+ * their snapshots intact; the next render will retry. Graduating without
+ * pending-state knowledge would risk silently dropping the processing
+ * indicator on a conversation that actually has a pending approval.
  *
  * Pass `pendingKeys` as a Set when the fetch succeeded. Every graduating key
  * is removed from `processingKeys`; ones that are pending also get added to
@@ -89,7 +87,6 @@ export function useAttentionTracking({
   );
   const activeConversationKey = useConversationStore.use.activeConversationKey();
   const processingKeys = useConversationStore.use.processingKeys();
-  const attentionKeys = useConversationStore.use.attentionKeys();
 
   const activeConversation = conversations.find(
     (c) => c.conversationKey === activeConversationKey,
@@ -179,70 +176,29 @@ export function useAttentionTracking({
   }, [conversations, processingKeys, activeConversationKey, assistantId]);
 
   // -------------------------------------------------------------------------
-  // Poll processing + attention conversations every 10s.
+  // Push-based attention reconciliation.
   //
-  // One bulk fetch per tick reconciles both directions:
-  //  - processing keys that are now pending → graduate to attention
-  //  - attention keys that are no longer pending → clear
-  //  - processing keys whose `latestAssistantMessageAt` advanced but have
-  //    nothing pending → drop from processing (the assistant responded fully)
-  //
-  // Previously each direction had its own 10s loop that issued one HTTP
-  // request per tracked key.
+  // The daemon publishes `interaction_resolved` on the bus-owned SSE
+  // connection the instant a pending interaction transitions to resolved
+  // (approved, rejected, answered, cancelled, or superseded). When that
+  // event fires for a non-active conversation, drop it from both
+  // `attentionKeys` and `processingKeys` — the user has either responded
+  // elsewhere or the daemon discarded the prompt.
   // -------------------------------------------------------------------------
-  useEffect(() => {
+  useBusSubscription("sse.event", (event) => {
     if (!assistantId) return;
-    if (processingKeys.size === 0 && attentionKeys.size === 0) return;
-
-    let cancelled = false;
-    const pollInterval = setInterval(async () => {
-      let pendingKeys: Set<string>;
-      try {
-        pendingKeys = await listConversationKeysWithPendingInteractions(assistantId);
-      } catch {
-        return; // Best-effort polling — skip this tick on transient failure.
-      }
-      if (cancelled) return;
-
-      // Read latest store + cache values inside the tick — the effect captured
-      // the sets at scheduling time, which would be stale ten seconds later.
-      const state = useConversationStore.getState();
-      const currentProcessingKeys = state.processingKeys;
-      const currentAttentionKeys = state.attentionKeys;
-      const currentSnapshots = state.processingSnapshots;
-      const currentActiveKey = state.activeConversationKey;
-
-      // Graduate processing keys that are now pending; drop ones the
-      // assistant has finished responding to without raising anything.
-      for (const key of currentProcessingKeys) {
-        if (key === currentActiveKey) continue;
-        if (currentAttentionKeys.has(key)) continue;
-        if (pendingKeys.has(key)) {
-          useConversationStore.getState().addAttentionKey(key);
-          useConversationStore.getState().removeProcessingKey(key);
-          continue;
-        }
-        const conv = findConversation(queryClient, assistantId, key);
-        const snapshot = currentSnapshots.get(key);
-        if (conv?.latestAssistantMessageAt && conv.latestAssistantMessageAt !== snapshot) {
-          useConversationStore.getState().removeProcessingKey(key);
-        }
-      }
-
-      // Clear attention keys whose interaction has been resolved.
-      for (const key of currentAttentionKeys) {
-        if (key === currentActiveKey) continue;
-        if (!pendingKeys.has(key)) {
-          useConversationStore.getState().removeAttentionKey(key);
-        }
-      }
-    }, 10_000);
-
-    return () => {
-      cancelled = true;
-      clearInterval(pollInterval);
-    };
-  }, [assistantId, processingKeys, attentionKeys, queryClient]);
+    if (event.type !== "interaction_resolved") return;
+    const key = event.conversationKey;
+    if (!key) return;
+    const state = useConversationStore.getState();
+    if (key === state.activeConversationKey) return;
+    if (state.attentionKeys.has(key)) {
+      state.removeAttentionKey(key);
+    }
+    if (state.processingKeys.has(key)) {
+      state.removeProcessingKey(key);
+    }
+  });
 
   // -------------------------------------------------------------------------
   // One-time sweep on mount: seed attention keys for every non-active
@@ -260,7 +216,7 @@ export function useAttentionTracking({
       try {
         pendingKeys = await listConversationKeysWithPendingInteractions(assistantId);
       } catch {
-        return; // Best-effort — sidebar can still graduate via the poller.
+        return; // Best-effort — sidebar can still graduate via SSE events.
       }
       if (cancelled || pendingKeys.size === 0) return;
       // Pull the current snapshot from the cache to avoid the closed-over

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -26,7 +26,16 @@ let mockCuClients: Array<{
 ];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    // `interaction_resolved` envelopes are emitted by the
+    // pending-interactions tracker for every resolution. They are
+    // orthogonal to the surface-proxy wire messages these tests assert
+    // on, so swallow them here.
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
+    sentMessages.push(msg);
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -31,6 +31,12 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
     _conversationId?: string,
     options?: unknown,
   ) => {
+    // `interaction_resolved` envelopes are emitted by the pending-interactions
+    // tracker for every resolution. They are orthogonal to the host-proxy
+    // wire messages these tests assert on, so swallow them here.
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -31,6 +31,13 @@ let mockClients: MockClient[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: {
     publish: async (event: unknown, _options?: unknown) => {
+      // `interaction_resolved` envelopes are emitted by the
+      // pending-interactions tracker for every resolution. They are
+      // orthogonal to the host-browser wire messages these tests assert
+      // on, so swallow them here.
+      if ((event as { type?: string } | null)?.type === "interaction_resolved") {
+        return;
+      }
       publishedEvents.push(event);
     },
     getMostRecentClientByCapability: (cap: string) =>
@@ -41,6 +48,9 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       mockClients.find((c) => c.clientId === clientId)?.actorPrincipalId,
   },
   broadcastMessage: (msg: unknown) => {
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
     publishedEvents.push(msg);
   },
 }));

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -10,7 +10,14 @@ type MockClient = {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    // Skip `interaction_resolved` envelopes — pending-interactions emits one
+    // on every resolve and these tests assert on host-proxy wire messages.
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
+    sentMessages.push(msg);
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -12,7 +12,14 @@ interface MockClient {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    // Skip `interaction_resolved` envelopes — pending-interactions emits one
+    // on every resolve and these tests assert on host-proxy wire messages.
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
+    sentMessages.push(msg);
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) => {
       if (mockClients.length > 0) {

--- a/assistant/src/__tests__/host-transfer-proxy.test.ts
+++ b/assistant/src/__tests__/host-transfer-proxy.test.ts
@@ -8,7 +8,14 @@ const sentMessages: unknown[] = [];
 let mockHasClient = false;
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  broadcastMessage: (msg: unknown) => {
+    // Skip `interaction_resolved` envelopes — pending-interactions emits one
+    // on every resolve and these tests assert on host-proxy wire messages.
+    if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
+      return;
+    }
+    sentMessages.push(msg);
+  },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,

--- a/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
+++ b/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Verifies that every resolution path through
+ * `runtime/pending-interactions.ts` publishes an `interaction_resolved`
+ * envelope on the event hub with the right state.
+ *
+ * Each test registers an interaction directly and calls `resolve()` or
+ * `removeByConversation()` so we exercise the tracker in isolation
+ * without spinning up a Conversation, prompter, or proxy.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+// Capture every broadcast emitted by the tracker. The real hub is replaced
+// with a thin recorder so we can assert payloads deterministically.
+const publishedMessages: ServerMessage[] = [];
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: ServerMessage) => {
+    publishedMessages.push(msg);
+  },
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async () => {},
+    subscribe: () => ({ dispose: () => {}, active: true }),
+  },
+}));
+
+const pendingInteractions = await import("../runtime/pending-interactions.js");
+
+beforeEach(() => {
+  publishedMessages.length = 0;
+  pendingInteractions.clear();
+});
+
+afterEach(() => {
+  pendingInteractions.clear();
+});
+
+function lastResolvedEvent() {
+  const evt = publishedMessages.find((m) => m.type === "interaction_resolved");
+  expect(evt).toBeDefined();
+  return evt as Extract<ServerMessage, { type: "interaction_resolved" }>;
+}
+
+describe("pendingInteractions.resolve emits interaction_resolved", () => {
+  test("default state is 'cancelled'", () => {
+    pendingInteractions.register("req-1", {
+      conversationId: "conv-1",
+      kind: "confirmation",
+    });
+    const returned = pendingInteractions.resolve("req-1");
+    expect(returned).toBeDefined();
+    const evt = lastResolvedEvent();
+    expect(evt.requestId).toBe("req-1");
+    expect(evt.conversationKey).toBe("conv-1");
+    expect(evt.conversationId).toBe("conv-1");
+    expect(evt.state).toBe("cancelled");
+    expect(evt.kind).toBe("confirmation");
+  });
+
+  test("approved state propagates", () => {
+    pendingInteractions.register("req-approve", {
+      conversationId: "conv-a",
+      kind: "confirmation",
+    });
+    pendingInteractions.resolve("req-approve", "approved");
+    expect(lastResolvedEvent().state).toBe("approved");
+  });
+
+  test("rejected state propagates", () => {
+    pendingInteractions.register("req-reject", {
+      conversationId: "conv-b",
+      kind: "confirmation",
+    });
+    pendingInteractions.resolve("req-reject", "rejected");
+    expect(lastResolvedEvent().state).toBe("rejected");
+  });
+
+  test("answered state propagates (secret response)", () => {
+    pendingInteractions.register("req-secret", {
+      conversationId: "conv-c",
+      kind: "secret",
+    });
+    pendingInteractions.resolve("req-secret", "answered");
+    const evt = lastResolvedEvent();
+    expect(evt.state).toBe("answered");
+    expect(evt.kind).toBe("secret");
+  });
+
+  test("superseded state propagates", () => {
+    pendingInteractions.register("req-super", {
+      conversationId: "conv-d",
+      kind: "confirmation",
+    });
+    pendingInteractions.resolve("req-super", "superseded");
+    expect(lastResolvedEvent().state).toBe("superseded");
+  });
+
+  test("no event is emitted when the requestId is unknown", () => {
+    pendingInteractions.resolve("never-registered", "approved");
+    expect(publishedMessages).toHaveLength(0);
+  });
+
+  test("a single resolve emits exactly one event", () => {
+    pendingInteractions.register("req-once", {
+      conversationId: "conv-e",
+      kind: "host_bash",
+    });
+    pendingInteractions.resolve("req-once", "answered");
+    // Second resolve is a no-op because the entry was already consumed.
+    pendingInteractions.resolve("req-once", "answered");
+    const events = publishedMessages.filter(
+      (m) => m.type === "interaction_resolved",
+    );
+    expect(events).toHaveLength(1);
+  });
+
+  test("clears the registered timer on resolve", () => {
+    let fired = false;
+    const timer = setTimeout(() => {
+      fired = true;
+    }, 10_000);
+    pendingInteractions.register("req-timer", {
+      conversationId: "conv-f",
+      kind: "confirmation",
+      timer,
+    });
+    pendingInteractions.resolve("req-timer", "approved");
+    clearTimeout(timer);
+    expect(fired).toBe(false);
+  });
+});
+
+describe("removeByConversation emits interaction_resolved per entry", () => {
+  test("emits superseded for every non-host interaction in the conversation", () => {
+    pendingInteractions.register("conf-1", {
+      conversationId: "conv-x",
+      kind: "confirmation",
+    });
+    pendingInteractions.register("secret-1", {
+      conversationId: "conv-x",
+      kind: "secret",
+    });
+    pendingInteractions.register("question-1", {
+      conversationId: "conv-x",
+      kind: "question",
+    });
+    pendingInteractions.register("host-bash-1", {
+      conversationId: "conv-x",
+      kind: "host_bash",
+    });
+    pendingInteractions.register("conf-other", {
+      conversationId: "conv-y",
+      kind: "confirmation",
+    });
+
+    pendingInteractions.removeByConversation("conv-x");
+
+    const events = publishedMessages.filter(
+      (m) => m.type === "interaction_resolved",
+    ) as Extract<ServerMessage, { type: "interaction_resolved" }>[];
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.state === "superseded")).toBe(true);
+    const requestIds = new Set(events.map((e) => e.requestId));
+    expect(requestIds).toEqual(new Set(["conf-1", "secret-1", "question-1"]));
+
+    // host_bash entries survive auto-deny — no event for them.
+    expect(pendingInteractions.get("host-bash-1")).toBeDefined();
+    // Unrelated conversation is untouched.
+    expect(pendingInteractions.get("conf-other")).toBeDefined();
+  });
+
+  test("explicit state arg overrides the default 'superseded'", () => {
+    pendingInteractions.register("conf-2", {
+      conversationId: "conv-z",
+      kind: "confirmation",
+    });
+    pendingInteractions.removeByConversation("conv-z", "cancelled");
+    const events = publishedMessages.filter(
+      (m) => m.type === "interaction_resolved",
+    );
+    expect(events).toHaveLength(1);
+    expect(
+      (events[0] as Extract<ServerMessage, { type: "interaction_resolved" }>)
+        .state,
+    ).toBe("cancelled");
+  });
+});

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -185,7 +185,7 @@ export class HostBashProxy extends HostProxyBase<
       timedOut: boolean;
     },
   ): void {
-    pendingInteractions.resolve(requestId);
+    pendingInteractions.resolve(requestId, "answered");
     this.resolve(requestId, response);
   }
 }

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -280,7 +280,7 @@ export class HostCuProxy {
     observation: CuObservationResult,
   ): ToolExecutionResult | undefined {
     this._ownedRequests.delete(requestId);
-    const interaction = pendingInteractions.resolve(requestId);
+    const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
       log.warn({ requestId }, "No pending host CU request for response");
       return undefined;

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -227,7 +227,7 @@ export class HostFileProxy {
     requestId: string,
     response: { content: string; isError: boolean; imageData?: string },
   ): void {
-    const interaction = pendingInteractions.resolve(requestId);
+    const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
       log.warn({ requestId }, "No pending host file request for response");
       return;

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -508,7 +508,7 @@ export class HostTransferProxy {
       errorMessage?: string;
     },
   ): void {
-    const interaction = pendingInteractions.resolve(requestId);
+    const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
       log.warn({ requestId }, "No pending host transfer request for response");
       return;

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -401,6 +401,45 @@ export interface ConfirmationStateChanged {
 }
 
 /**
+ * Lifecycle states reported by `interaction_resolved`.
+ *
+ *  - `"approved"` / `"rejected"` — user-supplied verdict on a confirmation.
+ *  - `"answered"` — user/client provided a response (secret value, question
+ *    answer, host-proxy result).
+ *  - `"cancelled"` — the interaction was torn down without a user response
+ *    (timeout, abort, dispose, prompter shutdown).
+ *  - `"superseded"` — invalidated by a newer event (auto-deny on enqueue, a
+ *    fresh user message arriving while a confirmation was outstanding).
+ */
+export type InteractionResolutionState =
+  | "approved"
+  | "rejected"
+  | "answered"
+  | "cancelled"
+  | "superseded";
+
+/**
+ * Broadcast when a pending interaction (confirmation, secret, question,
+ * host-proxy request) transitions to a resolved state. Clients use this to
+ * drop attention/processing indicators without polling.
+ */
+export interface InteractionResolved {
+  type: "interaction_resolved";
+  requestId: string;
+  /**
+   * Conversation key for the interaction. The daemon's internal conversation
+   * id and the web client's conversation key coincide today (see
+   * `conversation-key-store.ts`); the field is named after the client-facing
+   * concept.
+   */
+  conversationKey: string;
+  state: InteractionResolutionState;
+  /** Kind of the resolved interaction (e.g. "confirmation", "secret", "host_bash"). */
+  kind: string;
+  conversationId?: string;
+}
+
+/**
  * Server-side assistant activity lifecycle for thinking indicator placement.
  *
  * `activityVersion` is monotonically increasing per conversation. Clients must
@@ -528,4 +567,5 @@ export type _MessagesServerMessages =
   | ConfirmationStateChanged
   | AssistantActivityState
   | TurnProfileAutoRouted
-  | ConversationInferenceProfileUpdated;
+  | ConversationInferenceProfileUpdated
+  | InteractionResolved;

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -196,7 +196,10 @@ export class PermissionPrompter {
     }
     // The prompter owns deregistration; all callers use get() to peek before
     // routing to resolveConfirmation, which fires the rpcResolve callback.
-    const interaction = pendingInteractions.resolve(requestId);
+    const interaction = pendingInteractions.resolve(
+      requestId,
+      decision === "allow" ? "approved" : "rejected",
+    );
     this.ownedIds.delete(requestId);
     (interaction?.rpcResolve as ((v: ConfirmResult) => void) | undefined)?.(
       { decision, selectedPattern, selectedScope, decisionContext },
@@ -210,7 +213,7 @@ export class PermissionPrompter {
    */
   denyAllPending(): void {
     for (const requestId of [...this.ownedIds]) {
-      const interaction = pendingInteractions.resolve(requestId);
+      const interaction = pendingInteractions.resolve(requestId, "superseded");
       this.ownedIds.delete(requestId);
       (interaction?.rpcResolve as ((v: ConfirmResult) => void) | undefined)?.(
         {

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -130,7 +130,10 @@ export class SecretPrompter {
     }
     // approval-routes calls pendingInteractions.get() before routing here;
     // the prompter owns deregistration so it fires the Promise callback cleanly.
-    const interaction = pendingInteractions.resolve(requestId);
+    const interaction = pendingInteractions.resolve(
+      requestId,
+      value === undefined ? "cancelled" : "answered",
+    );
     this.ownedIds.delete(requestId);
     (interaction?.rpcResolve as ((v: SecretPromptResult) => void) | undefined)?.(
       { value: value ?? null, delivery: delivery ?? "store" },

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -27,6 +27,15 @@ export interface FileContent {
     filename: string;
   };
   extracted_text?: string;
+  /**
+   * Internal id linking this block to a row in the attachments table.
+   * Set when the file block originates from a persisted user-message
+   * attachment so downstream consumers (DB joins, inline-chip
+   * positioning) can correlate the block back to its attachment id.
+   * Stripped by `daemon/handlers/shared.ts` before sending to the
+   * model.
+   */
+  _attachmentId?: string;
 }
 
 export interface ToolUseContent {

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -18,7 +18,14 @@
  * resolve the interaction.
  */
 
+import type { InteractionResolutionState } from "../daemon/message-types/messages.js";
 import type { UserDecision } from "../permissions/types.js";
+import { getLogger } from "../util/logger.js";
+import { broadcastMessage } from "./assistant-event-hub.js";
+
+const log = getLogger("pending-interactions");
+
+export type { InteractionResolutionState } from "../daemon/message-types/messages.js";
 
 export interface ConfirmationDetails {
   toolName: string;
@@ -98,15 +105,48 @@ export function register(
  * Remove and return the pending interaction for the given requestId.
  * Auto-clears the proxy timer and detaches the abort listener if present.
  * Returns undefined if no interaction is registered.
+ *
+ * Emits `interaction_resolved` on the event hub when an interaction is
+ * actually removed (no-op when the entry was already consumed by another
+ * path). Callers pass `state` to communicate the lifecycle outcome
+ * — defaults to `"cancelled"`, the safest value when the call site has
+ * no extra context.
  */
-export function resolve(requestId: string): PendingInteraction | undefined {
+export function resolve(
+  requestId: string,
+  state: InteractionResolutionState = "cancelled",
+): PendingInteraction | undefined {
   const interaction = pending.get(requestId);
-  if (interaction) {
-    pending.delete(requestId);
-    if (interaction.timer != null) clearTimeout(interaction.timer);
-    interaction.detachAbort?.();
-  }
+  if (!interaction) return undefined;
+  pending.delete(requestId);
+  if (interaction.timer != null) clearTimeout(interaction.timer);
+  interaction.detachAbort?.();
+  emitResolved(requestId, interaction, state);
   return interaction;
+}
+
+function emitResolved(
+  requestId: string,
+  interaction: PendingInteraction,
+  state: InteractionResolutionState,
+): void {
+  log.info(
+    {
+      requestId,
+      conversationId: interaction.conversationId,
+      kind: interaction.kind,
+      state,
+    },
+    "Pending interaction resolved",
+  );
+  broadcastMessage({
+    type: "interaction_resolved",
+    requestId,
+    conversationId: interaction.conversationId,
+    conversationKey: interaction.conversationId,
+    kind: interaction.kind,
+    state,
+  });
 }
 
 /**
@@ -146,7 +186,10 @@ export function getByConversation(
  * /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  */
-export function removeByConversation(conversationId: string): void {
+export function removeByConversation(
+  conversationId: string,
+  state: InteractionResolutionState = "superseded",
+): void {
   // Snapshot keys to avoid mutation-during-iteration.
   for (const [requestId, interaction] of [...pending]) {
     if (
@@ -160,7 +203,7 @@ export function removeByConversation(conversationId: string): void {
       interaction.kind !== "acp_confirmation"
     ) {
       // resolve() clears the stored timer and detaches abort listeners.
-      resolve(requestId);
+      resolve(requestId, state);
     }
   }
 }

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -78,7 +78,10 @@ function handleConfirm({ body }: RouteHandlerArgs) {
   // ACP permissions: resolve directly without a Conversation object.
   // No PermissionPrompter involved, so the route owns deregistration.
   if (interaction.directResolve) {
-    pendingInteractions.resolve(requestId);
+    pendingInteractions.resolve(
+      requestId,
+      effectiveDecision === "allow" ? "approved" : "rejected",
+    );
     interaction.directResolve(effectiveDecision as UserDecision);
     return { accepted: true };
   }

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -105,7 +105,7 @@ function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
     });
   }
 
-  const interaction = pendingInteractions.resolve(requestId)!;
+  const interaction = pendingInteractions.resolve(requestId, "answered")!;
   const conversation = findConversation(interaction.conversationId);
   if (!conversation) {
     return { accepted: true };

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -150,7 +150,7 @@ export function resolveHostBrowserResultByRequestId(
   const normalizedContent = typeof content === "string" ? content : "";
   const normalizedIsError = typeof isError === "boolean" ? isError : false;
 
-  const interaction = pendingInteractions.resolve(requestId);
+  const interaction = pendingInteractions.resolve(requestId, "answered");
   interaction?.rpcResolve?.({
     content: normalizedContent,
     isError: normalizedIsError,

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -148,7 +148,10 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
 
   // Validation passed — deregister now to clear the prompter timer, then
   // hand the result to the prompter's caller via rpcResolve.
-  pendingInteractions.resolve(requestId);
+  pendingInteractions.resolve(
+    requestId,
+    response.kind === "close" ? "cancelled" : "answered",
+  );
 
   log.info(
     {


### PR DESCRIPTION
## Summary

- The daemon now broadcasts `interaction_resolved` on the SSE event hub whenever a pending interaction transitions to a resolved state (approved / rejected / answered / cancelled / superseded). Every resolution path — confirm/deny via the prompter, secret response, question response, host-proxy result, timeout / abort / dispose, and `removeByConversation` auto-deny — routes through `pendingInteractions.resolve()`, so coverage is centralised and logged.
- The web client adds a typed `InteractionResolvedEvent` to the parser/union and subscribes to `sse.event` from `useAttentionTracking`. When a matching event arrives for a non-active conversation, the conversation is dropped from both `attentionKeys` and `processingKeys` without an HTTP round-trip.
- Removes the 10-second `setInterval` reconciler in `use-attention-tracking.ts`. The one-time mount sweep stays (no event replay covers it), and the per-turn graduation effect stays (still needed when an assistant finishes responding without ever raising an interaction).

## Test plan

- [x] `cd assistant && bunx tsc --noEmit` clean
- [x] `cd assistant && bun run lint` clean
- [x] `cd assistant && bun test src/__tests__/pending-interactions-resolved-event.test.ts` — 10 new tests covering each lifecycle state, the de-dup path, the timer-clearing path, and `removeByConversation`
- [x] `cd assistant && bun test src/__tests__/host-bash-proxy.test.ts src/__tests__/host-cu-proxy.test.ts src/__tests__/host-file-proxy.test.ts src/__tests__/host-transfer-proxy.test.ts` — 139 pass after teaching the wire-message mocks to ignore the new envelope
- [x] `cd assistant && bun test src/__tests__/approval-routes-http.test.ts src/runtime/routes/__tests__/question-routes.test.ts` — green
- [x] `cd apps/web && bun run typecheck` clean
- [x] `cd apps/web && bun run lint` clean (one pre-existing unrelated warning)
- [x] `cd apps/web && bun test src/domains/conversations/use-attention-tracking-interaction-resolved.test.tsx src/domains/chat/api/event-parser.test.ts` — 6 new hook tests + 4 new parser tests, all green
- [ ] Manual: open two web tabs on the same conversation, approve a pending tool call in tab A, confirm the red dot disappears in tab B within SSE latency


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_