### PR TITLE
[codex] Use root Vite base during dev

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 // Reference: https://vite.dev/config/#using-environment-variables-in-config
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   // loadEnv with empty prefix loads all .env variables, not just VITE_-prefixed ones.
   const env = { ...process.env, ...loadEnv(mode, process.cwd(), "") };
 
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
   const sentryUploadEnabled = !!env.SENTRY_AUTH_TOKEN;
 
   return {
-    base: "/assistant/",
+    base: command === "build" ? "/assistant/" : "/",
     plugins: [
       tailwindcss(),
       react(),


### PR DESCRIPTION
## Summary

- Uses `/` as the Vite base when running the local dev server.
- Keeps `/assistant/` as the Vite base for built artifacts so deployed dev/prod assets still resolve under `/assistant/...`.

## Why

Vite treats `base` as the public mount prefix during `vite dev`, which causes local `/assistant` visits to hit the "server is configured with a public base url" guard when `base` is always `/assistant/`. The deployed artifact still needs `/assistant/`, so this keys the behavior off Vite's command (`serve` vs `build`) rather than an environment name.

We should remove this once everything's nested under `/assistant`.

## Validation

- `bun run build` from `apps/web`
- Confirmed the generated `dist/index.html` still references `/assistant/...` asset URLs