### PR TITLE
feat(web): persistent feature flag overrides in debug panel

### DIFF
--- a/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
@@ -4,9 +4,9 @@ import { createSelectors } from "@/utils/create-selectors.js";
 import { client } from "@/generated/api/client.gen.js";
 import { ASSISTANT_FLAG_DEFAULTS, storeKeyToLdKey } from "@/lib/feature-flags/feature-flag-catalog.js";
 
+let currentAssistantId: string | null = null;
+
 interface AssistantFeatureFlagActions {
-  assistantId: string | null;
-  setAssistantId: (id: string | null) => void;
   setFlags: (flags: Record<string, boolean>) => void;
   setFlag: (key: string, value: boolean) => void;
 }
@@ -15,12 +15,9 @@ type AssistantFeatureFlagStore = Record<string, boolean> &
   AssistantFeatureFlagActions;
 
 const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
-  (set, get) =>
+  (set) =>
     ({
       ...ASSISTANT_FLAG_DEFAULTS,
-      assistantId: null,
-
-      setAssistantId: (id: string | null) => set({ assistantId: id }),
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
@@ -33,11 +30,10 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
       setFlag: (key: string, value: boolean) => {
         set({ [key]: value });
 
-        const { assistantId } = get();
         const ldKey = storeKeyToLdKey(key);
-        if (assistantId && ldKey) {
+        if (currentAssistantId && ldKey) {
           void client.patch({
-            url: `/v1/assistants/${assistantId}/feature-flags/${ldKey}`,
+            url: `/v1/assistants/${currentAssistantId}/feature-flags/${ldKey}`,
             body: { enabled: value },
             throwOnError: false,
           } as Parameters<typeof client.patch>[0]);
@@ -49,3 +45,7 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
 export const useAssistantFeatureFlagStore = createSelectors(
   useAssistantFeatureFlagStoreBase,
 );
+
+export function setAssistantIdForFlags(id: string | null) {
+  currentAssistantId = id;
+}

--- a/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/assistant-feature-flag-store.ts
@@ -1,29 +1,49 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors.js";
-import { ASSISTANT_FLAG_DEFAULTS } from "@/lib/feature-flags/feature-flag-catalog.js";
+import { client } from "@/generated/api/client.gen.js";
+import { ASSISTANT_FLAG_DEFAULTS, storeKeyToLdKey } from "@/lib/feature-flags/feature-flag-catalog.js";
 
 interface AssistantFeatureFlagActions {
+  assistantId: string | null;
+  setAssistantId: (id: string | null) => void;
   setFlags: (flags: Record<string, boolean>) => void;
   setFlag: (key: string, value: boolean) => void;
 }
 
-type AssistantFeatureFlagStore = Record<string, boolean> & AssistantFeatureFlagActions;
+type AssistantFeatureFlagStore = Record<string, boolean> &
+  AssistantFeatureFlagActions;
 
 const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
-  (set) => ({
-    ...ASSISTANT_FLAG_DEFAULTS,
+  (set, get) =>
+    ({
+      ...ASSISTANT_FLAG_DEFAULTS,
+      assistantId: null,
 
-    setFlags: (flags: Record<string, boolean>) =>
-      set((prev) => {
-        const changed = Object.keys(flags).some(
-          (k) => flags[k] !== prev[k],
-        );
-        return changed ? flags : prev;
-      }),
+      setAssistantId: (id: string | null) => set({ assistantId: id }),
 
-    setFlag: (key: string, value: boolean) => set({ [key]: value }),
-  } as AssistantFeatureFlagStore),
+      setFlags: (flags: Record<string, boolean>) =>
+        set((prev) => {
+          const changed = Object.keys(flags).some(
+            (k) => flags[k] !== prev[k],
+          );
+          return changed ? flags : prev;
+        }),
+
+      setFlag: (key: string, value: boolean) => {
+        set({ [key]: value });
+
+        const { assistantId } = get();
+        const ldKey = storeKeyToLdKey(key);
+        if (assistantId && ldKey) {
+          void client.patch({
+            url: `/v1/assistants/${assistantId}/feature-flags/${ldKey}`,
+            body: { enabled: value },
+            throwOnError: false,
+          } as Parameters<typeof client.patch>[0]);
+        }
+      },
+    }) as AssistantFeatureFlagStore,
 );
 
 export const useAssistantFeatureFlagStore = createSelectors(

--- a/apps/web/src/lib/feature-flags/client-feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/client-feature-flag-store.ts
@@ -3,27 +3,68 @@ import { create } from "zustand";
 import { createSelectors } from "@/utils/create-selectors.js";
 import { CLIENT_FLAG_DEFAULTS } from "@/lib/feature-flags/feature-flag-catalog.js";
 
+const LS_PREFIX = "ff:client:";
+
+function readOverrides(): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+  const overrides: Record<string, boolean> = {};
+  try {
+    for (const key of Object.keys(CLIENT_FLAG_DEFAULTS)) {
+      const stored = localStorage.getItem(LS_PREFIX + key);
+      if (stored !== null) {
+        overrides[key] = stored === "true";
+      }
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return overrides;
+}
+
+const localOverrides = readOverrides();
+
 interface ClientFeatureFlagActions {
   setFlags: (flags: Record<string, boolean>) => void;
   setFlag: (key: string, value: boolean) => void;
+  clearOverride: (key: string) => void;
 }
 
-type ClientFeatureFlagStore = Record<string, boolean> & ClientFeatureFlagActions;
+type ClientFeatureFlagStore = Record<string, boolean> &
+  ClientFeatureFlagActions;
 
 const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
-  (set) => ({
-    ...CLIENT_FLAG_DEFAULTS,
+  (set) =>
+    ({
+      ...CLIENT_FLAG_DEFAULTS,
+      ...localOverrides,
 
-    setFlags: (flags: Record<string, boolean>) =>
-      set((prev) => {
-        const changed = Object.keys(flags).some(
-          (k) => flags[k] !== prev[k],
-        );
-        return changed ? flags : prev;
-      }),
+      setFlags: (flags: Record<string, boolean>) =>
+        set((prev) => {
+          const overrides = readOverrides();
+          const merged = { ...flags, ...overrides };
+          const changed = Object.keys(merged).some(
+            (k) => merged[k] !== prev[k],
+          );
+          return changed ? merged : prev;
+        }),
 
-    setFlag: (key: string, value: boolean) => set({ [key]: value }),
-  } as ClientFeatureFlagStore),
+      setFlag: (key: string, value: boolean) => {
+        try {
+          localStorage.setItem(LS_PREFIX + key, String(value));
+        } catch {
+          // localStorage unavailable
+        }
+        set({ [key]: value });
+      },
+
+      clearOverride: (key: string) => {
+        try {
+          localStorage.removeItem(LS_PREFIX + key);
+        } catch {
+          // localStorage unavailable
+        }
+      },
+    }) as ClientFeatureFlagStore,
 );
 
 export const useClientFeatureFlagStore = createSelectors(

--- a/apps/web/src/lib/feature-flags/client-feature-flag-store.ts
+++ b/apps/web/src/lib/feature-flags/client-feature-flag-store.ts
@@ -63,6 +63,10 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
+        const defaultValue = CLIENT_FLAG_DEFAULTS[key];
+        if (defaultValue !== undefined) {
+          set({ [key]: defaultValue });
+        }
       },
     }) as ClientFeatureFlagStore,
 );

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -51,8 +51,17 @@ for (const flag of flags) {
   STORE_KEY_TO_FLAG.set(kebabToStoreKey(flag.key), flag);
 }
 
+const STORE_KEY_TO_LD_KEY = new Map<string, string>();
+for (const flag of flags) {
+  STORE_KEY_TO_LD_KEY.set(kebabToStoreKey(flag.key), flag.key);
+}
+
 export function ldKeyToStoreKey(ldKey: string): string {
   return kebabToStoreKey(ldKey);
+}
+
+export function storeKeyToLdKey(storeKey: string): string | undefined {
+  return STORE_KEY_TO_LD_KEY.get(storeKey);
 }
 
 export function getFlagDefinition(storeKey: string): FlagDefinition | undefined {

--- a/apps/web/src/lib/feature-flags/use-assistant-feature-flag-sync.ts
+++ b/apps/web/src/lib/feature-flags/use-assistant-feature-flag-sync.ts
@@ -65,10 +65,12 @@ export function useAssistantFeatureFlagSync(assistantId: string | null) {
   const prevAssistantId = useRef(assistantId);
 
   useEffect(() => {
+    const store = useAssistantFeatureFlagStore.getState();
     if (prevAssistantId.current !== assistantId) {
-      useAssistantFeatureFlagStore.getState().setFlags(ASSISTANT_FLAG_DEFAULTS);
+      store.setFlags(ASSISTANT_FLAG_DEFAULTS);
       prevAssistantId.current = assistantId;
     }
+    store.setAssistantId(assistantId);
   }, [assistantId]);
 
   const { data } = useQuery({

--- a/apps/web/src/lib/feature-flags/use-assistant-feature-flag-sync.ts
+++ b/apps/web/src/lib/feature-flags/use-assistant-feature-flag-sync.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { client } from "@/generated/api/client.gen.js";
 import { assertHasResponse } from "@/lib/api-errors.js";
-import { useAssistantFeatureFlagStore } from "@/lib/feature-flags/assistant-feature-flag-store.js";
+import { useAssistantFeatureFlagStore, setAssistantIdForFlags } from "@/lib/feature-flags/assistant-feature-flag-store.js";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ldKeyToStoreKey,
@@ -65,12 +65,11 @@ export function useAssistantFeatureFlagSync(assistantId: string | null) {
   const prevAssistantId = useRef(assistantId);
 
   useEffect(() => {
-    const store = useAssistantFeatureFlagStore.getState();
     if (prevAssistantId.current !== assistantId) {
-      store.setFlags(ASSISTANT_FLAG_DEFAULTS);
+      useAssistantFeatureFlagStore.getState().setFlags(ASSISTANT_FLAG_DEFAULTS);
       prevAssistantId.current = assistantId;
     }
-    store.setAssistantId(assistantId);
+    setAssistantIdForFlags(assistantId);
   }, [assistantId]);
 
   const { data } = useQuery({


### PR DESCRIPTION
## Summary
- **Client flags**: `setFlag` writes overrides to localStorage (`ff:client:<key>`), store initializes from localStorage on page load, sync hook merges server values under local overrides so toggles survive polling
- **Assistant flags**: `setFlag` PATCHes the gateway endpoint (`/v1/assistants/{id}/feature-flags/{key}`) which persists the override server-side — the next poll returns the overridden value automatically
- Added `storeKeyToLdKey` to the catalog for reverse key mapping (needed by the gateway PATCH)
- Added `clearOverride` action to client store for resetting a flag to its server value

## Original prompt
The debug panel's flag toggles were ephemeral — they updated the in-memory Zustand store but got overwritten on the next 5-second poll. Client flag overrides now persist to localStorage, and assistant flag overrides persist via the gateway's PATCH endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)