### PR TITLE
Remove Slack late-join context notice

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -3015,37 +3015,6 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).not.toContain("dm context");
   });
 
-  test("slack late-join notice is model-facing and non-persisted", async () => {
-    const slackChannelCaps: ChannelCapabilities = {
-      channel: "slack",
-      dashboardCapable: false,
-      supportsDynamicUi: false,
-      supportsVoiceInput: false,
-      chatType: "channel",
-    };
-    const notice =
-      "Slack context note: this turn joined an existing thread. 3 earlier thread messages were backfilled before the current message.";
-
-    const { messages: result, blocks } = await applyRuntimeInjections(
-      [{ role: "user", content: [{ type: "text", text: "current turn" }] }],
-      {
-        channelCapabilities: slackChannelCaps,
-        slackRuntimeContextNotice: notice,
-        transportHints: [notice],
-      },
-    );
-
-    const allText = result
-      .flatMap((m) => m.content)
-      .filter((b): b is { type: "text"; text: string } => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
-    expect(allText).toContain("<slack_context_notice>");
-    expect(allText).toContain(notice);
-    expect(allText).not.toContain("<transport_hints>");
-    expect(JSON.stringify(blocks)).not.toContain(notice);
-  });
-
   // ── transport_hints kept for non-slack channels ───────────────────────
   test("non-slack conversations still receive <transport_hints>", async () => {
     const { messages: result } = await applyRuntimeInjections(

--- a/assistant/src/__tests__/process-message-background-slack.test.ts
+++ b/assistant/src/__tests__/process-message-background-slack.test.ts
@@ -95,7 +95,6 @@ type PersistUserMessageMock = ReturnType<
 type RunAgentLoopMock = ReturnType<
   typeof mock<(...args: unknown[]) => Promise<void>>
 >;
-type NoticeMock = ReturnType<typeof mock<(notice: string | undefined) => void>>;
 interface TestConversation {
   conversationId: string;
   trustContext: unknown;
@@ -123,13 +122,10 @@ interface TestConversation {
     estimatedCost: number;
   };
   persistUserMessage: PersistUserMessageMock;
-  setSlackRuntimeContextNotice: NoticeMock;
   runAgentLoop: RunAgentLoopMock;
   updateClient: (sender: (...args: unknown[]) => void) => void;
   getCurrentSender: () => ((...args: unknown[]) => void) | undefined;
   __loopDeferred: Deferred<void>;
-  __noticeCalls: Array<string | undefined>;
-  __loopNotices: Array<string | undefined>;
   __clientSenders: Array<((...args: unknown[]) => void) | undefined>;
 }
 
@@ -171,11 +167,8 @@ async function waitForRunAgentLoopCall(): Promise<void> {
 function makeConversation(): TestConversation {
   let turnChannelContext: TurnChannelContext | null = null;
   let turnInterfaceContext: TurnInterfaceContext | null = null;
-  let slackNotice: string | undefined;
   let currentSender: ((...args: unknown[]) => void) | undefined;
-  const noticeCalls: Array<string | undefined> = [];
   const loopDeferred = createDeferred<void>();
-  const loopNotices: Array<string | undefined> = [];
   const clientSenders: Array<((...args: unknown[]) => void) | undefined> = [];
   const messages: unknown[] = [];
 
@@ -223,12 +216,7 @@ function makeConversation(): TestConversation {
         _metadata?: Record<string, unknown>,
       ) => "persisted-user-message-id",
     ),
-    setSlackRuntimeContextNotice: mock((notice: string | undefined) => {
-      slackNotice = notice;
-      noticeCalls.push(notice);
-    }),
     runAgentLoop: mock(async (..._args: unknown[]) => {
-      loopNotices.push(slackNotice);
       await loopDeferred.promise;
     }),
     updateClient: (sender: (...args: unknown[]) => void) => {
@@ -237,8 +225,6 @@ function makeConversation(): TestConversation {
     },
     getCurrentSender: () => currentSender,
     __loopDeferred: loopDeferred,
-    __noticeCalls: noticeCalls,
-    __loopNotices: loopNotices,
     __clientSenders: clientSenders,
   };
 
@@ -252,15 +238,13 @@ describe("processMessageInBackground Slack option propagation", () => {
     broadcastMessages.length = 0;
   });
 
-  test("passes Slack inbound metadata to persistence and exposes the runtime notice during the loop", async () => {
+  test("passes Slack inbound metadata to persistence during background processing", async () => {
     const slackInbound = {
       channelId: "C0123CHANNEL",
       channelTs: "1700000001.111111",
       threadTs: "1700000000.000001",
       displayName: "Alice",
     };
-    const notice =
-      "Slack context note: this turn joined an existing thread. 2 earlier messages were backfilled.";
 
     const result = await processMessageInBackground(
       "conv-background-slack",
@@ -268,7 +252,6 @@ describe("processMessageInBackground Slack option propagation", () => {
       undefined,
       {
         slackInbound,
-        slackRuntimeContextNotice: notice,
       },
       "slack",
       "slack",
@@ -280,43 +263,10 @@ describe("processMessageInBackground Slack option propagation", () => {
       slackInbound,
     });
     expect(activeConversation.runAgentLoop).toHaveBeenCalledTimes(1);
-    expect(activeConversation.__loopNotices).toEqual([notice]);
 
     activeConversation.__loopDeferred.resolve();
     await activeConversation.__loopDeferred.promise;
     await Promise.resolve();
-
-    expect(activeConversation.__noticeCalls).toEqual([notice, undefined]);
-  });
-
-  test("clears the Slack runtime notice after normal message processing", async () => {
-    const notice =
-      "Slack context note: this turn joined an existing thread. 2 earlier messages were backfilled.";
-
-    const processing = processMessage(
-      "conv-background-slack",
-      "Reply from Slack",
-      undefined,
-      {
-        slackRuntimeContextNotice: notice,
-        isInteractive: true,
-      },
-      "slack",
-      "slack",
-    );
-
-    await waitForRunAgentLoopCall();
-
-    expect(activeConversation.runAgentLoop).toHaveBeenCalledTimes(1);
-    expect(activeConversation.__loopNotices).toEqual([notice]);
-
-    activeConversation.__loopDeferred.resolve();
-    await expect(processing).resolves.toEqual({
-      messageId: "persisted-user-message-id",
-    });
-
-    expect(activeConversation.__noticeCalls).toEqual([notice, undefined]);
-    expect(activeConversation.__clientSenders).toHaveLength(2);
   });
 
   test("observes live agent events without replacing the broadcast emitter", async () => {

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -360,6 +360,7 @@ describe("processMessage displayContent", () => {
     expect(persistedBlocks).toEqual([
       {
         type: "file",
+        _attachmentId: "att-1",
         source: {
           type: "base64",
           media_type: "application/pdf",
@@ -369,21 +370,26 @@ describe("processMessage displayContent", () => {
       },
     ]);
     expect(addMessageCalls[0]!.content).not.toContain("<external_content");
-    expect(conversation.getMessages()[0]).toEqual({
-      role: "user",
-      content: [
-        { type: "text", text: modelContent },
-        {
-          type: "file",
-          source: {
-            type: "base64",
-            media_type: "application/pdf",
-            data: Buffer.from("pdf bytes").toString("base64"),
-            filename: "attachment.pdf",
-          },
-          extracted_text: undefined,
-        },
-      ],
+    const inMemoryMessage = conversation.getMessages()[0]!;
+    expect(inMemoryMessage.role).toBe("user");
+    expect(inMemoryMessage.content[0]).toEqual({
+      type: "text",
+      text: modelContent,
+    });
+    const inMemoryFileBlock = inMemoryMessage.content[1] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(inMemoryFileBlock._attachmentId).toBe("att-1");
+    expect(inMemoryFileBlock).toMatchObject({
+      type: "file",
+      source: {
+        type: "base64",
+        media_type: "application/pdf",
+        data: Buffer.from("pdf bytes").toString("base64"),
+        filename: "attachment.pdf",
+      },
+      extracted_text: undefined,
     });
   });
 

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -196,7 +196,6 @@ function makeTestConversation() {
         metadata,
         displayContent,
       ),
-    setSlackRuntimeContextNotice: () => {},
     runAgentLoop,
     updateClient: () => {},
     getCurrentSender: () => undefined,

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -1775,7 +1775,6 @@ function buildSlackDmRequest(
 
 interface SlackInboundProcessOptions {
   displayContent?: string;
-  slackRuntimeContextNotice?: string;
   slackInbound?: {
     channelId: string;
     channelTs: string;
@@ -1934,18 +1933,15 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     ]);
 
     let capturedHints: string[] | undefined;
-    let capturedSlackNotice: string | undefined;
     const processMessage = async (
       _conversationId: string,
       _content: string,
       _attachmentIds?: string[],
       options?: {
         transport?: { hints?: string[] };
-        slackRuntimeContextNotice?: string;
       },
     ): Promise<{ messageId: string }> => {
       capturedHints = options?.transport?.hints;
-      capturedSlackNotice = options?.slackRuntimeContextNotice;
       return { messageId: "agent-result-id" };
     };
     setAdapterProcessMessage(processMessage);
@@ -1992,16 +1988,7 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(channelTimestamps.has("1234.0")).toBe(true);
     expect(channelTimestamps.has("1234.1")).toBe(true);
 
-    expect(
-      capturedHints?.some((hint) => hint.includes("joined an existing thread")),
-    ).not.toBe(true);
-    expect(capturedSlackNotice).toContain("joined an existing thread");
-    const contents = db.$client
-      .prepare("SELECT content FROM messages")
-      .all() as Array<{ content: string }>;
-    expect(
-      contents.some((row) => row.content.includes("Slack context note")),
-    ).toBe(false);
+    expect(capturedHints ?? []).toEqual([]);
   });
 
   test("live Slack non-guardian passes raw displayContent while wrapping model content", async () => {

--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -1622,8 +1622,8 @@ describe("web_fetch tool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Extracted text content is very short");
-    expect(result.content).toContain("JavaScript rendering");
+    expect(result.content).toContain("Extracted only");
+    expect(result.content).toContain("JavaScript-rendered");
   });
 
   test("does not suggest browser skill when HTML page has substantial content", async () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -546,7 +546,6 @@ export interface AgentLoopConversationContext {
   assistantId?: string;
   voiceCallControlPrompt?: string;
   transportHints?: string[];
-  slackRuntimeContextNotice?: string;
   clientTimezone?: string;
 
   readonly coreToolNames: Set<string>;
@@ -682,8 +681,9 @@ export async function runAgentLoopImpl(
   let yieldedForHandoff = false;
   let yieldedForBudget = false;
   let pendingCheckpointYield: "budget" | "handoff" | null = null;
-  let emitTerminalExit: ((reason: AgentLoopExitReason) => Promise<void>) | null =
-    null;
+  let emitTerminalExit:
+    | ((reason: AgentLoopExitReason) => Promise<void>)
+    | null = null;
 
   // Default user-initiated turns to the `mainAgent` call site. Other
   // invocation contexts (heartbeat, filing, analyze, etc.) pass their own
@@ -751,7 +751,9 @@ export async function runAgentLoopImpl(
       : undefined;
   const readCurrentOverrideProfile = (): string | undefined =>
     options?.overrideProfile ??
-    getConversationOverrideProfileFromRow(getConversation(ctx.conversationId)) ??
+    getConversationOverrideProfileFromRow(
+      getConversation(ctx.conversationId),
+    ) ??
     complexityRoutedProfile;
 
   const effectiveContextWindow = resolveEffectiveContextWindow({
@@ -1584,13 +1586,8 @@ export async function runAgentLoopImpl(
         overrideProfile: turnOverrideProfile ?? undefined,
       });
       const label = profileEntry?.label ?? effectiveProfileKey;
-      modelProfileStr = resolved.model
-        ? `${label} (${resolved.model})`
-        : label;
-      setLastNotifiedInferenceProfile(
-        ctx.conversationId,
-        effectiveProfileKey,
-      );
+      modelProfileStr = resolved.model ? `${label} (${resolved.model})` : label;
+      setLastNotifiedInferenceProfile(ctx.conversationId, effectiveProfileKey);
     }
 
     const baseTurnContext = {
@@ -1758,7 +1755,6 @@ export async function runAgentLoopImpl(
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
-      slackRuntimeContextNotice: ctx.slackRuntimeContextNotice ?? null,
       isNonInteractive: !isInteractiveResolved,
       isBackgroundConversation: isBackgroundConversationType(
         turnStartConversation?.conversationType,
@@ -3511,7 +3507,6 @@ export async function runAgentLoopImpl(
     ctx.diskPressureCleanupModeActive = false;
     ctx.preactivatedSkillIds = undefined;
     ctx.currentTurnOverrideProfile = undefined;
-    ctx.slackRuntimeContextNotice = undefined;
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1051,17 +1051,6 @@ function injectTransportHints(message: Message, hints: string[]): Message {
   };
 }
 
-function injectSlackRuntimeContextNotice(
-  message: Message,
-  notice: string,
-): Message {
-  const block = `<slack_context_notice>\n${notice}\n</slack_context_notice>`;
-  return {
-    ...message,
-    content: [{ type: "text", text: block }, ...message.content],
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Slack chronological transcript assembly
 // ---------------------------------------------------------------------------
@@ -1700,7 +1689,6 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<pkb>", // backward-compat: strip legacy tag from pre-rename history
   "<system_reminder>",
   "<transport_hints>",
-  "<slack_context_notice>",
   // The Slack active-thread focus block is non-persisted and injected on
   // the FINAL user turn only. Strip it here so re-assembly during compaction
   // and overflow recovery does not duplicate it across turns.
@@ -1994,7 +1982,6 @@ export interface RuntimeInjectionOptions {
    */
   isBackgroundConversation?: boolean;
   transportHints?: string[] | null;
-  slackRuntimeContextNotice?: string | null;
   /**
    * Pre-rendered Slack chronological transcript that replaces the
    * default `runMessages` history for any Slack conversation (channels
@@ -2331,23 +2318,6 @@ export async function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCapabilityContext(userTail, options.channelCapabilities),
-      ];
-    }
-  }
-
-  if (
-    mode === "full" &&
-    slackConversation &&
-    options.slackRuntimeContextNotice
-  ) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectSlackRuntimeContextNotice(
-          userTail,
-          options.slackRuntimeContextNotice,
-        ),
       ];
     }
   }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -240,7 +240,6 @@ export class Conversation {
   /** @internal */ loadedHistoryPersonalMemoryAllowed?: boolean;
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ transportHints?: string[];
-  /** @internal */ slackRuntimeContextNotice?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
     type: string;
@@ -1163,10 +1162,6 @@ export class Conversation {
 
   setTransportHints(hints: string[] | undefined): void {
     this.transportHints = hints;
-  }
-
-  setSlackRuntimeContextNotice(notice: string | undefined): void {
-    this.slackRuntimeContextNotice = notice;
   }
 
   /**

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -165,8 +165,6 @@ export interface ConversationCreateOptions {
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
-  /** Slack-only non-persisted notice injected into the active model turn. */
-  slackRuntimeContextNotice?: string;
   /**
    * Persisted user-facing content. When present, storage/UI use this value
    * while the model-facing turn continues to use `content`.

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -466,16 +466,12 @@ export async function processMessage(
   }
 
   try {
-    conversation.setSlackRuntimeContextNotice(
-      options?.slackRuntimeContextNotice,
-    );
     await conversation.runAgentLoop(resolvedContent, messageId, emitEvent, {
       isInteractive: options?.isInteractive ?? false,
       isUserMessage: true,
       ...(options?.callSite ? { callSite: options.callSite } : {}),
     });
   } finally {
-    conversation.setSlackRuntimeContextNotice(undefined);
     if (
       options?.isInteractive === true &&
       conversation.getCurrentSender() === broadcastMessage
@@ -532,7 +528,6 @@ export async function processMessageInBackground(
     getSubagentManager().updateParentSender(conversationId, broadcastMessage);
   }
 
-  conversation.setSlackRuntimeContextNotice(options?.slackRuntimeContextNotice);
   conversation
     .runAgentLoop(content, messageId, emitEvent, {
       isInteractive: options?.isInteractive ?? false,
@@ -540,7 +535,6 @@ export async function processMessageInBackground(
       ...(options?.callSite ? { callSite: options.callSite } : {}),
     })
     .finally(() => {
-      conversation.setSlackRuntimeContextNotice(undefined);
       if (
         options?.isInteractive === true &&
         conversation.getCurrentSender() === broadcastMessage

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -74,8 +74,6 @@ export interface RuntimeMessageConversationOptions {
   isInteractive?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
-  /** Slack-only non-persisted notice injected into the active model turn. */
-  slackRuntimeContextNotice?: string;
   /**
    * Persisted user-facing content. When present, storage/UI use this value
    * while the model-facing turn continues to use `content`.

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -772,7 +772,6 @@ export async function handleChannelInbound({
           typeof hint === "string" && hint.trim().length > 0,
       )
     : [];
-  let slackRuntimeContextNotice: string | undefined;
 
   // Inject channel-scoped permission hints for Slack channel messages
   if (sourceChannel === "slack") {
@@ -1118,12 +1117,10 @@ export async function handleChannelInbound({
       // the inbound reply; later turns use a delta window after the latest
       // stored thread ts and before the inbound ts. Awaited (mirrors the DM
       // cold-start path above) so the agent loop dispatched immediately
-      // afterwards observes hydrated context. A late-join notice is added only
-      // to the current turn's runtime context, not persisted as durable Slack
-      // metadata. Failures are swallowed inside the helper so they never block
-      // dispatch.
+      // afterwards observes hydrated context. Failures are swallowed inside
+      // the helper so they never block dispatch.
       if (slackThreadTs) {
-        const backfillResult = await triggerSlackThreadBackfillIfNeeded({
+        await triggerSlackThreadBackfillIfNeeded({
           conversationId: result.conversationId,
           channelId: conversationExternalId,
           threadTs: slackThreadTs,
@@ -1131,8 +1128,6 @@ export async function handleChannelInbound({
           account: slackAccount,
           guardianExternalUserId: trustCtx.guardianExternalUserId,
         });
-        const lateJoinNotice = buildSlackLateJoinNotice(backfillResult);
-        if (lateJoinNotice) slackRuntimeContextNotice = lateJoinNotice;
       }
 
       // Wrap non-guardian inbound content in external_content boundaries so
@@ -1165,7 +1160,6 @@ export async function handleChannelInbound({
         externalChatId: conversationExternalId,
         trustCtx,
         metadataHints,
-        slackRuntimeContextNotice,
         metadataUxBrief,
         commandIntent,
         sourceLanguageCode,
@@ -2176,18 +2170,6 @@ function sortSlackProviderMessages(
     if (compared !== null) return compared;
     return left.id.localeCompare(right.id);
   });
-}
-
-function buildSlackLateJoinNotice(
-  result: SlackThreadBackfillResult,
-): string | null {
-  if (result.reason !== "thread_late_join" || result.persisted === 0) {
-    return null;
-  }
-  const omitted = result.omittedMiddle
-    ? " Some middle thread messages were intentionally omitted from this turn's hydrated context to keep latency bounded."
-    : "";
-  return `Slack context note: this turn joined an existing thread. ${result.persisted} earlier thread message${result.persisted === 1 ? " was" : "s were"} backfilled before the current message.${omitted}`;
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -81,7 +81,6 @@ export interface BackgroundProcessingParams {
   externalChatId: string;
   trustCtx: TrustContext;
   metadataHints: string[];
-  slackRuntimeContextNotice?: string;
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
   assistantId?: string;
@@ -119,7 +118,6 @@ export function processChannelMessageInBackground(
     externalChatId,
     trustCtx,
     metadataHints,
-    slackRuntimeContextNotice,
     metadataUxBrief,
     replyCallbackUrl,
     assistantId,
@@ -256,7 +254,6 @@ export function processChannelMessageInBackground(
             isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
             ...(displayContent !== undefined ? { displayContent } : {}),
             ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
-            ...(slackRuntimeContextNotice ? { slackRuntimeContextNotice } : {}),
             ...(slackInbound ? { slackInbound } : {}),
             onEvent: observeAgentEvent,
           },


### PR DESCRIPTION
## Summary
- Stop constructing and forwarding Slack late-join runtime context notices.
- Remove the model injection path and runtime option for the old Slack notice wrapper.
- Update Slack backfill/background processing tests for the removed notice plumbing.

## Tests
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/thread-backfill.test.ts
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/process-message-background-slack.test.ts
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/conversation-runtime-assembly.test.ts --grep "Slack"

## Original prompt
The user asked to remove the `<slack_context_notice>...Slack context note...` block entirely.