### PR TITLE
feat(web): skip pre-chat onboarding for content-automation cohort

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -455,6 +455,7 @@ export async function postChatMessage(
     if (normalizedOnboarding.googleConnected !== undefined) onboardingDict.googleConnected = normalizedOnboarding.googleConnected;
     if (normalizedOnboarding.googleScopes !== undefined) onboardingDict.googleScopes = normalizedOnboarding.googleScopes;
     if (normalizedOnboarding.priorAssistants !== undefined) onboardingDict.priorAssistants = normalizedOnboarding.priorAssistants;
+    if (normalizedOnboarding.cohort !== undefined) onboardingDict.cohort = normalizedOnboarding.cohort;
     body.onboarding = onboardingDict;
   }
   if (normalizedOnboarding) {

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -180,10 +180,10 @@ export function PreChatFlow() {
     userId,
   ]);
 
-  // ── Content-automation cohort: skip all pre-chat screens ──
+  // ── Content-automation cohort: skip all pre-chat screens (web only) ──
   const autoSkippedRef = useRef(false);
   useEffect(() => {
-    if (cohort !== "content-automation") return;
+    if (cohort !== "content-automation" || isNative) return;
     if (isAuthLoading || !isLoggedIn || consentDecision !== "ok") return;
     if (readOnboardingCompleted()) return;
     if (autoSkippedRef.current) return;
@@ -206,7 +206,7 @@ export function PreChatFlow() {
     }
     clearPrivacyConsent();
     void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
-  }, [cohort, isAuthLoading, isLoggedIn, consentDecision, navigate, setOnboardingCompleted]);
+  }, [cohort, isNative, isAuthLoading, isLoggedIn, consentDecision, navigate, setOnboardingCompleted]);
 
   function finish(connectedScopes?: string[]): void {
     const context: PreChatOnboardingContext = {
@@ -254,7 +254,7 @@ export function PreChatFlow() {
     return null;
   }
 
-  if (cohort === "content-automation") {
+  if (cohort === "content-automation" && !isNative) {
     return null;
   }
 

--- a/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/apps/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { useIsIOSWeb } from "@/domains/nudges/ios-app-platform.js";
@@ -40,6 +40,7 @@ import {
   clearPrivacyConsent,
   hasRecentPrivacyConsent,
 } from "@/domains/onboarding/signals.js";
+import { resolveUserCohort } from "@/domains/onboarding/utm-cohort.js";
 import { useIsNativePlatform } from "@/runtime/native-auth.js";
 import { useAuthStore } from "@/stores/auth-store.js";
 import { routes } from "@/utils/routes.js";
@@ -67,6 +68,7 @@ export function PreChatFlow() {
   const lastName = user?.lastName ?? "";
   const isNative = useIsNativePlatform();
   const [, setOnboardingCompleted] = useOnboardingCompleted();
+  const [cohort, setCohort] = useState<string | null>(null);
 
   const isMacOSWeb = useIsMacOSWeb();
   const isIOSWeb = useIsIOSWeb();
@@ -145,6 +147,15 @@ export function PreChatFlow() {
   }, [consent, isAuthLoading, isLoggedIn, userId]);
 
   useEffect(() => {
+    if (isAuthLoading || !isLoggedIn) return;
+    let cancelled = false;
+    void resolveUserCohort().then((resolved) => {
+      if (!cancelled && resolved) setCohort(resolved);
+    });
+    return () => { cancelled = true; };
+  }, [isAuthLoading, isLoggedIn]);
+
+  useEffect(() => {
     if (isAuthLoading) return;
     if (!isLoggedIn) {
       void navigate(routes.account.login, { replace: true });
@@ -168,6 +179,34 @@ export function PreChatFlow() {
     setOnboardingCompleted,
     userId,
   ]);
+
+  // ── Content-automation cohort: skip all pre-chat screens ──
+  const autoSkippedRef = useRef(false);
+  useEffect(() => {
+    if (cohort !== "content-automation") return;
+    if (isAuthLoading || !isLoggedIn || consentDecision !== "ok") return;
+    if (readOnboardingCompleted()) return;
+    if (autoSkippedRef.current) return;
+    autoSkippedRef.current = true;
+
+    const context: PreChatOnboardingContext = {
+      tools: [],
+      tasks: ["writing", "research", "project-management"],
+      tone: DEFAULT_GROUP_ID,
+      googleConnected: false,
+      cohort: "content-automation",
+    };
+    setPendingPreChatContext(context);
+    try {
+      setOnboardingCompleted(true);
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { context: "prechat_auto_skip_content_automation" },
+      });
+    }
+    clearPrivacyConsent();
+    void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+  }, [cohort, isAuthLoading, isLoggedIn, consentDecision, navigate, setOnboardingCompleted]);
 
   function finish(connectedScopes?: string[]): void {
     const context: PreChatOnboardingContext = {
@@ -212,6 +251,10 @@ export function PreChatFlow() {
     !consentReady ||
     readOnboardingCompleted()
   ) {
+    return null;
+  }
+
+  if (cohort === "content-automation") {
     return null;
   }
 

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -46,6 +46,8 @@ export interface PreChatOnboardingContext {
    * Undefined when the user skipped Google connection.
    */
   googleScopes?: string[];
+  /** GTM cohort identifier, e.g. "content-automation". */
+  cohort?: string;
 }
 
 /**
@@ -216,6 +218,9 @@ function isPreChatOnboardingContext(
   if (candidate.priorAssistants !== undefined) {
     if (!Array.isArray(candidate.priorAssistants)) return false;
     if (!candidate.priorAssistants.every((s) => typeof s === "string")) return false;
+  }
+  if (candidate.cohort !== undefined && typeof candidate.cohort !== "string") {
+    return false;
   }
   return true;
 }

--- a/apps/web/src/domains/onboarding/utm-cohort.ts
+++ b/apps/web/src/domains/onboarding/utm-cohort.ts
@@ -1,0 +1,29 @@
+import { client } from "@/generated/api/client.gen.js";
+
+const UTM_CAMPAIGN_TO_COHORT: Record<string, string> = {
+  "content-automation": "content-automation",
+};
+
+interface UserMeWithAttribution {
+  marketing_attribution?: { utm_campaign?: string };
+}
+
+export async function resolveUserCohort(): Promise<string | null> {
+  try {
+    const { data, response } = await client.get<UserMeWithAttribution, unknown>({
+      url: "/v1/user/me/",
+      throwOnError: false,
+    });
+
+    if (!response?.ok || !data) return null;
+
+    const campaign = (data as UserMeWithAttribution).marketing_attribution
+      ?.utm_campaign;
+    if (typeof campaign === "string" && campaign) {
+      return UTM_CAMPAIGN_TO_COHORT[campaign] ?? null;
+    }
+  } catch {
+    // Network error or unauthenticated — degrade to default flow.
+  }
+  return null;
+}

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -656,6 +656,27 @@
       "updatedAt": "2026-04-21T16:02:02-04:00"
     },
     {
+      "id": "species-migration",
+      "name": "species-migration",
+      "description": "Migrate from OpenClaw, Hermes, Manus, and other assistant species into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives without hard-coded foreign-species porting logic.",
+      "metadata": {
+        "emoji": "🧬",
+        "vellum": {
+          "display-name": "Species Migration",
+          "activation-hints": [
+            "User wants to migrate from OpenClaw, Hermes, Manus, or another assistant species into Vellum",
+            "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system",
+            "User asks what can be preserved when switching assistant species"
+          ],
+          "avoid-when": [
+            "User is moving an existing Vellum assistant between Vellum homes; use backup/restore or teleport workflows instead"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-05-19T10:59:54-04:00"
+    },
+    {
       "id": "start-the-day",
       "name": "start-the-day",
       "description": "Get a personalized daily briefing with weather, news, and actionable insights",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -656,27 +656,6 @@
       "updatedAt": "2026-04-21T16:02:02-04:00"
     },
     {
-      "id": "species-migration",
-      "name": "species-migration",
-      "description": "Migrate from OpenClaw, Hermes, Manus, and other assistant species into Vellum by inspecting their exports, files, prompts, memory, tools, workflows, integrations, and relationships, then mapping as much as safely possible into Vellum primitives without hard-coded foreign-species porting logic.",
-      "metadata": {
-        "emoji": "🧬",
-        "vellum": {
-          "display-name": "Species Migration",
-          "activation-hints": [
-            "User wants to migrate from OpenClaw, Hermes, Manus, or another assistant species into Vellum",
-            "User has an assistant export, workspace, prompt bundle, memory dump, tool config, or migration request from another assistant system",
-            "User asks what can be preserved when switching assistant species"
-          ],
-          "avoid-when": [
-            "User is moving an existing Vellum assistant between Vellum homes; use backup/restore or teleport workflows instead"
-          ]
-        }
-      },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-19T10:59:54-04:00"
-    },
-    {
       "id": "start-the-day",
       "name": "start-the-day",
       "description": "Get a personalized daily briefing with weather, news, and actionable insights",


### PR DESCRIPTION
## Summary
- Content-automation cohort users (identified via `marketing_attribution.utm_campaign` from Django) now skip all pre-chat onboarding screens and land directly in chat
- Adds `cohort` field to `PreChatOnboardingContext` and forwards it to the daemon, which injects "I want to write articles that rank better in GEO" as the first message
- New `utm-cohort.ts` module resolves cohort from `/v1/user/me/` endpoint, mirroring the platform's `resolveUserCohort()`

Closes JARVIS-929

## Test plan
- [ ] Sign up with `utm_campaign=content-automation` attribution → verify user skips all pre-chat screens and lands in chat
- [ ] Verify the daemon receives `onboarding.cohort === "content-automation"` and injects the GEO-writing first message
- [ ] Sign up without any UTM campaign → verify standard pre-chat flow is unaffected
- [ ] Verify native (iOS) onboarding flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)