### PR TITLE
fix(workspace): rethrow rollback errors in 088 migration down()

### DIFF
--- a/assistant/src/workspace/migrations/088-deprecate-background-conversation-override.ts
+++ b/assistant/src/workspace/migrations/088-deprecate-background-conversation-override.ts
@@ -97,6 +97,7 @@ export const deprecateBackgroundConversationOverrideMigration: WorkspaceMigratio
           { err, from: deprecatedPath, to: overridePath },
           "Failed to restore background-conversation override",
         );
+        throw err;
       }
     },
   };


### PR DESCRIPTION
Addresses feedback on #31255 — the down() method silently swallowed renameSync errors, preventing the migration runner from tracking rollback failure. Rethrow after logging so checkpoint state stays consistent.