### PR TITLE
Show stop button for external-channel turns on web

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -73,7 +73,13 @@ import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/utils/rec
 import { buildTranscriptItems } from "@/domains/chat/transcript/build-items.js";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types.js";
 import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination.js";
-import { getThinkingStatusText, isSendDisabled, shouldShowThinkingIndicator, type UIContext } from "@/domains/messaging/turn-selectors.js";
+import {
+  canStopGeneration,
+  getThinkingStatusText,
+  isSendDisabled,
+  shouldShowThinkingIndicator,
+  type UIContext,
+} from "@/domains/messaging/turn-selectors.js";
 import { isSurfaceInteractive } from "@/domains/chat/types/types.js";
 
 import type { MainView, OpenedAppState, OpenedDocumentState } from "@/stores/viewer-store.js";
@@ -85,7 +91,7 @@ import { haptic } from "@/utils/haptics.js";
 import { isChannelConversation as _isChannelConversation } from "@/domains/chat/utils/conversation-channel.js";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure.js";
 import type { DiskPressureStatusEventPayload } from "@/assistant/use-disk-pressure-monitor.js";
-import { isSending, type TurnState, useTurnStore } from "@/domains/messaging/turn-store.js";
+import { type TurnState, useTurnStore } from "@/domains/messaging/turn-store.js";
 import type { QuestionResponseEntry, AllowlistOption, ScopeOption, DirectoryScopeOption, ConfirmationDecision } from "@/domains/chat/api/event-types.js";
 import type { CharacterComponents, CharacterTraits } from "@/domains/avatar/types.js";
 import { DiskPressureBanner, type DiskPressureBannerMode } from "@/domains/chat/components/disk-pressure-banner.js";
@@ -583,8 +589,10 @@ export function ChatRouteContent({
     [messages],
   );
 
+  const hasStreamingAssistantMessage = messages.some((m) => m.isStreaming);
+
   const uiContext: UIContext = {
-    hasStreamingAssistantMessage: messages.some((m) => m.isStreaming),
+    hasStreamingAssistantMessage,
     hasPendingSecret: !!pendingSecret,
     hasPendingConfirmation: !!pendingConfirmation,
     hasPendingQuestion: !!pendingQuestion,
@@ -596,9 +604,8 @@ export function ChatRouteContent({
 
   const showThinking = shouldShowThinkingIndicator(turnState, uiContext);
   const isAssistantStreaming =
-    showThinking || messages.some((m) => m.isStreaming);
-  const canStopGenerating =
-    isSending(turnState) && turnState.phase !== "awaiting_user_input";
+    showThinking || hasStreamingAssistantMessage;
+  const canStopGenerating = canStopGeneration(turnState, uiContext);
 
   const diskPressureChatBlockReason = getDiskPressureChatBlockReason({
     monitorEnabled: diskPressure.diskPressureMonitorEnabled,

--- a/apps/web/src/domains/messaging/turn-selectors.ts
+++ b/apps/web/src/domains/messaging/turn-selectors.ts
@@ -98,6 +98,37 @@ export function shouldShowAssistantBubble(
 }
 
 /**
+ * Whether the active assistant turn can be cancelled.
+ *
+ * Web-originated sends drive `TurnState` directly, but external-channel
+ * conversations (Slack, Telegram, phone) can stream into an already-open web
+ * tab without the web app ever calling `requestSend()`. In that case the live
+ * transcript or conversation processing marker is the only local proof that
+ * there is an active turn to stop.
+ */
+export function canStopGeneration(
+  state: TurnState,
+  ctx: UIContext,
+): boolean {
+  if (
+    state.phase === "awaiting_user_input" ||
+    ctx.hasPendingSecret ||
+    ctx.hasPendingConfirmation ||
+    ctx.hasPendingQuestion ||
+    ctx.hasPendingContactRequest ||
+    ctx.hasUncompletedVisibleSurface
+  ) {
+    return false;
+  }
+
+  return (
+    isSending(state) ||
+    ctx.hasStreamingAssistantMessage ||
+    ctx.activeConversationIsProcessing === true
+  );
+}
+
+/**
  * Label to display alongside the thinking indicator (e.g. "Processing
  * bash results", "Compacting context"). Returns `null` when no label
  * should be shown — callers should fall back to a default like

--- a/apps/web/src/domains/messaging/turn-store.test.ts
+++ b/apps/web/src/domains/messaging/turn-store.test.ts
@@ -4,6 +4,7 @@ import {
   getThinkingStatusText,
   shouldShowThinkingIndicator,
   shouldShowAssistantBubble,
+  canStopGeneration,
   isSendDisabled,
   type UIContext,
 } from "@/domains/messaging/turn-selectors.js";
@@ -1290,6 +1291,46 @@ describe("isSendDisabled", () => {
 
   test("enabled when idle with no competing UI", () => {
     expect(isSendDisabled(INITIAL_TURN_STATE, defaultCtx)).toBe(false);
+  });
+});
+
+describe("canStopGeneration", () => {
+  test("visible for a web-originated active turn", () => {
+    const thinking = turnReducer(INITIAL_TURN_STATE, {
+      type: "USER_SEND_REQUESTED",
+    });
+    expect(canStopGeneration(thinking, defaultCtx)).toBe(true);
+  });
+
+  test("visible for an externally-originated streaming assistant message", () => {
+    expect(
+      canStopGeneration(INITIAL_TURN_STATE, {
+        ...defaultCtx,
+        hasStreamingAssistantMessage: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("visible after switching back to a processing conversation", () => {
+    expect(
+      canStopGeneration(INITIAL_TURN_STATE, {
+        ...defaultCtx,
+        activeConversationIsProcessing: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("hidden while waiting on a user-input surface", () => {
+    const awaiting = applyEvents(INITIAL_TURN_STATE, [
+      { type: "USER_SEND_REQUESTED" },
+      { type: "CONFIRMATION_REQUEST" },
+    ]);
+    expect(
+      canStopGeneration(awaiting, {
+        ...defaultCtx,
+        hasPendingConfirmation: true,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- centralize stop-generation visibility in a turn selector
- show the read-only stop control for externally-originated turns that are streaming or marked processing
- keep stop hidden while the assistant is waiting on explicit user-input surfaces

## Tests
- `cd apps/web && bun test src/domains/messaging/turn-store.test.ts`
- `cd apps/web && bun test src/domains/chat/components/chat-body.test.tsx`
- `cd apps/web && bunx tsc --noEmit`
- `cd apps/web && bun run lint` (passes with an existing warning in `src/lib/errors/report.ts`)
