### PR TITLE
[codex] Fix Slack assistant attribution

### DIFF
--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -32,6 +32,11 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+let mockAssistantName: string | null = null;
+mock.module("../daemon/identity-helpers.js", () => ({
+  getAssistantName: () => mockAssistantName,
+}));
+
 import { createConversation } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -112,7 +117,10 @@ function callList(query: Record<string, string>): ListResponse {
 }
 
 describe("handleListMessages page=latest", () => {
-  beforeEach(resetTables);
+  beforeEach(() => {
+    resetTables();
+    mockAssistantName = null;
+  });
 
   test("page=latest with no limit returns all messages chronologically", () => {
     const conv = createConversation();
@@ -301,6 +309,62 @@ describe("handleListMessages page=latest", () => {
           "https://example.slack.com/archives/C123ABCDEF/p1710000000000200",
       },
     });
+  });
+
+  test("assistant Slack messages without stored sender use the assistant name", () => {
+    mockAssistantName = "Nova";
+    const conv = createConversation();
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "msg-slack-assistant",
+        conversationId: conv.id,
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Slack response" }]),
+        metadata: JSON.stringify({
+          slackMeta: writeSlackMetadata({
+            source: "slack",
+            channelId: "C123ABCDEF",
+            channelTs: "1710000000.000300",
+            eventKind: "message",
+          }),
+        }),
+        createdAt: 1,
+      })
+      .run();
+
+    const body = callList({ conversationId: conv.id, page: "latest" });
+
+    expect(body.messages[0].slackMessage?.sender).toEqual({
+      displayName: "Nova",
+    });
+  });
+
+  test("user Slack messages without stored sender do not use the assistant name", () => {
+    mockAssistantName = "Nova";
+    const conv = createConversation();
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "msg-slack-user",
+        conversationId: conv.id,
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Slack request" }]),
+        metadata: JSON.stringify({
+          slackMeta: writeSlackMetadata({
+            source: "slack",
+            channelId: "C123ABCDEF",
+            channelTs: "1710000000.000300",
+            eventKind: "message",
+          }),
+        }),
+        createdAt: 1,
+      })
+      .run();
+
+    const body = callList({ conversationId: conv.id, page: "latest" });
+
+    expect(body.messages[0].slackMessage?.sender).toBeUndefined();
   });
 
   test("page=latest on unresolved conversationKey returns null metadata contract", () => {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -45,6 +45,7 @@ import {
   preactivateHostProxySkills,
   shouldAttachHostProxyForCapability,
 } from "../../daemon/host-proxy-preactivation.js";
+import { getAssistantName } from "../../daemon/identity-helpers.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type {
   HostProxyTransportMetadata,
@@ -157,6 +158,7 @@ function isHiddenMessage(metadata: string | null): boolean {
 
 function buildSlackHistoryMessage(
   slackMeta: SlackMessageMetadata | null,
+  opts?: { role?: string; assistantDisplayName?: string },
 ): RuntimeMessagePayload["slackMessage"] | undefined {
   if (!slackMeta) return undefined;
 
@@ -180,18 +182,20 @@ function buildSlackHistoryMessage(
         messageTs: replyThreadTs,
       })
     : undefined;
+  const assistantDisplayName =
+    opts?.role === "assistant" ? opts.assistantDisplayName : undefined;
+  const senderDisplayName =
+    slackMeta.displayName?.trim() || assistantDisplayName;
 
   return {
     channelId: slackMeta.channelId,
     ...(slackMeta.channelName ? { channelName: slackMeta.channelName } : {}),
     channelTs: slackMeta.channelTs,
     ...(slackMeta.threadTs ? { threadTs: slackMeta.threadTs } : {}),
-    ...(slackMeta.displayName || slackMeta.actorExternalUserId
+    ...(senderDisplayName || slackMeta.actorExternalUserId
       ? {
           sender: {
-            ...(slackMeta.displayName
-              ? { displayName: slackMeta.displayName }
-              : {}),
+            ...(senderDisplayName ? { displayName: senderDisplayName } : {}),
             ...(slackMeta.actorExternalUserId
               ? { externalUserId: slackMeta.actorExternalUserId }
               : {}),
@@ -536,6 +540,7 @@ export function handleListMessages({
   // (consecutive tool refs grouped together).
   const { messages: consolidatedMessages, mergedIdMap } =
     mergeConsecutiveAssistantMessages(mergedMessages);
+  const assistantSlackDisplayName = getAssistantName()?.trim() || undefined;
 
   // Parse content blocks and extract text + tool calls
   const parsed = consolidatedMessages.map((msg) => {
@@ -587,6 +592,10 @@ export function handleListMessages({
     }
     const slackMessage = buildSlackHistoryMessage(
       readSlackMetadataFromMessageMetadata(msg.metadata),
+      {
+        role: msg.role,
+        assistantDisplayName: assistantSlackDisplayName,
+      },
     );
 
     // Strip <no_response/> markers from assistant messages so web/API


### PR DESCRIPTION
## Summary

Fixes the read-only Slack conversation attribution for assistant-authored messages that do not have a stored Slack sender display name.

The history serializer now falls back to the configured assistant identity only for assistant-role Slack rows. User-role Slack rows without sender metadata remain unnamed so they do not incorrectly inherit the assistant name.

## Root Cause

Outbound assistant Slack rows can have `slackMeta` with channel/thread provenance but no `displayName`. The web read-only transcript then received no sender metadata and rendered its generic assistant fallback.

## Validation

- `bun test src/__tests__/list-messages-page-latest.test.ts`
- `bunx eslint src/runtime/routes/conversation-routes.ts src/__tests__/list-messages-page-latest.test.ts`
- `bunx prettier --check src/runtime/routes/conversation-routes.ts src/__tests__/list-messages-page-latest.test.ts`
- `bunx tsc --noEmit`

Note: the repo pre-push hook also reran assistant type-check and lint successfully, then printed a non-fatal shell compatibility warning before exiting 0.