### PR TITLE
refactor(web): derive LD→store flag key mapping from DEFAULT_FLAGS

### DIFF
--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -131,7 +131,7 @@ export function ChatPage() {
     setOnSearchClick,
     setFooterBanner,
   } = useAssistantContext();
-  const chatPullToRefresh = useFeatureFlagStore.use.chatPullToRefresh();
+  const chatPullToRefreshEnabled = useFeatureFlagStore.use.chatPullToRefreshEnabled();
   const deployToVercel = useFeatureFlagStore.use.deployToVercel();
   const doctor = useFeatureFlagStore.use.doctor();
   const conversationGroupsUI = useFeatureFlagStore.use.conversationGroupsUI();
@@ -1148,7 +1148,7 @@ export function ChatPage() {
     assistantId,
     assistantState,
     assistantIdentity,
-    chatPullToRefresh,
+    chatPullToRefreshEnabled,
     deployToVercel,
     doctor,
     isMobile,

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -234,7 +234,7 @@ export interface ChatRouteContentProps {
   assistantIdentity: AssistantIdentity | null;
 
   // Feature flags
-  chatPullToRefresh: boolean;
+  chatPullToRefreshEnabled: boolean;
   deployToVercel: boolean;
   doctor: boolean;
 
@@ -373,7 +373,7 @@ export function ChatRouteContent({
   assistantId,
   assistantState,
   assistantIdentity: _assistantIdentity,
-  chatPullToRefresh,
+  chatPullToRefreshEnabled,
   deployToVercel,
   doctor: doctorEnabled,
   isMobile,
@@ -1117,7 +1117,7 @@ export function ChatRouteContent({
           )
         : undefined,
     onPullRefresh: handlePullRefresh,
-    pullRefreshEnabled: chatPullToRefresh && touchSupported,
+    pullRefreshEnabled: chatPullToRefreshEnabled && touchSupported,
     subagentEntries,
     onSubagentClick,
     onStopSubagent,

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -47,7 +47,7 @@ const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
       "Show the 'Analyze' option in conversation context menus and title actions dropdown.",
     defaultValue: false,
   },
-  chatPullToRefresh: {
+  chatPullToRefreshEnabled: {
     ldKey: "chat-pull-to-refresh-enabled",
     label: "Chat Pull to Refresh",
     description: "Enable pull-to-refresh gesture in the chat view.",
@@ -67,7 +67,7 @@ const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
       "Enable the Deploy to Vercel / Publish option in the app workspace header share menu.",
     defaultValue: false,
   },
-  developerSettings: {
+  settingsDeveloperNav: {
     ldKey: "settings-developer-nav",
     label: "Settings Developer Nav",
     description: "Control Developer nav visibility in settings.",

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -17,7 +17,7 @@ import { useSettingsSync } from "@/domains/settings/hooks/use-settings-sync.js";
  * fresh while the user is on any settings page.
  */
 export function SettingsLayout() {
-  const developerSettings = useFeatureFlagStore.use.developerSettings();
+  const settingsDeveloperNav = useFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useFeatureFlagStore.use.platformNotifications();
   const sounds = useFeatureFlagStore.use.sounds();
   const { pathname } = useLocation();
@@ -41,10 +41,10 @@ export function SettingsLayout() {
 
   const bottomItems = useMemo(
     () =>
-      developerSettings
+      settingsDeveloperNav
         ? SETTINGS_SIDEBAR.filter((item) => item.id === "developer")
         : [],
-    [developerSettings],
+    [settingsDeveloperNav],
   );
 
   const pageTitle = useMemo(() => {

--- a/apps/web/src/lib/feature-flags/feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-store.ts
@@ -30,10 +30,10 @@ export interface AppFeatureFlags {
   a2aChannel: boolean;
   accountDeletion: boolean;
   analyzeConversation: boolean;
-  chatPullToRefresh: boolean;
+  chatPullToRefreshEnabled: boolean;
   conversationGroupsUI: boolean;
   deployToVercel: boolean;
-  developerSettings: boolean;
+  settingsDeveloperNav: boolean;
   doctor: boolean;
   homePage: boolean;
   multiPlatformAssistant: boolean;
@@ -56,10 +56,10 @@ export const DEFAULT_FLAGS: AppFeatureFlags = {
   a2aChannel: false,
   accountDeletion: false,
   analyzeConversation: false,
-  chatPullToRefresh: false,
+  chatPullToRefreshEnabled: false,
   conversationGroupsUI: false,
   deployToVercel: false,
-  developerSettings: false,
+  settingsDeveloperNav: false,
   doctor: false,
   homePage: false,
   multiPlatformAssistant: false,

--- a/apps/web/src/lib/feature-flags/use-feature-flag-sync.ts
+++ b/apps/web/src/lib/feature-flags/use-feature-flag-sync.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { client } from "@/generated/api/client.gen.js";
 import { assertHasResponse } from "@/lib/api-errors.js";
 import {
+  DEFAULT_FLAGS,
   useFeatureFlagStore,
   type AppFeatureFlags,
 } from "@/lib/feature-flags/feature-flag-store.js";
@@ -12,27 +13,14 @@ interface ClientFlagValuesResponse {
   flags: Record<string, boolean>;
 }
 
-const LD_KEY_TO_STORE_KEY: Record<string, keyof AppFeatureFlags> = {
-  "a2a-channel": "a2aChannel",
-  "account-deletion": "accountDeletion",
-  "analyze-conversation": "analyzeConversation",
-  "chat-pull-to-refresh-enabled": "chatPullToRefresh",
-  "conversation-groups-ui": "conversationGroupsUI",
-  "deploy-to-vercel": "deployToVercel",
-  "settings-developer-nav": "developerSettings",
-  doctor: "doctor",
-  "home-page": "homePage",
-  "multi-platform-assistant": "multiPlatformAssistant",
-  "openai-compatible-endpoints": "openAICompatibleEndpoints",
-  "platform-notifications": "platformNotifications",
-  "pro-plan-adjust": "proPlanAdjust",
-  "rollback-enabled": "rollbackEnabled",
-  "safe-storage-limits": "safeStorageLimits",
-  "self-hosted-assistant": "selfHostedAssistant",
-  "settings-sleep-policy": "settingsSleepPolicy",
-  sounds: "sounds",
-  velvet: "velvet",
-};
+const NORMALIZED_TO_STORE_KEY: Record<string, keyof AppFeatureFlags> = {};
+for (const key of Object.keys(DEFAULT_FLAGS) as (keyof AppFeatureFlags)[]) {
+  NORMALIZED_TO_STORE_KEY[key.toLowerCase()] = key;
+}
+
+function ldKeyToStoreKey(ldKey: string): keyof AppFeatureFlags | undefined {
+  return NORMALIZED_TO_STORE_KEY[ldKey.replace(/-/g, "").toLowerCase()];
+}
 
 const FEATURE_FLAG_QUERY_KEY = ["feature-flag-values"] as const;
 
@@ -57,7 +45,7 @@ function mapFlags(
 ): Partial<AppFeatureFlags> {
   const mapped: Partial<AppFeatureFlags> = {};
   for (const [ldKey, value] of Object.entries(serverFlags)) {
-    const storeKey = LD_KEY_TO_STORE_KEY[ldKey];
+    const storeKey = ldKeyToStoreKey(ldKey);
     if (storeKey) {
       Object.assign(mapped, { [storeKey]: value });
     }


### PR DESCRIPTION
## Summary
- Replaced the hand-maintained 19-entry `LD_KEY_TO_STORE_KEY` static map with a normalization-based lookup derived from `DEFAULT_FLAGS` at module init — adding a new flag now only requires adding it to `AppFeatureFlags` and `DEFAULT_FLAGS`
- Renamed two store keys to match their LD key structure: `chatPullToRefresh` → `chatPullToRefreshEnabled`, `developerSettings` → `settingsDeveloperNav`
- Net -12 lines

## Original prompt
Follow-up to the feature flag hydration PR. The `LD_KEY_TO_STORE_KEY` map duplicated every flag key and required manual maintenance. The user asked to simplify so the mapping isn't needed. Both kebab-case LD keys and camelCase store keys normalize to the same lowercase string when hyphens are stripped, handling acronyms like `UI`/`AI` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)