### PR TITLE
Remove Slack transcript parent arrows

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2344,7 +2344,6 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   const T1 = "1700000010.000002"; // top-level message starting thread B
   const T2 = "1700000030.000003"; // newer top-level message
   const ALIAS_T0 = parentAlias(T0);
-  const ALIAS_T1 = parentAlias(T1);
   const ALIAS_T2 = parentAlias(T2);
 
   const SLACK_CHANNEL_ID = "C0123CHANNEL";
@@ -2539,16 +2538,16 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(lines[2]).toContain("Reply in thread B");
     expect(lines[3]).toContain("Reply in thread A");
     // Cross-thread visibility: thread B's reply is in the rendered output
-    // alongside thread A's reply.
-    expect(lines[2]).toContain(`→ ${ALIAS_T1}`);
-    expect(lines[3]).toContain(`→ ${ALIAS_T0}`);
+    // alongside thread A's reply, without parent-arrow prefixes.
+    expect(lines[2]).not.toContain("→ M");
+    expect(lines[3]).not.toContain("→ M");
     // Sender labels appear.
     expect(lines[0]).toContain("alice");
     expect(lines[1]).toContain("bob");
   });
 
   // ── Scenario 2: reply to a top-level (starts new thread) ─────────────
-  test("scenario 2 — reply to top-level renders thread tag pointing at parent", async () => {
+  test("scenario 2 — reply to top-level renders without parent arrow", async () => {
     const rows: MessageRow[] = [
       userRow({
         id: "m1",
@@ -2572,15 +2571,13 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const lines = texts(result);
 
     expect(lines.length).toBe(2);
-    // Top-level has no thread tag.
     expect(lines[0]).not.toContain("→ M");
-    // Reply points at the parent's deterministic alias.
-    expect(lines[1]).toContain(`→ ${ALIAS_T0}`);
+    expect(lines[1]).not.toContain("→ M");
     expect(lines[1]).toContain("Reply that starts a new thread");
   });
 
   // ── Scenario 3: reply to the most-recent top-level message ───────────
-  test("scenario 3 — reply to last top-level still renders thread tag", async () => {
+  test("scenario 3 — reply to last top-level still renders chronologically", async () => {
     const rows: MessageRow[] = [
       userRow({
         id: "m1",
@@ -2610,13 +2607,12 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const lines = texts(result);
 
     expect(lines.length).toBe(3);
-    // The reply targets the newer top-level alias, not the older one.
-    expect(lines[2]).toContain(`→ ${ALIAS_T1}`);
-    expect(lines[2]).not.toContain(`→ ${ALIAS_T0}`);
+    expect(lines[2]).toContain("Reply to the newer top-level");
+    expect(lines[2]).not.toContain("→ M");
   });
 
   // ── Scenario 4: brand-new top-level message ──────────────────────────
-  test("scenario 4 — new top-level message has no thread tag", async () => {
+  test("scenario 4 — new top-level message has no parent arrow", async () => {
     const rows: MessageRow[] = [
       userRow({
         id: "m1",
@@ -2636,7 +2632,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const lines = texts(result);
 
     expect(lines.length).toBe(2);
-    // Both lines render without a thread tag — they are siblings, not
+    // Both lines render without a parent arrow — they are siblings, not
     // members of the same thread.
     expect(lines[0]).not.toContain("→ M");
     expect(lines[1]).not.toContain("→ M");
@@ -2651,9 +2647,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
   // ── Scenario 5: legacy mixed with post-upgrade rows ──────────────────
   // Pre-upgrade rows have no `slackMeta` sub-key. Post-upgrade rows have
   // it. Both kinds must appear in the rendered transcript with legacy
-  // rows rendered flat (no thread tag) and post-upgrade rows carrying
-  // their thread tags. The renderer's chronological sort must intermix
-  // them on the appropriate timeline.
+  // rows and post-upgrade rows both rendered without parent-arrow prefixes.
+  // The renderer's chronological sort must intermix them on the appropriate
+  // timeline.
   test("scenario 5 — legacy rows mixed with post-upgrade rows render chronologically", async () => {
     const rows: MessageRow[] = [
       // Legacy user row with a displayName hint only — no slackMeta.
@@ -2670,8 +2666,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         text: "Legacy assistant reply",
       }),
       // Post-upgrade row anchored to a thread parent that has no record
-      // in storage (legacy parent) — the renderer still emits the alias
-      // because the metadata is intact.
+      // in storage (legacy parent).
       userRow({
         id: "m3",
         createdAt: 1700000000_000,
@@ -2694,11 +2689,9 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(lines[0]).toContain("Legacy user message");
     expect(lines[1]).toContain("Legacy assistant reply");
     expect(lines[2]).toContain("Post-upgrade thread reply");
-    // Legacy rows render flat — no thread tag arrow.
     expect(lines[0]).not.toContain("→ M");
     expect(lines[1]).not.toContain("→ M");
-    // Post-upgrade row carries its thread tag.
-    expect(lines[2]).toContain(`→ ${ALIAS_T0}`);
+    expect(lines[2]).not.toContain("→ M");
     // Sender labels: legacy rows carry no structured displayName, and the
     // role slot already conveys user-vs-assistant identity, so the row
     // mapper emits `null` senderLabel and the renderer omits the label
@@ -3400,15 +3393,14 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(focusBlock).not.toBeNull();
     expect(focusBlock!).toContain("<active_thread>");
     expect(focusBlock!).toContain("</active_thread>");
-    // Parent (T0) is included, both by content and via the parent alias.
+    // Parent (T0) is included by content.
     expect(focusBlock!).toContain("Top-level in thread A");
     // The new reply is included.
     expect(focusBlock!).toContain("New reply in thread A");
-    expect(focusBlock!).toContain(`→ ${ALIAS_T0}`);
+    expect(focusBlock!).not.toContain("→ M");
     // Thread B's content is NOT in the focus block.
     expect(focusBlock!).not.toContain("Top-level in thread B");
     expect(focusBlock!).not.toContain("Cross-thread reply in B");
-    expect(focusBlock!).not.toContain(`→ ${ALIAS_T1}`);
 
     // The focus block is appended to the FINAL user message as a tail
     // text block — not to any earlier message.
@@ -4470,17 +4462,16 @@ describe("assembleSlackChronologicalMessages", () => {
     });
   });
 
-  test("post-reconciliation: assistant rows with channelTs participate in thread tagging", () => {
+  test("post-reconciliation: assistant rows with channelTs participate in chronological rendering", () => {
     // Once `deliverReplyViaCallback` reconciles `channelTs` from the
     // gateway's response, assistant rows carry a fully-formed slackMeta
     // envelope. They must then render through the Slack chronological
     // path (not the legacy fallback) so reply rows pointing at the
-    // assistant's prior message get a `→ Mxxxxxx` parent-alias arrow.
+    // assistant's prior message appear in Slack timestamp order.
     //
     // This is the cross-thread visibility that the slack-thread-aware-
     // context plan promises: a follow-up user reply to the assistant's
-    // earlier post should render with a parent-alias arrow that the model
-    // can use to reason about which prior assistant message it threads off.
+    // earlier post should render alongside the prior assistant row.
     const SLACK_CHANNEL_ID_2 = "C0THREAD";
     const ASSISTANT_TS = "1700001000.000111";
     const REPLY_TS = "1700001020.000222";
@@ -4525,13 +4516,13 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(result).not.toBeNull();
     expect(result!.length).toBe(2);
 
-    // The user follow-up MUST carry a `→ Mxxxxxx` parent-alias arrow that
-    // points at the assistant's prior message. Before reconciliation, the
-    // assistant row was treated as legacy/null-metadata and excluded from
-    // alias issuance — the user reply rendered without the arrow.
+    // The user follow-up keeps timestamp/sender attribution without carrying
+    // the old parent-alias arrow.
     const replyText = (result![1].content[0] as { text: string }).text;
-    expect(replyText).toMatch(/→ M[0-9a-f]{6}/);
-    expect(replyText).toContain(parentAlias(ASSISTANT_TS));
+    expect(replyText).toBe(
+      `[11/14/23 22:30 @alice]: ${slackExternal("Following up", "@alice")}`,
+    );
+    expect(replyText).not.toContain("→ M");
   });
 
   test("post-reconciliation: assistant row appears in active-thread focus block", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -119,14 +119,11 @@ describe("renderSlackTranscript — basics", () => {
     expect(out).toEqual([textMsg("user", "[11/14/23 14:25 @alice]: hi")]);
   });
 
-  test("renders thread reply with parent alias arrow", () => {
+  test("renders thread reply without parent alias arrow", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_28, "@bob", "got it", { threadTs: TS_14_25 }),
     ]);
-    const alias = parentAlias(TS_14_25);
-    expect(out).toEqual([
-      textMsg("user", `[11/14/23 14:28 @bob → ${alias}]: got it`),
-    ]);
+    expect(out).toEqual([textMsg("user", "[11/14/23 14:28 @bob]: got it")]);
   });
 
   test("renders edited message with editedAt suffix", () => {
@@ -153,18 +150,17 @@ describe("renderSlackTranscript — basics", () => {
     ]);
   });
 
-  test("edited message in a thread renders both arrow and edit suffix", () => {
+  test("edited message in a thread renders edit suffix without thread arrow", () => {
     const out = renderSlackTranscript([
       userMsg(TS_14_28, "@bob", "got it (edit)", {
         threadTs: TS_14_25,
         editedAt: MS_14_30,
       }),
     ]);
-    const alias = parentAlias(TS_14_25);
     expect(out).toEqual([
       textMsg(
         "user",
-        `[11/14/23 14:28 @bob → ${alias}, edited 11/14/23 14:30]: got it (edit)`,
+        "[11/14/23 14:28 @bob, edited 11/14/23 14:30]: got it (edit)",
       ),
     ]);
   });
@@ -865,13 +861,12 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
       userMsg(replyTs, "@dan", "I'll join", { threadTs: aliceTopTs }),
     ];
     const out = renderSlackTranscript(messages);
-    const aliceAlias = parentAlias(aliceTopTs);
     expect(extractTagLineTexts(out)).toEqual([
       "[11/14/23 14:25 @alice]: lunch?",
-      `[11/14/23 14:26 @bob → ${aliceAlias}]: yes!`,
-      `[11/14/23 14:27 @alice → ${aliceAlias}]: 12:30 ok?`,
+      "[11/14/23 14:26 @bob]: yes!",
+      "[11/14/23 14:27 @alice]: 12:30 ok?",
       "[11/14/23 14:28 @carol]: standup soon",
-      `[11/14/23 14:28 @dan → ${aliceAlias}]: I'll join`,
+      "[11/14/23 14:28 @dan]: I'll join",
     ]);
   });
 
@@ -883,12 +878,8 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
       userMsg(replyTs, "@ed", "joining now", { threadTs: carolTopTs }),
     ];
     const out = renderSlackTranscript(messages);
-    const carolAlias = parentAlias(carolTopTs);
     const texts = extractTagLineTexts(out);
-    // The reply tag points at carol's alias; carol's top stays untagged.
-    expect(texts[texts.length - 1]).toBe(
-      `[11/14/23 14:28 @ed → ${carolAlias}]: joining now`,
-    );
+    expect(texts[texts.length - 1]).toBe("[11/14/23 14:28 @ed]: joining now");
     expect(texts[3]).toBe("[11/14/23 14:28 @carol]: standup soon");
   });
 
@@ -900,11 +891,8 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
       userMsg(replyTs, "@frank", "+1", { threadTs: carolTopTs }),
     ];
     const out = renderSlackTranscript(messages);
-    const carolAlias = parentAlias(carolTopTs);
     const texts = extractTagLineTexts(out);
-    expect(texts[texts.length - 1]).toBe(
-      `[11/14/23 14:28 @frank → ${carolAlias}]: +1`,
-    );
+    expect(texts[texts.length - 1]).toBe("[11/14/23 14:28 @frank]: +1");
   });
 
   test("scenario: new top-level message (no threadTs)", () => {
@@ -924,7 +912,7 @@ describe("renderSlackTranscript — four design-brief scenarios", () => {
 // ── mixed legacy + post-upgrade fixture ──────────────────────────────────────
 
 describe("renderSlackTranscript — mixed legacy + post-upgrade", () => {
-  test("legacy rows render flat with no thread tag and intermix chronologically", () => {
+  test("legacy rows intermix chronologically with post-upgrade rows", () => {
     const messages: RenderableSlackMessage[] = [
       // Post-upgrade: 14:28 reply in alice's thread
       userMsg("1699972080.000900", "@bob", "yes!", { threadTs: TS_14_25 }),
@@ -935,16 +923,14 @@ describe("renderSlackTranscript — mixed legacy + post-upgrade", () => {
       userMsg(TS_14_25, "@alice", "lunch?"),
     ];
     const out = renderSlackTranscript(messages);
-    const alias = parentAlias(TS_14_25);
 
     const texts = extractTagLineTexts(out);
     expect(texts).toEqual([
       "[11/14/23 14:25 @alice]: lunch?",
       "[11/14/23 14:26 @dana]: drive-by note",
-      `[11/14/23 14:28 @bob → ${alias}]: yes!`,
+      "[11/14/23 14:28 @bob]: yes!",
     ]);
-    // Ensure the legacy row has no arrow.
-    expect(texts[1].includes("→")).toBe(false);
+    expect(texts.every((text) => !text.includes("→"))).toBe(true);
   });
 
   test("legacy assistant row carries assistant role and emits content verbatim", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -1,10 +1,10 @@
 /**
- * Pure chronological thread-tag rendering for Slack transcripts.
+ * Pure chronological transcript rendering for Slack transcripts.
  *
  * Given a list of stored messages (post-upgrade rows with structured metadata
  * AND legacy pre-upgrade rows with `metadata === null`), produces a flat
- * `{role, content}[]` chronologically ordered with compact thread tags so
- * the model can reason across sibling threads in one channel.
+ * `{role, content}[]` chronologically ordered with compact Slack tags so the
+ * model can reason across sibling threads in one channel.
  *
  * The function is pure: no I/O, no implicit clock reads. Time is taken from
  * `opts.now` only when needed for relative formatting. Sort and tag rendering
@@ -242,22 +242,17 @@ function maxNullableSlackTs(a: string | null, b: string | null): string | null {
  * is preserved without carrying a mimickable timestamp.
  *
  * Tradeoffs deliberately accepted by this simplification:
- * - Thread arrows (`→ Mxxxxxx`) are dropped from assistant rows. In the
- *   common single-thread-at-a-time case, role alternation + chronological
- *   adjacency tells the model which user turn each assistant reply answers,
- *   so no attribution is lost. The degenerate case is a channel where the
- *   assistant is fielding two thread conversations in parallel and the
- *   model has to disambiguate which reply lands in which thread from the
- *   full chronological transcript — the bracketed arrow previously carried
- *   that signal and is now absent. The `<active_thread>` focus block
- *   (single thread by construction) is unaffected.
+ * - Thread arrows (`→ Mxxxxxx`) are dropped from message-row tag lines. The
+ *   common single-thread-at-a-time case still has role alternation +
+ *   chronological adjacency, and the `<active_thread>` focus block remains a
+ *   single-thread view by construction.
  * - Edited assistant rows render only the latest content, not an edit
  *   marker. Edits are rare for the assistant and the latest content is the
  *   only replayable signal anyway.
  *
- * Any alternative "subtle" marker (e.g. an unbracketed `→ Mxxxxxx`) would
- * reintroduce a consistent, mimickable prefix pattern — the very problem
- * this function is designed to avoid — so we keep the content-only form.
+ * Any alternative "subtle" assistant marker would reintroduce a consistent,
+ * mimickable prefix pattern — the very problem this function is designed to
+ * avoid — so we keep the content-only form.
  */
 function renderMessage(msg: RenderableSlackMessage): string {
   if (msg.role === "assistant") {
@@ -268,7 +263,7 @@ function renderMessage(msg: RenderableSlackMessage): string {
   const meta = msg.metadata;
   const senderPart = msg.senderLabel ? ` ${msg.senderLabel}` : "";
   if (!meta) {
-    // Legacy pre-upgrade row: flat render, no thread tag.
+    // Legacy pre-upgrade row: flat render, no Slack metadata-derived fields.
     const time = formatEpochMs(msg.createdAt);
     return `[${time}${senderPart}]: ${renderModelBodyWithSlackFiles(msg, undefined)}`;
   }
@@ -281,9 +276,6 @@ function renderMessage(msg: RenderableSlackMessage): string {
   }
 
   let head = `[${time}${senderPart}`;
-  if (meta.threadTs && meta.threadTs !== meta.channelTs) {
-    head += ` → ${parentAlias(meta.threadTs)}`;
-  }
   if (meta.editedAt !== undefined) {
     head += `, edited ${formatEpochMs(meta.editedAt)}`;
   }
@@ -444,7 +436,7 @@ function buildMessageContentBlocks(
 }
 
 /**
- * Render a chronological transcript with compact thread tags.
+ * Render a chronological transcript with compact Slack tags.
  *
  * Sort is stable: messages with identical sort keys preserve their input
  * order so callers controlling input ordering can break ties deterministically.


### PR DESCRIPTION
## Summary
- Remove `→ Mxxxxxx` parent-alias arrows from Slack message-row prefixes.
- Keep chronological timestamp/sender tags otherwise unchanged.
- Preserve `Mxxxxxx` aliases for reaction targets and overflow trailers.

## Tests
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/messaging/providers/slack/render-transcript.test.ts
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/conversation-runtime-assembly.test.ts --grep "Slack"
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bunx tsc --noEmit

## Split note
This PR is now the narrow parent-arrow removal only. The explicit timezone/UTC tag changes will live in a separate stacked PR.