### PR TITLE
Keep backfilled Slack bot messages unwrapped

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -77,6 +77,14 @@ mock.module("../messaging/providers/slack/adapter.js", () => ({
     _account: string | undefined,
     fn: (token: string) => Promise<unknown>,
   ) => fn("test-slack-token"),
+  resolveSlackBotUserId: async (
+    _account: string | undefined,
+    botId: string,
+  ) => {
+    if (botId === "B_ASSISTANT") return "U_BOT";
+    if (botId === "B_OTHER") return "U_OTHER_BOT";
+    return null;
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -1192,6 +1200,35 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     ]);
   });
 
+  test("backfilled bot-id-only assistant text resolves to assistant history", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "earlier assistant reply from bot id",
+        threadId: undefined,
+        sender: { id: "B_ASSISTANT", name: "Douglas" },
+        metadata: { isBot: true, slackBotId: "B_ASSISTANT" },
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    const [persisted] = readPersistedSlackRows(conv.id).filter(
+      (p) => p.channelTs === "1234.0",
+    );
+    expect(persisted).toBeDefined();
+    expect(persisted.role).toBe("assistant");
+    expect(persisted.rawContent).toBe("earlier assistant reply from bot id");
+    expect(persisted.actorExternalUserId).toBe("B_ASSISTANT");
+    expect(persisted.provenanceRequesterIdentifier).toBe("B_ASSISTANT");
+  });
+
   test("backfilled third-party bot-authored text stays user history", async () => {
     const conv = createTestConversation();
 
@@ -1201,7 +1238,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
         text: "deployment bot status update",
         threadId: undefined,
         sender: { id: "U_OTHER_BOT", name: "Deploy Bot" },
-        metadata: { isBot: true },
+        metadata: { isBot: true, slackBotId: "B_OTHER" },
       }),
     ]);
 

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -978,7 +978,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(contextImage).toBeDefined();
   });
 
-  test("backfilled bot Slack image files are persisted as user image history", async () => {
+  test("backfilled bot Slack image files are persisted as assistant image history", async () => {
     const conv = createTestConversation();
 
     seedSlackRow(conv.id, "1234.0", undefined, "parent already here");
@@ -1020,7 +1020,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       row.content.includes("bot posted a diagram"),
     );
     expect(botRow).toBeDefined();
-    expect(botRow?.role).toBe("user");
+    expect(botRow?.role).toBe("assistant");
     const blocks = JSON.parse(botRow!.content) as Message["content"];
     const textBlock = blocks.find(
       (block): block is Extract<Message["content"][number], { type: "text" }> =>
@@ -1042,6 +1042,27 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     });
 
     expect(context).not.toBeNull();
+    const contextBotMessage = context!.messages.find(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some(
+          (block) =>
+            block.type === "text" &&
+            block.text.includes("bot posted a diagram"),
+        ),
+    );
+    expect(contextBotMessage).toBeDefined();
+    expect(
+      contextBotMessage!.content
+        .filter(
+          (
+            block,
+          ): block is Extract<Message["content"][number], { type: "text" }> =>
+            block.type === "text",
+        )
+        .map((block) => block.text)
+        .join("\n"),
+    ).not.toContain("<external_content");
     const contextImage = context!.messages
       .flatMap((message) => message.content)
       .find((block) => block.type === "image");
@@ -1115,7 +1136,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.provenanceRequesterIdentifier).toBe("U_GUARDIAN");
   });
 
-  test("backfilled bot-authored text is persisted raw as user history", async () => {
+  test("backfilled bot-authored text is persisted raw as assistant history", async () => {
     const conv = createTestConversation();
 
     backfillThreadMock.mockImplementation(async () => [
@@ -1138,13 +1159,25 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       (p) => p.channelTs === "1234.0",
     );
     expect(persisted).toBeDefined();
-    expect(persisted.role).toBe("user");
+    expect(persisted.role).toBe("assistant");
     expect(persisted.rawContent).toBe("earlier assistant reply");
     expect(persisted.rawContent).not.toContain("<external_content");
     expect(persisted.actorExternalUserId).toBe("U_BOT");
     expect(persisted.provenanceTrustClass).toBe("unknown");
     expect(persisted.provenanceSourceChannel).toBe("slack");
     expect(persisted.provenanceRequesterIdentifier).toBe("U_BOT");
+
+    const context = loadSlackChronologicalContext(conv.id, SLACK_CHANNEL_CAPS, {
+      loader: readMessageRowsByConversation,
+      trustClass: "guardian",
+    });
+    expect(context).not.toBeNull();
+    expect(context!.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "earlier assistant reply" }],
+      },
+    ]);
   });
 
   test("backfilled non-bot message with empty text is persisted unwrapped", async () => {

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -85,6 +85,11 @@ mock.module("../messaging/providers/slack/adapter.js", () => ({
 
 import { v4 as uuid } from "uuid";
 
+import {
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../config/loader.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import {
   type ChannelCapabilities,
@@ -162,6 +167,13 @@ function resetState(): void {
   backfillDmMock.mockImplementation(async () => []);
   downloadSlackFileMock.mockReset();
   downloadSlackFileMock.mockResolvedValue(null);
+  setConfiguredSlackBotUserId("U_BOT");
+}
+
+function setConfiguredSlackBotUserId(botUserId: string): void {
+  const raw = loadRawConfig();
+  setNestedValue(raw, "slack.botUserId", botUserId);
+  saveRawConfig(raw);
 }
 
 let convCounter = 0;
@@ -978,7 +990,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(contextImage).toBeDefined();
   });
 
-  test("backfilled bot Slack image files are persisted as assistant image history", async () => {
+  test("backfilled assistant Slack image files are persisted as assistant image history", async () => {
     const conv = createTestConversation();
 
     seedSlackRow(conv.id, "1234.0", undefined, "parent already here");
@@ -992,7 +1004,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
         id: "1234.1",
         text: "bot posted a diagram",
         threadId: "1234.0",
-        sender: { id: "B_IMAGE", name: "Build Bot" },
+        sender: { id: "U_BOT", name: "Douglas" },
         metadata: {
           isBot: true,
           slackFiles: [
@@ -1136,7 +1148,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.provenanceRequesterIdentifier).toBe("U_GUARDIAN");
   });
 
-  test("backfilled bot-authored text is persisted raw as assistant history", async () => {
+  test("backfilled assistant-authored text is persisted raw as assistant history", async () => {
     const conv = createTestConversation();
 
     backfillThreadMock.mockImplementation(async () => [
@@ -1178,6 +1190,37 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
         content: [{ type: "text", text: "earlier assistant reply" }],
       },
     ]);
+  });
+
+  test("backfilled third-party bot-authored text stays user history", async () => {
+    const conv = createTestConversation();
+
+    backfillThreadMock.mockImplementation(async () => [
+      makeBackfillMessage({
+        id: "1234.0",
+        text: "deployment bot status update",
+        threadId: undefined,
+        sender: { id: "U_OTHER_BOT", name: "Deploy Bot" },
+        metadata: { isBot: true },
+      }),
+    ]);
+
+    await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: "1234.0",
+    });
+
+    const [persisted] = readPersistedSlackRows(conv.id).filter(
+      (p) => p.channelTs === "1234.0",
+    );
+    expect(persisted).toBeDefined();
+    expect(persisted.role).toBe("user");
+    expect(persisted.rawContent).toBe("deployment bot status update");
+    expect(persisted.actorExternalUserId).toBe("U_OTHER_BOT");
+    expect(persisted.provenanceTrustClass).toBe("unknown");
+    expect(persisted.provenanceSourceChannel).toBe("slack");
+    expect(persisted.provenanceRequesterIdentifier).toBe("U_OTHER_BOT");
   });
 
   test("backfilled non-bot message with empty text is persisted unwrapped", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -60,6 +60,22 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   const method = parsed.pathname.split("/").at(-1);
 
   if (method === "conversations.history") {
+    if (parsed.searchParams.get("channel") === "C_BOT_HISTORY") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            subtype: "bot_message",
+            ts: "1700000003.000400",
+            bot_id: "B_ASSISTANT",
+            text: "Bot-authored history",
+          },
+        ],
+      };
+    }
+
     return {
       ok: true,
       has_more: false,
@@ -188,6 +204,17 @@ describe("Slack adapter mention rendering", () => {
     expect(messages[0].threadId).toBe("1700000000.000100");
     expect(messages[0].replyCount).toBe(2);
     expect(messages[0].reactions).toEqual([{ name: "eyes", count: 1 }]);
+  });
+
+  test("getHistory preserves bot ids for bot-authored Slack messages", async () => {
+    const messages = await slackProvider.getHistory(undefined, "C_BOT_HISTORY");
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toEqual({ id: "B_ASSISTANT", name: "unknown" });
+    expect(messages[0].metadata).toEqual({
+      isBot: true,
+      slackBotId: "B_ASSISTANT",
+    });
   });
 
   test("getThreadReplies renders Slack user mentions for model-facing text without changing sender identity", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
@@ -49,7 +49,11 @@ mock.module("../../../../contacts/contacts-write.js", () => ({
   upsertContactChannel: () => {},
 }));
 
-import { slackProvider, withSlackBotToken } from "../adapter.js";
+import {
+  resolveSlackBotUserId,
+  slackProvider,
+  withSlackBotToken,
+} from "../adapter.js";
 
 // ── fetch capture ───────────────────────────────────────────────────────────
 
@@ -103,6 +107,16 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
   }
   if (url.includes("/chat.postMessage")) {
     return { ok: true, ts: "1700000000.000100", channel: "C123" };
+  }
+  if (url.includes("/bots.info")) {
+    const botId = new URL(url).searchParams.get("bot");
+    return {
+      ok: true,
+      bot: {
+        id: botId,
+        user_id: botId === "B_ASSISTANT" ? "U_BOT" : "U_OTHER_BOT",
+      },
+    };
   }
   // Default envelope for any other method the adapter might call.
   return { ok: true };
@@ -318,5 +332,17 @@ describe("Slack adapter token routing", () => {
     expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("slack", {
       account: "workspace-b",
     });
+  });
+
+  test("bot id resolver maps Slack bot ids through the bot token", async () => {
+    const resolved = await slackProvider.resolveConnection!();
+    expect(resolved).toBeUndefined();
+
+    const userId = await resolveSlackBotUserId(undefined, "B_ASSISTANT");
+
+    expect(userId).toBe("U_BOT");
+    const botsInfoCall = captured.find((c) => c.url.includes("/bots.info"));
+    expect(botsInfoCall).toBeDefined();
+    expect(botsInfoCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
   });
 });

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-token-routing.test.ts
@@ -339,10 +339,17 @@ describe("Slack adapter token routing", () => {
     expect(resolved).toBeUndefined();
 
     const userId = await resolveSlackBotUserId(undefined, "B_ASSISTANT");
+    const repeatedUserId = await resolveSlackBotUserId(
+      undefined,
+      "B_ASSISTANT",
+    );
 
     expect(userId).toBe("U_BOT");
-    const botsInfoCall = captured.find((c) => c.url.includes("/bots.info"));
-    expect(botsInfoCall).toBeDefined();
-    expect(botsInfoCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+    expect(repeatedUserId).toBe("U_BOT");
+    const botsInfoCalls = captured.filter((c) => c.url.includes("/bots.info"));
+    expect(botsInfoCalls).toHaveLength(2);
+    for (const call of botsInfoCalls) {
+      expect(call.authorization).toBe(`Bearer ${BOT_TOKEN}`);
+    }
   });
 });

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -58,6 +58,7 @@ const userNameCache = new Map<string, string>();
  */
 let _cachedSlackWriteAuth: OAuthConnection | string | null = null;
 let _cachedSlackReadAuth: OAuthConnection | string | null = null;
+const botUserIdByBotIdCache = new Map<string, string>();
 
 /**
  * Get the Slack auth value to pass to Slack client functions.
@@ -121,6 +122,30 @@ export async function withSlackBotToken<T>(
   if (!auth) return null;
   if (typeof auth === "string") return fn(auth);
   return auth.withToken(fn);
+}
+
+export async function resolveSlackBotUserId(
+  account: string | undefined,
+  botId: string,
+): Promise<string | null> {
+  const trimmedBotId = botId.trim();
+  if (!trimmedBotId) return null;
+
+  const cacheKey = `${account ?? ""}:${trimmedBotId}`;
+  if (botUserIdByBotIdCache.has(cacheKey)) {
+    return botUserIdByBotIdCache.get(cacheKey) ?? null;
+  }
+
+  const resolvedUserId = await withSlackBotToken(account, async (token) => {
+    const resp = await slack.botsInfo(token, trimmedBotId);
+    const userId = resp.bot.user_id?.trim();
+    return userId && userId.length > 0 ? userId : null;
+  });
+  if (resolvedUserId) {
+    botUserIdByBotIdCache.set(cacheKey, resolvedUserId);
+    return resolvedUserId;
+  }
+  return null;
 }
 
 /**
@@ -258,6 +283,7 @@ function mapMessage(
   const isBot =
     msg.subtype === "bot_message" || (msg.bot_id != null && !msg.user);
   const slackFiles = mapSlackFiles(msg.files);
+  const slackBotId = msg.bot_id?.trim();
   return {
     id: msg.ts,
     conversationId: channelId,
@@ -273,6 +299,7 @@ function mapMessage(
       ? {
           metadata: {
             ...(isBot ? { isBot: true } : {}),
+            ...(slackBotId ? { slackBotId } : {}),
             ...(slackFiles ? { slackFiles } : {}),
           },
         }

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -131,8 +131,8 @@ export async function resolveSlackBotUserId(
   const trimmedBotId = botId.trim();
   if (!trimmedBotId) return null;
 
-  const cacheKey = `${account ?? ""}:${trimmedBotId}`;
-  if (botUserIdByBotIdCache.has(cacheKey)) {
+  const cacheKey = account ? `${account}:${trimmedBotId}` : null;
+  if (cacheKey && botUserIdByBotIdCache.has(cacheKey)) {
     return botUserIdByBotIdCache.get(cacheKey) ?? null;
   }
 
@@ -142,7 +142,9 @@ export async function resolveSlackBotUserId(
     return userId && userId.length > 0 ? userId : null;
   });
   if (resolvedUserId) {
-    botUserIdByBotIdCache.set(cacheKey, resolvedUserId);
+    if (cacheKey) {
+      botUserIdByBotIdCache.set(cacheKey, resolvedUserId);
+    }
     return resolvedUserId;
   }
   return null;

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -14,6 +14,7 @@ import type { OAuthConnection } from "../../../oauth/connection.js";
 import type {
   SlackApiResponse,
   SlackAuthTestResponse,
+  SlackBotsInfoResponse,
   SlackConversationHistoryResponse,
   SlackConversationMarkResponse,
   SlackConversationRepliesResponse,
@@ -284,6 +285,17 @@ export async function authTest(
   connectionOrToken: OAuthConnection | string,
 ): Promise<SlackAuthTestResponse> {
   return request<SlackAuthTestResponse>(connectionOrToken, "auth.test");
+}
+
+export async function botsInfo(
+  connectionOrToken: OAuthConnection | string,
+  botId: string,
+  teamId?: string,
+): Promise<SlackBotsInfoResponse> {
+  return request<SlackBotsInfoResponse>(connectionOrToken, "bots.info", {
+    bot: botId,
+    team_id: teamId,
+  });
 }
 
 export async function listConversations(

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -13,6 +13,17 @@ export interface SlackAuthTestResponse extends SlackApiResponse {
   user_id: string;
 }
 
+export interface SlackBotsInfoResponse extends SlackApiResponse {
+  bot: {
+    id: string;
+    user_id?: string;
+    app_id?: string;
+    name?: string;
+    deleted?: boolean;
+    updated?: number;
+  };
+}
+
 export interface SlackConversation {
   id: string;
   name?: string;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -15,6 +15,7 @@ import {
   isChannelId,
   parseInterfaceId,
 } from "../../channels/types.js";
+import { getConfig } from "../../config/loader.js";
 import {
   createApprovalConversationGenerator,
   createApprovalCopyGenerator,
@@ -1452,9 +1453,10 @@ function readStoredSlackThreadState(
  *
  * Shared insertion point for any path that hydrates Slack history lazily
  * (DM cold-start backfill, thread gap/delta backfill, etc.). Backfilled Slack
- * rows normally persist as `user` history, but bot-authored rows are replayed
- * as assistant history so prior assistant messages do not enter model context
- * wrapped as external user content.
+ * rows normally persist as `user` history, but rows authored by this
+ * assistant's configured Slack bot are replayed as assistant history so prior
+ * assistant messages do not enter model context wrapped as external user
+ * content.
  * Caller is responsible for dedup checks before invoking; this helper
  * performs no idempotency check itself.
  */
@@ -1492,7 +1494,9 @@ async function persistBackfilledSlackMessage(params: {
     message,
     params.guardianExternalUserId,
   );
-  const role = isBackfilledSlackBotMessage(message) ? "assistant" : "user";
+  const role = isBackfilledSlackAssistantMessage(message)
+    ? "assistant"
+    : "user";
 
   const rawText = message.text ?? "";
 
@@ -1624,8 +1628,18 @@ function isBackfilledSlackGuardianMessage(
   return canonicalSender === canonicalGuardian;
 }
 
-function isBackfilledSlackBotMessage(message: ProviderMessage): boolean {
-  return message.metadata?.isBot === true;
+function isBackfilledSlackAssistantMessage(message: ProviderMessage): boolean {
+  if (message.metadata?.isBot !== true) return false;
+
+  const botUserId = getConfig().slack.botUserId.trim();
+  const rawSenderId = message.sender?.id?.trim();
+  if (!botUserId || !rawSenderId) return false;
+
+  const canonicalSender =
+    canonicalizeInboundIdentity("slack", rawSenderId) ?? rawSenderId;
+  const canonicalBot =
+    canonicalizeInboundIdentity("slack", botUserId) ?? botUserId;
+  return canonicalSender === canonicalBot;
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -56,7 +56,10 @@ import {
 import { markProcessed } from "../../memory/delivery-status.js";
 import { upsertBinding } from "../../memory/external-conversation-store.js";
 import type { Message as ProviderMessage } from "../../messaging/provider-types.js";
-import { withSlackBotToken } from "../../messaging/providers/slack/adapter.js";
+import {
+  resolveSlackBotUserId,
+  withSlackBotToken,
+} from "../../messaging/providers/slack/adapter.js";
 import {
   backfillDm,
   backfillThreadWindowPage,
@@ -1494,7 +1497,10 @@ async function persistBackfilledSlackMessage(params: {
     message,
     params.guardianExternalUserId,
   );
-  const role = isBackfilledSlackAssistantMessage(message)
+  const role = (await isBackfilledSlackAssistantMessage(
+    message,
+    params.account,
+  ))
     ? "assistant"
     : "user";
 
@@ -1628,17 +1634,44 @@ function isBackfilledSlackGuardianMessage(
   return canonicalSender === canonicalGuardian;
 }
 
-function isBackfilledSlackAssistantMessage(message: ProviderMessage): boolean {
+async function isBackfilledSlackAssistantMessage(
+  message: ProviderMessage,
+  account: string | undefined,
+): Promise<boolean> {
   if (message.metadata?.isBot !== true) return false;
 
   const botUserId = getConfig().slack.botUserId.trim();
   const rawSenderId = message.sender?.id?.trim();
-  if (!botUserId || !rawSenderId) return false;
+  if (!botUserId) return false;
 
+  if (rawSenderId && slackIdentityMatches(rawSenderId, botUserId)) return true;
+
+  const rawBotId =
+    typeof message.metadata.slackBotId === "string"
+      ? message.metadata.slackBotId.trim()
+      : "";
+  if (!rawBotId) return false;
+
+  try {
+    const resolvedBotUserId = await resolveSlackBotUserId(account, rawBotId);
+    return (
+      typeof resolvedBotUserId === "string" &&
+      slackIdentityMatches(resolvedBotUserId, botUserId)
+    );
+  } catch (err) {
+    log.warn(
+      { err, slackBotId: rawBotId, channelTs: message.id },
+      "Failed to resolve Slack bot id for backfilled assistant detection",
+    );
+    return false;
+  }
+}
+
+function slackIdentityMatches(left: string, right: string): boolean {
   const canonicalSender =
-    canonicalizeInboundIdentity("slack", rawSenderId) ?? rawSenderId;
+    canonicalizeInboundIdentity("slack", left) ?? left.trim();
   const canonicalBot =
-    canonicalizeInboundIdentity("slack", botUserId) ?? botUserId;
+    canonicalizeInboundIdentity("slack", right) ?? right.trim();
   return canonicalSender === canonicalBot;
 }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1452,9 +1452,9 @@ function readStoredSlackThreadState(
  *
  * Shared insertion point for any path that hydrates Slack history lazily
  * (DM cold-start backfill, thread gap/delta backfill, etc.). Backfilled Slack
- * rows are always persisted as `user` history: `assistant` rows are reserved
- * for messages produced by the local assistant loop, not third-party channel
- * replay.
+ * rows normally persist as `user` history, but bot-authored rows are replayed
+ * as assistant history so prior assistant messages do not enter model context
+ * wrapped as external user content.
  * Caller is responsible for dedup checks before invoking; this helper
  * performs no idempotency check itself.
  */
@@ -1492,7 +1492,7 @@ async function persistBackfilledSlackMessage(params: {
     message,
     params.guardianExternalUserId,
   );
-  const role = "user";
+  const role = isBackfilledSlackBotMessage(message) ? "assistant" : "user";
 
   const rawText = message.text ?? "";
 
@@ -1622,6 +1622,10 @@ function isBackfilledSlackGuardianMessage(
     canonicalizeInboundIdentity("slack", guardianExternalUserId) ??
     guardianExternalUserId.trim();
   return canonicalSender === canonicalGuardian;
+}
+
+function isBackfilledSlackBotMessage(message: ProviderMessage): boolean {
+  return message.metadata?.isBot === true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Persist bot-authored Slack backfill rows as assistant history instead of user history.
- Assert backfilled bot text/image context remains raw and never enters the model transcript as `<external_content>`.

## Original prompt
The user asked that Slack assistant messages not be wrapped with `<external_content source="slack" ...>` and that assistant messages not be wrapped with anything.