### PR TITLE
fix(context): cap Gemini tiling at 3072px and use safer fallback for unparseable images

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -279,12 +279,7 @@ describe("token estimator", () => {
       "not-a-valid-image-header-at-all",
     ).toString("base64");
 
-    for (const providerName of [
-      "anthropic",
-      "openai",
-      "openrouter",
-      "gemini",
-    ]) {
+    for (const providerName of ["anthropic", "openai", "openrouter"]) {
       const tokens = estimateContentBlockTokens(
         {
           type: "image",
@@ -304,11 +299,59 @@ describe("token estimator", () => {
     }
   });
 
+  test("Gemini falls back to its max-tile budget for unparseable / HEIC images", () => {
+    // HEIC/HEIF coming from iOS attachments aren't parsed by
+    // parseImageDimensions, so the estimator sees null dims. The generic
+    // 1,600-token cap would under-count by ~2.5x for a typical iPhone photo
+    // that ends up at Gemini's 16-tile / 4,128-token ceiling. Use the
+    // Gemini-specific cap instead to avoid skipping compaction.
+    for (const mediaType of [
+      "image/heic",
+      "image/heif",
+      "image/png", // corrupted PNG also exercises the fallback
+    ]) {
+      const data = Buffer.from("not-a-valid-image-header-at-all").toString(
+        "base64",
+      );
+      const tokens = estimateContentBlockTokens(
+        {
+          type: "image",
+          source: { type: "base64", media_type: mediaType, data },
+        },
+        { providerName: "gemini" },
+      );
+      // 4128 (16 tiles * 258) + 16 (block overhead) + ceil(mediaType len / 4)
+      expect(tokens).toBeGreaterThanOrEqual(4_128);
+      expect(tokens).toBeLessThan(4_200);
+    }
+  });
+
   test("Gemini image tokens scale with image area via 768x768 tiling", () => {
     // Per Google's docs, Gemini tiles images larger than 384px into 768x768
-    // chunks at 258 tokens each. The Anthropic-style ~1,600 cap under-counts
-    // large images badly enough to skip compaction and overflow context.
-    // 4000x4000 → ceil(4000/768)^2 = 6*6 = 36 tiles → 9,288 image tokens.
+    // chunks at 258 tokens each, after resizing the longest side to ≤3072px.
+    // 3000x3000 (under the cap) → ceil(3000/768)^2 = 4*4 = 16 tiles → 4,128
+    // image tokens.
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(3000, 3000),
+        },
+      },
+      { providerName: "gemini" },
+    );
+    expect(tokens).toBeGreaterThanOrEqual(4_128);
+    expect(tokens).toBeLessThan(4_200);
+  });
+
+  test("Gemini clamps image dimensions to 3072px before tiling", () => {
+    // Google's docs state images are resized to a 3072px max side before
+    // tiling. Without the clamp, a 4000x4000 image would be counted as
+    // ceil(4000/768)^2 = 36 tiles (~9,288 tokens) instead of the actual
+    // ceil(3072/768)^2 = 16 tiles (~4,128 tokens), over-counting by ~2.25x
+    // and triggering spurious compaction.
     const tokens = estimateContentBlockTokens(
       {
         type: "image",
@@ -320,8 +363,8 @@ describe("token estimator", () => {
       },
       { providerName: "gemini" },
     );
-    expect(tokens).toBeGreaterThan(9_000);
-    expect(tokens).toBeLessThan(9_500);
+    expect(tokens).toBeGreaterThanOrEqual(4_128);
+    expect(tokens).toBeLessThan(4_200);
   });
 
   test("Gemini images ≤384px on both sides count as a single 258-token tile", () => {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -53,14 +53,22 @@ const IMAGE_TOKENS_PER_PIXEL = 1 / 750;
 const IMAGE_MAX_TOKENS = 1_600;
 
 // Gemini prices images differently: any side ≤384px counts as a single 258-token
-// tile; anything larger is split into 768x768 tiles at 258 tokens each. A
-// 4000x4000 image is ceil(4000/768)^2 = 36 tiles ≈ 9,288 tokens — well above
-// the dimension-based cap — so under-counting these as ~1,600 tokens lets
-// shouldCompact() skip compaction and hit upstream context overflow.
+// tile; anything larger is resized so the longest side is ≤3072px and then
+// split into 768x768 tiles at 258 tokens each. A 4000x4000 image clamps to
+// 3072x3072 → ceil(3072/768)^2 = 16 tiles = 4,128 tokens. Without the clamp
+// we'd over-count it as 36 tiles (~9,288 tokens) and trigger spurious
+// compaction. The clamped 16-tile, 4,128-token figure is also the per-image
+// ceiling we fall back to when dimensions are unparseable (e.g. HEIC/HEIF
+// from iOS attachments) — the generic 1,600 cap can under-count Gemini
+// images by ~2.5x.
 // See: https://ai.google.dev/gemini-api/docs/tokens#multimodal-tokens
 const GEMINI_IMAGE_SMALL_THRESHOLD = 384;
 const GEMINI_IMAGE_TILE_SIZE = 768;
 const GEMINI_IMAGE_TOKENS_PER_TILE = 258;
+const GEMINI_IMAGE_MAX_DIMENSION = 3072;
+const GEMINI_IMAGE_MAX_TOKENS =
+  Math.ceil(GEMINI_IMAGE_MAX_DIMENSION / GEMINI_IMAGE_TILE_SIZE) ** 2 *
+  GEMINI_IMAGE_TOKENS_PER_TILE;
 
 // Anthropic renders each PDF page as an image (~1,568 tokens at standard
 // resolution) plus any extracted text. Typical PDF pages are 50-150 KB.
@@ -146,8 +154,11 @@ function estimateGeminiImageTokens(width: number, height: number): number {
   ) {
     return GEMINI_IMAGE_TOKENS_PER_TILE;
   }
-  const tilesWide = Math.ceil(width / GEMINI_IMAGE_TILE_SIZE);
-  const tilesHigh = Math.ceil(height / GEMINI_IMAGE_TILE_SIZE);
+  // Gemini resizes images so the longest side is ≤3072px before tiling.
+  const clampedWidth = Math.min(width, GEMINI_IMAGE_MAX_DIMENSION);
+  const clampedHeight = Math.min(height, GEMINI_IMAGE_MAX_DIMENSION);
+  const tilesWide = Math.ceil(clampedWidth / GEMINI_IMAGE_TILE_SIZE);
+  const tilesHigh = Math.ceil(clampedHeight / GEMINI_IMAGE_TILE_SIZE);
   return tilesWide * tilesHigh * GEMINI_IMAGE_TOKENS_PER_TILE;
 }
 
@@ -162,9 +173,15 @@ function estimateImageTokens(
     }
     return estimateImageTokensByDimensions(dims.width, dims.height);
   }
-  // Dimensions unparseable (corrupt header, exotic format): use the per-image
-  // cap rather than the raw base64 length, which over-counts by 30-100x for
-  // non-Anthropic providers and trips spurious compaction.
+  // Dimensions unparseable (corrupt header, or formats parseImageDimensions
+  // doesn't recognize like HEIC/HEIF coming from iOS attachments). Fall back
+  // to the per-provider per-image ceiling rather than the raw base64 length,
+  // which over-counts by 30-100x. Gemini's tile pricing tops out well above
+  // the universal 1,600-token cap, so use its max-tile budget instead to
+  // avoid under-counting large iPhone screenshots.
+  if (options?.providerName === "gemini") {
+    return GEMINI_IMAGE_MAX_TOKENS;
+  }
   return IMAGE_MAX_TOKENS;
 }
 


### PR DESCRIPTION
Addresses feedback on #31254 — applies Gemini's documented 3072px pre-tile cap and uses a more conservative fallback for HEIC/HEIF and other unparseable image types so the estimator no longer over-counts large images or under-counts when dims are unknown.