### PR TITLE
Remove stale channel prompt constraints

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -245,7 +245,7 @@ describe("injectChannelCapabilityContext", () => {
     expect(text).toContain("CHANNEL CONSTRAINTS");
     expect(text).toContain("Do NOT reference the dashboard UI");
     expect(text).toContain("Do NOT use ui_show");
-    expect(text).toContain("Do NOT ask the user to use voice");
+    expect(text).not.toContain("microphone");
     expect(text).toContain("dashboard_capable: false");
   });
 
@@ -654,7 +654,8 @@ describe("trust-gating via channel capabilities", () => {
     expect(injected).toContain("Do NOT reference the dashboard UI");
     expect(injected).toContain("Do NOT use ui_show, ui_update, or app_create");
     expect(injected).toContain("Present information as well-formatted text");
-    expect(injected).toContain("desktop app");
+    expect(injected).not.toContain("accent color selection");
+    expect(injected).not.toContain("complete those steps");
   });
 
   test("vellum web interface allows dynamic UI but constrains dashboard references", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -693,20 +693,11 @@ export function injectChannelCapabilityContext(
         "- Present information as well-formatted text instead of dynamic UI.",
       );
     }
-    lines.push(
-      "- Defer dashboard-specific actions (e.g. accent color selection) by telling the user",
-    );
-    lines.push("  they can complete those steps later from the desktop app.");
-
     if (caps.channel === "whatsapp") {
       lines.push(
         "- Do NOT use markdown tables — use bullet lists instead. No markdown headers — use **bold** or CAPS for emphasis.",
       );
     }
-  }
-
-  if (!caps.supportsVoiceInput) {
-    lines.push("- Do NOT ask the user to use voice or microphone input.");
   }
 
   // Inject group chat etiquette only when the chat type indicates a multi-party


### PR DESCRIPTION
## Summary
- Remove the prompt guidance that defers dashboard-specific actions to the desktop app.
- Remove the prompt guidance forbidding voice or microphone suggestions.
- Update channel capability runtime tests to assert those removed phrases stay absent while preserving the remaining channel constraints.

## Tests
- cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/__tests__/conversation-runtime-assembly.test.ts --grep "injectChannelCapabilityContext|trust-gating"

## Original prompt
The user asked to remove those two prompt guidance lines entirely.