### PR TITLE
fix(web): set body text color to content-default for dark mode support

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,6 +2,11 @@
 @import "@vellum/design-library/tokens.css";
 @source "../node_modules/@vellum/design-library/src/**/*.tsx";
 
+/* Base element styles — theme-aware defaults inherited by all descendants. */
+body {
+  color: var(--content-default);
+}
+
 /* Functional keyframes — app-only animations. Animations consumed by
  * design-library primitives (popoverIn, bottomSheetIn, panelitem-marquee,
  * collapsible-slide-*) live in the library's tokens.css. */


### PR DESCRIPTION
## Summary

- The `body` element in `apps/web/src/index.css` had no base text color set, so all text inherited the browser-default black (`#000`).
- In dark mode, this made text invisible against dark backgrounds. The most visible symptom was the homepage greeting title ("Good evening") being black on a dark background.
- Added `body { color: var(--content-default); }` which resolves to `#24292E` in light mode and `#F6F5F4` in dark mode, ensuring all text inherits a theme-aware color.

## Test plan

- [ ] Open the app in dark mode and verify the homepage greeting title is visible (light text on dark background)
- [ ] Open the app in light mode and verify text still looks correct (dark text on light background)
- [ ] Check other pages (settings, conversation) to confirm no regressions from the inherited body color

🤖 Generated with [Claude Code](https://claude.com/claude-code)