### PR TITLE
[codex] Import legacy BYOK credentials into CES

### DIFF
--- a/credential-executor/src/__tests__/ces-migrations-003-legacy-secure-key-import.test.ts
+++ b/credential-executor/src/__tests__/ces-migrations-003-legacy-secure-key-import.test.ts
@@ -1,0 +1,125 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createLocalSecureKeyBackend } from "../materializers/local-secure-key-backend.js";
+import { getManagedCesMigrations } from "../migrations/registry.js";
+import { runCesMigrations } from "../migrations/runner.js";
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `ces-legacy-migration-test-${randomBytes(8).toString("hex")}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("legacy secure key import migration (003)", () => {
+  let tmpDir: string | undefined;
+  let savedLegacySecurityDir: string | undefined;
+
+  afterEach(() => {
+    if (savedLegacySecurityDir !== undefined) {
+      process.env.CREDENTIAL_LEGACY_SECURITY_DIR = savedLegacySecurityDir;
+    } else {
+      delete process.env.CREDENTIAL_LEGACY_SECURITY_DIR;
+    }
+    if (tmpDir && existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    tmpDir = undefined;
+    savedLegacySecurityDir = undefined;
+  });
+
+  function setup() {
+    tmpDir = makeTmpDir();
+    savedLegacySecurityDir = process.env.CREDENTIAL_LEGACY_SECURITY_DIR;
+
+    const legacyDir = join(tmpDir, "legacy-protected");
+    const targetDir = join(tmpDir, "ces-security");
+    const cesDataRoot = join(tmpDir, "ces-data");
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    mkdirSync(cesDataRoot, { recursive: true });
+
+    process.env.CREDENTIAL_LEGACY_SECURITY_DIR = legacyDir;
+
+    const legacyBackend = createLocalSecureKeyBackend(tmpDir!, {
+      securityDirOverride: legacyDir,
+    });
+    const targetBackend = createLocalSecureKeyBackend(tmpDir!, {
+      securityDirOverride: targetDir,
+    });
+
+    return { cesDataRoot, legacyBackend, targetBackend };
+  }
+
+  test("does not append the import migration until the legacy dir is configured", () => {
+    savedLegacySecurityDir = process.env.CREDENTIAL_LEGACY_SECURITY_DIR;
+    delete process.env.CREDENTIAL_LEGACY_SECURITY_DIR;
+
+    expect(getManagedCesMigrations().map((migration) => migration.id)).toEqual([
+      "001-no-op",
+      "002-api-keys-to-credentials",
+    ]);
+  });
+
+  test("imports legacy BYOK keys once and rekeys bare provider keys", async () => {
+    const { cesDataRoot, legacyBackend, targetBackend } = setup();
+
+    await legacyBackend.set("anthropic", "legacy-ant");
+    await targetBackend.set("credential/vellum/assistant_api_key", "platform");
+
+    await runCesMigrations(
+      cesDataRoot,
+      targetBackend,
+      getManagedCesMigrations(),
+    );
+
+    expect(await targetBackend.get("credential/anthropic/api_key")).toBe(
+      "legacy-ant",
+    );
+    expect(await targetBackend.get("anthropic")).toBeUndefined();
+    expect(await targetBackend.get("credential/vellum/assistant_api_key")).toBe(
+      "platform",
+    );
+
+    const checkpoint = JSON.parse(
+      readFileSync(join(cesDataRoot, ".ces-migrations.json"), "utf-8"),
+    );
+    expect(
+      checkpoint.applied["003-import-legacy-secure-keys"].status,
+    ).toBe("completed");
+  });
+
+  test("does not resurrect a CES credential deleted after the import checkpoint", async () => {
+    const { cesDataRoot, legacyBackend, targetBackend } = setup();
+
+    await legacyBackend.set("credential/anthropic/api_key", "legacy-ant");
+
+    await runCesMigrations(
+      cesDataRoot,
+      targetBackend,
+      getManagedCesMigrations(),
+    );
+    expect(await targetBackend.get("credential/anthropic/api_key")).toBe(
+      "legacy-ant",
+    );
+
+    await targetBackend.delete("credential/anthropic/api_key");
+
+    await runCesMigrations(
+      cesDataRoot,
+      targetBackend,
+      getManagedCesMigrations(),
+    );
+
+    expect(
+      await targetBackend.get("credential/anthropic/api_key"),
+    ).toBeUndefined();
+  });
+});

--- a/credential-executor/src/__tests__/ces-migrations-runner.test.ts
+++ b/credential-executor/src/__tests__/ces-migrations-runner.test.ts
@@ -173,7 +173,11 @@ describe("runCesMigrations", () => {
     await runCesMigrations(CES_DATA_ROOT, backend, [m1]);
 
     expect(m1.run).toHaveBeenCalledTimes(1);
-    expect(logWarnFn).toHaveBeenCalled();
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(2);
+    const completedWrite = (writeFileSyncFn.mock.calls[1] as unknown[])[1] as
+      string;
+    const completedParsed = JSON.parse(completedWrite);
+    expect(completedParsed.applied["001"].status).toBe("completed");
   });
 
   test("failed migration is NOT re-run", async () => {
@@ -215,8 +219,6 @@ describe("runCesMigrations", () => {
 
     // m2 should still run after m1's failure
     expect(m2.run).toHaveBeenCalledTimes(1);
-    // error was logged
-    expect(logErrorFn).toHaveBeenCalled();
 
     // Checkpoint writes: started m1, failed m1, started m2, completed m2 = 4
     expect(writeFileSyncFn).toHaveBeenCalledTimes(4);

--- a/credential-executor/src/__tests__/legacy-secure-key-import.test.ts
+++ b/credential-executor/src/__tests__/legacy-secure-key-import.test.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { importLegacySecureKeys } from "../legacy-secure-key-import.js";
+import { createLocalSecureKeyBackend } from "../materializers/local-secure-key-backend.js";
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `legacy-key-import-test-${randomBytes(8).toString("hex")}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("importLegacySecureKeys", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir && existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    tmpDir = undefined;
+  });
+
+  function setup() {
+    tmpDir = makeTmpDir();
+    const legacyDir = join(tmpDir, "legacy-protected");
+    const targetDir = join(tmpDir, "ces-security");
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+
+    const legacyBackend = createLocalSecureKeyBackend(tmpDir!, {
+      securityDirOverride: legacyDir,
+    });
+    const targetBackend = createLocalSecureKeyBackend(tmpDir!, {
+      securityDirOverride: targetDir,
+    });
+
+    return { legacyDir, legacyBackend, targetBackend };
+  }
+
+  test("imports missing legacy keys into an existing CES store", async () => {
+    const { legacyDir, legacyBackend, targetBackend } = setup();
+
+    await legacyBackend.set("credential/anthropic/api_key", "legacy-ant");
+    await legacyBackend.set("credential/openai/api_key", "legacy-openai");
+    await targetBackend.set("credential/vellum/assistant_api_key", "platform");
+
+    const summary = await importLegacySecureKeys({
+      legacySecurityDir: legacyDir,
+      targetBackend,
+    });
+
+    expect(summary).toMatchObject({
+      discovered: 2,
+      imported: 2,
+      skippedExisting: 0,
+      unreadable: 0,
+      failed: 0,
+    });
+    expect(await targetBackend.get("credential/anthropic/api_key")).toBe(
+      "legacy-ant",
+    );
+    expect(await targetBackend.get("credential/openai/api_key")).toBe(
+      "legacy-openai",
+    );
+    expect(await targetBackend.get("credential/vellum/assistant_api_key")).toBe(
+      "platform",
+    );
+  });
+
+  test("keeps current values when the CES store already has a key", async () => {
+    const { legacyDir, legacyBackend, targetBackend } = setup();
+
+    await legacyBackend.set("credential/anthropic/api_key", "legacy-ant");
+    await targetBackend.set("credential/anthropic/api_key", "current-ant");
+
+    const summary = await importLegacySecureKeys({
+      legacySecurityDir: legacyDir,
+      targetBackend,
+    });
+
+    expect(summary.imported).toBe(0);
+    expect(summary.skippedExisting).toBe(1);
+    expect(await targetBackend.get("credential/anthropic/api_key")).toBe(
+      "current-ant",
+    );
+  });
+
+  test("is a no-op when the legacy store is absent", async () => {
+    tmpDir = makeTmpDir();
+    const targetDir = join(tmpDir, "ces-security");
+    const targetBackend = createLocalSecureKeyBackend(tmpDir, {
+      securityDirOverride: targetDir,
+    });
+
+    const summary = await importLegacySecureKeys({
+      legacySecurityDir: join(tmpDir, "missing"),
+      targetBackend,
+    });
+
+    expect(summary).toMatchObject({
+      discovered: 0,
+      imported: 0,
+      skippedExisting: 0,
+      unreadable: 0,
+      failed: 0,
+    });
+  });
+});

--- a/credential-executor/src/legacy-secure-key-import.ts
+++ b/credential-executor/src/legacy-secure-key-import.ts
@@ -1,0 +1,70 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import type { SecureKeyBackend } from "@vellumai/credential-storage";
+
+import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
+
+const KEYS_ENC_FILENAME = "keys.enc";
+
+export type LegacySecureKeyImportSummary = {
+  legacySecurityDir: string | null;
+  discovered: number;
+  imported: number;
+  skippedExisting: number;
+  unreadable: number;
+  failed: number;
+};
+
+export async function importLegacySecureKeys(options: {
+  legacySecurityDir?: string | null;
+  targetBackend: SecureKeyBackend;
+}): Promise<LegacySecureKeyImportSummary> {
+  const legacySecurityDir = options.legacySecurityDir?.trim() || null;
+  const emptySummary: LegacySecureKeyImportSummary = {
+    legacySecurityDir,
+    discovered: 0,
+    imported: 0,
+    skippedExisting: 0,
+    unreadable: 0,
+    failed: 0,
+  };
+
+  if (!legacySecurityDir) return emptySummary;
+  if (!existsSync(join(legacySecurityDir, KEYS_ENC_FILENAME))) {
+    return emptySummary;
+  }
+
+  const legacyBackend = createLocalSecureKeyBackend(legacySecurityDir, {
+    securityDirOverride: legacySecurityDir,
+  });
+
+  const keys = await legacyBackend.list();
+  const summary: LegacySecureKeyImportSummary = {
+    ...emptySummary,
+    discovered: keys.length,
+  };
+
+  for (const key of keys) {
+    const existing = await options.targetBackend.get(key);
+    if (existing !== undefined) {
+      summary.skippedExisting++;
+      continue;
+    }
+
+    const value = await legacyBackend.get(key);
+    if (value === undefined) {
+      summary.unreadable++;
+      continue;
+    }
+
+    const stored = await options.targetBackend.set(key, value);
+    if (stored) {
+      summary.imported++;
+    } else {
+      summary.failed++;
+    }
+  }
+
+  return summary;
+}

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -61,11 +61,9 @@ import { buildLazyGetters, type ApiKeyRef, type AssistantIdRef } from "./managed
 import { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "./managed-errors.js";
 import type { SecureKeyBackend } from "@vellumai/credential-storage";
 import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
-import { importLegacySecureKeys } from "./legacy-secure-key-import.js";
 import { handleCredentialRoute, type CredentialRouteDeps } from "./http/credential-routes.js";
 import { handleLogExportRoute } from "./http/log-export-routes.js";
-import { CES_MIGRATIONS } from "./migrations/registry.js";
-import { apiKeyToCredentialsMigration } from "./migrations/002-api-keys-to-credentials.js";
+import { getManagedCesMigrations } from "./migrations/registry.js";
 import { runCesMigrations } from "./migrations/runner.js";
 
 // ---------------------------------------------------------------------------
@@ -547,36 +545,12 @@ async function main(): Promise<void> {
   const vellumRoot = join(assistantDataMount, ".vellum");
   const secureKeyBackend = createLocalSecureKeyBackend(vellumRoot);
 
-  const legacySecurityDir =
-    process.env["CREDENTIAL_LEGACY_SECURITY_DIR"] ??
-    join(vellumRoot, "protected");
-  const legacyImportSummary = await importLegacySecureKeys({
-    legacySecurityDir,
-    targetBackend: secureKeyBackend,
-  });
-  if (
-    legacyImportSummary.discovered > 0 ||
-    legacyImportSummary.imported > 0 ||
-    legacyImportSummary.unreadable > 0 ||
-    legacyImportSummary.failed > 0
-  ) {
-    log.info(
-      {
-        discovered: legacyImportSummary.discovered,
-        imported: legacyImportSummary.imported,
-        skippedExisting: legacyImportSummary.skippedExisting,
-        unreadable: legacyImportSummary.unreadable,
-        failed: legacyImportSummary.failed,
-      },
-      "CES managed startup: checked legacy secure key store",
-    );
-  }
-  if (legacyImportSummary.discovered > 0) {
-    await apiKeyToCredentialsMigration.run(secureKeyBackend);
-  }
-
   // Run one-time credential store migrations before accepting connections.
-  await runCesMigrations(getCesDataRoot("managed"), secureKeyBackend, CES_MIGRATIONS);
+  await runCesMigrations(
+    getCesDataRoot("managed"),
+    secureKeyBackend,
+    getManagedCesMigrations(),
+  );
   log.info("CES managed startup: migrations complete");
 
   // Set up credential CRUD routes if a service token is configured.

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -61,9 +61,11 @@ import { buildLazyGetters, type ApiKeyRef, type AssistantIdRef } from "./managed
 import { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "./managed-errors.js";
 import type { SecureKeyBackend } from "@vellumai/credential-storage";
 import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
+import { importLegacySecureKeys } from "./legacy-secure-key-import.js";
 import { handleCredentialRoute, type CredentialRouteDeps } from "./http/credential-routes.js";
 import { handleLogExportRoute } from "./http/log-export-routes.js";
 import { CES_MIGRATIONS } from "./migrations/registry.js";
+import { apiKeyToCredentialsMigration } from "./migrations/002-api-keys-to-credentials.js";
 import { runCesMigrations } from "./migrations/runner.js";
 
 // ---------------------------------------------------------------------------
@@ -544,6 +546,34 @@ async function main(): Promise<void> {
     process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
   const vellumRoot = join(assistantDataMount, ".vellum");
   const secureKeyBackend = createLocalSecureKeyBackend(vellumRoot);
+
+  const legacySecurityDir =
+    process.env["CREDENTIAL_LEGACY_SECURITY_DIR"] ??
+    join(vellumRoot, "protected");
+  const legacyImportSummary = await importLegacySecureKeys({
+    legacySecurityDir,
+    targetBackend: secureKeyBackend,
+  });
+  if (
+    legacyImportSummary.discovered > 0 ||
+    legacyImportSummary.imported > 0 ||
+    legacyImportSummary.unreadable > 0 ||
+    legacyImportSummary.failed > 0
+  ) {
+    log.info(
+      {
+        discovered: legacyImportSummary.discovered,
+        imported: legacyImportSummary.imported,
+        skippedExisting: legacyImportSummary.skippedExisting,
+        unreadable: legacyImportSummary.unreadable,
+        failed: legacyImportSummary.failed,
+      },
+      "CES managed startup: checked legacy secure key store",
+    );
+  }
+  if (legacyImportSummary.discovered > 0) {
+    await apiKeyToCredentialsMigration.run(secureKeyBackend);
+  }
 
   // Run one-time credential store migrations before accepting connections.
   await runCesMigrations(getCesDataRoot("managed"), secureKeyBackend, CES_MIGRATIONS);

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -102,8 +102,15 @@ const KEYS_ENC_FILENAME = "keys.enc";
  * When the env var is unset, falls back to `<vellumRoot>/protected/` for
  * backwards compatibility.
  */
-function resolveSecurityDir(vellumRoot: string): string {
-  return process.env.CREDENTIAL_SECURITY_DIR || join(vellumRoot, "protected");
+function resolveSecurityDir(
+  vellumRoot: string,
+  securityDirOverride?: string,
+): string {
+  return (
+    securityDirOverride ||
+    process.env.CREDENTIAL_SECURITY_DIR ||
+    join(vellumRoot, "protected")
+  );
 }
 
 /**
@@ -111,9 +118,9 @@ function resolveSecurityDir(vellumRoot: string): string {
  * Returns the raw 32-byte key buffer, or null if the file is missing,
  * wrong size, or unreadable.
  */
-function readStoreKey(vellumRoot: string): Buffer | null {
+function readStoreKey(securityDir: string): Buffer | null {
   try {
-    const keyPath = join(resolveSecurityDir(vellumRoot), STORE_KEY_FILENAME);
+    const keyPath = join(securityDir, STORE_KEY_FILENAME);
     if (!existsSync(keyPath)) return null;
     const buf = readFileSync(keyPath);
     if (buf.length !== KEY_LENGTH) return null;
@@ -131,11 +138,10 @@ function readStoreKey(vellumRoot: string): Buffer | null {
  * Read or generate the v2 store key. If the key file does not exist,
  * creates a new 32-byte random key and writes it atomically.
  */
-function getOrReadStoreKey(vellumRoot: string): Buffer {
-  const existing = readStoreKey(vellumRoot);
+function getOrReadStoreKey(securityDir: string): Buffer {
+  const existing = readStoreKey(securityDir);
   if (existing) return existing;
 
-  const securityDir = resolveSecurityDir(vellumRoot);
   mkdirSync(securityDir, { recursive: true });
 
   const key = randomBytes(KEY_LENGTH);
@@ -157,14 +163,14 @@ function getOrReadStoreKey(vellumRoot: string): Buffer {
  */
 function getOrCreateStore(
   storePath: string,
-  vellumRoot: string,
+  securityDir: string,
 ): { store: StoreFile; aesKey: Buffer } {
   const existing = readStore(storePath);
   if (existing) {
     if (existing.version === 1) {
       throw new Error("v1 store cannot be auto-initialized");
     }
-    const storeKey = readStoreKey(vellumRoot);
+    const storeKey = readStoreKey(securityDir);
     if (!storeKey) {
       throw new Error("v2 store exists but store.key is missing or corrupt");
     }
@@ -172,7 +178,7 @@ function getOrCreateStore(
   }
 
   // No store exists — create a new empty v2 store
-  const aesKey = getOrReadStoreKey(vellumRoot);
+  const aesKey = getOrReadStoreKey(securityDir);
   const store: StoreFileV2 = { version: 2, entries: {} };
   writeStore(store, storePath);
   return { store, aesKey };
@@ -302,9 +308,17 @@ function readStore(storePath: string): StoreFile | null {
  */
 export function createLocalSecureKeyBackend(
   vellumRoot: string,
-  options?: { entropyOverride?: string; entropyGetter?: () => string | undefined },
+  options?: {
+    entropyOverride?: string;
+    entropyGetter?: () => string | undefined;
+    securityDirOverride?: string;
+  },
 ): SecureKeyBackend {
-  const storePath = join(resolveSecurityDir(vellumRoot), KEYS_ENC_FILENAME);
+  const securityDir = resolveSecurityDir(
+    vellumRoot,
+    options?.securityDirOverride,
+  );
+  const storePath = join(securityDir, KEYS_ENC_FILENAME);
   const staticEntropy = options?.entropyOverride;
   const entropyGetter = options?.entropyGetter;
 
@@ -319,7 +333,7 @@ export function createLocalSecureKeyBackend(
 
         let aesKey: Buffer;
         if (store.version === 2) {
-          const storeKey = readStoreKey(vellumRoot);
+          const storeKey = readStoreKey(securityDir);
           if (!storeKey) return undefined;
           aesKey = storeKey;
         } else {
@@ -346,7 +360,7 @@ export function createLocalSecureKeyBackend(
         let aesKey: Buffer;
 
         try {
-          const result = getOrCreateStore(storePath, vellumRoot);
+          const result = getOrCreateStore(storePath, securityDir);
           store = result.store;
           aesKey = result.aesKey;
         } catch {

--- a/credential-executor/src/migrations/003-import-legacy-secure-keys.ts
+++ b/credential-executor/src/migrations/003-import-legacy-secure-keys.ts
@@ -1,0 +1,51 @@
+import type { CesMigration } from "./types.js";
+
+import { importLegacySecureKeys } from "../legacy-secure-key-import.js";
+import { getLogger } from "../logger.js";
+import { apiKeyToCredentialsMigration } from "./002-api-keys-to-credentials.js";
+
+const log = getLogger("ces-migrations");
+
+export function createLegacySecureKeyImportMigration(
+  legacySecurityDir: string,
+): CesMigration {
+  return {
+    id: "003-import-legacy-secure-keys",
+    description: "Import legacy BYOK credentials into the CES store",
+
+    async run(backend): Promise<void> {
+      const summary = await importLegacySecureKeys({
+        legacySecurityDir,
+        targetBackend: backend,
+      });
+
+      if (
+        summary.discovered > 0 ||
+        summary.imported > 0 ||
+        summary.unreadable > 0 ||
+        summary.failed > 0
+      ) {
+        log.info(
+          {
+            discovered: summary.discovered,
+            imported: summary.imported,
+            skippedExisting: summary.skippedExisting,
+            unreadable: summary.unreadable,
+            failed: summary.failed,
+          },
+          "CES migration: checked legacy secure key store",
+        );
+      }
+
+      if (summary.discovered > 0) {
+        await apiKeyToCredentialsMigration.run(backend);
+      }
+    },
+
+    async down(): Promise<void> {
+      // Forward-only. Imported credentials may have been edited or deleted
+      // after migration, so rollback cannot distinguish imported values from
+      // intentional current CES state.
+    },
+  };
+}

--- a/credential-executor/src/migrations/registry.ts
+++ b/credential-executor/src/migrations/registry.ts
@@ -1,9 +1,10 @@
 import { apiKeyToCredentialsMigration } from "./002-api-keys-to-credentials.js";
+import { createLegacySecureKeyImportMigration } from "./003-import-legacy-secure-keys.js";
 import { noOpMigration } from "./001-no-op.js";
 import type { CesMigration } from "./types.js";
 
 /**
- * Ordered list of all CES data migrations.
+ * Ordered list of unconditional CES data migrations.
  *
  * New migrations are appended to the end. Never reorder or remove entries —
  * the runner uses array position for ordering and the `id` field for
@@ -13,3 +14,18 @@ export const CES_MIGRATIONS: CesMigration[] = [
   noOpMigration,
   apiKeyToCredentialsMigration,
 ];
+
+/**
+ * Managed-mode migrations can include platform-wired one-time recovery steps.
+ * Keep the legacy import absent until the platform supplies the legacy mount
+ * env var, so the checkpoint is not consumed before the old store is visible.
+ */
+export function getManagedCesMigrations(): CesMigration[] {
+  const legacySecurityDir =
+    process.env["CREDENTIAL_LEGACY_SECURITY_DIR"]?.trim() || "";
+  if (!legacySecurityDir) return CES_MIGRATIONS;
+  return [
+    ...CES_MIGRATIONS,
+    createLegacySecureKeyImportMigration(legacySecurityDir),
+  ];
+}


### PR DESCRIPTION
## Summary

- import missing legacy encrypted BYOK credentials into the CES credential store during managed startup
- preserve current CES values when a user has already re-added a key
- rerun the provider API-key rekey migration when a legacy store is discovered, so bare provider keys are restored into the canonical `credential/{provider}/api_key` namespace

## Root Cause

Managed upgrades split credentials from the old assistant data store into the CES-owned security store. If `/ces-security/keys.enc` already existed, even empty or platform-only, the old init-container copy path skipped the legacy `assistant-data/.vellum/protected/keys.enc` store. Settings reads through CES, so legacy BYOK keys still on the PVC appeared to be gone.

## Impact

After the companion platform mount/env change is deployed, affected assistants can self-heal on startup by importing the old encrypted store into CES. Existing CES values win on conflicts, so users who already re-added keys will not have those values overwritten.

Companion platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/7623

## Validation

- `bun test src/__tests__/legacy-secure-key-import.test.ts src/__tests__/ces-migrations-002-api-keys.test.ts src/__tests__/local-secure-key-backend.test.ts src/__tests__/transport.test.ts`
- `bunx tsc --noEmit`
