### PR TITLE
[codex] Label Slack DM conversation footers

### DIFF
--- a/apps/web/src/domains/chat/api/conversations.test.ts
+++ b/apps/web/src/domains/chat/api/conversations.test.ts
@@ -321,6 +321,27 @@ describe("parseConversation — Slack channel binding", () => {
     expect(parsed?.channelBinding).toBeUndefined();
   });
 
+  test("preserves Slack actor identity fields on channel bindings", () => {
+    const parsed = parseConversation({
+      conversationKey: "conv-dm",
+      channelBinding: {
+        sourceChannel: "slack",
+        externalChatId: "D0123ABCDEF",
+        externalUserId: "U0123ABCDEF",
+        displayName: "Alice",
+        username: "alice",
+      },
+    });
+
+    expect(parsed?.channelBinding).toMatchObject({
+      sourceChannel: "slack",
+      externalChatId: "D0123ABCDEF",
+      externalUserId: "U0123ABCDEF",
+      displayName: "Alice",
+      username: "alice",
+    });
+  });
+
   test("does not throw for malformed or absent channelBinding", () => {
     expect(
       parseConversation({

--- a/apps/web/src/domains/chat/api/conversations.ts
+++ b/apps/web/src/domains/chat/api/conversations.ts
@@ -63,6 +63,9 @@ export interface ConversationChannelBinding {
   externalChatId: string;
   externalThreadId?: string;
   externalChatName?: string;
+  externalUserId?: string;
+  displayName?: string;
+  username?: string;
   slackChannel?: ConversationSlackChannel;
   slackThread?: ConversationSlackThread;
 }
@@ -171,6 +174,14 @@ function parseChannelBinding(
       typeof record.externalChatName === "string"
         ? record.externalChatName
         : undefined,
+    externalUserId:
+      typeof record.externalUserId === "string"
+        ? record.externalUserId
+        : undefined,
+    displayName:
+      typeof record.displayName === "string" ? record.displayName : undefined,
+    username:
+      typeof record.username === "string" ? record.username : undefined,
     ...(slackChannel ? { slackChannel } : {}),
     ...(slackThread ? { slackThread } : {}),
   };

--- a/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
@@ -100,12 +100,68 @@ describe("SlackChannelFooter lazy channel name resolution", () => {
           channelBinding: {
             sourceChannel: "slack",
             externalChatId: "D0123ABCDEF",
+            displayName: "Alice",
           },
         }}
       />,
     );
 
-    expect(screen.queryByText("D0123ABCDEF")).not.toBeNull();
+    expect(screen.queryByText("DM with Alice")).not.toBeNull();
+    expect(screen.queryByText("D0123ABCDEF")).toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("labels Slack direct-message channels from message sender metadata", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-direct-message-message-sender",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "D0123ABCDEF",
+          },
+        }}
+        messages={[
+          {
+            stableId: "msg-1",
+            id: "msg-1",
+            role: "user",
+            content: "Hello",
+            slackMessage: {
+              channelId: "D0123ABCDEF",
+              channelTs: "1710000000.000100",
+              sender: { displayName: "Alice" },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("DM with Alice")).not.toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("uses a generic Slack DM label when the participant name is unavailable", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-direct-message-unknown",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "D0123ABCDEF",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Slack DM")).not.toBeNull();
+    expect(screen.queryByText("D0123ABCDEF")).toBeNull();
     await Promise.resolve();
     expect(postCalls).toHaveLength(0);
   });

--- a/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.test.tsx
@@ -145,6 +145,28 @@ describe("SlackChannelFooter lazy channel name resolution", () => {
     expect(postCalls).toHaveLength(0);
   });
 
+  test("labels Slack direct-message channels from a known channel binding name", async () => {
+    render(
+      <SlackChannelFooter
+        assistantId="assistant-1"
+        conversation={{
+          conversationKey: "conv-direct-message-channel-name",
+          originChannel: "slack",
+          channelBinding: {
+            sourceChannel: "slack",
+            externalChatId: "D0123ABCDEF",
+            externalChatName: "Alice",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("DM with Alice")).not.toBeNull();
+    expect(screen.queryByText("Slack DM")).toBeNull();
+    await Promise.resolve();
+    expect(postCalls).toHaveLength(0);
+  });
+
   test("uses a generic Slack DM label when the participant name is unavailable", async () => {
     render(
       <SlackChannelFooter

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -142,6 +142,7 @@ function cleanLabel(value: string | undefined): string | undefined {
 function getSlackDmParticipantName(
   channelBinding: ConversationChannelBinding,
   messageChannel: SlackMessageChannel | undefined,
+  friendlyChannelName: string | undefined,
 ): string | undefined {
   const sender = messageChannel?.sender;
   return (
@@ -149,7 +150,8 @@ function getSlackDmParticipantName(
     cleanLabel(channelBinding.username) ??
     cleanLabel(sender?.displayName) ??
     cleanLabel(sender?.name) ??
-    cleanLabel(sender?.username)
+    cleanLabel(sender?.username) ??
+    friendlyChannelName
   );
 }
 
@@ -157,11 +159,13 @@ function getSlackDmDisplayText(
   channelBinding: ConversationChannelBinding,
   channelId: string | undefined,
   messageChannel: SlackMessageChannel | undefined,
+  friendlyChannelName: string | undefined,
 ): string | undefined {
   if (!isSlackDmChannelId(channelId)) return undefined;
   const participantName = getSlackDmParticipantName(
     channelBinding,
     messageChannel,
+    friendlyChannelName,
   );
   return participantName ? `DM with ${participantName}` : "Slack DM";
 }
@@ -187,14 +191,22 @@ export function SlackChannelFooter({
     channelBinding?.externalChatId;
   const messageChannel = getSlackMessageChannel(messages, channelId);
   const isDmChannel = isSlackDmChannelId(channelId);
-  const dmDisplayText = channelBinding
-    ? getSlackDmDisplayText(channelBinding, channelId, messageChannel)
-    : undefined;
   const channelDisplayText = channelBinding
     ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
     : undefined;
+  const friendlyChannelName =
+    channelBinding &&
+    channelDisplayText &&
+    !isChannelIdFallback(channelDisplayText, channelBinding)
+      ? channelDisplayText
+      : undefined;
   const fallbackDisplayText = channelBinding
-    ? (dmDisplayText ?? channelDisplayText)
+    ? (getSlackDmDisplayText(
+        channelBinding,
+        channelId,
+        messageChannel,
+        friendlyChannelName,
+      ) ?? channelDisplayText)
     : undefined;
   const conversationId = conversation?.conversationKey;
   const resolutionKey =

--- a/apps/web/src/domains/chat/components/slack-channel-footer.tsx
+++ b/apps/web/src/domains/chat/components/slack-channel-footer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { ExternalLink, Hash } from "lucide-react";
+import { ExternalLink, Hash, MessageCircle } from "lucide-react";
 
 import { resolveSlackChannelName } from "@/domains/chat/api/slack-channel-name.js";
 import type {
@@ -18,6 +18,7 @@ type SlackFooterConversation = Pick<
   "channelBinding" | "originChannel"
 > &
   Partial<Pick<Conversation, "conversationKey">>;
+type SlackMessageChannel = NonNullable<DisplayMessage["slackMessage"]>;
 
 export interface SlackChannelFooterProps {
   assistantId?: string;
@@ -133,6 +134,38 @@ function isSlackDmChannelId(channelId: string | undefined): boolean {
   return channelId?.startsWith("D") === true;
 }
 
+function cleanLabel(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function getSlackDmParticipantName(
+  channelBinding: ConversationChannelBinding,
+  messageChannel: SlackMessageChannel | undefined,
+): string | undefined {
+  const sender = messageChannel?.sender;
+  return (
+    cleanLabel(channelBinding.displayName) ??
+    cleanLabel(channelBinding.username) ??
+    cleanLabel(sender?.displayName) ??
+    cleanLabel(sender?.name) ??
+    cleanLabel(sender?.username)
+  );
+}
+
+function getSlackDmDisplayText(
+  channelBinding: ConversationChannelBinding,
+  channelId: string | undefined,
+  messageChannel: SlackMessageChannel | undefined,
+): string | undefined {
+  if (!isSlackDmChannelId(channelId)) return undefined;
+  const participantName = getSlackDmParticipantName(
+    channelBinding,
+    messageChannel,
+  );
+  return participantName ? `DM with ${participantName}` : "Slack DM";
+}
+
 export function SlackChannelFooter({
   assistantId,
   conversation,
@@ -153,8 +186,15 @@ export function SlackChannelFooter({
     slackChannel?.id ??
     channelBinding?.externalChatId;
   const messageChannel = getSlackMessageChannel(messages, channelId);
-  const fallbackDisplayText = channelBinding
+  const isDmChannel = isSlackDmChannelId(channelId);
+  const dmDisplayText = channelBinding
+    ? getSlackDmDisplayText(channelBinding, channelId, messageChannel)
+    : undefined;
+  const channelDisplayText = channelBinding
     ? getSlackChannelDisplayText(channelBinding, messageChannel?.channelName)
+    : undefined;
+  const fallbackDisplayText = channelBinding
+    ? (dmDisplayText ?? channelDisplayText)
     : undefined;
   const conversationId = conversation?.conversationKey;
   const resolutionKey =
@@ -237,9 +277,10 @@ export function SlackChannelFooter({
     messageChannel?.messageLink,
     channelId,
   );
+  const LabelIcon = isDmChannel ? MessageCircle : Hash;
   const content = (
     <>
-      <Hash className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <LabelIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
       <span className="truncate">{displayText}</span>
       {href ? (
         <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Preserve Slack actor identity fields from conversation channel bindings in the web conversation parser.
- Render Slack DM read-only footers as `DM with <name>` when a binding or message sender provides a participant name.
- Fall back to `Slack DM` instead of exposing the raw `D...` Slack channel ID when no name is available.

## Root Cause

Read-only Slack footers already recognized `D...` IDs as direct-message channels, but they skipped channel-name resolution and then rendered the raw fallback ID. The web parser also dropped the actor identity fields that the assistant already includes on channel bindings.

## Validation

- `bun test src/domains/chat/components/slack-channel-footer.test.tsx`
- `bun test src/domains/chat/api/conversations.test.ts`
- `bunx tsc --noEmit`
- `bun run lint -- src/domains/chat/api/conversations.ts src/domains/chat/components/slack-channel-footer.tsx src/domains/chat/api/conversations.test.ts src/domains/chat/components/slack-channel-footer.test.tsx`