### PR TITLE
fix(memory-v2): enforce global max_page_ids after batch union

### DIFF
--- a/assistant/src/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/memory/v2/__tests__/router.test.ts
@@ -710,6 +710,31 @@ describe("runRouter — batched (batch_size set)", () => {
     expect(result.selectedSlugs).toEqual([]);
   });
 
+  test("union across batches is truncated to global max_page_ids", async () => {
+    // 5 pages, batch_size=1 → 5 batches, each picks its own local id 1.
+    // Without a global cap the union would be 5; max_page_ids=2 forces
+    // truncation back to 2.
+    providerStub = makeProvider(toolUseResponse([1]));
+
+    const result = await runRouter({
+      workspaceDir,
+      ...COMMON_PARAMS,
+      config: makeConfig({ batchSize: 1, maxPageIds: 2 }),
+    });
+
+    expect(result.failureReason).toBeNull();
+    expect(result.selectedSlugs).toHaveLength(2);
+    // sourceBySlug must stay aligned with the truncated selection.
+    expect(result.sourceBySlug.size).toBe(2);
+    for (const slug of result.selectedSlugs) {
+      expect(result.sourceBySlug.get(slug)).toBeDefined();
+    }
+    const warned = warnLogs.some((l) =>
+      JSON.stringify(l.args).includes("union across batches exceeded"),
+    );
+    expect(warned).toBe(true);
+  });
+
   test("batch_size larger than index size is single batch (same as v3)", async () => {
     providerStub = makeProvider(toolUseResponse([1]));
     const result = await runRouter({

--- a/assistant/src/memory/v2/router.ts
+++ b/assistant/src/memory/v2/router.ts
@@ -297,6 +297,21 @@ export async function runRouter(
       "Some router batches failed; returning union of successful batches",
     );
   }
+
+  // Each per-batch call caps at max_page_ids, but the union across batches can
+  // exceed it (e.g. 10 batches × 10 selections each ≫ 25 cap). Apply a final
+  // truncation so RouterResult honors the contract that injection.ts trusts.
+  // Iteration order above is tier 1 → tier 2 → tier 3:0 → … so earlier-tier
+  // slugs win the truncation.
+  const maxPageIds = config.memory?.v2?.router?.max_page_ids ?? 25;
+  if (selectedSlugs.length > maxPageIds) {
+    log.warn(
+      { unionSize: selectedSlugs.length, max: maxPageIds },
+      "Router union across batches exceeded max_page_ids; truncating",
+    );
+    const dropped = selectedSlugs.splice(maxPageIds);
+    for (const slug of dropped) sourceBySlug.delete(slug);
+  }
   return { selectedSlugs, sourceBySlug, failureReason: null };
 }
 


### PR DESCRIPTION
Addresses feedback on #31453. Each per-batch router call caps at max_page_ids, but the union across batches did not, so a partitioned index could return many times the configured per-turn cap. Apply a final truncation after merging, matching the RouterResult contract that injection.ts trusts.