### PR TITLE
chore(memory): drop file_read instruction from pkb-reminder body

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -8,7 +8,6 @@ const BASE_REMINDER =
   "<system_reminder>" +
   "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
   "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-  '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
   "\n</system_reminder>";
 
 describe("buildPkbReminder", () => {
@@ -22,7 +21,6 @@ describe("buildPkbReminder", () => {
       "<system_reminder>" +
       "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-      '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
       "\n</system_reminder>";
@@ -43,7 +41,6 @@ describe("buildPkbReminder", () => {
       "<system_reminder>" +
       "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
       "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-      '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.' +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- a.md" +
       "\n- sub/b.md" +

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -1,7 +1,6 @@
 const BODY =
   "\nStay present in this conversation. Use `remember` when something feels worth pausing to mark — corrections (highest priority), plans, decisions, felt moments. You don't have to capture everything in the moment — a retrospective pass reviews this conversation in the background and saves what you didn't capture." +
-  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
-  '\nUse `file_read("memory/concepts/path/to/file.md")` to read the full pages for any of the injected memory summaries you want more information on.';
+  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing.";
 
 /**
  * Render the PKB system_reminder text, optionally with a bulleted list of


### PR DESCRIPTION
Addresses feedback on #31258. The added file_read instruction is dead under memory v2 (pkb-reminder is silenced) and misleading under v1 (no concept paths exist). The same guidance already lives in INJECTION_HEADER for v2.