### PR TITLE
fix(home-feed): sync selectedItem on restore, show Restore in detail for dismissed items

### DIFF
--- a/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
+++ b/apps/web/src/domains/home/detail-panel/home-detail-panel.tsx
@@ -1,4 +1,11 @@
-import { CircleX, Mail, MailOpen, MoreVertical, X } from "lucide-react";
+import {
+  CircleX,
+  Mail,
+  MailOpen,
+  MoreVertical,
+  RotateCcw,
+  X,
+} from "lucide-react";
 
 import { Button, Menu, Typography } from "@vellum/design-library";
 import { CATEGORY_STYLES } from "../home-feed-filter-bar.js";
@@ -36,6 +43,7 @@ export function HomeDetailPanel({
   const categoryStyle = resolveCategoryStyle(item.category);
   const CategoryIcon = categoryStyle.icon;
   const isUnread = item.status === "new";
+  const isDismissed = item.status === "dismissed";
 
   return (
     <div className="flex h-full flex-col rounded-[var(--radius-lg)] border border-[var(--border-base)] bg-[var(--surface-overlay)]">
@@ -86,26 +94,37 @@ export function HomeDetailPanel({
             />
           </Menu.Trigger>
           <Menu.Content align="end">
-            <Menu.Item
-              onSelect={() =>
-                onUpdateStatus(item.id, isUnread ? "seen" : "new")
-              }
-              leftIcon={
-                isUnread ? (
-                  <MailOpen className="size-4" />
-                ) : (
-                  <Mail className="size-4" />
-                )
-              }
-            >
-              {isUnread ? "Mark as read" : "Mark as unread"}
-            </Menu.Item>
-            <Menu.Item
-              onSelect={() => onDismiss(item.id)}
-              leftIcon={<CircleX className="size-4" />}
-            >
-              Dismiss
-            </Menu.Item>
+            {isDismissed ? (
+              <Menu.Item
+                onSelect={() => onUpdateStatus(item.id, "seen")}
+                leftIcon={<RotateCcw className="size-4" />}
+              >
+                Restore
+              </Menu.Item>
+            ) : (
+              <>
+                <Menu.Item
+                  onSelect={() =>
+                    onUpdateStatus(item.id, isUnread ? "seen" : "new")
+                  }
+                  leftIcon={
+                    isUnread ? (
+                      <MailOpen className="size-4" />
+                    ) : (
+                      <Mail className="size-4" />
+                    )
+                  }
+                >
+                  {isUnread ? "Mark as read" : "Mark as unread"}
+                </Menu.Item>
+                <Menu.Item
+                  onSelect={() => onDismiss(item.id)}
+                  leftIcon={<CircleX className="size-4" />}
+                >
+                  Dismiss
+                </Menu.Item>
+              </>
+            )}
           </Menu.Content>
         </Menu.Root>
 

--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -89,6 +89,9 @@ export function HomePage({
   const handleRestoreItem = useCallback(
     (itemId: string) => {
       feedQuery.updateStatus.mutate({ itemId, status: "seen" });
+      setSelectedItem((prev) =>
+        prev?.id === itemId ? { ...prev, status: "seen" } : prev,
+      );
     },
     [feedQuery.updateStatus],
   );


### PR DESCRIPTION
Addresses feedback on #31332. (1) handleRestoreItem now updates the local selectedItem so the detail panel reflects the new 'seen' status instead of acting on stale 'dismissed' state. (2) Detail panel surfaces a Restore action for dismissed items instead of confusing 'Mark as unread' labeling.