### PR TITLE
[codex] Expose Slack task progress UI tools

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -49,11 +49,8 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
 
 // Dynamic imports after mock.module calls so the stubs take effect
 // before the modules under test are loaded.
-const {
-  HOST_TOOL_NAMES,
-  HOST_TOOL_TO_CAPABILITY,
-  isToolActiveForContext,
-} = await import("../conversation-tool-setup.js");
+const { HOST_TOOL_NAMES, HOST_TOOL_TO_CAPABILITY, isToolActiveForContext } =
+  await import("../conversation-tool-setup.js");
 type SkillProjectionContext =
   import("../conversation-tool-setup.js").SkillProjectionContext;
 type SkillProjectionCache =
@@ -73,6 +70,66 @@ function makeCtx(
 
 beforeEach(() => {
   mockClientCountByCapability.clear();
+});
+
+describe("isToolActiveForContext — Slack task_progress UI exception", () => {
+  test("ui_show and ui_update are active for Slack task_progress turns", () => {
+    const ctx = makeCtx({
+      hasNoClient: false,
+      channelCapabilities: {
+        channel: "slack",
+        supportsDynamicUi: false,
+      },
+    });
+
+    expect(isToolActiveForContext("ui_show", ctx)).toBe(true);
+    expect(isToolActiveForContext("ui_update", ctx)).toBe(true);
+  });
+
+  test("ui_dismiss remains hidden for Slack without dynamic UI support", () => {
+    expect(
+      isToolActiveForContext(
+        "ui_dismiss",
+        makeCtx({
+          hasNoClient: false,
+          channelCapabilities: {
+            channel: "slack",
+            supportsDynamicUi: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("Slack task_progress UI tools still require a connected client path", () => {
+    expect(
+      isToolActiveForContext(
+        "ui_show",
+        makeCtx({
+          hasNoClient: true,
+          channelCapabilities: {
+            channel: "slack",
+            supportsDynamicUi: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("other non-dynamic channels still hide UI surface tools", () => {
+    expect(
+      isToolActiveForContext(
+        "ui_show",
+        makeCtx({
+          hasNoClient: false,
+          channelCapabilities: {
+            channel: "telegram",
+            supportsDynamicUi: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("isToolActiveForContext — host tool capability gating", () => {
@@ -331,7 +388,10 @@ describe("isToolActiveForContext — cross-client exposure for host_file_*", () 
       expect(
         isToolActiveForContext(
           tool,
-          makeCtx({ hasNoClient: true, transportInterface: "chrome-extension" }),
+          makeCtx({
+            hasNoClient: true,
+            transportInterface: "chrome-extension",
+          }),
         ),
       ).toBe(false);
     });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -331,6 +331,7 @@ export interface SkillProjectionContext {
 // ── Conditional tool sets ────────────────────────────────────────────
 
 const UI_SURFACE_TOOL_NAMES = new Set(["ui_show", "ui_update", "ui_dismiss"]);
+const SLACK_TASK_PROGRESS_UI_TOOL_NAMES = new Set(["ui_show", "ui_update"]);
 /**
  * Single source of truth for which tools are host tools and the capability
  * each one requires from the connected client interface. Adding a tool here
@@ -437,6 +438,12 @@ export function isToolActiveForContext(
     return false;
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
+    if (
+      ctx.channelCapabilities?.channel === "slack" &&
+      SLACK_TASK_PROGRESS_UI_TOOL_NAMES.has(name)
+    ) {
+      return !ctx.hasNoClient;
+    }
     return ctx.channelCapabilities?.supportsDynamicUi ?? !ctx.hasNoClient;
   }
   if (HOST_TOOL_NAMES.has(name)) {


### PR DESCRIPTION
## Summary

- Expose `ui_show` and `ui_update` to Slack turns even though Slack does not support general dynamic UI.
- Keep the existing resolver enforcement that only permits Slack `task_progress` card surfaces on that path.
- Add regression coverage for Slack tool visibility, connected-client gating, and other non-dynamic channels remaining blocked.

## Root Cause

Slack prompt context told the assistant to use `task_progress`, and the surface resolver already had a Slack-specific `task_progress` exception. However, the earlier tool visibility gate filtered out all UI surface tools whenever `supportsDynamicUi` was false, so the model never received `ui_show` or `ui_update` in its callable tool list.

## Validation

- `cd assistant && bun test src/daemon/__tests__/conversation-tool-setup.test.ts`
- `cd assistant && bun test src/__tests__/conversation-surfaces-task-progress.test.ts`
- `cd assistant && bunx tsc --noEmit`
- Pre-push hook: assistant typecheck and lint passed