### PR TITLE
fix(memory): pin fork snapshot to cutoff, fix nested fork boundary, add fork-path tests

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -47,6 +47,7 @@ let forkFlagEnabled = false;
 let forkedConversationId = "fork-conv-1";
 let forkCalls: Array<{
   conversationId: string;
+  throughMessageId?: string;
   source: string;
   title: string;
   conversationType?: string;
@@ -55,8 +56,28 @@ let forkCalls: Array<{
 let addMessageCalls: Array<{
   conversationId: string;
   role: string;
+  content: string;
   metadata: unknown;
 }> = [];
+
+// Per-conversation overrides for getConversation. Lets fork-path tests stage
+// a fork-kind prior retrospective row alongside the default legacy stub.
+type ConversationStub = {
+  source: string;
+  forkParentMessageId: string | null;
+  title?: string;
+};
+let conversationOverrides: Record<string, ConversationStub> = {};
+
+// Per-conversation overrides for getMessages so fork-path tests can return
+// fork-shaped message rows (with metadata stamps + createdAt boundaries).
+type StubMessage = {
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+};
+let messagesByConversationId: Record<string, StubMessage[]> = {};
 
 mock.module("../memory-retrospective-state.js", () => ({
   getRetrospectiveState: (_id: string) => mockState,
@@ -75,6 +96,7 @@ mock.module("../memory-retrospective-state.js", () => ({
 mock.module("../conversation-crud.js", () => ({
   getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
   getMessages: (id: string) => {
+    if (messagesByConversationId[id]) return messagesByConversationId[id];
     if (id === priorRetroId) return priorRetroMessages;
     return [];
   },
@@ -83,9 +105,11 @@ mock.module("../conversation-crud.js", () => ({
   // The fork path calls `getConversation(sourceConversationId)` to read the
   // source's title for the fork title. `collectPriorRetrospectiveRemembers`
   // also calls it with the prior retro id to discriminate legacy vs fork
-  // sources — for that id return a legacy-shaped row so the existing tests
-  // exercise the unchanged extract-everything code path.
+  // sources — for that id return a legacy-shaped row by default so existing
+  // tests exercise the unchanged extract-everything code path.
+  // `conversationOverrides` lets per-test setup stage fork-kind priors.
   getConversation: (id: string) => {
+    if (conversationOverrides[id]) return conversationOverrides[id];
     if (id === priorRetroId) {
       return {
         source: "memory-retrospective",
@@ -100,6 +124,7 @@ mock.module("../conversation-crud.js", () => ({
   },
   forkConversation: (params: {
     conversationId: string;
+    throughMessageId?: string;
     source: string;
     title: string;
     conversationType?: string;
@@ -111,10 +136,10 @@ mock.module("../conversation-crud.js", () => ({
   addMessage: async (
     conversationId: string,
     role: string,
-    _content: string,
+    content: string,
     metadata: unknown,
   ) => {
-    addMessageCalls.push({ conversationId, role, metadata });
+    addMessageCalls.push({ conversationId, role, content, metadata });
   },
   deleteConversation: (id: string) => {
     deletedConversationIds.push(id);
@@ -268,6 +293,8 @@ describe("memoryRetrospectiveJob", () => {
     forkedConversationId = "fork-conv-1";
     forkCalls = [];
     addMessageCalls = [];
+    conversationOverrides = {};
+    messagesByConversationId = {};
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -513,5 +540,186 @@ describe("memoryRetrospectiveJob", () => {
     expect(opts.skipHintInjection).toBe(true);
     expect(opts.suppressAutoCompaction).toBe(true);
     expect(opts.hintRole).toBe("user");
+  });
+
+  test("fork path: fork is pinned to the computed cutoffMessageId so late-arriving messages don't sneak into this run", async () => {
+    // Without `throughMessageId`, the fork snapshots the latest source
+    // message at fork time. If a new user/assistant turn lands between the
+    // slice read and the fork, this run would process the late turn while
+    // state advances only to `cutoffMessageId`, causing the next
+    // retrospective to reprocess it.
+    forkFlagEnabled = true;
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(forkCalls).toHaveLength(1);
+    expect(forkCalls[0]!.throughMessageId).toBe("m3");
+  });
+
+  test("fork path: prior fork-kind retrospective with nested-fork ancestry still surfaces its post-fork remembers in <already_remembered>", async () => {
+    // The source conversation was itself a fork. Its assistant messages
+    // therefore carry `forkSourceMessageId` values pointing at the
+    // ANCESTOR's message ids — not at the new fork's `forkParentMessageId`.
+    // The boundary detector must locate the boundary by scanning for the
+    // last metadata stamp regardless of value, not by equality against
+    // `forkParentMessageId` (which would miss every copied row and lose
+    // dedup context).
+    forkFlagEnabled = true;
+    priorRetroId = "prior-fork-retro-1";
+
+    // The fork's `forkParentMessageId` is the source conv's tip ("m-src-2"),
+    // but the cloned messages preserve ancestor stamps ("m-ancestor-*").
+    conversationOverrides[priorRetroId] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: "m-src-2",
+    };
+    messagesByConversationId[priorRetroId] = [
+      // Copied prefix — note metadata stamps point at the ANCESTOR, not
+      // `forkParentMessageId`. The old detector would return null here.
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "hi" }]),
+        createdAt: 1000,
+        metadata: JSON.stringify({ forkSourceMessageId: "m-ancestor-1" }),
+      },
+      {
+        role: "assistant",
+        // An inline `remember` from the source conv (should NOT leak into
+        // dedup baseline — it's part of the copied prefix, not the post-fork
+        // retrospective tail).
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: "source-inline save — must be excluded" },
+          },
+        ]),
+        createdAt: 2000,
+        metadata: JSON.stringify({ forkSourceMessageId: "m-ancestor-2" }),
+      },
+      // Post-fork instruction (no forkSourceMessageId) + the wake's tail
+      // assistant turn with the retrospective's own remember call.
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Retrospective instruction" },
+        ]),
+        createdAt: 3000,
+        metadata: JSON.stringify({
+          kind: "memory_retrospective_instruction",
+          hidden: true,
+        }),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: "retrospective save — must be included" },
+          },
+        ]),
+        createdAt: 4000,
+        metadata: null,
+      },
+    ];
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    // The fork path persists the prompt as a user-role message, not via the
+    // wake's hint. Pull the rendered text block out of the persisted JSON.
+    expect(addMessageCalls).toHaveLength(1);
+    const blocks = JSON.parse(addMessageCalls[0]!.content) as Array<{
+      type: string;
+      text: string;
+    }>;
+    const instructionText = blocks[0]!.text;
+    expect(instructionText).toContain(
+      "- retrospective save — must be included",
+    );
+    expect(instructionText).not.toContain("source-inline save");
+    // Sanity: the "first retrospective" sentinel should not appear — we
+    // located dedup context.
+    expect(instructionText).not.toContain(
+      "(none — this is your first retrospective over this conversation)",
+    );
+  });
+
+  test("fork path: prior fork-kind retrospective with no copied messages degrades to empty dedup", async () => {
+    // Corrupted/empty fork-kind prior: no message carries
+    // `forkSourceMessageId`. The detector should return null and the
+    // handler should treat dedup as empty rather than dumping everything
+    // (which would leak any pre-fork content into the baseline).
+    forkFlagEnabled = true;
+    priorRetroId = "prior-fork-retro-2";
+
+    conversationOverrides[priorRetroId] = {
+      source: "memory-retrospective-fork",
+      forkParentMessageId: "m-src-2",
+    };
+    messagesByConversationId[priorRetroId] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            name: "remember",
+            input: { content: "would-be-leaked save" },
+          },
+        ]),
+        createdAt: 1000,
+        metadata: null,
+      },
+    ];
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(addMessageCalls).toHaveLength(1);
+    const blocks = JSON.parse(addMessageCalls[0]!.content) as Array<{
+      type: string;
+      text: string;
+    }>;
+    const instructionText = blocks[0]!.text;
+    expect(instructionText).not.toContain("- would-be-leaked save");
+    expect(instructionText).toContain(
+      "(none — this is your first retrospective over this conversation)",
+    );
+  });
+
+  test("fork path: prompt anchors review window at first turn_context current_time and disambiguates first-pass vs incremental", async () => {
+    forkFlagEnabled = true;
+    // Stage a user turn whose content carries a turn_context current_time
+    // block — the handler should anchor the prompt at that timestamp.
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "text",
+            text: "<turn_context>\ncurrent_time: 2026-05-11T10:00:00-07:00\n</turn_context>\n\nhi",
+          },
+        ]),
+      },
+      // Wake's response — no turn_context, not used as anchor.
+      {
+        id: "m2",
+        createdAt: Date.parse("2026-05-11T10:05:00Z"),
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "hello" }]),
+      },
+    ] as Array<{ id: string; createdAt: number } & Record<string, unknown>>;
+
+    // Incremental run — `lastProcessedMessageId` already set.
+    mockState = {
+      conversationId: "src-conv-1",
+      lastProcessedMessageId: "prev-msg",
+      lastRunAt: Date.now() - 60 * 60 * 1000,
+    };
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(addMessageCalls).toHaveLength(1);
+    expect(forkCalls).toHaveLength(1);
+    expect(forkCalls[0]!.throughMessageId).toBe("m2");
   });
 });

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -331,15 +331,22 @@ async function runForkBasedRetrospective(
   const priorRemembers =
     collectPriorRetrospectiveRemembers(sourceConversationId);
 
+  // Pin the fork to `cutoffMessageId` so messages arriving between the slice
+  // read above and this call don't sneak into the fork. Without
+  // `throughMessageId`, the fork snapshots the latest source message at fork
+  // time and this run would process turns past the cutoff while state only
+  // advances to `cutoffMessageId`, causing the next retrospective to
+  // reprocess (and potentially re-`remember`) those same turns.
+  //
   // `forkConversation` inherits `contextSummary` /
   // `contextCompactedMessageCount` / `contextCompactedAt` when the fork
-  // point sits within the visible window — always true here since no
-  // `throughMessageId` means fork through latest. Compacted source ⇒
-  // compacted fork ⇒ summary + tail visible to the agent natively.
+  // point sits within the visible window. Compacted source ⇒ compacted
+  // fork ⇒ summary + tail visible to the agent natively.
   let forkConversationRow: ReturnType<typeof forkConversation>;
   try {
     forkConversationRow = forkConversation({
       conversationId: sourceConversationId,
+      throughMessageId: cutoffMessageId,
       source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
       title: `${sourceConversation.title ?? "Untitled"} (Retrospective)`,
       conversationType: "background",
@@ -556,30 +563,18 @@ function collectPriorRetrospectiveRemembers(
   const priorConv = getConversation(prior.id);
   if (priorConv?.source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
     // For fork-kind rows, prior `remember` calls live in the post-fork
-    // tail (messages created after the last copied source message).
-    // `cloneForkMessageMetadata` stamps every copied message with
-    // `forkSourceMessageId`; the cloned row whose stamp equals
-    // `forkParentMessageId` sits at the boundary, and the fork preserves
-    // `createdAt` on cloned messages, so everything strictly greater than
-    // that timestamp is post-fork.
-    if (priorConv.forkParentMessageId == null) {
-      log.warn(
-        { priorConversationId: prior.id },
-        "memory-retrospective: fork-kind prior has null forkParentMessageId; treating dedup as empty",
-      );
-      return [];
-    }
-    const boundaryCreatedAt = findForkBoundaryCreatedAt(
-      messages,
-      priorConv.forkParentMessageId,
-    );
+    // tail. `cloneForkMessageMetadata` stamps every copied message with
+    // `forkSourceMessageId` (preserving any existing value when the source
+    // was itself a fork), so the LAST message in the fork carrying
+    // `forkSourceMessageId` is the boundary — its value can point to any
+    // ancestor when the source was a nested fork, so we can't match it
+    // against `forkParentMessageId`. Everything strictly past that
+    // timestamp is post-fork.
+    const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
     if (boundaryCreatedAt == null) {
       log.warn(
-        {
-          priorConversationId: prior.id,
-          forkParentMessageId: priorConv.forkParentMessageId,
-        },
-        "memory-retrospective: fork-kind prior's boundary message missing; treating dedup as empty",
+        { priorConversationId: prior.id },
+        "memory-retrospective: fork-kind prior has no message with forkSourceMessageId metadata; treating dedup as empty",
       );
       return [];
     }
@@ -593,10 +588,13 @@ function collectPriorRetrospectiveRemembers(
 
 /**
  * Locate the boundary timestamp between the fork's prefix and its post-fork
- * tail. The cloned row with `metadata.forkSourceMessageId === forkParentMessageId`
- * marks the last copied source message; its `createdAt` is the boundary.
- * Returns `null` only if the stamp is missing — which indicates corrupted
- * fork metadata (caller logs + degrades).
+ * tail. Scans from the end for the last message whose metadata carries a
+ * `forkSourceMessageId` stamp (the last copied source message); its
+ * `createdAt` is the boundary. The stamp's value may point at any ancestor
+ * when the source was itself a fork (`cloneForkMessageMetadata` preserves
+ * pre-existing values), so we only check for presence, not equality.
+ * Returns `null` only if no copied messages remain (corrupted fork metadata
+ * or empty fork — caller logs + degrades).
  */
 function findForkBoundaryCreatedAt(
   forkMessages: Array<{
@@ -604,15 +602,15 @@ function findForkBoundaryCreatedAt(
     createdAt: number;
     metadata: string | null;
   }>,
-  forkParentMessageId: string,
 ): number | null {
-  for (const row of forkMessages) {
+  for (let i = forkMessages.length - 1; i >= 0; i--) {
+    const row = forkMessages[i]!;
     if (!row.metadata) continue;
     try {
       const parsed = JSON.parse(row.metadata) as {
-        forkSourceMessageId?: string;
+        forkSourceMessageId?: unknown;
       };
-      if (parsed.forkSourceMessageId === forkParentMessageId) {
+      if (typeof parsed.forkSourceMessageId === "string") {
         return row.createdAt;
       }
     } catch {


### PR DESCRIPTION
Addresses feedback on #31260: (1) pin fork snapshot to computed cutoffMessageId so re-runs don't reprocess late-arriving messages; (2) fix findForkBoundaryCreatedAt for nested forks where cloneForkMessageMetadata preserves ancestor IDs; (3) add fork-path test coverage that previously didn't exist.