### PR TITLE
docs(web): remove stale 10s polling references

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -137,12 +137,11 @@ export function ChatLayout() {
     isAssistantActive && conversationGroupsUI,
   );
 
-  // Track processing/attention indicators for every conversation in the
-  // sidebar, on every chat-layout child route. Mounted here (not ChatPage)
-  // so the 10s polling loop and graduation logic stay live when the user is
-  // on home/library/contacts/identity. Pass lifecycle values directly —
-  // `useAssistantContext()` would crash here since this hook runs inside
-  // the layout that PROVIDES that context (no parent outlet to read from).
+  // Track processing/attention indicators for every conversation in
+  // the sidebar, on every chat-layout child route. Mounted at layout
+  // scope so the bus-driven `interaction_resolved` subscriber and the
+  // post-reconnect reconcile sweep stay live across home, library,
+  // contacts, identity, and chat — not only inside `/assistant`.
   useAttentionTracking({
     assistantId: lifecycle.assistantId,
     assistantStateKind: lifecycle.assistantState.kind,

--- a/apps/web/src/domains/conversations/use-conversation-loader.ts
+++ b/apps/web/src/domains/conversations/use-conversation-loader.ts
@@ -130,8 +130,9 @@ interface UseConversationLoaderParams {
  * Delegates to:
  * - `useConversationHistory` -- conversation switch, cache, and history loading
  *
- * Attention/processing-key tracking is now owned by `useAttentionTracking`,
- * mounted in `ChatLayout` so its 10s polling loop covers every chat-layout
+ * Attention/processing-key tracking is owned by `useAttentionTracking`,
+ * mounted in `ChatLayout` so the bus-driven `interaction_resolved`
+ * subscriber and post-reconnect reconcile cover every chat-layout
  * route (home/library/contacts/identity), not only `/assistant`.
  */
 export function useConversationLoader({


### PR DESCRIPTION
## Summary

Two stale comments referencing the 10s attention-tracking polling loop that LUM-1813 removed:

- `apps/web/src/domains/chat/chat-layout.tsx` — the rationale for mounting `useAttentionTracking` at layout scope.
- `apps/web/src/domains/conversations/use-conversation-loader.ts` — the file header reference to where attention tracking lives.

Both rewritten to describe the current bus-driven mechanism (`interaction_resolved` subscriber + post-reconnect reconcile).

No code changes.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (pre-existing unrelated warning)


---
_Generated by [Claude Code](https://claude.ai/code/session_016MqUMB2Fq1TU3QpzSHvbkg)_