### PR TITLE
feat(memory): add buffer-size trigger for v2 consolidation

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -23,6 +23,7 @@ describe("MemoryV2ConfigSchema", () => {
       bm25_k1: 1.2,
       bm25_b: 0.4,
       consolidation_interval_hours: 4,
+      consolidation_max_buffer_lines: null,
       max_page_chars: 5000,
       consolidation_prompt_path: null,
       rerank: {

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -194,6 +194,19 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Hours between scheduled consolidation runs that synthesize buffered memories into concept pages",
       ),
+    consolidation_max_buffer_lines: z
+      .number({
+        error: "memory.v2.consolidation_max_buffer_lines must be a number",
+      })
+      .int("memory.v2.consolidation_max_buffer_lines must be an integer")
+      .positive(
+        "memory.v2.consolidation_max_buffer_lines must be a positive integer",
+      )
+      .nullable()
+      .default(null)
+      .describe(
+        "Optional size-based trigger. When set, consolidation also runs once `memory/buffer.md` reaches this many non-empty lines, in addition to the time-based interval. `null` (default) disables the size trigger.",
+      ),
     max_page_chars: z
       .number({ error: "memory.v2.max_page_chars must be a number" })
       .int("memory.v2.max_page_chars must be an integer")

--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -19,7 +19,7 @@
  * Tests use a temp workspace pinned via `VELLUM_WORKSPACE_DIR` so the DB
  * lives under `tmpdir()` and `~/.vellum/` is never touched.
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -66,7 +66,7 @@ const { initializeDb } = await import("../db-init.js");
 const { resetTestTables } = await import("../raw-query.js");
 const { memoryJobs } = await import("../schema.js");
 const { applyNestedDefaults } = await import("../../config/loader.js");
-const { setMemoryCheckpoint, deleteMemoryCheckpoint } =
+const { getMemoryCheckpoint, setMemoryCheckpoint, deleteMemoryCheckpoint } =
   await import("../checkpoints.js");
 const { maybeEnqueueGraphMaintenanceJobs } = await import("../jobs-worker.js");
 
@@ -75,6 +75,7 @@ const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
 function buildConfig(overrides: {
   v2Enabled?: boolean;
   intervalHours?: number;
+  maxBufferLines?: number | null;
 }) {
   const partial = applyNestedDefaults({});
   if (overrides.v2Enabled !== undefined) {
@@ -83,7 +84,24 @@ function buildConfig(overrides: {
   if (overrides.intervalHours !== undefined) {
     partial.memory.v2.consolidation_interval_hours = overrides.intervalHours;
   }
+  if (overrides.maxBufferLines !== undefined) {
+    partial.memory.v2.consolidation_max_buffer_lines = overrides.maxBufferLines;
+  }
   return partial;
+}
+
+function writeBuffer(lineCount: number): void {
+  const memoryDir = join(tmpWorkspace, "memory");
+  mkdirSync(memoryDir, { recursive: true });
+  const entries = Array.from(
+    { length: lineCount },
+    (_, i) => `- [Jan 15, 2:${String(i).padStart(2, "0")} PM] note ${i}`,
+  );
+  writeFileSync(join(memoryDir, "buffer.md"), entries.join("\n") + "\n");
+}
+
+function removeBuffer(): void {
+  rmSync(join(tmpWorkspace, "memory", "buffer.md"), { force: true });
 }
 
 function countPendingJobs(type: string): number {
@@ -213,6 +231,105 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     expect(countPendingJobs("graph_consolidate")).toBe(1);
     expect(countPendingJobs("graph_pattern_scan")).toBe(1);
     expect(countPendingJobs("graph_narrative_refine")).toBe(1);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+});
+
+describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
+  test("default null leaves size trigger disabled", () => {
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    const now = Date.now();
+    // Recent checkpoint so the time-based trigger does not fire.
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    writeBuffer(100);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("enqueues when buffer reaches the threshold even if interval not elapsed", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    writeBuffer(10);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+    // Checkpoint refreshed so the next tick doesn't immediately re-fire.
+    expect(getMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY)).toBe(String(now));
+  });
+
+  test("does not enqueue when buffer is under the threshold", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    writeBuffer(3);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("treats missing buffer file as zero lines", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 1,
+    });
+
+    const now = Date.now();
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+    removeBuffer();
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("does not double-enqueue when both triggers would fire", () => {
+    const config = buildConfig({
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 5,
+    });
+
+    const now = Date.now();
+    // Stale checkpoint so time-based fires, AND buffer over threshold.
+    setMemoryCheckpoint(
+      CONSOLIDATE_CHECKPOINT_KEY,
+      String(now - 2 * 60 * 60 * 1000),
+    );
+    writeBuffer(10);
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("size trigger inert when v2 is disabled", () => {
+    const config = buildConfig({
+      v2Enabled: false,
+      intervalHours: 1,
+      maxBufferLines: 1,
+    });
+
+    writeBuffer(100);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
     expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
   });
 });

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import {
@@ -6,6 +8,7 @@ import {
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import {
   getLastScheduledCleanupEnqueueMs,
@@ -75,7 +78,10 @@ import {
   memoryV2MigrateJob,
   memoryV2ReembedJob,
 } from "./v2/backfill-jobs.js";
-import { memoryV2ConsolidateJob } from "./v2/consolidation-job.js";
+import {
+  countBufferLines,
+  memoryV2ConsolidateJob,
+} from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -739,11 +745,25 @@ export function maybeEnqueueGraphMaintenanceJobs(
         },
       ];
 
+  let enqueuedV2 = false;
   for (const { key, intervalMs, jobType } of schedule) {
     const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);
     if (nowMs - lastRun >= intervalMs) {
       enqueueMemoryJob(jobType, {});
       setMemoryCheckpoint(key, String(nowMs));
+      if (jobType === "memory_v2_consolidate") enqueuedV2 = true;
+    }
+  }
+
+  const maxLines = config.memory.v2.consolidation_max_buffer_lines;
+  if (v2Active && !enqueuedV2 && maxLines !== null) {
+    const bufferPath = join(getWorkspaceDir(), "memory", "buffer.md");
+    if (countBufferLines(bufferPath) >= maxLines) {
+      enqueueMemoryJob("memory_v2_consolidate", {});
+      setMemoryCheckpoint(
+        GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
+        String(nowMs),
+      );
     }
   }
 }

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -245,6 +245,20 @@ function readBufferContent(bufferPath: string): string {
 }
 
 /**
+ * Count non-empty lines in `memory/buffer.md`. Used by the scheduler to
+ * implement the size-based consolidation trigger. Missing file → 0.
+ *
+ * Each entry is one line (`- [Mon D, h:mm AM/PM] …\n`), so non-empty-line
+ * count == entry count for a well-formed buffer; blank lines and trailing
+ * newlines don't inflate the count.
+ */
+export function countBufferLines(bufferPath: string): number {
+  const content = readBufferContent(bufferPath);
+  if (content.length === 0) return 0;
+  return content.split("\n").filter((line) => line.trim().length > 0).length;
+}
+
+/**
  * Atomically create the lock file with `wx` (O_CREAT | O_EXCL) flags. Returns
  * `null` on success, or the current holder string (file contents, typically
  * `pid timestamp`) when the file already exists and the holder is still alive.


### PR DESCRIPTION
## Summary
- Adds `memory.v2.consolidation_max_buffer_lines` (nullable positive int, default `null`) to `config.json`.
- When set, `maybeEnqueueGraphMaintenanceJobs` also enqueues `memory_v2_consolidate` once `memory/buffer.md` reaches the configured non-empty-line count — in addition to the existing time-based `consolidation_interval_hours` trigger.
- Both triggers share the same checkpoint key, so dedupe is automatic and a size-based fire also resets the time window.

## Original prompt
Consolidation currently runs only on a time interval. For users who generate dense buffers between scheduled runs, the working set the agent must process in one pass grows unbounded. Add a complementary size-based trigger that fires when the buffer crosses a configurable line count, defaulting to disabled so existing behavior is preserved and users opt in via `config.json`.