### PR TITLE
fix(macos): add missing .attachment case in MessageBubbleView switch

### DIFF
--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -184,7 +184,7 @@ public struct MessageBubbleView: View {
         for ref in message.contentOrder {
             switch ref {
             case .text: hasText = true
-            case .toolCall, .surface, .thinking: hasNonText = true
+            case .toolCall, .surface, .thinking, .attachment: hasNonText = true
             }
             if hasText && hasNonText { return true }
         }


### PR DESCRIPTION
## Summary

- Adds the missing `.attachment` case to the `hasInterleavedContent` switch in `MessageBubbleView.swift`, fixing a non-exhaustive switch compiler error introduced by #31543.

## Test plan

- [x] Swift build passes locally
- [ ] Verify interleaved content detection still works correctly for messages with attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)